### PR TITLE
Fix WsSession.send race (4.x)

### DIFF
--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/ClientWsConnection.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/ClientWsConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package io.helidon.webclient.websocket;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -44,10 +47,11 @@ public class ClientWsConnection implements WsSession, Runnable {
     private final BufferData sendBuffer = BufferData.growing(1024);
     private final ClientConnection connection;
     private final HelidonSocket helidonSocket;
+    private final Lock sendLock = new ReentrantLock();
 
     private ContinuationType recvContinuation = ContinuationType.NONE;
     private boolean sendContinuation;
-    private boolean closeSent;
+    private final AtomicBoolean closeSent = new AtomicBoolean();
     private boolean terminated;
 
     ClientWsConnection(ClientConnection connection,
@@ -113,22 +117,42 @@ public class ClientWsConnection implements WsSession, Runnable {
 
     @Override
     public WsSession send(String text, boolean last) {
-        return send(ClientWsFrame.data(text, last));
+        sendLock.lock();
+        try {
+            return sendLocked(ClientWsFrame.data(text, last));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     @Override
     public WsSession send(BufferData bufferData, boolean last) {
-        return send(ClientWsFrame.data(bufferData, last));
+        sendLock.lock();
+        try {
+            return sendLocked(ClientWsFrame.data(bufferData, last));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     @Override
     public WsSession ping(BufferData bufferData) {
-        return send(ClientWsFrame.control(WsOpCode.PING, bufferData));
+        sendLock.lock();
+        try {
+            return sendLocked(ClientWsFrame.control(WsOpCode.PING, bufferData));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     @Override
     public WsSession pong(BufferData bufferData) {
-        return send(ClientWsFrame.control(WsOpCode.PONG, bufferData));
+        sendLock.lock();
+        try {
+            return sendLocked(ClientWsFrame.control(WsOpCode.PONG, bufferData));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     /**
@@ -142,17 +166,24 @@ public class ClientWsConnection implements WsSession, Runnable {
      */
     @Override
     public WsSession close(int code, String reason) {
-        closeSent = true;
+        if (!closeSent.compareAndSet(false, true)) {
+            return this;
+        }
 
-        // send empty close (no code or reason) if code is negative
-        if (code < 0) {
-            send(ClientWsFrame.control(WsOpCode.CLOSE, BufferData.empty()));
-        } else {
-            byte[] reasonBytes = reason.getBytes(StandardCharsets.UTF_8);
-            BufferData bufferData = BufferData.create(2 + reasonBytes.length);
-            bufferData.writeInt16(code);
-            bufferData.write(reasonBytes);
-            send(ClientWsFrame.control(WsOpCode.CLOSE, bufferData));
+        sendLock.lock();
+        try {
+            // send empty close (no code or reason) if code is negative
+            if (code < 0) {
+                sendLocked(ClientWsFrame.control(WsOpCode.CLOSE, BufferData.empty()));
+            } else {
+                byte[] reasonBytes = reason.getBytes(StandardCharsets.UTF_8);
+                BufferData bufferData = BufferData.create(2 + reasonBytes.length);
+                bufferData.writeInt16(code);
+                bufferData.write(reasonBytes);
+                sendLocked(ClientWsFrame.control(WsOpCode.CLOSE, bufferData));
+            }
+        } finally {
+            sendLock.unlock();
         }
         return this;
     }
@@ -175,7 +206,7 @@ public class ClientWsConnection implements WsSession, Runnable {
         return helidonSocket;
     }
 
-    private ClientWsConnection send(ClientWsFrame frame) {
+    private ClientWsConnection sendLocked(ClientWsFrame frame) {
         WsOpCode opCode = frame.opCode();
         if (opCode == WsOpCode.TEXT || opCode == WsOpCode.BINARY) {
             if (sendContinuation) {
@@ -230,7 +261,7 @@ public class ClientWsConnection implements WsSession, Runnable {
             } catch (DataReader.InsufficientDataAvailableException e) {
                 return;
             } catch (WsCloseException e) {
-                if (!closeSent) {
+                if (!closeSent.get()) {
                     try {
                         close(e.closeCode(), e.getMessage());
                     } catch (Exception ex) {

--- a/webclient/websocket/src/test/java/io/helidon/webclient/websocket/ClientWsConnectionTest.java
+++ b/webclient/websocket/src/test/java/io/helidon/webclient/websocket/ClientWsConnectionTest.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package io.helidon.webserver.websocket;
+package io.helidon.webclient.websocket;
 
-import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
-import java.net.SocketException;
-import java.util.List;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -28,63 +26,45 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
-import io.helidon.http.Headers;
-import io.helidon.http.HttpPrologue;
-import io.helidon.webserver.ConnectionContext;
-import io.helidon.webserver.ListenerConfig;
-import io.helidon.webserver.ListenerContext;
-import io.helidon.webserver.ServerConnectionException;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.PeerInfo;
+import io.helidon.webclient.api.ClientConnection;
 import io.helidon.websocket.WsCloseCodes;
 import io.helidon.websocket.WsListener;
+import io.helidon.websocket.WsSession;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-class WsConnectionTest {
+class ClientWsConnectionTest {
     private static final long TEST_TIMEOUT_SECONDS = 5;
-
-    @Test
-    void sendWrapsUncheckedIOException() {
-        DataWriter dataWriter = mock(DataWriter.class);
-        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
-                .when(dataWriter)
-                .writeNow(any(BufferData.class));
-
-        WsConnection connection = createConnection(dataWriter);
-
-        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
-                                                           () -> connection.send("hello", true));
-
-        assertAll(
-                () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
-                () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
-        );
-    }
 
     @Test
     void closePublishesStateBeforeWaitingForSendLock() throws Exception {
         BlockingDataWriter dataWriter = new BlockingDataWriter();
-        WsConnection connection = createConnection(dataWriter);
+        ClientWsConnection connection = ClientWsConnection.create(new TestClientConnection(dataWriter),
+                                                                  new WsListener() {
+                                                                      @Override
+                                                                      public void onMessage(WsSession session,
+                                                                                            String text,
+                                                                                            boolean last) {
+                                                                      }
+                                                                  });
 
         AtomicReference<Throwable> sendFailure = new AtomicReference<>();
-        Thread sendThread = new Thread(() -> invoke(() -> connection.send("hello", true), sendFailure), "ws-send");
+        Thread sendThread = new Thread(() -> invoke(() -> connection.send("hello", true), sendFailure), "client-ws-send");
         sendThread.start();
         dataWriter.awaitFirstWrite();
 
         AtomicReference<Throwable> closeFailure = new AtomicReference<>();
-        Thread closeThread = new Thread(() -> invoke(() -> connection.close(WsCloseCodes.NORMAL_CLOSE, "done"), closeFailure),
-                                        "ws-close");
+        Thread closeThread = new Thread(() -> invoke(() -> connection.close(WsCloseCodes.NORMAL_CLOSE, "done"),
+                                                     closeFailure),
+                                        "client-ws-close");
         closeThread.start();
 
         assertThat("close flag was not published while send lock was held",
@@ -103,27 +83,9 @@ class WsConnectionTest {
         );
     }
 
-    private static WsConnection createConnection(DataWriter dataWriter) {
-        ListenerConfig listenerConfig = mock(ListenerConfig.class);
-        when(listenerConfig.protocols()).thenReturn(List.of(WsConfig.builder().build()));
-
-        ListenerContext listenerContext = mock(ListenerContext.class);
-        when(listenerContext.config()).thenReturn(listenerConfig);
-
-        ConnectionContext ctx = mock(ConnectionContext.class);
-        when(ctx.listenerContext()).thenReturn(listenerContext);
-        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
-        when(ctx.dataWriter()).thenReturn(dataWriter);
-
-        return WsConnection.create(ctx,
-                                   mock(HttpPrologue.class),
-                                   mock(Headers.class),
-                                   "key",
-                                   mock(WsListener.class));
-    }
-
-    private static boolean awaitCloseSent(WsConnection connection) throws ReflectiveOperationException, InterruptedException {
-        Field field = WsConnection.class.getDeclaredField("closeSent");
+    private static boolean awaitCloseSent(ClientWsConnection connection)
+            throws ReflectiveOperationException, InterruptedException {
+        Field field = ClientWsConnection.class.getDeclaredField("closeSent");
         field.setAccessible(true);
         AtomicBoolean closeSent = (AtomicBoolean) field.get(connection);
 
@@ -149,6 +111,92 @@ class WsConnectionTest {
     @FunctionalInterface
     private interface ThrowingRunnable {
         void run() throws Exception;
+    }
+
+    private static final class TestClientConnection implements ClientConnection {
+        private final DataWriter dataWriter;
+        private final HelidonSocket socket = new TestHelidonSocket();
+
+        private TestClientConnection(DataWriter dataWriter) {
+            this.dataWriter = dataWriter;
+        }
+
+        @Override
+        public DataReader reader() {
+            return null;
+        }
+
+        @Override
+        public DataWriter writer() {
+            return dataWriter;
+        }
+
+        @Override
+        public String channelId() {
+            return "test";
+        }
+
+        @Override
+        public HelidonSocket helidonSocket() {
+            return socket;
+        }
+
+        @Override
+        public void readTimeout(Duration readTimeout) {
+        }
+
+        @Override
+        public void closeResource() {
+        }
+    }
+
+    private static final class TestHelidonSocket implements HelidonSocket {
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void idle() {
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+        }
+
+        @Override
+        public PeerInfo remotePeer() {
+            return null;
+        }
+
+        @Override
+        public PeerInfo localPeer() {
+            return null;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public String socketId() {
+            return "test";
+        }
+
+        @Override
+        public String childSocketId() {
+            return "test";
+        }
+
+        @Override
+        public byte[] get() {
+            return new byte[0];
+        }
     }
 
     private static final class BlockingDataWriter implements DataWriter {

--- a/webclient/websocket/src/test/java/io/helidon/webclient/websocket/ClientWsConnectionTest.java
+++ b/webclient/websocket/src/test/java/io/helidon/webclient/websocket/ClientWsConnectionTest.java
@@ -165,6 +165,12 @@ class ClientWsConnectionTest {
         }
 
         @Override
+        @SuppressWarnings("removal")
+        public int read(BufferData buffer) {
+            return 0;
+        }
+
+        @Override
         public void write(BufferData buffer) {
         }
 

--- a/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketConcurrentSendTest.java
+++ b/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketConcurrentSendTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.websocket;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.websocket.WsRouting;
+import io.helidon.websocket.WsCloseCodes;
+import io.helidon.websocket.WsListener;
+import io.helidon.websocket.WsSession;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+
+@ServerTest
+class WebSocketConcurrentSendTest {
+    private static final int SENDERS = 2;
+    private static final int SEND_ITERATIONS = 200;
+    private static final int PAYLOAD_SIZE = 32 * 1024;
+    private static final long TIMEOUT_SECONDS = 30;
+    private static final String FIRST_PAYLOAD = "1" + "a".repeat(PAYLOAD_SIZE - 1);
+    private static final String SECOND_PAYLOAD = "2" + "b".repeat(PAYLOAD_SIZE - 1);
+    private static final ConcurrentSendService SERVICE = new ConcurrentSendService();
+
+    private final int port;
+    private final HttpClient client;
+
+    WebSocketConcurrentSendTest(WebServer server) {
+        this.port = server.port();
+        this.client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @SetUpRoute
+    static void router(Router.RouterBuilder<?> router) {
+        router.addRouting(WsRouting.builder().endpoint("/race", SERVICE));
+    }
+
+    @Test
+    void testConcurrentServerSends() throws Exception {
+        SERVICE.reset();
+
+        ClientListener listener = new ClientListener();
+        client.newWebSocketBuilder()
+                .buildAsync(URI.create("ws://localhost:" + port + "/race"), listener)
+                .get(5, TimeUnit.SECONDS);
+
+        boolean completed = SERVICE.awaitCompletion();
+        assertThat("timed out waiting for server senders to finish", completed, is(true));
+
+        ClientResult result = listener.result();
+        assertThat("server-side sender failed: " + SERVICE.failure(), SERVICE.failure(), is(nullValue()));
+        assertThat("unexpected client payload: " + result.unexpectedMessage(), result.unexpectedMessage(), is(nullValue()));
+        assertThat(result.closeCode(), is(WsCloseCodes.NORMAL_CLOSE));
+        assertThat(result.closeReason(), is("done"));
+        assertThat(result.receivedMessages(), is(SENDERS * SEND_ITERATIONS));
+    }
+
+    private static final class ConcurrentSendService implements WsListener {
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        private final AtomicBoolean started = new AtomicBoolean();
+        private volatile CountDownLatch completion = new CountDownLatch(1);
+
+        void reset() {
+            failure.set(null);
+            started.set(false);
+            completion = new CountDownLatch(1);
+        }
+
+        Throwable failure() {
+            return failure.get();
+        }
+
+        boolean awaitCompletion() throws InterruptedException {
+            return completion.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void onOpen(WsSession session) {
+            if (!started.compareAndSet(false, true)) {
+                failure.compareAndSet(null, new IllegalStateException("Concurrent send test service reused unexpectedly"));
+                completion.countDown();
+                return;
+            }
+
+            CountDownLatch ready = new CountDownLatch(SENDERS);
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(SENDERS);
+            AtomicBoolean stop = new AtomicBoolean();
+
+            startSender("ws-send-1", session, FIRST_PAYLOAD, ready, start, done, stop);
+            startSender("ws-send-2", session, SECOND_PAYLOAD, ready, start, done, stop);
+
+            Thread controller = new Thread(() -> finishRun(session, ready, start, done, stop), "ws-send-controller");
+            controller.setDaemon(true);
+            controller.start();
+        }
+
+        @Override
+        public void onError(WsSession session, Throwable t) {
+            failure.compareAndSet(null, t);
+        }
+
+        private void startSender(String name,
+                                 WsSession session,
+                                 String payload,
+                                 CountDownLatch ready,
+                                 CountDownLatch start,
+                                 CountDownLatch done,
+                                 AtomicBoolean stop) {
+            Thread sender = new Thread(() -> {
+                ready.countDown();
+                try {
+                    if (!start.await(10, TimeUnit.SECONDS)) {
+                        throw new TimeoutException("Timed out waiting for concurrent send start");
+                    }
+                    for (int i = 0; i < SEND_ITERATIONS && !stop.get(); i++) {
+                        session.send(payload, true);
+                    }
+                } catch (Throwable t) {
+                    stop.set(true);
+                    failure.compareAndSet(null, t);
+                } finally {
+                    done.countDown();
+                }
+            }, name);
+            sender.setDaemon(true);
+            sender.start();
+        }
+
+        private void finishRun(WsSession session,
+                               CountDownLatch ready,
+                               CountDownLatch start,
+                               CountDownLatch done,
+                               AtomicBoolean stop) {
+            try {
+                if (!ready.await(10, TimeUnit.SECONDS)) {
+                    throw new TimeoutException("Timed out waiting for sender startup");
+                }
+                start.countDown();
+                if (!done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    throw new TimeoutException("Timed out waiting for concurrent send completion");
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            } finally {
+                stop.set(true);
+                try {
+                    session.close(WsCloseCodes.NORMAL_CLOSE, "done");
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+                completion.countDown();
+            }
+        }
+    }
+
+    private static final class ClientListener implements WebSocket.Listener {
+        private final StringBuilder buffered = new StringBuilder();
+        private final CompletableFuture<ClientResult> result = new CompletableFuture<>();
+        private int receivedMessages;
+        private String unexpectedMessage;
+
+        @Override
+        public void onOpen(WebSocket webSocket) {
+            webSocket.request(1);
+        }
+
+        @Override
+        public java.util.concurrent.CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            buffered.append(data);
+            if (last) {
+                String message = buffered.toString();
+                buffered.setLength(0);
+                receivedMessages++;
+                if (!FIRST_PAYLOAD.equals(message) && !SECOND_PAYLOAD.equals(message) && unexpectedMessage == null) {
+                    unexpectedMessage = message;
+                }
+            }
+            webSocket.request(1);
+            return null;
+        }
+
+        @Override
+        public java.util.concurrent.CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            result.complete(new ClientResult(statusCode, reason, receivedMessages, unexpectedMessage));
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket webSocket, Throwable error) {
+            result.completeExceptionally(error);
+        }
+
+        ClientResult result() throws ExecutionException, InterruptedException, TimeoutException {
+            return result.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+    }
+
+    private record ClientResult(int closeCode, String closeReason, int receivedMessages, String unexpectedMessage) {
+    }
+}

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
@@ -23,6 +23,9 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -62,10 +65,11 @@ public class WsConnection implements ServerConnection, WsSession {
 
     private final BufferData sendBuffer = BufferData.growing(1024);
     private final DataReader dataReader;
+    private final Lock sendLock = new ReentrantLock();
 
     private ContinuationType recvContinuation = ContinuationType.NONE;
     private boolean sendContinuation;
-    private boolean closeSent;
+    private final AtomicBoolean closeSent = new AtomicBoolean();
 
     private volatile Thread myThread;
     private volatile boolean canRun = true;
@@ -180,33 +184,61 @@ public class WsConnection implements ServerConnection, WsSession {
 
     @Override
     public WsSession send(String text, boolean last) {
-        return send(ServerWsFrame.data(text, last));
+        sendLock.lock();
+        try {
+            return sendLocked(ServerWsFrame.data(text, last));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     @Override
     public WsSession send(BufferData bufferData, boolean last) {
-        return send(ServerWsFrame.data(bufferData, last));
+        sendLock.lock();
+        try {
+            return sendLocked(ServerWsFrame.data(bufferData, last));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     @Override
     public WsSession ping(BufferData bufferData) {
-        return send(ServerWsFrame.control(WsOpCode.PING, bufferData));
+        sendLock.lock();
+        try {
+            return sendLocked(ServerWsFrame.control(WsOpCode.PING, bufferData));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     @Override
     public WsSession pong(BufferData bufferData) {
-        return send(ServerWsFrame.control(WsOpCode.PONG, bufferData));
+        sendLock.lock();
+        try {
+            return sendLocked(ServerWsFrame.control(WsOpCode.PONG, bufferData));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     @Override
     public WsSession close(int code, String reason) {
-        closeSent = true;
-        byte[] reasonBytes = reason.getBytes(StandardCharsets.UTF_8);
-        BufferData bufferData = BufferData.create(2 + reasonBytes.length);
-        bufferData.writeInt16(code);
-        bufferData.write(reasonBytes);
+        if (!closeSent.compareAndSet(false, true)) {
+            return this;
+        }
 
-        return send(ServerWsFrame.control(WsOpCode.CLOSE, bufferData));
+        sendLock.lock();
+        try {
+            byte[] reasonBytes = reason.getBytes(StandardCharsets.UTF_8);
+            BufferData bufferData = BufferData.create(2 + reasonBytes.length);
+            bufferData.writeInt16(code);
+            bufferData.write(reasonBytes);
+
+            return sendLocked(ServerWsFrame.control(WsOpCode.CLOSE, bufferData));
+        } finally {
+            sendLock.unlock();
+        }
     }
 
     @Override
@@ -288,7 +320,7 @@ public class WsConnection implements ServerConnection, WsSession {
                 }
             }
             listener.onClose(this, status, reason);
-            if (!closeSent) {
+            if (!closeSent.get()) {
                 close(WsCloseCodes.NORMAL_CLOSE, "normal");
             }
             return false;
@@ -311,7 +343,7 @@ public class WsConnection implements ServerConnection, WsSession {
         }
     }
 
-    private WsSession send(ServerWsFrame frame) {
+    private WsSession sendLocked(ServerWsFrame frame) {
         WsOpCode usedCode = frame.opCode();
         if (frame.isPayload()) {
             // check if continuation or set continuation


### PR DESCRIPTION
Resolves #11794

Backport of #11787. Serialize outbound WebSocket sends per session with a `ReentrantLock` so concurrent `WsSession.send(...)` calls cannot corrupt shared frame state, and add focused client- and server-side regression coverage for the race on `helidon-4.x`.
