### PR TITLE
Fix Unix address parsing in WebServer and WebClient configuration (27.x)

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -62,6 +62,7 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      *
      * @return base address of the client requests
      */
+    @Option.Configured
     Optional<SocketAddress> baseAddress();
 
     /**

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
@@ -39,6 +39,7 @@ import io.helidon.webclient.spi.DnsResolver;
 import io.helidon.webclient.spi.DnsResolverProvider;
 
 class HttpClientConfigSupport {
+    private static final String UNIX_DOMAIN_SOCKET_PREFIX = "unix:";
     private static final LazyValue<Tls> EMPTY_TLS = LazyValue.create(() -> Tls.builder().build());
     private static final LazyValue<DnsResolver> DISCOVERED_DNS_RESOLVER = LazyValue.create(() -> {
         return HelidonServiceLoader.builder(ServiceLoader.load(DnsResolverProvider.class))
@@ -190,8 +191,8 @@ class HttpClientConfigSupport {
         static SocketAddress createBaseAddress(Config config) {
             String address = config.asString().get();
             // unix:/path/to/socket
-            if (address.startsWith("unix:")) {
-                String path = address.substring(7);
+            if (address.startsWith(UNIX_DOMAIN_SOCKET_PREFIX)) {
+                String path = address.substring(UNIX_DOMAIN_SOCKET_PREFIX.length());
                 return UnixDomainSocketAddress.of(path);
             }
             // must be localhost:8080 or similar (localhost, :8080 are also OK)

--- a/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientConfigTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientConfigTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.api;
 
 import java.net.UnixDomainSocketAddress;
+import java.nio.file.Path;
 import java.util.Map;
 
 import io.helidon.config.Config;
@@ -37,6 +38,6 @@ class HttpClientConfigTest {
                 .baseAddress()
                 .orElseThrow();
 
-        assertThat(socketAddress.getPath().toString(), is("/tmp/client.sock"));
+        assertThat(socketAddress.getPath(), is(Path.of("/tmp/client.sock")));
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientConfigTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientConfigTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.net.UnixDomainSocketAddress;
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class HttpClientConfigTest {
+
+    @Test
+    void testUnixBaseAddressKeepsConfiguredPath() {
+        Config config = Config.just(ConfigSources.create(Map.of("base-address", "unix:/tmp/client.sock")));
+
+        var socketAddress = (UnixDomainSocketAddress) HttpClientConfig.create(config)
+                .baseAddress()
+                .orElseThrow();
+
+        assertThat(socketAddress.getPath().toString(), is("/tmp/client.sock"));
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
@@ -40,6 +40,7 @@ import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.spi.ServerFeature;
 
 class WebServerConfigSupport {
+    private static final String UNIX_DOMAIN_SOCKET_PREFIX = "unix:";
 
     static class CustomMethods {
 
@@ -187,8 +188,8 @@ class WebServerConfigSupport {
         static SocketAddress createBindAddress(Config config) {
             String address = config.asString().get();
             // unix:/path/to/socket
-            if (address.startsWith("unix:")) {
-                String path = address.substring(7);
+            if (address.startsWith(UNIX_DOMAIN_SOCKET_PREFIX)) {
+                String path = address.substring(UNIX_DOMAIN_SOCKET_PREFIX.length());
                 return UnixDomainSocketAddress.of(path);
             }
             // must be localhost:8080 or similar

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package io.helidon.webserver;
 
+import java.net.UnixDomainSocketAddress;
+import java.util.Map;
+
 import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +28,17 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ListenerConfigTest {
+
+    @Test
+    void testUnixBindAddressKeepsConfiguredPath() {
+        Config config = Config.just(ConfigSources.create(Map.of("bind-address", "unix:/tmp/server.sock")));
+
+        var socketAddress = (UnixDomainSocketAddress) ListenerConfig.create(config)
+                .bindAddress()
+                .orElseThrow();
+
+        assertThat(socketAddress.getPath().toString(), is("/tmp/server.sock"));
+    }
 
     @Test
     void testListenerConfig() {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webserver;
 
 import java.net.UnixDomainSocketAddress;
+import java.nio.file.Path;
 import java.util.Map;
 
 import io.helidon.config.Config;
@@ -37,7 +38,7 @@ public class ListenerConfigTest {
                 .bindAddress()
                 .orElseThrow();
 
-        assertThat(socketAddress.getPath().toString(), is("/tmp/server.sock"));
+        assertThat(socketAddress.getPath(), is(Path.of("/tmp/server.sock")));
     }
 
     @Test


### PR DESCRIPTION
Resolves #11842

Fixes Unix-domain socket address parsing for configured WebServer `bind-address` and WebClient `base-address` values so the `unix:` prefix is stripped by its actual length.

Also wires WebClient `base-address` into generated config handling and adds focused regression coverage for both configured keys.
