### PR TITLE
Remove declarative WebServer startup warning (4.x)

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerStarterService.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerStarterService.java
@@ -16,33 +16,21 @@
 
 package io.helidon.webserver;
 
-import io.helidon.config.Configuration;
 import io.helidon.service.registry.Service;
 
 @Service.Singleton
 @Service.RunLevel(Service.RunLevel.SERVER)
 class WebServerStarterService {
-    private static final System.Logger LOGGER = System.getLogger(WebServerStarterService.class.getName());
 
     private final LoomServer server;
-    private final boolean ignoreIncubating;
 
-    WebServerStarterService(LoomServer server,
-                            @Configuration.Value("${declarative.ignore-incubating:false}")
-                            boolean ignoreIncubating) {
+    WebServerStarterService(LoomServer server) {
         this.server = server;
-        this.ignoreIncubating = ignoreIncubating;
     }
 
     @Service.PostConstruct
     void postConstruct() {
         server.start();
-        if (!ignoreIncubating) {
-            LOGGER.log(System.Logger.Level.WARNING,
-                       "Helidon WebServer is starting through Helidon Declarative. This is currently an incubating feature (and"
-                               + " as such it may be changed including backward incompatible changes). This warning can be "
-                               + "disabled by setting configuration option 'declarative.ignore-incubating' to true");
-        }
     }
 
     @Service.PreDestroy


### PR DESCRIPTION
Related to https://github.com/helidon-io/helidon/issues/11565 - removes warning during startup

Removes the warning emitted when Helidon Declarative starts the WebServer.

Validation:
- `mvn -pl webserver/webserver -am -DskipTests test-compile`
- `mvn -Pcopyright -pl webserver/webserver -am -DskipTests validate`
