### PR TITLE
Fix helidon-config-metadata modules (4.x)

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -130,7 +130,7 @@
             <artifactId>helidon-config-mp</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -209,6 +209,11 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.helidon.config.metadata</groupId>
+                <artifactId>helidon-config-metadata</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.helidon.config</groupId>
                 <artifactId>helidon-config-metadata</artifactId>
                 <version>${helidon.version}</version>

--- a/builder/tests/builder/pom.xml
+++ b/builder/tests/builder/pom.xml
@@ -60,7 +60,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/builder/tests/codegen/pom.xml
+++ b/builder/tests/codegen/pom.xml
@@ -79,7 +79,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <scope>test</scope>
         </dependency>

--- a/builder/tests/configured/pom.xml
+++ b/builder/tests/configured/pom.xml
@@ -56,7 +56,7 @@
             <artifactId>helidon-common-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/builder/tests/third-party-factory/pom.xml
+++ b/builder/tests/third-party-factory/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/builder/tests/wildcard/pom.xml
+++ b/builder/tests/wildcard/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/concurrency/limits/pom.xml
+++ b/common/concurrency/limits/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/configurable/pom.xml
+++ b/common/configurable/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/context/http/pom.xml
+++ b/common/context/http/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/key-util/pom.xml
+++ b/common/key-util/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/socket/pom.xml
+++ b/common/socket/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/common/tls/pom.xml
+++ b/common/tls/pom.xml
@@ -52,7 +52,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/config-mp/pom.xml
+++ b/config/config-mp/pom.xml
@@ -63,7 +63,7 @@
             <artifactId>helidon-config-encryption</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/metadata/README.md
+++ b/config/metadata/README.md
@@ -8,10 +8,12 @@ Other types may be annotated with annotations from `io.helidon.config.metadata` 
 
 The following modules for handling config metadata exist:
 
-- `io.helidon.config:helidon-config-metadata`: annotations to add to non-Blueprint types to generate documentation
+- `io.helidon.config.metadata:helidon-config-metadata`: annotations to add to non-Blueprint types to generate documentation
 - `io.helidon.config.metadata:helidon-config-metadata-codegen`: code generator that reads annotations and creates `config-metadata.json`
 - `io.helidon.config:helidon-config-metadata-processor`: deprecated processor that does the same as `codegen` above
 - `io.helidon.config.metadata:helidon-config-metadata-docs`: code generator that reads `config.metadata.json` and generates Helidon `.adoc` files that are part of Helidon Config reference documentation
+
+For Maven compatibility in Helidon 4.x, the legacy `io.helidon.config:helidon-config-metadata` coordinates relocate to `io.helidon.config.metadata:helidon-config-metadata`.
 
 How to handle each task is described below.
 
@@ -82,7 +84,7 @@ To add meta configuration:
 1. Add the following dependency to your `pom.xml` (optional dependency, as it only defines annotations):
     ```xml
     <dependency>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata</artifactId>
     </dependency>
     ```

--- a/config/metadata/codegen/pom.xml
+++ b/config/metadata/codegen/pom.xml
@@ -22,7 +22,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.4.1-SNAPSHOT</version>
     </parent>

--- a/config/metadata/compatibility/pom.xml
+++ b/config/metadata/compatibility/pom.xml
@@ -16,8 +16,9 @@
     limitations under the License.
 
 -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="http://maven.apache.org/POM/4.0.0"
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -26,23 +27,21 @@
         <version>4.4.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>io.helidon.config.metadata.tests</groupId>
-    <artifactId>helidon-config-metadata-tests-project</artifactId>
 
-    <name>Helidon Config Metadata Tests Project</name>
+    <groupId>io.helidon.config</groupId>
+    <artifactId>helidon-config-metadata</artifactId>
     <packaging>pom</packaging>
+    <name>Helidon Config Metadata Compatibility POM</name>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-        <maven.sources.skip>true</maven.sources.skip>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <spotbugs.skip>true</spotbugs.skip>
-        <dependency-check.skip>true</dependency-check.skip>
-        <checkstyle.skip>true</checkstyle.skip>
-        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
-    </properties>
+    <description>
+        Compatibility POM relocating the legacy config metadata coordinates to the current group.
+    </description>
 
