### PR TITLE
4.x: Upgrade maven api to 3.9.15

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -346,4 +346,18 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
 </suppress>
 
 
+<!--
+  This CVE is fixed in 3.6.1: https://github.com/codehaus-plexus/plexus-utils/releases/tag/plexus-utils-3.6.1
+  But NVD CPE data only states it as fixed in 4.0.3: https://nvd.nist.gov/vuln/detail/CVE-2025-67030
+  I have e-mailed a correction request to NVD. For now we exclude it as a false positive.
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: plexus-utils-3.6.1.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus-utils@.*$</packageUrl>
+    <cve>CVE-2025-67030</cve>
+</suppress>
+
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <version.lib.plexus.classworlds>2.7.0</version.lib.plexus.classworlds>
         <version.lib.plexus.utils>3.3.0</version.lib.plexus.utils>
         <version.lib.maven.plugin.annotations>3.9.0</version.lib.maven.plugin.annotations>
-        <version.lib.maven.plugin.api>3.9.3</version.lib.maven.plugin.api>
+        <version.lib.maven.plugin.api>3.9.15</version.lib.maven.plugin.api>
         <version.lib.maven.plugin.project>2.2.1</version.lib.maven.plugin.project>
         <version.lib.apiguardian.api>1.1.2</version.lib.apiguardian.api>
         <version.lib.groovy>2.4.16</version.lib.groovy>
@@ -146,7 +146,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.1.9</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.2.1</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

Upgrades maven api to 3.9.15 so that we get plexus-utils upgraded to 3.6.1

Add suppression for plexus-utils CVE because fix is in 3.6.1, but NVD CPE data does not reflect that (stating only that it is fixed in 4.0.3).

Also upgrades dependency check plugin.