### PR TITLE
Move declarative data APIs to preview (4.x)

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -3,6 +3,9 @@ Helidon Data
 
 Repository based database access.
 
+Helidon Data is a preview feature. It is ready for production use, but its APIs may change without
+the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
+
 # Glossary
 
 | Name             | Description                                                                                                          |

--- a/data/data/src/main/java/io/helidon/data/Data.java
+++ b/data/data/src/main/java/io/helidon/data/Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,14 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.registry.Service;
 
 /**
  * Helidon Data Repository annotations and interfaces.
  */
+@Api.Preview
 public final class Data {
 
     private Data() {

--- a/data/data/src/main/java/io/helidon/data/DataException.java
+++ b/data/data/src/main/java/io/helidon/data/DataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@ package io.helidon.data;
 
 import java.util.Objects;
 
+import io.helidon.common.Api;
+
 /**
  * A {@link RuntimeException} that indicates an operation on a data repository has failed.
  */
+@Api.Preview
 public class DataException extends RuntimeException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/EntityExistsException.java
+++ b/data/data/src/main/java/io/helidon/data/EntityExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when persistence entity being inserted already exists.
  */
+@Api.Preview
 public class EntityExistsException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/EntityNotFoundException.java
+++ b/data/data/src/main/java/io/helidon/data/EntityNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when requested persistence entity cannot be found.
  */
+@Api.Preview
 public class EntityNotFoundException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/NoResultException.java
+++ b/data/data/src/main/java/io/helidon/data/NoResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when a query was expected to produce a result, but did not.
  */
+@Api.Preview
 public class NoResultException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/NonUniqueResultException.java
+++ b/data/data/src/main/java/io/helidon/data/NonUniqueResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when a query was expected to produce exactly one record but produced many instead.
  */
+@Api.Preview
 public class NonUniqueResultException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/OptimisticLockException.java
+++ b/data/data/src/main/java/io/helidon/data/OptimisticLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when an optimistic locking conflict occurs.
  */
+@Api.Preview
 public class OptimisticLockException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/OrderBlueprint.java
+++ b/data/data/src/main/java/io/helidon/data/OrderBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.data;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Single rule of the dynamic ordering of the query result.
@@ -26,6 +27,7 @@ import io.helidon.builder.api.Prototype;
  * {@code SELECT t FROM Type t WHERE t.name = :name ORDER BY t.name DESC, t.id} this is the
  * {@code t.name DESC} and {@code t.id} as two separate {@link Order} instances.
  */
+@Api.Preview
 @Prototype.Blueprint
 @Prototype.CustomMethods(OrderSupport.class)
 interface OrderBlueprint {

--- a/data/data/src/main/java/io/helidon/data/OrderDirection.java
+++ b/data/data/src/main/java/io/helidon/data/OrderDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Direction of the query result ordering.
  */
+@Api.Preview
 public enum OrderDirection {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/Page.java
+++ b/data/data/src/main/java/io/helidon/data/Page.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package io.helidon.data;
 
 import java.util.List;
 
+import io.helidon.common.Api;
+
 /**
  * Pageable query result as pages with total size of the result.
  * <p>
@@ -29,6 +31,7 @@ import java.util.List;
  *
  * @param <T> query result type (entity or entity attribute)
  */
+@Api.Preview
 public interface Page<T> extends Slice<T> {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/PageRequestBlueprint.java
+++ b/data/data/src/main/java/io/helidon/data/PageRequestBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.helidon.data;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Request pageable query result as page with page number and size.
@@ -27,6 +28,7 @@ import io.helidon.builder.api.Prototype;
  * Repository interface method must always be of {@link Slice} or {@link Page} type when
  * it contains {@link PageRequest} argument.
  */
+@Api.Preview
 @Prototype.Blueprint
 @Prototype.CustomMethods(PageRequestSupport.class)
 interface PageRequestBlueprint {

--- a/data/data/src/main/java/io/helidon/data/Slice.java
+++ b/data/data/src/main/java/io/helidon/data/Slice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.helidon.data;
 import java.util.List;
 import java.util.stream.Stream;
 
+import io.helidon.common.Api;
+
 /**
  * Pageable query result as pages without total size of the result.
  * <p>
@@ -29,6 +31,7 @@ import java.util.stream.Stream;
  *
  * @param <T> query result type (entity or entity attribute)
  */
+@Api.Preview
 public interface Slice<T> extends Iterable<T> {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/SortBlueprint.java
+++ b/data/data/src/main/java/io/helidon/data/SortBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.List;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Dynamic ordering of the query result.
@@ -27,6 +28,7 @@ import io.helidon.builder.api.Prototype;
  * {@code SELECT t FROM Type t WHERE t.name = :name ORDER BY t.name DESC, t.id} this is the whole
  * content of the {@code ORDER BY} clause.
  */
+@Api.Preview
 @Prototype.Blueprint
 @Prototype.CustomMethods(SortSupport.class)
 interface SortBlueprint {

--- a/data/data/src/main/java/io/helidon/data/package-info.java
+++ b/data/data/src/main/java/io/helidon/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,5 +39,8 @@
  *         </ul>
  *     </li>
  * </ul>
+ *
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
  */
 package io.helidon.data;

--- a/data/data/src/main/java/module-info.java
+++ b/data/data/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,20 @@ import io.helidon.common.features.api.Features;
 
 /**
  * Helidon Data Repository API.
+ * <p>
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
+ *
  * @see io.helidon.data
  */
 @Features.Name("Data")
 @Features.Since("4.3.0")
 @Features.Path("Data")
 @Features.Description("Helidon Data - repository pattern")
-@Features.Incubating
 module io.helidon.data {
 
     requires static io.helidon.common.features.api;
+    requires static io.helidon.common;
     requires io.helidon.service.registry;
     requires transitive io.helidon.builder.api;
 

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaPersistenceUnitConfigBlueprint.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaPersistenceUnitConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,14 @@ import java.util.Set;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.data.sql.common.SqlConfig;
 import io.helidon.service.registry.Service;
 
 /**
  * Configuration of Helidon Data for Jakarta Persistence.
  */
+@Api.Preview
 @SuppressWarnings("rawtypes")
 @Prototype.Blueprint
 @Prototype.Configured(value = PersistenceUnitFactory.JPA_PU_CONFIG_KEY)

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaRepositoryExecutor.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaRepositoryExecutor.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Functions;
 import io.helidon.service.registry.Service;
 
@@ -30,6 +31,7 @@ import jakarta.persistence.PersistenceUnitUtil;
 /**
  * Jakarta Persistence specific repository tasks executor.
  */
+@Api.Preview
 @Service.Contract
 public interface JpaRepositoryExecutor extends AutoCloseable {
     /**

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/PersistenceUnitTransactionType.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/PersistenceUnitTransactionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.data.jakarta.persistence;
 
+import io.helidon.common.Api;
 import io.helidon.data.DataException;
 
 /**
@@ -23,6 +24,7 @@ import io.helidon.data.DataException;
  *
  * @deprecated Will be replaced by Jakarta Persistence 3.2 API
  */
+@Api.Preview
 @Deprecated
 public enum PersistenceUnitTransactionType {
 

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/package-info.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,5 +16,8 @@
 
 /**
  * Helidon Data Repository with Jakarta Persistence Runtime.
+ * <p>
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
  */
 package io.helidon.data.jakarta.persistence;

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/spi/JpaEntityProvider.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/spi/JpaEntityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.data.jakarta.persistence.spi;
 
+import io.helidon.common.Api;
 import io.helidon.service.registry.Service;
 
 /**
@@ -28,6 +29,7 @@ import io.helidon.service.registry.Service;
  *
  * @param <T> type of the entity supported by this provider
  */
+@Api.Preview
 @Service.Contract
 public interface JpaEntityProvider<T> {
     /**

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/spi/package-info.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,5 +16,8 @@
 
 /**
  * Service provider interface for repository with Jakarta Persistence Runtime.
+ * <p>
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
  */
 package io.helidon.data.jakarta.persistence.spi;

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/module-info.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/module-info.java
@@ -16,12 +16,16 @@
 
 /**
  * Helidon Data Repository with Jakarta Persistence Runtime.
+ * <p>
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
  */
 module io.helidon.data.jakarta.persistence {
 
     requires transitive jakarta.persistence;
     requires transitive io.helidon.service.registry;
 
+    requires io.helidon.common;
     requires io.helidon.config;
     requires io.helidon.data;
     requires io.helidon.data.sql.common;

--- a/docs/src/main/asciidoc/includes/data.adoc
+++ b/docs/src/main/asciidoc/includes/data.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -26,6 +26,10 @@ interfaces with query definitions to be translated into implementation classes a
 
 The Helidon Data Repository supports Jakarta Persistence and major providers such as EclipseLink
 and Hibernate.
+
+[NOTE]
+Helidon Data Repository is a preview feature. It is ready for production use, but its APIs may change without
+the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
 
 include::{rootdir}/includes/dependencies.adoc[]
 


### PR DESCRIPTION
Related to #11565

Move Helidon Data and Jakarta Persistence data APIs from incubating to preview:

- mark public API and SPI entry points with `@Api.Preview`
- remove the module incubating marker from Helidon Data
- update Data README, shared SE/MP docs, and module/package Javadocs to describe Data as preview