-    <modules>
-        <module>test-codegen</module>
-    </modules>
+    <distributionManagement>
+        <relocation>
+            <groupId>io.helidon.config.metadata</groupId>
+            <artifactId>helidon-config-metadata</artifactId>
+            <message>Artifact moved to io.helidon.config.metadata:helidon-config-metadata.</message>
+        </relocation>
+    </distributionManagement>
 </project>

--- a/config/metadata/docs/pom.xml
+++ b/config/metadata/docs/pom.xml
@@ -22,7 +22,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.4.1-SNAPSHOT</version>
     </parent>

--- a/config/metadata/metadata/pom.xml
+++ b/config/metadata/metadata/pom.xml
@@ -22,7 +22,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.4.1-SNAPSHOT</version>
     </parent>

--- a/config/metadata/model/pom.xml
+++ b/config/metadata/model/pom.xml
@@ -22,7 +22,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.4.1-SNAPSHOT</version>
     </parent>

--- a/config/metadata/pom.xml
+++ b/config/metadata/pom.xml
@@ -26,7 +26,7 @@
         <artifactId>helidon-config-project</artifactId>
         <version>4.4.1-SNAPSHOT</version>
     </parent>
-    <!-- normally we would use io.helidon.config.metadata group id, but this would introduce backward incompatibility -->
+    <groupId>io.helidon.config.metadata</groupId>
     <artifactId>helidon-config-metadata-project</artifactId>
     <name>Helidon Config Metadata Project</name>
     <packaging>pom</packaging>
@@ -41,6 +41,7 @@
 
     <modules>
         <module>metadata</module>
+        <module>compatibility</module>
         <module>model</module>
         <module>codegen</module>
         <module>processor</module>

--- a/config/metadata/processor/pom.xml
+++ b/config/metadata/processor/pom.xml
@@ -22,10 +22,11 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.config</groupId>
+        <groupId>io.helidon.config.metadata</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.4.1-SNAPSHOT</version>
     </parent>
+    <groupId>io.helidon.config</groupId>
     <artifactId>helidon-config-metadata-processor</artifactId>
     <name>Helidon Config Metadata Annotation Processor</name>
 

--- a/config/metadata/tests/test-codegen/pom.xml
+++ b/config/metadata/tests/test-codegen/pom.xml
@@ -31,7 +31,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/tests/config-metadata-builder-api/pom.xml
+++ b/config/tests/config-metadata-builder-api/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/tests/config-metadata-meta-api/pom.xml
+++ b/config/tests/config-metadata-meta-api/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/config/tests/config-metadata-processor/pom.xml
+++ b/config/tests/config-metadata-processor/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/cors/pom.xml
+++ b/cors/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/jakarta-persistence/jakarta-persistence/pom.xml
+++ b/data/jakarta-persistence/jakarta-persistence/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/common/pom.xml
+++ b/data/sql/common/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/datasource/datasource/pom.xml
+++ b/data/sql/datasource/datasource/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/datasource/hikari/pom.xml
+++ b/data/sql/datasource/hikari/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/datasource/jdbc/pom.xml
+++ b/data/sql/datasource/jdbc/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/data/sql/datasource/ucp/pom.xml
+++ b/data/sql/datasource/ucp/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/dbclient/hikari/pom.xml
+++ b/dbclient/hikari/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/dbclient/jdbc/pom.xml
+++ b/dbclient/jdbc/pom.xml
@@ -54,7 +54,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/discovery/providers/eureka/pom.xml
+++ b/discovery/providers/eureka/pom.xml
@@ -61,7 +61,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/fault-tolerance/fault-tolerance/pom.xml
+++ b/fault-tolerance/fault-tolerance/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/encoding/encoding/pom.xml
+++ b/http/encoding/encoding/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/http/pom.xml
+++ b/http/http/pom.xml
@@ -77,7 +77,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/http/media/gson/pom.xml
+++ b/http/media/gson/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/jackson/pom.xml
+++ b/http/media/jackson/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/json-binding/pom.xml
+++ b/http/media/json-binding/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/json/pom.xml
+++ b/http/media/json/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/jsonb/pom.xml
+++ b/http/media/jsonb/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/jsonp/pom.xml
+++ b/http/media/jsonp/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/media/pom.xml
+++ b/http/media/media/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/http/media/smile/pom.xml
+++ b/http/media/smile/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/eureka/eureka/pom.xml
+++ b/integrations/eureka/eureka/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/langchain4j/pom.xml
+++ b/integrations/langchain4j/langchain4j/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/cohere/pom.xml
+++ b/integrations/langchain4j/providers/cohere/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/coherence/pom.xml
+++ b/integrations/langchain4j/providers/coherence/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/google-gemini/pom.xml
+++ b/integrations/langchain4j/providers/google-gemini/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/jlama/pom.xml
+++ b/integrations/langchain4j/providers/jlama/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/lc4j-in-process/pom.xml
+++ b/integrations/langchain4j/providers/lc4j-in-process/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/mock/pom.xml
+++ b/integrations/langchain4j/providers/mock/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/ollama/pom.xml
+++ b/integrations/langchain4j/providers/ollama/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/open-ai/pom.xml
+++ b/integrations/langchain4j/providers/open-ai/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/oracle-genai/pom.xml
+++ b/integrations/langchain4j/providers/oracle-genai/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/langchain4j/providers/oracle/pom.xml
+++ b/integrations/langchain4j/providers/oracle/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/micrometer/micrometer/pom.xml
+++ b/integrations/micrometer/micrometer/pom.xml
@@ -92,7 +92,7 @@
             <artifactId>helidon-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/neo4j/neo4j/pom.xml
