### PR TITLE
Add validation codegen tests#11372

### DIFF
--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -31,13 +31,12 @@ import io.helidon.validation.Validation;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.codegen.testing.CodegenMatchers.matches;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ValidationCodegenTest {
+class ValidationCodegenTest {
     private static final List<Class<?>> CLASSPATH = List.of(
             Generated.class,
             Validation.Constraint.class,
@@ -47,69 +46,245 @@ public class ValidationCodegenTest {
     );
 
     @Test
-    void testFieldValidation() throws IOException {
-        var result = TestCompiler.builder()
-                .currentRelease()
-                .addClasspath(CLASSPATH)
-                .addProcessor(AptProcessor::new)
-                .addSource("Foo.java", """
-                        package com.example;
-                        
-                        import io.helidon.validation.Validation;
-                        
-                        @Validation.Validated
-                        public class Foo {
-                            @Validation.Integer.Min(1)
-                            Integer id;
-                        }
-                        """)
-                .build()
-                .compile();
+    void testSupportedClassElements() throws IOException {
+        var result = compile("""
+                package com.example;
 
-        assertThat(result.success(), is(true));
-        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
-        assertThat(Files.exists(validator), is(true));
+                import io.helidon.validation.Validation;
 
-        var content = Files.readString(validator, StandardCharsets.UTF_8);
-        assertThat(content, matches("""
-                                            //...
-                                            class Foo__Validated implements TypeValidator<Foo> {
-                                            //...
-                                                        case "id" -> checkId(ctx, (Integer) value);
-                                            //...
-                                            }
-                                            """));
-        String diags = String.join("\n", result.diagnostics());
-        assertThat(diags, not(containsString("warning:")));
+                @Validation.Validated
+                public class Foo {
+                    @Validation.Integer.Min(1)
+                    Integer id;
+
+                    @Validation.Integer.Min(1)
+                    public Integer getAge() {
+                        return 42;
+                    }
+
+                    @Validation.Integer.Min(1)
+                    Integer size() {
+                        return 1;
+                    }
+                }
+                """);
+
+        assertGeneratedAndContainsCases(result, "Foo", "id", "age", "size");
     }
 
     @Test
-    void testPrivateFieldValidation() throws IOException {
-        var result = TestCompiler.builder()
+    void testSupportedRecordElements() throws IOException {
+        var result = compile("""
+                package com.example;
+
+                import io.helidon.validation.Validation;
+
+                @Validation.Validated
+                public record Foo(@Validation.Integer.Min(1) Integer id,
+                                  @Validation.Integer.Min(1) Integer age) {
+                }
+                """);
+
+        assertGeneratedAndContainsCases(result, "Foo", "id", "age");
+    }
+
+    @Test
+    void testSupportedInterfaceElements() throws IOException {
+        var result = compile("""
+                package com.example;
+
+                import io.helidon.validation.Validation;
+
+                @Validation.Validated
+                public interface Foo {
+                    @Validation.Integer.Min(1)
+                    Integer getId();
+
+                    @Validation.Integer.Min(1)
+                    Integer size();
+                }
+                """);
+
+        assertGeneratedAndContainsCases(result, "Foo", "id", "size");
+    }
+
+    @Test
+    void testUnsupportedClassElements() {
+        for (UnsupportedCase unsupportedCase : unsupportedClassElements()) {
+            var result = compile(unsupportedCase.source());
+
+            assertCompilationFails(result,
+                                   "Only non-private fields and getter methods are supported",
+                                   unsupportedCase.expectedElement());
+            var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+            assertThat("The Foo__Validated.java should not be generated (" + unsupportedCase.name() + ")",
+                       Files.exists(validator),
+                       is(false));
+        }
+    }
+
+    @Test
+    void testUnsupportedValidatedTypeKind() {
+        var result = compile("""
+                package com.example;
+
+                import io.helidon.validation.Validation;
+
+                @Validation.Validated
+                enum Foo {
+                    INSTANCE
+                }
+                """);
+
+        assertCompilationFails(result, "Only record, class, or interface are currently supported");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated", Files.exists(validator), is(false));
+    }
+
+    private static List<UnsupportedCase> unsupportedClassElements() {
+        return List.of(
+                new UnsupportedCase("private field",
+                                    """
+                                     package com.example;
+
+                                     import io.helidon.validation.Validation;
+
+                                     @Validation.Validated
+                                     public class Foo {
+                                         @Validation.Integer.Min(1)
+                                         private Integer id;
+                                     }
+                                     """,
+                                    "private Integer id"),
+                new UnsupportedCase("static field",
+                                    """
+                                     package com.example;
+
+                                     import io.helidon.validation.Validation;
+
+                                     @Validation.Validated
+                                     public class Foo {
+                                         @Validation.Integer.Min(1)
+                                         static Integer id;
+                                     }
+                                     """,
+                                    "static Integer id"),
+                new UnsupportedCase("private method",
+                                    """
+                                     package com.example;
+
+                                     import io.helidon.validation.Validation;
+
+                                     @Validation.Validated
+                                     public class Foo {
+                                         @Validation.Valid
+                                         private Integer id() {
+                                             return 1;
+                                         }
+                                     }
+                                     """,
+                                    "private Integer id()"),
+                new UnsupportedCase("static method",
+                                    """
+                                     package com.example;
+
+                                     import io.helidon.validation.Validation;
+
+                                     @Validation.Validated
+                                     public class Foo {
+                                         @Validation.Valid
+                                         static Integer id() {
+                                             return 1;
+                                         }
+                                     }
+                                     """,
+                                    "static Integer id()"),
+                new UnsupportedCase("method with arguments",
+                                    """
+                                     package com.example;
+
+                                     import io.helidon.validation.Validation;
+
+                                     @Validation.Validated
+                                     public class Foo {
+                                         @Validation.Valid
+                                         Integer id(Integer value) {
+                                             return value;
+                                         }
+                                     }
+                                     """,
+                                    "Integer id(Integer value)"),
+                new UnsupportedCase("void method",
+                                    """
+                                     package com.example;
+
+                                     import io.helidon.validation.Validation;
+
+                                     @Validation.Validated
+                                     public class Foo {
+                                         @Validation.Valid
+                                         void ping() {
+                                         }
+                                     }
+                                     """,
+                                    "void ping()"),
+                new UnsupportedCase("constructor",
+                                    """
+                                     package com.example;
+
+                                     import io.helidon.validation.Validation;
+
+                                     @Validation.Validated
+                                     public class Foo {
+                                         @Validation.Valid
+                                         Foo() {
+                                         }
+                                     }
+                                     """,
+                                    "Foo()")
+        );
+    }
+
+    private TestCompiler.Result compile(String source) {
+        return TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(CLASSPATH)
                 .addProcessor(AptProcessor::new)
-                .addSource("Foo.java", """
-                        package com.example;
-                        
-                        import io.helidon.validation.Validation;
-                        
-                        @Validation.Validated
-                        public class Foo {
-                            @Validation.Integer.Min(1)
-                            private Integer id;
-                        }
-                        """)
+                .addSource("Foo.java", source)
                 .build()
                 .compile();
+    }
 
-        assertThat("Build should fail, as we do not support constraints on private fields", result.success(), is(false));
-        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
-        assertThat("The Foo__Validator.java should not be generated", Files.exists(validator), is(false));
-
+    private void assertGeneratedAndContainsCases(TestCompiler.Result result,
+                                                 String typeName,
+                                                 String... propertyNames) throws IOException {
         String diagnostics = String.join("\n", result.diagnostics());
+        assertThat("Compilation diagnostics: " + diagnostics, result.success(), is(true));
+        assertThat(diagnostics, not(containsString("warning:")));
+
+        var validator = result.sourceOutput().resolve("com/example/" + typeName + "__Validated.java");
+        assertThat(Files.exists(validator), is(true));
+
+        var content = Files.readString(validator, StandardCharsets.UTF_8);
+        for (String propertyName : propertyNames) {
+            assertThat(content, containsString("case \"" + propertyName + "\" -> check"
+                                                       + capitalize(propertyName) + "(ctx, (Integer) value);"));
+        }
+    }
+
+    private void assertCompilationFails(TestCompiler.Result result, String... diagnosticParts) {
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat("Build should fail", result.success(), is(false));
         assertThat(diagnostics, containsString("error:"));
-        assertThat(diagnostics, containsString("private Integer id"));
-        assertThat(diagnostics, containsString("Only non-private fields and getter methods are supported"));
+        for (String diagnosticPart : diagnosticParts) {
+            assertThat(diagnostics, containsString(diagnosticPart));
+        }
+    }
+
+    private static String capitalize(String name) {
+        return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    }
+
+    private record UnsupportedCase(String name, String source, String expectedElement) {
     }
 }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -47,240 +47,284 @@ class ValidationCodegenTest {
             Prototype.class
     );
 
-    // ------ Supported kind/type tests ---------------//
-
     @Test
     void testSupportedClassElements() throws IOException {
-        var result = compile("""
-                package com.example;
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
 
-                import io.helidon.validation.Validation;
+                        import io.helidon.validation.Validation;
 
-                @Validation.Validated
-                public class Foo {
-                    @Validation.Integer.Min(1)
-                    Integer id;
+                        @Validation.Validated
+                        public class Foo {
+                            @Validation.Integer.Min(1)
+                            Integer id;
 
-                    @Validation.Integer.Min(1)
-                    public Integer getAge() {
-                        return 42;
-                    }
+                            @Validation.Integer.Min(1)
+                            public Integer getAge() {
+                                return 42;
+                            }
 
-                    @Validation.Integer.Min(1)
-                    Integer size() {
-                        return 1;
-                    }
-                }
-                """);
+                            @Validation.Integer.Min(1)
+                            Integer size() {
+                                return 1;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertGeneratedAndContainsCases(result, "Foo", "id", "age", "size");
     }
 
     @Test
     void testSupportedRecordElements() throws IOException {
-        var result = compile("""
-                package com.example;
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
 
-                import io.helidon.validation.Validation;
+                        import io.helidon.validation.Validation;
 
-                @Validation.Validated
-                public record Foo(@Validation.Integer.Min(1) Integer id,
-                                  @Validation.Integer.Min(1) Integer age) {
-                }
-                """);
+                        @Validation.Validated
+                        public record Foo(@Validation.Integer.Min(1) Integer id,
+                                          @Validation.Integer.Min(1) Integer age) {
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertGeneratedAndContainsCases(result, "Foo", "id", "age");
     }
 
     @Test
     void testSupportedInterfaceElements() throws IOException {
-        var result = compile("""
-                package com.example;
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
 
-                import io.helidon.validation.Validation;
+                        import io.helidon.validation.Validation;
 
-                @Validation.Validated
-                public interface Foo {
-                    @Validation.Integer.Min(1)
-                    Integer getId();
+                        @Validation.Validated
+                        public interface Foo {
+                            @Validation.Integer.Min(1)
+                            Integer getId();
 
-                    @Validation.Integer.Min(1)
-                    Integer size();
-                }
-                """);
+                            @Validation.Integer.Min(1)
+                            Integer size();
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertGeneratedAndContainsCases(result, "Foo", "id", "size");
     }
 
-    // ------ Unsupported kind/type tests ---------------//
-
     @Test
     void testUnsupportedPrivateField() {
-        UnsupportedCase unsupported = new UnsupportedCase("private field",
-                                                  """
-                                                   package com.example;
-              
-                                                   import io.helidon.validation.Validation;
-              
-                                                   @Validation.Validated
-                                                   public class Foo {
-                                                       @Validation.Integer.Min(1)
-                                                       private Integer id;
-                                                   }
-                                                   """,
-                                                  "private Integer id");
-        var result = compile(unsupported.source());
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public class Foo {
+                            @Validation.Integer.Min(1)
+                            private Integer id;
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertCompilationFails(result,
                                "Only non-private fields and getter methods are supported",
-                               unsupported.expectedElement());
-        assertFileNotGenerated(result, unsupported);
+                               "private Integer id");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (private field)", Files.exists(validator), is(false));
     }
 
     @Test
     void testUnsupportedStaticField() {
-        UnsupportedCase unsupported = new UnsupportedCase("static field",
-                                                      """
-                                                       package com.example;
-                  
-                                                       import io.helidon.validation.Validation;
-                  
-                                                       @Validation.Validated
-                                                       public class Foo {
-                                                           @Validation.Integer.Min(1)
-                                                           static Integer id;
-                                                       }
-                                                       """,
-                                                      "static Integer id");
-        var result = compile(unsupported.source());
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public class Foo {
+                            @Validation.Integer.Min(1)
+                            static Integer id;
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertCompilationFails(result,
                                "Only non-private fields and getter methods are supported",
-                               unsupported.expectedElement());
-        assertFileNotGenerated(result, unsupported);
+                               "static Integer id");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (static field)", Files.exists(validator), is(false));
     }
 
     @Test
     void testUnsupportedPrivateMethod() {
-        UnsupportedCase unsupported = new UnsupportedCase("private method",
-                                                      """
-                                                       package com.example;
-                  
-                                                       import io.helidon.validation.Validation;
-                  
-                                                       @Validation.Validated
-                                                       public class Foo {
-                                                           @Validation.Valid
-                                                           private Integer id() {
-                                                               return 1;
-                                                           }
-                                                       }
-                                                       """,
-                                                      "private Integer id()");
-        var result = compile(unsupported.source());
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public class Foo {
+                            @Validation.Valid
+                            private Integer id() {
+                                return 1;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertCompilationFails(result,
                                "Only non-private fields and getter methods are supported",
-                               unsupported.expectedElement());
-        assertFileNotGenerated(result, unsupported);
+                               "private Integer id()");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (private method)", Files.exists(validator), is(false));
     }
 
     @Test
     void testUnsupportedStaticMethod() {
-        UnsupportedCase unsupported = new UnsupportedCase("static method",
-                                                      """
-                                                       package com.example;
-                  
-                                                       import io.helidon.validation.Validation;
-                  
-                                                       @Validation.Validated
-                                                       public class Foo {
-                                                           @Validation.Valid
-                                                           static Integer id() {
-                                                               return 1;
-                                                           }
-                                                       }
-                                                       """,
-                                                      "static Integer id()");
-        var result = compile(unsupported.source());
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public class Foo {
+                            @Validation.Valid
+                            static Integer id() {
+                                return 1;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertCompilationFails(result,
                                "Only non-private fields and getter methods are supported",
-                               unsupported.expectedElement());
-        assertFileNotGenerated(result, unsupported);
+                               "static Integer id()");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (static method)", Files.exists(validator), is(false));
     }
 
     @Test
     void testUnsupportedMethodWithArguments() {
-        UnsupportedCase unsupported = new UnsupportedCase("method with arguments",
-                                                      """
-                                                       package com.example;
-                  
-                                                       import io.helidon.validation.Validation;
-                  
-                                                       @Validation.Validated
-                                                       public class Foo {
-                                                           @Validation.Valid
-                                                           Integer id(Integer value) {
-                                                               return value;
-                                                           }
-                                                       }
-                                                       """,
-                                                      "Integer id(Integer value)");
-        var result = compile(unsupported.source());
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public class Foo {
+                            @Validation.Valid
+                            Integer id(Integer value) {
+                                return value;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertCompilationFails(result,
                                "Only non-private fields and getter methods are supported",
-                               unsupported.expectedElement());
-        assertFileNotGenerated(result, unsupported);
+                               "Integer id(Integer value)");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (method with arguments)",
+                   Files.exists(validator),
+                   is(false));
     }
 
     @Test
     void testUnsupportedVoidMethod() {
-        UnsupportedCase unsupported = new UnsupportedCase("void method",
-                                                      """
-                                                       package com.example;
-                  
-                                                       import io.helidon.validation.Validation;
-                  
-                                                       @Validation.Validated
-                                                       public class Foo {
-                                                           @Validation.Valid
-                                                           void ping() {
-                                                           }
-                                                       }
-                                                       """,
-                                                      "void ping()");
-        var result = compile(unsupported.source());
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public class Foo {
+                            @Validation.Valid
+                            void ping() {
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertCompilationFails(result,
                                "Only non-private fields and getter methods are supported",
-                               unsupported.expectedElement());
-        assertFileNotGenerated(result, unsupported);
+                               "void ping()");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (void method)", Files.exists(validator), is(false));
     }
 
     @Test
     void testUnsupportedConstructor() {
-        UnsupportedCase unsupported = new UnsupportedCase("constructor",
-                                                      """
-                                                       package com.example;
-                  
-                                                       import io.helidon.validation.Validation;
-                  
-                                                       @Validation.Validated
-                                                       public class Foo {
-                                                           @Validation.Valid
-                                                           Foo() {
-                                                           }
-                                                       }
-                                                       """,
-                                                      "Foo()");
-        var result = compile(unsupported.source());
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public class Foo {
+                            @Validation.Valid
+                            Foo() {
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
 
         assertCompilationFails(result,
                                "Only non-private fields and getter methods are supported",
-                               unsupported.expectedElement());
-        assertFileNotGenerated(result, unsupported);
+                               "Foo()");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (constructor)", Files.exists(validator), is(false));
     }
 
     @Test
@@ -318,35 +362,32 @@ class ValidationCodegenTest {
 
     @Test
     void testInterfaceStaticAnnotatedMethodFailsCompilation() {
-        UnsupportedCase unsupported = new UnsupportedCase("interface static method",
-                                                          """
-                                                          package com.example;
-
-                                                          import io.helidon.validation.Validation;
-
-                                                          @Validation.Validated
-                                                          public interface Foo {
-                                                              @Validation.Integer.Min(1)
-                                                              static Integer id() {
-                                                                  return 1;
-                                                              }
-                                                          }
-                                                          """,
-                                                          "id");
         var result = TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(CLASSPATH)
                 .addProcessor(AptProcessor::new)
-                .addSource("Foo.java", unsupported.source())
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public interface Foo {
+                            @Validation.Integer.Min(1)
+                            static Integer id() {
+                                return 1;
+                            }
+                        }
+                        """)
                 .build()
                 .compile();
 
         String diagnostics = String.join("\n", result.diagnostics());
         assertThat("Build should fail", result.success(), is(false));
         assertThat(diagnostics, containsString("error:"));
-        assertThat(diagnostics, containsString(unsupported.expectedElement()));
+        assertThat(diagnostics, containsString("id"));
         var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
-        assertThat("The Foo__Validated.java should be generated (" + unsupported.name() + ")",
+        assertThat("The Foo__Validated.java should be generated (interface static method)",
                    Files.exists(validator),
                    is(true));
     }
@@ -447,61 +488,50 @@ class ValidationCodegenTest {
 
     @Test
     void testUnsupportedEnumType() {
-        UnsupportedCase unsupported = new UnsupportedCase("enum",
-                                                      """
-                                                      package com.example;
-
-                                                      import io.helidon.validation.Validation;
-
-                                                      @Validation.Validated
-                                                      enum Foo {
-                                                         INSTANCE
-                                                      }
-                                                      """,
-                                                      "Foo");
-
-        var result = compile(unsupported.source());
-        assertCompilationFails(result, "Only record, class, or interface are currently supported");
-        assertFileNotGenerated(result, unsupported);
-    }
-
-    @Test
-    void testUnsupportedAnnotationType() {
-        UnsupportedCase unsupported = new UnsupportedCase("annotation type",
-                                                          """
-                                                          package com.example;
-
-                                                          import io.helidon.validation.Validation;
-
-                                                          @Validation.Validated
-                                                          public @interface Foo {
-                                                              @Validation.Integer.Min(1)
-                                                              int value();
-                                                          }
-                                                          """,
-                                                          "Foo");
         var result = TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(CLASSPATH)
                 .addProcessor(AptProcessor::new)
-                .addSource("Foo.java", unsupported.source())
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        enum Foo {
+                            INSTANCE
+                        }
+                        """)
+                .build()
+                .compile();
+        assertCompilationFails(result, "Only record, class, or interface are currently supported");
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (enum)", Files.exists(validator), is(false));
+    }
+
+    @Test
+    void testUnsupportedAnnotationType() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public @interface Foo {
+                            @Validation.Integer.Min(1)
+                            int value();
+                        }
+                        """)
                 .build()
                 .compile();
 
         assertCompilationFails(result, "Only record, class, or interface are currently supported");
-        assertFileNotGenerated(result, unsupported);
-    }
-
-    // --------- Helper Methods ----------------//
-
-    private TestCompiler.Result compile(String source) {
-        return TestCompiler.builder()
-                .currentRelease()
-                .addClasspath(CLASSPATH)
-                .addProcessor(AptProcessor::new)
-                .addSource("Foo.java", source)
-                .build()
-                .compile();
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (annotation type)", Files.exists(validator), is(false));
     }
 
     private void assertGeneratedAndContainsCases(TestCompiler.Result result,
@@ -530,13 +560,4 @@ class ValidationCodegenTest {
         }
     }
 
-    private void assertFileNotGenerated(TestCompiler.Result result, UnsupportedCase unsupportedCase) {
-        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
-        assertThat("The Foo__Validated.java should not be generated (" + unsupportedCase.name() + ")",
-                   Files.exists(validator),
-                   is(false));
-    }
-
-    private record UnsupportedCase(String name, String source, String expectedElement) {
-    }
 }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -31,6 +31,8 @@ import io.helidon.validation.Validation;
 
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.codegen.CodegenUtil.capitalize;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -44,6 +46,8 @@ class ValidationCodegenTest {
             Service.class,
             Prototype.class
     );
+
+    // ------ Supported kind/type tests ---------------//
 
     @Test
     void testSupportedClassElements() throws IOException {
@@ -108,142 +112,387 @@ class ValidationCodegenTest {
         assertGeneratedAndContainsCases(result, "Foo", "id", "size");
     }
 
-    @Test
-    void testUnsupportedClassElements() {
-        for (UnsupportedCase unsupportedCase : unsupportedClassElements()) {
-            var result = compile(unsupportedCase.source());
+    // ------ Unsupported kind/type tests ---------------//
 
-            assertCompilationFails(result,
-                                   "Only non-private fields and getter methods are supported",
-                                   unsupportedCase.expectedElement());
-            var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
-            assertThat("The Foo__Validated.java should not be generated (" + unsupportedCase.name() + ")",
-                       Files.exists(validator),
-                       is(false));
-        }
+    @Test
+    void testUnsupportedPrivateField() {
+        UnsupportedCase unsupported = new UnsupportedCase("private field",
+                                                  """
+                                                   package com.example;
+              
+                                                   import io.helidon.validation.Validation;
+              
+                                                   @Validation.Validated
+                                                   public class Foo {
+                                                       @Validation.Integer.Min(1)
+                                                       private Integer id;
+                                                   }
+                                                   """,
+                                                  "private Integer id");
+        var result = compile(unsupported.source());
+
+        assertCompilationFails(result,
+                               "Only non-private fields and getter methods are supported",
+                               unsupported.expectedElement());
+        assertFileNotGenerated(result, unsupported);
     }
 
     @Test
-    void testUnsupportedValidatedTypeKind() {
-        var result = compile("""
-                package com.example;
+    void testUnsupportedStaticField() {
+        UnsupportedCase unsupported = new UnsupportedCase("static field",
+                                                      """
+                                                       package com.example;
+                  
+                                                       import io.helidon.validation.Validation;
+                  
+                                                       @Validation.Validated
+                                                       public class Foo {
+                                                           @Validation.Integer.Min(1)
+                                                           static Integer id;
+                                                       }
+                                                       """,
+                                                      "static Integer id");
+        var result = compile(unsupported.source());
 
-                import io.helidon.validation.Validation;
+        assertCompilationFails(result,
+                               "Only non-private fields and getter methods are supported",
+                               unsupported.expectedElement());
+        assertFileNotGenerated(result, unsupported);
+    }
 
-                @Validation.Validated
-                enum Foo {
-                    INSTANCE
-                }
-                """);
+    @Test
+    void testUnsupportedPrivateMethod() {
+        UnsupportedCase unsupported = new UnsupportedCase("private method",
+                                                      """
+                                                       package com.example;
+                  
+                                                       import io.helidon.validation.Validation;
+                  
+                                                       @Validation.Validated
+                                                       public class Foo {
+                                                           @Validation.Valid
+                                                           private Integer id() {
+                                                               return 1;
+                                                           }
+                                                       }
+                                                       """,
+                                                      "private Integer id()");
+        var result = compile(unsupported.source());
+
+        assertCompilationFails(result,
+                               "Only non-private fields and getter methods are supported",
+                               unsupported.expectedElement());
+        assertFileNotGenerated(result, unsupported);
+    }
+
+    @Test
+    void testUnsupportedStaticMethod() {
+        UnsupportedCase unsupported = new UnsupportedCase("static method",
+                                                      """
+                                                       package com.example;
+                  
+                                                       import io.helidon.validation.Validation;
+                  
+                                                       @Validation.Validated
+                                                       public class Foo {
+                                                           @Validation.Valid
+                                                           static Integer id() {
+                                                               return 1;
+                                                           }
+                                                       }
+                                                       """,
+                                                      "static Integer id()");
+        var result = compile(unsupported.source());
+
+        assertCompilationFails(result,
+                               "Only non-private fields and getter methods are supported",
+                               unsupported.expectedElement());
+        assertFileNotGenerated(result, unsupported);
+    }
+
+    @Test
+    void testUnsupportedMethodWithArguments() {
+        UnsupportedCase unsupported = new UnsupportedCase("method with arguments",
+                                                      """
+                                                       package com.example;
+                  
+                                                       import io.helidon.validation.Validation;
+                  
+                                                       @Validation.Validated
+                                                       public class Foo {
+                                                           @Validation.Valid
+                                                           Integer id(Integer value) {
+                                                               return value;
+                                                           }
+                                                       }
+                                                       """,
+                                                      "Integer id(Integer value)");
+        var result = compile(unsupported.source());
+
+        assertCompilationFails(result,
+                               "Only non-private fields and getter methods are supported",
+                               unsupported.expectedElement());
+        assertFileNotGenerated(result, unsupported);
+    }
+
+    @Test
+    void testUnsupportedVoidMethod() {
+        UnsupportedCase unsupported = new UnsupportedCase("void method",
+                                                      """
+                                                       package com.example;
+                  
+                                                       import io.helidon.validation.Validation;
+                  
+                                                       @Validation.Validated
+                                                       public class Foo {
+                                                           @Validation.Valid
+                                                           void ping() {
+                                                           }
+                                                       }
+                                                       """,
+                                                      "void ping()");
+        var result = compile(unsupported.source());
+
+        assertCompilationFails(result,
+                               "Only non-private fields and getter methods are supported",
+                               unsupported.expectedElement());
+        assertFileNotGenerated(result, unsupported);
+    }
+
+    @Test
+    void testUnsupportedConstructor() {
+        UnsupportedCase unsupported = new UnsupportedCase("constructor",
+                                                      """
+                                                       package com.example;
+                  
+                                                       import io.helidon.validation.Validation;
+                  
+                                                       @Validation.Validated
+                                                       public class Foo {
+                                                           @Validation.Valid
+                                                           Foo() {
+                                                           }
+                                                       }
+                                                       """,
+                                                      "Foo()");
+        var result = compile(unsupported.source());
+
+        assertCompilationFails(result,
+                               "Only non-private fields and getter methods are supported",
+                               unsupported.expectedElement());
+        assertFileNotGenerated(result, unsupported);
+    }
+
+    @Test
+    void testInterfacePrivateAnnotatedMethodFailsCompilation() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public interface Foo {
+                            @Validation.Integer.Min(1)
+                            private Integer id() {
+                                return 1;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat("Build should fail", result.success(), is(false));
+        assertThat(diagnostics, containsString("error:"));
+        assertThat(diagnostics, containsString("unreachable statement"));
+
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat(Files.exists(validator), is(true));
+        var content = Files.readString(validator, StandardCharsets.UTF_8);
+        assertThat(content, not(containsString("case \"id\" -> checkId(ctx, (Integer) value);")));
+    }
+
+    @Test
+    void testInterfaceStaticAnnotatedMethodFailsCompilation() {
+        UnsupportedCase unsupported = new UnsupportedCase("interface static method",
+                                                          """
+                                                          package com.example;
+
+                                                          import io.helidon.validation.Validation;
+
+                                                          @Validation.Validated
+                                                          public interface Foo {
+                                                              @Validation.Integer.Min(1)
+                                                              static Integer id() {
+                                                                  return 1;
+                                                              }
+                                                          }
+                                                          """,
+                                                          "id");
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", unsupported.source())
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat("Build should fail", result.success(), is(false));
+        assertThat(diagnostics, containsString("error:"));
+        assertThat(diagnostics, containsString(unsupported.expectedElement()));
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should be generated (" + unsupported.name() + ")",
+                   Files.exists(validator),
+                   is(true));
+    }
+
+    @Test
+    void testInterfaceDefaultAnnotatedMethodSupported() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public interface Foo {
+                            @Validation.Integer.Min(1)
+                            default Integer id() {
+                                return 1;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat("Compilation diagnostics: " + diagnostics, result.success(), is(true));
+        assertThat(diagnostics, not(containsString("warning:")));
+
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat(Files.exists(validator), is(true));
+        var content = Files.readString(validator, StandardCharsets.UTF_8);
+        assertThat(content, containsString("case \"id\" -> checkId(ctx, (Integer) value);"));
+    }
+
+    @Test
+    void testInterfaceAnnotatedMethodWithArgumentsFailsCompilation() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public interface Foo {
+                            @Validation.Valid
+                            Integer id(Integer value);
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat("Build should fail", result.success(), is(false));
+        assertThat(diagnostics, containsString("error:"));
+        assertThat(diagnostics, containsString("unreachable statement"));
+
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat(Files.exists(validator), is(true));
+        var content = Files.readString(validator, StandardCharsets.UTF_8);
+        assertThat(content, not(containsString("case \"id\" -> checkId(ctx, (Integer) value);")));
+    }
+
+    @Test
+    void testInterfaceAnnotatedVoidMethodFailsCompilation() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public interface Foo {
+                            @Validation.Valid
+                            void ping();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat("Build should fail", result.success(), is(false));
+        assertThat(diagnostics, containsString("error:"));
+        assertThat(diagnostics, containsString("unreachable statement"));
+
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat(Files.exists(validator), is(true));
+        var content = Files.readString(validator, StandardCharsets.UTF_8);
+        assertThat(content, not(containsString("case \"ping\" -> checkPing(ctx, (Integer) value);")));
+    }
+
+    @Test
+    void testUnsupportedEnumType() {
+        UnsupportedCase unsupported = new UnsupportedCase("enum",
+                                                      """
+                                                      package com.example;
+
+                                                      import io.helidon.validation.Validation;
+
+                                                      @Validation.Validated
+                                                      enum Foo {
+                                                         INSTANCE
+                                                      }
+                                                      """,
+                                                      "Foo");
+
+        var result = compile(unsupported.source());
+        assertCompilationFails(result, "Only record, class, or interface are currently supported");
+        assertFileNotGenerated(result, unsupported);
+    }
+
+    @Test
+    void testUnsupportedAnnotationType() {
+        UnsupportedCase unsupported = new UnsupportedCase("annotation type",
+                                                          """
+                                                          package com.example;
+
+                                                          import io.helidon.validation.Validation;
+
+                                                          @Validation.Validated
+                                                          public @interface Foo {
+                                                              @Validation.Integer.Min(1)
+                                                              int value();
+                                                          }
+                                                          """,
+                                                          "Foo");
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("Foo.java", unsupported.source())
+                .build()
+                .compile();
 
         assertCompilationFails(result, "Only record, class, or interface are currently supported");
-        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
-        assertThat("The Foo__Validated.java should not be generated", Files.exists(validator), is(false));
+        assertFileNotGenerated(result, unsupported);
     }
 
-    private static List<UnsupportedCase> unsupportedClassElements() {
-        return List.of(
-                new UnsupportedCase("private field",
-                                    """
-                                     package com.example;
-
-                                     import io.helidon.validation.Validation;
-
-                                     @Validation.Validated
-                                     public class Foo {
-                                         @Validation.Integer.Min(1)
-                                         private Integer id;
-                                     }
-                                     """,
-                                    "private Integer id"),
-                new UnsupportedCase("static field",
-                                    """
-                                     package com.example;
-
-                                     import io.helidon.validation.Validation;
-
-                                     @Validation.Validated
-                                     public class Foo {
-                                         @Validation.Integer.Min(1)
-                                         static Integer id;
-                                     }
-                                     """,
-                                    "static Integer id"),
-                new UnsupportedCase("private method",
-                                    """
-                                     package com.example;
-
-                                     import io.helidon.validation.Validation;
-
-                                     @Validation.Validated
-                                     public class Foo {
-                                         @Validation.Valid
-                                         private Integer id() {
-                                             return 1;
-                                         }
-                                     }
-                                     """,
-                                    "private Integer id()"),
-                new UnsupportedCase("static method",
-                                    """
-                                     package com.example;
-
-                                     import io.helidon.validation.Validation;
-
-                                     @Validation.Validated
-                                     public class Foo {
-                                         @Validation.Valid
-                                         static Integer id() {
-                                             return 1;
-                                         }
-                                     }
-                                     """,
-                                    "static Integer id()"),
-                new UnsupportedCase("method with arguments",
-                                    """
-                                     package com.example;
-
-                                     import io.helidon.validation.Validation;
-
-                                     @Validation.Validated
-                                     public class Foo {
-                                         @Validation.Valid
-                                         Integer id(Integer value) {
-                                             return value;
-                                         }
-                                     }
-                                     """,
-                                    "Integer id(Integer value)"),
-                new UnsupportedCase("void method",
-                                    """
-                                     package com.example;
-
-                                     import io.helidon.validation.Validation;
-
-                                     @Validation.Validated
-                                     public class Foo {
-                                         @Validation.Valid
-                                         void ping() {
-                                         }
-                                     }
-                                     """,
-                                    "void ping()"),
-                new UnsupportedCase("constructor",
-                                    """
-                                     package com.example;
-
-                                     import io.helidon.validation.Validation;
-
-                                     @Validation.Validated
-                                     public class Foo {
-                                         @Validation.Valid
-                                         Foo() {
-                                         }
-                                     }
-                                     """,
-                                    "Foo()")
-        );
-    }
+    // --------- Helper Methods ----------------//
 
     private TestCompiler.Result compile(String source) {
         return TestCompiler.builder()
@@ -281,8 +530,11 @@ class ValidationCodegenTest {
         }
     }
 
-    private static String capitalize(String name) {
-        return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    private void assertFileNotGenerated(TestCompiler.Result result, UnsupportedCase unsupportedCase) {
+        var validator = result.sourceOutput().resolve("com/example/Foo__Validated.java");
+        assertThat("The Foo__Validated.java should not be generated (" + unsupportedCase.name() + ")",
+                   Files.exists(validator),
+                   is(false));
     }
 
     private record UnsupportedCase(String name, String source, String expectedElement) {


### PR DESCRIPTION
### Description

Resolves https://github.com/helidon-io/helidon/issues/11372

https://github.com/helidon-io/helidon/issues/11360 resolves an issues where unsupported type (private field with constraint) is causing Codegen failure. 

This is a followup change to add tests to Codegen to cover for all supported and unsupported type of kind/elements.

Supported types
==============
class: non-private non-static field + supported methods
record: record components
interface: supported methods

Unsupported Types
===============
private field
static field
private method
static method
method with args
void method
constructor
Negative test for unsupported @Validation.Validated type kind (enum), asserting the illegal type error

### Documentation
None

Testing
-------
Build project and run the tests successfully with the following command (locally)
mvn -f declarative/tests/codegen/pom.xml -Dtest=ValidationCodegenTest test