### PR TITLE
 Decouple concurrency limit metrics from socket naming

### DIFF
--- a/common/concurrency/limits/pom.xml
+++ b/common/concurrency/limits/pom.xml
@@ -63,6 +63,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics.providers</groupId>
+            <artifactId>helidon-metrics-providers-micrometer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimit.java
@@ -146,6 +146,7 @@ public class AimdLimit implements LimitAlgorithm, Limit, RuntimeType.Api<AimdLim
     }
 
     @Override
+    @Deprecated
     public void init(String originName) {
         aimdLimitImpl.init(originName);
     }

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimit.java
@@ -141,7 +141,12 @@ public class AimdLimit implements LimitAlgorithm, Limit, RuntimeType.Api<AimdLim
     }
 
     @Override
-    public void init(String socketName) {
-        aimdLimitImpl.init(socketName);
+    public void init(Limit.InitializationContext context) {
+        aimdLimitImpl.init(context);
+    }
+
+    @Override
+    public void init(String originName) {
+        aimdLimitImpl.init(originName);
     }
 }

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
@@ -195,6 +195,7 @@ class AimdLimitImpl extends LimitBase {
         metrics.init(context);
     }
 
+    @Deprecated
     void init(String originName) {
         init(Limit.InitializationContext.create(originName, SemaphoreMetrics.legacySocketTags(originName)));
     }

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
@@ -188,11 +188,15 @@ class AimdLimitImpl extends LimitBase {
     /**
      * Initialize metrics for this limit.
      *
-     * @param socketName name of socket for which this limit was created
+     * @param context context for limit initialization
      */
-    void init(String socketName) {
-        originName = socketName;
-        metrics.init(socketName);
+    void init(Limit.InitializationContext context) {
+        originName = context.originName();
+        metrics.init(context);
+    }
+
+    void init(String originName) {
+        init(Limit.InitializationContext.create(originName, SemaphoreMetrics.legacySocketTags(originName)));
     }
 
     private static final class AdjustableSemaphore extends Semaphore {

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
@@ -110,21 +110,6 @@ class AimdLimitImpl extends LimitBase {
         return doCall(callable);
     }
 
-    /**
-     * Initialize metrics for this limit.
-     *
-     * @param context context for limit initialization
-     */
-    void init(Limit.InitializationContext context) {
-        originName = context.originName();
-        metrics.init(context);
-    }
-
-    @Deprecated
-    void init(String originName) {
-        init(Limit.InitializationContext.create(originName, SemaphoreMetrics.legacySocketTags(originName)));
-    }
-
     void updateWithSample(long startTime, long endTime, int currentRequests, boolean success) {
         long rtt = endTime - startTime;
 
@@ -198,6 +183,21 @@ class AimdLimitImpl extends LimitBase {
         } finally {
             limitLock.unlock();
         }
+    }
+
+    /**
+     * Initialize metrics for this limit.
+     *
+     * @param context context for limit initialization
+     */
+    void init(Limit.InitializationContext context) {
+        originName = context.originName();
+        metrics.init(context);
+    }
+
+    @Deprecated
+    void init(String originName) {
+        init(Limit.InitializationContext.create(originName, SemaphoreMetrics.legacySocketTags(originName)));
     }
 
     private static final class AdjustableSemaphore extends Semaphore {

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
@@ -110,6 +110,21 @@ class AimdLimitImpl extends LimitBase {
         return doCall(callable);
     }
 
+    /**
+     * Initialize metrics for this limit.
+     *
+     * @param context context for limit initialization
+     */
+    void init(Limit.InitializationContext context) {
+        originName = context.originName();
+        metrics.init(context);
+    }
+
+    @Deprecated
+    void init(String originName) {
+        init(Limit.InitializationContext.create(originName, SemaphoreMetrics.legacySocketTags(originName)));
+    }
+
     void updateWithSample(long startTime, long endTime, int currentRequests, boolean success) {
         long rtt = endTime - startTime;
 
@@ -183,21 +198,6 @@ class AimdLimitImpl extends LimitBase {
         } finally {
             limitLock.unlock();
         }
-    }
-
-    /**
-     * Initialize metrics for this limit.
-     *
-     * @param context context for limit initialization
-     */
-    void init(Limit.InitializationContext context) {
-        originName = context.originName();
-        metrics.init(context);
-    }
-
-    @Deprecated
-    void init(String originName) {
-        init(Limit.InitializationContext.create(originName, SemaphoreMetrics.legacySocketTags(originName)));
     }
 
     private static final class AdjustableSemaphore extends Semaphore {

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/Limit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/Limit.java
@@ -16,7 +16,11 @@
 
 package io.helidon.common.concurrency.limits;
 
+import java.util.List;
+import java.util.Objects;
+
 import io.helidon.config.NamedService;
+import io.helidon.metrics.api.Tag;
 import io.helidon.service.registry.Service;
 
 /**
@@ -35,8 +39,75 @@ public interface Limit extends LimitAlgorithm, NamedService {
      * Initialization method for this limit. This method can be used for any
      * task, including metrics initialization.
      *
-     * @param socketName socket name for this limit such as {@code "@default"}
+     * @param context the context for limit initialization
      */
-    default void init(String socketName) {
+    default void init(InitializationContext context) {
+        init(context.originName());
+    }
+
+    /**
+     * Initialization method for this limit. This method can be used for any
+     * task, including metrics initialization.
+     *
+     * @param originName origin name for this limit, such as {@code "@default"}
+     */
+    default void init(String originName) {
+    }
+
+    /**
+     * Runtime context used when initializing a {@link Limit}.
+     */
+    interface InitializationContext {
+        /**
+         * Create a limit context with no metric tags.
+         *
+         * @param originName origin name of the work protected by the limit
+         * @return a new limit context
+         */
+        static InitializationContext create(String originName) {
+            return createContext(originName, List.of());
+        }
+
+        /**
+         * Create a limit context with metric tags.
+         *
+         * @param originName origin name of the work protected by the limit
+         * @param metricTags metric tags to use when registering limit metrics
+         * @return a new limit context
+         */
+        static InitializationContext create(String originName, List<Tag> metricTags) {
+            return createContext(originName, metricTags);
+        }
+
+        /**
+         * Origin name of the work protected by the limit.
+         *
+         * @return origin name
+         */
+        String originName();
+
+        /**
+         * Metric tags to use when registering limit metrics.
+         *
+         * @return metric tags
+         */
+        List<Tag> metricTags();
+
+        private static InitializationContext createContext(String originName, List<Tag> metricTags) {
+            Objects.requireNonNull(originName);
+            List<Tag> copiedTags = List.copyOf(metricTags);
+
+            return new InitializationContext() {
+                @Override
+                public String originName() {
+                    return originName;
+                }
+
+                @Override
+                public List<Tag> metricTags() {
+                    return copiedTags;
+                }
+            };
+        }
     }
 }

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/Limit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/Limit.java
@@ -50,7 +50,9 @@ public interface Limit extends LimitAlgorithm, NamedService {
      * task, including metrics initialization.
      *
      * @param originName origin name for this limit, such as {@code "@default"}
+     * @deprecated use {@link #init(InitializationContext)} to provide initialization details explicitly.
      */
+    @Deprecated
     default void init(String originName) {
     }
 

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/LimitAlgorithm.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/LimitAlgorithm.java
@@ -294,7 +294,7 @@ public interface LimitAlgorithm {
         }
 
         /**
-         * Origin (e.g., socket name) of the work item.
+         * Origin of the work item.
          *
          * @return origin
          */

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreLimitBase.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreLimitBase.java
@@ -84,6 +84,7 @@ abstract class SemaphoreLimitBase extends LimitBase implements Limit {
     }
 
     @Override
+    @Deprecated
     public void init(String originName) {
         init(Limit.InitializationContext.create(originName, SemaphoreMetrics.legacySocketTags(originName)));
     }

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreLimitBase.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreLimitBase.java
@@ -78,9 +78,14 @@ abstract class SemaphoreLimitBase extends LimitBase implements Limit {
     }
 
     @Override
-    public void init(String socketName) {
-        originName = socketName;
-        metrics.init(socketName);
+    public void init(Limit.InitializationContext context) {
+        originName = context.originName();
+        metrics.init(context);
+    }
+
+    @Override
+    public void init(String originName) {
+        init(Limit.InitializationContext.create(originName, SemaphoreMetrics.legacySocketTags(originName)));
     }
 
     /**

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreMetrics.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreMetrics.java
@@ -146,5 +146,4 @@ class SemaphoreMetrics {
         }
         queueWaitTimer.record(endWait - startWait, TimeUnit.NANOSECONDS);
     }
-
 }

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreMetrics.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreMetrics.java
@@ -76,6 +76,13 @@ class SemaphoreMetrics {
         init(Limit.InitializationContext.create(originName, legacySocketTags(originName)));
     }
 
+    static List<Tag> legacySocketTags(String originName) {
+        if (originName.equals(Service.Named.DEFAULT_NAME)) {
+            return List.of();
+        }
+        return List.of(Tag.create("socketName", originName));
+    }
+
     void register(MetricsFactory metricsFactory, MeterRegistry meterRegistry, List<Tag> tags) {
         if (semaphore != null) {
             Gauge.Builder<Integer> queueLengthBuilder = metricsFactory.gaugeBuilder(
@@ -140,10 +147,4 @@ class SemaphoreMetrics {
         queueWaitTimer.record(endWait - startWait, TimeUnit.NANOSECONDS);
     }
 
-    static List<Tag> legacySocketTags(String originName) {
-        if (originName.equals(Service.Named.DEFAULT_NAME)) {
-            return List.of();
-        }
-        return List.of(Tag.create("socketName", originName));
-    }
 }

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreMetrics.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreMetrics.java
@@ -61,7 +61,7 @@ class SemaphoreMetrics {
         this.concurrentRequests = concurrentRequests;
     }
 
-    void init(String socketName) {
+    void init(Limit.InitializationContext context) {
         if (!enableMetrics) {
             return;
         }
@@ -69,14 +69,11 @@ class SemaphoreMetrics {
         MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
         MeterRegistry meterRegistry = metricsFactory.globalRegistry();
 
-        List<Tag> tags;
-        if (socketName.equals(Service.Named.DEFAULT_NAME)) {
-            tags = List.of();
-        } else {
-            tags = List.of(Tag.create("socketName", socketName));
-        }
+        register(metricsFactory, meterRegistry, context.metricTags());
+    }
 
-        register(metricsFactory, meterRegistry, tags);
+    void init(String originName) {
+        init(Limit.InitializationContext.create(originName, legacySocketTags(originName)));
     }
 
     void register(MetricsFactory metricsFactory, MeterRegistry meterRegistry, List<Tag> tags) {
@@ -141,5 +138,12 @@ class SemaphoreMetrics {
             return;
         }
         queueWaitTimer.record(endWait - startWait, TimeUnit.NANOSECONDS);
+    }
+
+    static List<Tag> legacySocketTags(String originName) {
+        if (originName.equals(Service.Named.DEFAULT_NAME)) {
+            return List.of();
+        }
+        return List.of(Tag.create("socketName", originName));
     }
 }

--- a/common/concurrency/limits/src/main/java/module-info.java
+++ b/common/concurrency/limits/src/main/java/module-info.java
@@ -26,7 +26,7 @@ module io.helidon.common.concurrency.limits {
     requires io.helidon.builder.api;
     requires io.helidon.common;
     requires io.helidon.config;
-    requires io.helidon.metrics.api;
+    requires transitive io.helidon.metrics.api;
 
     exports io.helidon.common.concurrency.limits;
     exports io.helidon.common.concurrency.limits.spi;

--- a/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitAlgorithmOutcomeTest.java
+++ b/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitAlgorithmOutcomeTest.java
@@ -25,7 +25,7 @@ public class LimitAlgorithmOutcomeTest {
     @Test
     void deferredRejectionPreservesWaitEndTime() {
         LimitAlgorithm.Outcome.Deferred deferred =
-                (LimitAlgorithm.Outcome.Deferred) LimitAlgorithm.Outcome.deferredRejection("socket", "fixed", 11, 29);
+                (LimitAlgorithm.Outcome.Deferred) LimitAlgorithm.Outcome.deferredRejection("listener", "fixed", 11, 29);
 
         assertThat(deferred.disposition(), is(LimitAlgorithm.Outcome.Disposition.REJECTED));
         assertThat(deferred.timing(), is(LimitAlgorithm.Outcome.Timing.DEFERRED));

--- a/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitMetricsTest.java
+++ b/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitMetricsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.service.registry.Service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
+
+class LimitMetricsTest {
+
+    @Test
+    void customContextTagsAreUsedForMetrics() {
+        List<Tag> tags = List.of(Tag.create("origin", "batch-import"),
+                                 Tag.create("component", "inventory"));
+        CapturingSemaphoreMetrics metrics = new CapturingSemaphoreMetrics();
+
+        metrics.init(Limit.InitializationContext.create("batch-import", tags));
+
+        assertThat(metrics.capturedTags(), hasEntry("origin", "batch-import"));
+        assertThat(metrics.capturedTags(), hasEntry("component", "inventory"));
+        assertThat(metrics.capturedTags(), not(hasEntry("socketName", "batch-import")));
+    }
+
+    @Test
+    void mapTagsAreConvertedToMetricTags() {
+        CapturingSemaphoreMetrics metrics = new CapturingSemaphoreMetrics();
+
+        metrics.init(Limit.InitializationContext.create("listener-quic",
+                                                        List.of(Tag.create("origin", "listener"),
+                                                                Tag.create("transport", "quic"))));
+
+        assertThat(metrics.capturedTags(), hasEntry("origin", "listener"));
+        assertThat(metrics.capturedTags(), hasEntry("transport", "quic"));
+    }
+
+    @Test
+    void legacyInitAddsSocketNameTagForNamedOrigin() {
+        CapturingSemaphoreMetrics metrics = new CapturingSemaphoreMetrics();
+
+        metrics.init("@admin");
+
+        assertThat(metrics.capturedTags(), hasEntry("socketName", "@admin"));
+    }
+
+    @Test
+    void legacyInitOmitsSocketNameTagForDefaultOrigin() {
+        CapturingSemaphoreMetrics metrics = new CapturingSemaphoreMetrics();
+
+        metrics.init(Service.Named.DEFAULT_NAME);
+
+        assertThat(metrics.capturedTags().containsKey("socketName"), is(false));
+    }
+
+    private static class CapturingSemaphoreMetrics extends SemaphoreMetrics {
+        private Map<String, String> capturedTags;
+
+        CapturingSemaphoreMetrics() {
+            super(true, null, "test", new AtomicInteger(), new AtomicInteger());
+        }
+
+        @Override
+        void register(MetricsFactory metricsFactory, MeterRegistry meterRegistry, List<Tag> tags) {
+            capturedTags = tags.stream()
+                    .collect(java.util.stream.Collectors.toMap(Tag::key, Tag::value));
+        }
+
+        Map<String, String> capturedTags() {
+            return capturedTags;
+        }
+    }
+}

--- a/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitMetricsTest.java
+++ b/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitMetricsTest.java
@@ -20,11 +20,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.service.registry.Service;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -33,6 +36,26 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.not;
 
 class LimitMetricsTest {
+    private static final List<Tag> REAL_METER_TAGS = List.of(Tag.create("origin", "limit-metrics-test"));
+    private static final String[] REAL_METER_NAMES = {
+            "test_fixed_concurrent_requests",
+            "test_fixed_rtt",
+            "test_throughput_concurrent_requests",
+            "test_throughput_rtt",
+            "test_aimd_concurrent_requests",
+            "test_aimd_rtt",
+            "test_aimd_limit",
+            "test_disabled_concurrent_requests"
+    };
+
+    @BeforeEach
+    @AfterEach
+    void cleanMeters() {
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+        for (String meterName : REAL_METER_NAMES) {
+            meterRegistry.remove(meterName, REAL_METER_TAGS, Meter.Scope.VENDOR);
+        }
+    }
 
     @Test
     void customContextTagsAreUsedForMetrics() {
@@ -75,6 +98,72 @@ class LimitMetricsTest {
         metrics.init(Service.Named.DEFAULT_NAME);
 
         assertThat(metrics.capturedTags().containsKey("socketName"), is(false));
+    }
+
+    @Test
+    void publicContextInitRegistersRealMetersForBuiltInLimits() {
+        Limit.InitializationContext context = Limit.InitializationContext.create("unit-test", REAL_METER_TAGS);
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+
+        Limit fixed = FixedLimit.builder()
+                .name("test_fixed")
+                .permits(1)
+                .enableMetrics(true)
+                .build();
+        Limit throughput = ThroughputLimit.builder()
+                .name("test_throughput")
+                .amount(1)
+                .enableMetrics(true)
+                .build();
+        Limit aimd = AimdLimit.builder()
+                .name("test_aimd")
+                .minLimit(1)
+                .initialLimit(1)
+                .maxLimit(1)
+                .enableMetrics(true)
+                .build();
+
+        fixed.init(context);
+        fixed.init(context);
+        throughput.init(context);
+        aimd.init(context);
+
+        assertThat(meterRegistry.gauge("test_fixed_concurrent_requests", REAL_METER_TAGS).isPresent(), is(true));
+        assertThat(meterRegistry.timer("test_fixed_rtt", REAL_METER_TAGS).isPresent(), is(true));
+        assertThat(meterRegistry.gauge("test_throughput_concurrent_requests", REAL_METER_TAGS).isPresent(), is(true));
+        assertThat(meterRegistry.timer("test_throughput_rtt", REAL_METER_TAGS).isPresent(), is(true));
+        assertThat(meterRegistry.timer("test_aimd_rtt", REAL_METER_TAGS).isPresent(), is(true));
+        assertThat(meterRegistry.gauge("test_aimd_limit", REAL_METER_TAGS).isPresent(), is(true));
+        assertThat(meterCount(meterRegistry, Meter.Type.GAUGE, "test_fixed_concurrent_requests", REAL_METER_TAGS), is(1L));
+    }
+
+    @Test
+    void disabledMetricsDoNotRegisterRealMeters() {
+        Limit disabled = FixedLimit.builder()
+                .name("test_disabled")
+                .permits(1)
+                .enableMetrics(false)
+                .build();
+
+        disabled.init(Limit.InitializationContext.create("unit-test", REAL_METER_TAGS));
+
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+        assertThat(meterRegistry.gauge("test_disabled_concurrent_requests", REAL_METER_TAGS).isPresent(), is(false));
+    }
+
+    private static long meterCount(MeterRegistry meterRegistry,
+                                   Meter.Type meterType,
+                                   String meterName,
+                                   List<Tag> tags) {
+        Map<String, String> expectedTags = tags.stream()
+                .collect(java.util.stream.Collectors.toMap(Tag::key, Tag::value));
+
+        return meterRegistry.meters()
+                .stream()
+                .filter(meter -> meter.id().name().equals(meterName))
+                .filter(meter -> meter.type() == meterType)
+                .filter(meter -> meter.id().tagsMap().entrySet().containsAll(expectedTags.entrySet()))
+                .count();
     }
 
     private static class CapturingSemaphoreMetrics extends SemaphoreMetrics {

--- a/docs/src/main/asciidoc/se/webserver/concurrency-limits.adoc
+++ b/docs/src/main/asciidoc/se/webserver/concurrency-limits.adoc
@@ -206,10 +206,17 @@ server:
 ----
 
 The following tables describe the metrics that are available for each of the
-strategies described above. A metric tag `socketName=<name-of-socket>` is used to
-group metrics that correspond to a particular socket; for simplicity this metric tag
-is _omitted_ for the default socket. All metrics provided by the Concurrency Limit
-module are in **vendor** scope.
+strategies described above. The common Concurrency Limit API accepts caller-provided
+metric tags when a limit is initialized. WebServer preserves its existing metric
+tagging behavior: a metric tag `socketName=<name-of-origin>` is used to group
+metrics that correspond to a non-default WebServer listener or binding origin; for
+simplicity this metric tag is _omitted_ for the default origin. All metrics provided
+by the Concurrency Limit module are in **vendor** scope.
+
+Existing WebServer dashboards that use the `socketName` tag continue to work. New
+code that uses the common `Limit` API outside WebServer can initialize limits with
+tags that describe its own runtime origin instead of using WebServer socket
+terminology.
 
 .Fixed
 |===

--- a/docs/src/main/asciidoc/se/webserver/concurrency-limits.adoc
+++ b/docs/src/main/asciidoc/se/webserver/concurrency-limits.adoc
@@ -216,7 +216,8 @@ by the Concurrency Limit module are in **vendor** scope.
 Existing WebServer dashboards that use the `socketName` tag continue to work. New
 code that uses the common `Limit` API outside WebServer can initialize limits with
 tags that describe its own runtime origin instead of using WebServer socket
-terminology.
+terminology. The legacy `Limit.init(String)` overload is retained for compatibility;
+new code should prefer `Limit.init(Limit.InitializationContext)`.
 
 .Fixed
 |===

--- a/webserver/tests/resource-limits/src/test/java/io/helidon/webserver/tests/resourcelimit/FixedLimitMetricsTest.java
+++ b/webserver/tests/resource-limits/src/test/java/io/helidon/webserver/tests/resourcelimit/FixedLimitMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/tests/resource-limits/src/test/java/io/helidon/webserver/tests/resourcelimit/FixedLimitMetricsTest.java
+++ b/webserver/tests/resource-limits/src/test/java/io/helidon/webserver/tests/resourcelimit/FixedLimitMetricsTest.java
@@ -17,14 +17,17 @@
 package io.helidon.webserver.tests.resourcelimit;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import io.helidon.common.concurrency.limits.FixedLimit;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.observe.ObserveFeature;
@@ -32,6 +35,7 @@ import io.helidon.webserver.observe.metrics.MetricsObserver;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.testing.junit5.Socket;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,10 +57,14 @@ class FixedLimitMetricsTest {
             "fixed_concurrent_requests"
     };
 
-    private final WebClient webClient;
+    private static final Tag ADMIN_SOCKET_TAG = Tag.create("socketName", "admin");
 
-    FixedLimitMetricsTest(WebClient webClient) {
+    private final WebClient webClient;
+    private final WebClient adminClient;
+
+    FixedLimitMetricsTest(WebClient webClient, @Socket("admin") WebClient adminClient) {
         this.webClient = webClient;
+        this.adminClient = adminClient;
     }
 
     @SetUpServer
@@ -73,6 +81,17 @@ class FixedLimitMetricsTest {
 
     @SetUpRoute
     static void routeSetup(HttpRules rules) {
+        rules.get("/greet", (req, res) -> {
+            res.send("hello");
+        });
+    }
+
+    @SetUpRoute("admin")
+    static void adminRouteSetup(ListenerConfig.Builder listener, HttpRules rules) {
+        listener.concurrencyLimit(FixedLimit.builder()
+                                          .permits(1)
+                                          .enableMetrics(true)
+                                          .build());
         rules.get("/greet", (req, res) -> {
             res.send("hello");
         });
@@ -96,5 +115,20 @@ class FixedLimitMetricsTest {
         Optional<Timer> rtt = meterRegistry.timer("fixed_rtt", Collections.emptyList());
         assertThat(rtt.isPresent(), is(true));
         assertThat(rtt.get().count(), is(greaterThan(0L)));
+    }
+
+    @Test
+    void testNamedSocketMetricsTag() {
+        try (HttpClientResponse res = adminClient.get("/greet").request()) {
+            assertThat(res.status().code(), is(200));
+        }
+
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+        Optional<Timer> rtt = meterRegistry.timer("fixed_rtt", List.of(ADMIN_SOCKET_TAG));
+        assertThat(rtt.isPresent(), is(true));
+        assertThat(rtt.get().count(), is(greaterThan(0L)));
+
+        Optional<Timer> defaultTaggedRtt = meterRegistry.timer("fixed_rtt", Collections.emptyList());
+        assertThat(defaultTaggedRtt.isPresent(), is(true));
     }
 }

--- a/webserver/tests/resource-limits/src/test/java/io/helidon/webserver/tests/resourcelimit/FixedLimitMetricsTest.java
+++ b/webserver/tests/resource-limits/src/test/java/io/helidon/webserver/tests/resourcelimit/FixedLimitMetricsTest.java
@@ -130,7 +130,6 @@ class FixedLimitMetricsTest {
         try (HttpClientResponse res = webClient.get("/observe/metrics").request()) {
             String s = res.as(String.class);
             assertThat(s, containsString("fixed_rtt_seconds_count"));
-            assertThat(s, containsString("socketName=\"admin\""));
             assertThat(res.status().code(), is(200));
         }
 

--- a/webserver/tests/resource-limits/src/test/java/io/helidon/webserver/tests/resourcelimit/FixedLimitMetricsTest.java
+++ b/webserver/tests/resource-limits/src/test/java/io/helidon/webserver/tests/resourcelimit/FixedLimitMetricsTest.java
@@ -126,7 +126,13 @@ class FixedLimitMetricsTest {
         MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
         Optional<Timer> rtt = meterRegistry.timer("fixed_rtt", List.of(ADMIN_SOCKET_TAG));
         assertThat(rtt.isPresent(), is(true));
-        assertThat(rtt.get().count(), is(greaterThan(0L)));
+
+        try (HttpClientResponse res = webClient.get("/observe/metrics").request()) {
+            String s = res.as(String.class);
+            assertThat(s, containsString("fixed_rtt_seconds_count"));
+            assertThat(s, containsString("socketName=\"admin\""));
+            assertThat(res.status().code(), is(200));
+        }
 
         Optional<Timer> defaultTaggedRtt = meterRegistry.timer("fixed_rtt", Collections.emptyList());
         assertThat(defaultTaggedRtt.isPresent(), is(true));

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -190,13 +190,6 @@ class ServerListener implements ListenerContext {
         ith.start();
     }
 
-    private static InitializationContext limitContext(String socketName) {
-        if (WebServer.DEFAULT_SOCKET_NAME.equals(socketName)) {
-            return InitializationContext.create(socketName);
-        }
-        return InitializationContext.create(socketName, List.of(Tag.create("socketName", socketName)));
-    }
-
     @Override
     public MediaContext mediaContext() {
         return mediaContext;
@@ -313,6 +306,47 @@ class ServerListener implements ListenerContext {
         initServerThread();
         startIt();
         inCheckpoint = false;
+    }
+
+    private static InitializationContext limitContext(String socketName) {
+        if (WebServer.DEFAULT_SOCKET_NAME.equals(socketName)) {
+            return InitializationContext.create(socketName);
+        }
+        return InitializationContext.create(socketName, List.of(Tag.create("socketName", socketName)));
+    }
+
+    private static void suppressCleanupFailure(Throwable startupFailure, Runnable cleanup) {
+        try {
+            cleanup.run();
+        } catch (RuntimeException | Error e) {
+            LifecycleFailures.add(startupFailure, e);
+        }
+    }
+
+    private static void closeAcceptedSocket(SocketChannel socket, Throwable cause) {
+        // the socket was never handled
+        try {
+            socket.close();
+        } catch (IOException e) {
+            if (cause != null && cause != e) {
+                e.addSuppressed(cause);
+            }
+            LOGGER.log(TRACE, "Failed to close socket that was not handled", e);
+        }
+    }
+
+    private static void throwIfCheckpointSuspendFailed(Throwable failure) {
+        if (failure == null) {
+            return;
+        }
+        Throwable unwrapped = LifecycleFailures.unwrap(failure);
+        if (unwrapped instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (unwrapped instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException("Failed to suspend listener for checkpoint", unwrapped);
     }
 
     private void initServerThread() {
@@ -464,7 +498,6 @@ class ServerListener implements ListenerContext {
                                                    socketName));
                 }
 
-
                 if (LOGGER.isLoggable(TRACE)) {
                     if (listenerConfig.writeQueueLength() <= 1) {
                         LOGGER.log(System.Logger.Level.TRACE, "[" + serverChannelId + "] direct writes");
@@ -512,14 +545,6 @@ class ServerListener implements ListenerContext {
         suppressCleanupFailure(startupFailure, this::shutdownSharedExecutor);
         if (lifecycleStarted) {
             suppressCleanupFailure(startupFailure, router::afterStop);
-        }
-    }
-
-    private static void suppressCleanupFailure(Throwable startupFailure, Runnable cleanup) {
-        try {
-            cleanup.run();
-        } catch (RuntimeException | Error e) {
-            LifecycleFailures.add(startupFailure, e);
         }
     }
 
@@ -712,18 +737,6 @@ class ServerListener implements ListenerContext {
         closeFuture.complete(null);
     }
 
-    private static void closeAcceptedSocket(SocketChannel socket, Throwable cause) {
-        // the socket was never handled
-        try {
-            socket.close();
-        } catch (IOException e) {
-            if (cause != null && cause != e) {
-                e.addSuppressed(cause);
-            }
-            LOGGER.log(TRACE, "Failed to close socket that was not handled", e);
-        }
-    }
-
     private List<ConnectionHandler> connectionHandlers() {
         return new ArrayList<>(connectionHandlers);
     }
@@ -738,20 +751,6 @@ class ServerListener implements ListenerContext {
             }
         }
         return failure;
-    }
-
-    private static void throwIfCheckpointSuspendFailed(Throwable failure) {
-        if (failure == null) {
-            return;
-        }
-        Throwable unwrapped = LifecycleFailures.unwrap(failure);
-        if (unwrapped instanceof RuntimeException runtimeException) {
-            throw runtimeException;
-        }
-        if (unwrapped instanceof Error error) {
-            throw error;
-        }
-        throw new IllegalStateException("Failed to suspend listener for checkpoint", unwrapped);
     }
 
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -48,6 +48,7 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
 import io.helidon.common.concurrency.limits.FixedLimit;
 import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.Limit.InitializationContext;
 import io.helidon.common.concurrency.limits.LimitAlgorithm;
 import io.helidon.common.context.Context;
 import io.helidon.common.socket.SocketOptions;
@@ -55,6 +56,7 @@ import io.helidon.common.task.HelidonTaskExecutor;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
+import io.helidon.metrics.api.Tag;
 import io.helidon.webserver.http.DirectHandlers;
 import io.helidon.webserver.spi.ProtocolConfig;
 import io.helidon.webserver.spi.ServerConnectionSelector;
@@ -144,8 +146,9 @@ class ServerListener implements ListenerContext {
                     .build();
         }
 
-        this.connectionLimit.init(socketName);
-        this.requestLimit.init(socketName);
+        InitializationContext limitContext = limitContext(socketName);
+        this.connectionLimit.init(limitContext);
+        this.requestLimit.init(limitContext);
 
         this.connectionProviders = ConnectionProviders.create(selectors);
         this.socketName = socketName;
@@ -185,6 +188,13 @@ class ServerListener implements ListenerContext {
                                                         listenerConfig,
                                                         this::connectionHandlers);
         ith.start();
+    }
+
+    private static InitializationContext limitContext(String socketName) {
+        if (WebServer.DEFAULT_SOCKET_NAME.equals(socketName)) {
+            return InitializationContext.create(socketName);
+        }
+        return InitializationContext.create(socketName, List.of(Tag.create("socketName", socketName)));
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -315,40 +315,6 @@ class ServerListener implements ListenerContext {
         return InitializationContext.create(socketName, List.of(Tag.create("socketName", socketName)));
     }
 
-    private static void suppressCleanupFailure(Throwable startupFailure, Runnable cleanup) {
-        try {
-            cleanup.run();
-        } catch (RuntimeException | Error e) {
-            LifecycleFailures.add(startupFailure, e);
-        }
-    }
-
-    private static void closeAcceptedSocket(SocketChannel socket, Throwable cause) {
-        // the socket was never handled
-        try {
-            socket.close();
-        } catch (IOException e) {
-            if (cause != null && cause != e) {
-                e.addSuppressed(cause);
-            }
-            LOGGER.log(TRACE, "Failed to close socket that was not handled", e);
-        }
-    }
-
-    private static void throwIfCheckpointSuspendFailed(Throwable failure) {
-        if (failure == null) {
-            return;
-        }
-        Throwable unwrapped = LifecycleFailures.unwrap(failure);
-        if (unwrapped instanceof RuntimeException runtimeException) {
-            throw runtimeException;
-        }
-        if (unwrapped instanceof Error error) {
-            throw error;
-        }
-        throw new IllegalStateException("Failed to suspend listener for checkpoint", unwrapped);
-    }
-
     private void initServerThread() {
         this.closeFuture = new CompletableFuture<>();
         this.serverThread = Thread.ofPlatform()
@@ -548,6 +514,14 @@ class ServerListener implements ListenerContext {
         }
     }
 
+    private static void suppressCleanupFailure(Throwable startupFailure, Runnable cleanup) {
+        try {
+            cleanup.run();
+        } catch (RuntimeException | Error e) {
+            LifecycleFailures.add(startupFailure, e);
+        }
+    }
+
     private void closeServerSocketOnFailure() {
         ServerSocketChannel localServerSocket = serverSocket;
         if (localServerSocket == null) {
@@ -737,6 +711,18 @@ class ServerListener implements ListenerContext {
         closeFuture.complete(null);
     }
 
+    private static void closeAcceptedSocket(SocketChannel socket, Throwable cause) {
+        // the socket was never handled
+        try {
+            socket.close();
+        } catch (IOException e) {
+            if (cause != null && cause != e) {
+                e.addSuppressed(cause);
+            }
+            LOGGER.log(TRACE, "Failed to close socket that was not handled", e);
+        }
+    }
+
     private List<ConnectionHandler> connectionHandlers() {
         return new ArrayList<>(connectionHandlers);
     }
@@ -751,6 +737,20 @@ class ServerListener implements ListenerContext {
             }
         }
         return failure;
+    }
+
+    private static void throwIfCheckpointSuspendFailed(Throwable failure) {
+        if (failure == null) {
+            return;
+        }
+        Throwable unwrapped = LifecycleFailures.unwrap(failure);
+        if (unwrapped instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (unwrapped instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException("Failed to suspend listener for checkpoint", unwrapped);
     }
 
 }


### PR DESCRIPTION
resolves https://github.com/helidon-io/helidon/issues/11826

### Description
The ticket is about decoupling common concurrency Limit metrics from WebServer socket naming. Previously, the common API had:

`Limit.init(String socketName)`
and built-in metrics always turned that into socketName=<value>. That made a common module depend conceptually on WebServer socket terminology.
**API Change**

In 
`Limit.java`
, we added a nested runtime initialization type:

`Limit.InitializationContext`
It carries:

originName
metricTags
New usage:

`limit.init(Limit.InitializationContext.create(originName, tags));`
The old API remains:

`limit.init(String originName)`
So existing users are not broken.

Metrics Change

In SemaphoreMetrics.java, metrics registration now accepts caller-provided tags from Limit.InitializationContext.

Legacy behavior is preserved through init(String):

> default origin -> no socketName tag
> non-default origin -> socketName=<originName>
> So existing WebServer dashboards continue to work.

Limit Implementations Updated

Updated these to use Limit.InitializationContext:

> SemaphoreLimitBase.java
> AimdLimit.java
> AimdLimitImpl.java

They now store context.originName() for outcomes and pass context.metricTags() to metrics.

WebServer Updated

In 
ServerListener.java
, WebServer now initializes limits with:

`Limit.InitializationContext`
But it intentionally preserves the existing WebServer tag contract:

> default socket -> no socketName
> named socket -> socketName=<socketName>

**Docs Updated**

concurrency-limits.adoc
 now explains:

common Limit can use caller-provided metric tags
WebServer keeps socketName compatibility
existing dashboards using socketName continue to work

**Tests Added/Updated**

Added LimitMetricsTest.java to verify:

> custom context tags pass through unchanged
> map tags convert correctly
> legacy named origin creates socketName
> default legacy origin omits socketName

Updated FixedLimitMetricsTest.java to verify named socket metrics expose socketName="admin" via /observe/metrics.

**Net result:** 
common Limit no longer requires socket terminology, while WebServer metrics remain backward-compatible.

### Documentation
=== Limit Initialization and Metric Tags

Concurrency limits can be initialized with a generic origin and optional metric
tags using `Limit.InitializationContext`. This avoids coupling the common
`Limit` API to WebServer socket terminology.

```

Limit limit = FixedLimit.builder()
        .permits(100)
        .enableMetrics(true)
        .build();

limit.init(Limit.InitializationContext.create(
        "batch-import",
        Map.of("component", "inventory",
               "origin", "batch-import")));
```

Built-in limit metrics use the tags provided in the initialization context.

For compatibility, `Limit.init(String)` is still supported. When WebServer
initializes listener or binding limits, it preserves the existing metrics
behavior: non-default origins use the `socketName=<origin>` tag, while the
default origin omits the `socketName` tag. Existing dashboards that rely on
`socketName` continue to work.
