### PR TITLE
BufferDataInputStream: implement Drainable, skip, and readAllBytes

### DIFF
--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -640,9 +640,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         @Override
         public byte[] readAllBytes() {
             // single exact-size allocation; avoids the default growing-array loop
-            byte[] result = new byte[bufferData.available()];
-            bufferData.read(result);
-            return result;
+            return bufferData.readBytes();
         }
     }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -66,6 +66,7 @@ import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Drainable;
 import io.grpc.KnownLength;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -591,7 +592,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
      * knowledge for optimizations. It can also copy a byte array directly on a
      * single read.
      */
-    static class BufferDataInputStream extends InputStream implements KnownLength {
+    static class BufferDataInputStream extends InputStream implements KnownLength, Drainable {
         private final BufferData bufferData;
 
         BufferDataInputStream(BufferData bufferData) {
@@ -619,6 +620,29 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         @Override
         public int available() {
             return bufferData.available();
+        }
+
+        @Override
+        public int drainTo(OutputStream target) {
+            int count = bufferData.available();
+            bufferData.writeTo(target);
+            return count;
+        }
+
+        @Override
+        public long skip(long n) {
+            // advance readPosition directly; avoids the default read()-in-a-loop
+            int toSkip = (int) Math.min(bufferData.available(), n);
+            bufferData.skip(toSkip);
+            return toSkip;
+        }
+
+        @Override
+        public byte[] readAllBytes() {
+            // single exact-size allocation; avoids the default growing-array loop
+            byte[] result = new byte[bufferData.available()];
+            bufferData.read(result);
+            return result;
         }
     }
 }

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -17,10 +17,12 @@
 package io.helidon.webserver.grpc;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -46,12 +48,14 @@ import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.ServerConnectionException;
 
+import io.grpc.Drainable;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.Status;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -397,6 +401,99 @@ class GrpcProtocolHandlerTest {
                 return 0;
             }
         };
+    }
+
+    @Nested
+    class BufferDataInputStreamTest {
+
+        @Test
+        void drainsFullBuffer() throws IOException {
+            byte[] content = "grpc payload".getBytes(StandardCharsets.UTF_8);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (var stream = stream(content)) {
+                int count = stream.drainTo(out);
+                assertThat(count, is(content.length));
+                assertThat(out.toByteArray(), is(content));
+            }
+        }
+
+        @Test
+        void drainsRemainingBytesAfterPartialRead() throws IOException {
+            byte[] content = "grpc payload".getBytes(StandardCharsets.UTF_8);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (var stream = stream(content)) {
+                stream.read(); // consume 'g'
+                stream.read(); // consume 'r'
+                int count = stream.drainTo(out);
+                assertThat(count, is(content.length - 2));
+                assertThat(out.toByteArray(), is(Arrays.copyOfRange(content, 2, content.length)));
+            }
+        }
+
+        @Test
+        void drainsNothingFromEmptyBuffer() throws IOException {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (var stream = stream(new byte[0])) {
+                int count = stream.drainTo(out);
+                assertThat(count, is(0));
+                assertThat(out.toByteArray().length, is(0));
+            }
+        }
+
+        @Test
+        void readAllBytesReturnsRemainingAfterPartialRead() throws IOException {
+            byte[] content = "grpc payload".getBytes(StandardCharsets.UTF_8);
+            try (var stream = stream(content)) {
+                stream.read(); // consume 'g'
+                stream.read(); // consume 'r'
+                assertThat(stream.readAllBytes(), is(Arrays.copyOfRange(content, 2, content.length)));
+            }
+        }
+
+        @Test
+        void readAllBytesOnExhaustedBufferReturnsEmptyArray() throws IOException {
+            try (var stream = stream(new byte[0])) {
+                assertThat(stream.readAllBytes().length, is(0));
+            }
+        }
+
+        @Test
+        void skipAdvancesPosition() throws IOException {
+            byte[] content = "grpc payload".getBytes(StandardCharsets.UTF_8);
+            try (var stream = stream(content)) {
+                long skipped = stream.skip(4);
+                assertThat(skipped, is(4L));
+                assertThat(stream.readAllBytes(), is(Arrays.copyOfRange(content, 4, content.length)));
+            }
+        }
+
+        @Test
+        void skipClampsToAvailable() throws IOException {
+            byte[] content = "hi".getBytes(StandardCharsets.UTF_8);
+            try (var stream = stream(content)) {
+                long skipped = stream.skip(100);
+                assertThat(skipped, is((long) content.length));
+                assertThat(stream.available(), is(0));
+            }
+        }
+
+        @Test
+        void skipZeroDoesNothing() throws IOException {
+            byte[] content = "grpc payload".getBytes(StandardCharsets.UTF_8);
+            try (var stream = stream(content)) {
+                long skipped = stream.skip(0);
+                assertThat(skipped, is(0L));
+                assertThat(stream.available(), is(content.length));
+            }
+        }
+
+        private GrpcProtocolHandler.BufferDataInputStream stream(String content) {
+            return stream(content.getBytes(StandardCharsets.UTF_8));
+        }
+
+        private GrpcProtocolHandler.BufferDataInputStream stream(byte[] content) {
+            return new GrpcProtocolHandler.BufferDataInputStream(BufferData.create(content));
+        }
     }
 
     private static class UnimplementedGrpcConnectionContext implements ConnectionContext {


### PR DESCRIPTION
`BufferDataInputStream` already implements `KnownLength`, letting gRPC pre-allocate a buffer of the right size. This PR adds three more optimizations on the inbound message path:

**`Drainable.drainTo(OutputStream)`**

Callers that detect `Drainable` can drain bytes directly to a destination `OutputStream` without an intermediate copy buffer. The implementation delegates to `BufferData.writeTo()`, which writes the underlying byte array directly.

**`InputStream.readAllBytes()`**

The default implementation accumulates bytes into a growing `byte[]`, doubling it on overflow. Since `available()` returns the exact byte count, the override allocates a single exact-size array and fills it in one call.

**`InputStream.skip(long)`**

The default implementation reads and discards bytes via a temporary buffer. Since `BufferData` tracks its read position explicitly, the override advances the read position directly in O(1) without touching any bytes.

Closes #11742

## Documentation

No changes required.