### PR TITLE
Backport 4.4.1 fixes from release branch (4.x)

### DIFF
--- a/docs/src/main/asciidoc/includes/security/providers/jwt.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/jwt.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ security:
     - provider:
         atn-token:
           jwk.resource.resource-path: "verifying-jwk.json"
+          jwt-issuer: "http://trusted.issuer"
           jwt-audience: "http://my.service"
         sign-token:
           jwk.resource.resource-path: "signing-jwk.json"
@@ -74,5 +75,4 @@ of the JWT subject claim.
 
 For outbound, we support either token propagation (e.g. the token from request is propagated further) or
 support for generating a brand new token based on configuration of this provider.
-
 

--- a/security/providers/jwt/docs/full.yaml
+++ b/security/providers/jwt/docs/full.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,10 @@ security:
             url: "http://url/of/jwk"
             content-plain: "{}"
             content: "base64"
+          # optional expected issuer of inbound JWTs
+          jwt-issuer: "issuer.of.JWT"
+          # optional expected audience of inbound JWTs
+          jwt-audience: "audience"
           handler:
             # name of header to extract token from (see providers-common module for all options), defaults to "Authorization"
             header: "Authorization"

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -912,6 +912,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
          * Issuer expected in inbound JWTs.
          *
          * @param issuer issuer string
+         * @return updated builder instance
          */
         @ConfiguredOption(key = "atn-token.jwt-issuer")
         public Builder expectedIssuer(String issuer) {

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -77,6 +77,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
     private final TokenHandler defaultTokenHandler;
     private final JwkKeys verifyKeys;
     private final String expectedAudience;
+    private final String expectedIssuer;
     private final JwkKeys signKeys;
     private final OutboundConfig outboundConfig;
     private final String issuer;
@@ -96,6 +97,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         this.signKeys = builder.signKeys;
         this.issuer = builder.issuer;
         this.expectedAudience = builder.expectedAudience;
+        this.expectedIssuer = builder.expectedIssuer;
         this.verifySignature = builder.verifySignature;
         this.useJwtGroups = builder.useJwtGroups;
 
@@ -115,7 +117,8 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         }
 
         if (!verifySignature) {
-            LOGGER.log(Level.INFO, "JWT Signature validation is disabled. Any JWT will be accepted.");
+            LOGGER.log(Level.INFO,
+                       "JWT signature validation is disabled. JWT claims will still be validated.");
         }
     }
 
