### PR TITLE
Finish ServiceLoader internalization (27.x)

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegenProvider.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -29,11 +30,9 @@ import io.helidon.common.types.TypeName;
  */
 public class BuilderCodegenProvider implements CodegenExtensionProvider {
     /**
-     * Public constructor is required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated please do not use directly
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public BuilderCodegenProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/cors/CorsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/cors/CorsExtensionProvider.java
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.cors;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class CorsExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public CorsExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.faulttolerance;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.spi.RegistryCodegenExtension;
@@ -31,11 +32,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class FtExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public FtExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.http.webserver;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -32,11 +33,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 @Weight(Weighted.DEFAULT_WEIGHT + 10)
 public class RestServerExtensionProvider implements RegistryCodegenExtensionProvider {
     /**
-     * Required by {@link java.util.ServiceLoader}.
-     *
-     * @deprecated required by service loader
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public RestServerExtensionProvider() {
         super();
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.metrics;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class MetricsExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public MetricsExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/scheduling/SchedulingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/scheduling/SchedulingExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.scheduling;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class SchedulingExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public SchedulingExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.tracing;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class TracingExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public TracingExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.validation;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -37,11 +38,9 @@ import static io.helidon.declarative.codegen.validation.ValidationTypes.VALIDATI
 @Weight(Weighted.DEFAULT_WEIGHT - 30)
 public class ValidationExtensionProvider implements RegistryCodegenExtensionProvider {
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public ValidationExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/client/WebSocketClientExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/client/WebSocketClientExtensionProvider.java
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.websocket.client;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class WebSocketClientExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public WebSocketClientExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/server/WebSocketServerExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/server/WebSocketServerExtensionProvider.java
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.websocket.server;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class WebSocketServerExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public WebSocketServerExtensionProvider() {
     }
 

--- a/metrics/providers/micrometer/pom.xml
+++ b/metrics/providers/micrometer/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>helidon-metrics-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatterProvider.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.metrics.providers.micrometer;
 
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.metrics.api.MeterRegistry;
@@ -30,11 +31,9 @@ import io.helidon.metrics.spi.MeterRegistryFormatterProvider;
 public class MicrometerPrometheusFormatterProvider implements MeterRegistryFormatterProvider {
 
     /**
-     * Constructs a new instance for service loading.
-     *
-     * @deprecated
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public MicrometerPrometheusFormatterProvider() {
     }
 

--- a/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
+++ b/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import io.helidon.common.Api;
 import io.helidon.metrics.api.BuiltInMeterNameFormat;
 import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MetricsFactory;
@@ -161,11 +162,9 @@ public class SystemMetersProvider implements MetersProvider {
     private MetricsFactory metricsFactory;
 
     /**
-     * Constructs a new instance for service loading.
-     *
-     * @deprecated
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public SystemMetersProvider() {
     }
 

--- a/metrics/system-meters/src/main/java/module-info.java
+++ b/metrics/system-meters/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Path({"Metrics", "System Meters"})
 module io.helidon.metrics.systemmeters {
     requires io.helidon;
+    requires io.helidon.common;
     requires io.helidon.common.features.api;
     requires io.helidon.common.resumable;
     requires io.helidon.metrics.api;

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeatureProvider.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.openapi;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -26,11 +27,9 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 @Weight(OpenApiFeature.WEIGHT)
 public class OpenApiFeatureProvider implements ServerFeatureProvider<OpenApiFeature> {
     /**
-     * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public OpenApiFeatureProvider() {
     }
 

--- a/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingProvider.java
+++ b/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingProvider.java
@@ -23,11 +23,7 @@ import io.helidon.webclient.grpc.spi.GrpcClientServiceProvider;
 
 /**
  * gRPC client tracing SPI provider implementation.
- *
- * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
- *         Use {@link io.helidon.webclient.grpc.tracing.GrpcClientTracing} instead.
  */
-@Deprecated
 public class GrpcClientTracingProvider implements GrpcClientServiceProvider {
 
     /**

--- a/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
+++ b/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
@@ -22,11 +22,7 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
 
 /**
  * Client metrics SPI provider implementation.
- *
- * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
- *  Use {@link WebClientMetrics} instead
  */
-@Deprecated
 public class WebClientMetricsProvider implements WebClientServiceProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurityProvider.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurityProvider.java
@@ -22,11 +22,7 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
 
 /**
  * Client security SPI provider.
- *
- * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
- *  Use {@link WebClientSecurity} instead
  */
-@Deprecated
 public class WebClientSecurityProvider implements WebClientServiceProvider {
 
     /**

--- a/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
+++ b/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
@@ -28,11 +28,7 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
  *
  * Weight must exceed that of WebClientSecurityProvider because WebClientSecurity depends on span information having already
  * been added to the request context by WebClientTracing.
- *
- * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
- *  Use {@link WebClientTracing} instead
  */
-@Deprecated
 @Weight(Weighted.DEFAULT_WEIGHT + 100)
 public class WebClientTracingProvider implements WebClientServiceProvider {
     /**

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
@@ -23,10 +23,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for config observe provider.
- *
- * @deprecated only for {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class ConfigObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
@@ -23,10 +23,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for health observe provider.
- *
- * @deprecated this type is only to be used from {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class HealthObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
@@ -23,10 +23,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for application information observe provider.
- *
- * @deprecated only for {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class InfoObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
@@ -28,10 +28,7 @@ import io.helidon.webserver.observe.spi.Observer;
  *  so changing a log level for a logger may be temporary (in case a garbage collector runs and the reference is not kept
  *  anywhere).
  * In Helidon, most loggers are referenced for the duration of the application, so this should not impact Helidon components.
- *
- * @deprecated only for {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class LogObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
@@ -23,10 +23,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for metrics observe provider.
- *
- * @deprecated only for {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class MetricsObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
@@ -27,10 +27,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for tracing observe provider.
- *
- * @deprecated this type is only to be used from {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class TracingObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.


### PR DESCRIPTION
Resolves #11757

Finishes the ServiceLoader internalization follow-up by marking the remaining public ServiceLoader-only constructors as `@Api.Internal`, removing the remaining class-level provider deprecations, and adding the missing `helidon-common` dependency and module wiring exposed by the constructor changes.
