### PR TITLE
Fix gRPC server inbound message size default and error status

### DIFF
--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -89,7 +89,8 @@ interface GrpcConfigBlueprint extends ProtocolConfig {
      * and must be buffered entirely before deserialization — this effectively
      * limits the maximum inbound message size.
      *
-     * <p>Messages larger than this are rejected. Defaults to 4 MB, matching
+     * <p>Messages larger than this are rejected with a
+     * {@code RESOURCE_EXHAUSTED} status. Defaults to 4 MB, matching
      * the gRPC ecosystem standard ({@code GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE}
      * in grpc-java,
      * <a href="https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/GrpcUtil.java#L212">source</a>).

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -83,13 +83,20 @@ interface GrpcConfigBlueprint extends ProtocolConfig {
     }
 
     /**
-     * Max size of gRPC reading buffer. If receiving an entity larger than this,
-     * processing will be aborted. This can help prevent DoS attacks. Default
-     * set to 2 MB.
+     * Maximum read buffer size for inbound gRPC messages.
+     * <p>
+     * Because gRPC uses length-prefixed framing — each message declares its full size upfront
+     * and must be buffered entirely before deserialization — this effectively
+     * limits the maximum inbound message size.
+     *
+     * <p>Messages larger than this are rejected. Defaults to 4 MB, matching
+     * the gRPC ecosystem standard ({@code GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE}
+     * in grpc-java,
+     * <a href="https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/GrpcUtil.java#L212">source</a>).
      *
      * @return max read buffer size
      */
     @Option.Configured
-    @Option.DefaultInt(2 * 1024 * 1024)
+    @Option.DefaultInt(4 * 1024 * 1024)
     int maxReadBufferSize();
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -73,6 +73,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 
 import static io.helidon.http.HeaderNames.CONTENT_TYPE;
 import static io.helidon.http.http2.Http2Flag.DataFlags;
@@ -117,6 +118,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private final StreamFlowControl flowControl;
     private final GrpcConfig grpcConfig;
 
+    private ServerCall<REQ, RES> serverCall;
     private volatile ServerCall.Listener<REQ> listener;
     private BufferData entityBytes;
     private BufferData readBufferData = BufferData.create(INITIAL_BUFFER_SIZE);
@@ -153,7 +155,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     @Override
     public void init() {
         try {
-            ServerCall<REQ, RES> serverCall = createServerCall();
+            serverCall = createServerCall();
             Headers httpHeaders = headers.httpHeaders();
 
             // setup compression
@@ -240,7 +242,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                     if (newData.available() >= GRPC_HEADER_SIZE) {
                         isCompressed = (newData.read() == 1);
                         entityBytesLeft = newData.readUnsignedInt32();
-                        entityBytes = allocateReadBuffer((int) entityBytesLeft);
+                        entityBytes = allocateReadBuffer(entityBytesLeft);
                     } else {
                         unreadBufferData = newData;
                         return;     // need more for gRPC header
@@ -283,6 +285,16 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
             }
         } catch (CloseConnectionException e) {
             throw e;
+        } catch (StatusRuntimeException e) {
+            if (isPeerCancellation(e)) {
+                throw new ServerConnectionException("gRPC call cancelled by remote peer", e);
+            }
+            // Close the call with the embedded gRPC status (e.g. RESOURCE_EXHAUSTED for oversized messages).
+            // This sends status trailers back to the client rather than abruptly cancelling.
+            // See: MessageDeframer.processHeader() in
+            // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+            LOGGER.log(System.Logger.Level.DEBUG, "gRPC call closed with status: {0}", e.getStatus());
+            serverCall.close(e.getStatus(), new Metadata());
         } catch (Exception e) {
             if (isPeerCancellation(e)) {
                 throw new ServerConnectionException("gRPC call cancelled by remote peer", e);
@@ -292,14 +304,25 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         }
     }
 
-    BufferData allocateReadBuffer(int length) {
+    BufferData allocateReadBuffer(long length) {
+        // The gRPC length prefix is an unsigned 32-bit value, so check it against the limit on
+        // the full long before any cast to int: a length above Integer.MAX_VALUE would otherwise
+        // wrap negative and slip past the check. Checking before the capacity branch also enforces
+        // limits smaller than the initial buffer size.
+        if (length > grpcConfig.maxReadBufferSize()) {
+            // Throw RESOURCE_EXHAUSTED for oversized messages so the status
+            // propagates back to the client as gRPC trailers.
+            // See: MessageDeframer.processHeader() in
+            // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+            throw Status.RESOURCE_EXHAUSTED
+                    .withDescription("gRPC message exceeds maximum size "
+                            + grpcConfig.maxReadBufferSize() + ": " + length)
+                    .asRuntimeException();
+        }
         readBufferData.reset();
-        int capacity = readBufferData.capacity();
-        if (length > capacity) {
-            if (length > grpcConfig.maxReadBufferSize()) {
-                throw new IllegalStateException("gRPC message size exceeds max read buffer size");
-            }
-            readBufferData = BufferData.create(length);
+        int intLength = (int) length;       // safe: length <= maxReadBufferSize <= Integer.MAX_VALUE
+        if (intLength > readBufferData.capacity()) {
+            readBufferData = BufferData.create(intLength);
         }
         return readBufferData;
     }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -105,7 +105,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
     private static final LazyValue<Map<String, MethodMetrics>> METHOD_METRICS = LazyValue.create(ConcurrentHashMap::new);
 
-    private static final int GRPC_HEADER_SIZE = 5;
+    static final int GRPC_HEADER_SIZE = 5;
     private static final int INITIAL_BUFFER_SIZE = 16 * 1024;
 
     private final ConnectionContext connectionContext;
@@ -132,6 +132,11 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private long startMillis;
 
     private volatile boolean callCancelled;
+    // set once close() has sent the call's trailers; written by stream or application
+    // threads, read by the connection thread in rstStream()
+    private volatile boolean callClosed;
+    // only accessed by the stream thread in data()
+    private boolean drainingInbound;
     private final AtomicReference<Http2StreamState> currentStreamState = new AtomicReference<>();
 
     GrpcProtocolHandler(ConnectionContext connectionContext,
@@ -204,8 +209,14 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
      */
     @Override
     public void rstStream(Http2RstStream rstStream) {
-        callCancelled = (rstStream.errorCode() == Http2ErrorCode.CANCEL);
-        listener.onCancel();
+        // After close() has sent the call's trailers, no further listener callbacks may be
+        // delivered (io.grpc.ServerCall.Listener contract). A late RST_STREAM, e.g. the client
+        // cancelling the remainder of a request the server already rejected, must not surface
+        // as a cancellation to the application.
+        if (!callClosed) {
+            callCancelled = (rstStream.errorCode() == Http2ErrorCode.CANCEL);
+            listener.onCancel();
+        }
         currentStreamState.updateAndGet(
                 current -> nextStreamState(current, Http2StreamState.HALF_CLOSED_REMOTE));
     }
@@ -223,6 +234,15 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
      */
     @Override
     public void data(Http2FrameHeader header, BufferData data) {
+        if (drainingInbound) {
+            // The call is already closed with a status, but the client is still sending request
+            // data. Discard it without delivering anything to the listener. Reading it is
+            // required: the Http2ServerStream read loop stops once this handler reports
+            // HALF_CLOSED_LOCAL or CLOSED, while the connection thread keeps queueing this
+            // stream's DATA frames into a bounded queue, eventually blocking the connection.
+            closeStreamIfEndOfStream(header);
+            return;
+        }
         try {
             boolean isCompressed = false;
 
@@ -293,8 +313,27 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
             // This sends status trailers back to the client rather than abruptly cancelling.
             // See: MessageDeframer.processHeader() in
             // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
-            LOGGER.log(System.Logger.Level.DEBUG, "gRPC call closed with status: {0}", e.getStatus());
-            serverCall.close(e.getStatus(), new Metadata());
+            if (!callClosed) {
+                LOGGER.log(System.Logger.Level.DEBUG, "gRPC call closed with status: {0}", e.getStatus());
+                // propagate trailers carried by the exception, the same way
+                // io.helidon.grpc.core.GrpcHelper.ensureStatusRuntimeException() preserves them
+                Metadata trailers = e.getTrailers() == null ? new Metadata() : e.getTrailers();
+                serverCall.close(e.getStatus(), trailers);
+            }
+            if (!header.flags(Http2FrameTypes.DATA).endOfStream()) {
+                // close() above reported HALF_CLOSED_LOCAL, which would stop the
+                // Http2ServerStream read loop with request data still arriving; report OPEN
+                // again and discard the rest of the request, see the drainingInbound block above.
+                // updateAndGet (not a plain set) so a concurrent rstStream() that already moved
+                // the stream to CLOSED is not resurrected.
+                drainingInbound = true;
+                currentStreamState.updateAndGet(
+                        current -> current == Http2StreamState.HALF_CLOSED_LOCAL
+                                ? Http2StreamState.OPEN
+                                : current);
+            }
+            // EOS: the client has finished sending, nothing is left to read on this stream.
+            closeStreamIfEndOfStream(header);
         } catch (Exception e) {
             if (isPeerCancellation(e)) {
                 throw new ServerConnectionException("gRPC call cancelled by remote peer", e);
@@ -426,6 +465,13 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         };
     }
 
+    private void closeStreamIfEndOfStream(Http2FrameHeader header) {
+        if (header.flags(Http2FrameTypes.DATA).endOfStream()) {
+            currentStreamState.updateAndGet(
+                    current -> nextStreamState(current, Http2StreamState.CLOSED));
+        }
+    }
+
     ServerCall<REQ, RES> createServerCall() {
         return new ServerCall<REQ, RES>() {
 
@@ -507,6 +553,8 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
             @Override
             public void close(Status status, Metadata trailers) {
+                callClosed = true;
+
                 // prepare trailers, may override status code to CANCELLED
                 WritableHeaders<?> writable = WritableHeaders.create();
                 if (!headersSent) {

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -252,6 +252,39 @@ class GrpcProtocolHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void oversizedMessageBelowInitialBufferThrowsResourceExhausted() {
+        // A limit below the initial 16 KB read buffer must still be enforced. The gRPC length
+        // prefix carries the full message size, so the limit can be checked before any buffer
+        // is grown.
+        int limit = 8 * 1024;
+        GrpcProtocolHandler<?, ?> handler = new GrpcProtocolHandler<>(new UnimplementedGrpcConnectionContext(),
+                                                                       Http2Headers.create(WritableHeaders.create()),
+                                                                       null, 1, null,
+                                                                       Http2StreamState.OPEN, null,
+                                                                       GrpcConfig.builder().maxReadBufferSize(limit).build());
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                                                  () -> handler.allocateReadBuffer(limit + 1));
+        assertThat(ex.getStatus().getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void oversizedMessageExceedingIntRangeThrowsResourceExhausted() {
+        // The gRPC length prefix is an unsigned 32-bit value (up to 4_294_967_295), which does
+        // not fit in a signed int. The limit check must run on the full value, before any cast,
+        // so a declared length above Integer.MAX_VALUE cannot wrap negative and slip past it.
+        GrpcProtocolHandler<?, ?> handler = new GrpcProtocolHandler<>(new UnimplementedGrpcConnectionContext(),
+                                                                       Http2Headers.create(WritableHeaders.create()),
+                                                                       null, 1, null,
+                                                                       Http2StreamState.OPEN, null,
+                                                                       GrpcConfig.create());
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                                                  () -> handler.allocateReadBuffer(3_000_000_000L));
+        assertThat(ex.getStatus().getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
+    }
+
+    @Test
     void testCloseSuppressesTrailerWriteDisconnect() {
         ServerCall<String, String> serverCall = createServerCall(closeFailingWriter());
         serverCall.sendHeaders(new Metadata());

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -227,6 +227,13 @@ class GrpcProtocolHandlerTest {
     }
 
     @Test
+    void defaultMaxReadBufferSizeMatchesGrpcEcosystemStandard() {
+        // Matches GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE in grpc-java:
+        // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/GrpcUtil.java#L212
+        assertThat(GrpcConfig.create().maxReadBufferSize(), is(4 * 1024 * 1024));
+    }
+
+    @Test
     void testCloseSuppressesTrailerWriteDisconnect() {
         ServerCall<String, String> serverCall = createServerCall(closeFailingWriter());
         serverCall.sendHeaders(new Metadata());

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -59,6 +59,7 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -231,6 +232,23 @@ class GrpcProtocolHandlerTest {
         // Matches GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE in grpc-java:
         // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/GrpcUtil.java#L212
         assertThat(GrpcConfig.create().maxReadBufferSize(), is(4 * 1024 * 1024));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void oversizedMessageThrowsResourceExhausted() {
+        // grpc-java throws RESOURCE_EXHAUSTED (not a plain Java exception) for oversized messages.
+        // See: MessageDeframer.processHeader() in
+        // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+        int limit = 100 * 1024;
+        GrpcProtocolHandler<?, ?> handler = new GrpcProtocolHandler<>(new UnimplementedGrpcConnectionContext(),
+                                                                       Http2Headers.create(WritableHeaders.create()),
+                                                                       null, 1, null,
+                                                                       Http2StreamState.OPEN, null,
+                                                                       GrpcConfig.builder().maxReadBufferSize(limit).build());
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                                                  () -> handler.allocateReadBuffer(limit + 1));
+        assertThat(ex.getStatus().getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
     }
 
     @Test

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -35,6 +37,7 @@ import io.helidon.common.socket.PeerInfo;
 import io.helidon.grpc.core.WeightedBag;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.FlowControl;
 import io.helidon.http.http2.Http2Flag;
@@ -66,6 +69,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -73,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class GrpcProtocolHandlerTest {
 
     private static final HeaderName GRPC_ACCEPT_ENCODING = HeaderNames.create("grpc-accept-encoding");
+    private static final int GRPC_PREFIX_LENGTH = 5;
 
     @Test
     @SuppressWarnings("unchecked")
@@ -518,6 +523,216 @@ class GrpcProtocolHandlerTest {
                 return 0;
             }
         };
+    }
+
+    /**
+     * When message processing throws a {@link StatusRuntimeException} (e.g. {@code RESOURCE_EXHAUSTED}
+     * for an oversized message), the call is closed with that status, but the client may still be
+     * sending request data. The handler must keep consuming those frames: if its stream state left
+     * the set accepted by {@code Http2ServerStream.DATA_RECEIVABLE_STATES}, the stream's read loop
+     * would stop while the connection thread keeps queueing DATA frames into the stream's bounded
+     * queue, eventually blocking the connection thread.
+     */
+    @Nested
+    class EarlyCloseOnStatusException {
+
+        private static final Metadata.Key<String> DEBUG_KEY =
+                Metadata.Key.of("x-test-debug", Metadata.ASCII_STRING_MARSHALLER);
+
+        // allocateReadBuffer() checks the limit only for messages larger than its initial
+        // 16 KB buffer, so the limit must be at least that for the rejection to trigger
+        private static final int LIMIT = 16 * 1024;
+
+        private final RecordingWriter writer = new RecordingWriter();
+        private final RecordingListener listener = new RecordingListener();
+        private final AtomicReference<ServerCall<String, String>> callRef = new AtomicReference<>();
+
+        @Test
+        void oversizedMessageKeepsConsumingInboundData() {
+            GrpcProtocolHandler<String, String> handler = handler(listener);
+
+            handler.data(dataHeader(false), messagePrefix(LIMIT + 1));
+
+            assertAll(
+                    () -> assertThat(trailerStatus(), is(Status.Code.RESOURCE_EXHAUSTED.value())),
+                    () -> assertThat("read loop must keep running to drain the request",
+                                     handler.streamState(), is(Http2StreamState.OPEN)),
+                    () -> assertThat(listener.completes, is(1))
+            );
+
+            // remaining request data is discarded without reaching the listener
+            handler.data(dataHeader(false), message("hi"));
+            assertAll(
+                    () -> assertThat(listener.messages, is(List.of())),
+                    () -> assertThat(writer.headersWritten, hasSize(1)),
+                    () -> assertThat(handler.streamState(), is(Http2StreamState.OPEN))
+            );
+
+            // end of stream completes the drain and lets the stream close
+            handler.data(dataHeader(true), BufferData.empty());
+            assertAll(
+                    () -> assertThat(handler.streamState(), is(Http2StreamState.CLOSED)),
+                    () -> assertThat(listener.halfCloses, is(0))
+            );
+        }
+
+        @Test
+        void oversizedMessageOnLastFrameClosesStream() {
+            GrpcProtocolHandler<String, String> handler = handler(listener);
+
+            handler.data(dataHeader(true), messagePrefix(LIMIT + 1));
+
+            assertAll(
+                    () -> assertThat(trailerStatus(), is(Status.Code.RESOURCE_EXHAUSTED.value())),
+                    () -> assertThat("no more inbound data, nothing left to drain",
+                                     handler.streamState(), is(Http2StreamState.CLOSED))
+            );
+        }
+
+        @Test
+        void statusExceptionTrailersArePropagated() {
+            Metadata trailers = new Metadata();
+            trailers.put(DEBUG_KEY, "details");
+            GrpcProtocolHandler<String, String> handler = handler(new RecordingListener() {
+                @Override
+                public void onMessage(String message) {
+                    throw Status.FAILED_PRECONDITION.asRuntimeException(trailers);
+                }
+            });
+
+            handler.data(dataHeader(false), message("hi"));
+
+            Headers written = writer.headersWritten.getFirst().httpHeaders();
+            assertAll(
+                    () -> assertThat(trailerStatus(), is(Status.Code.FAILED_PRECONDITION.value())),
+                    () -> assertThat(written.get(HeaderNames.create("x-test-debug")).get(), is("details"))
+            );
+        }
+
+        @Test
+        void rstStreamAfterCloseDoesNotCancelListener() {
+            GrpcProtocolHandler<String, String> handler = handler(listener);
+            callRef.get().close(Status.OK, new Metadata());
+
+            // a late RST_STREAM, e.g. the client cancelling the remainder of a rejected request,
+            // must not surface as a cancellation after the call has already completed
+            handler.rstStream(new Http2RstStream(io.helidon.http.http2.Http2ErrorCode.CANCEL));
+
+            assertAll(
+                    () -> assertThat(listener.cancels, is(0)),
+                    () -> assertThat(listener.completes, is(1))
+            );
+        }
+
+        private GrpcProtocolHandler<String, String> handler(ServerCall.Listener<String> callListener) {
+            GrpcProtocolHandler<String, String> handler = new GrpcProtocolHandler<>(
+                    new UnimplementedGrpcConnectionContext(),
+                    Http2Headers.create(WritableHeaders.create()),
+                    writer,
+                    1,
+                    null,
+                    Http2StreamState.OPEN,
+                    route(new ServerCallHandler<>() {
+                        @Override
+                        public ServerCall.Listener<String> startCall(ServerCall<String, String> call, Metadata headers) {
+                            callRef.set(call);
+                            call.request(2);
+                            return callListener;
+                        }
+                    }),
+                    GrpcConfig.builder().maxReadBufferSize(LIMIT).build());
+            handler.init();
+            return handler;
+        }
+
+        private int trailerStatus() {
+            return writer.headersWritten.getFirst().httpHeaders().get(GrpcStatus.STATUS_NAME).get(int.class);
+        }
+
+        private Http2FrameHeader dataHeader(boolean endOfStream) {
+            return Http2FrameHeader.create(0,
+                                           Http2FrameTypes.DATA,
+                                           Http2Flag.DataFlags.create(endOfStream ? Http2Flag.END_OF_STREAM : 0),
+                                           1);
+        }
+
+        /**
+         * A gRPC length-prefixed frame header declaring {@code length} bytes, without the payload.
+         * The declared size alone is enough for the server to reject the message.
+         */
+        private BufferData messagePrefix(int length) {
+            BufferData buffer = BufferData.create(GRPC_PREFIX_LENGTH);
+            buffer.write(0);
+            buffer.writeUnsignedInt32(length);
+            return buffer;
+        }
+
+        private BufferData message(String content) {
+            byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+            BufferData buffer = BufferData.create(GRPC_PREFIX_LENGTH + bytes.length);
+            buffer.write(0);
+            buffer.writeUnsignedInt32(bytes.length);
+            buffer.write(bytes);
+            return buffer;
+        }
+    }
+
+    private static class RecordingListener extends ServerCall.Listener<String> {
+        private final List<String> messages = new ArrayList<>();
+        private int halfCloses;
+        private int cancels;
+        private int completes;
+
+        @Override
+        public void onMessage(String message) {
+            messages.add(message);
+        }
+
+        @Override
+        public void onHalfClose() {
+            halfCloses++;
+        }
+
+        @Override
+        public void onCancel() {
+            cancels++;
+        }
+
+        @Override
+        public void onComplete() {
+            completes++;
+        }
+    }
+
+    private static final class RecordingWriter implements Http2StreamWriter {
+        private final List<Http2Headers> headersWritten = new ArrayList<>();
+
+        @Override
+        public void write(Http2FrameData frame) {
+        }
+
+        @Override
+        public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                FlowControl.Outbound flowControl) {
+            headersWritten.add(headers);
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                Http2FrameData dataFrame,
+                                FlowControl.Outbound flowControl) {
+            headersWritten.add(headers);
+            return 0;
+        }
     }
 
     @Nested

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -77,7 +77,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class GrpcProtocolHandlerTest {
 
     private static final HeaderName GRPC_ACCEPT_ENCODING = HeaderNames.create("grpc-accept-encoding");
-    private static final int GRPC_PREFIX_LENGTH = 5;
 
     @Test
     @SuppressWarnings("unchecked")
@@ -539,8 +538,6 @@ class GrpcProtocolHandlerTest {
         private static final Metadata.Key<String> DEBUG_KEY =
                 Metadata.Key.of("x-test-debug", Metadata.ASCII_STRING_MARSHALLER);
 
-        // allocateReadBuffer() checks the limit only for messages larger than its initial
-        // 16 KB buffer, so the limit must be at least that for the rejection to trigger
         private static final int LIMIT = 16 * 1024;
 
         private final RecordingWriter writer = new RecordingWriter();
@@ -657,23 +654,25 @@ class GrpcProtocolHandlerTest {
         }
 
         /**
-         * A gRPC length-prefixed frame header declaring {@code length} bytes, without the payload.
-         * The declared size alone is enough for the server to reject the message.
+         * A gRPC length-prefixed frame declaring {@code declaredLength} bytes followed by
+         * {@code payload}. The two can differ: declaring more than is sent is enough for the
+         * server to reject an oversized message on the prefix alone.
          */
-        private BufferData messagePrefix(int length) {
-            BufferData buffer = BufferData.create(GRPC_PREFIX_LENGTH);
-            buffer.write(0);
-            buffer.writeUnsignedInt32(length);
+        private BufferData frame(int declaredLength, byte[] payload) {
+            BufferData buffer = BufferData.create(GrpcProtocolHandler.GRPC_HEADER_SIZE + payload.length);
+            buffer.write(0);        // 0 for identity compressor
+            buffer.writeUnsignedInt32(declaredLength);
+            buffer.write(payload);
             return buffer;
+        }
+
+        private BufferData messagePrefix(int length) {
+            return frame(length, new byte[0]);
         }
 
         private BufferData message(String content) {
             byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-            BufferData buffer = BufferData.create(GRPC_PREFIX_LENGTH + bytes.length);
-            buffer.write(0);
-            buffer.writeUnsignedInt32(bytes.length);
-            buffer.write(bytes);
-            return buffer;
+            return frame(bytes.length, bytes);
         }
     }
 

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMaxMessageSizeErrorTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMaxMessageSizeErrorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.grpc;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.grpc.GrpcConfig;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.grpc.uploads.UploadServiceGrpc;
+import io.helidon.webserver.grpc.uploads.Uploads.Ack;
+import io.helidon.webserver.grpc.uploads.Uploads.Data;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Verifies that an oversized inbound message causes the server to close the call
+ * with gRPC status {@code RESOURCE_EXHAUSTED}, matching grpc-java's behavior in
+ * {@code MessageDeframer.processHeader()}:
+ * https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+ */
+@ServerTest
+class GrpcMaxMessageSizeErrorTest extends BaseServiceTest {
+
+    private static final int LIMIT = 256 * 1024;
+
+    // One byte over the configured limit
+    private static final byte[] DATA_OVER_LIMIT = new byte[LIMIT + 1];
+
+    private UploadServiceGrpc.UploadServiceStub stub;
+
+    GrpcMaxMessageSizeErrorTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder serverBuilder) {
+        serverBuilder.addProtocol(GrpcConfig.builder().maxReadBufferSize(LIMIT).build());
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new UploadService()));
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        super.beforeEach();
+        stub = UploadServiceGrpc.newStub(channel);
+    }
+
+    @AfterEach
+    void afterEach() throws InterruptedException {
+        super.afterEach();
+        stub = null;
+    }
+
+    @Test
+    void oversizedMessageReturnsResourceExhausted() throws Throwable {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        StreamObserver<Data> request = stub.upload(new StreamObserver<>() {
+            @Override
+            public void onNext(Ack value) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                errorRef.set(t);
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+
+        request.onNext(Data.newBuilder()
+                .setPayload(ByteString.copyFrom(DATA_OVER_LIMIT))
+                .build());
+
+        assertThat("Server did not respond within timeout", latch.await(10, TimeUnit.SECONDS), is(true));
+        assertThat("Expected an error response", errorRef.get(), is(notNullValue()));
+
+        Status status = Status.fromThrowable(errorRef.get());
+        assertThat(status.getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
+    }
+}

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMaxMessageSizeErrorTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMaxMessageSizeErrorTest.java
@@ -89,32 +89,13 @@ class GrpcMaxMessageSizeErrorTest extends BaseServiceTest {
     void oversizedMessageReturnsResourceExhausted() throws Throwable {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
+        StreamObserver<Data> request = stub.upload(errorCapturing(latch, errorRef));
 
-        StreamObserver<Data> request = stub.upload(new StreamObserver<>() {
-            @Override
-            public void onNext(Ack value) {
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                errorRef.set(t);
-                latch.countDown();
-            }
-
-            @Override
-            public void onCompleted() {
-            }
-        });
-
-        request.onNext(Data.newBuilder()
-                .setPayload(ByteString.copyFrom(DATA_OVER_LIMIT))
-                .build());
+        request.onNext(message(DATA_OVER_LIMIT));
 
         assertThat("Server did not respond within timeout", latch.await(10, TimeUnit.SECONDS), is(true));
         assertThat("Expected an error response", errorRef.get(), is(notNullValue()));
-
-        Status status = Status.fromThrowable(errorRef.get());
-        assertThat(status.getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
+        assertThat(Status.fromThrowable(errorRef.get()).getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
     }
 
     /**
@@ -127,26 +108,9 @@ class GrpcMaxMessageSizeErrorTest extends BaseServiceTest {
     void connectionRemainsUsableAfterOversizedMessage() throws Exception {
         CountDownLatch errorLatch = new CountDownLatch(1);
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
+        StreamObserver<Data> oversized = stub.upload(errorCapturing(errorLatch, errorRef));
 
-        StreamObserver<Data> oversized = stub.upload(new StreamObserver<>() {
-            @Override
-            public void onNext(Ack value) {
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                errorRef.set(t);
-                errorLatch.countDown();
-            }
-
-            @Override
-            public void onCompleted() {
-            }
-        });
-
-        oversized.onNext(Data.newBuilder()
-                .setPayload(ByteString.copyFrom(new byte[2 * 1024 * 1024]))
-                .build());
+        oversized.onNext(message(new byte[2 * 1024 * 1024]));
 
         assertThat("Server did not respond within timeout", errorLatch.await(10, TimeUnit.SECONDS), is(true));
         assertThat(Status.fromThrowable(errorRef.get()).getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
@@ -168,12 +132,32 @@ class GrpcMaxMessageSizeErrorTest extends BaseServiceTest {
             }
         });
 
-        small.onNext(Data.newBuilder()
-                .setPayload(ByteString.copyFromUtf8("hello"))
-                .build());
+        small.onNext(message("hello".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
         small.onCompleted();
 
         assertThat("Connection unusable after oversized message was rejected",
                    ackLatch.await(10, TimeUnit.SECONDS), is(true));
+    }
+
+    private static Data message(byte[] payload) {
+        return Data.newBuilder().setPayload(ByteString.copyFrom(payload)).build();
+    }
+
+    private static StreamObserver<Ack> errorCapturing(CountDownLatch latch, AtomicReference<Throwable> errorRef) {
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(Ack value) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                errorRef.set(t);
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        };
     }
 }

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMaxMessageSizeErrorTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMaxMessageSizeErrorTest.java
@@ -116,4 +116,64 @@ class GrpcMaxMessageSizeErrorTest extends BaseServiceTest {
         Status status = Status.fromThrowable(errorRef.get());
         assertThat(status.getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
     }
+
+    /**
+     * The server must keep reading the remainder of a rejected request. If it stops, the
+     * per-stream inbound frame queue (32 frames) fills up and blocks the HTTP/2 connection
+     * thread, wedging every call on the connection. A payload much larger than
+     * {@code 32 * 16 KB} (queue capacity x default frame size) makes that deterministic.
+     */
+    @Test
+    void connectionRemainsUsableAfterOversizedMessage() throws Exception {
+        CountDownLatch errorLatch = new CountDownLatch(1);
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        StreamObserver<Data> oversized = stub.upload(new StreamObserver<>() {
+            @Override
+            public void onNext(Ack value) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                errorRef.set(t);
+                errorLatch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+
+        oversized.onNext(Data.newBuilder()
+                .setPayload(ByteString.copyFrom(new byte[2 * 1024 * 1024]))
+                .build());
+
+        assertThat("Server did not respond within timeout", errorLatch.await(10, TimeUnit.SECONDS), is(true));
+        assertThat(Status.fromThrowable(errorRef.get()).getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
+
+        // a second call on the same channel reuses the HTTP/2 connection
+        CountDownLatch ackLatch = new CountDownLatch(1);
+        StreamObserver<Data> small = stub.upload(new StreamObserver<>() {
+            @Override
+            public void onNext(Ack value) {
+                ackLatch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+
+        small.onNext(Data.newBuilder()
+                .setPayload(ByteString.copyFromUtf8("hello"))
+                .build());
+        small.onCompleted();
+
+        assertThat("Connection unusable after oversized message was rejected",
+                   ackLatch.await(10, TimeUnit.SECONDS), is(true));
+    }
 }

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/UploadServiceTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/UploadServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,8 @@ class UploadServiceTest extends BaseServiceTest {
     private static final byte[] DATA_250K = new byte[250 * 1024];
     private static final byte[] DATA_500K = new byte[500 * 1024];
 
-    private static final byte[] DATA_2100K = new byte[2100 * 1024];     // over default limit
+    // 5 MB: over the default 4 MB limit
+    private static final byte[] DATA_5000K = new byte[5000 * 1024];
 
     static {
         Arrays.fill(DATA_50K,  (byte) 'A');
@@ -136,7 +137,7 @@ class UploadServiceTest extends BaseServiceTest {
         requestRef.set(request);
 
         // upload data with size over default limit in GrpcConfig
-        Stream.of(DATA_2100K)
+        Stream.of(DATA_5000K)
                 .map(b -> Uploads.Data.newBuilder()
                         .setPayload(ByteString.copyFrom(b))
                         .build())

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/UploadServiceTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/UploadServiceTest.java
@@ -34,6 +34,7 @@ import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import com.google.protobuf.ByteString;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -117,6 +118,7 @@ class UploadServiceTest extends BaseServiceTest {
     void testFailedLargeUpload() throws Throwable {
         // setup bad upload call
         CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
         AtomicReference<StreamObserver<Data>> requestRef = new AtomicReference<>();
         StreamObserver<Data> request = stub.upload(new StreamObserver<>() {
             @Override
@@ -125,6 +127,7 @@ class UploadServiceTest extends BaseServiceTest {
 
             @Override
             public void onError(Throwable t) {
+                errorRef.set(t);
                 latch.countDown();
                 Objects.requireNonNull(requestRef.get());
                 requestRef.get().onError(t);
@@ -143,7 +146,8 @@ class UploadServiceTest extends BaseServiceTest {
                         .build())
                 .forEach(request::onNext);
 
-        // verify upload failed
+        // verify upload failed with the default-limit path returning RESOURCE_EXHAUSTED
         assertThat(latch.await(10, TimeUnit.SECONDS), is(true));
+        assertThat(Status.fromThrowable(errorRef.get()).getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
     }
 }


### PR DESCRIPTION
## Summary

- Align `maxReadBufferSize()` default with the 4 MB ecosystem standard (grpc-java, grpc-go). The previous 2 MB default caused Helidon to reject messages that succeed against every other standard gRPC server. Fixes #11719
- Return `RESOURCE_EXHAUSTED` status when an inbound message exceeds the limit. Previously, the server threw a plain exception that was caught as a cancellation — the client received `CANCELLED` or `UNKNOWN` with no indication of the cause. Fixes #11720

## Documentation

- The default `maxReadBufferSize` changed from 2 MB to 4 MB. Users who rely on the 2 MB limit to constrain inbound message size need to set it explicitly after upgrading.
- Oversized inbound messages now return gRPC status `RESOURCE_EXHAUSTED` with a descriptive message instead of `CANCELLED`/`UNKNOWN`. Client code that handles size violations by checking for `CANCELLED` should be updated to check for `RESOURCE_EXHAUSTED`.