+++ b/integrations/neo4j/neo4j/pom.xml
@@ -49,7 +49,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/oci/metrics/metrics/pom.xml
+++ b/integrations/oci/metrics/metrics/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>oci-java-sdk-monitoring</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/oci/oci/pom.xml
+++ b/integrations/oci/oci/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/oci/sdk/runtime/pom.xml
+++ b/integrations/oci/sdk/runtime/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/oci/tls-certificates/pom.xml
+++ b/integrations/oci/tls-certificates/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/integrations/openapi-ui/pom.xml
+++ b/integrations/openapi-ui/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/json/binding/pom.xml
+++ b/json/binding/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/messaging/connectors/aq/pom.xml
+++ b/messaging/connectors/aq/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/messaging/connectors/jms/pom.xml
+++ b/messaging/connectors/jms/pom.xml
@@ -80,7 +80,7 @@
             <artifactId>jakarta.jms-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/messaging/connectors/kafka/pom.xml
+++ b/messaging/connectors/kafka/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config-mp</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -54,7 +54,7 @@
             <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/metrics/providers/micrometer/pom.xml
+++ b/metrics/providers/micrometer/pom.xml
@@ -60,7 +60,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/microprofile/grpc/client/pom.xml
+++ b/microprofile/grpc/client/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/microprofile/jwt-auth/pom.xml
+++ b/microprofile/jwt-auth/pom.xml
@@ -72,7 +72,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/microprofile/rest-client-metrics/pom.xml
+++ b/microprofile/rest-client-metrics/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -38,7 +38,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/openapi/openapi/pom.xml
+++ b/openapi/openapi/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -581,7 +581,7 @@
                                 <failOnWarning>true</failOnWarning>
                                 <ignoredDependencies>
                                     <dependency>io.helidon.common.features:helidon-common-features-api:*</dependency>
-                                    <dependency>io.helidon.config:helidon-config-metadata:*</dependency>
+                                    <dependency>io.helidon.config.metadata:helidon-config-metadata:*</dependency>
                                 </ignoredDependencies>
                             </configuration>
                         </execution>

