### PR TITLE
Deprecate Services.get replacement accessors (4.x)

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
@@ -57,7 +57,7 @@ public interface MetricsFactory {
      *
      * @return current or new metrics factory
      * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} - i.e.
-     *          {@code Services.get(MetricsFactory.class)}, or use your registry instance in a similar way
+     *          {@code Services.get(MetricsFactory.class)}
      */
     @Deprecated(since = "4.5.0", forRemoval = true)
     static MetricsFactory getInstance() {
@@ -72,7 +72,7 @@ public interface MetricsFactory {
      * @param config config node
      * @return new instance configured as directed
      * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} - i.e.
-     *          {@code Services.get(MetricsFactory.class)}, or use your registry instance in a similar way
+     *          {@code Services.get(MetricsFactory.class)}
      */
     @SuppressWarnings("removal")
     @Deprecated(since = "4.4.0", forRemoval = true)
@@ -88,7 +88,7 @@ public interface MetricsFactory {
      * @param metricsConfigNode metrics config node
      * @return new instance configured as directed
      * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} - i.e.
-     *          {@code Services.get(MetricsFactory.class)}, or use your registry instance in a similar way
+     *          {@code Services.get(MetricsFactory.class)}
      */
     @Deprecated(since = "4.5.0", forRemoval = true)
     static MetricsFactory getInstance(Config metricsConfigNode) {

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
@@ -56,7 +56,10 @@ public interface MetricsFactory {
      * current config.
      *
      * @return current or new metrics factory
+     * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} - i.e.
+     *          {@code Services.get(MetricsFactory.class)}, or use your registry instance in a similar way
      */
+    @Deprecated(since = "4.5.0", forRemoval = true)
     static MetricsFactory getInstance() {
         return MetricsFactoryManager.getMetricsFactory();
     }
@@ -68,7 +71,8 @@ public interface MetricsFactory {
      *
      * @param config config node
      * @return new instance configured as directed
-     * @deprecated use {@link #getInstance(io.helidon.config.Config)} instead
+     * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} - i.e.
+     *          {@code Services.get(MetricsFactory.class)}, or use your registry instance in a similar way
      */
     @SuppressWarnings("removal")
     @Deprecated(since = "4.4.0", forRemoval = true)
@@ -83,7 +87,10 @@ public interface MetricsFactory {
      *
      * @param metricsConfigNode metrics config node
      * @return new instance configured as directed
+     * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} - i.e.
+     *          {@code Services.get(MetricsFactory.class)}, or use your registry instance in a similar way
      */
+    @Deprecated(since = "4.5.0", forRemoval = true)
     static MetricsFactory getInstance(Config metricsConfigNode) {
         return MetricsFactoryManager.getMetricsFactory(metricsConfigNode);
     }

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
@@ -109,7 +109,10 @@ public class OpenTelemetryTracerProvider implements TracerProvider {
      * Registered global tracer, or tracer from global open telemetry.
      *
      * @return tracer
+     * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} - i.e.
+     *          {@code Services.get(Tracer.class)}, or use your registry instance in a similar way
      */
+    @Deprecated(since = "4.5.0", forRemoval = true)
     public static Tracer globalTracer() {
         return GLOBAL_TRACER.get();
     }

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
@@ -110,7 +110,7 @@ public class OpenTelemetryTracerProvider implements TracerProvider {
      *
      * @return tracer
      * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} - i.e.
-     *          {@code Services.get(Tracer.class)}, or use your registry instance in a similar way
+     *          {@code Services.get(Tracer.class)}
      */
     @Deprecated(since = "4.5.0", forRemoval = true)
     public static Tracer globalTracer() {


### PR DESCRIPTION
Related to #11565

Deprecates the remaining static factory and global accessor methods that should be replaced by `Services.get(..)`, except for `Config.global()`.

Validation:
- `mvn -pl metrics/api,tracing/providers/opentelemetry -am -DskipTests test-compile`
- `mvn -Pcopyright -pl metrics/api,tracing/providers/opentelemetry -am -DskipTests validate`
