### PR TITLE
API stability annotations follow up (27.x)

### DIFF
--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptProcessor.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptProcessor.java
@@ -41,6 +41,7 @@ import io.helidon.codegen.CodegenEvent;
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.ElementInfoPredicates;
 import io.helidon.codegen.Option;
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ModuleTypeInfo;
 import io.helidon.common.types.TypeInfo;
@@ -57,6 +58,8 @@ import static java.lang.System.Logger.Level.WARNING;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
+@SuppressWarnings("removal")
 public final class AptProcessor extends AbstractProcessor {
     private static final TypeName GENERATOR = TypeName.create(AptProcessor.class);
 

--- a/codegen/apt/src/main/java/module-info.java
+++ b/codegen/apt/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ module io.helidon.codegen.apt {
     requires jdk.compiler;
     requires transitive io.helidon.codegen;
 
+    requires static io.helidon.common;
     requires transitive io.helidon.common.types;
     requires transitive java.compiler;
 

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocReader.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocReader.java
@@ -26,6 +26,7 @@ import io.helidon.codegen.JavadocTree.AttrValue;
 import io.helidon.codegen.JavadocTree.BlockTag;
 import io.helidon.codegen.JavadocTree.Document;
 import io.helidon.codegen.JavadocTree.Text;
+import io.helidon.common.Api;
 
 /**
  * Javadoc reader.
@@ -35,6 +36,7 @@ import io.helidon.codegen.JavadocTree.Text;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public final class JavadocReader {
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocTree.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocTree.java
@@ -28,6 +28,7 @@ import io.helidon.codegen.JavadocReader.EltStartImpl;
 import io.helidon.codegen.JavadocReader.EscapeImpl;
 import io.helidon.codegen.JavadocReader.InlineTagImpl;
 import io.helidon.codegen.JavadocReader.TextImpl;
+import io.helidon.common.Api;
 
 /**
  * Javadoc tree node.
@@ -37,6 +38,7 @@ import io.helidon.codegen.JavadocReader.TextImpl;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public sealed interface JavadocTree permits JavadocTree.EltStart,
                                             JavadocTree.InlineTag,
                                             JavadocTree.BlockTag,

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
@@ -27,6 +27,7 @@ import io.helidon.codegen.JavadocTree.EltStart;
 import io.helidon.codegen.JavadocTree.Escape;
 import io.helidon.codegen.JavadocTree.InlineTag;
 import io.helidon.codegen.JavadocTree.Text;
+import io.helidon.common.Api;
 
 /**
  * A tool that renders Javadoc to simplified HTML.
@@ -51,6 +52,7 @@ import io.helidon.codegen.JavadocTree.Text;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public final class JavadocWriter {
 
     private final StringBuilder buf;

--- a/codegen/testing/pom.xml
+++ b/codegen/testing/pom.xml
@@ -43,6 +43,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.codegen</groupId>
             <artifactId>helidon-codegen</artifactId>
         </dependency>

--- a/codegen/testing/src/main/java/io/helidon/codegen/testing/CodegenMatchers.java
+++ b/codegen/testing/src/main/java/io/helidon/codegen/testing/CodegenMatchers.java
@@ -18,6 +18,8 @@ package io.helidon.codegen.testing;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.helidon.common.Api;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -31,6 +33,7 @@ import org.intellij.lang.annotations.Language;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public final class CodegenMatchers {
 
     private CodegenMatchers() {

--- a/codegen/testing/src/main/java/io/helidon/codegen/testing/TestCompiler.java
+++ b/codegen/testing/src/main/java/io/helidon/codegen/testing/TestCompiler.java
@@ -32,6 +32,8 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
+import io.helidon.common.Api;
+
 import org.intellij.lang.annotations.Language;
 
 /**
@@ -42,6 +44,7 @@ import org.intellij.lang.annotations.Language;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public final class TestCompiler {
 
     private final List<Supplier<Processor>> processors;

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmModel.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmModel.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.config.metadata.model.CmModelImpl.CmAllowedValueImpl;
 import io.helidon.config.metadata.model.CmModelImpl.CmEnumImpl;
 import io.helidon.config.metadata.model.CmModelImpl.CmModuleImpl;
@@ -39,6 +40,7 @@ import io.helidon.metadata.hson.Hson;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public sealed interface CmModel permits CmModelImpl {
 
     /**

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmNode.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmNode.java
@@ -19,6 +19,7 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.config.metadata.model.CmModel.CmOption;
 import io.helidon.config.metadata.model.CmModel.CmType;
 import io.helidon.config.metadata.model.CmNodeImpl.CmOptionNodeImpl;
@@ -32,6 +33,7 @@ import io.helidon.config.metadata.model.CmNodeImpl.CmPathNodeImpl;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public sealed interface CmNode extends Comparable<CmNode> permits CmNode.CmOptionNode,
                                                                   CmNode.CmPathNode,
                                                                   CmNodeImpl {

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmResolver.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmResolver.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.config.metadata.model.CmModel.CmEnum;
 import io.helidon.config.metadata.model.CmModel.CmType;
 
@@ -31,6 +32,7 @@ import io.helidon.config.metadata.model.CmModel.CmType;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
+@Api.Internal
 public interface CmResolver {
 
     /**

--- a/json/tests/binding/src/test/java/io/helidon/json/tests/GeneratedSourceMetadataTest.java
+++ b/json/tests/binding/src/test/java/io/helidon/json/tests/GeneratedSourceMetadataTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import io.helidon.codegen.apt.AptProcessor;
 import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Api;
 import io.helidon.common.Generated;
 import io.helidon.common.buffers.Bytes;
 import io.helidon.json.JsonGenerator;
@@ -37,6 +38,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
+@SuppressWarnings(Api.SUPPRESS_INTERNAL)
 class GeneratedSourceMetadataTest {
     private static final String PACKAGE_NAME = "io.helidon.json.tests.generated";
     private static final String PACKAGE_PATH = PACKAGE_NAME.replace('.', '/') + "/";

--- a/metrics/api/src/main/java/io/helidon/metrics/api/LabeledSnapshot.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/LabeledSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,11 @@ import io.helidon.metrics.api.Sample.Derived;
 import io.helidon.metrics.api.Sample.Labeled;
 
 /**
- * Internal interface prescribing minimum behavior of a snapshot needed to produce output.
+ * Snapshot view of a metric's derived and labeled sample values.
+ * <p>
+ * Implementations expose summary values computed for the metric at a point in time, such as quantiles, max, mean,
+ * and observation count.
+ * </p>
  */
 public interface LabeledSnapshot {
     /**

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SnapshotMetric.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SnapshotMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 package io.helidon.metrics.api;
 
 /**
- * A metric that is capable of providing snapshots.
+ * A metric that can provide a {@link LabeledSnapshot} of its current sampled values.
  */
 public interface SnapshotMetric {
     /**
-     * Snapshot of the metric.
+     * Returns a snapshot of the metric's current sampled values.
      *
      * @return snapshot
      */

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/Storage.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/Storage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package io.helidon.testing.junit5.suite;
 
+import io.helidon.common.Api;
+
 /**
- * Suite specific storage.
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal suite-specific storage exposed to test suite providers.
  */
-@Deprecated
+@Api.Internal
 public interface Storage {
 
     /**

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteDescriptor.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import io.helidon.testing.junit5.suite.spi.SuiteProvider;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 // Suite descriptor
-@SuppressWarnings("deprecation")
 class SuiteDescriptor {
 
     private final SuiteProvider provider;

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteExtension.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.testing.junit5.suite;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.testing.junit5.suite.spi.SuiteProvider;
 
@@ -30,12 +31,9 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 
 /**
- * Suite junit 5 extension.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal JUnit 5 extension backing the test suite annotations.
  */
-@Deprecated
+@Api.Internal
 public class SuiteExtension
         implements BeforeAllCallback, ExtensionContext.Store.CloseableResource, ParameterResolver {
 

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteResolver.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,12 @@ package io.helidon.testing.junit5.suite;
 
 import java.lang.reflect.Type;
 
+import io.helidon.common.Api;
+
 /**
- * {@code SuiteResolver} defines API for suite providers
- * to dynamically resolve arguments for constructors and methods at runtime.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal contract for suite providers that resolve constructor and method parameters at runtime.
  */
-@Deprecated
+@Api.Internal
 public interface SuiteResolver {
 
     /**

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteStorage.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/SuiteStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,11 @@
  */
 package io.helidon.testing.junit5.suite;
 
+import io.helidon.common.Api;
+
 /**
- * {@code SuiteStorage} defines API for suite providers to provide suite specific storage
- * shared for all tests running as part of the suite.
- * Storage is available as arguments resolver for the {@link Storage} class.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal marker for suite providers that expose shared {@link Storage} to suite lifecycle callbacks.
  */
-@Deprecated
+@Api.Internal
 public interface SuiteStorage {
 }

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/TestSuite.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/TestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.helidon.common.Api;
 import io.helidon.testing.junit5.suite.spi.SuiteProvider;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Test suite annotations.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal test suite annotations support.
  */
-@Deprecated
+@Api.Internal
 public final class TestSuite {
 
     private TestSuite() {
@@ -39,11 +37,8 @@ public final class TestSuite {
 
     /**
      * Test suite annotation.
-     *
-     * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
-     *         use with care
      */
-    @Deprecated
+    @Api.Internal
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     @ExtendWith(SuiteExtension.class)
@@ -60,11 +55,8 @@ public final class TestSuite {
 
     /**
      * After {@link io.helidon.testing.junit5.suite.TestSuite} cleanup method.
-     *
-     * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
-     *         use with care
      */
-    @Deprecated
+    @Api.Internal
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @Inherited
@@ -73,11 +65,9 @@ public final class TestSuite {
 
     /**
      * Before {@link io.helidon.testing.junit5.suite.TestSuite} initialization method.
-     *
-     * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
-     *         use with care
      */
-    @Deprecated@Retention(RetentionPolicy.RUNTIME)
+    @Api.Internal
+    @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @Inherited
     public @interface BeforeSuite {

--- a/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/spi/SuiteProvider.java
+++ b/testing/junit5-suite/src/main/java/io/helidon/testing/junit5/suite/spi/SuiteProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,16 @@
  */
 package io.helidon.testing.junit5.suite.spi;
 
+import io.helidon.common.Api;
+
 /**
- * Integration tests suite provider.
- * Any {@link io.helidon.testing.junit5.suite.TestSuite} class must implement this interface.
+ * Internal contract implemented by providers used with {@link io.helidon.testing.junit5.suite.TestSuite.Suite}.
  * <p>
- * A Suite may provide methods annotated with {@link io.helidon.testing.junit5.suite.TestSuite.BeforeSuite} and/or
+ * A provider may define methods annotated with {@link io.helidon.testing.junit5.suite.TestSuite.BeforeSuite} and/or
  * {@link io.helidon.testing.junit5.suite.TestSuite.AfterSuite}.
- * Currently supported parameter is the {@link io.helidon.testing.junit5.suite.SuiteStorage}.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Providers that also implement {@link io.helidon.testing.junit5.suite.SuiteStorage} receive
+ * {@link io.helidon.testing.junit5.suite.Storage} in those callbacks.
  */
-@Deprecated
+@Api.Internal
 public interface SuiteProvider {
 }

--- a/testing/junit5-suite/src/main/java/module-info.java
+++ b/testing/junit5-suite/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,8 @@
  */
 
 /**
- * Helidon Integration Tests Suite Extension.
- *
- * @deprecated this is a feature in progress of development, there may be backward incompatible changes done to it, so please
- *         use with care
+ * Internal support for Helidon JUnit 5 test suites.
  */
-@Deprecated
 module io.helidon.testing.junit5.suite {
 
     requires transitive org.junit.jupiter.api;

--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WebSocketClient.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WebSocketClient.java
@@ -23,17 +23,17 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.helidon.common.Api;
 import io.helidon.service.registry.Service;
 
 /**
  * Annotations and APIs for type safe WebSocket clients.
  * <p>
  * The type safe WebSocket client is backed by Helidon {@link io.helidon.webclient.websocket.WsClient}.
- *
- * @deprecated this API is part of incubating features of Helidon. This API may change including backward incompatible changes
- *         and full removal. We welcome feedback for incubating features.
+ * <p>
+ * This API is preview and may change between minor releases.
  */
-@Deprecated
+@Api.Preview
 public final class WebSocketClient {
     private WebSocketClient() {
     }
@@ -54,6 +54,7 @@ public final class WebSocketClient {
      * If such a class already exists, there will be a name conflict, use {@link #factoryClassName()} to specify a custom
      * class name in such a case. The factory will always be in the same package as the annotated type.
      */
+    @Api.Preview
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.CLASS)
     @Documented

--- a/webclient/websocket/src/main/java/module-info.java
+++ b/webclient/websocket/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module io.helidon.webclient.websocket {
     requires io.helidon.webclient;
     requires io.helidon.websocket;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
     requires static io.helidon.config.metadata;
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http;
 
+import io.helidon.common.Api;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.RoutedPath;
 
@@ -29,6 +30,7 @@ public interface RoutingRequest extends ServerRequest {
      * @param routedPath routed path, that provides matched path parameters from path pattern
      * @return this instance
      */
+    @Api.Internal
     RoutingRequest path(RoutedPath routedPath);
 
     /**
@@ -37,15 +39,17 @@ public interface RoutingRequest extends ServerRequest {
      * @param newPrologue new prologue to use (on rerouting)
      * @return this instance
      */
+    @Api.Internal
     RoutingRequest prologue(HttpPrologue newPrologue);
 
     /**
      * Update the pattern used to match this request. Such as "/foo/{bar}".
-     *  For internal use only to Helidon.
+     * For internal use only to Helidon.
      *
      * @param matchingPattern the matching pattern
      * @return this instance
      */
+    @Api.Internal
     default RoutingRequest matchingPattern(String matchingPattern) {
         return this;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/ErrorHandlerProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/ErrorHandlerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http.spi;
 
+import io.helidon.common.Api;
 import io.helidon.webserver.http.ErrorHandler;
 
 /**
@@ -25,15 +26,15 @@ import io.helidon.webserver.http.ErrorHandler;
  * Instances of this service discovered by service registry are only used when the whole server is started using it
  * (i.e. Helidon Declarative approach).
  * <p>
- * To manually register an error handle, please use
+ * NOTE: this API is part of preview features of Helidon. This API may still change between minor releases,
+ * but it is intended for supported external use.
+ * <p>
+ * To manually register an error handler, please use
  * {@link io.helidon.webserver.http.HttpRouting.Builder#error(Class, io.helidon.webserver.http.ErrorHandler)}.
  *
  * @param <T> type of the exception handled by the handler
- *
- * @deprecated this API is part of incubating features of Helidon. This API may change including backward incompatible changes
- *               and full removal. We welcome feedback for incubating features.
  */
-@Deprecated
+@Api.Preview
 public interface ErrorHandlerProvider<T extends Throwable> {
     /**
      * Type of the exception to handle.


### PR DESCRIPTION
Resolves #11801

Carries the surviving API-stability cleanup from PR #11783 onto `main`, replacing deprecation-only markers with explicit preview and internal annotations where those types still exist on 27.x, and clarifying the retained metrics snapshot API docs.
