### PR TITLE
27.x upgrade maven api to 3.9.15

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -185,4 +185,71 @@
    <cve>CVE-2020-29582</cve>
 </suppress>
 
+<!-- False Positive.
+   These CVEs are against OpenTelemetry-Go, not Java
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-proto-1.5.0-alpha.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.proto/opentelemetry-proto@.*$</packageUrl>
+    <cve>CVE-2026-39882</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-semconv-1.37.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+    <cve>CVE-2026-29181</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-semconv-1.37.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+    <cve>CVE-2026-39883</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-semconv-1.37.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+    <cve>CVE-2026-39882</cve>
+</suppress>
+
+
+
+<!-- False Positive.
+     This CVE is against gRPC-Go servers not gRPC Java
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-core-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*@.*$</packageUrl>
+   <cve>CVE-2026-33186</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-protobuf-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc-protobuf@.*$</packageUrl>
+   <cve>CVE-2026-33186</cve>
+</suppress>
+
+
+<!--
+  This CVE is fixed in 3.6.1: https://github.com/codehaus-plexus/plexus-utils/releases/tag/plexus-utils-3.6.1
+  But NVD CPE data only states it as fixed in 4.0.3: https://nvd.nist.gov/vuln/detail/CVE-2025-67030
+  I have e-mailed a correction request to NVD. For now we exclude it as a false positive.
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: plexus-utils-3.6.1.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus-utils@.*$</packageUrl>
+    <cve>CVE-2025-67030</cve>
+</suppress>
+
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.lib.commons-text>1.15.0</version.lib.commons-text>
         <version.lib.classgraph>4.8.165</version.lib.classgraph>
         <version.lib.maven.plugin.annotations>3.15.1</version.lib.maven.plugin.annotations>
-        <version.lib.maven.plugin.api>3.9.3</version.lib.maven.plugin.api>
+        <version.lib.maven.plugin.api>3.9.15</version.lib.maven.plugin.api>
         <version.lib.maven.plugin.project>2.2.1</version.lib.maven.plugin.project>
         <version.lib.groovy>2.5.23</version.lib.groovy>
         <version.lib.groovy-all>${version.lib.groovy}</version.lib.groovy-all>
@@ -124,7 +124,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.9.8.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.1.9</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.2.1</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.buildnumber>3.1.0</version.plugin.buildnumber>


### PR DESCRIPTION
### Description

Upgrades maven api to 3.9.15 so that we get plexus-utils upgraded to 3.6.1

Add suppression for plexus-utils CVE because fix is in 3.6.1, but NVD CPE data does not reflect that (stating only that it is fixed in 4.0.3).

Add suppression for Go implementations of gRPC and OpenTelemetry.

Upgrades dependency check plugin.