@@ -178,29 +181,32 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         }
         if (verifySignature) {
             Errors errors = signedJwt.verifySignature(verifyKeys, defaultJwk);
-            if (errors.isValid()) {
-                Jwt jwt = signedJwt.getJwt();
-                // perform all validations, including expected audience verification
-                JwtValidator.Builder jwtValidatorBuilder = JwtValidator.builder()
-                        .addDefaultTimeValidators()
-                        .addCriticalValidator()
-                        .addUserPrincipalValidator();
-                if (expectedAudience != null) {
-                    jwtValidatorBuilder.addAudienceValidator(expectedAudience);
-                }
-                JwtValidator jwtValidator =  jwtValidatorBuilder.build();
-                Errors validate = jwtValidator.validate(jwt);
-                if (validate.isValid()) {
-                    return AuthenticationResponse.success(buildSubject(jwt, signedJwt));
-                } else {
-                    return failOrAbstain(validate.toString());
-                }
-            } else {
+            if (!errors.isValid()) {
                 return failOrAbstain(errors.toString());
             }
-        } else {
-            return AuthenticationResponse.success(buildSubject(signedJwt.getJwt(), signedJwt));
         }
+
+        Jwt jwt = signedJwt.getJwt();
+        Errors validate = validateJwt(jwt);
+        if (!validate.isValid()) {
+            return failOrAbstain(validate.toString());
+        }
+        return AuthenticationResponse.success(buildSubject(jwt, signedJwt));
+    }
+
+    private Errors validateJwt(Jwt jwt) {
+        JwtValidator.Builder jwtValidatorBuilder = JwtValidator.builder()
+                .addDefaultTimeValidators()
+                .addCriticalValidator()
+                .addUserPrincipalValidator();
+        if (expectedAudience != null) {
+            jwtValidatorBuilder.addAudienceValidator(expectedAudience);
+        }
+        if (expectedIssuer != null) {
+            jwtValidatorBuilder.addIssuerValidator(expectedIssuer);
+        }
+        JwtValidator jwtValidator = jwtValidatorBuilder.build();
+        return jwtValidator.validate(jwt);
     }
 
     private AuthenticationResponse failOrAbstain(String message) {
@@ -663,6 +669,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         private JwkKeys signKeys;
         private String issuer;
         private String expectedAudience;
+        private String expectedIssuer;
         private boolean useJwtGroups = true;
 
         private Builder() {
@@ -739,7 +746,8 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
          * <p>
          * <b>Make sure your service is properly secured on network level and only
          * accessible from a secure endpoint that provides the JWTs when signature verification
-         * is disabled. If signature verification is disabled, this service will accept <i>ANY</i> JWT</b>
+         * is disabled. If signature verification is disabled, configured claim validation still applies,
+         * but signatures are not checked.</b>
          *
          * @param shouldValidate set to false to disable validation of JWT signatures
          * @return updated builder instance
@@ -876,6 +884,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
             if (atnToken.exists()) {
                 verifyKeys(atnToken);
                 atnToken.get("jwt-audience").asString().ifPresent(this::expectedAudience);
+                atnToken.get("jwt-issuer").asString().ifPresent(this::expectedIssuer);
                 atnToken.get("verify-signature").asBoolean().ifPresent(this::verifySignature);
             }
             Config signToken = config.get("sign-token");
@@ -897,6 +906,17 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         @ConfiguredOption(key = "atn-token.jwt-audience")
         public void expectedAudience(String audience) {
             this.expectedAudience = audience;
+        }
+
+        /**
+         * Issuer expected in inbound JWTs.
+         *
+         * @param issuer issuer string
+         */
+        @ConfiguredOption(key = "atn-token.jwt-issuer")
+        public Builder expectedIssuer(String issuer) {
+            this.expectedIssuer = issuer;
+            return this;
         }
 
         /**

--- a/security/providers/jwt/src/test/java/io/helidon/security/providers/jwt/JwtProviderTest.java
+++ b/security/providers/jwt/src/test/java/io/helidon/security/providers/jwt/JwtProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,11 +61,16 @@ public class JwtProviderTest {
     private static final String WRONG_TOKEN =
             "yJ4NXQjUzI1NiI6IlZjeXl1TVdxSGp4UjRVNmYzOTV3YmhUZXNZRmFaWXFSbDdBbUxjZE5sNXciLCJ4NXQiOiJTdEZFTlFaM2NMNndQaHFxODZnVmJTTG54TkUiLCJraWQiOiJTSUdOSU5HX0tFWSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiJIU01BcHAtY2xpZW50X0FQUElEIiwidXNlci50ZW5hbnQubmFtZSI6ImlkY3MtNzNmYTNlZDY5ZTgxNDFhN2I5MDFmYWY3Zjg3M2U3OGUiLCJzdWJfbWFwcGluZ2F0dHIiOiJ1c2VyTmFtZSIsImlzcyI6Imh0dHBzOlwvXC9pZGVudGl0eS5vcmFjbGVjbG91ZC5jb21cLyIsInRva190eXBlIjoiQVQiLCJjbGllbnRfaWQiOiJIU01BcHAtY2xpZW50X0FQUElEIiwiYXVkIjoiaHR0cDpcL1wvc2NhMDBjangudXMub3JhY2xlLmNvbTo3Nzc3Iiwic3ViX3R5cGUiOiJjbGllbnQiLCJzY29wZSI6InVybjpvcGM6cmVzb3VyY2U6Y29uc3VtZXI6OmFsbCIsImNsaWVudF90ZW5hbnRuYW1lIjoiaWRjcy03M2ZhM2VkNjllODE0MWE3YjkwMWZhZjdmODczZTc4ZSIsImV4cCI6MTU1MDU5NTk0MiwiaWF0IjoxNTUwNTA5NTQyLCJ0ZW5hbnRfaXNzIjoiaHR0cHM6XC9cL2lkY3MtNzNmYTNlZDY5ZTgxNDFhN2I5MDFmYWY3Zjg3M2U3OGUuaWRlbnRpdHkuYzlkZXYxLm9jOXFhZGV2LmNvbSIsImNsaWVudF9ndWlkIjoiN2JmZDM3MjM1ZGY3NDVjNDg5ZjYxZDM1ZTYzZGQ4ZmUiLCJjbGllbnRfbmFtZSI6IkhTTUFwcC1jbGllbnQiLCJ0ZW5hbnQiOiJpZGNzLTczZmEzZWQ2OWU4MTQxYTdiOTAxZmFmN2Y4NzNlNzhlIiwianRpIjoiYzRkNjlhZjUtOGQ4OC00N2Q2LTkzMDctN2RjMmI3NWY4MDQyIn0.ZsngUzzso_sW6rMg3jB-lueiC2sknIDRlgvjumMjp5rRSdLux2X4XZIm2Oa15JbcrnC6I4sgqB0xU1Wte-TW4hbBDLFhaJKYKiNaHBE0L7J73ZK7ITg7dORKkyjLrofGt0m8Rse1OlE9AWevz-l27gtQMO_mctGfHri2BxiMbSN1HwOjWW3kGoqPgCJZJfh2TiFlocEpsXDH4qB1qwhuIoT91gw3kIJlQov0_a9uGEepMU_RWMRjVZCIvuV2hPq_mdeWy2IhkHPxq422CLZ9MDOfbv8F6dY6DralCH4mmKbGM3dbqpZokWQxXG7LG9vWX1PFWw0N9clYHJ4QqBJ4pA";
 
+    private static JwkKeys signKeys;
     private static JwkKeys verifyKeys;
     private static Config providersConfig;
 
     @BeforeAll
     public static void initClass() {
+        signKeys = JwkKeys.builder()
+                .resource(Resource.create("sign-jwk.json"))
+                .build();
+
         verifyKeys = JwkKeys.builder()
                 .resource(Resource.create("verify-jwk.json"))
                 .build();
@@ -81,6 +86,73 @@ public class JwtProviderTest {
         ProviderRequest atnRequest = mock(ProviderRequest.class);
         SecurityEnvironment se = SecurityEnvironment.builder()
                 .header("Authorization", "bearer " + WRONG_TOKEN)
+                .build();
+
+        when(atnRequest.env()).thenReturn(se);
+
+        AuthenticationResponse authenticationResponse = provider.authenticate(atnRequest);
+
+        assertThat(authenticationResponse.service(), is(Optional.empty()));
+        assertThat(authenticationResponse.user(), is(Optional.empty()));
+        assertThat(authenticationResponse.status(), is(SecurityResponse.SecurityStatus.FAILURE));
+    }
+
+    @Test
+    @DisplayName("Valid signature with wrong issuer is rejected")
+    public void testWrongIssuer() {
+        JwtProvider provider = JwtProvider.create(providersConfig.get("jwt"));
+
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.builder()
+                .subject("user1-id")
+                .preferredUsername("user1")
+                .issuer("unexpected.example.com")
+                .algorithm(JwkRSA.ALG_RS256)
+                .keyId("verify-rsa")
+                .issueTime(now)
+                .expirationTime(now.plus(1, ChronoUnit.HOURS))
+                .addAudience("audience.application.id")
+                .build();
+
+        SignedJwt signedJwt = SignedJwt.sign(jwt, signKeys.forKeyId("sign-rsa").orElseThrow());
+        signedJwt.verifySignature(verifyKeys).checkValid();
+
+        ProviderRequest atnRequest = mock(ProviderRequest.class);
+        SecurityEnvironment se = SecurityEnvironment.builder()
+                .header("Authorization", "bearer " + signedJwt.tokenContent())
+                .build();
+
+        when(atnRequest.env()).thenReturn(se);
+
+        AuthenticationResponse authenticationResponse = provider.authenticate(atnRequest);
+
+        assertThat(authenticationResponse.service(), is(Optional.empty()));
+        assertThat(authenticationResponse.user(), is(Optional.empty()));
+        assertThat(authenticationResponse.status(), is(SecurityResponse.SecurityStatus.FAILURE));
+    }
+
+    @Test
+    @DisplayName("Wrong issuer is rejected even when verify-signature = false")
+    public void testWrongIssuerWithoutSignatureVerification() {
+        JwtProvider provider = JwtProvider.create(providersConfig.get("jwt-no-verification"));
+
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.builder()
+                .subject("user1-id")
+                .preferredUsername("user1")
+                .issuer("unexpected.example.com")
+                .algorithm(JwkRSA.ALG_RS256)
+                .keyId("verify-rsa")
+                .issueTime(now)
+                .expirationTime(now.plus(1, ChronoUnit.HOURS))
+                .addAudience("audience.application.id")
+                .build();
+
+        SignedJwt signedJwt = SignedJwt.sign(jwt, signKeys.forKeyId("sign-rsa").orElseThrow());
+
+        ProviderRequest atnRequest = mock(ProviderRequest.class);
+        SecurityEnvironment se = SecurityEnvironment.builder()
+                .header("Authorization", "bearer " + signedJwt.tokenContent())
                 .build();
 
         when(atnRequest.env()).thenReturn(se);

--- a/security/providers/jwt/src/test/resources/application.yaml
+++ b/security/providers/jwt/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ jwt:
     # JWK configuration (where to get keys for verification/signatures)
     # either of the following (as defined in Resource utility):
     jwk.resource.resource-path: "verify-jwk.json"
+    # Expected issuer (if not defined, any issuer is accepted)
+    jwt-issuer: "jwt.example.com"
     # Expected audience (if not defined, any audience is accepted - security issue...)
     jwt-audience: "audience.application.id"
   sign-token:
@@ -70,6 +72,8 @@ jwt-no-verification:
     # either of the following (as defined in Resource utility):
     # Not needed, as we do not verify signature
     # jwk.resource.resource-path: "verify-jwk.json"
+    # Expected issuer (if not defined, any issuer is accepted)
+    jwt-issuer: "jwt.example.com"
     # Expected audience (if not defined, any audience is accepted - security issue...)
     jwt-audience: "audience.application.id"
     verify-signature: false

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import io.helidon.common.uri.UriEncoding;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
@@ -75,10 +76,13 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private final String protocolId;
     private final Method method;
     private final ClientUri clientUri;
+    private final ClientUri redirectSourceUri;
     private final Map<String, String> properties;
+    private final Set<HeaderName> redirectSensitiveHeaders;
     private final ClientRequestHeaders headers;
     private final String requestId;
     private final MediaContext mediaContext;
+    private final boolean filterRedirectHeaders;
 
     private SocketAddress socketAddress;
     private String uriTemplate;
@@ -109,13 +113,27 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                                 ClientUri clientUri,
                                 Boolean sendExpectContinue,
                                 Map<String, String> properties) {
+        this(clientConfig, cookieManager, protocolId, method, clientUri, sendExpectContinue, properties, null);
+    }
+
+    protected ClientRequestBase(HttpClientConfig clientConfig,
+                                WebClientCookieManager cookieManager,
+                                String protocolId,
+                                Method method,
+                                ClientUri clientUri,
+                                Boolean sendExpectContinue,
+                                Map<String, String> properties,
+                                ClientUri redirectSourceUri) {
         this.clientConfig = clientConfig;
         this.cookieManager = cookieManager;
         this.protocolId = protocolId;
         this.method = method;
         this.clientUri = clientUri;
+        this.redirectSourceUri = redirectSourceUri == null ? null : ClientUri.create(redirectSourceUri);
         this.sendExpectContinue = sendExpectContinue;
         this.properties = new HashMap<>(properties);
+        this.filterRedirectHeaders = clientConfig.filterRedirectHeaders();
+        this.redirectSensitiveHeaders = clientConfig.redirectSensitiveHeaders();
 
         this.headers = clientConfig.defaultRequestHeaders();
         this.readTimeout = clientConfig.socketOptions().readTimeout();
@@ -471,6 +489,18 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     }
 
     /**
+     * Remove headers that must not cross redirect trust boundaries.
+     *
+     * @param requestUri URI that will be used for the request
+     * @param requestHeaders headers to sanitize
+     */
+    protected final void sanitizeRedirectSensitiveHeaders(ClientUri requestUri, ClientRequestHeaders requestHeaders) {
+        if (filterRedirectHeaders && redirectSourceUri != null && !sameOrigin(redirectSourceUri, requestUri)) {
+            redirectSensitiveHeaders.forEach(requestHeaders::remove);
+        }
+    }
+
+    /**
      * Media context configured for this request.
      *
      * @return media context
@@ -501,6 +531,12 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private static String nextRequestId(String protocolId) {
         AtomicLong counter = COUNTERS.computeIfAbsent(protocolId, it -> new AtomicLong());
         return "client-" + protocolId + "-" + Long.toHexString(counter.getAndIncrement());
+    }
+
+    private static boolean sameOrigin(ClientUri sourceUri, ClientUri targetUri) {
+        return sourceUri.scheme().equalsIgnoreCase(targetUri.scheme())
+                && sourceUri.host().equalsIgnoreCase(targetUri.host())
+                && sourceUri.port() == targetUri.port();
     }
 
     private R validateAndSubmit(Object entity) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -34,6 +34,7 @@ import io.helidon.common.uri.UriQuery;
 import io.helidon.config.Config;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
@@ -136,6 +137,31 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      */
     @Option.Singular
     Set<Header> headers();
+
+    /**
+     * Whether headers sensitive to cross-origin redirects should be filtered before the redirected request is sent.
+     * <p>
+     * When enabled, header names from {@link #redirectSensitiveHeaders()} are stripped on cross-origin redirects.
+     *
+     * @return whether redirect header filtering is enabled
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(true)
+    boolean filterRedirectHeaders();
+
+    /**
+     * Request header names to strip on cross-origin redirects.
+     * <p>
+     * Header names are matched case-insensitively.
+     * The returned set always contains {@value io.helidon.http.HeaderNames#AUTHORIZATION_NAME},
+     * even if it was not explicitly configured.
+     *
+     * @return sensitive redirect headers
+     */
+    @Option.Configured
+    @Option.Singular
+    @Option.DefaultCode("new @java.util.LinkedHashSet@<>(@java.util.Set@.of(@io.helidon.http.HeaderNames@.AUTHORIZATION))")
+    Set<HeaderName> redirectSensitiveHeaders();
 
     /**
      * Default headers as a headers object. Creates a new instance for each call, so the returned value

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
@@ -20,7 +20,9 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.UnixDomainSocketAddress;
+import java.util.LinkedHashSet;
 import java.util.ServiceLoader;
+import java.util.Set;
 
 import io.helidon.builder.api.Prototype;
 import io.helidon.common.HelidonServiceLoader;
@@ -29,6 +31,7 @@ import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.tls.Tls;
 import io.helidon.config.Config;
 import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
@@ -149,6 +152,17 @@ class HttpClientConfigSupport {
         }
 
         /**
+         * Add a header name to strip on cross-origin redirects.
+         *
+         * @param builder builder to update
+         * @param headerName header name to add
+         */
+        @Prototype.BuilderMethod
+        static void addRedirectSensitiveHeader(HttpClientConfig.BuilderBase<?, ?> builder, String headerName) {
+            builder.addRedirectSensitiveHeader(HeaderNames.create(headerName));
+        }
+
+        /**
          * Config method to get {@link io.helidon.webclient.api.ClientUri}.
          *
          * @param config configuration instance
@@ -157,6 +171,19 @@ class HttpClientConfigSupport {
         @Prototype.ConfigFactoryMethod("baseUri")
         static ClientUri createBaseUri(Config config) {
             return config.as(URI.class).map(ClientUri::create).orElseThrow();
+        }
+
+        /**
+         * Config method to get redirect-sensitive header names.
+         *
+         * @param config configuration instance
+         * @return header name configured on the config node
+         */
+        @Prototype.ConfigFactoryMethod("redirectSensitiveHeaders")
+        static HeaderName createRedirectSensitiveHeader(Config config) {
+            return config.asString()
+                    .map(HeaderNames::create)
+                    .orElseThrow(() -> new IllegalStateException("Config node did not contain a header name"));
         }
 
         @Prototype.ConfigFactoryMethod("baseAddress")
@@ -210,6 +237,10 @@ class HttpClientConfigSupport {
             target.defaultHeadersMap()
                     .forEach(target::addHeader);
 
+            if (!target.redirectSensitiveHeaders().contains(HeaderNames.AUTHORIZATION)) {
+                target.redirectSensitiveHeaders(withAuthorizationRedirectSensitiveHeader(target.redirectSensitiveHeaders()));
+            }
+
             if (!target.mediaSupports().isEmpty()) {
                 target.mediaContext(MediaContext.builder()
                                             .update(it -> target.mediaSupports().forEach(it::addMediaSupport))
@@ -228,6 +259,13 @@ class HttpClientConfigSupport {
             if (target.proxy().isEmpty()) {
                 target.proxy(Proxy.create());
             }
+        }
+
+        private static Set<HeaderName> withAuthorizationRedirectSensitiveHeader(Set<HeaderName> headerNames) {
+            Set<HeaderName> effectiveHeaderNames = new LinkedHashSet<>(headerNames.size() + 1);
+            effectiveHeaderNames.add(HeaderNames.AUTHORIZATION);
+            effectiveHeaderNames.addAll(headerNames);
+            return Set.copyOf(effectiveHeaderNames);
         }
     }
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -156,6 +156,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         ClientRequestHeaders headers = serviceRequest.headers();
 
         writeBuffer.clear();
+        originalRequest.sanitizeRedirectHeaders(uri, headers);
         prologue(effectiveConnection, writeBuffer, serviceRequest, uri);
         headers.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -489,10 +489,10 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                 }
                 lastUri = redirectUri;
                 connection.releaseResource();
-                Http1ClientRequestImpl clientRequest = new Http1ClientRequestImpl(originalRequest,
+                Http1ClientRequestImpl clientRequest = new Http1ClientRequestImpl(lastRequest,
                                                                                   method,
                                                                                   redirectUri,
-                                                                                  request.properties());
+                                                                                  lastRequest.properties());
                 Http1ClientResponseImpl response;
                 if (sendEntity) {
                     response = (Http1ClientResponseImpl) clientRequest

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -56,13 +56,24 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
                            ClientUri clientUri,
                            Boolean sendExpectContinue,
                            Map<String, String> properties) {
+        this(http1Client, delegate, method, clientUri, sendExpectContinue, properties, null);
+    }
+
+    private Http1ClientRequestImpl(Http1ClientImpl http1Client,
+                                   FullClientRequest<?> delegate,
+                                   Method method,
+                                   ClientUri clientUri,
+                                   Boolean sendExpectContinue,
+                                   Map<String, String> properties,
+                                   ClientUri redirectSourceUri) {
         super(http1Client.clientConfig(),
               http1Client.webClient().cookieManager(),
               Http1Client.PROTOCOL_ID,
               method,
               clientUri,
               sendExpectContinue,
-              properties);
+              properties,
+              redirectSourceUri);
         this.http1Client = http1Client;
         this.delegate = delegate;
     }
@@ -77,7 +88,8 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
              method,
              clientUri,
              null,
-             properties);
+             properties,
+             request.resolvedUri());
 
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
@@ -209,6 +221,10 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
 
     Http1ClientImpl http1Client() {
         return http1Client;
+    }
+
+    void sanitizeRedirectHeaders(ClientUri requestUri, ClientRequestHeaders requestHeaders) {
+        super.sanitizeRedirectSensitiveHeaders(requestUri, requestHeaders);
     }
 
     /**

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -106,6 +106,7 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
         ClientUri uri = serviceRequest.uri();
         requestHeaders = serviceRequest.headers();
 
+        clientRequest.sanitizeRedirectHeaders(uri, requestHeaders);
         requestHeaders.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
         requestHeaders.remove(HeaderNames.CONNECTION, LogHeaderConsumer.INSTANCE);
         requestHeaders.setIfAbsent(USER_AGENT_HEADER);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -109,6 +109,8 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                                                                         Method.GET,
                                                                         redirectUri,
                                                                         outputStream.lastRequest.properties());
+            request.outputStreamRedirect(false);
+            request.readTimeout(outputStream.originalRequest.readTimeout());
             int numberOfRedirects = outputStream.numberOfRedirects;
             Http2ClientResponseImpl clientResponse = RedirectionProcessor.invokeWithFollowRedirects(request,
                                                                                                     numberOfRedirects,
@@ -307,10 +309,12 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 }
                 lastUri = redirectUri;
                 stream.close();
-                Http2ClientRequestImpl clientRequest = new Http2ClientRequestImpl(originalRequest,
+                Http2ClientRequestImpl clientRequest = new Http2ClientRequestImpl(lastRequest,
                                                                                   method,
                                                                                   redirectUri,
-                                                                                  originalRequest.properties());
+                                                                                  lastRequest.properties());
+                clientRequest.followRedirects(false);
+                clientRequest.readTimeout(originalRequest.readTimeout());
                 try {
                     Http2ClientResponseImpl response;
                     if (sendEntity) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -44,12 +44,23 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
                            Method method,
                            ClientUri clientUri,
                            Map<String, String> properties) {
+        this(http2Client, delegate, method, clientUri, properties, null);
+    }
+
+    private Http2ClientRequestImpl(Http2ClientImpl http2Client,
+                                   FullClientRequest<?> delegate,
+                                   Method method,
+                                   ClientUri clientUri,
+                                   Map<String, String> properties,
+                                   ClientUri redirectSourceUri) {
         super(http2Client.clientConfig(),
                 http2Client.webClient().cookieManager(),
                 Http2Client.PROTOCOL_ID,
                 method,
                 clientUri,
-                properties);
+                null,
+                properties,
+                redirectSourceUri);
 
         this.http2Client = http2Client;
         Http2ClientProtocolConfig protocolConfig = http2Client.protocolConfig();
@@ -61,7 +72,7 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
                            Method method,
                            ClientUri clientUri,
                            Map<String, String> properties) {
-        this(request.http2Client, request.delegate, method, clientUri, properties);
+        this(request.http2Client, request.delegate, method, clientUri, properties, request.resolvedUri());
 
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
@@ -157,6 +168,10 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
 
     boolean outputStreamRedirect() {
         return outputStreamRedirect;
+    }
+
+    void sanitizeRedirectHeaders(ClientUri requestUri, ClientRequestHeaders requestHeaders) {
+        super.sanitizeRedirectSensitiveHeaders(requestUri, requestHeaders);
     }
 
     Http2ClientResponseImpl invokeEntity(Object entity) {

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/CrossOriginRedirectHeaderTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/CrossOriginRedirectHeaderTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.tests;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webclient.spi.WebClientService;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.ServerRequest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class CrossOriginRedirectHeaderTest {
+    private static final HeaderName API_KEY_HEADER = HeaderNames.create("X-Api-Key");
+    private static final String AUTHORIZATION = "Bearer secret-token";
+    private static final String API_KEY = "key-0xDEADBEEF";
+
+    private static final AtomicReference<CapturedHeaders> SAME_ORIGIN_CAPTURE = new AtomicReference<>();
+    private static final AtomicReference<CapturedHeaders> CROSS_ORIGIN_CAPTURE = new AtomicReference<>();
+
+    private static WebServer trustedServer;
+    private static WebServer redirectTargetServer;
+
+    @BeforeAll
+    static void beforeAll() {
+        redirectTargetServer = WebServer.builder()
+                .host("127.0.0.1")
+                .port(0)
+                .routing(rules -> rules.get("/capture", (req, res) -> {
+                    CROSS_ORIGIN_CAPTURE.set(capturedHeaders(req));
+                    res.send("captured");
+                }).get("/redirect/back-to-trusted", (req, res) -> {
+                    res.status(Status.FOUND_302)
+                            .header(HeaderNames.LOCATION,
+                                    "http://127.0.0.1:" + trustedServer.port() + "/capture")
+                            .send();
+                }))
+                .build()
+                .start();
+
+        trustedServer = WebServer.builder()
+                .host("127.0.0.1")
+                .port(0)
+                .routing(rules -> rules.get("/redirect/cross-origin", (req, res) -> {
+                            res.status(Status.FOUND_302)
+                                    .header(HeaderNames.LOCATION,
+                                            "http://localhost:" + redirectTargetServer.port() + "/capture")
+                                    .send();
+                        })
+                        .get("/redirect/same-origin", (req, res) -> {
+                            res.status(Status.FOUND_302)
+                                    .header(HeaderNames.LOCATION, "/capture")
+                                    .send();
+                        })
+                        .put("/redirect/cross-origin-round-trip", (req, res) -> {
+                            res.status(Status.FOUND_302)
+                                    .header(HeaderNames.LOCATION,
+                                            "http://localhost:" + redirectTargetServer.port() + "/redirect/back-to-trusted")
+                                    .send();
+                        })
+                        .get("/capture", (req, res) -> {
+                            SAME_ORIGIN_CAPTURE.set(capturedHeaders(req));
+                            res.send("captured");
+                        }))
+                .build()
+                .start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (trustedServer != null) {
+            trustedServer.stop();
+        }
+        if (redirectTargetServer != null) {
+            redirectTargetServer.stop();
+        }
+    }
+
+    @BeforeEach
+    void resetCapturedHeaders() {
+        SAME_ORIGIN_CAPTURE.set(null);
+        CROSS_ORIGIN_CAPTURE.set(null);
+    }
+
+    @Test
+    void stripsAuthorizationOnCrossOriginRedirect() {
+        try (Http1ClientResponse response = newClient().get("/redirect/cross-origin").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = CROSS_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(nullValue()));
+        assertThat(captured.apiKey(), is(API_KEY));
+    }
+
+    @Test
+    void stripsConfiguredHeadersOnCrossOriginRedirect() {
+        try (Http1ClientResponse response = newClient(true, true).get("/redirect/cross-origin").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = CROSS_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(nullValue()));
+        assertThat(captured.apiKey(), is(nullValue()));
+    }
+
+    @Test
+    void preservesConfiguredHeadersOnSameOriginRedirect() {
+        try (Http1ClientResponse response = newClient(true, true).get("/redirect/same-origin").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = SAME_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(AUTHORIZATION));
+        assertThat(captured.apiKey(), is(API_KEY));
+    }
+
+    @Test
+    void preservesHeadersWhenRedirectFilteringDisabled() {
+        try (Http1ClientResponse response = newClient(true, false).get("/redirect/cross-origin").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = CROSS_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(AUTHORIZATION));
+        assertThat(captured.apiKey(), is(API_KEY));
+    }
+
+    @Test
+    void stripsConfiguredHeadersAcrossCrossOriginRoundTripRedirects() {
+        try (Http1ClientResponse response = newClient(true, true).put("/redirect/cross-origin-round-trip")
+                .outputStream(it -> {
+                    it.write(API_KEY.getBytes(StandardCharsets.UTF_8));
+                    it.close();
+                })) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = SAME_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(nullValue()));
+        assertThat(captured.apiKey(), is(nullValue()));
+    }
+
+    private static Http1Client newClient() {
+        return newClient(false, true);
+    }
+
+    private static Http1Client newClient(boolean stripApiKeyOnRedirect, boolean filterRedirectHeaders) {
+        var builder = Http1Client.builder()
+                .servicesDiscoverServices(false)
+                .baseUri("http://127.0.0.1:" + trustedServer.port())
+                .addHeader(API_KEY_HEADER, API_KEY)
+                .addService(new AuthorizationService())
+                .filterRedirectHeaders(filterRedirectHeaders);
+        if (stripApiKeyOnRedirect) {
+            builder.addRedirectSensitiveHeader(API_KEY_HEADER);
+        }
+        return builder.build();
+    }
+
+    private record AuthorizationService() implements WebClientService {
+        @Override
+        public WebClientServiceResponse handle(Chain chain, WebClientServiceRequest request) {
+            request.headers().set(HeaderNames.AUTHORIZATION, AUTHORIZATION);
+            return chain.proceed(request);
+        }
+    }
+
+    private static CapturedHeaders capturedHeaders(ServerRequest request) {
+        return new CapturedHeaders(request.headers().first(HeaderNames.AUTHORIZATION).orElse(null),
+                                   request.headers().first(API_KEY_HEADER).orElse(null));
+    }
+
+    private record CapturedHeaders(String authorization, String apiKey) {
+    }
+}

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/CrossOriginRedirectHeaderTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/CrossOriginRedirectHeaderTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.tests.http2;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webclient.http2.Http2ClientResponse;
+import io.helidon.webclient.spi.WebClientService;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.ServerRequest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class CrossOriginRedirectHeaderTest {
+    private static final HeaderName API_KEY_HEADER = HeaderNames.create("X-Api-Key");
+    private static final String API_KEY_HEADER_CONFIG_NAME = "x-API-key";
+    private static final String AUTHORIZATION = "Bearer secret-token";
+    private static final String API_KEY = "key-0xDEADBEEF";
+
+    private static final AtomicReference<CapturedHeaders> SAME_ORIGIN_CAPTURE = new AtomicReference<>();
+    private static final AtomicReference<CapturedHeaders> CROSS_ORIGIN_CAPTURE = new AtomicReference<>();
+
+    private static WebServer trustedServer;
+    private static WebServer redirectTargetServer;
+
+    @BeforeAll
+    static void beforeAll() {
+        redirectTargetServer = WebServer.builder()
+                .host("127.0.0.1")
+                .port(-1)
+                .routing(rules -> rules.get("/capture", (req, res) -> {
+                    CROSS_ORIGIN_CAPTURE.set(capturedHeaders(req));
+                    res.send("captured");
+                }).get("/redirect/back-to-trusted", (req, res) -> {
+                    res.status(Status.FOUND_302)
+                            .header(HeaderNames.LOCATION,
+                                    "http://127.0.0.1:" + trustedServer.port() + "/capture")
+                            .send();
+                }))
+                .build()
+                .start();
+
+        trustedServer = WebServer.builder()
+                .host("127.0.0.1")
+                .port(-1)
+                .routing(rules -> rules.get("/redirect/cross-origin", (req, res) -> {
+                            res.status(Status.FOUND_302)
+                                    .header(HeaderNames.LOCATION,
+                                            "http://localhost:" + redirectTargetServer.port() + "/capture")
+                                    .send();
+                        })
+                        .get("/redirect/same-origin", (req, res) -> {
+                            res.status(Status.FOUND_302)
+                                    .header(HeaderNames.LOCATION, "/capture")
+                                    .send();
+                        })
+                        .put("/redirect/cross-origin-round-trip", (req, res) -> {
+                            res.status(Status.FOUND_302)
+                                    .header(HeaderNames.LOCATION,
+                                            "http://localhost:" + redirectTargetServer.port() + "/redirect/back-to-trusted")
+                                    .send();
+                        })
+                        .get("/capture", (req, res) -> {
+                            SAME_ORIGIN_CAPTURE.set(capturedHeaders(req));
+                            res.send("captured");
+                        }))
+                .build()
+                .start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (trustedServer != null) {
+            trustedServer.stop();
+        }
+        if (redirectTargetServer != null) {
+            redirectTargetServer.stop();
+        }
+    }
+
+    @BeforeEach
+    void resetCapturedHeaders() {
+        SAME_ORIGIN_CAPTURE.set(null);
+        CROSS_ORIGIN_CAPTURE.set(null);
+    }
+
+    @Test
+    void stripsAuthorizationOnCrossOriginRedirect() {
+        try (Http2ClientResponse response = newClient().get("/redirect/cross-origin").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = CROSS_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(nullValue()));
+        assertThat(captured.apiKey(), is(API_KEY));
+    }
+
+    @Test
+    void stripsConfiguredHeadersOnCrossOriginRedirect() {
+        try (Http2ClientResponse response = newClient(true, true).get("/redirect/cross-origin").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = CROSS_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(nullValue()));
+        assertThat(captured.apiKey(), is(nullValue()));
+    }
+
+    @Test
+    void preservesConfiguredHeadersOnSameOriginRedirect() {
+        try (Http2ClientResponse response = newClient(true, true).get("/redirect/same-origin").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = SAME_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(AUTHORIZATION));
+        assertThat(captured.apiKey(), is(API_KEY));
+    }
+
+    @Test
+    void preservesHeadersWhenRedirectFilteringDisabled() {
+        try (Http2ClientResponse response = newClient(true, false).get("/redirect/cross-origin").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = CROSS_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(AUTHORIZATION));
+        assertThat(captured.apiKey(), is(API_KEY));
+    }
+
+    @Test
+    void stripsConfiguredHeadersAcrossCrossOriginRoundTripRedirects() {
+        try (Http2ClientResponse response = newClient(true, true).put("/redirect/cross-origin-round-trip")
+                .outputStream(it -> {
+                    it.write(API_KEY.getBytes(StandardCharsets.UTF_8));
+                    it.close();
+                })) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        CapturedHeaders captured = SAME_ORIGIN_CAPTURE.get();
+        assertThat(captured, is(notNullValue()));
+        assertThat(captured.authorization(), is(nullValue()));
+        assertThat(captured.apiKey(), is(nullValue()));
+    }
+
+    private static Http2Client newClient() {
+        return newClient(false, true);
+    }
+
+    private static Http2Client newClient(boolean stripApiKeyOnRedirect, boolean filterRedirectHeaders) {
+        var builder = Http2Client.builder()
+                .servicesDiscoverServices(false)
+                .baseUri("http://127.0.0.1:" + trustedServer.port())
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .addHeader(API_KEY_HEADER, API_KEY)
+                .addService(new AuthorizationService())
+                .filterRedirectHeaders(filterRedirectHeaders);
+        if (stripApiKeyOnRedirect) {
+            builder.addRedirectSensitiveHeader(API_KEY_HEADER_CONFIG_NAME);
+        }
+        return builder.build();
+    }
+
+    private record AuthorizationService() implements WebClientService {
+        @Override
+        public WebClientServiceResponse handle(Chain chain, WebClientServiceRequest request) {
+            request.headers().set(HeaderNames.AUTHORIZATION, AUTHORIZATION);
+            return chain.proceed(request);
+        }
+    }
+
+    private static CapturedHeaders capturedHeaders(ServerRequest request) {
+        return new CapturedHeaders(request.headers().first(HeaderNames.AUTHORIZATION).orElse(null),
+                                   request.headers().first(API_KEY_HEADER).orElse(null));
+    }
+
+    private record CapturedHeaders(String authorization, String apiKey) {
+    }
+}

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,10 +67,35 @@ class FollowRedirectTest {
             res.status(Status.TEMPORARY_REDIRECT_307)
                     .header(HeaderNames.LOCATION, "/plain")
                     .send();
+        }).route(Method.PUT, "/redirectKeepMethodThenGet", (req, res) -> {
+            res.status(Status.TEMPORARY_REDIRECT_307)
+                    .header(HeaderNames.LOCATION, "/redirectNoEntityAfterKeepMethod")
+                    .send();
+        }).route(Method.PUT, "/redirectKeepMethodThenRedirectAfterUpload", (req, res) -> {
+            res.status(Status.TEMPORARY_REDIRECT_307)
+                    .header(HeaderNames.LOCATION, "/redirectAfterUploadDelayed")
+                    .send();
         }).route(Method.PUT, "/redirectNoEntity", (req, res) -> {
             res.status(Status.FOUND_302)
                     .header(HeaderNames.LOCATION, "/plain")
                     .send();
+        }).route(Method.PUT, "/redirectNoEntityAfterKeepMethod", (req, res) -> {
+            res.status(Status.FOUND_302)
+                    .header(HeaderNames.LOCATION, "/delayedPlain")
+                    .send();
+        }).route(Method.PUT, "/redirectAfterUploadDelayed", (req, res) -> {
+            try (InputStream in = req.content().inputStream()) {
+                byte[] buffer = new byte[128];
+                while (in.read(buffer) > 0) {
+                    // Do nothing and just drain the entity.
+                }
+                res.status(Status.SEE_OTHER_303)
+                        .header(HeaderNames.LOCATION, "/delayedPlain")
+                        .send();
+            } catch (Exception e) {
+                res.status(INTERNAL_SERVER_ERROR_500)
+                        .send(e.getMessage());
+            }
         }).route(Method.PUT, "/plain", (req, res) -> {
             try (InputStream in = req.content().inputStream()) {
                 byte[] buffer = new byte[128];
@@ -101,6 +126,9 @@ class FollowRedirectTest {
             res.send("Upload completed!" + BUFFER);
         }).route(Method.GET, "/plain", (req, res) -> {
             res.send("GET plain endpoint reached");
+        }).route(Method.GET, "/delayedPlain", (req, res) -> {
+            TimeUnit.MILLISECONDS.sleep(250);
+            res.send("GET delayed endpoint reached");
         }).route(Method.PUT, "/close", (req, res) -> {
             byte[] buffer = new byte[10];
             try (InputStream in = req.content().inputStream()) {
@@ -158,6 +186,36 @@ class FollowRedirectTest {
                 .outputStream(it -> {
                     it.write("0123456789".getBytes(StandardCharsets.UTF_8));
                     it.write("0123456789".getBytes(StandardCharsets.UTF_8));
+                    it.write("0123456789".getBytes(StandardCharsets.UTF_8));
+                    it.close();
+                })) {
+            assertThat(response.entity().as(String.class), is(expected));
+        }
+    }
+
+    @Test
+    void testReadTimeoutPreservedAcrossMixedRedirects() {
+        String expected = "GET delayed endpoint reached";
+        try (Http2ClientResponse response = webClient.put()
+                .path("/redirectKeepMethodThenGet")
+                .readContinueTimeout(Duration.ofMillis(50))
+                .readTimeout(Duration.ofSeconds(1))
+                .outputStream(it -> {
+                    it.write("0123456789".getBytes(StandardCharsets.UTF_8));
+                    it.close();
+                })) {
+            assertThat(response.entity().as(String.class), is(expected));
+        }
+    }
+
+    @Test
+    void testReadTimeoutPreservedAcrossRedirectAfterUpload() {
+        String expected = "GET delayed endpoint reached";
+        try (Http2ClientResponse response = webClient.put()
+                .path("/redirectKeepMethodThenRedirectAfterUpload")
+                .readContinueTimeout(Duration.ofMillis(50))
+                .readTimeout(Duration.ofSeconds(1))
+                .outputStream(it -> {
                     it.write("0123456789".getBytes(StandardCharsets.UTF_8));
                     it.close();
                 })) {


### PR DESCRIPTION
Backport of the missing fixes from `release-4.4.1` into `helidon-4.x`.

This carries:

- `6a9dc9c198fd5901b7f914080679f6e98da057ce` - JWT inbound issuer validation.
- `1da076ed2b442f8512cecbaebf395ccab675883e` - sensitive WebClient header filtering on cross-origin redirects.

Validation:

- `mvn -pl security/providers/jwt -Dtest=JwtProviderTest test`
- `mvn -Ptests -pl webclient/tests/http1,webclient/tests/http2 -am -Dtest=CrossOriginRedirectHeaderTest,FollowRedirectTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./etc/scripts/copyright.sh`
