### PR TITLE
Enable custom values to be added to the ExecutionContext in graphql calls

### DIFF
--- a/graphql/server/pom.xml
+++ b/graphql/server/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
         </dependency>

--- a/graphql/server/src/main/java/io/helidon/graphql/server/ExecutionContext.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/ExecutionContext.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 
 /**
  * GraphQL execution context to support partial results and context values.
+ * Context values are backed by Helidon common context and are also available from
+ * {@link io.helidon.common.context.Contexts#context()} during GraphQL execution.
  */
 public interface ExecutionContext {
     /**
@@ -28,7 +30,8 @@ public interface ExecutionContext {
      * @param name name of the context value
      * @param value context value
      */
-    void setContextValue(String name, Object value);
+    default void setContextValue(String name, Object value) {
+    }
 
     /**
      * Retrieve a context value.
@@ -36,7 +39,9 @@ public interface ExecutionContext {
      * @param name name of the context value
      * @return the context value, or empty if it is not present
      */
-    Optional<Object> contextValue(String name);
+    default Optional<Object> contextValue(String name) {
+        return Optional.empty();
+    }
 
     /**
      * Retrieve a typed context value.
@@ -44,10 +49,11 @@ public interface ExecutionContext {
      * @param name name of the context value
      * @param type expected type of the context value
      * @param <T> type of the context value
-     * @return the context value, or empty if it is not present
-     * @throws ClassCastException in case the context value is not assignable to the requested type
+     * @return the context value, or empty if it is not present or not assignable to the requested type
      */
-    <T> Optional<T> contextValue(String name, Class<T> type);
+    default <T> Optional<T> contextValue(String name, Class<T> type) {
+        return Optional.empty();
+    }
 
     /**
      * Add a partial results {@link Throwable}.

--- a/graphql/server/src/main/java/io/helidon/graphql/server/ExecutionContext.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/ExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,39 @@
 
 package io.helidon.graphql.server;
 
+import java.util.Optional;
+
 /**
- * GraphQL execution context to support partial results.
+ * GraphQL execution context to support partial results and context values.
  */
 public interface ExecutionContext {
+    /**
+     * Set a context value.
+     *
+     * @param name name of the context value
+     * @param value context value
+     */
+    void setContextValue(String name, Object value);
+
+    /**
+     * Retrieve a context value.
+     *
+     * @param name name of the context value
+     * @return the context value, or empty if it is not present
+     */
+    Optional<Object> contextValue(String name);
+
+    /**
+     * Retrieve a typed context value.
+     *
+     * @param name name of the context value
+     * @param type expected type of the context value
+     * @param <T> type of the context value
+     * @return the context value, or empty if it is not present
+     * @throws ClassCastException in case the context value is not assignable to the requested type
+     */
+    <T> Optional<T> contextValue(String name, Class<T> type);
+
     /**
      * Add a partial results {@link Throwable}.
      *

--- a/graphql/server/src/main/java/io/helidon/graphql/server/ExecutionContextImpl.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/ExecutionContextImpl.java
@@ -16,33 +16,33 @@
 
 package io.helidon.graphql.server;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.context.Context;
 
 class ExecutionContextImpl implements ExecutionContext {
     private final AtomicReference<Throwable> currentThrowable = new AtomicReference<>();
-    private final Map<String, Object> contextValues = new ConcurrentHashMap<>();
+    private final Context context;
 
-    ExecutionContextImpl() {
+    ExecutionContextImpl(Context context) {
+        this.context = context;
     }
 
     @Override
     public void setContextValue(String name, Object value) {
-        contextValues.put(Objects.requireNonNull(name), Objects.requireNonNull(value));
+        context.register(Objects.requireNonNull(name), Objects.requireNonNull(value));
     }
 
     @Override
     public Optional<Object> contextValue(String name) {
-        return Optional.ofNullable(contextValues.get(Objects.requireNonNull(name)));
+        return context.get(Objects.requireNonNull(name), Object.class);
     }
 
     @Override
     public <T> Optional<T> contextValue(String name, Class<T> type) {
-        Objects.requireNonNull(type);
-        return contextValue(name).map(type::cast);
+        return context.get(Objects.requireNonNull(name), Objects.requireNonNull(type));
     }
 
     @Override

--- a/graphql/server/src/main/java/io/helidon/graphql/server/ExecutionContextImpl.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/ExecutionContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,33 @@
 
 package io.helidon.graphql.server;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 class ExecutionContextImpl implements ExecutionContext {
     private final AtomicReference<Throwable> currentThrowable = new AtomicReference<>();
+    private final Map<String, Object> contextValues = new ConcurrentHashMap<>();
 
     ExecutionContextImpl() {
+    }
+
+    @Override
+    public void setContextValue(String name, Object value) {
+        contextValues.put(Objects.requireNonNull(name), Objects.requireNonNull(value));
+    }
+
+    @Override
+    public Optional<Object> contextValue(String name) {
+        return Optional.ofNullable(contextValues.get(Objects.requireNonNull(name)));
+    }
+
+    @Override
+    public <T> Optional<T> contextValue(String name, Class<T> type) {
+        Objects.requireNonNull(type);
+        return contextValue(name).map(type::cast);
     }
 
     @Override

--- a/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandler.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandler.java
@@ -16,9 +16,12 @@
 
 package io.helidon.graphql.server;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import io.helidon.config.Config;
@@ -101,11 +104,25 @@ public interface InvocationHandler {
     Set<String> whitelistedExceptions();
 
     /**
+     * Handler used to update the {@link ExecutionContext} before GraphQL execution.
+     */
+    @FunctionalInterface
+    interface ContextHandler {
+        /**
+         * Update the execution context.
+         *
+         * @param context execution context
+         */
+        void update(ExecutionContext context);
+    }
+
+    /**
      * Fluent API builder to configure the invocation handler.
      */
     class Builder implements io.helidon.common.Builder<Builder, InvocationHandler> {
         private final Set<String> blacklistedExceptions = new HashSet<>();
         private final Set<String> whitelistedExceptions = new HashSet<>();
+        private final List<ContextHandler> contextHandlers = new ArrayList<>();
 
         private String defaultErrorMessage = DEFAULT_ERROR_MESSAGE;
         private GraphQLSchema schema;
@@ -205,6 +222,17 @@ public interface InvocationHandler {
         }
 
         /**
+         * Add a context handler to update the {@link ExecutionContext} before GraphQL execution.
+         *
+         * @param contextHandler context handler
+         * @return updated builder instance
+         */
+        public Builder addContextHandler(ContextHandler contextHandler) {
+            contextHandlers.add(Objects.requireNonNull(contextHandler));
+            return this;
+        }
+
+        /**
          * Blacklisted error classes that will not return error message back to caller.
          *
          * @param classNames names of classes to deny for checked exceptions
@@ -268,6 +296,10 @@ public interface InvocationHandler {
 
         Set<String> allowExceptions() {
             return whitelistedExceptions;
+        }
+
+        List<ContextHandler> contextHandlers() {
+            return Collections.unmodifiableList(contextHandlers);
         }
 
         SchemaPrinter schemaPrinter() {

--- a/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandlerImpl.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandlerImpl.java
@@ -65,11 +65,13 @@ class InvocationHandlerImpl implements InvocationHandler {
     private final GraphQLSchema schema;
     private final GraphQL graphQl;
     private final SchemaPrinter schemaPrinter;
+    private final List<InvocationHandler.ContextHandler> contextHandlers;
 
     InvocationHandlerImpl(InvocationHandler.Builder builder, GraphQL graphQl) {
         this.schema = builder.schema();
         this.schemaPrinter = builder.schemaPrinter();
         this.defaultErrorMessage = builder.defaultErrorMessage();
+        this.contextHandlers = List.copyOf(builder.contextHandlers());
 
         this.graphQl = graphQl;
 
@@ -91,6 +93,8 @@ class InvocationHandlerImpl implements InvocationHandler {
 
     private Map<String, Object> doExecute(String query, String operationName, Map<String, Object> variables) {
         ExecutionContext context = new ExecutionContextImpl();
+        contextHandlers.forEach(handler -> handler.update(context));
+
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()
                 .query(query)
                 .operationName(operationName)

--- a/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandlerImpl.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandlerImpl.java
@@ -29,6 +29,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+
 import graphql.ExceptionWhileDataFetching;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
@@ -92,7 +95,18 @@ class InvocationHandlerImpl implements InvocationHandler {
     }
 
     private Map<String, Object> doExecute(String query, String operationName, Map<String, Object> variables) {
-        ExecutionContext context = new ExecutionContextImpl();
+        Context commonContext = Contexts.context().orElseGet(Context::create);
+        ExecutionContext context = new ExecutionContextImpl(commonContext);
+        return Contexts.runInContext(commonContext, () -> doExecuteInContext(query,
+                                                                             operationName,
+                                                                             variables,
+                                                                             context));
+    }
+
+    private Map<String, Object> doExecuteInContext(String query,
+                                                   String operationName,
+                                                   Map<String, Object> variables,
+                                                   ExecutionContext context) {
         contextHandlers.forEach(handler -> handler.update(context));
 
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()

--- a/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandlerImpl.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandlerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/graphql/server/src/main/java/module-info.java
+++ b/graphql/server/src/main/java/module-info.java
@@ -21,6 +21,7 @@ module io.helidon.graphql.server {
 
     requires io.helidon.config;
     requires io.helidon.common;
+    requires io.helidon.common.context;
 
     requires transitive com.graphqljava;
 

--- a/graphql/server/src/test/java/io/helidon/graphql/server/InvocationHandlerContextTest.java
+++ b/graphql/server/src/test/java/io/helidon/graphql/server/InvocationHandlerContextTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.graphql.server;
+
+import java.util.Map;
+import java.util.Optional;
+
+import graphql.Scalars;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+
+import org.junit.jupiter.api.Test;
+
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLObjectType.newObject;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InvocationHandlerContextTest {
+    @Test
+    void contextValuesAreAvailableToDataFetchers() {
+        InvocationHandler handler = InvocationHandler.builder()
+                .schema(schema(InvocationHandlerContextTest::contextValue))
+                .addContextHandler(context -> {
+                    context.setContextValue("authorization", "Bearer secret");
+                    context.setContextValue("requestId", 49L);
+                })
+                .build();
+
+        Map<String, Object> result = handler.execute("{value}");
+
+        assertThat(((Map<?, ?>) result.get("data")).get("value"), is("Bearer secret:49"));
+    }
+
+    @Test
+    void contextValuesCanBeReadByType() {
+        ExecutionContext context = new ExecutionContextImpl();
+
+        context.setContextValue("answer", 42);
+
+        assertThat(context.contextValue("answer", Integer.class), is(Optional.of(42)));
+        assertThat(context.contextValue("missing", Integer.class), is(Optional.empty()));
+        assertThrows(ClassCastException.class, () -> context.contextValue("answer", String.class));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static GraphQLSchema schema(DataFetcher<String> dataFetcher) {
+        GraphQLObjectType queryType = newObject()
+                .name("Query")
+                .field(newFieldDefinition()
+                        .name("value")
+                        .type(Scalars.GraphQLString)
+                        .dataFetcher(dataFetcher))
+                .build();
+
+        return GraphQLSchema.newSchema()
+                .query(queryType)
+                .build();
+    }
+
+    @SuppressWarnings("deprecation")
+    private static String contextValue(DataFetchingEnvironment env) {
+        ExecutionContext context = env.getContext();
+        String authorization = context.contextValue("authorization", String.class).orElse("missing");
+        Long requestId = context.contextValue("requestId", Long.class).orElse(-1L);
+
+        return authorization + ":" + requestId;
+    }
+}

--- a/graphql/server/src/test/java/io/helidon/graphql/server/InvocationHandlerContextTest.java
+++ b/graphql/server/src/test/java/io/helidon/graphql/server/InvocationHandlerContextTest.java
@@ -19,6 +19,9 @@ package io.helidon.graphql.server;
 import java.util.Map;
 import java.util.Optional;
 
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -31,7 +34,6 @@ import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InvocationHandlerContextTest {
     @Test
@@ -51,13 +53,27 @@ class InvocationHandlerContextTest {
 
     @Test
     void contextValuesCanBeReadByType() {
-        ExecutionContext context = new ExecutionContextImpl();
+        ExecutionContext context = new ExecutionContextImpl(Context.create());
 
         context.setContextValue("answer", 42);
 
         assertThat(context.contextValue("answer", Integer.class), is(Optional.of(42)));
         assertThat(context.contextValue("missing", Integer.class), is(Optional.empty()));
-        assertThrows(ClassCastException.class, () -> context.contextValue("answer", String.class));
+        assertThat(context.contextValue("answer", String.class), is(Optional.empty()));
+    }
+
+    @Test
+    void existingHelidonContextIsReused() {
+        Context context = Context.create();
+        context.register("authorization", "Bearer request-context");
+
+        InvocationHandler handler = InvocationHandler.builder()
+                .schema(schema(InvocationHandlerContextTest::authorizationValue))
+                .build();
+
+        Map<String, Object> result = Contexts.runInContext(context, () -> handler.execute("{value}"));
+
+        assertThat(((Map<?, ?>) result.get("data")).get("value"), is("Bearer request-context"));
     }
 
     @SuppressWarnings("deprecation")
@@ -79,8 +95,16 @@ class InvocationHandlerContextTest {
     private static String contextValue(DataFetchingEnvironment env) {
         ExecutionContext context = env.getContext();
         String authorization = context.contextValue("authorization", String.class).orElse("missing");
-        Long requestId = context.contextValue("requestId", Long.class).orElse(-1L);
+        Long requestId = Contexts.context()
+                .flatMap(it -> it.get("requestId", Long.class))
+                .orElse(-1L);
 
         return authorization + ":" + requestId;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static String authorizationValue(DataFetchingEnvironment env) {
+        ExecutionContext context = env.getContext();
+        return context.contextValue("authorization", String.class).orElse("missing");
     }
 }


### PR DESCRIPTION
resolves ... #2990: Enable custom values to be added to the ExecutionContext in graphql calls

### Description
Added support for per-invocation GraphQL context values.

ExecutionContext now lets callers set and retrieve named values, including typed retrieval via contextValue(String, Class<T>). ExecutionContextImpl stores those values in a concurrent map.

InvocationHandler.Builder now accepts addContextHandler(...) callbacks. Each callback runs before GraphQL execution, so it can attach request-specific data such as an authorization token, request ID, or logging metadata to the ExecutionContext.

InvocationHandlerImpl applies those handlers before creating the ExecutionInput, making the populated ExecutionContext available to GraphQL Java data fetchers.

A new test verifies both typed context access and that context values set by a builder handler are visible during data fetching.

### Documentation

If enhancement: provide description with example code/config snippet or pointer to issue with the description

InvocationHandlerContextTest.java shows example of setting the values to the ExectionContext