### PR TITLE
4.x: Revert making jsr305 provided

### DIFF
--- a/microprofile/grpc/client/pom.xml
+++ b/microprofile/grpc/client/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>


### PR DESCRIPTION
### Description

Reverts  #11773 

There are concerns that customers will need this compile time dependency during their rpc code generation.


