### PR TITLE
Avoid duplicate metrics registry init in declarative apps (27.x)

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryFactory.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,6 @@ class MetricsFactoryFactory implements Supplier<MetricsFactory> {
 
     @Override
     public MetricsFactory get() {
-        return MetricsFactoryManager.getMetricsFactory(config);
+        return MetricsFactoryManager.getOrCreateMetricsFactory(config);
     }
 }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
@@ -108,14 +108,7 @@ class MetricsFactoryManager {
      * @return new metrics factory
      */
     static MetricsFactory getMetricsFactory(Config metricsConfigNode) {
-
-        MetricsFactoryManager.metricsConfigNode = metricsConfigNode;
-
-        MetricsConfig metricsConfig = MetricsConfig.create(metricsConfigNode);
-
-        metricsFactory = access(() -> completeGetInstance(metricsConfig, metricsConfigNode));
-
-        return metricsFactory;
+        return access(() -> createCurrentMetricsFactory(metricsConfigNode));
     }
 
     /**
@@ -127,12 +120,25 @@ class MetricsFactoryManager {
      */
     static MetricsFactory getMetricsFactory() {
         return access(() -> {
-            metricsConfigNode = Objects.requireNonNullElseGet(metricsConfigNode,
-                                                              MetricsFactoryManager::externalMetricsConfig);
-            metricsFactory = Objects.requireNonNullElseGet(metricsFactory,
-                                                           () -> getMetricsFactory(metricsConfigNode));
-            return metricsFactory;
+            return Objects.requireNonNullElseGet(metricsFactory,
+                                                () -> createCurrentMetricsFactory(
+                                                        Objects.requireNonNullElseGet(
+                                                                metricsConfigNode,
+                                                                MetricsFactoryManager::externalMetricsConfig)));
         });
+    }
+
+    /**
+     * Returns the current {@link MetricsFactory}, creating and saving one from the provided root config only if the current
+     * factory is absent.
+     *
+     * @param rootConfig root configuration for resolving the metrics config node when needed
+     * @return current or newly created metrics factory
+     */
+    static MetricsFactory getOrCreateMetricsFactory(Config rootConfig) {
+        return access(() -> Objects.requireNonNullElseGet(metricsFactory,
+                                                          () -> createCurrentMetricsFactory(
+                                                                  selectMetricsConfigNode(rootConfig))));
     }
 
     /**
@@ -156,10 +162,20 @@ class MetricsFactoryManager {
     }
 
     private static Config externalMetricsConfig() {
-        Config currentConfig = Services.get(Config.class);
-        Config serverFeaturesMetricsConfig = currentConfig.get("server.features.observe.observers.metrics");
+        return selectMetricsConfigNode(Services.get(Config.class));
+    }
+
+    private static MetricsFactory createCurrentMetricsFactory(Config metricsConfigNode) {
+        MetricsFactoryManager.metricsConfigNode = metricsConfigNode;
+        MetricsConfig metricsConfig = MetricsConfig.create(metricsConfigNode);
+        metricsFactory = completeGetInstance(metricsConfig, metricsConfigNode);
+        return metricsFactory;
+    }
+
+    private static Config selectMetricsConfigNode(Config rootConfig) {
+        Config serverFeaturesMetricsConfig = rootConfig.get("server.features.observe.observers.metrics");
         if (!serverFeaturesMetricsConfig.exists()) {
-            serverFeaturesMetricsConfig = currentConfig.get("metrics");
+            serverFeaturesMetricsConfig = rootConfig.get(MetricsConfig.METRICS_CONFIG_KEY);
         }
         return serverFeaturesMetricsConfig;
     }

--- a/metrics/api/src/test/java/io/helidon/metrics/api/MetricsFactoryFactoryTest.java
+++ b/metrics/api/src/test/java/io/helidon/metrics/api/MetricsFactoryFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.api;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+
+class MetricsFactoryFactoryTest {
+    private static final Config ROOT_CONFIG = Config.just(ConfigSources.create(Map.of(
+            "metrics.app-name", "metrics-app",
+            "server.features.observe.observers.metrics.app-name", "observe-app")));
+
+    @BeforeEach
+    void setUp() {
+        MetricsFactory.closeAll();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MetricsFactory.closeAll();
+    }
+
+    @Test
+    void reusesCurrentMetricsFactory() {
+        MetricsFactory currentFactory =
+                MetricsFactory.getInstance(ROOT_CONFIG.get("server.features.observe.observers.metrics"));
+        MetricsFactoryFactory serviceFactory = new MetricsFactoryFactory(ROOT_CONFIG);
+
+        MetricsFactory serviceResolvedFactory = serviceFactory.get();
+
+        assertThat(serviceResolvedFactory, sameInstance(currentFactory));
+        assertThat(MetricsFactory.getInstance(), sameInstance(currentFactory));
+    }
+
+    @Test
+    void createsCurrentMetricsFactoryOnceWhenAbsent() {
+        MetricsFactoryFactory serviceFactory = new MetricsFactoryFactory(ROOT_CONFIG);
+
+        MetricsFactory firstFactory = serviceFactory.get();
+        MetricsFactory secondFactory = serviceFactory.get();
+
+        assertThat(secondFactory, sameInstance(firstFactory));
+    }
+}


### PR DESCRIPTION
Resolves #11813

Carries forward the metrics factory reuse fix from #11810 to `main` so declarative `MeterRegistry` resolution and the observe metrics feature reuse the same global registry.
