### PR TITLE
2.x: Upgrade log4j to 2.25.4

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -95,7 +95,7 @@
         <version.lib.jsonp-impl>1.1.6</version.lib.jsonp-impl>
         <version.lib.junit>5.7.0</version.lib.junit>
         <version.lib.kafka>3.9.2</version.lib.kafka>
-        <version.lib.log4j>2.25.3</version.lib.log4j>
+        <version.lib.log4j>2.25.4</version.lib.log4j>
         <version.lib.logback>1.4.14</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>


### PR DESCRIPTION
### Description

Upgrade log4j to 2.25.4

