### PR TITLE
Support Optional<List<T>> for provider-backed builder options (27.x)

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Option.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Option.java
@@ -95,17 +95,29 @@ public final class Option {
     }
 
     /**
-     * Mark option as sourced from a {@link java.util.ServiceLoader}.
+     * Mark option as sourced from services discovered by a {@link java.util.ServiceLoader}, or by Helidon Service
+     * Registry when {@link io.helidon.builder.api.Prototype.RegistrySupport} is enabled.
      * Use if the configuration may be provided by another module not known to us.
      * <p>
-     * To control whether to discover services or not, you can specify a key {@code config-key-discover-services}
-     * on the same level as the section for the provider based property. This is aligned with the generated methods on the
-     * builder, and allows for the shallowest possible configuration tree (this would  override {@link #discoverServices()}
-     * defined on this annotation).
+     * When the option is also {@link io.helidon.builder.api.Option.Configured}, discovered configured providers are
+     * used to create services from configuration.
      * <p>
-     * Also there is no difference regardless whether we return a single value, or a list of values.
-     * If the method returns a list, the provider configuration must be under config key {@code providers} under
-     * the configured option. On the same level as {@code providers}, there can be {@code discover-services} boolean
+     * A configured provider option uses the option's configured key as the provider configuration node. For example,
+     * if the provider option key is {@code my-providers}, provider entries are read from {@code my-providers}. There
+     * is no extra nested {@code providers} key unless the option itself is configured with that key.
+     * <p>
+     * To control whether to discover services or not for a configured provider option, you can specify a sibling
+     * boolean key named {@code <option-config-key>-discover-services}, such as
+     * {@code my-providers-discover-services}. This is aligned with the generated methods on the builder and overrides
+     * {@link #discoverServices()} defined on this annotation.
+     * <p>
+     * The configuration key rules are the same regardless whether the method returns a single value, a single
+     * {@link java.util.Optional} value, a list of values, or an optional list of values. A single value or optional
+     * value must have at most one configured provider entry.
+     * <p>
+     * When using an optional list, an absent configuration node does not by itself set the optional value; the value
+     * stays empty unless builder values or service discovery provide entries. An explicitly empty list or object
+     * configuration node produces {@code Optional.of(List.of())}.
      * <p>
      * Option called {@code myProvider} that returns a single provider, or an {@link java.util.Optional} provider example
      * in configuration:
@@ -134,20 +146,24 @@ public final class Option {
     @Retention(RetentionPolicy.CLASS)
     public @interface Provider {
         /**
-         * The service provider interface that is used to discover
-         * implementations. The type of the property is the service provided by that provider.
+         * The service provider interface, or service contract for a non-configured option, that is used to discover
+         * implementations. For configured provider options, the type of the property is the service provided by that
+         * provider.
          *
          * @return type of the provider
          */
         Class<?> value();
 
         /**
-         * Whether to discover all services using a service loader by default.
-         * When set to {@code true}, all services discovered by the service loader will be added (even if no configuration
-         * node exists for them). When set to {@code false}, only services that have a configuration node will be added.
-         * This can be overridden by {@code discover-services} configuration option under this option's key.
-         * In case the option is not {@link io.helidon.builder.api.Option.Configured}, this is always considered true,
-         * as otherwise this annotation would not make any sense (i.e. it would never provide a value).
+         * Whether to discover services by default.
+         * When set to {@code true}, services discovered by the service loader, or by Helidon Service Registry if
+         * {@link io.helidon.builder.api.Prototype.RegistrySupport} is enabled, are used even if no configuration node
+         * exists for them. When set to {@code false}, configured provider options use only services that have a
+         * configuration node, and non-configured options ignore automatic discovery.
+         * For configured provider options, this can be overridden by a sibling configuration option named
+         * {@code <option-config-key>-discover-services}.
+         * In case the option is not {@link io.helidon.builder.api.Option.Configured}, this value initializes the
+         * generated discovery flag, which can still be changed using the generated builder method.
          *
          * @return whether to discover services by default for a provider
          */

