### PR TITLE
Fix generated data repository deprecation warning (4.x)

### DIFF
--- a/data/codegen/common/src/main/java/io/helidon/data/codegen/common/BaseRepositoryInterfaceGenerator.java
+++ b/data/codegen/common/src/main/java/io/helidon/data/codegen/common/BaseRepositoryInterfaceGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,14 +80,12 @@ public abstract class BaseRepositoryInterfaceGenerator
 
     /**
      * Generate {@code  <T> Optional<T> RepositoryExecutor#optionalFromQuery(List<T>)} call.
-     * This is Jakarta Persistence 3.1 workaround.
+     * This is Jakarta Persistence 3.1 workaround until the 4.x line can use Jakarta Persistence 3.2 item-or-null APIs.
      *
      * @param builder      method builder
      * @param content      additional statement content
      * @param executorType repository executor type
-     * @deprecated will be removed with Jakarta Persistence 3.2
      */
-    @Deprecated
     protected static void optionalFromQuery(Method.Builder builder, Consumer<Method.Builder> content, TypeName executorType) {
         builder.addContent(executorType)
                 .addContent(".optionalFromQuery(");

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaRepositoryExecutor.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaRepositoryExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,14 +57,12 @@ public interface JpaRepositoryExecutor extends AutoCloseable {
 
     /**
      * Transform query result as {@link java.util.Optional}.
-     * This is Jakarta Persistence 3.1 workaround.
+     * This is Jakarta Persistence 3.1 workaround until the 4.x line can use Jakarta Persistence 3.2 item-or-null APIs.
      *
      * @param queryResult the query result as {@link java.util.Optional}
      * @param <T>         type of the result
      * @return query result as {@link java.util.Optional}
-     * @deprecated will be removed with Jakarta Persistence 3.2
      */
-    @Deprecated
     static <T> Optional<T> optionalFromQuery(List<T> queryResult) {
         return queryResult == null || queryResult.isEmpty()
                 ? Optional.empty() : Optional.of(queryResult.getFirst());


### PR DESCRIPTION
Resolves #11803

Remove the misleading deprecation from the shared `optionalFromQuery(...)` workaround used by generated Jakarta Persistence repositories. This keeps generated 4.x data repositories warning-clean without changing runtime behavior.