--- a/scheduling/pom.xml
+++ b/scheduling/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/abac/pom.xml
+++ b/security/providers/abac/pom.xml
@@ -48,7 +48,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/common/pom.xml
+++ b/security/providers/common/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/config-vault/pom.xml
+++ b/security/providers/config-vault/pom.xml
@@ -55,7 +55,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/google-login/pom.xml
+++ b/security/providers/google-login/pom.xml
@@ -59,7 +59,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/header/pom.xml
+++ b/security/providers/header/pom.xml
@@ -44,7 +44,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/http-auth/pom.xml
+++ b/security/providers/http-auth/pom.xml
@@ -52,7 +52,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/http-sign/pom.xml
+++ b/security/providers/http-sign/pom.xml
@@ -52,7 +52,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/idcs-mapper/pom.xml
+++ b/security/providers/idcs-mapper/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/jwt/pom.xml
+++ b/security/providers/jwt/pom.xml
@@ -57,7 +57,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/oidc-common/pom.xml
+++ b/security/providers/oidc-common/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/providers/oidc/pom.xml
+++ b/security/providers/oidc/pom.xml
@@ -87,7 +87,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/security/pom.xml
+++ b/security/security/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>helidon-metadata-reflection</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/security/util/pom.xml
+++ b/security/util/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/service/tests/codegen/pom.xml
+++ b/service/tests/codegen/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/telemetry/opentelemetry-config/pom.xml
+++ b/telemetry/opentelemetry-config/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/config/pom.xml
+++ b/tracing/config/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/providers/jaeger/pom.xml
+++ b/tracing/providers/jaeger/pom.xml
@@ -81,7 +81,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/providers/opentelemetry/pom.xml
+++ b/tracing/providers/opentelemetry/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/providers/opentracing/pom.xml
+++ b/tracing/providers/opentracing/pom.xml
@@ -52,7 +52,7 @@
             <artifactId>opentracing-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/providers/zipkin/pom.xml
+++ b/tracing/providers/zipkin/pom.xml
@@ -67,7 +67,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tracing/tracing/pom.xml
+++ b/tracing/tracing/pom.xml
@@ -54,7 +54,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/api/pom.xml
+++ b/webclient/api/pom.xml
@@ -73,7 +73,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/context/pom.xml
+++ b/webclient/context/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/discovery/pom.xml
+++ b/webclient/discovery/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/grpc/pom.xml
+++ b/webclient/grpc/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/http1/pom.xml
+++ b/webclient/http1/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/http2/pom.xml
+++ b/webclient/http2/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/jsonrpc/pom.xml
+++ b/webclient/jsonrpc/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webclient/websocket/pom.xml
+++ b/webclient/websocket/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/access-log/pom.xml
+++ b/webserver/access-log/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/concurrency-limits/pom.xml
+++ b/webserver/concurrency-limits/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/context/pom.xml
+++ b/webserver/context/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/cors/pom.xml
+++ b/webserver/cors/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/grpc/pom.xml
+++ b/webserver/grpc/pom.xml
@@ -81,7 +81,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/webserver/http2/pom.xml
+++ b/webserver/http2/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/config/pom.xml
+++ b/webserver/observe/config/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/health/pom.xml
+++ b/webserver/observe/health/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/info/pom.xml
+++ b/webserver/observe/info/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/log/pom.xml
+++ b/webserver/observe/log/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/metrics/pom.xml
+++ b/webserver/observe/metrics/pom.xml
@@ -63,7 +63,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/observe/pom.xml
+++ b/webserver/observe/observe/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/telemetry/tracing/pom.xml
+++ b/webserver/observe/telemetry/tracing/pom.xml
@@ -64,7 +64,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/observe/tracing/pom.xml
+++ b/webserver/observe/tracing/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/webserver/security/pom.xml
+++ b/webserver/security/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/service-common/pom.xml
+++ b/webserver/service-common/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>helidon-webserver-cors</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/static-content/pom.xml
+++ b/webserver/static-content/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -93,7 +93,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/webserver/websocket/pom.xml
+++ b/webserver/websocket/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Resolves #11765

Backport the `helidon-config-metadata` coordinate move from PR #11751 to `helidon-4.x`, while intentionally keeping `helidon-config-metadata-processor` on its existing 4.x coordinates.

This change updates in-repo consumers and published BOM/`all` wiring to the new `io.helidon.config.metadata` group and adds a relocation-based compatibility POM on the old `io.helidon.config:helidon-config-metadata` coordinates.
