### PR TITLE
Avoid late reactor API in invoker tests

### DIFF
--- a/codegen/api-stability/src/it/projects/default/consumer/pom.xml
+++ b/codegen/api-stability/src/it/projects/default/consumer/pom.xml
@@ -42,11 +42,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-mapper</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.codegen.api.stability.it</groupId>
             <artifactId>api-stability-dependency</artifactId>
             <version>${project.version}</version>

--- a/codegen/api-stability/src/it/projects/default/consumer/src/main/java/io/helidon/codegen/tests/apistability/consumer/UsesApis.java
+++ b/codegen/api-stability/src/it/projects/default/consumer/src/main/java/io/helidon/codegen/tests/apistability/consumer/UsesApis.java
@@ -17,13 +17,13 @@
 package io.helidon.codegen.tests.apistability.consumer;
 
 import io.helidon.codegen.tests.apistability.dependency.DeprecatedApi;
+import io.helidon.codegen.tests.apistability.dependency.PreviewApi;
 import io.helidon.common.DeprecationSupport;
 import io.helidon.common.ParserHelper;
-import io.helidon.common.mapper.DefaultsResolver;
 
 class UsesApis {
     DeprecationSupport internalApi;
     ParserHelper incubatingApi;
-    DefaultsResolver previewApi;
+    PreviewApi previewApi;
     DeprecatedApi deprecatedApi;
 }

--- a/codegen/api-stability/src/it/projects/default/dependency/src/main/java/io/helidon/codegen/tests/apistability/dependency/PreviewApi.java
+++ b/codegen/api-stability/src/it/projects/default/dependency/src/main/java/io/helidon/codegen/tests/apistability/dependency/PreviewApi.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-module io.helidon.codegen.tests.apistability.consumer {
-    requires io.helidon.common;
-    requires io.helidon.codegen.tests.apistability.dependency;
+package io.helidon.codegen.tests.apistability.dependency;
+
+import io.helidon.common.Api;
+
+@Api.Preview
+public class PreviewApi {
 }

--- a/codegen/api-stability/src/it/projects/suppressed/consumer/pom.xml
+++ b/codegen/api-stability/src/it/projects/suppressed/consumer/pom.xml
@@ -42,11 +42,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-mapper</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.codegen.api.stability.it</groupId>
             <artifactId>api-stability-dependency</artifactId>
             <version>${project.version}</version>

--- a/codegen/api-stability/src/it/projects/suppressed/consumer/src/main/java/io/helidon/codegen/tests/apistability/consumer/SuppressedUsesApis.java
+++ b/codegen/api-stability/src/it/projects/suppressed/consumer/src/main/java/io/helidon/codegen/tests/apistability/consumer/SuppressedUsesApis.java
@@ -17,9 +17,9 @@
 package io.helidon.codegen.tests.apistability.consumer;
 
 import io.helidon.codegen.tests.apistability.dependency.DeprecatedApi;
+import io.helidon.codegen.tests.apistability.dependency.PreviewApi;
 import io.helidon.common.DeprecationSupport;
 import io.helidon.common.ParserHelper;
-import io.helidon.common.mapper.DefaultsResolver;
 
 @SuppressWarnings({
         "helidon:api:internal",
@@ -30,6 +30,6 @@ import io.helidon.common.mapper.DefaultsResolver;
 class SuppressedUsesApis {
     DeprecationSupport internalApi;
     ParserHelper incubatingApi;
-    DefaultsResolver previewApi;
+    PreviewApi previewApi;
     DeprecatedApi deprecatedApi;
 }

--- a/codegen/api-stability/src/it/projects/suppressed/consumer/src/main/java/module-info.java
+++ b/codegen/api-stability/src/it/projects/suppressed/consumer/src/main/java/module-info.java
@@ -16,6 +16,5 @@
 
 module io.helidon.codegen.tests.apistability.consumer {
     requires io.helidon.common;
-    requires io.helidon.common.mapper;
     requires io.helidon.codegen.tests.apistability.dependency;
 }

--- a/codegen/api-stability/src/it/projects/suppressed/dependency/src/main/java/io/helidon/codegen/tests/apistability/dependency/PreviewApi.java
+++ b/codegen/api-stability/src/it/projects/suppressed/dependency/src/main/java/io/helidon/codegen/tests/apistability/dependency/PreviewApi.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-module io.helidon.codegen.tests.apistability.consumer {
-    requires io.helidon.common;
-    requires io.helidon.codegen.tests.apistability.dependency;
+package io.helidon.codegen.tests.apistability.dependency;
+
+import io.helidon.common.Api;
+
+@Api.Preview
+public class PreviewApi {
 }

--- a/codegen/api-stability/src/it/projects/warn/consumer/pom.xml
+++ b/codegen/api-stability/src/it/projects/warn/consumer/pom.xml
@@ -42,11 +42,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-mapper</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.codegen.api.stability.it</groupId>
             <artifactId>api-stability-dependency</artifactId>
             <version>${project.version}</version>

--- a/codegen/api-stability/src/it/projects/warn/consumer/src/main/java/io/helidon/codegen/tests/apistability/consumer/UsesApis.java
+++ b/codegen/api-stability/src/it/projects/warn/consumer/src/main/java/io/helidon/codegen/tests/apistability/consumer/UsesApis.java
@@ -17,13 +17,13 @@
 package io.helidon.codegen.tests.apistability.consumer;
 
 import io.helidon.codegen.tests.apistability.dependency.DeprecatedApi;
+import io.helidon.codegen.tests.apistability.dependency.PreviewApi;
 import io.helidon.common.DeprecationSupport;
 import io.helidon.common.ParserHelper;
-import io.helidon.common.mapper.DefaultsResolver;
 
 class UsesApis {
     DeprecationSupport internalApi;
     ParserHelper incubatingApi;
-    DefaultsResolver previewApi;
+    PreviewApi previewApi;
     DeprecatedApi deprecatedApi;
 }

--- a/codegen/api-stability/src/it/projects/warn/consumer/src/main/java/module-info.java
+++ b/codegen/api-stability/src/it/projects/warn/consumer/src/main/java/module-info.java
@@ -16,6 +16,5 @@
 
 module io.helidon.codegen.tests.apistability.consumer {
     requires io.helidon.common;
-    requires io.helidon.common.mapper;
     requires io.helidon.codegen.tests.apistability.dependency;
 }

--- a/codegen/api-stability/src/it/projects/warn/dependency/src/main/java/io/helidon/codegen/tests/apistability/dependency/PreviewApi.java
+++ b/codegen/api-stability/src/it/projects/warn/dependency/src/main/java/io/helidon/codegen/tests/apistability/dependency/PreviewApi.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-module io.helidon.codegen.tests.apistability.consumer {
-    requires io.helidon.common;
-    requires io.helidon.codegen.tests.apistability.dependency;
+package io.helidon.codegen.tests.apistability.dependency;
+
+import io.helidon.common.Api;
+
+@Api.Preview
+public class PreviewApi {
 }


### PR DESCRIPTION
The codegen API stability invoker tests used `DefaultsResolver` as the preview API sample, which pulled in `helidon-common-mapper`. That module is compiled later in the reactor than `codegen/api-stability`, so clean CI invoker runs could fail when the artifact was not already available.

This updates the invoker projects to use local `@Api.Preview` test classes from their own dependency modules and removes the `helidon-common-mapper` dependency from the consumers.

This is needed to fix builds, to be fully independent on local maven repository state