### PR TITLE
Fix OTLP self-tracing in packaging sample (27.x)

### DIFF
--- a/tests/integration/packaging/se-1/src/main/java/io/helidon/tests/integration/packaging/se1/Se1Main.java
+++ b/tests/integration/packaging/se-1/src/main/java/io/helidon/tests/integration/packaging/se1/Se1Main.java
@@ -74,8 +74,9 @@ public final class Se1Main {
                         .build())
                 .build();
 
+        Config observeConfig = config.get("server").get("features").get("observe");
         ObserveFeature observe = ObserveFeature.builder()
-                .config(config)
+                .config(observeConfig)
                 .addObserver(health)
                 .build();
 


### PR DESCRIPTION
Resolves #11780

Use the observe feature config subtree when building the packaging sample so the configured `/otlp/*` tracing exclusion is actually applied. This keeps the in-process OTLP mock collector from tracing itself in the affected packaging paths.

Validation:
- `mvn -pl tests/integration/packaging/se-1 -am -Ptests -Pjar-image -Dit.test=Se1JarClassPathTestIT -Dsurefire.failIfNoSpecifiedTests=false verify`
- `mvn -Ptests -pl tests/integration/packaging/se-1 -am -Pfat-jar-image -rf :helidon-tests-integration-packaging-se-1 -Dit.test=Se1FatJarAssemblyTestIT -Dsurefire.failIfNoSpecifiedTests=false verify`
