### PR TITLE
Fix helidon-config-metadata modules (27.x)

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>helidon-config-object-mapping</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -112,7 +112,7 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.helidon.config</groupId>
+                <groupId>io.helidon.config.metadata</groupId>
                 <artifactId>helidon-config-metadata</artifactId>
                 <version>${helidon.version}</version>
             </dependency>

--- a/builder/tests/builder/pom.xml
+++ b/builder/tests/builder/pom.xml
@@ -56,7 +56,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/builder/tests/codegen/pom.xml
+++ b/builder/tests/codegen/pom.xml
@@ -74,7 +74,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <scope>test</scope>
         </dependency>

--- a/builder/tests/configured/pom.xml
+++ b/builder/tests/configured/pom.xml
@@ -52,7 +52,7 @@
             <artifactId>helidon-common-mapper</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/builder/tests/third-party-factory/pom.xml
+++ b/builder/tests/third-party-factory/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/builder/tests/wildcard/pom.xml
+++ b/builder/tests/wildcard/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/concurrency/limits/pom.xml
+++ b/common/concurrency/limits/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/configurable/pom.xml
+++ b/common/configurable/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/context/http/pom.xml
+++ b/common/context/http/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/key-util/pom.xml
+++ b/common/key-util/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/socket/pom.xml
+++ b/common/socket/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/tls/pom.xml
+++ b/common/tls/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/metadata/README.md
+++ b/config/metadata/README.md
@@ -8,7 +8,7 @@ Other types may be annotated with annotations from `io.helidon.config.metadata` 
 
 The following modules for handling config metadata exist:
 
-- `io.helidon.config:helidon-config-metadata`: annotations to add to non-Blueprint types to generate documentation
+- `io.helidon.config.metadata:helidon-config-metadata`: annotations to add to non-Blueprint types to generate documentation
 - `io.helidon.config.metadata:helidon-config-metadata-codegen`: code generator that reads annotations and creates `config-metadata.json`
 - `io.helidon.config.metadata:helidon-config-metadata-docs`: code generator that reads `config.metadata.json` and generates Helidon `.adoc` files that are part of Helidon Config reference documentation
 
@@ -81,7 +81,7 @@ To add meta configuration:
 1. Add the following dependency to your `pom.xml` (optional dependency, as it only defines annotations):
     ```xml
     <dependency>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata</artifactId>
     </dependency>
     ```

--- a/config/metadata/codegen/pom.xml
+++ b/config/metadata/codegen/pom.xml
@@ -22,7 +22,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>27.0.0-SNAPSHOT</version>
     </parent>

--- a/config/metadata/docs/pom.xml
+++ b/config/metadata/docs/pom.xml
@@ -22,7 +22,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>27.0.0-SNAPSHOT</version>
     </parent>

--- a/config/metadata/metadata/pom.xml
+++ b/config/metadata/metadata/pom.xml
@@ -22,7 +22,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>27.0.0-SNAPSHOT</version>
     </parent>

--- a/config/metadata/model/pom.xml
+++ b/config/metadata/model/pom.xml
@@ -22,7 +22,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>27.0.0-SNAPSHOT</version>
     </parent>

--- a/config/metadata/pom.xml
+++ b/config/metadata/pom.xml
@@ -26,7 +26,7 @@
         <artifactId>helidon-config-project</artifactId>
         <version>27.0.0-SNAPSHOT</version>
     </parent>
-    <!-- normally we would use io.helidon.config.metadata group id, but this would introduce backward incompatibility -->
+    <groupId>io.helidon.config.metadata</groupId>
     <artifactId>helidon-config-metadata-project</artifactId>
     <name>Helidon Config Metadata Project</name>
     <packaging>pom</packaging>

--- a/config/metadata/tests/pom.xml
+++ b/config/metadata/tests/pom.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>27.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/config/metadata/tests/test-codegen/pom.xml
+++ b/config/metadata/tests/test-codegen/pom.xml
@@ -31,7 +31,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/tests/config-metadata-builder-api/pom.xml
+++ b/config/tests/config-metadata-builder-api/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/tests/config-metadata-meta-api/pom.xml
+++ b/config/tests/config-metadata-meta-api/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/tests/config-metadata-processor/pom.xml
+++ b/config/tests/config-metadata-processor/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/jakarta-persistence/jakarta-persistence/pom.xml
+++ b/data/jakarta-persistence/jakarta-persistence/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/common/pom.xml
+++ b/data/sql/common/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/datasource/datasource/pom.xml
+++ b/data/sql/datasource/datasource/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/datasource/hikari/pom.xml
+++ b/data/sql/datasource/hikari/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/datasource/jdbc/pom.xml
+++ b/data/sql/datasource/jdbc/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/datasource/ucp/pom.xml
+++ b/data/sql/datasource/ucp/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/dbclient/hikari/pom.xml
+++ b/dbclient/hikari/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/dbclient/jdbc/pom.xml
+++ b/dbclient/jdbc/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/fault-tolerance/fault-tolerance/pom.xml
+++ b/fault-tolerance/fault-tolerance/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/encoding/encoding/pom.xml
+++ b/http/encoding/encoding/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/http/pom.xml
+++ b/http/http/pom.xml
@@ -72,7 +72,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/http/media/jackson/pom.xml
+++ b/http/media/jackson/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/json-binding/pom.xml
+++ b/http/media/json-binding/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/json/pom.xml
+++ b/http/media/json/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/jsonb/pom.xml
+++ b/http/media/jsonb/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/jsonp/pom.xml
+++ b/http/media/jsonp/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/media/pom.xml
+++ b/http/media/media/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/json/binding/pom.xml
+++ b/json/binding/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/metrics/providers/micrometer/pom.xml
+++ b/metrics/providers/micrometer/pom.xml
@@ -60,7 +60,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/openapi/openapi/pom.xml
+++ b/openapi/openapi/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
                                 <failOnWarning>true</failOnWarning>
                                 <ignoredDependencies>
                                     <dependency>io.helidon.common.features:helidon-common-features-api:*</dependency>
