### PR TITLE
Fix builder generic type variable handling (27.x)

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
@@ -884,15 +884,69 @@ final class FactoryOption {
                 .build();
     }
 
-    // if no package, assume same package as blueprint (generated as part of this annotation round)
+    // Blank-package names are either same-round generated types or type variables.
+    // Keep the latter unqualified and recursively repair the former.
     static TypeName fixEmptyPackage(TypeName typeName, String packageName) {
-        if (typeName.packageName().isBlank()) {
-            // if not package, assume same package as blueprint (generated as part of this annotation round)
-            return TypeName.builder(typeName)
-                    .packageName(packageName)
-                    .build();
+        boolean changed = false;
+        var builder = TypeName.builder(typeName);
+
+        if (typeName.packageName().isBlank() && !preserveEmptyPackage(typeName)) {
+            builder.packageName(packageName);
+            changed = true;
         }
-        return typeName;
+
+        List<TypeName> typeArguments = fixEmptyPackage(typeName.typeArguments(), packageName);
+        if (!typeArguments.equals(typeName.typeArguments())) {
+            builder.typeArguments(typeArguments);
+            changed = true;
+        }
+
+        List<TypeName> lowerBounds = fixEmptyPackage(typeName.lowerBounds(), packageName);
+        if (!lowerBounds.equals(typeName.lowerBounds())) {
+            builder.lowerBounds(lowerBounds);
+            changed = true;
+        }
+
+        List<TypeName> upperBounds = fixEmptyPackage(typeName.upperBounds(), packageName);
+        if (!upperBounds.equals(typeName.upperBounds())) {
+            builder.upperBounds(upperBounds);
+            changed = true;
+        }
+
+        if (typeName.componentType().isPresent()) {
+            TypeName componentType = typeName.componentType().orElseThrow();
+            TypeName fixedComponentType = fixEmptyPackage(componentType, packageName);
+            if (!fixedComponentType.equals(componentType)) {
+                builder.componentType(fixedComponentType);
+                changed = true;
+            }
+        }
+
+        return changed ? builder.build() : typeName;
+    }
+
+    private static List<TypeName> fixEmptyPackage(List<TypeName> typeNames, String packageName) {
+        return typeNames.stream()
+                .map(it -> fixEmptyPackage(it, packageName))
+                .toList();
+    }
+
+    private static boolean preserveEmptyPackage(TypeName typeName) {
+        if (typeName.wildcard()) {
+            return true;
+        }
+        if (!typeName.packageName().isBlank()
+                || !typeName.enclosingNames().isEmpty()
+                || !typeName.typeArguments().isEmpty()) {
+            return false;
+        }
+        if (typeName.generic()) {
+            return true;
+        }
+
+        return typeName.className()
+                .chars()
+                .allMatch(it -> Character.isUpperCase(it) || Character.isDigit(it) || it == '_');
     }
 
     private static TypeName propertyTypeName(PrototypeInfo prototypeInfo, TypedElementInfo element) {
@@ -902,33 +956,7 @@ final class FactoryOption {
                 .flatMap(Annotation::value)
                 .map(TypeName::create)
                 .orElseGet(element::typeName);
-        typeName = fixEmptyPackage(typeName, blueprintPackage);
-
-        if (typeName.typeArguments().size() == 1) {
-            // we may have an Optional, List, Set of the same
-            if (typeName.typeArguments().getFirst().packageName().isBlank()) {
-                return TypeName.builder(typeName)
-                        .typeArguments(List.of(TypeName.builder(typeName.typeArguments().getFirst())
-                                                       .packageName(blueprintPackage)
-                                                       .build()))
-                        .build();
-            }
-            return typeName;
-        }
-        if (typeName.typeArguments().size() == 2) {
-            // and finally a map
-            // we may have an Optional, List, Set of the same
-            if (typeName.typeArguments().get(1).packageName().isBlank()) {
-                return TypeName.builder(typeName)
-                        .typeArguments(List.of(typeName.typeArguments().get(0),
-                                               TypeName.builder(typeName.typeArguments().get(1))
-                                                       .packageName(blueprintPackage)
-                                                       .build()))
-                        .build();
-            }
-            return typeName;
-        }
-        return typeName;
+        return fixEmptyPackage(typeName, blueprintPackage);
     }
 
     private static String setterName(String name, boolean recordStyle) {

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/GenericsBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/GenericsBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.helidon.builder.api.Option;
@@ -36,6 +37,8 @@ interface GenericsBlueprint<T extends CharSequence & Serializable, X extends T> 
 
     @Option.Singular
     Map<T, X> mappedValues();
+
+    Function<T, X> fn();
 
     Optional<Supplier<? extends T>> complicatedValue();
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/GenericTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/GenericTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.builder.test;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.helidon.builder.test.testsubjects.Generics;
@@ -41,15 +42,24 @@ class GenericTest {
         builder.addXValue(new ImplOfT("secondXValue"));
         builder.putMappedValue(new ImplOfT("key"), new ImplOfT("value"));
         builder.putMappedValue(new ImplOfT("key2"), new ImplOfT("value2"));
+        builder.fn(new Mapper());
         builder.complicatedValue(new Supply());
 
         Generics<ImplOfT, ImplOfT> generics = builder.build();
 
         assertThat(generics.tValues(), hasItems(new ImplOfT("firstTValue"), new ImplOfT("secondTValue")));
         assertThat(generics.xValues(), hasItems(new ImplOfT("firstXValue"), new ImplOfT("secondXValue")));
+        assertThat(generics.fn().apply(new ImplOfT("source")), is(new ImplOfT("mapped")));
         assertThat(generics.complicatedValue(), not(Optional.empty()));
         assertThat(generics.complicatedValue().get().get(), is(new ImplOfT("supplied")));
         assertThat(generics.mappedValues().size(), is(2));
+    }
+
+    private static class Mapper implements Function<ImplOfT, ImplOfT> {
+        @Override
+        public ImplOfT apply(ImplOfT value) {
+            return new ImplOfT("mapped");
+        }
     }
 
     private static class Supply implements Supplier<ImplOfT> {


### PR DESCRIPTION
Resolves #11533

Preserve generic declarations when builder codegen repairs blank-package type names so type variables such as `T` and `X` are not rewritten as same-package classes. Add a focused builder regression case that uses `Function<T, X>` on a generic blueprint.
