### PR TITLE
API stability annotations follow up (4.x)

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegenProvider.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -30,10 +31,8 @@ import io.helidon.common.types.TypeName;
 public class BuilderCodegenProvider implements CodegenExtensionProvider {
     /**
      * Public constructor is required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated please do not use directly
      */
-    @Deprecated
+    @Api.Internal
     public BuilderCodegenProvider() {
     }
 

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptProcessor.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptProcessor.java
@@ -40,6 +40,7 @@ import io.helidon.codegen.Codegen;
 import io.helidon.codegen.CodegenEvent;
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.Option;
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ModuleTypeInfo;
 import io.helidon.common.types.TypeInfo;
@@ -56,6 +57,7 @@ import static java.lang.System.Logger.Level.WARNING;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 @SuppressWarnings("removal")
 public final class AptProcessor extends AbstractProcessor {
     private static final TypeName GENERATOR = TypeName.create(AptProcessor.class);

--- a/codegen/apt/src/main/java/module-info.java
+++ b/codegen/apt/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ module io.helidon.codegen.apt {
     requires jdk.compiler;
     requires transitive io.helidon.codegen;
 
+    requires static io.helidon.common;
     requires transitive io.helidon.common.types;
     requires transitive java.compiler;
 

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocReader.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocReader.java
@@ -21,12 +21,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.helidon.common.Api;
 import io.helidon.codegen.JavadocParser.Event;
 import io.helidon.codegen.JavadocTree.AttrValue;
 import io.helidon.codegen.JavadocTree.BlockTag;
 import io.helidon.codegen.JavadocTree.Document;
 import io.helidon.codegen.JavadocTree.Text;
+import io.helidon.common.Api;
 
 /**
  * Javadoc reader.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocReader.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocReader.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.helidon.common.Api;
 import io.helidon.codegen.JavadocParser.Event;
 import io.helidon.codegen.JavadocTree.AttrValue;
 import io.helidon.codegen.JavadocTree.BlockTag;
@@ -35,6 +36,7 @@ import io.helidon.codegen.JavadocTree.Text;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public final class JavadocReader {
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocTree.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocTree.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import io.helidon.common.Api;
 import io.helidon.codegen.JavadocReader.BlockTagImpl;
 import io.helidon.codegen.JavadocReader.CdataImpl;
 import io.helidon.codegen.JavadocReader.CommentImpl;
@@ -29,6 +28,7 @@ import io.helidon.codegen.JavadocReader.EltStartImpl;
 import io.helidon.codegen.JavadocReader.EscapeImpl;
 import io.helidon.codegen.JavadocReader.InlineTagImpl;
 import io.helidon.codegen.JavadocReader.TextImpl;
+import io.helidon.common.Api;
 
 /**
  * Javadoc tree node.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocTree.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocTree.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import io.helidon.common.Api;
 import io.helidon.codegen.JavadocReader.BlockTagImpl;
 import io.helidon.codegen.JavadocReader.CdataImpl;
 import io.helidon.codegen.JavadocReader.CommentImpl;
@@ -37,6 +38,7 @@ import io.helidon.codegen.JavadocReader.TextImpl;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public sealed interface JavadocTree permits JavadocTree.EltStart,
                                             JavadocTree.InlineTag,
                                             JavadocTree.BlockTag,

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import io.helidon.common.Api;
 import io.helidon.codegen.JavadocTree.AttrValue;
 import io.helidon.codegen.JavadocTree.AttrValue.Kind;
 import io.helidon.codegen.JavadocTree.EltClose;
@@ -51,6 +52,7 @@ import io.helidon.codegen.JavadocTree.Text;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public final class JavadocWriter {
 
     private final StringBuilder buf;

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import io.helidon.common.Api;
 import io.helidon.codegen.JavadocTree.AttrValue;
 import io.helidon.codegen.JavadocTree.AttrValue.Kind;
 import io.helidon.codegen.JavadocTree.EltClose;
@@ -28,6 +27,7 @@ import io.helidon.codegen.JavadocTree.EltStart;
 import io.helidon.codegen.JavadocTree.Escape;
 import io.helidon.codegen.JavadocTree.InlineTag;
 import io.helidon.codegen.JavadocTree.Text;
+import io.helidon.common.Api;
 
 /**
  * A tool that renders Javadoc to simplified HTML.

--- a/codegen/testing/pom.xml
+++ b/codegen/testing/pom.xml
@@ -43,6 +43,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.codegen</groupId>
             <artifactId>helidon-codegen</artifactId>
         </dependency>

--- a/codegen/testing/src/main/java/io/helidon/codegen/testing/CodegenMatchers.java
+++ b/codegen/testing/src/main/java/io/helidon/codegen/testing/CodegenMatchers.java
@@ -18,6 +18,7 @@ package io.helidon.codegen.testing;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.helidon.common.Api;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -31,6 +32,7 @@ import org.intellij.lang.annotations.Language;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public final class CodegenMatchers {
 
     private CodegenMatchers() {

--- a/codegen/testing/src/main/java/io/helidon/codegen/testing/CodegenMatchers.java
+++ b/codegen/testing/src/main/java/io/helidon/codegen/testing/CodegenMatchers.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.helidon.common.Api;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;

--- a/codegen/testing/src/main/java/io/helidon/codegen/testing/TestCompiler.java
+++ b/codegen/testing/src/main/java/io/helidon/codegen/testing/TestCompiler.java
@@ -32,6 +32,7 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
+import io.helidon.common.Api;
 import org.intellij.lang.annotations.Language;
 
 /**
@@ -42,6 +43,7 @@ import org.intellij.lang.annotations.Language;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public final class TestCompiler {
 
     private final List<Supplier<Processor>> processors;

--- a/codegen/testing/src/main/java/io/helidon/codegen/testing/TestCompiler.java
+++ b/codegen/testing/src/main/java/io/helidon/codegen/testing/TestCompiler.java
@@ -33,6 +33,7 @@ import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
 import io.helidon.common.Api;
+
 import org.intellij.lang.annotations.Language;
 
 /**

--- a/common/testing/junit5/src/main/java/io/helidon/common/testing/junit5/TemporaryFolderExt.java
+++ b/common/testing/junit5/src/main/java/io/helidon/common/testing/junit5/TemporaryFolderExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * The extension automatically deletes the temporary files after all tests in
  * the test class have finished.
  *
+ * @deprecated Use JUnit 5 {@link org.junit.jupiter.api.io.TempDir @TempDir} support for temporary files and
+ *         directories instead.
  */
-@Deprecated
+@Deprecated(since = "4.5.0", forRemoval = true)
 public class TemporaryFolderExt implements BeforeEachCallback, AfterEachCallback {
 
     private Path root;

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpEncryptionFilter.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpEncryptionFilter.java
@@ -25,6 +25,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.Keys;
 import io.helidon.config.encryption.ConfigEncryptionException;
@@ -79,9 +80,9 @@ public final class MpEncryptionFilter implements MpConfigFilter {
     private MpConfigFilter aliasFilter;
 
     /**
-     * This constructor is only for use by {@link io.helidon.config.mp.spi.MpConfigFilter} service loader.
+     * This constructor is only for use by the {@link io.helidon.config.mp.spi.MpConfigFilter} service loader.
      */
-    @Deprecated
+    @Api.Internal
     public MpEncryptionFilter() {
     }
 

--- a/config/config/src/main/java/io/helidon/config/HelidonConfigProvider.java
+++ b/config/config/src/main/java/io/helidon/config/HelidonConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.config;
 
+import io.helidon.common.Api;
 import io.helidon.common.LazyValue;
 
 /**
@@ -29,11 +30,9 @@ public class HelidonConfigProvider implements io.helidon.common.config.spi.Confi
     private static final LazyValue<io.helidon.config.Config> DEFAULT_CONFIG = LazyValue.create(io.helidon.config.Config::create);
 
     /**
-     * This should only be used by service loader and (possibly) tests.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
+     * This should only be used by service loader and, possibly, tests.
      */
-    @Deprecated
+    @Api.Internal
     public HelidonConfigProvider() {
     }
 

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmModel.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmModel.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.config.metadata.model.CmModelImpl.CmAllowedValueImpl;
 import io.helidon.config.metadata.model.CmModelImpl.CmEnumImpl;
 import io.helidon.config.metadata.model.CmModelImpl.CmModuleImpl;
@@ -39,6 +40,7 @@ import io.helidon.metadata.hson.Hson;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public sealed interface CmModel permits CmModelImpl {
 
     /**

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmNode.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmNode.java
@@ -19,6 +19,7 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.config.metadata.model.CmModel.CmOption;
 import io.helidon.config.metadata.model.CmModel.CmType;
 import io.helidon.config.metadata.model.CmNodeImpl.CmOptionNodeImpl;
@@ -32,6 +33,7 @@ import io.helidon.config.metadata.model.CmNodeImpl.CmPathNodeImpl;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public sealed interface CmNode extends Comparable<CmNode> permits CmNode.CmOptionNode,
                                                                   CmNode.CmPathNode,
                                                                   CmNodeImpl {

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmResolver.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmResolver.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.config.metadata.model.CmModel.CmEnum;
 import io.helidon.config.metadata.model.CmModel.CmType;
 
@@ -31,6 +32,7 @@ import io.helidon.config.metadata.model.CmModel.CmType;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public interface CmResolver {
 
     /**

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/cors/CorsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/cors/CorsExtensionProvider.java
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.cors;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class CorsExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public CorsExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.faulttolerance;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.spi.RegistryCodegenExtension;
@@ -31,11 +32,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class FtExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public FtExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.http.webserver;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -33,10 +34,8 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class RestServerExtensionProvider implements RegistryCodegenExtensionProvider {
     /**
      * Required by {@link java.util.ServiceLoader}.
-     *
-     * @deprecated required by service loader
      */
-    @Deprecated
+    @Api.Internal
     public RestServerExtensionProvider() {
         super();
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.metrics;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class MetricsExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public MetricsExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/scheduling/SchedulingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/scheduling/SchedulingExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.scheduling;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class SchedulingExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public SchedulingExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.tracing;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class TracingExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public TracingExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.validation;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -37,11 +38,9 @@ import static io.helidon.declarative.codegen.validation.ValidationTypes.VALIDATI
 @Weight(Weighted.DEFAULT_WEIGHT - 30)
 public class ValidationExtensionProvider implements RegistryCodegenExtensionProvider {
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public ValidationExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/client/WebSocketClientExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/client/WebSocketClientExtensionProvider.java
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.websocket.client;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class WebSocketClientExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public WebSocketClientExtensionProvider() {
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/server/WebSocketServerExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/server/WebSocketServerExtensionProvider.java
@@ -18,6 +18,7 @@ package io.helidon.declarative.codegen.websocket.server;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -34,11 +35,9 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 public class WebSocketServerExtensionProvider implements RegistryCodegenExtensionProvider {
 
     /**
-     * Default constructor.
-     *
-     * @deprecated required by Java {@link java.util.ServiceLoader}
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public WebSocketServerExtensionProvider() {
     }
 

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UCPBackedDataSourceExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UCPBackedDataSourceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import javax.sql.DataSource;
 
+import io.helidon.common.Api;
 import io.helidon.integrations.datasource.cdi.AbstractDataSourceExtension;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -98,11 +99,9 @@ public class UCPBackedDataSourceExtension extends AbstractDataSourceExtension {
     private final Map<String, Boolean> xa;
 
     /**
-     * Creates a new {@link UCPBackedDataSourceExtension}.
-     *
-     * @deprecated For use by CDI only.
+     * Creates a new {@link UCPBackedDataSourceExtension} for CDI use only.
      */
-    @Deprecated // For use by CDI only
+    @Api.Internal
     public UCPBackedDataSourceExtension() {
         super();
         this.xa = new HashMap<>();

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.integrations.datasource.ucp.cdi;
 import java.util.Properties;
 import java.util.regex.Matcher;
 
+import io.helidon.common.Api;
 import io.helidon.integrations.cdi.configurable.AbstractConfigurableExtension;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -89,11 +90,9 @@ import static io.helidon.integrations.datasource.ucp.cdi.UCPBackedDataSourceExte
 public class UniversalConnectionPoolExtension extends AbstractConfigurableExtension<UniversalConnectionPool> {
 
     /**
-     * Creates a new {@link UniversalConnectionPoolExtension}.
-     *
-     * @deprecated For use by CDI only.
+     * Creates a new {@link UniversalConnectionPoolExtension} for CDI use only.
      */
-    @Deprecated // For use by CDI only
+    @Api.Internal
     public UniversalConnectionPoolExtension() {
         super();
     }

--- a/integrations/cdi/datasource-ucp/src/main/java/module-info.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 @SuppressWarnings({ "requires-automatic"})
 module io.helidon.integrations.datasource.ucp.cdi {
 
+    requires static io.helidon.common;
     requires com.oracle.database.jdbc; // com.oracle.database.ucp needs this (!)
     requires com.oracle.database.ucp;
     requires java.desktop; // For java.beans

--- a/integrations/cdi/eclipselink-cdi/pom.xml
+++ b/integrations/cdi/eclipselink-cdi/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test-scoped dependencies. -->
         <dependency>

--- a/integrations/cdi/eclipselink-cdi/src/main/java/io/helidon/integrations/cdi/eclipselink/CDISEPlatformExtension.java
+++ b/integrations/cdi/eclipselink-cdi/src/main/java/io/helidon/integrations/cdi/eclipselink/CDISEPlatformExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.helidon.integrations.cdi.eclipselink;
 import java.lang.reflect.Field;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import io.helidon.common.Api;
 
 import jakarta.enterprise.inject.spi.Extension;
 import org.eclipse.persistence.platform.server.NoServerPlatform;
@@ -45,11 +47,9 @@ public final class CDISEPlatformExtension implements Extension {
 
 
     /**
-     * Creates a new {@link CDISEPlatformExtension}.
-     *
-     * @deprecated Only a CDI container should invoke this constructor.
+     * Creates a new {@link CDISEPlatformExtension} for CDI container use only.
      */
-    @Deprecated
+    @Api.Internal
     public CDISEPlatformExtension() {
         super();
         final Object serverPlatformClassName = ServerPlatformUtils.detectServerPlatform(null);

--- a/integrations/cdi/eclipselink-cdi/src/main/java/io/helidon/integrations/cdi/eclipselink/CDISEPlatformExtension.java
+++ b/integrations/cdi/eclipselink-cdi/src/main/java/io/helidon/integrations/cdi/eclipselink/CDISEPlatformExtension.java
@@ -34,10 +34,7 @@ import org.eclipse.persistence.platform.server.ServerPlatformUtils;
  * whose versions are higher than 1.8.  There is no need for end users
  * to instantiate this class.  Any public APIs exposed by this class
  * are subject to change without prior notice.</p>
- *
- * @deprecated Only a CDI container should instantiate this class.
  */
-@Deprecated
 public final class CDISEPlatformExtension implements Extension {
 
 

--- a/integrations/cdi/eclipselink-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/eclipselink-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ module io.helidon.integrations.cdi.eclipselink {
     requires java.management;
     requires java.sql;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive org.eclipse.persistence.core;

--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatformProvider.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatformProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package io.helidon.integrations.cdi.hibernate;
 
 import java.lang.System.Logger;
+
+import io.helidon.common.Api;
 
 import jakarta.enterprise.inject.spi.CDI;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
@@ -54,11 +56,9 @@ public final class CDISEJtaPlatformProvider implements JtaPlatformProvider {
 
 
     /**
-     * Creates a new {@link CDISEJtaPlatformProvider}.
-     *
-     * @deprecated For Hibernate use only.
+     * Creates a new {@link CDISEJtaPlatformProvider} for Hibernate use only.
      */
-    @Deprecated
+    @Api.Internal
     public CDISEJtaPlatformProvider() {
         super();
     }

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/DataSourceBackedDialectFactory.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/DataSourceBackedDialectFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import javax.sql.DataSource;
+
+import io.helidon.common.Api;
 
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -120,11 +122,9 @@ public final class DataSourceBackedDialectFactory
 
 
     /**
-     * Creates a new {@link DataSourceBackedDialectFactory}.
-     *
-     * @deprecated For use by {@link java.util.ServiceLoader} instances only.
+     * Creates a new {@link DataSourceBackedDialectFactory} for {@link java.util.ServiceLoader} use only.
      */
-    @Deprecated
+    @Api.Internal
     public DataSourceBackedDialectFactory() {
         super();
     }

--- a/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ module io.helidon.integrations.cdi.hibernate {
     requires org.graalvm.nativeimage;
     requires transitive org.hibernate.orm.core;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     exports io.helidon.integrations.cdi.hibernate;

--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -207,6 +207,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
  *
  * @deprecated Please use {@link PersistenceExtension} instead.
  */
-@Deprecated(since = "4.0")
+@Deprecated(since = "4.0.0", forRemoval = true)
 @SuppressWarnings("checkstyle:IllegalToken") // deprecated, to be removed
 public class JpaExtension implements Extension {
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -45,6 +45,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import io.helidon.common.Api;
 import io.helidon.integrations.cdi.jpa.PersistenceUnitInfoBean.DataSourceProvider;
 import io.helidon.integrations.cdi.jpa.jaxb.Persistence;
 import io.helidon.integrations.cdi.referencecountedcontext.ReferenceCounted;
@@ -311,6 +312,7 @@ public class JpaExtension implements Extension {
      *
      * @see Extension
      */
+    @Api.Internal
     public JpaExtension() {
         super();
         String cn = JpaExtension.class.getName();

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import io.helidon.common.Api;
 import io.helidon.integrations.cdi.jpa.PersistenceUnitInfoBean.DataSourceProvider;
 import io.helidon.integrations.cdi.jpa.jaxb.Persistence;
 
@@ -261,11 +262,9 @@ public final class PersistenceExtension implements Extension {
 
 
     /**
-     * Creates a new {@link PersistenceExtension}.
-     *
-     * @deprecated For invocation by CDI only.
+     * Creates a new {@link PersistenceExtension} for invocation by CDI only.
      */
-    @Deprecated // For invocation by CDI only.
+    @Api.Internal
     public PersistenceExtension() {
         super();
         this.enabled =

--- a/integrations/cdi/jpa-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ module io.helidon.integrations.cdi.jpa {
 
     requires microprofile.config.api;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     // Static metamodel generation requires access to java.compiler at

--- a/integrations/cdi/jta-weld/pom.xml
+++ b/integrations/cdi/jta-weld/pom.xml
@@ -89,6 +89,11 @@
 
         <!-- Compile-scoped dependencies. -->
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>narayana-jta</artifactId>
         </dependency>

--- a/integrations/cdi/jta-weld/src/main/java/io/helidon/integrations/jta/weld/NarayanaTransactionServices.java
+++ b/integrations/cdi/jta-weld/src/main/java/io/helidon/integrations/jta/weld/NarayanaTransactionServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package io.helidon.integrations.jta.weld;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import io.helidon.common.Api;
 
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import jakarta.enterprise.inject.Instance;
@@ -69,10 +71,9 @@ public final class NarayanaTransactionServices implements TransactionServices {
 
 
     /**
-     * Creates a new {@link NarayanaTransactionServices}.
-     * @deprecated Only intended for service loader, do not instantiate
+     * Creates a new {@link NarayanaTransactionServices} for service loader use only.
      */
-    @Deprecated
+    @Api.Internal
     public NarayanaTransactionServices() {
         super();
         final String cn = NarayanaTransactionServices.class.getName();

--- a/integrations/cdi/jta-weld/src/main/java/module-info.java
+++ b/integrations/cdi/jta-weld/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ module io.helidon.integrations.jta.weld {
     requires java.rmi;
     requires narayana.jta;
 
+    requires static io.helidon.common;
     requires transitive weld.spi;
 
     exports io.helidon.integrations.jta.weld;

--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.integrations.oci.metrics</groupId>
             <artifactId>helidon-integrations-oci-metrics</artifactId>
         </dependency>

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.integrations.oci.metrics.cdi;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.integrations.oci.metrics.OciMetricsSupport;
 import io.helidon.integrations.oci.metrics.OciMetricsSupportFactory;
@@ -46,7 +47,7 @@ public class OciMetricsBean extends OciMetricsSupportFactory {
     /**
      * For CDI use only.
      */
-    @Deprecated
+    @Api.Internal
     public OciMetricsBean() {
     }
 

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package io.helidon.integrations.oci.metrics.cdi;
 
+import io.helidon.common.Api;
+
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
@@ -27,7 +29,7 @@ public class OciMetricsCdiExtension implements Extension {
     /**
      * For CDI use only.
      */
-    @Deprecated
+    @Api.Internal
     public OciMetricsCdiExtension() {
     }
 

--- a/integrations/oci/metrics/cdi/src/main/java/module-info.java
+++ b/integrations/oci/metrics/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ module io.helidon.integrations.oci.metrics.cdi {
     requires io.helidon.microprofile.server;
     requires oci.java.sdk.monitoring;
 
+    requires static io.helidon.common;
     requires transitive jakarta.cdi;
     requires transitive jakarta.inject;
 

--- a/integrations/oci/sdk/cdi/pom.xml
+++ b/integrations/oci/sdk/cdi/pom.xml
@@ -40,6 +40,11 @@
     <dependencies>
 
         <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>com.oracle.oci.sdk</groupId>

--- a/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/OciExtension.java
+++ b/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/OciExtension.java
@@ -38,6 +38,8 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.helidon.common.Api;
+
 import com.oracle.bmc.ConfigFileReader.ConfigFile;
 import com.oracle.bmc.Service;
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
@@ -612,11 +614,9 @@ public final class OciExtension implements Extension {
 
 
     /**
-     * Creates a new {@link OciExtension}.
-     *
-     * @deprecated For {@link java.util.ServiceLoader} use only.
+     * Creates a new {@link OciExtension} for {@link java.util.ServiceLoader} use only.
      */
-    @Deprecated // for java.util.ServiceLoader use only
+    @Api.Internal
     public OciExtension() {
         super();
         this.lenientClassloading = true;

--- a/integrations/oci/sdk/cdi/src/main/java/module-info.java
+++ b/integrations/oci/sdk/cdi/src/main/java/module-info.java
@@ -32,6 +32,8 @@ module io.helidon.integrations.oci.sdk.cdi {
     requires oci.java.sdk.common;
     requires oci.java.sdk.addons.oke.workload.identity;
 
+    requires static io.helidon.common;
+
     exports io.helidon.integrations.oci.sdk.cdi;
 
     provides jakarta.enterprise.inject.spi.Extension

--- a/integrations/oci/sdk/codegen/pom.xml
+++ b/integrations/oci/sdk/codegen/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>helidon-codegen-class-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.service</groupId>
              <artifactId>helidon-service-codegen</artifactId>
         </dependency>

--- a/integrations/oci/sdk/codegen/src/main/java/io/helidon/integrations/oci/sdk/codegen/OciInjectCodegenObserverProvider.java
+++ b/integrations/oci/sdk/codegen/src/main/java/io/helidon/integrations/oci/sdk/codegen/OciInjectCodegenObserverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import io.helidon.codegen.Option;
+import io.helidon.common.Api;
 import io.helidon.common.GenericType;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.spi.InjectCodegenObserver;
@@ -47,10 +48,8 @@ public class OciInjectCodegenObserverProvider implements InjectCodegenObserverPr
 
     /**
      * Service loader based constructor.
-     *
-     * @deprecated this is a Java ServiceLoader implementation and the constructor should not be used directly
      */
-    @Deprecated
+    @Api.Internal
     public OciInjectCodegenObserverProvider() {
     }
 

--- a/integrations/oci/sdk/codegen/src/main/java/module-info.java
+++ b/integrations/oci/sdk/codegen/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ module io.helidon.integrations.oci.sdk.codegen {
     requires io.helidon.codegen;
     requires io.helidon.codegen.classmodel;
 
+    requires static io.helidon.common;
     requires transitive io.helidon.common.types;
     requires transitive io.helidon.service.codegen;
 

--- a/integrations/vault/auths/approle/pom.xml
+++ b/integrations/vault/auths/approle/pom.xml
@@ -45,6 +45,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/integrations/vault/auths/approle/src/main/java/io/helidon/integrations/vault/auths/approle/AppRoleVaultAuth.java
+++ b/integrations/vault/auths/approle/src/main/java/io/helidon/integrations/vault/auths/approle/AppRoleVaultAuth.java
@@ -19,6 +19,7 @@ package io.helidon.integrations.vault.auths.approle;
 import java.lang.System.Logger.Level;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
@@ -42,11 +43,9 @@ public class AppRoleVaultAuth implements VaultAuth {
     private final String methodPath;
 
     /**
-     * Constructor required for Java Service Loader.
-     *
-     * @deprecated please use {@link #builder()}
+     * Constructor required for Java Service Loader. Use {@link #builder()} for application code.
      */
-    @Deprecated
+    @Api.Internal
     public AppRoleVaultAuth() {
         this.appRoleId = null;
         this.secretId = null;

--- a/integrations/vault/auths/approle/src/main/java/module-info.java
+++ b/integrations/vault/auths/approle/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ module io.helidon.integrations.vault.auths.approle {
     requires io.helidon.integrations.vault.auths.common;
     requires io.helidon.webclient;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.integrations.vault;

--- a/integrations/vault/auths/k8s/pom.xml
+++ b/integrations/vault/auths/k8s/pom.xml
@@ -49,6 +49,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/integrations/vault/auths/k8s/src/main/java/io/helidon/integrations/vault/auths/k8s/K8sVaultAuth.java
+++ b/integrations/vault/auths/k8s/src/main/java/io/helidon/integrations/vault/auths/k8s/K8sVaultAuth.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
@@ -47,11 +48,9 @@ public class K8sVaultAuth implements VaultAuth {
     private final String methodPath;
 
     /**
-     * Constructor required for Java Service Loader.
-     *
-     * @deprecated please use {@link #builder()}
+     * Constructor required for Java Service Loader. Use {@link #builder()} for application code.
      */
-    @Deprecated
+    @Api.Internal
     public K8sVaultAuth() {
         this.serviceAccountToken = null;
         this.tokenRole = null;

--- a/integrations/vault/auths/k8s/src/main/java/module-info.java
+++ b/integrations/vault/auths/k8s/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ module io.helidon.integrations.vault.auths.k8s {
     requires io.helidon.integrations.vault.auths.common;
     requires io.helidon.webclient;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.integrations.common.rest;

--- a/integrations/vault/secrets/cubbyhole/pom.xml
+++ b/integrations/vault/secrets/cubbyhole/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrations/vault/secrets/cubbyhole/src/main/java/io/helidon/integrations/vault/secrets/cubbyhole/CubbyholeEngineProvider.java
+++ b/integrations/vault/secrets/cubbyhole/src/main/java/io/helidon/integrations/vault/secrets/cubbyhole/CubbyholeEngineProvider.java
@@ -19,6 +19,7 @@ package io.helidon.integrations.vault.secrets.cubbyhole;
 import java.util.LinkedList;
 import java.util.List;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.integrations.common.rest.RestApi;
 import io.helidon.integrations.vault.Engine;
@@ -44,9 +45,9 @@ public class CubbyholeEngineProvider implements SecretsEngineProvider<CubbyholeS
     }
 
     /**
-     * @deprecated Do not use this constructor, this is a service loader service!
+     * Required by this service loader service.
      */
-    @Deprecated
+    @Api.Internal
     public CubbyholeEngineProvider() {
     }
 

--- a/integrations/vault/secrets/cubbyhole/src/main/java/io/helidon/integrations/vault/secrets/cubbyhole/CubbyholeSecurityService.java
+++ b/integrations/vault/secrets/cubbyhole/src/main/java/io/helidon/integrations/vault/secrets/cubbyhole/CubbyholeSecurityService.java
@@ -16,6 +16,7 @@
 
 package io.helidon.integrations.vault.secrets.cubbyhole;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.integrations.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
@@ -26,9 +27,9 @@ import io.helidon.security.spi.SecurityProviderService;
  */
 public class CubbyholeSecurityService implements SecurityProviderService {
     /**
-     * @deprecated Do not use this constructor, this is a service loader service!
+     * Required by this service loader service.
      */
-    @Deprecated
+    @Api.Internal
     public CubbyholeSecurityService() {
     }
 

--- a/integrations/vault/secrets/cubbyhole/src/main/java/module-info.java
+++ b/integrations/vault/secrets/cubbyhole/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ module io.helidon.integrations.vault.secrets.cubbyhole {
 
     requires io.helidon.integrations.common.rest;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.integrations.vault;

--- a/integrations/vault/secrets/kv1/pom.xml
+++ b/integrations/vault/secrets/kv1/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrations/vault/secrets/kv1/src/main/java/io/helidon/integrations/vault/secrets/kv1/Kv1SecurityService.java
+++ b/integrations/vault/secrets/kv1/src/main/java/io/helidon/integrations/vault/secrets/kv1/Kv1SecurityService.java
@@ -16,6 +16,7 @@
 
 package io.helidon.integrations.vault.secrets.kv1;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.integrations.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
@@ -26,9 +27,9 @@ import io.helidon.security.spi.SecurityProviderService;
  */
 public class Kv1SecurityService implements SecurityProviderService {
     /**
-     * @deprecated Do not use this constructor, this is a service loader service!
+     * Required by this service loader service.
      */
-    @Deprecated
+    @Api.Internal
     public Kv1SecurityService() {
     }
 

--- a/integrations/vault/secrets/kv1/src/main/java/module-info.java
+++ b/integrations/vault/secrets/kv1/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ module io.helidon.integrations.vault.secrets.kvone {
 
     requires io.helidon.integrations.common.rest;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.integrations.vault;

--- a/integrations/vault/secrets/kv2/pom.xml
+++ b/integrations/vault/secrets/kv2/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrations/vault/secrets/kv2/src/main/java/io/helidon/integrations/vault/secrets/kv2/Kv2SecurityService.java
+++ b/integrations/vault/secrets/kv2/src/main/java/io/helidon/integrations/vault/secrets/kv2/Kv2SecurityService.java
@@ -16,6 +16,7 @@
 
 package io.helidon.integrations.vault.secrets.kv2;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.integrations.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
@@ -26,9 +27,9 @@ import io.helidon.security.spi.SecurityProviderService;
  */
 public class Kv2SecurityService implements SecurityProviderService {
     /**
-     * @deprecated Do not use this constructor, this is a service loader service!
+     * Required by this service loader service.
      */
-    @Deprecated
+    @Api.Internal
     public Kv2SecurityService() {
     }
 

--- a/integrations/vault/secrets/kv2/src/main/java/module-info.java
+++ b/integrations/vault/secrets/kv2/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ module io.helidon.integrations.vault.secrets.kv {
     requires io.helidon.http;
     requires io.helidon.integrations.common.rest;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.integrations.vault;

--- a/metrics/api/src/main/java/io/helidon/metrics/api/LabeledSnapshot.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/LabeledSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,11 @@ import io.helidon.metrics.api.Sample.Derived;
 import io.helidon.metrics.api.Sample.Labeled;
 
 /**
- * Internal interface prescribing minimum behavior of a snapshot needed to produce output.
+ * Snapshot view of a metric's derived and labeled sample values.
+ * <p>
+ * Implementations expose summary values computed for the metric at a point in time, such as quantiles, max, mean,
+ * and observation count.
+ * </p>
  */
 public interface LabeledSnapshot {
     /**

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SnapshotMetric.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SnapshotMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 package io.helidon.metrics.api;
 
 /**
- * A metric that is capable of providing snapshots.
+ * A metric that can provide a {@link io.helidon.metrics.api.LabeledSnapshot} of its current sampled values.
  */
 public interface SnapshotMetric {
     /**
-     * Snapshot of the metric.
+     * Returns a snapshot of the metric's current sampled values.
      *
      * @return snapshot
      */

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatterProvider.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.metrics.providers.micrometer;
 
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.metrics.api.MeterRegistry;
@@ -31,10 +32,8 @@ public class MicrometerPrometheusFormatterProvider implements MeterRegistryForma
 
     /**
      * Constructs a new instance for service loading.
-     *
-     * @deprecated
      */
-    @Deprecated
+    @Api.Internal
     public MicrometerPrometheusFormatterProvider() {
     }
 

--- a/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
+++ b/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import io.helidon.common.Api;
 import io.helidon.metrics.api.BuiltInMeterNameFormat;
 import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MetricsFactory;
@@ -162,10 +163,8 @@ public class SystemMetersProvider implements MetersProvider {
 
     /**
      * Constructs a new instance for service loading.
-     *
-     * @deprecated
      */
-    @Deprecated
+    @Api.Internal
     public SystemMetersProvider() {
     }
 

--- a/metrics/system-meters/src/main/java/module-info.java
+++ b/metrics/system-meters/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ module io.helidon.metrics.systemmeters {
     requires io.helidon.metrics.api;
     requires java.management;
     requires jdk.jfr;
+    requires static io.helidon.common;
 
     // we must see these classes, as they are used in generated ApplicationBinding
     exports io.helidon.metrics.systemmeters;

--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/ServiceRegistryExtension.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/ServiceRegistryExtension.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.helidon.Main;
+import io.helidon.common.Api;
 import io.helidon.common.Weighted;
 import io.helidon.common.Weights;
 import io.helidon.common.types.ResolvedType;
@@ -98,11 +99,9 @@ public class ServiceRegistryExtension implements Extension {
     private static final ResolvedType TRACER = ResolvedType.create("io.helidon.tracing.Tracer");
 
     /**
-     * Creates a new {@link ServiceRegistryExtension}.
-     *
-     * @deprecated For CDI use only.
+     * Creates a new {@link ServiceRegistryExtension} for CDI use only.
      */
-    @Deprecated
+    @Api.Internal
     public ServiceRegistryExtension() {
         super();
     }

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeatureProvider.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.openapi;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -27,10 +28,8 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 public class OpenApiFeatureProvider implements ServerFeatureProvider<OpenApiFeature> {
     /**
      * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
      */
-    @Deprecated
+    @Api.Internal
     public OpenApiFeatureProvider() {
     }
 

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/Storage.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/Storage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package io.helidon.testing.junit5.suite;
 
+import io.helidon.common.Api;
+
 /**
- * Suite specific storage.
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal suite-specific storage exposed to test suite providers.
  */
-@Deprecated
+@Api.Internal
 public interface Storage {
 
     /**

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteDescriptor.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import io.helidon.testing.junit5.suite.spi.SuiteProvider;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 // Suite descriptor
-@SuppressWarnings("deprecation")
 class SuiteDescriptor {
 
     private final SuiteProvider provider;

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteExtension.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.testing.junit5.suite;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.testing.junit5.suite.spi.SuiteProvider;
 
@@ -30,12 +31,9 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 
 /**
- * Suite junit 5 extension.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal JUnit 5 extension backing the test suite annotations.
  */
-@Deprecated
+@Api.Internal
 public class SuiteExtension
         implements BeforeAllCallback, ExtensionContext.Store.CloseableResource, ParameterResolver {
 

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteResolver.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,12 @@ package io.helidon.testing.junit5.suite;
 
 import java.lang.reflect.Type;
 
+import io.helidon.common.Api;
+
 /**
- * {@code SuiteResolver} defines API for suite providers
- * to dynamically resolve arguments for constructors and methods at runtime.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal contract for suite providers that resolve constructor and method parameters at runtime.
  */
-@Deprecated
+@Api.Internal
 public interface SuiteResolver {
 
     /**

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteStorage.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,11 @@
  */
 package io.helidon.testing.junit5.suite;
 
+import io.helidon.common.Api;
+
 /**
- * {@code SuiteStorage} defines API for suite providers to provide suite specific storage
- * shared for all tests running as part of the suite.
- * Storage is available as arguments resolver for the {@link Storage} class.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal marker for suite providers that expose shared {@link Storage} to suite lifecycle callbacks.
  */
-@Deprecated
+@Api.Internal
 public interface SuiteStorage {
 }

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/TestSuite.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/TestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.helidon.common.Api;
 import io.helidon.testing.junit5.suite.spi.SuiteProvider;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Test suite annotations.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal test suite annotations support.
  */
-@Deprecated
+@Api.Internal
 public final class TestSuite {
 
     private TestSuite() {
@@ -39,11 +37,8 @@ public final class TestSuite {
 
     /**
      * Test suite annotation.
-     *
-     * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
-     *         use with care
      */
-    @Deprecated
+    @Api.Internal
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     @ExtendWith(SuiteExtension.class)
@@ -60,11 +55,8 @@ public final class TestSuite {
 
     /**
      * After {@link io.helidon.testing.junit5.suite.TestSuite} cleanup method.
-     *
-     * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
-     *         use with care
      */
-    @Deprecated
+    @Api.Internal
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @Inherited
@@ -73,11 +65,9 @@ public final class TestSuite {
 
     /**
      * Before {@link io.helidon.testing.junit5.suite.TestSuite} initialization method.
-     *
-     * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
-     *         use with care
      */
-    @Deprecated@Retention(RetentionPolicy.RUNTIME)
+    @Api.Internal
+    @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @Inherited
     public @interface BeforeSuite {

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/spi/SuiteProvider.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/spi/SuiteProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,16 @@
  */
 package io.helidon.testing.junit5.suite.spi;
 
+import io.helidon.common.Api;
+
 /**
- * Integration tests suite provider.
- * Any {@link io.helidon.testing.junit5.suite.TestSuite} class must implement this interface.
+ * Internal contract implemented by providers used with {@link io.helidon.testing.junit5.suite.TestSuite.Suite}.
  * <p>
- * A Suite may provide methods annotated with {@link io.helidon.testing.junit5.suite.TestSuite.BeforeSuite} and/or
+ * A provider may define methods annotated with {@link io.helidon.testing.junit5.suite.TestSuite.BeforeSuite} and/or
  * {@link io.helidon.testing.junit5.suite.TestSuite.AfterSuite}.
- * Currently supported parameter is the {@link io.helidon.testing.junit5.suite.SuiteStorage}.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Providers that also implement {@link io.helidon.testing.junit5.suite.SuiteStorage} receive
+ * {@link io.helidon.testing.junit5.suite.Storage} in those callbacks.
  */
-@Deprecated
+@Api.Internal
 public interface SuiteProvider {
 }

--- a/testing/junit5-suite/src/main/java/module-info.java
+++ b/testing/junit5-suite/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,8 @@
  */
 
 /**
- * Helidon Integration Tests Suite Extension.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal support for Helidon JUnit 5 test suites.
  */
-@Deprecated
 module io.helidon.testing.junit5.suite {
 
     requires transitive org.junit.jupiter.api;

--- a/tracing/exporter-jaeger/pom.xml
+++ b/tracing/exporter-jaeger/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!--
         The following dependencies are needed to provide an outbound client to supplant the okhttp one that OpenTelemetry
         normally depends on.

--- a/tracing/exporter-jaeger/src/main/java/io/helidon/tracing/exporter/jaeger/JaegerGrpcSpanExporter.java
+++ b/tracing/exporter-jaeger/src/main/java/io/helidon/tracing/exporter/jaeger/JaegerGrpcSpanExporter.java
@@ -40,7 +40,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
  *     href="https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/otlp/all">opentelemetry-exporter-otlp</a>
  *     instead.
  */
-@Deprecated
+@Deprecated(since = "4.5.0", forRemoval = true)
 public final class JaegerGrpcSpanExporter implements SpanExporter {
 
   private static final String DEFAULT_HOST_NAME = "unknown";

--- a/tracing/exporter-jaeger/src/main/java/io/helidon/tracing/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
+++ b/tracing/exporter-jaeger/src/main/java/io/helidon/tracing/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
@@ -41,7 +41,7 @@ import static java.util.Objects.requireNonNull;
  *     href="https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/otlp/all">opentelemetry-exporter-otlp</a>
  *     instead.
  */
-@Deprecated
+@Deprecated(since = "4.5.0", forRemoval = true)
 public final class JaegerGrpcSpanExporterBuilder {
 
   private static final String GRPC_SERVICE_NAME = "jaeger.api_v2.CollectorService";

--- a/tracing/exporter-jaeger/src/main/java/io/helidon/tracing/exporter/jaeger/JaegerGrpcSpanExporterProvider.java
+++ b/tracing/exporter-jaeger/src/main/java/io/helidon/tracing/exporter/jaeger/JaegerGrpcSpanExporterProvider.java
@@ -34,12 +34,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
- *
- * @deprecated Use {@code OtlpGrpcSpanExporter} or {@code OtlpHttpSpanExporter} from <a
- *     href="https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/otlp/all">opentelemetry-exporter-otlp</a>
- *     instead.
  */
-@Deprecated
 public class JaegerGrpcSpanExporterProvider implements ConfigurableSpanExporterProvider {
 
   /**

--- a/tracing/exporter-jaeger/src/main/java/io/helidon/tracing/exporter/jaeger/JaegerGrpcSpanExporterProvider.java
+++ b/tracing/exporter-jaeger/src/main/java/io/helidon/tracing/exporter/jaeger/JaegerGrpcSpanExporterProvider.java
@@ -22,6 +22,8 @@ package io.helidon.tracing.exporter.jaeger;
 
 import java.time.Duration;
 
+import io.helidon.common.Api;
+
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -43,7 +45,7 @@ public class JaegerGrpcSpanExporterProvider implements ConfigurableSpanExporterP
   /**
    * For service loading.
    */
-  @Deprecated
+  @Api.Internal
   public JaegerGrpcSpanExporterProvider() {
   }
 

--- a/tracing/exporter-jaeger/src/main/java/module-info.java
+++ b/tracing/exporter-jaeger/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module io.helidon.tracing.exporter.jaeger {
     requires io.grpc.stub;
     requires com.google.protobuf;
     requires java.annotation;
+    requires static io.helidon.common;
     requires io.grpc.protobuf;
     requires static io.helidon.common.features.api;
 

--- a/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingProvider.java
+++ b/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingProvider.java
@@ -22,12 +22,8 @@ import io.helidon.webclient.grpc.spi.GrpcClientService;
 import io.helidon.webclient.grpc.spi.GrpcClientServiceProvider;
 
 /**
- * gRPC client tracing SPI provider implementation.
- *
- * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
- *         Use {@link io.helidon.webclient.grpc.tracing.GrpcClientTracing} instead.
+ * gRPC client tracing SPI provider implementation for {@link java.util.ServiceLoader}.
  */
-@Deprecated
 public class GrpcClientTracingProvider implements GrpcClientServiceProvider {
 
     /**

--- a/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
+++ b/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
@@ -21,12 +21,8 @@ import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webclient.spi.WebClientServiceProvider;
 
 /**
- * Client metrics SPI provider implementation.
- *
- * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
- *  Use {@link WebClientMetrics} instead
+ * Client metrics SPI provider implementation for {@link java.util.ServiceLoader}.
  */
-@Deprecated
 public class WebClientMetricsProvider implements WebClientServiceProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurityProvider.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurityProvider.java
@@ -21,12 +21,8 @@ import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webclient.spi.WebClientServiceProvider;
 
 /**
- * Client security SPI provider.
- *
- * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
- *  Use {@link WebClientSecurity} instead
+ * Client security SPI provider for {@link java.util.ServiceLoader}.
  */
-@Deprecated
 public class WebClientSecurityProvider implements WebClientServiceProvider {
 
     /**

--- a/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
+++ b/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
@@ -28,11 +28,7 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
  *
  * Weight must exceed that of WebClientSecurityProvider because WebClientSecurity depends on span information having already
  * been added to the request context by WebClientTracing.
- *
- * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
- *  Use {@link WebClientTracing} instead
  */
-@Deprecated
 @Weight(Weighted.DEFAULT_WEIGHT + 100)
 public class WebClientTracingProvider implements WebClientServiceProvider {
     /**

--- a/webclient/websocket/pom.xml
+++ b/webclient/websocket/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>helidon-common-buffers</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.websocket</groupId>
             <artifactId>helidon-websocket</artifactId>
         </dependency>
@@ -135,4 +140,3 @@
         </plugins>
     </build>
 </project>
-

--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WebSocketClient.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WebSocketClient.java
@@ -23,17 +23,17 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.helidon.common.Api;
 import io.helidon.service.registry.Service;
 
 /**
  * Annotations and APIs for type safe WebSocket clients.
  * <p>
  * The type safe WebSocket client is backed by Helidon {@link io.helidon.webclient.websocket.WsClient}.
- *
- * @deprecated this API is part of incubating features of Helidon. This API may change including backward incompatible changes
- *         and full removal. We welcome feedback for incubating features.
+ * <p>
+ * This API is preview and may change between minor releases.
  */
-@Deprecated
+@Api.Preview
 public final class WebSocketClient {
     private WebSocketClient() {
     }
@@ -54,6 +54,7 @@ public final class WebSocketClient {
      * If such a class already exists, there will be a name conflict, use {@link #factoryClassName()} to specify a custom
      * class name in such a case. The factory will always be in the same package as the annotated type.
      */
+    @Api.Preview
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.CLASS)
     @Documented

--- a/webclient/websocket/src/main/java/module-info.java
+++ b/webclient/websocket/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module io.helidon.webclient.websocket {
     requires io.helidon.webclient;
     requires io.helidon.websocket;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
     requires static io.helidon.config.metadata;
 

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsFeatureProvider.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.cors;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -33,10 +34,8 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 public class CorsFeatureProvider implements ServerFeatureProvider<CorsFeature> {
     /**
      * Required for {@link java.util.ServiceLoader}.
-     *
-     * @deprecated only for {@link java.util.ServiceLoader}
      */
-    @Deprecated
+    @Api.Internal
     public CorsFeatureProvider() {
     }
 

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
@@ -23,10 +23,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for config observe provider.
- *
- * @deprecated only for {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class ConfigObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
@@ -23,10 +23,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for health observe provider.
- *
- * @deprecated this type is only to be used from {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class HealthObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
@@ -23,10 +23,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for application information observe provider.
- *
- * @deprecated only for {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class InfoObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
@@ -28,10 +28,7 @@ import io.helidon.webserver.observe.spi.Observer;
  *  so changing a log level for a logger may be temporary (in case a garbage collector runs and the reference is not kept
  *  anywhere).
  * In Helidon, most loggers are referenced for the duration of the application, so this should not impact Helidon components.
- *
- * @deprecated only for {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class LogObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
@@ -23,10 +23,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for metrics observe provider.
- *
- * @deprecated only for {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class MetricsObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
@@ -27,10 +27,7 @@ import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for tracing observe provider.
- *
- * @deprecated this type is only to be used from {@link java.util.ServiceLoader}
  */
-@Deprecated
 public class TracingObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http;
 
+import io.helidon.common.Api;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.RoutedPath;
 
@@ -29,6 +30,7 @@ public interface RoutingRequest extends ServerRequest {
      * @param routedPath routed path, that provides matched path parameters from path pattern
      * @return this instance
      */
+    @Api.Internal
     RoutingRequest path(RoutedPath routedPath);
 
     /**
@@ -37,15 +39,17 @@ public interface RoutingRequest extends ServerRequest {
      * @param newPrologue new prologue to use (on rerouting)
      * @return this instance
      */
+    @Api.Internal
     RoutingRequest prologue(HttpPrologue newPrologue);
 
     /**
      * Update the pattern used to match this request. Such as "/foo/{bar}".
-     *  For internal use only to Helidon.
+     * For internal use only to Helidon.
      *
      * @param matchingPattern the matching pattern
      * @return this instance
      */
+    @Api.Internal
     default RoutingRequest matchingPattern(String matchingPattern) {
         return this;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/ErrorHandlerProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/ErrorHandlerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http.spi;
 
+import io.helidon.common.Api;
 import io.helidon.webserver.http.ErrorHandler;
 
 /**
@@ -25,15 +26,15 @@ import io.helidon.webserver.http.ErrorHandler;
  * Instances of this service discovered by service registry are only used when the whole server is started using it
  * (i.e. Helidon Declarative approach).
  * <p>
- * To manually register an error handle, please use
+ * NOTE: this API is part of preview features of Helidon. This API may still change between minor releases,
+ *               but it is intended for supported external use.
+ * <p>
+ * To manually register an error handler, please use
  * {@link io.helidon.webserver.http.HttpRouting.Builder#error(Class, io.helidon.webserver.http.ErrorHandler)}.
  *
  * @param <T> type of the exception handled by the handler
- *
- * @deprecated this API is part of incubating features of Helidon. This API may change including backward incompatible changes
- *               and full removal. We welcome feedback for incubating features.
  */
-@Deprecated
+@Api.Preview
 public interface ErrorHandlerProvider<T extends Throwable> {
     /**
      * Type of the exception to handle.


### PR DESCRIPTION
Resolves #11565

Finishes the remaining 4.x API-stability cleanup after PR #11688 by replacing the remaining Javadoc-only stability signals with explicit annotations where appropriate, keeping the metrics snapshot contract public, and updating the related module wiring.

There may be additional changes in the future, if we decide to change public APIs to internal (i.e. some codegen APIs)