### PR TITLE
Deprecate Prometheus metrics API integration (4.x)

### DIFF
--- a/docs/src/main/asciidoc/se/metrics/metrics.adoc
+++ b/docs/src/main/asciidoc/se/metrics/metrics.adoc
@@ -289,14 +289,14 @@ include::{rootdir}/includes/metrics/metrics-shared.adoc[tag=format-refcs-no-head
 - <<Usage, Usage>>
 - <<API, API>>
 
-Helidon provides optional support for the Prometheus metrics API.
+Helidon provides optional, deprecated support for the Prometheus metrics API.
 
-To use it, your service registers Prometheus support with your routing set-up.
+WARNING: `helidon-metrics-prometheus` is deprecated as of Helidon 4.5.0 and will be removed in a future major release.
+Prefer Helidon's built-in metrics implementation, which already exposes Prometheus (OpenMetrics) output without requiring direct use of the Prometheus client API.
+
+If you are maintaining an existing application that already uses the Prometheus client API, your service can still register Prometheus support with your routing set-up.
 You can customize its configuration. For information about using Prometheus, see the
 Prometheus documentation: https://prometheus.io/docs/introduction/overview/.
-
-NOTE: Helidon's fully-functional, built-in metrics implementation supports Prometheus (OpenMetrics) output.
- Use the optional support described in _this_ section only if you want to use the Prometheus _API_ from your application code.
 
 [[prom-maven-coordinates]]
 ==== Maven Coordinates
@@ -312,7 +312,7 @@ NOTE: Helidon's fully-functional, built-in metrics implementation supports Prome
 
 [[prom-usage]]
 ==== Usage
-Your application code uses the Prometheus API to manage metrics.
+If you are maintaining an existing application, your code uses the Prometheus API to manage metrics.
 To expose those metrics to clients via a REST endpoint, your code uses the `PrometheusSupport` interface which Helidon provides.
 
 [[prom-api]]

--- a/metrics/prometheus/src/main/java/io/helidon/metrics/prometheus/PrometheusSupport.java
+++ b/metrics/prometheus/src/main/java/io/helidon/metrics/prometheus/PrometheusSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,11 @@ import io.prometheus.client.CollectorRegistry;
  * HttpRouting.builder()
  *        ..addFeature(PrometheusSupport.create())
  * }</pre>
+ *
+ * @deprecated use Helidon's built-in metrics implementation, which already supports
+ *             Prometheus/OpenMetrics output, instead
  */
+@Deprecated(since = "4.5.0", forRemoval = true)
 public final class PrometheusSupport extends HelidonFeatureSupport {
 
     private static final System.Logger LOGGER = System.getLogger(PrometheusSupport.class.getName());
@@ -212,7 +216,11 @@ public final class PrometheusSupport extends HelidonFeatureSupport {
 
     /**
      * A builder of {@link PrometheusSupport}.
+     *
+     * @deprecated use Helidon's built-in metrics implementation, which already supports
+     *             Prometheus/OpenMetrics output, instead
      */
+    @Deprecated(since = "4.5.0", forRemoval = true)
     public static final class Builder extends HelidonFeatureSupport.Builder<Builder, PrometheusSupport> {
 
         private CollectorRegistry registry = CollectorRegistry.defaultRegistry;

--- a/metrics/prometheus/src/main/java/io/helidon/metrics/prometheus/package-info.java
+++ b/metrics/prometheus/src/main/java/io/helidon/metrics/prometheus/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,5 +24,8 @@
  * }</pre>
  *
  * @see io.helidon.metrics.prometheus.PrometheusSupport
+ * @deprecated use Helidon's built-in metrics implementation, which already supports
+ *             Prometheus/OpenMetrics output, instead
  */
+@Deprecated(since = "4.5.0", forRemoval = true)
 package io.helidon.metrics.prometheus;

--- a/metrics/prometheus/src/main/java/module-info.java
+++ b/metrics/prometheus/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 /**
  * Prometheus support.
+ *
+ * @deprecated use Helidon's built-in metrics implementation, which already exposes
+ *             Prometheus/OpenMetrics output, instead
  */
+@Deprecated(since = "4.5.0", forRemoval = true)
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module io.helidon.metrics.prometheus {
 


### PR DESCRIPTION
Resolves #11747

Deprecate the legacy Prometheus metrics API integration in Helidon 4.x.
This marks the `metrics/prometheus` module and its public API as deprecated
and updates the SE metrics guide to direct users to Helidon's built-in
Prometheus/OpenMetrics support.
