### PR TITLE
Fix flaky observe log level test on Windows (27.x)

### DIFF
--- a/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveTest.java
+++ b/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveTest.java
@@ -146,6 +146,8 @@ class ObserveTest {
     @Test
     void testLogObserverSetLevel(WebClient client) {
         String loggerName = getClass().getName() + ".level";
+        // Keep a strong reference so JUL does not drop this ad hoc logger between requests.
+        Logger logger = Logger.getLogger(loggerName);
 
         try {
             ClientResponseTyped<String> response = client.post("/observe/log/loggers/" + loggerName)
@@ -159,13 +161,13 @@ class ObserveTest {
 
             assertThat(loggerResponse.status(), is(Status.OK_200));
             JsonObject entity = loggerResponse.entity();
+            JsonObject loggerEntity = entity.objectValue(loggerName).orElse(null);
+            assertThat("Entity: " + entity, loggerEntity, notNullValue());
             assertThat("Entity: " + entity,
-                       entity.objectValue(loggerName)
-                               .flatMap(it -> it.stringValue("configuredLevel"))
-                               .orElseThrow(),
+                       loggerEntity.stringValue("configuredLevel").orElse(null),
                        is("WARNING"));
         } finally {
-            Logger.getLogger(loggerName).setLevel(null);
+            logger.setLevel(null);
         }
     }
 


### PR DESCRIPTION
Resolves #11732

Carry the merged 4.x test hardening from PR #11729 into main so the observe log-level test keeps the ad hoc JUL logger strongly reachable and reports the returned JSON entity on failure.