-                                    <dependency>io.helidon.config:helidon-config-metadata:*</dependency>
+                                    <dependency>io.helidon.config.metadata:helidon-config-metadata:*</dependency>
                                 </ignoredDependencies>
                             </configuration>
                         </execution>

--- a/scheduling/pom.xml
+++ b/scheduling/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/abac/pom.xml
+++ b/security/providers/abac/pom.xml
@@ -48,7 +48,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/common/pom.xml
+++ b/security/providers/common/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/header/pom.xml
+++ b/security/providers/header/pom.xml
@@ -48,7 +48,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/http-auth/pom.xml
+++ b/security/providers/http-auth/pom.xml
@@ -48,7 +48,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/http-sign/pom.xml
+++ b/security/providers/http-sign/pom.xml
@@ -56,7 +56,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/idcs-mapper/pom.xml
+++ b/security/providers/idcs-mapper/pom.xml
@@ -68,7 +68,7 @@
             <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/jwt/pom.xml
+++ b/security/providers/jwt/pom.xml
@@ -61,7 +61,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/oidc-common/pom.xml
+++ b/security/providers/oidc-common/pom.xml
@@ -71,7 +71,7 @@
             <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/oidc/pom.xml
+++ b/security/providers/oidc/pom.xml
@@ -82,7 +82,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/security/pom.xml
+++ b/security/security/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>helidon-metadata-reflection</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/util/pom.xml
+++ b/security/util/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/service/tests/codegen/pom.xml
+++ b/service/tests/codegen/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/telemetry/opentelemetry-config/pom.xml
+++ b/telemetry/opentelemetry-config/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/config/pom.xml
+++ b/tracing/config/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/providers/opentelemetry/pom.xml
+++ b/tracing/providers/opentelemetry/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/tracing/pom.xml
+++ b/tracing/tracing/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/api/pom.xml
+++ b/webclient/api/pom.xml
@@ -73,7 +73,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/context/pom.xml
+++ b/webclient/context/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/discovery/pom.xml
+++ b/webclient/discovery/pom.xml
@@ -66,7 +66,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/grpc/pom.xml
+++ b/webclient/grpc/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/http1/pom.xml
+++ b/webclient/http1/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/http2/pom.xml
+++ b/webclient/http2/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/jsonrpc/pom.xml
+++ b/webclient/jsonrpc/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/websocket/pom.xml
+++ b/webclient/websocket/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/access-log/pom.xml
+++ b/webserver/access-log/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/concurrency-limits/pom.xml
+++ b/webserver/concurrency-limits/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/context/pom.xml
+++ b/webserver/context/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/cors/pom.xml
+++ b/webserver/cors/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/grpc-tracing/pom.xml
+++ b/webserver/grpc-tracing/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/webserver/grpc/pom.xml
+++ b/webserver/grpc/pom.xml
@@ -77,7 +77,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/webserver/hsts/pom.xml
+++ b/webserver/hsts/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/http2/pom.xml
+++ b/webserver/http2/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/config/pom.xml
+++ b/webserver/observe/config/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/health/pom.xml
+++ b/webserver/observe/health/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/info/pom.xml
+++ b/webserver/observe/info/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/log/pom.xml
+++ b/webserver/observe/log/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/metrics/pom.xml
+++ b/webserver/observe/metrics/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/observe/pom.xml
+++ b/webserver/observe/observe/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/telemetry/tracing/pom.xml
+++ b/webserver/observe/telemetry/tracing/pom.xml
@@ -64,7 +64,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/tracing/pom.xml
+++ b/webserver/observe/tracing/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/webserver/security/pom.xml
+++ b/webserver/security/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/static-content/pom.xml
+++ b/webserver/static-content/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -93,7 +93,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/websocket/pom.xml
+++ b/webserver/websocket/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Resolves #9058

Move helidon-config-metadata to the io.helidon.config.metadata group and update in-repo consumers, BOM/all wiring, and metadata README examples to use the new coordinates.

This change will temporarily break examples, as we are changing a group ID of a module. I will create a follow up PR as soon as this is merged.