### PR TITLE
Fix writeTo(OutputStream) writing excess bytes after partial read

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/FixedBufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/FixedBufferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ class FixedBufferData implements BufferData {
     @Override
     public void writeTo(OutputStream out) {
         try {
-            out.write(bytes, readPosition, writePosition);
+            out.write(bytes, readPosition, writePosition - readPosition);
             readPosition = writePosition;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class ReadOnlyArrayData extends ReadOnlyBufferData {
     @Override
     public void writeTo(OutputStream out) {
         try {
-            out.write(bytes, offset + position, length);
+            out.write(bytes, offset + position, length - position);
             position = length;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.common.buffers;
 
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.HexFormat;
 import java.util.stream.Stream;
@@ -310,6 +311,25 @@ class BufferDataTest {
             }
         });
         assertThat(b.available(), is(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void writeToOutputStreamAfterPartialRead(TestContext context) {
+        // Regression test for https://github.com/helidon-io/helidon/issues/11738:
+        // writeTo(OutputStream) passed writePosition as the length argument instead of
+        // writePosition - readPosition, causing excess bytes to be written when readPosition > 0.
+        byte[] data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        BufferData b = context.bufferData();
+        b.write(data, 0, data.length);
+
+        // Advance readPosition by consuming 3 bytes
+        b.skip(3);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        b.writeTo(out);
+
+        assertThat(out.toByteArray(), is(new byte[] {4, 5, 6, 7, 8, 9, 10}));
     }
 
     BufferData dataFromHex(String hexEncoded) {

--- a/common/buffers/src/test/java/io/helidon/common/buffers/ReadOnlyArrayDataTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/ReadOnlyArrayDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,34 @@
 
 package io.helidon.common.buffers;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class ReadOnlyArrayDataTest {
+    @Test
+    void writeToOutputStreamAfterPartialRead() throws Exception {
+        // Regression test for https://github.com/helidon-io/helidon/issues/11738:
+        // writeTo(OutputStream) passed `length` as the byte count instead of
+        // `length - position`, causing excess bytes to be written when position > 0.
+        byte[] data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        ReadOnlyArrayData buf = new ReadOnlyArrayData(data, 0, data.length);
+
+        // Advance position by consuming 3 bytes
+        buf.skip(3);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        buf.writeTo(out);
+
+        assertThat(out.toByteArray(), is(new byte[] {4, 5, 6, 7, 8, 9, 10}));
+    }
+
     @Test
     void testDebugData() {
         byte[] test = "Hello World!".getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
Fixes #11738

This is functionally identical to #11739, cherry-picked onto `main`.

## Changes

`OutputStream.write(byte[], off, len)` takes a byte count as the third
argument, not an end position. Two implementations passed the wrong value:

- `FixedBufferData`: passed `writePosition` (an end position) instead of
  `writePosition - readPosition`
- `ReadOnlyArrayData`: passed `length` (total slice length) instead of
  `length - position`

Both bugs are invisible when the read position is zero — the position and
the count happen to be equal. They manifest once any bytes have been consumed
from the buffer before `writeTo` is called: the stream receives more bytes than
`available()` reports, sourced from uninitialized array memory beyond the valid
data range. With a tightly-sized array, `ReadOnlyArrayData` throws
`IndexOutOfBoundsException` instead.

`GrowingBufferData` already used the correct form and served as the reference.
`CompositeArrayBufferData` and `CompositeListBufferData` delegate to their
children and are not independently affected.

Regression tests added to `BufferDataTest` (covers both `FixedBufferData`
variants via the existing parameterized setup) and `ReadOnlyArrayDataTest`.

## Documentation

No changes required.