### PR TITLE
Avoid unnecessary DNS resolution without proxy

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -185,9 +185,9 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html which states: "The absoluteURI form is REQUIRED when the
             // request is being made to a proxy."
             String absoluteUri = uri.scheme() + "://" + uri.host() + ":" + uri.port();
-            InetSocketAddress uriAddress = new InetSocketAddress(uri.host(), uri.port());
             String requestUri = proxy == Proxy.noProxy()
-                    || (proxy.type() == Proxy.ProxyType.HTTP && proxy.isNoHosts(uriAddress))
+                    || (proxy.type() == Proxy.ProxyType.HTTP
+                            && proxy.isNoHosts(new InetSocketAddress(uri.host(), uri.port())))
                     || (proxy.type() == Proxy.ProxyType.SYSTEM && !proxy.isUsingSystemProxy(absoluteUri))
                     || clientConfig.relativeUris()
                     ? "" // don't set host details, so it becomes relative URI


### PR DESCRIPTION
### Description

### Documentation

This is a small backport of the already-merged fix from #11812 to `helidon-4.x`. It only changes when `InetSocketAddress` is created internally in the HTTP/1 client proxy URI logic and does not change user-facing APIs, configuration, or documented behavior.

