### PR TITLE
4.x: Upgrade log4j to 2.25.4

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -108,7 +108,7 @@
         <version.lib.kotlin>1.9.10</version.lib.kotlin>
         <version.lib.langchain4j>1.12.1</version.lib.langchain4j>
         <version.lib.langchain4j-community>1.12.1-beta21</version.lib.langchain4j-community>
-        <version.lib.log4j>2.25.3</version.lib.log4j>
+        <version.lib.log4j>2.25.4</version.lib.log4j>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.micrometer>1.15.2</version.lib.micrometer>


### PR DESCRIPTION
### Description

Upgrade log4j to 2.25.4


