### PR TITLE
Avoid unnecessary DNS resolution without proxy

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -185,9 +185,9 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html which states: "The absoluteURI form is REQUIRED when the
             // request is being made to a proxy."
             String absoluteUri = uri.scheme() + "://" + uri.host() + ":" + uri.port();
-            InetSocketAddress uriAddress = new InetSocketAddress(uri.host(), uri.port());
             String requestUri = proxy == Proxy.noProxy()
-                    || (proxy.type() == Proxy.ProxyType.HTTP && proxy.isNoHosts(uriAddress))
+                    || (proxy.type() == Proxy.ProxyType.HTTP
+                            && proxy.isNoHosts(new InetSocketAddress(uri.host(), uri.port())))
                     || (proxy.type() == Proxy.ProxyType.SYSTEM && !proxy.isUsingSystemProxy(absoluteUri))
                     || clientConfig.relativeUris()
                     ? "" // don't set host details, so it becomes relative URI


### PR DESCRIPTION
Delay construction of the proxy no-host address until the HTTP proxy branch needs it, keeping the common no-proxy request path free of per-request DNS resolution.

### Description

Fixes #11800.

`Http1CallChainBase.prologue()` previously created an `InetSocketAddress` for every request before checking whether proxy handling was needed. `InetSocketAddress(String, int)` can perform DNS resolution, so this added unnecessary per-request work when `proxy == Proxy.noProxy()`.

This change moves the `InetSocketAddress` construction into the HTTP proxy `isNoHosts(...)` branch, allowing the common no-proxy path to short-circuit before any address resolution.

### Documentation

None. This is an internal performance optimization with no user-facing API or configuration changes.