### PR TITLE
Mark ServiceLoader constructors internal (27.x)

### DIFF
--- a/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.media.type.MediaType;
@@ -86,12 +87,9 @@ public class HoconConfigParser implements ConfigParser {
     }
 
     /**
-     * To be used by Java Service Loader only!!!
-     *
-     * @deprecated Use {@link #builder()} to construct a customized instance, or {@link #create()} to get an instance with
-     *         defaults
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public HoconConfigParser() {
         this(builder());
     }

--- a/config/metadata/codegen/pom.xml
+++ b/config/metadata/codegen/pom.xml
@@ -38,6 +38,10 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-types</artifactId>
         </dependency>
         <dependency>

--- a/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfigMetadataCodegenProvider.java
+++ b/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfigMetadataCodegenProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 import static io.helidon.config.metadata.codegen.ConfigMetadataTypes.CONFIGURED;
@@ -32,8 +33,9 @@ import static io.helidon.config.metadata.codegen.ConfigMetadataTypes.OPTIONS;
  */
 public class ConfigMetadataCodegenProvider implements CodegenExtensionProvider {
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public ConfigMetadataCodegenProvider() {
     }
 

--- a/http/encoding/deflate/pom.xml
+++ b/http/encoding/deflate/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
         </dependency>

--- a/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncodingProvider.java
+++ b/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncodingProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.encoding.deflate;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.http.encoding.ContentEncoding;
 import io.helidon.http.encoding.spi.ContentEncodingProvider;
@@ -25,8 +26,9 @@ import io.helidon.http.encoding.spi.ContentEncodingProvider;
  */
 public class DeflateEncodingProvider implements ContentEncodingProvider {
     /**
-     * Default constructor required by Java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public DeflateEncodingProvider() {
     }
 

--- a/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncodingProvider.java
+++ b/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncodingProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.encoding.gzip;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
 import io.helidon.http.encoding.ContentEncoding;
@@ -26,8 +27,9 @@ import io.helidon.http.encoding.spi.ContentEncodingProvider;
  */
 public class GzipEncodingProvider implements ContentEncodingProvider, Weighted {
     /**
-     * Default constructor required by Java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public GzipEncodingProvider() {
     }
 

--- a/http/media/jackson/src/main/java/io/helidon/http/media/jackson/JacksonMediaSupportProvider.java
+++ b/http/media/jackson/src/main/java/io/helidon/http/media/jackson/JacksonMediaSupportProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.media.jackson;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
 import io.helidon.http.media.MediaSupport;
@@ -27,11 +28,10 @@ import io.helidon.http.media.spi.MediaSupportProvider;
 public class JacksonMediaSupportProvider implements MediaSupportProvider, Weighted {
 
     /**
-     * This class should be only instantiated as part of java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public JacksonMediaSupportProvider() {
-        super();
     }
 
     @Override

--- a/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingMediaSupportProvider.java
+++ b/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingMediaSupportProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.media.json.binding;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
 import io.helidon.http.media.MediaSupport;
@@ -30,11 +31,10 @@ import io.helidon.http.media.spi.MediaSupportProvider;
 public class JsonBindingMediaSupportProvider implements MediaSupportProvider, Weighted {
 
     /**
-     * This class should be only instantiated as part of java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public JsonBindingMediaSupportProvider() {
-        super();
     }
 
     @Override

--- a/http/media/json/src/main/java/io/helidon/http/media/json/JsonMediaSupportProvider.java
+++ b/http/media/json/src/main/java/io/helidon/http/media/json/JsonMediaSupportProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.media.json;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.http.media.MediaSupport;
 import io.helidon.http.media.spi.MediaSupportProvider;
@@ -28,11 +29,10 @@ import io.helidon.http.media.spi.MediaSupportProvider;
  */
 public class JsonMediaSupportProvider implements MediaSupportProvider {
     /**
-     * This class should be only instantiated as part of java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public JsonMediaSupportProvider() {
-        super();
     }
 
     @Override

--- a/http/media/jsonb/src/main/java/io/helidon/http/media/jsonb/JsonbMediaSupportProvider.java
+++ b/http/media/jsonb/src/main/java/io/helidon/http/media/jsonb/JsonbMediaSupportProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.media.jsonb;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
 import io.helidon.http.media.MediaSupport;
@@ -27,11 +28,10 @@ import io.helidon.http.media.spi.MediaSupportProvider;
 public class JsonbMediaSupportProvider implements MediaSupportProvider, Weighted {
 
     /**
-     * This class should be only instantiated as part of java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public JsonbMediaSupportProvider() {
-        super();
     }
 
     @Override

--- a/http/media/jsonp/src/main/java/io/helidon/http/media/jsonp/JsonpMediaSupportProvider.java
+++ b/http/media/jsonp/src/main/java/io/helidon/http/media/jsonp/JsonpMediaSupportProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.media.jsonp;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
 import io.helidon.http.media.MediaSupport;
@@ -27,11 +28,10 @@ import io.helidon.http.media.spi.MediaSupportProvider;
 public class JsonpMediaSupportProvider implements MediaSupportProvider, Weighted {
 
     /**
-     * This class should be only instantiated as part of java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public JsonpMediaSupportProvider() {
-        super();
     }
 
     @Override

--- a/http/media/multipart/src/main/java/io/helidon/http/media/multipart/MultiPartSupportProvider.java
+++ b/http/media/multipart/src/main/java/io/helidon/http/media/multipart/MultiPartSupportProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.media.multipart;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.http.media.MediaSupport;
 import io.helidon.http.media.spi.MediaSupportProvider;
@@ -26,11 +27,10 @@ import io.helidon.http.media.spi.MediaSupportProvider;
 public class MultiPartSupportProvider implements MediaSupportProvider {
 
     /**
-     * This class should be only instantiated as part of java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public MultiPartSupportProvider() {
-        super();
     }
 
     @Override

--- a/json/codegen/src/main/java/io/helidon/json/codegen/JsonCodegenProvider.java
+++ b/json/codegen/src/main/java/io/helidon/json/codegen/JsonCodegenProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -33,11 +34,9 @@ import io.helidon.common.types.TypeName;
 public class JsonCodegenProvider implements CodegenExtensionProvider {
 
     /**
-     * Public constructor is required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated please do not use directly
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public JsonCodegenProvider() {
     }
 

--- a/json/schema/codegen/pom.xml
+++ b/json/schema/codegen/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-types</artifactId>
         </dependency>
         <dependency>

--- a/json/schema/codegen/src/main/java/io/helidon/json/schema/codegen/SchemaCodegenProvider.java
+++ b/json/schema/codegen/src/main/java/io/helidon/json/schema/codegen/SchemaCodegenProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -30,11 +31,9 @@ import io.helidon.common.types.TypeName;
 public class SchemaCodegenProvider implements CodegenExtensionProvider {
 
     /**
-     * Public constructor is required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated please do not use directly
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public SchemaCodegenProvider() {
     }
 

--- a/service/codegen/src/main/java/io/helidon/service/codegen/EventEmitterObserverProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/EventEmitterObserverProvider.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenUtil;
 import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.Annotations;
@@ -48,8 +49,9 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SET_OF_QUALIFIERS;
  */
 public class EventEmitterObserverProvider implements InjectCodegenObserverProvider {
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public EventEmitterObserverProvider() {
     }
 

--- a/service/codegen/src/main/java/io/helidon/service/codegen/EventObserverExtensionProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/EventObserverExtensionProvider.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenUtil;
 import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.Annotations;
@@ -48,8 +49,9 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_EVENT_OBS
  */
 public class EventObserverExtensionProvider implements RegistryCodegenExtensionProvider {
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public EventObserverExtensionProvider() {
     }
 

--- a/service/codegen/src/main/java/io/helidon/service/codegen/MapNamedByTypeMapperProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/MapNamedByTypeMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.CodegenOptions;
 import io.helidon.codegen.spi.AnnotationMapper;
 import io.helidon.codegen.spi.AnnotationMapperProvider;
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.Annotation;
@@ -38,11 +39,9 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_
 @Weight(Weighted.DEFAULT_WEIGHT - 10) // lower weight than JavaxAnnotationMapper
 public class MapNamedByTypeMapperProvider implements AnnotationMapperProvider {
     /**
-     * Required default constructor.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public MapNamedByTypeMapperProvider() {
     }
 

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceExtensionProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceExtensionProvider.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.helidon.codegen.Option;
+import io.helidon.common.Api;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.codegen.spi.InjectCodegenObserverProvider;
@@ -45,11 +46,9 @@ public class ServiceExtensionProvider implements RegistryCodegenExtensionProvide
                     .asList();
 
     /**
-     * Required default constructor for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public ServiceExtensionProvider() {
     }
 

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.helidon.codegen.Option;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
 import io.helidon.codegen.spi.CodegenProvider;
+import io.helidon.common.Api;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
@@ -72,11 +73,9 @@ public class ServiceRegistryCodegenProvider implements CodegenExtensionProvider 
                     .collect(Collectors.toUnmodifiableSet());
 
     /**
-     * Required default constructor.
-     *
-     * @deprecated required by {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public ServiceRegistryCodegenProvider() {
     }
 

--- a/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/BindingGenerator.java
+++ b/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/BindingGenerator.java
@@ -139,13 +139,6 @@ class BindingGenerator {
         classModel.addMethod(bindingMethod -> bindingMethod
                 .addAnnotation(Annotations.OVERRIDE)
                 .name("binding")
-                // constructors of services for service loader are marked as private API
-                .addAnnotation(Annotation.builder()
-                                       .type(SuppressWarnings.class)
-                                       .putProperty("value", AnnotationProperty.create(Api.SUPPRESS_ALL,
-                                                                                       TypeName.create(Api.class),
-                                                                                       "SUPPRESS_ALL"))
-                                       .build())
                 .addParameter(binderParam -> binderParam
                         .name("binder")
                         .type(SERVICE_PLAN_BINDER))
@@ -157,6 +150,13 @@ class BindingGenerator {
         classModel.addMethod(configureMethod -> configureMethod
                 .addAnnotation(Annotations.OVERRIDE)
                 .name("configure")
+                // service-loaded service descriptors use constructor references to internal constructors
+                .addAnnotation(Annotation.builder()
+                                       .type(SuppressWarnings.class)
+                                       .putProperty("value", AnnotationProperty.create(Api.SUPPRESS_ALL,
+                                                                                       TypeName.create(Api.class),
+                                                                                       "SUPPRESS_ALL"))
+                                       .build())
                 .addParameter(configBuilder -> configBuilder
                         .name("builder")
                         .type(SERVICE_CONFIG_BUILDER)

--- a/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/BindingGenerator.java
+++ b/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/BindingGenerator.java
@@ -139,6 +139,13 @@ class BindingGenerator {
         classModel.addMethod(bindingMethod -> bindingMethod
                 .addAnnotation(Annotations.OVERRIDE)
                 .name("binding")
+                // service-loaded service descriptors use constructor references to internal constructors
+                .addAnnotation(Annotation.builder()
+                                       .type(SuppressWarnings.class)
+                                       .putProperty("value", AnnotationProperty.create(Api.SUPPRESS_ALL,
+                                                                                       TypeName.create(Api.class),
+                                                                                       "SUPPRESS_ALL"))
+                                       .build())
                 .addParameter(binderParam -> binderParam
                         .name("binder")
                         .type(SERVICE_PLAN_BINDER))

--- a/service/registry/src/main/java/io/helidon/service/registry/RegistryStartupProvider.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/RegistryStartupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.service.registry;
 
 import io.helidon.Main;
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.spi.HelidonShutdownHandler;
@@ -29,11 +30,9 @@ import io.helidon.spi.HelidonStartupProvider;
 @Weight(Weighted.DEFAULT_WEIGHT) // explicit default weight, this should be the "default" startup class
 public class RegistryStartupProvider implements HelidonStartupProvider {
     /**
-     * Default constructor required by {@link java.util.ServiceLoader}.
-     *
-     * @deprecated please do not use directly
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public RegistryStartupProvider() {
     }
 

--- a/tracing/providers/opentelemetry/pom.xml
+++ b/tracing/providers/opentelemetry/pom.xml
@@ -34,6 +34,10 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-context</artifactId>
         </dependency>
         <dependency>

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryDataPropagationProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryDataPropagationProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.tracing.providers.opentelemetry;
 
+import io.helidon.common.Api;
 import io.helidon.common.context.Contexts;
 import io.helidon.common.context.spi.DataPropagationProvider;
 import io.helidon.tracing.Scope;
@@ -31,9 +32,9 @@ public class OpenTelemetryDataPropagationProvider
     private static final System.Logger LOGGER = System.getLogger(OpenTelemetryDataPropagationProvider.class.getName());
 
     /**
-     * Creates a new instance. (For service loading/registration.)
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public OpenTelemetryDataPropagationProvider() {
     }
 

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.helidon.common.Api;
 import io.helidon.common.LazyValue;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
@@ -88,9 +89,9 @@ public class OpenTelemetryTracerProvider implements TracerProvider {
     }
 
     /**
-     * Creates a new provider; reserved for service loading.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public OpenTelemetryTracerProvider() {
     }
 

--- a/webclient/dns-resolver/first/pom.xml
+++ b/webclient/dns-resolver/first/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-api</artifactId>
         </dependency>

--- a/webclient/dns-resolver/first/src/main/java/io/helidon/webclient/dns/resolver/first/FirstDnsResolverProvider.java
+++ b/webclient/dns-resolver/first/src/main/java/io/helidon/webclient/dns/resolver/first/FirstDnsResolverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.dns.resolver.first;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.webclient.spi.DnsResolver;
@@ -27,11 +28,9 @@ import io.helidon.webclient.spi.DnsResolverProvider;
 @Weight(Weighted.DEFAULT_WEIGHT)
 public class FirstDnsResolverProvider implements DnsResolverProvider {
     /**
-     * Public constructor is required for service loader, do not use directly.
-     *
-     * @deprecated do not use directly
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public FirstDnsResolverProvider() {
     }
 

--- a/webclient/grpc-tracing/pom.xml
+++ b/webclient/grpc-tracing/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-core</artifactId>
         </dependency>
@@ -114,4 +118,3 @@
         </plugins>
     </build>
 </project>
-

--- a/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingProvider.java
+++ b/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.grpc.tracing;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webclient.grpc.spi.GrpcClientService;
 import io.helidon.webclient.grpc.spi.GrpcClientServiceProvider;
@@ -30,11 +31,9 @@ import io.helidon.webclient.grpc.spi.GrpcClientServiceProvider;
 public class GrpcClientTracingProvider implements GrpcClientServiceProvider {
 
     /**
-     * Required public constructor.
-     *
-     * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public GrpcClientTracingProvider() {
     }
 

--- a/webclient/grpc/pom.xml
+++ b/webclient/grpc/pom.xml
@@ -34,6 +34,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-core</artifactId>
         </dependency>
@@ -184,4 +188,3 @@
         </plugins>
     </build>
 </project>
-

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcProtocolProvider.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcProtocolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.grpc;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.spi.ClientProtocolProvider;
 
@@ -26,8 +27,9 @@ public class GrpcProtocolProvider implements ClientProtocolProvider<GrpcClient, 
     static final String CONFIG_KEY = "grpc";
 
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public GrpcProtocolProvider() {
     }
 

--- a/webclient/http1/pom.xml
+++ b/webclient/http1/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-api</artifactId>
         </dependency>

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientSpiProvider.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientSpiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.http1;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.spi.HttpClientSpi;
 import io.helidon.webclient.spi.HttpClientSpiProvider;
@@ -26,8 +27,9 @@ import io.helidon.webclient.spi.HttpClientSpiProvider;
 public class Http1ClientSpiProvider implements HttpClientSpiProvider<Http1ClientProtocolConfig> {
 
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public Http1ClientSpiProvider() {
     }
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ProtocolConfigProvider.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ProtocolConfigProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.http1;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webclient.spi.ProtocolConfigProvider;
 
@@ -24,9 +25,9 @@ import io.helidon.webclient.spi.ProtocolConfigProvider;
  */
 public class Http1ProtocolConfigProvider implements ProtocolConfigProvider<Http1ClientProtocolConfig> {
     /**
-     * Required to be used by {@link java.util.ServiceLoader}.
-     * @deprecated do not use directly, use Http1ClientProtocol
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public Http1ProtocolConfigProvider() {
     }
 

--- a/webclient/http2/pom.xml
+++ b/webclient/http2/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http</groupId>
             <artifactId>helidon-http-http2</artifactId>
         </dependency>

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientSpiProvider.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientSpiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.http2;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.spi.HttpClientSpi;
 import io.helidon.webclient.spi.HttpClientSpiProvider;
@@ -25,8 +26,9 @@ import io.helidon.webclient.spi.HttpClientSpiProvider;
  */
 public class Http2ClientSpiProvider implements HttpClientSpiProvider<Http2ClientProtocolConfig> {
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public Http2ClientSpiProvider() {
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ProtocolConfigProvider.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ProtocolConfigProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.http2;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webclient.spi.ProtocolConfigProvider;
 
@@ -24,9 +25,9 @@ import io.helidon.webclient.spi.ProtocolConfigProvider;
  */
 public class Http2ProtocolConfigProvider implements ProtocolConfigProvider<Http2ClientProtocolConfig> {
     /**
-     * Required to be used by {@link java.util.ServiceLoader}.
-     * @deprecated do not use directly, use Http1ClientProtocol
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public Http2ProtocolConfigProvider() {
     }
 

--- a/webclient/jsonrpc/pom.xml
+++ b/webclient/jsonrpc/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
         </dependency>

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcProtocolProvider.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcProtocolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.webclient.jsonrpc;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.spi.ClientProtocolProvider;
 
@@ -26,8 +27,9 @@ public class JsonRpcProtocolProvider implements ClientProtocolProvider<JsonRpcCl
     static final String CONFIG_KEY = "jsonrpc";
 
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public JsonRpcProtocolProvider() {
     }
 

--- a/webclient/metrics/pom.xml
+++ b/webclient/metrics/pom.xml
@@ -31,6 +31,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
         </dependency>

--- a/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
+++ b/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.webclient.metrics;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webclient.spi.WebClientServiceProvider;
@@ -28,11 +29,9 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
 @Deprecated
 public class WebClientMetricsProvider implements WebClientServiceProvider {
     /**
-     * Required public constructor.
-     *
-     * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public WebClientMetricsProvider() {
     }
 

--- a/webclient/security/pom.xml
+++ b/webclient/security/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
         </dependency>

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurityProvider.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurityProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.webclient.security;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webclient.spi.WebClientServiceProvider;
@@ -29,11 +30,9 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
 public class WebClientSecurityProvider implements WebClientServiceProvider {
 
     /**
-     * Required public constructor.
-     *
-     * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public WebClientSecurityProvider() {
     }
 

--- a/webclient/telemetry/telemetry/pom.xml
+++ b/webclient/telemetry/telemetry/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-api</artifactId>
         </dependency>

--- a/webclient/telemetry/telemetry/src/main/java/io/helidon/webclient/telemetry/WebClientTelemetryProvider.java
+++ b/webclient/telemetry/telemetry/src/main/java/io/helidon/webclient/telemetry/WebClientTelemetryProvider.java
@@ -19,6 +19,7 @@ package io.helidon.webclient.telemetry;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
@@ -35,9 +36,9 @@ public class WebClientTelemetryProvider implements WebClientServiceProvider {
     private final List<WebClientService> subservices = new ArrayList<>();
 
     /**
-     * For service loader use only.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public WebClientTelemetryProvider() {
     }
 

--- a/webclient/tracing/pom.xml
+++ b/webclient/tracing/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
         </dependency>

--- a/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
+++ b/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.tracing;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
@@ -35,11 +36,9 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
 @Weight(Weighted.DEFAULT_WEIGHT + 100)
 public class WebClientTracingProvider implements WebClientServiceProvider {
     /**
-     * Required public constructor.
-     *
-     * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public WebClientTracingProvider() {
     }
 

--- a/webclient/websocket/pom.xml
+++ b/webclient/websocket/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
         </dependency>
@@ -135,4 +139,3 @@
         </plugins>
     </build>
 </project>
-

--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsProtocolConfigProvider.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsProtocolConfigProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.websocket;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webclient.spi.ProtocolConfigProvider;
 
@@ -24,10 +25,9 @@ import io.helidon.webclient.spi.ProtocolConfigProvider;
  */
 public class WsProtocolConfigProvider implements ProtocolConfigProvider<WsClientProtocolConfig> {
     /**
-     * Required to be used by {@link java.util.ServiceLoader}.
-     *
-     * @deprecated do not use directly, use WsClientProtocolConfig
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public WsProtocolConfigProvider() {
     }
 

--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsProtocolProvider.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsProtocolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.websocket;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.spi.ClientProtocolProvider;
@@ -28,8 +29,9 @@ public class WsProtocolProvider implements ClientProtocolProvider<WsClient, WsCl
     static final String CONFIG_KEY = "websocket";
 
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public WsProtocolProvider() {
     }
 

--- a/webserver/access-log/pom.xml
+++ b/webserver/access-log/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/access-log/src/main/java/io/helidon/webserver/accesslog/AccessLogFeatureProvider.java
+++ b/webserver/access-log/src/main/java/io/helidon/webserver/accesslog/AccessLogFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.accesslog;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -26,11 +27,9 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 @Weight(AccessLogFeature.WEIGHT)
 public class AccessLogFeatureProvider implements ServerFeatureProvider<AccessLogFeature> {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public AccessLogFeatureProvider() {
     }
 

--- a/webserver/concurrency-limits/pom.xml
+++ b/webserver/concurrency-limits/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsFeatureProvider.java
+++ b/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.concurrency.limits;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -38,8 +39,9 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 @Weight(LimitsFeature.WEIGHT)
 public class LimitsFeatureProvider implements ServerFeatureProvider<LimitsFeature> {
     /**
-     * Public constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public LimitsFeatureProvider() {
     }
 

--- a/webserver/context/pom.xml
+++ b/webserver/context/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/context/src/main/java/io/helidon/webserver/context/ContextFeatureProvider.java
+++ b/webserver/context/src/main/java/io/helidon/webserver/context/ContextFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.context;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -26,11 +27,9 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 @Weight(ContextFeature.WEIGHT)
 public class ContextFeatureProvider implements ServerFeatureProvider<ContextFeature> {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public ContextFeatureProvider() {
     }
 

--- a/webserver/grpc/pom.xml
+++ b/webserver/grpc/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <!-- todo required for @Generated -->
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolProvider.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.grpc;
 
+import io.helidon.common.Api;
 import io.helidon.webserver.ProtocolConfigs;
 import io.helidon.webserver.http2.spi.Http2SubProtocolProvider;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
@@ -27,11 +28,9 @@ public class GrpcProtocolProvider implements Http2SubProtocolProvider<GrpcConfig
     static final String CONFIG_NAME = "grpc";
 
     /**
-     * Default constructor required by Java {@link java.util.ServiceLoader}.
-     *
-     * @deprecated please do not use directly outside of testing, this is reserved for Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public GrpcProtocolProvider() {
     }
 

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcReflectionFeatureProvider.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcReflectionFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.grpc;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
 
@@ -25,11 +26,9 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
  */
 public class GrpcReflectionFeatureProvider implements ServerFeatureProvider<GrpcReflectionFeature> {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public GrpcReflectionFeatureProvider() {
     }
 

--- a/webserver/hsts/pom.xml
+++ b/webserver/hsts/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/hsts/src/main/java/io/helidon/webserver/hsts/HstsFeatureProvider.java
+++ b/webserver/hsts/src/main/java/io/helidon/webserver/hsts/HstsFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.hsts;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -27,8 +28,9 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 @Weight(HstsFeature.WEIGHT)
 public class HstsFeatureProvider implements ServerFeatureProvider<HstsFeature> {
     /**
-     * Required for {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public HstsFeatureProvider() {
     }
 

--- a/webserver/http2/pom.xml
+++ b/webserver/http2/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConnectionProvider.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 
+import io.helidon.common.Api;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.webserver.ProtocolConfigs;
 import io.helidon.webserver.http2.spi.Http2SubProtocolProvider;
@@ -42,11 +43,9 @@ public class Http2ConnectionProvider implements ServerConnectionSelectorProvider
             .asList();
 
     /**
-     * Creates an instance of HTTP/2 server connection provider.
-     *
-     * @deprecated to be used solely by {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public Http2ConnectionProvider() {
     }
 

--- a/webserver/observe/config/pom.xml
+++ b/webserver/observe/config/pom.xml
@@ -34,6 +34,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
             <artifactId>helidon-webserver-observe</artifactId>
         </dependency>

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.observe.config;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
@@ -28,11 +29,9 @@ import io.helidon.webserver.observe.spi.Observer;
 @Deprecated
 public class ConfigObserveProvider implements ObserveProvider {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public ConfigObserveProvider() {
     }
 

--- a/webserver/observe/health/pom.xml
+++ b/webserver/observe/health/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
             <artifactId>helidon-webserver-observe</artifactId>
         </dependency>

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.observe.health;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
@@ -28,11 +29,9 @@ import io.helidon.webserver.observe.spi.Observer;
 @Deprecated
 public class HealthObserveProvider implements ObserveProvider {
     /**
-     * Default constructor required by {@link java.util.ServiceLoader}. Do not use.
-     *
-     * @deprecated this constructor must be public for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public HealthObserveProvider() {
     }
 

--- a/webserver/observe/info/pom.xml
+++ b/webserver/observe/info/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
             <artifactId>helidon-webserver-observe</artifactId>
         </dependency>

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.observe.info;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
@@ -28,11 +29,9 @@ import io.helidon.webserver.observe.spi.Observer;
 @Deprecated
 public class InfoObserveProvider implements ObserveProvider {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public InfoObserveProvider() {
     }
 

--- a/webserver/observe/log/pom.xml
+++ b/webserver/observe/log/pom.xml
@@ -35,6 +35,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
             <artifactId>helidon-webserver-observe</artifactId>
         </dependency>

--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.observe.log;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
@@ -33,11 +34,9 @@ import io.helidon.webserver.observe.spi.Observer;
 @Deprecated
 public class LogObserveProvider implements ObserveProvider {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public LogObserveProvider() {
     }
 

--- a/webserver/observe/metrics/pom.xml
+++ b/webserver/observe/metrics/pom.xml
@@ -31,6 +31,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
             <artifactId>helidon-webserver-observe</artifactId>
         </dependency>

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.observe.metrics;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
@@ -28,11 +29,9 @@ import io.helidon.webserver.observe.spi.Observer;
 @Deprecated
 public class MetricsObserveProvider implements ObserveProvider {
     /**
-     * Default constructor required by {@link java.util.ServiceLoader}. Do not use.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public MetricsObserveProvider() {
     }
 

--- a/webserver/observe/observe/pom.xml
+++ b/webserver/observe/observe/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureProvider.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.observe;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -26,11 +27,9 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 @Weight(ObserveFeature.WEIGHT)
 public class ObserveFeatureProvider implements ServerFeatureProvider<ObserveFeature> {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public ObserveFeatureProvider() {
     }
 

--- a/webserver/observe/tracing/pom.xml
+++ b/webserver/observe/tracing/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
             <artifactId>helidon-webserver-observe</artifactId>
         </dependency>

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.observe.tracing;
 
+import io.helidon.common.Api;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.service.registry.Services;
@@ -32,11 +33,9 @@ import io.helidon.webserver.observe.spi.Observer;
 @Deprecated
 public class TracingObserveProvider implements ObserveProvider {
     /**
-     * Default constructor required by {@link java.util.ServiceLoader}. Do not use.
-     *
-     * @deprecated this constructor must be public for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public TracingObserveProvider() {
     }
 

--- a/webserver/static-content/pom.xml
+++ b/webserver/static-content/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentFeatureProvider.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.staticcontent;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -26,11 +27,9 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 @Weight(StaticContentFeature.WEIGHT)
 public class StaticContentFeatureProvider implements ServerFeatureProvider<StaticContentFeature> {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public StaticContentFeatureProvider() {
     }
 

--- a/webserver/testing/junit5/junit5/pom.xml
+++ b/webserver/testing/junit5/junit5/pom.xml
@@ -35,6 +35,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/DirectClientConnection.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/DirectClientConnection.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.helidon.common.Api;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
@@ -145,6 +146,7 @@ class DirectClientConnection implements ClientConnection {
         });
     }
 
+    @SuppressWarnings(Api.SUPPRESS_INTERNAL)
     private void startServer() {
         ServerConnection connection = new Http1ConnectionProvider()
                 .create(WebServer.DEFAULT_SOCKET_NAME, Http1Config.create(), ProtocolConfigs.create(List.of()))

--- a/webserver/validation/pom.xml
+++ b/webserver/validation/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/webserver/validation/src/main/java/io/helidon/webserver/validation/WebServerValidationFeatureProvider.java
+++ b/webserver/validation/src/main/java/io/helidon/webserver/validation/WebServerValidationFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.validation;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
@@ -30,8 +31,9 @@ public class WebServerValidationFeatureProvider implements ServerFeatureProvider
     static final String VALIDATION_TYPE = "validation";
 
     /**
-     * Constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public WebServerValidationFeatureProvider() {
     }
 

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon</groupId>
             <artifactId>helidon</artifactId>
         </dependency>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConnectionProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ServiceLoader;
 
+import io.helidon.common.Api;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.webserver.ProtocolConfigs;
 import io.helidon.webserver.http1.spi.Http1UpgradeProvider;
@@ -39,13 +40,9 @@ public class Http1ConnectionProvider implements ServerConnectionSelectorProvider
     static final String CONFIG_NAME = "http_1_1";
 
     /**
-     * Create a new instance with default configuration.
-     * To customize instance programmatically, use {@link Http1ConnectionSelector}
-     * instead.
-     *
-     * @deprecated to be used solely by {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public Http1ConnectionProvider() {
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ProtocolConfigProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ProtocolConfigProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http1;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ProtocolConfigProvider;
 
@@ -24,8 +25,9 @@ import io.helidon.webserver.spi.ProtocolConfigProvider;
  */
 public class Http1ProtocolConfigProvider implements ProtocolConfigProvider<Http1Config> {
     /**
-     * Required default constructor for {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public Http1ProtocolConfigProvider() {
     }
 

--- a/webserver/websocket/pom.xml
+++ b/webserver/websocket/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.websocket</groupId>
             <artifactId>helidon-websocket</artifactId>
         </dependency>
@@ -158,4 +162,3 @@
         </plugins>
     </build>
 </project>
-

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgradeProvider.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgradeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.websocket;
 
+import io.helidon.common.Api;
 import io.helidon.webserver.ProtocolConfigs;
 import io.helidon.webserver.http1.spi.Http1UpgradeProvider;
 import io.helidon.webserver.http1.spi.Http1Upgrader;
@@ -30,12 +31,9 @@ public class WsUpgradeProvider implements Http1UpgradeProvider<WsConfig> {
     protected static final String CONFIG_NAME = "websocket";
 
     /**
-     * Create a new instance with default configuration.
-     *
-     * @deprecated This constructor is only to be used by {@link java.util.ServiceLoader},
-     *      use {@link WsUpgrader#create(WsConfig)} for manual setup
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated()
+    @Api.Internal
     public WsUpgradeProvider() {
     }
 


### PR DESCRIPTION
Resolves #11757

Carries forward #11688 onto `main`, marking ServiceLoader-only public constructors as `@Api.Internal`, moving generated binding suppression to `configure(...)`, and aligning matching `27.x`-only providers with the same constructor treatment.

Related to #11500.
