### PR TITLE
BufferDataInputStream must return -1 at EOF, not 0 or throw

### DIFF
--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -600,16 +600,21 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
         @Override
         public int read() {
-            return bufferData.read();
+            // BufferData.read() throws when exhausted; InputStream requires -1 at EOF
+            return bufferData.available() > 0 ? bufferData.read() : -1;
         }
 
         @Override
         public int read(byte[] b) {
+            // BufferData.read(byte[]) returns 0 when exhausted; InputStream requires -1 at EOF
+            if (bufferData.available() == 0) return -1;
             return bufferData.read(b);
         }
 
         @Override
         public int read(byte[] b, int off, int len) {
+            // BufferData.read(byte[],int,int) returns 0 when exhausted; InputStream requires -1 at EOF
+            if (bufferData.available() == 0) return -1;
             return bufferData.read(b, off, len);
         }
 

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -607,15 +607,13 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         @Override
         public int read(byte[] b) {
             // BufferData.read(byte[]) returns 0 when exhausted; InputStream requires -1 at EOF
-            if (bufferData.available() == 0) return -1;
-            return bufferData.read(b);
+            return bufferData.available() == 0 ? -1 : bufferData.read(b);
         }
 
         @Override
         public int read(byte[] b, int off, int len) {
             // BufferData.read(byte[],int,int) returns 0 when exhausted; InputStream requires -1 at EOF
-            if (bufferData.available() == 0) return -1;
-            return bufferData.read(b, off, len);
+            return bufferData.available() == 0 ? -1 : bufferData.read(b, off, len);
         }
 
         @Override

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -187,6 +187,38 @@ class GrpcProtocolHandlerTest {
     }
 
     @Test
+    void bufferDataInputStreamReturnsMinusOneAtEof() throws IOException {
+        byte[] content = "hello".getBytes(StandardCharsets.UTF_8);
+        BufferData bufferData = BufferData.create(content);
+        try (var stream = new GrpcProtocolHandler.BufferDataInputStream(bufferData)) {
+            // drain the stream
+            for (int i = 0; i < content.length; i++) {
+                assertThat("byte " + i, stream.read(), is(content[i] & 0xFF));
+            }
+
+            // InputStream contract: all three read overloads must return -1 at EOF
+            assertAll(
+                    () -> assertThat("read()", stream.read(), is(-1)),
+                    () -> assertThat("read(byte[])", stream.read(new byte[8]), is(-1)),
+                    () -> assertThat("read(byte[],off,len)", stream.read(new byte[8], 0, 8), is(-1))
+            );
+        }
+    }
+
+    @Test
+    void bufferDataInputStreamReadAllBytes() throws IOException {
+        byte[] content = "grpc payload".getBytes(StandardCharsets.UTF_8);
+        BufferData bufferData = BufferData.create(content);
+        try (var stream = new GrpcProtocolHandler.BufferDataInputStream(bufferData)) {
+            // readAllBytes() internally loops on read(byte[],off,len) until -1.
+            // Before the fix, this hung forever because the stream returned 0 instead of -1.
+            byte[] result = stream.readAllBytes();
+
+            assertThat(result, is(content));
+        }
+    }
+
+    @Test
     void testCloseSuppressesTrailerWriteDisconnect() {
         ServerCall<String, String> serverCall = createServerCall(closeFailingWriter());
         serverCall.sendHeaders(new Metadata());


### PR DESCRIPTION
BufferDataInputStream delegated directly to BufferData without translating to InputStream semantics. BufferData.read() throws ArrayIndexOutOfBoundsException when exhausted; the bulk read overloads return 0. The InputStream contract requires -1 at EOF. Without the guard, any marshaller that reads until EOF (e.g. readAllBytes()) loops or throws instead of completing, and the gRPC call hangs indefinitely.

Add available() checks before each delegation. The same pattern already existed in BufferData.toInputStream() but was missed when BufferDataInputStream was written as a separate class to implement the KnownLength marker interface.

Fixes #11735

### Documentation

None


This is the same as #11736, but for `main` whereas the other is for `helidon-4.x`
