### PR TITLE
4.x: upgrade postgres jdbc driver to 42.7.11

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -157,7 +157,7 @@
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.perfmark-api>0.25.0</version.lib.perfmark-api>
         <version.lib.parsson>1.1.7</version.lib.parsson>
-        <version.lib.postgresql>42.7.2</version.lib.postgresql>
+        <version.lib.postgresql>42.7.11</version.lib.postgresql>
         <version.lib.prometheus>0.16.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <version.lib.slf4j>2.0.17</version.lib.slf4j>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -345,6 +345,23 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <cve>CVE-2026-39882</cve>
 </suppress>
 
+<!--
+   These CVEs are against OpenTelemetry dotnet, not Java
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-proto-1.5.0-alpha.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.proto/opentelemetry-proto@.*$</packageUrl>
+    <cve>CVE-2026-41078</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-proto-1.5.0-alpha.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.proto/opentelemetry-proto@.*$</packageUrl>
+    <cve>CVE-2026-40894</cve>
+</suppress>
 
 <!--
   This CVE is fixed in 3.6.1: https://github.com/codehaus-plexus/plexus-utils/releases/tag/plexus-utils-3.6.1


### PR DESCRIPTION
### Description

- Upgrades postgres jdbc driver to 42.7.11
- Suppresses false positives for OpenTelemetry dotnet

