### PR TITLE
Fix validated interface codegen switch (4.x)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidatedTypeGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidatedTypeGenerator.java
@@ -395,7 +395,7 @@ class ValidatedTypeGenerator {
                 .addContent("(")
                 .addContentLiteral("Invalid property name: ")
                 .addContentLine(" + propertyName);")
-                .addContentLine("};");
+                .addContentLine("}");
 
         classModel.addMethod(checkProperty);
 
@@ -428,7 +428,7 @@ class ValidatedTypeGenerator {
                 .addContent("(")
                 .addContentLiteral("Invalid property name: ")
                 .addContentLine(" + propertyName);")
-                .addContentLine("};");
+                .addContentLine("}");
 
         classModel.addMethod(checkPropertyValue);
     }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -84,6 +84,44 @@ public class ValidationCodegenTest {
     }
 
     @Test
+    void testValidatedInterfaceWithOnlyParameterConstraints() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import java.util.Optional;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        public interface DefaultApi {
+                            String listStoreItems(@Validation.Integer.Min(1)
+                                                  @Validation.Integer.Max(100) Optional<Integer> pageSize);
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(diagnostics, not(containsString("unreachable statement")));
+
+        var validator = result.sourceOutput().resolve("com/example/DefaultApi__Validated.java");
+        assertThat(Files.exists(validator), is(true));
+
+        var content = Files.readString(validator, StandardCharsets.UTF_8);
+        assertThat(content, matches("""
+                                            //...
+                                            class DefaultApi__Validated implements TypeValidator<DefaultApi> {
+                                            //...
+                                            }
+                                            """));
+    }
+
+    @Test
     void testPrivateFieldValidation() throws IOException {
         var result = TestCompiler.builder()
                 .currentRelease()


### PR DESCRIPTION
Resolves #11861

Fixes validation type code generation so property-check switch statements are emitted without an extra trailing statement. This lets generated validators compile when a `@Validation.Validated` interface only has method parameter constraints and no validated property methods.

Adds a TestCompiler regression for a validated interface with parameter-only constraints.