--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -52,6 +52,9 @@ public final class Prototype {
         /**
          * Create an instance of the {@link Prototype}. This method is available on
          * all generated builders for {@link Prototype.Blueprint}.
+         * <p>
+         * Calling this method may update the builder from providers and decorators, so repeated calls may have side
+         * effects such as repeated provider discovery.
          *
          * @return an instance of the setup object created from this builder
          */

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import io.helidon.builder.codegen.spi.BuilderCodegenExtension;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Constructor;
+import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.codegen.classmodel.InnerClass;
 import io.helidon.codegen.classmodel.Javadoc;
 import io.helidon.codegen.classmodel.Method;
@@ -149,6 +150,10 @@ final class GenerateAbstractBuilder {
 
         Method.Builder builder = Method.builder()
                 .name("build")
+                .description(isBuilder
+                                     ? "Create an instance from this builder. Calling this method may update this builder"
+                                             + " from providers and decorators, so repeated calls may have side effects."
+                                     : "Create a new runtime instance from this prototype.")
                 .addAnnotation(Annotations.OVERRIDE)
                 .returnType(runtimeType)
                 .addContent("return ");
@@ -555,6 +560,42 @@ final class GenerateAbstractBuilder {
                 .anyMatch(it -> it.provider().isPresent());
     }
 
+    private static boolean optionalProviderList(TypeName typeName) {
+        return typeName.isOptional()
+                && !typeName.typeArguments().isEmpty()
+                && typeName.typeArguments().getFirst().isList();
+    }
+
+    private static TypeName providerContainerType(TypeName typeName) {
+        if (typeName.isOptional()) {
+            return typeName.typeArguments().getFirst();
+        }
+        return typeName;
+    }
+
+    private static TypeName providerValueType(OptionHandler optionHandler) {
+        TypeName providerContainerType = providerContainerType(optionHandler.option().declaredType());
+        if (providerContainerType.isList() || providerContainerType.isSet()) {
+            return providerContainerType.typeArguments().getFirst();
+        }
+        return optionHandler.typeHandler().type();
+    }
+
+    private static void optionalProviderListExisting(ContentBuilder<?> content, OptionInfo option) {
+        content.addContent(option.name())
+                .addContent(" == null ? ")
+                .addContent(List.class)
+                .addContent(".of() : ")
+                .addContent(option.name());
+    }
+
+    private static void optionalProviderListEmpty(ContentBuilder<?> content, TypeName providerValueType) {
+        content.addContent(List.class)
+                .addContent(".<")
+                .addContent(providerValueType.genericTypeName())
+                .addContent(">of()");
+    }
+
     private static void serviceLoaderPropertyDiscovery(Method.Builder preBuildBuilder,
                                                        OptionHandler optionHandler,
                                                        boolean propertyConfigured,
@@ -563,11 +604,48 @@ final class GenerateAbstractBuilder {
         TypeHandler typeHandler = optionHandler.typeHandler();
         OptionInfo option = optionHandler.option();
         TypeName typeName = option.declaredType();
+        TypeName providerValueType = providerValueType(optionHandler);
 
         if (propertyConfigured) {
             OptionConfigured configured = option.configured().get();
 
-            if (typeName.isList() || typeName.isSet()) {
+            if (optionalProviderList(typeName)) {
+                preBuildBuilder.addContentLine("{")
+                        .addContent("var optionConfig = config.get(\"")
+                        .addContent(configured.configKey())
+                        .addContentLine("\");")
+                        .addContent("var discovered = optionConfig.exists() && optionConfig.asNodeList().orElseGet(")
+                        .addContent(List.class)
+                        .addContentLine("::of).isEmpty()")
+                        .increaseContentPadding()
+                        .increaseContentPadding()
+                        .addContent("? ")
+                        .update(it -> optionalProviderListEmpty(it, providerValueType))
+                        .addContentLine("")
+                        .addContent(": ")
+                        .addContent(CONFIG_BUILDER_SUPPORT)
+                        .addContent(".discoverServices(config, \"")
+                        .addContent(configured.configKey())
+                        .addContent("\", ")
+                        .addContent(providerType.genericTypeName())
+                        .addContent(".class, ")
+                        .addContent(providerValueType.genericTypeName())
+                        .addContent(".class, ")
+                        .addContent(option.name())
+                        .addContent("DiscoverServices, ")
+                        .update(it -> optionalProviderListExisting(it, option))
+                        .addContentLine(");")
+                        .decreaseContentPadding()
+                        .decreaseContentPadding()
+                        .addContent("if (optionConfig.exists() || ")
+                        .addContent(option.name())
+                        .addContentLine(" != null || !discovered.isEmpty()) {")
+                        .addContent("this.add")
+                        .addContent(capitalize(option.name()))
+                        .addContentLine("(discovered);")
+                        .addContentLine("}")
+                        .addContentLine("}");
+            } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
                         .addContent(capitalize(option.name()))
                         .addContent("(")
@@ -577,7 +655,7 @@ final class GenerateAbstractBuilder {
                         .addContent("\", ")
                         .addContent(providerType.genericTypeName())
                         .addContent(".class, ")
-                        .addContent(typeHandler.type().genericTypeName())
+                        .addContent(providerValueType.genericTypeName())
                         .addContent(".class, ")
                         .addContent(option.name())
                         .addContent("DiscoverServices, ")
@@ -603,7 +681,26 @@ final class GenerateAbstractBuilder {
                         .addContentLine(");");
             }
         } else {
-            if (typeName.isList() || typeName.isSet()) {
+            if (optionalProviderList(typeName)) {
+                preBuildBuilder.addContentLine("{")
+                        .addContent("var discovered = ")
+                        .addContent(BUILDER_SUPPORT)
+                        .addContent(".discoverServices(")
+                        .addContent(providerType.genericTypeName())
+                        .addContent(".class, ")
+                        .addContent(option.name())
+                        .addContent("DiscoverServices, ")
+                        .update(it -> optionalProviderListExisting(it, option))
+                        .addContentLine(");")
+                        .addContent("if (")
+                        .addContent(option.name())
+                        .addContentLine(" != null || !discovered.isEmpty()) {")
+                        .addContent("this.add")
+                        .addContent(capitalize(option.name()))
+                        .addContentLine("(discovered);")
+                        .addContentLine("}")
+                        .addContentLine("}");
+            } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
                         .addContent(capitalize(option.name()))
                         .addContent("(")
@@ -763,11 +860,18 @@ final class GenerateAbstractBuilder {
         TypeHandler typeHandler = optionHandler.typeHandler();
         OptionInfo option = optionHandler.option();
         TypeName typeName = option.declaredType();
+        TypeName providerValueType = providerValueType(optionHandler);
 
         if (propertyConfigured) {
             OptionConfigured configured = option.configured().get();
 
-            if (typeName.isList() || typeName.isSet()) {
+            if (optionalProviderList(typeName)) {
+                serviceRegistryConfiguredOptionalProviderList(preBuildBuilder,
+                                                              option,
+                                                              configured,
+                                                              providerType,
+                                                              providerValueType);
+            } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
                         .addContent(capitalize(option.name()))
                         .addContent("(")
@@ -782,7 +886,7 @@ final class GenerateAbstractBuilder {
                         .addContentLine("registry,")
                         .addContent(providerType.genericTypeName())
                         .addContentLine(".class,")
-                        .addContent(typeHandler.type().genericTypeName())
+                        .addContent(providerValueType.genericTypeName())
                         .addContentLine(".class,")
                         .addContent(option.name())
                         .addContentLine("DiscoverServices,")
@@ -820,7 +924,26 @@ final class GenerateAbstractBuilder {
                         .decreaseContentPadding();
             }
         } else {
-            if (typeName.isList()) {
+            if (optionalProviderList(typeName)) {
+                preBuildBuilder.addContentLine("{")
+                        .addContent("var discovered = ")
+                        .addContent(REGISTRY_BUILDER_SUPPORT)
+                        .addContent(".<")
+                        .addContent(providerValueType.genericTypeName())
+                        .addContent(">serviceList(registry, ")
+                        .addContentCreate(providerValueType)
+                        .addContent(", ")
+                        .addContent(option.name())
+                        .addContentLine("DiscoverServices);")
+                        .addContent("if (")
+                        .addContent(option.name())
+                        .addContentLine(" != null || !discovered.isEmpty()) {")
+                        .addContent("this.add")
+                        .addContent(capitalize(option.name()))
+                        .addContentLine("(discovered);")
+                        .addContentLine("}")
+                        .addContentLine("}");
+            } else if (typeName.isList()) {
                 preBuildBuilder
                         .addContent("this.add")
                         .addContent(capitalize(option.name()))
@@ -858,6 +981,56 @@ final class GenerateAbstractBuilder {
                         .addContentLine(");");
             }
         }
+    }
+
+    private static void serviceRegistryConfiguredOptionalProviderList(Method.Builder preBuildBuilder,
+                                                                     OptionInfo option,
+                                                                     OptionConfigured configured,
+                                                                     TypeName providerType,
+                                                                     TypeName providerValueType) {
+        preBuildBuilder.addContentLine("{")
+                .addContent("var optionConfig = config.get(\"")
+                .addContent(configured.configKey())
+                .addContentLine("\");")
+                .addContent("var discovered = optionConfig.exists() && optionConfig.asNodeList().orElseGet(")
+                .addContent(List.class)
+                .addContentLine("::of).isEmpty()")
+                .increaseContentPadding()
+                .increaseContentPadding()
+                .addContent("? ")
+                .update(it -> optionalProviderListEmpty(it, providerValueType))
+                .addContentLine("")
+                .addContent(": ")
+                .addContent(CONFIG_BUILDER_SUPPORT)
+                .addContentLine(".discoverServices(config,")
+                .increaseContentPadding()
+                .increaseContentPadding()
+                .increaseContentPadding()
+                .addContent("\"")
+                .addContent(configured.configKey())
+                .addContentLine("\",")
+                .addContentLine("registry,")
+                .addContent(providerType.genericTypeName())
+                .addContentLine(".class,")
+                .addContent(providerValueType.genericTypeName())
+                .addContentLine(".class,")
+                .addContent(option.name())
+                .addContentLine("DiscoverServices,")
+                .update(it -> optionalProviderListExisting(it, option))
+                .addContentLine(");")
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .addContent("if (optionConfig.exists() || ")
+                .addContent(option.name())
+                .addContentLine(" != null || !discovered.isEmpty()) {")
+                .addContent("this.add")
+                .addContent(capitalize(option.name()))
+                .addContentLine("(discovered);")
+                .addContentLine("}")
+                .addContentLine("}");
     }
 
     private static void validatePrototypeMethod(List<BuilderCodegenExtension> extensions, InnerClass.Builder classBuilder,
@@ -1268,7 +1441,17 @@ final class GenerateAbstractBuilder {
             constructor.addContent("this." + option.name() + " = ");
             TypeName declaredType = option.declaredType();
 
-            if (declaredType.isOptional()) {
+            if (declaredType.isOptional() && optionHandler.typeHandler().type().isList()) {
+                constructor.addContent("builder." + getterName + "().map(")
+                        .addContent(List.class)
+                        .addContentLine("::copyOf);");
+            } else if (declaredType.isOptional() && optionHandler.typeHandler().type().isSet()) {
+                constructor.addContent("builder." + getterName + "().map(it -> ")
+                        .addContent(Collections.class)
+                        .addContent(".unmodifiableSet(new ")
+                        .addContent(LinkedHashSet.class)
+                        .addContentLine("<>(it)));");
+            } else if (declaredType.isOptional()) {
                 constructor.addContent("builder." + getterName + "().map(")
                         .addContent(Function.class)
                         .addContentLine(".identity());");

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,8 @@ final class GenerateBuilder {
                     })
                     .addMethod(method -> {
                         method.name("buildPrototype")
+                                .description("Create an instance of the prototype. Calling this method may update this builder"
+                                                     + " from providers and decorators, so repeated calls may have side effects.")
                                 .returnType(prototype)
                                 .addAnnotation(Annotations.OVERRIDE)
                                 .addContentLine("preBuildPrototype();")
@@ -94,6 +96,8 @@ final class GenerateBuilder {
             } else {
                 // build method returns the same as buildPrototype method
                 builder.addMethod(method -> method.name("build")
+                        .description("Create an instance from this builder. Calling this method may update this builder"
+                                             + " from providers and decorators, so repeated calls may have side effects.")
                         .addAnnotation(Annotations.OVERRIDE)
                         .returnType(runtimeType)
                         .addContentLine("return buildPrototype();"));

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerOptional.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerOptional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.builder.codegen;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -64,7 +66,61 @@ class TypeHandlerOptional extends TypeHandlerBasic {
     }
 
     @Override
+    GeneratedMethod prepareBuilderSetter(Javadoc getterJavadoc) {
+        if (!optionalCollection()) {
+            return super.prepareBuilderSetter(getterJavadoc);
+        }
+
+        TypeName returnType = Utils.builderReturnType();
+        String name = option().name();
+
+        var method = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(option().accessModifier())
+                .typeName(returnType)
+                .elementName(option().setterName())
+                .update(this::deprecation)
+                .update(it -> option().annotations().forEach(it::addAnnotation));
+
+        method.addParameterArgument(param -> param
+                .kind(ElementKind.PARAMETER)
+                .typeName(collectionParameterType())
+                .elementName(name)
+        );
+
+        Consumer<ContentBuilder<?>> contentConsumer = it -> {
+            it.addContent(Objects.class)
+                    .addContentLine(".requireNonNull(" + name + ");");
+            option().decorator()
+                    .ifPresent(decorator -> {
+                        it.addContent("new ")
+                                .addContent(decorator)
+                                .addContent("().decorate(this, ");
+                        optionalDecoratorValue(it);
+                        it.addContentLine(");");
+                    });
+
+            it.addContent("this.")
+                    .addContent(name)
+                    .addContent(" = ");
+            mutableCollection(it, name);
+            it.addContentLine(";")
+                    .addContentLine("return self();");
+        };
+
+        return GeneratedMethod.builder()
+                .method(method.build())
+                .javadoc(setterJavadoc(getterJavadoc, name, ""))
+                .contentBuilder(contentConsumer)
+                .build();
+    }
+
+    @Override
     Optional<GeneratedMethod> prepareBuilderSetterDeclared(Javadoc getterJavadoc) {
+        if (optionalCollection()) {
+            return prepareOptionalCollectionSetterDeclared(getterJavadoc);
+        }
+
         TypeName typeName = asTypeArgument(TypeNames.OPTIONAL);
         TypeName returnType = Utils.builderReturnType();
 
@@ -116,6 +172,59 @@ class TypeHandlerOptional extends TypeHandlerBasic {
     }
 
     @Override
+    Optional<GeneratedMethod> prepareBuilderAddCollection(Javadoc getterJavadoc) {
+        if (!optionalCollection()) {
+            return Optional.empty();
+        }
+
+        TypeName returnType = Utils.builderReturnType();
+        String name = option().name();
+
+        var method = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(option().accessModifier())
+                .typeName(returnType)
+                .elementName("add" + capitalize(option().name()))
+                .update(this::deprecation)
+                .update(it -> option().annotations().forEach(it::addAnnotation));
+
+        method.addParameterArgument(param -> param
+                .kind(ElementKind.PARAMETER)
+                .typeName(collectionParameterType())
+                .elementName(name)
+        );
+
+        Consumer<ContentBuilder<?>> contentConsumer = it -> {
+            it.addContent(Objects.class)
+                    .addContentLine(".requireNonNull(" + name + ");");
+            option().decorator()
+                    .ifPresent(decorator -> {
+                        it.addContent("new ")
+                                .addContent(decorator)
+                                .addContent("().decorate(this, ");
+                        optionalDecoratorValue(it);
+                        it.addContentLine(");");
+                    });
+
+            it.addContentLine("if (this." + name + " == null) {")
+                    .addContent("this.")
+                    .addContent(name)
+                    .addContent(" = ");
+            emptyMutableCollection(it);
+            it.addContentLine(";")
+                    .addContentLine("}")
+                    .addContentLine("this." + name + ".addAll(" + name + ");")
+                    .addContentLine("return self();");
+        };
+
+        return Optional.of(GeneratedMethod.builder()
+                                   .method(method.build())
+                                   .javadoc(setterJavadoc(getterJavadoc, name, "add values to "))
+                                   .contentBuilder(contentConsumer)
+                                   .build());
+    }
+
+    @Override
     Optional<GeneratedMethod> prepareBuilderClear(Javadoc getterJavadoc) {
         TypeName returnType = Utils.builderReturnType();
 
@@ -159,5 +268,95 @@ class TypeHandlerOptional extends TypeHandlerBasic {
                 .addContent(".of(")
                 .addContent(optionName)
                 .addContent(")");
+    }
+
+    private Optional<GeneratedMethod> prepareOptionalCollectionSetterDeclared(Javadoc getterJavadoc) {
+        TypeName typeName = asTypeArgument(TypeNames.OPTIONAL);
+        TypeName returnType = Utils.builderReturnType();
+
+        String name = option().name();
+
+        var method = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PACKAGE_PRIVATE)
+                .typeName(returnType)
+                .elementName(option().setterName())
+                .update(this::deprecation)
+                .update(it -> option().annotations().forEach(it::addAnnotation));
+
+        method.addParameterArgument(param -> param
+                .kind(ElementKind.PARAMETER)
+                .typeName(typeName)
+                .elementName(name)
+        );
+
+        Consumer<ContentBuilder<?>> contentConsumer = it -> {
+            it.addContent(Objects.class)
+                    .addContentLine(".requireNonNull(" + name + ");")
+                    .addContent(name)
+                    .addContent(".ifPresent(it -> this.")
+                    .addContent(name)
+                    .addContent(" = ");
+            mutableCollection(it, "it");
+            it.addContentLine(");")
+                    .addContentLine("return self();");
+        };
+
+        return Optional.of(GeneratedMethod.builder()
+                                   .method(method.build())
+                                   .javadoc(setterJavadoc(getterJavadoc, name, ""))
+                                   .contentBuilder(contentConsumer)
+                                   .build());
+    }
+
+    private boolean optionalCollection() {
+        return type().isList() || type().isSet();
+    }
+
+    private TypeName collectionParameterType() {
+        return TypeName.builder(collectionType())
+                .addTypeArgument(Utils.toWildcard(type().typeArguments().getFirst()))
+                .build();
+    }
+
+    private TypeName collectionType() {
+        return type().isList() ? TypeNames.LIST : TypeNames.SET;
+    }
+
+    private void optionalDecoratorValue(ContentBuilder<?> content) {
+        content.addContent(Optional.class)
+                .addContent(".of(")
+                .addContent(collectionType())
+                .addContent(".copyOf(")
+                .addContent(option().name())
+                .addContent("))");
+    }
+
+    private void mutableCollection(ContentBuilder<?> content, String source) {
+        if (type().isList()) {
+            content.addContent("new ")
+                    .addContent(ArrayList.class)
+                    .addContent("<>(")
+                    .addContent(source)
+                    .addContent(")");
+        } else {
+            content.addContent("new ")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("<>(")
+                    .addContent(source)
+                    .addContent(")");
+        }
+    }
+
+    private void emptyMutableCollection(ContentBuilder<?> content) {
+        if (type().isList()) {
+            content.addContent("new ")
+                    .addContent(ArrayList.class)
+                    .addContent("<>()");
+        } else {
+            content.addContent("new ")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("<>()");
+        }
     }
 }

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,8 +46,16 @@ interface WithProviderBlueprint {
     List<SomeProvider.SomeService> listDiscover();
 
     @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<List<SomeProvider.SomeService>> optionalListDiscover();
+
+    @Option.Configured
     @Option.Provider(value = SomeProvider.class, discoverServices = false)
     List<SomeProvider.SomeService> listNotDiscover();
+
+    @Option.Configured
+    @Option.Provider(value = SomeProvider.class, discoverServices = false)
+    Optional<List<SomeProvider.SomeService>> optionalListNotDiscover();
 
     /*
     The following should always be empty, as there are no implementations
@@ -59,6 +67,9 @@ interface WithProviderBlueprint {
     @Option.Access("")
     @Option.Provider(ProviderNoImpls.SomeService.class)
     List<ProviderNoImpls.SomeService> listNoImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<List<ProviderNoImpls.SomeService>> optionalListNoImplDiscoverNoConfig();
 
     @Option.Provider(ProviderNoImpls.SomeService.class)
     Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderRegistryBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderRegistryBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,16 @@ interface WithProviderRegistryBlueprint {
     List<SomeProvider.SomeService> listDiscover();
 
     @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<List<SomeProvider.SomeService>> optionalListDiscover();
+
+    @Option.Configured
     @Option.Provider(value = SomeProvider.class, discoverServices = false)
     List<SomeProvider.SomeService> listNotDiscover();
+
+    @Option.Configured
+    @Option.Provider(value = SomeProvider.class, discoverServices = false)
+    Optional<List<SomeProvider.SomeService>> optionalListNotDiscover();
 
     /*
     The following should always be empty, as there are no implementations
@@ -70,6 +78,9 @@ interface WithProviderRegistryBlueprint {
     @Option.Access("")
     @Option.Provider(ProviderNoImpls.SomeService.class)
     List<ProviderNoImpls.SomeService> listNoImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<List<ProviderNoImpls.SomeService>> optionalListNoImplDiscoverNoConfig();
 
     @Option.Provider(ProviderNoImpls.SomeService.class)
     Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.builder.test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.helidon.builder.test.testsubjects.SomeProvider;
@@ -61,7 +62,12 @@ class ProviderRegistryTest {
         assertThat(value.optionalNotDiscover().map(SomeProvider.SomeService::prop), optionalEmpty());
 
         assertThat(value.listDiscover(), hasSize(2));
+        List<SomeProvider.SomeService> services = value.optionalListDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("some-1"));
+        assertThat(services.get(1).prop(), is("some-2"));
         assertThat(value.listNotDiscover(), hasSize(0));
+        assertThat(value.optionalListNotDiscover(), optionalEmpty());
 
         /*
         Test all the methods for a provider with no implementations
@@ -69,6 +75,7 @@ class ProviderRegistryTest {
         assertThat(value.optionalNoImplDiscover(), optionalEmpty());
         assertThat(value.optionalNoImplNotDiscover(), optionalEmpty());
         assertThat(value.listNoImplDiscover(), hasSize(0));
+        assertThat(value.optionalListNoImplDiscoverNoConfig(), optionalEmpty());
         assertThat(value.listNoImplNotDiscover(), hasSize(0));
     }
 
@@ -93,8 +100,18 @@ class ProviderRegistryTest {
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("config2"));
 
+        services = value.optionalListDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("config"));
+        assertThat(services.get(1).prop(), is("config2"));
+
         services = value.listNotDiscover();
         assertThat(value.listNotDiscover(), hasSize(2));
+        assertThat(services.get(0).prop(), is("config"));
+        assertThat(services.get(1).prop(), is("config2"));
+
+        services = value.optionalListNotDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("config2"));
     }
@@ -132,9 +149,112 @@ class ProviderRegistryTest {
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("some-2"));
 
+        services = value.optionalListDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("config"));
+        assertThat(services.get(1).prop(), is("some-2"));
+
         services = value.listNotDiscover();
         assertThat(value.listNotDiscover(), hasSize(1));
         assertThat(services.get(0).prop(), is("config2"));
+
+        services = value.optionalListNotDiscover().orElseThrow();
+        assertThat(services, hasSize(1));
+        assertThat(services.get(0).prop(), is("config2"));
+    }
+
+    @Test
+    void testEmptyOptionalList() {
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .config(config.get("empty-optional-list-object"))
+                .mappersExplicit(Mappers.create())
+                .build();
+
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+
+        value = WithProviderRegistry.builder()
+                .config(config.get("empty-optional-list-array"))
+                .mappersExplicit(Mappers.create())
+                .build();
+
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+    }
+
+    @Test
+    void testOptionalListBuilderMethods() {
+        SomeProvider.SomeService someService = new DummyService();
+
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .optionalListNotDiscover(List.of())
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+
+        value = WithProviderRegistry.builder()
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .addOptionalListNotDiscover(List.of(someService))
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of(someService))));
+
+        value = WithProviderRegistry.builder()
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .optionalListNotDiscover(List.of(someService))
+                .clearOptionalListNotDiscover()
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalEmpty());
+    }
+
+    @Test
+    void testOptionalListDefensiveCopy() {
+        SomeProvider.SomeService someService = new DummyService();
+        List<SomeProvider.SomeService> configuredServices = new ArrayList<>();
+        configuredServices.add(someService);
+
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .optionalListNotDiscover(configuredServices)
+                .build();
+        configuredServices.clear();
+
+        List<SomeProvider.SomeService> builtServices = value.optionalListNotDiscover().orElseThrow();
+        assertThat(builtServices, is(List.of(someService)));
+        assertThrows(UnsupportedOperationException.class, () -> builtServices.add(new DummyService()));
+    }
+
+    @Test
+    void testOptionalListDiscoveryEnabled() {
+        SomeProvider.SomeService someService = new DummyService();
+
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .config(config.get("min-defined"))
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .optionalListNotDiscoverDiscoverServices(true)
+                .build();
+
+        List<SomeProvider.SomeService> services = value.optionalListNotDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("some-1"));
+        assertThat(services.get(1).prop(), is("some-2"));
+    }
+
+    @Test
+    void testOptionalListDiscoveryEnabledFromConfig() {
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .config(config.get("discover-optional-list-from-config"))
+                .mappersExplicit(Mappers.create())
+                .build();
+
+        List<SomeProvider.SomeService> services = value.optionalListNotDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("some-1"));
+        assertThat(services.get(1).prop(), is("some-2"));
     }
 
     @Test

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.builder.test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.helidon.builder.test.testsubjects.SomeProvider;
@@ -60,7 +61,12 @@ class ProviderTest {
         assertThat(value.optionalNotDiscover().map(SomeProvider.SomeService::prop), optionalEmpty());
 
         assertThat(value.listDiscover(), hasSize(2));
+        List<SomeProvider.SomeService> services = value.optionalListDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("some-1"));
+        assertThat(services.get(1).prop(), is("some-2"));
         assertThat(value.listNotDiscover(), hasSize(0));
+        assertThat(value.optionalListNotDiscover(), optionalEmpty());
 
         /*
         Test all the methods for a provider with no implementations
@@ -68,6 +74,7 @@ class ProviderTest {
         assertThat(value.optionalNoImplDiscover(), optionalEmpty());
         assertThat(value.optionalNoImplNotDiscover(), optionalEmpty());
         assertThat(value.listNoImplDiscover(), hasSize(0));
+        assertThat(value.optionalListNoImplDiscoverNoConfig(), optionalEmpty());
         assertThat(value.listNoImplNotDiscover(), hasSize(0));
     }
 
@@ -89,8 +96,18 @@ class ProviderTest {
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("config2"));
 
+        services = value.optionalListDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("config"));
+        assertThat(services.get(1).prop(), is("config2"));
+
         services = value.listNotDiscover();
         assertThat(value.listNotDiscover(), hasSize(2));
+        assertThat(services.get(0).prop(), is("config"));
+        assertThat(services.get(1).prop(), is("config2"));
+
+        services = value.optionalListNotDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("config2"));
     }
@@ -122,9 +139,98 @@ class ProviderTest {
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("some-2"));
 
+        services = value.optionalListDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("config"));
+        assertThat(services.get(1).prop(), is("some-2"));
+
         services = value.listNotDiscover();
         assertThat(value.listNotDiscover(), hasSize(1));
         assertThat(services.get(0).prop(), is("config2"));
+
+        services = value.optionalListNotDiscover().orElseThrow();
+        assertThat(services, hasSize(1));
+        assertThat(services.get(0).prop(), is("config2"));
+    }
+
+    @Test
+    void testEmptyOptionalList() {
+        WithProvider value = WithProvider.create(config.get("empty-optional-list-object"));
+
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+
+        value = WithProvider.create(config.get("empty-optional-list-array"));
+
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+    }
+
+    @Test
+    void testOptionalListBuilderMethods() {
+        SomeProvider.SomeService someService = new DummyService();
+
+        WithProvider value = WithProvider.builder()
+                .oneNotDiscover(someService)
+                .optionalListNotDiscover(List.of())
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+
+        value = WithProvider.builder()
+                .oneNotDiscover(someService)
+                .addOptionalListNotDiscover(List.of(someService))
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of(someService))));
+
+        value = WithProvider.builder()
+                .oneNotDiscover(someService)
+                .optionalListNotDiscover(List.of(someService))
+                .clearOptionalListNotDiscover()
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalEmpty());
+    }
+
+    @Test
+    void testOptionalListDefensiveCopy() {
+        SomeProvider.SomeService someService = new DummyService();
+        List<SomeProvider.SomeService> configuredServices = new ArrayList<>();
+        configuredServices.add(someService);
+
+        WithProvider value = WithProvider.builder()
+                .oneNotDiscover(someService)
+                .optionalListNotDiscover(configuredServices)
+                .build();
+        configuredServices.clear();
+
+        List<SomeProvider.SomeService> builtServices = value.optionalListNotDiscover().orElseThrow();
+        assertThat(builtServices, is(List.of(someService)));
+        assertThrows(UnsupportedOperationException.class, () -> builtServices.add(new DummyService()));
+    }
+
+    @Test
+    void testOptionalListDiscoveryEnabled() {
+        SomeProvider.SomeService someService = new DummyService();
+
+        WithProvider value = WithProvider.builder()
+                .config(config.get("min-defined"))
+                .oneNotDiscover(someService)
+                .optionalListNotDiscoverDiscoverServices(true)
+                .build();
+
+        List<SomeProvider.SomeService> services = value.optionalListNotDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("some-1"));
+        assertThat(services.get(1).prop(), is("some-2"));
+    }
+
+    @Test
+    void testOptionalListDiscoveryEnabledFromConfig() {
+        WithProvider value = WithProvider.create(config.get("discover-optional-list-from-config"));
+
+        List<SomeProvider.SomeService> services = value.optionalListNotDiscover().orElseThrow();
+        assertThat(services, hasSize(2));
+        assertThat(services.get(0).prop(), is("some-1"));
+        assertThat(services.get(1).prop(), is("some-2"));
     }
 
     @Test

--- a/builder/tests/builder/src/test/resources/provider-test.yaml
+++ b/builder/tests/builder/src/test/resources/provider-test.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,7 +37,17 @@ all-defined:
       prop: "config"
     some-2:
       prop: "config2"
+  optional-list-discover:
+    some-1:
+      prop: "config"
+    some-2:
+      prop: "config2"
   list-not-discover:
+    some-1:
+      prop: "config"
+    some-2:
+      prop: "config2"
+  optional-list-not-discover:
     some-1:
       prop: "config"
     some-2:
@@ -50,6 +60,29 @@ single-list:
   list-discover:
     some-1:
       prop: "config"
+  optional-list-discover:
+    some-1:
+      prop: "config"
   list-not-discover:
     some-2:
       prop: "config2"
+  optional-list-not-discover:
+    some-2:
+      prop: "config2"
+empty-optional-list-object:
+  one-not-discover:
+    some-1:
+      prop: "config"
+  optional-list-discover: {}
+  optional-list-not-discover: {}
+empty-optional-list-array:
+  one-not-discover:
+    some-1:
+      prop: "config"
+  optional-list-discover: []
+  optional-list-not-discover: []
+discover-optional-list-from-config:
+  one-not-discover:
+    some-1:
+      prop: "config"
+  optional-list-not-discover-discover-services: true


### PR DESCRIPTION
Resolves #11838

Adds builder code generation support for provider-backed `Optional<List<T>>` options for both service loader and service registry discovery. The change preserves absent versus explicitly empty optional list configuration, copies optional collection values defensively, and updates provider Javadocs to match the generated config keys.

Validation:
- `mvn -Ptests -pl builder/tests/builder -am -Dtest=ProviderTest,ProviderRegistryTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -Ptests,copyright -pl builder/api,builder/codegen,builder/tests/builder -am -DskipTests validate`
- `mvn clean install -Dlong-tests=false`
- `mvn -Pcopyright -pl builder/api -am -DskipTests validate`
- `./etc/scripts/checkstyle.sh`
- `mvn -Ptests -pl builder/tests/builder -am -Dtest=ProviderRegistryTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`
