### PR TITLE
Fix codegen TypeName annotation handling (4.x)

### DIFF
--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
@@ -132,7 +132,9 @@ public interface ContentBuilder<T extends ContentBuilder<T>> {
      * To create a type name without type arguments (such as when used with {@code .class}), use
      * {@link io.helidon.common.types.TypeName#genericTypeName()}.
      * <p>
-     * The generated content will be similar to: {@code TypeName.create("some.type.Name")}
+     * Simple type names use generated content similar to: {@code TypeName.create("some.type.Name")}.
+     * Type names with direct or inherited type-use annotations use generated builder content to preserve annotations
+     * on the root type, type arguments, wildcard bounds, and array component types.
      *
      * @param typeName type name to code generate
      * @return updated builder instance

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentSupport.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentSupport.java
@@ -264,7 +264,7 @@ final class ContentSupport {
 
     private static void addAnnotationValue(ContentBuilder<?> contentBuilder, Object objectValue) {
         switch (objectValue) {
-        case String value -> contentBuilder.addContent("\"" + value + "\"");
+        case String value -> contentBuilder.addContentLiteral(value);
         case Boolean value -> contentBuilder.addContent(String.valueOf(value));
         case Long value -> contentBuilder.addContent(String.valueOf(value) + 'L');
         case Double value -> contentBuilder.addContent(String.valueOf(value) + 'D');

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentSupport.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentSupport.java
@@ -62,6 +62,11 @@ final class ContentSupport {
                     .addContentLine("\")");
         }
 
+        element.enclosingType()
+                .ifPresent(it -> contentBuilder.addContent(".enclosingType(")
+                        .addContentCreate(it)
+                        .addContentLine(")"));
+
         for (Annotation annotation : element.annotations()) {
             contentBuilder.addContent(".addAnnotation(")
                     .addContentCreate(annotation)
@@ -153,11 +158,108 @@ final class ContentSupport {
     }
 
     static void addCreateTypeName(ContentBuilder<?> builder, TypeName typeName) {
+        if (hasNestedAnnotations(typeName)) {
+            builder.addContent(TypeNames.TYPE_NAME)
+                    .addContentLine(".builder()")
+                    .increaseContentPadding()
+                    .increaseContentPadding();
+
+            addBuilderString(builder, "packageName", typeName.packageName());
+            addBuilderString(builder, "className", typeName.className());
+            typeName.enclosingNames().forEach(it -> addBuilderString(builder, "addEnclosingName", it));
+            if (typeName.primitive()) {
+                builder.addContentLine(".primitive(true)");
+            }
+            if (typeName.array()) {
+                builder.addContentLine(".array(true)");
+            }
+            if (typeName.vararg()) {
+                builder.addContentLine(".vararg(true)");
+            }
+            if (typeName.generic()) {
+                builder.addContentLine(".generic(true)");
+            }
+            if (typeName.wildcard()) {
+                builder.addContentLine(".wildcard(true)");
+            }
+
+            for (Annotation annotation : typeName.annotations()) {
+                builder.addContent(".addAnnotation(")
+                        .addContentCreate(annotation)
+                        .addContentLine(")");
+            }
+
+            for (Annotation annotation : typeName.inheritedAnnotations()) {
+                builder.addContent(".addInheritedAnnotation(")
+                        .addContentCreate(annotation)
+                        .addContentLine(")");
+            }
+
+            for (TypeName typeArgument : typeName.typeArguments()) {
+                builder.addContent(".addTypeArgument(")
+                        .addContentCreate(typeArgument)
+                        .addContentLine(")");
+            }
+
+            typeName.typeParameters().forEach(it -> addBuilderString(builder, "addTypeParameter", it));
+
+            for (TypeName lowerBound : typeName.lowerBounds()) {
+                builder.addContent(".addLowerBound(")
+                        .addContentCreate(lowerBound)
+                        .addContentLine(")");
+            }
+
+            for (TypeName upperBound : typeName.upperBounds()) {
+                builder.addContent(".addUpperBound(")
+                        .addContentCreate(upperBound)
+                        .addContentLine(")");
+            }
+
+            typeName.componentType()
+                    .ifPresent(componentType -> builder.addContent(".componentType(")
+                            .addContentCreate(componentType)
+                            .addContentLine(")"));
+
+            builder.addContentLine(".build()")
+                    .decreaseContentPadding()
+                    .decreaseContentPadding();
+            return;
+        }
+
         // TypeName.create("my.type.Name<my.type.TypeArgument>")
         builder.addContent(TypeNames.TYPE_NAME)
                 .addContent(".create(\"")
                 .addContent(typeName.resolvedName())
                 .addContent("\")");
+    }
+
+    private static void addBuilderString(ContentBuilder<?> builder, String method, String value) {
+        if (value.isEmpty()) {
+            return;
+        }
+        builder.addContent(".")
+                .addContent(method)
+                .addContent("(")
+                .addContentLiteral(value)
+                .addContentLine(")");
+    }
+
+    private static boolean hasNestedAnnotations(TypeName typeName) {
+        if (!typeName.annotations().isEmpty() || !typeName.inheritedAnnotations().isEmpty()) {
+            return true;
+        }
+        if (typeName.typeArguments().stream().anyMatch(ContentSupport::hasNestedAnnotations)) {
+            return true;
+        }
+        if (typeName.lowerBounds().stream().anyMatch(ContentSupport::hasNestedAnnotations)) {
+            return true;
+        }
+        if (typeName.upperBounds().stream().anyMatch(ContentSupport::hasNestedAnnotations)) {
+            return true;
+        }
+        return typeName.componentType()
+                .map(ContentSupport::hasNestedAnnotations)
+                .orElse(false);
     }
 
     private static void addAnnotationValue(ContentBuilder<?> contentBuilder, Object objectValue) {

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/ContentBuilderTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/ContentBuilderTest.java
@@ -47,6 +47,14 @@ class ContentBuilderTest {
     }
 
     @Test
+    void testAddContentLiteralBackslash() {
+        var c = new TestContentBuilder();
+        c.addContentLiteral("test string with \\ backslash");
+
+        assertThat(c.generatedString(), is("    \"test string with \\\\ backslash\""));
+    }
+
+    @Test
     void testAddContentLiteralNewLine() {
         var c = new TestContentBuilder();
         c.addContentLiteral("test string with\n lines");

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypesCodegenTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypesCodegenTest.java
@@ -27,8 +27,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -109,6 +111,7 @@ class TypesCodegenTest {
     void testAnnotatedNestedTypeName(@TempDir Path tempDir) throws Exception {
         Annotation annotation = Annotation.builder()
                 .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .property("value", "quoted \" backslash \\ tab \t")
                 .build();
         TypeName typeName = TypeName.builder(TypeNames.MAP)
                 .addTypeArgument(TypeNames.STRING)
@@ -128,7 +131,8 @@ class TypesCodegenTest {
                    not(containsString("@io.helidon.common.types.TypeName@.create(\"java.util.Map<java.lang.String,")));
         assertThat(createString, containsString(".className(\"Map\")"));
         assertThat(createString, containsString(".addTypeArgument(@io.helidon.common.types.TypeName@.builder()"));
-        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.builder()"));
+        assertThat(createString, containsString(".property(\"value\", \"quoted \\\" backslash \\\\ tab \\t\")"));
         assertTypeName("NestedTypeName", typeName, compileAndCreateTypeName(tempDir, "NestedTypeName", createString));
     }
 
@@ -194,7 +198,7 @@ class TypesCodegenTest {
         TypeName componentType = TypeName.builder(TypeNames.STRING)
                 .addAnnotation(annotation)
                 .build();
-        TypeName typeName = TypeName.builder(componentType)
+        TypeName typeName = TypeName.builder(TypeNames.STRING)
                 .array(true)
                 .componentType(componentType)
                 .build();
@@ -209,6 +213,25 @@ class TypesCodegenTest {
         assertThat(createString, containsString(".componentType(@io.helidon.common.types.TypeName@.builder()"));
         assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
         assertTypeName("ComponentTypeName", typeName, compileAndCreateTypeName(tempDir, "ComponentTypeName", createString));
+    }
+
+    @Test
+    void testTypedElementEnclosingType(@TempDir Path tempDir) throws Exception {
+        TypeName enclosingType = TypeName.create("io.helidon.codegen.classmodel.EnclosingType");
+        TypedElementInfo elementInfo = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("method")
+                .typeName(TypeNames.STRING)
+                .enclosingType(enclosingType)
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateElement(contentBuilder, elementInfo);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString, containsString(".enclosingType("));
+        TypedElementInfo actual = compileAndCreateElement(tempDir, "ElementInfo", createString);
+        assertThat(actual.enclosingType().orElseThrow(), is(enclosingType));
     }
 
     private static TypeName compileAndCreateTypeName(Path tempDir, String className, String createString) throws Exception {
@@ -238,6 +261,37 @@ class TypesCodegenTest {
             Class<?> generatedType = classLoader.loadClass(className);
             Method create = generatedType.getMethod("create");
             return (TypeName) create.invoke(null);
+        }
+    }
+
+    private static TypedElementInfo compileAndCreateElement(Path tempDir, String className, String createString)
+            throws Exception {
+        Path source = tempDir.resolve(className + ".java");
+        Path output = Files.createDirectory(tempDir.resolve("classes-" + className));
+        String sourceContent = """
+                import io.helidon.common.types.TypedElementInfo;
+
+                public final class %s {
+                    public static TypedElementInfo create() {
+                        return %s;
+                    }
+                }
+                """.formatted(className, javaSource(createString));
+        Files.writeString(source, sourceContent, StandardCharsets.UTF_8);
+
+        List<String> command = javacCommand(output, source);
+        Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+        String compilerOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int result = process.waitFor();
+        assertThat(compilerOutput, result, is(0));
+
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[] {output.toUri().toURL()},
+                                                             TypesCodegenTest.class.getClassLoader())) {
+            Class<?> generatedType = classLoader.loadClass(className);
+            Method create = generatedType.getMethod("create");
+            return (TypedElementInfo) create.invoke(null);
         }
     }
 

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypesCodegenTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypesCodegenTest.java
@@ -17,13 +17,6 @@
 package io.helidon.codegen.classmodel;
 
 import java.lang.annotation.ElementType;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 
 import io.helidon.common.types.Annotation;
@@ -33,7 +26,6 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -108,7 +100,7 @@ class TypesCodegenTest {
     }
 
     @Test
-    void testAnnotatedNestedTypeName(@TempDir Path tempDir) throws Exception {
+    void testAnnotatedNestedTypeName() {
         Annotation annotation = Annotation.builder()
                 .typeName(TypeName.create("io.helidon.RandomAnnotation"))
                 .property("value", "quoted \" backslash \\ tab \t")
@@ -133,11 +125,10 @@ class TypesCodegenTest {
         assertThat(createString, containsString(".addTypeArgument(@io.helidon.common.types.TypeName@.builder()"));
         assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.builder()"));
         assertThat(createString, containsString(".property(\"value\", \"quoted \\\" backslash \\\\ tab \\t\")"));
-        assertTypeName("NestedTypeName", typeName, compileAndCreateTypeName(tempDir, "NestedTypeName", createString));
     }
 
     @Test
-    void testAnnotatedBoundTypeName(@TempDir Path tempDir) throws Exception {
+    void testAnnotatedBoundTypeName() {
         Annotation annotation = Annotation.builder()
                 .typeName(TypeName.create("io.helidon.RandomAnnotation"))
                 .build();
@@ -160,11 +151,10 @@ class TypesCodegenTest {
         assertThat(createString, containsString(".wildcard(true)"));
         assertThat(createString, containsString(".addUpperBound(@io.helidon.common.types.TypeName@.builder()"));
         assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
-        assertTypeName("BoundTypeName", typeName, compileAndCreateTypeName(tempDir, "BoundTypeName", createString));
     }
 
     @Test
-    void testAnnotatedLowerBoundTypeName(@TempDir Path tempDir) throws Exception {
+    void testAnnotatedLowerBoundTypeName() {
         Annotation annotation = Annotation.builder()
                 .typeName(TypeName.create("io.helidon.RandomAnnotation"))
                 .build();
@@ -187,11 +177,10 @@ class TypesCodegenTest {
         assertThat(createString, containsString(".wildcard(true)"));
         assertThat(createString, containsString(".addLowerBound(@io.helidon.common.types.TypeName@.builder()"));
         assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
-        assertTypeName("LowerBoundTypeName", typeName, compileAndCreateTypeName(tempDir, "LowerBoundTypeName", createString));
     }
 
     @Test
-    void testAnnotatedComponentTypeName(@TempDir Path tempDir) throws Exception {
+    void testAnnotatedComponentTypeName() {
         Annotation annotation = Annotation.builder()
                 .typeName(TypeName.create("io.helidon.RandomAnnotation"))
                 .build();
@@ -212,11 +201,10 @@ class TypesCodegenTest {
         assertThat(createString, containsString(".array(true)"));
         assertThat(createString, containsString(".componentType(@io.helidon.common.types.TypeName@.builder()"));
         assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
-        assertTypeName("ComponentTypeName", typeName, compileAndCreateTypeName(tempDir, "ComponentTypeName", createString));
     }
 
     @Test
-    void testTypedElementEnclosingType(@TempDir Path tempDir) throws Exception {
+    void testTypedElementEnclosingType() {
         TypeName enclosingType = TypeName.create("io.helidon.codegen.classmodel.EnclosingType");
         TypedElementInfo elementInfo = TypedElementInfo.builder()
                 .kind(ElementKind.METHOD)
@@ -230,127 +218,9 @@ class TypesCodegenTest {
         String createString = contentBuilder.generatedString();
 
         assertThat(createString, containsString(".enclosingType("));
-        TypedElementInfo actual = compileAndCreateElement(tempDir, "ElementInfo", createString);
-        assertThat(actual.enclosingType().orElseThrow(), is(enclosingType));
-    }
-
-    private static TypeName compileAndCreateTypeName(Path tempDir, String className, String createString) throws Exception {
-        Path source = tempDir.resolve(className + ".java");
-        Path output = Files.createDirectory(tempDir.resolve("classes-" + className));
-        String sourceContent = """
-                import io.helidon.common.types.TypeName;
-
-                public final class %s {
-                    public static TypeName create() {
-                        return %s;
-                    }
-                }
-                """.formatted(className, javaSource(createString));
-        Files.writeString(source, sourceContent, StandardCharsets.UTF_8);
-
-        List<String> command = javacCommand(output, source);
-        Process process = new ProcessBuilder(command)
-                .redirectErrorStream(true)
-                .start();
-        String compilerOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-        int result = process.waitFor();
-        assertThat(compilerOutput, result, is(0));
-
-        try (URLClassLoader classLoader = new URLClassLoader(new URL[] {output.toUri().toURL()},
-                                                             TypesCodegenTest.class.getClassLoader())) {
-            Class<?> generatedType = classLoader.loadClass(className);
-            Method create = generatedType.getMethod("create");
-            return (TypeName) create.invoke(null);
-        }
-    }
-
-    private static TypedElementInfo compileAndCreateElement(Path tempDir, String className, String createString)
-            throws Exception {
-        Path source = tempDir.resolve(className + ".java");
-        Path output = Files.createDirectory(tempDir.resolve("classes-" + className));
-        String sourceContent = """
-                import io.helidon.common.types.TypedElementInfo;
-
-                public final class %s {
-                    public static TypedElementInfo create() {
-                        return %s;
-                    }
-                }
-                """.formatted(className, javaSource(createString));
-        Files.writeString(source, sourceContent, StandardCharsets.UTF_8);
-
-        List<String> command = javacCommand(output, source);
-        Process process = new ProcessBuilder(command)
-                .redirectErrorStream(true)
-                .start();
-        String compilerOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-        int result = process.waitFor();
-        assertThat(compilerOutput, result, is(0));
-
-        try (URLClassLoader classLoader = new URLClassLoader(new URL[] {output.toUri().toURL()},
-                                                             TypesCodegenTest.class.getClassLoader())) {
-            Class<?> generatedType = classLoader.loadClass(className);
-            Method create = generatedType.getMethod("create");
-            return (TypedElementInfo) create.invoke(null);
-        }
-    }
-
-    private static String javaSource(String createString) {
-        return createString.replaceAll("@([^@]+)@", "$1");
-    }
-
-    private static List<String> javacCommand(Path output, Path source) {
-        List<String> command = new ArrayList<>();
-        command.add(javac().toString());
-        String modulePath = System.getProperty("jdk.module.path");
-        if (modulePath != null && !modulePath.isBlank()) {
-            command.add("--module-path");
-            command.add(modulePath);
-            command.add("--add-modules");
-            command.add("io.helidon.common.types");
-        }
-        command.add("-classpath");
-        command.add(System.getProperty("java.class.path"));
-        command.add("-d");
-        command.add(output.toString());
-        command.add(source.toString());
-        return command;
-    }
-
-    private static Path javac() {
-        String executable = System.getProperty("os.name").toLowerCase().contains("win") ? "javac.exe" : "javac";
-        Path javac = Path.of(System.getProperty("java.home"), "bin", executable);
-        assertThat("JDK javac is required", Files.isRegularFile(javac), is(true));
-        return javac;
-    }
-
-    private static void assertTypeName(String description, TypeName expected, TypeName actual) {
-        assertThat(description + " package name", actual.packageName(), is(expected.packageName()));
-        assertThat(description + " class name", actual.className(), is(expected.className()));
-        assertThat(description + " enclosing names", actual.enclosingNames(), is(expected.enclosingNames()));
-        assertThat(description + " primitive", actual.primitive(), is(expected.primitive()));
-        assertThat(description + " array", actual.array(), is(expected.array()));
-        assertThat(description + " vararg", actual.vararg(), is(expected.vararg()));
-        assertThat(description + " generic", actual.generic(), is(expected.generic()));
-        assertThat(description + " wildcard", actual.wildcard(), is(expected.wildcard()));
-        assertThat(description + " annotations", actual.annotations(), is(expected.annotations()));
-        assertThat(description + " inherited annotations", actual.inheritedAnnotations(), is(expected.inheritedAnnotations()));
-        assertThat(description + " type parameters", actual.typeParameters(), is(expected.typeParameters()));
-        assertTypeNames(description + " type argument", expected.typeArguments(), actual.typeArguments());
-        assertTypeNames(description + " lower bound", expected.lowerBounds(), actual.lowerBounds());
-        assertTypeNames(description + " upper bound", expected.upperBounds(), actual.upperBounds());
-        assertThat(description + " component type present",
-                   actual.componentType().isPresent(),
-                   is(expected.componentType().isPresent()));
-        if (expected.componentType().isPresent()) {
-            assertTypeName(description + " component type", expected.componentType().orElseThrow(), actual.componentType().orElseThrow());
-        }
-    }
-
-    private static void assertTypeNames(String description, List<TypeName> expected, List<TypeName> actual) {
-        assertThat(description + " size", actual.size(), is(expected.size()));
-        for (int i = 0; i < expected.size(); i++) {
-            assertTypeName(description + " " + i, expected.get(i), actual.get(i));
-        }
+        assertThat(createString,
+                   containsString(".enclosingType(@io.helidon.common.types.TypeName@.create(\""
+                                          + enclosingType.fqName()
+                                          + "\"))"));
     }
 }

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypesCodegenTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypesCodegenTest.java
@@ -17,14 +17,25 @@
 package io.helidon.codegen.classmodel;
 
 import java.lang.annotation.ElementType;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class TypesCodegenTest {
@@ -92,5 +103,200 @@ class TypesCodegenTest {
                               .property("ltype", @java.util.List@.of(@io.helidon.common.types.TypeName@.create("io.helidon.codegen.classmodel.TypesCodegenTest"),@io.helidon.common.types.TypeName@.create("io.helidon.codegen.classmodel.TypesCodegenTest")))
                               .property("lenum", @java.util.List@.of(@io.helidon.common.types.EnumValue@.create(@io.helidon.common.types.TypeName@.create("java.lang.annotation.ElementType"),"FIELD"),@io.helidon.common.types.EnumValue@.create(@io.helidon.common.types.TypeName@.create("java.lang.annotation.ElementType"),"MODULE")))
                               .build()"""));
+    }
+
+    @Test
+    void testAnnotatedNestedTypeName(@TempDir Path tempDir) throws Exception {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.MAP)
+                .addTypeArgument(TypeNames.STRING)
+                .addTypeArgument(TypeName.builder(TypeNames.MAP)
+                                         .addTypeArgument(TypeNames.STRING)
+                                         .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                                                  .addAnnotation(annotation)
+                                                                  .build())
+                                         .build())
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateTypeName(contentBuilder, typeName);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString,
+                   not(containsString("@io.helidon.common.types.TypeName@.create(\"java.util.Map<java.lang.String,")));
+        assertThat(createString, containsString(".className(\"Map\")"));
+        assertThat(createString, containsString(".addTypeArgument(@io.helidon.common.types.TypeName@.builder()"));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
+        assertTypeName("NestedTypeName", typeName, compileAndCreateTypeName(tempDir, "NestedTypeName", createString));
+    }
+
+    @Test
+    void testAnnotatedBoundTypeName(@TempDir Path tempDir) throws Exception {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(annotation)
+                                                        .build())
+                                         .build())
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateTypeName(contentBuilder, typeName);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString,
+                   not(containsString("@io.helidon.common.types.TypeName@.create(\"java.util.List<? extends")));
+        assertThat(createString, containsString(".wildcard(true)"));
+        assertThat(createString, containsString(".addUpperBound(@io.helidon.common.types.TypeName@.builder()"));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
+        assertTypeName("BoundTypeName", typeName, compileAndCreateTypeName(tempDir, "BoundTypeName", createString));
+    }
+
+    @Test
+    void testAnnotatedLowerBoundTypeName(@TempDir Path tempDir) throws Exception {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(annotation)
+                                                        .build())
+                                         .build())
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateTypeName(contentBuilder, typeName);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString,
+                   not(containsString("@io.helidon.common.types.TypeName@.create(\"java.util.List<? super")));
+        assertThat(createString, containsString(".wildcard(true)"));
+        assertThat(createString, containsString(".addLowerBound(@io.helidon.common.types.TypeName@.builder()"));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
+        assertTypeName("LowerBoundTypeName", typeName, compileAndCreateTypeName(tempDir, "LowerBoundTypeName", createString));
+    }
+
+    @Test
+    void testAnnotatedComponentTypeName(@TempDir Path tempDir) throws Exception {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+        TypeName componentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(annotation)
+                .build();
+        TypeName typeName = TypeName.builder(componentType)
+                .array(true)
+                .componentType(componentType)
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateTypeName(contentBuilder, typeName);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString,
+                   not(containsString("@io.helidon.common.types.TypeName@.create(\"java.lang.String[]")));
+        assertThat(createString, containsString(".array(true)"));
+        assertThat(createString, containsString(".componentType(@io.helidon.common.types.TypeName@.builder()"));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
+        assertTypeName("ComponentTypeName", typeName, compileAndCreateTypeName(tempDir, "ComponentTypeName", createString));
+    }
+
+    private static TypeName compileAndCreateTypeName(Path tempDir, String className, String createString) throws Exception {
+        Path source = tempDir.resolve(className + ".java");
+        Path output = Files.createDirectory(tempDir.resolve("classes-" + className));
+        String sourceContent = """
+                import io.helidon.common.types.TypeName;
+
+                public final class %s {
+                    public static TypeName create() {
+                        return %s;
+                    }
+                }
+                """.formatted(className, javaSource(createString));
+        Files.writeString(source, sourceContent, StandardCharsets.UTF_8);
+
+        List<String> command = javacCommand(output, source);
+        Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+        String compilerOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int result = process.waitFor();
+        assertThat(compilerOutput, result, is(0));
+
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[] {output.toUri().toURL()},
+                                                             TypesCodegenTest.class.getClassLoader())) {
+            Class<?> generatedType = classLoader.loadClass(className);
+            Method create = generatedType.getMethod("create");
+            return (TypeName) create.invoke(null);
+        }
+    }
+
+    private static String javaSource(String createString) {
+        return createString.replaceAll("@([^@]+)@", "$1");
+    }
+
+    private static List<String> javacCommand(Path output, Path source) {
+        List<String> command = new ArrayList<>();
+        command.add(javac().toString());
+        String modulePath = System.getProperty("jdk.module.path");
+        if (modulePath != null && !modulePath.isBlank()) {
+            command.add("--module-path");
+            command.add(modulePath);
+            command.add("--add-modules");
+            command.add("io.helidon.common.types");
+        }
+        command.add("-classpath");
+        command.add(System.getProperty("java.class.path"));
+        command.add("-d");
+        command.add(output.toString());
+        command.add(source.toString());
+        return command;
+    }
+
+    private static Path javac() {
+        String executable = System.getProperty("os.name").toLowerCase().contains("win") ? "javac.exe" : "javac";
+        Path javac = Path.of(System.getProperty("java.home"), "bin", executable);
+        assertThat("JDK javac is required", Files.isRegularFile(javac), is(true));
+        return javac;
+    }
+
+    private static void assertTypeName(String description, TypeName expected, TypeName actual) {
+        assertThat(description + " package name", actual.packageName(), is(expected.packageName()));
+        assertThat(description + " class name", actual.className(), is(expected.className()));
+        assertThat(description + " enclosing names", actual.enclosingNames(), is(expected.enclosingNames()));
+        assertThat(description + " primitive", actual.primitive(), is(expected.primitive()));
+        assertThat(description + " array", actual.array(), is(expected.array()));
+        assertThat(description + " vararg", actual.vararg(), is(expected.vararg()));
+        assertThat(description + " generic", actual.generic(), is(expected.generic()));
+        assertThat(description + " wildcard", actual.wildcard(), is(expected.wildcard()));
+        assertThat(description + " annotations", actual.annotations(), is(expected.annotations()));
+        assertThat(description + " inherited annotations", actual.inheritedAnnotations(), is(expected.inheritedAnnotations()));
+        assertThat(description + " type parameters", actual.typeParameters(), is(expected.typeParameters()));
+        assertTypeNames(description + " type argument", expected.typeArguments(), actual.typeArguments());
+        assertTypeNames(description + " lower bound", expected.lowerBounds(), actual.lowerBounds());
+        assertTypeNames(description + " upper bound", expected.upperBounds(), actual.upperBounds());
+        assertThat(description + " component type present",
+                   actual.componentType().isPresent(),
+                   is(expected.componentType().isPresent()));
+        if (expected.componentType().isPresent()) {
+            assertTypeName(description + " component type", expected.componentType().orElseThrow(), actual.componentType().orElseThrow());
+        }
+    }
+
+    private static void assertTypeNames(String description, List<TypeName> expected, List<TypeName> actual) {
+        assertThat(description + " size", actual.size(), is(expected.size()));
+        for (int i = 0; i < expected.size(); i++) {
+            assertTypeName(description + " " + i, expected.get(i), actual.get(i));
+        }
     }
 }

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -212,7 +212,11 @@ public final class TypeHierarchy {
     }
 
     /**
-     * Annotations on the {@code typeInfo}, it's methods, and method parameters.
+     * Annotations on the {@code typeInfo}, its methods, method parameters, and the type-use positions nested in their
+     * {@link TypeName}s.
+     * <p>
+     * Type-use positions include type arguments, wildcard bounds, and array component types of the type itself,
+     * element return or field types, and parameter types.
      *
      * @param ctx context
      * @param typeInfo type info to check
@@ -318,7 +322,11 @@ public final class TypeHierarchy {
 
     /**
      * Merge type-use annotations from a source type name into a target type name.
-     * Only structurally matching nested type arguments, wildcard bounds, and array component types are merged.
+     * If the type names do not have the same structure, the target type name is returned unchanged.
+     * <p>
+     * Matching type names merge direct and inherited annotations on the root type, type arguments, wildcard bounds,
+     * and array component types. When both type names contain the same annotation type at a matching position, the
+     * target annotation is preserved. Formal type parameter names do not block merging.
      *
      * @param typeName       target type name
      * @param sourceTypeName source type name
@@ -370,7 +378,6 @@ public final class TypeHierarchy {
     private static boolean sameStructure(TypeName typeName, TypeName sourceTypeName) {
         if (typeName.primitive() != sourceTypeName.primitive()
                 || typeName.array() != sourceTypeName.array()
-                || typeName.vararg() != sourceTypeName.vararg()
                 || typeName.generic() != sourceTypeName.generic()
                 || typeName.wildcard() != sourceTypeName.wildcard()
                 || typeName.typeArguments().size() != sourceTypeName.typeArguments().size()
@@ -382,7 +389,6 @@ public final class TypeHierarchy {
         return typeName.packageName().equals(sourceTypeName.packageName())
                 && typeName.className().equals(sourceTypeName.className())
                 && typeName.enclosingNames().equals(sourceTypeName.enclosingNames())
-                && typeName.typeParameters().equals(sourceTypeName.typeParameters())
                 && sameStructure(typeName.typeArguments(), sourceTypeName.typeArguments())
                 && sameStructure(typeName.lowerBounds(), sourceTypeName.lowerBounds())
                 && sameStructure(typeName.upperBounds(), sourceTypeName.upperBounds())
@@ -406,7 +412,7 @@ public final class TypeHierarchy {
     }
 
     private static void addAnnotationIfAbsent(List<Annotation> annotations, Annotation annotation) {
-        if (!annotations.contains(annotation)) {
+        if (annotations.stream().noneMatch(it -> it.typeName().equals(annotation.typeName()))) {
             annotations.add(annotation);
         }
     }

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -325,6 +325,10 @@ public final class TypeHierarchy {
      * @return type name with annotations merged from the source
      */
     public static TypeName mergeTypeNameAnnotations(TypeName typeName, TypeName sourceTypeName) {
+        if (!sameStructure(typeName, sourceTypeName)) {
+            return typeName;
+        }
+
         List<Annotation> annotations = new ArrayList<>(typeName.annotations());
         sourceTypeName.annotations().forEach(it -> addAnnotationIfAbsent(annotations, it));
         List<Annotation> inheritedAnnotations = new ArrayList<>(typeName.inheritedAnnotations());
@@ -340,8 +344,6 @@ public final class TypeHierarchy {
         if (typeName.componentType().isPresent() && sourceTypeName.componentType().isPresent()) {
             builder.componentType(mergeTypeNameAnnotations(typeName.componentType().get(),
                                                           sourceTypeName.componentType().get()));
-        } else if (typeName.componentType().isEmpty() && sourceTypeName.componentType().isPresent()) {
-            builder.componentType(sourceTypeName.componentType().get());
         }
 
         return builder.build();
@@ -352,7 +354,7 @@ public final class TypeHierarchy {
             return typeNames;
         }
         if (typeNames.isEmpty()) {
-            return sourceTypeNames;
+            return typeNames;
         }
         if (typeNames.size() != sourceTypeNames.size()) {
             return typeNames;
@@ -363,6 +365,24 @@ public final class TypeHierarchy {
             merged.add(mergeTypeNameAnnotations(typeNames.get(i), sourceTypeNames.get(i)));
         }
         return merged;
+    }
+
+    private static boolean sameStructure(TypeName typeName, TypeName sourceTypeName) {
+        if (typeName.primitive() != sourceTypeName.primitive()
+                || typeName.array() != sourceTypeName.array()
+                || typeName.vararg() != sourceTypeName.vararg()
+                || typeName.generic() != sourceTypeName.generic()
+                || typeName.wildcard() != sourceTypeName.wildcard()
+                || typeName.typeArguments().size() != sourceTypeName.typeArguments().size()
+                || typeName.lowerBounds().size() != sourceTypeName.lowerBounds().size()
+                || typeName.upperBounds().size() != sourceTypeName.upperBounds().size()
+                || typeName.componentType().isPresent() != sourceTypeName.componentType().isPresent()) {
+            return false;
+        }
+        return typeName.packageName().equals(sourceTypeName.packageName())
+                && typeName.className().equals(sourceTypeName.className())
+                && typeName.enclosingNames().equals(sourceTypeName.enclosingNames())
+                && typeName.typeParameters().equals(sourceTypeName.typeParameters());
     }
 
     private static void addAnnotationIfAbsent(List<Annotation> annotations, Annotation annotation) {

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
@@ -301,6 +302,7 @@ public final class TypeHierarchy {
      * @param typeName type name to scan
      * @return nested annotation instances
      */
+    @Api.Internal
     public static List<Annotation> typeNameAnnotations(TypeName typeName) {
         List<Annotation> result = new ArrayList<>();
         result.addAll(typeName.annotations());
@@ -332,6 +334,7 @@ public final class TypeHierarchy {
      * @param sourceTypeName source type name
      * @return type name with annotations merged from the source
      */
+    @Api.Internal
     public static TypeName mergeTypeNameAnnotations(TypeName typeName, TypeName sourceTypeName) {
         if (!sameStructure(typeName, sourceTypeName)) {
             return typeName;

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -225,6 +225,10 @@ public final class TypeHierarchy {
      */
     public static Set<TypeName> nestedAnnotations(CodegenContext ctx, TypeInfo typeInfo) {
         Set<TypeName> result = new HashSet<>();
+        List<TypedElementInfo> elements = typeInfo.elementInfo()
+                .stream()
+                .map(it -> mergeHierarchyAnnotations(typeInfo, it))
+                .toList();
 
         // on type
         typeInfo.annotations()
@@ -241,22 +245,19 @@ public final class TypeHierarchy {
                 .forEach(result::add);
 
         // on fields, methods etc.
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::annotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
 
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::inheritedAnnotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
 
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::typeName)
                 .map(TypeHierarchy::typeNameAnnotations)
                 .flatMap(List::stream)
@@ -264,16 +265,14 @@ public final class TypeHierarchy {
                 .forEach(result::add);
 
         // on parameters
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::parameterArguments)
                 .flatMap(List::stream)
                 .map(TypedElementInfo::annotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::parameterArguments)
                 .flatMap(List::stream)
                 .map(TypedElementInfo::inheritedAnnotations)
@@ -281,8 +280,7 @@ public final class TypeHierarchy {
                 .map(Annotation::typeName)
                 .forEach(result::add);
 
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::parameterArguments)
                 .flatMap(List::stream)
                 .map(TypedElementInfo::typeName)
@@ -292,6 +290,87 @@ public final class TypeHierarchy {
                 .forEach(result::add);
 
         return result;
+    }
+
+    /**
+     * Merge method and parameter annotations, and return and parameter type-use annotations, from overridden methods and
+     * interface methods into the provided method element. Non-method elements are returned unchanged.
+     * <p>
+     * When the same annotation type exists on both the target method and an inherited method, the target method annotation
+     * is preserved. Type-use annotations are merged using {@link #mergeTypeNameAnnotations(TypeName, TypeName)}.
+     *
+     * @param type    type declaring the element
+     * @param element element to merge
+     * @return element with matching hierarchy annotations merged in
+     */
+    @Api.Internal
+    public static TypedElementInfo mergeHierarchyAnnotations(TypeInfo type, TypedElementInfo element) {
+        if (element.kind() != ElementKind.METHOD) {
+            return element;
+        }
+
+        List<TypedElementInfo> prototypes = new ArrayList<>();
+        Set<TypeName> processedTypes = new HashSet<>();
+        String packageName = type.typeName().packageName();
+
+        type.superTypeInfo().ifPresent(it -> collectInheritedMethods(
+                processedTypes,
+                prototypes,
+                it,
+                element,
+                packageName));
+        type.interfaceTypeInfo().forEach(it -> collectInheritedMethods(
+                processedTypes,
+                prototypes,
+                it,
+                element,
+                packageName));
+
+        if (prototypes.isEmpty()) {
+            return element;
+        }
+
+        Map<TypeName, Annotation> annotations = new LinkedHashMap<>();
+        element.annotations().forEach(it -> annotations.put(it.typeName(), it));
+        prototypes.stream()
+                .map(TypedElementInfo::annotations)
+                .flatMap(List::stream)
+                .forEach(it -> annotations.putIfAbsent(it.typeName(), it));
+
+        TypeName returnType = element.typeName();
+        for (TypedElementInfo prototype : prototypes) {
+            returnType = mergeTypeNameAnnotations(returnType, prototype.typeName());
+        }
+
+        List<TypedElementInfo> parameters = new ArrayList<>();
+        List<TypedElementInfo> elementParameters = element.parameterArguments();
+        for (int i = 0; i < elementParameters.size(); i++) {
+            TypedElementInfo parameter = elementParameters.get(i);
+            Map<TypeName, Annotation> parameterAnnotations = new LinkedHashMap<>();
+            parameter.annotations().forEach(it -> parameterAnnotations.put(it.typeName(), it));
+
+            TypeName parameterType = parameter.typeName();
+            for (TypedElementInfo prototype : prototypes) {
+                List<TypedElementInfo> prototypeParameters = prototype.parameterArguments();
+                if (prototypeParameters.size() > i) {
+                    TypedElementInfo prototypeParameter = prototypeParameters.get(i);
+                    prototypeParameter.annotations()
+                            .forEach(it -> parameterAnnotations.putIfAbsent(it.typeName(), it));
+                    parameterType = mergeTypeNameAnnotations(parameterType, prototypeParameter.typeName());
+                }
+            }
+
+            parameters.add(TypedElementInfo.builder(parameter)
+                                   .annotations(List.copyOf(parameterAnnotations.values()))
+                                   .typeName(parameterType)
+                                   .build());
+        }
+
+        return TypedElementInfo.builder(element)
+                .annotations(List.copyOf(annotations.values()))
+                .typeName(returnType)
+                .parameterArguments(parameters)
+                .build();
     }
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -33,6 +33,7 @@ import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
 
+import static io.helidon.common.types.TypeNames.GENERATED;
 import static io.helidon.common.types.TypeNames.INHERITED;
 import static java.util.function.Predicate.not;
 
@@ -225,10 +226,12 @@ public final class TypeHierarchy {
      */
     public static Set<TypeName> nestedAnnotations(CodegenContext ctx, TypeInfo typeInfo) {
         Set<TypeName> result = new HashSet<>();
-        List<TypedElementInfo> elements = typeInfo.elementInfo()
-                .stream()
-                .map(it -> mergeHierarchyAnnotations(typeInfo, it))
-                .toList();
+        List<TypedElementInfo> elements = typeInfo.hasAnnotation(GENERATED)
+                ? typeInfo.elementInfo()
+                : typeInfo.elementInfo()
+                        .stream()
+                        .map(it -> mergeHierarchyAnnotations(typeInfo, it))
+                        .toList();
 
         // on type
         typeInfo.annotations()

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,7 +230,7 @@ public final class TypeHierarchy {
                 .stream()
                 .map(Annotation::typeName)
                 .forEach(result::add);
-        genericTypeAnnotations(typeInfo.typeName())
+        typeNameAnnotations(typeInfo.typeName())
                 .stream()
                 .map(Annotation::typeName)
                 .forEach(result::add);
@@ -253,7 +253,7 @@ public final class TypeHierarchy {
         typeInfo.elementInfo()
                 .stream()
                 .map(TypedElementInfo::typeName)
-                .map(TypeHierarchy::genericTypeAnnotations)
+                .map(TypeHierarchy::typeNameAnnotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
@@ -281,7 +281,7 @@ public final class TypeHierarchy {
                 .map(TypedElementInfo::parameterArguments)
                 .flatMap(List::stream)
                 .map(TypedElementInfo::typeName)
-                .map(TypeHierarchy::genericTypeAnnotations)
+                .map(TypeHierarchy::typeNameAnnotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
@@ -289,14 +289,86 @@ public final class TypeHierarchy {
         return result;
     }
 
-    private static List<Annotation> genericTypeAnnotations(TypeName typeName) {
-        // annotations on type arguments (i.e. Set<@Valid SomeType>)
+    /**
+     * Annotation instances nested inside a type name.
+     * This includes annotations declared directly on the provided type name and annotations declared on nested
+     * type arguments, wildcard bounds, and array component types.
+     *
+     * @param typeName type name to scan
+     * @return nested annotation instances
+     */
+    public static List<Annotation> typeNameAnnotations(TypeName typeName) {
         List<Annotation> result = new ArrayList<>();
+        result.addAll(typeName.annotations());
+        result.addAll(typeName.inheritedAnnotations());
         for (TypeName typeArgument : typeName.typeArguments()) {
-            result.addAll(typeArgument.annotations());
-            genericTypeAnnotations(typeArgument);
+            result.addAll(typeNameAnnotations(typeArgument));
         }
+        for (TypeName lowerBound : typeName.lowerBounds()) {
+            result.addAll(typeNameAnnotations(lowerBound));
+        }
+        for (TypeName upperBound : typeName.upperBounds()) {
+            result.addAll(typeNameAnnotations(upperBound));
+        }
+        typeName.componentType()
+                .map(TypeHierarchy::typeNameAnnotations)
+                .ifPresent(result::addAll);
         return result;
+    }
+
+    /**
+     * Merge type-use annotations from a source type name into a target type name.
+     * Only structurally matching nested type arguments, wildcard bounds, and array component types are merged.
+     *
+     * @param typeName       target type name
+     * @param sourceTypeName source type name
+     * @return type name with annotations merged from the source
+     */
+    public static TypeName mergeTypeNameAnnotations(TypeName typeName, TypeName sourceTypeName) {
+        List<Annotation> annotations = new ArrayList<>(typeName.annotations());
+        sourceTypeName.annotations().forEach(it -> addAnnotationIfAbsent(annotations, it));
+        List<Annotation> inheritedAnnotations = new ArrayList<>(typeName.inheritedAnnotations());
+        sourceTypeName.inheritedAnnotations().forEach(it -> addAnnotationIfAbsent(inheritedAnnotations, it));
+
+        TypeName.Builder builder = TypeName.builder(typeName)
+                .annotations(annotations)
+                .inheritedAnnotations(inheritedAnnotations)
+                .typeArguments(mergeTypeNameLists(typeName.typeArguments(), sourceTypeName.typeArguments()))
+                .lowerBounds(mergeTypeNameLists(typeName.lowerBounds(), sourceTypeName.lowerBounds()))
+                .upperBounds(mergeTypeNameLists(typeName.upperBounds(), sourceTypeName.upperBounds()));
+
+        if (typeName.componentType().isPresent() && sourceTypeName.componentType().isPresent()) {
+            builder.componentType(mergeTypeNameAnnotations(typeName.componentType().get(),
+                                                          sourceTypeName.componentType().get()));
+        } else if (typeName.componentType().isEmpty() && sourceTypeName.componentType().isPresent()) {
+            builder.componentType(sourceTypeName.componentType().get());
+        }
+
+        return builder.build();
+    }
+
+    private static List<TypeName> mergeTypeNameLists(List<TypeName> typeNames, List<TypeName> sourceTypeNames) {
+        if (sourceTypeNames.isEmpty()) {
+            return typeNames;
+        }
+        if (typeNames.isEmpty()) {
+            return sourceTypeNames;
+        }
+        if (typeNames.size() != sourceTypeNames.size()) {
+            return typeNames;
+        }
+
+        List<TypeName> merged = new ArrayList<>(typeNames.size());
+        for (int i = 0; i < typeNames.size(); i++) {
+            merged.add(mergeTypeNameAnnotations(typeNames.get(i), sourceTypeNames.get(i)));
+        }
+        return merged;
+    }
+
+    private static void addAnnotationIfAbsent(List<Annotation> annotations, Annotation annotation) {
+        if (!annotations.contains(annotation)) {
+            annotations.add(annotation);
+        }
     }
 
     private static void processMetaAnnotations(CodegenContext ctx,

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -382,7 +382,27 @@ public final class TypeHierarchy {
         return typeName.packageName().equals(sourceTypeName.packageName())
                 && typeName.className().equals(sourceTypeName.className())
                 && typeName.enclosingNames().equals(sourceTypeName.enclosingNames())
-                && typeName.typeParameters().equals(sourceTypeName.typeParameters());
+                && typeName.typeParameters().equals(sourceTypeName.typeParameters())
+                && sameStructure(typeName.typeArguments(), sourceTypeName.typeArguments())
+                && sameStructure(typeName.lowerBounds(), sourceTypeName.lowerBounds())
+                && sameStructure(typeName.upperBounds(), sourceTypeName.upperBounds())
+                && sameStructure(typeName.componentType(), sourceTypeName.componentType());
+    }
+
+    private static boolean sameStructure(List<TypeName> typeNames, List<TypeName> sourceTypeNames) {
+        for (int i = 0; i < typeNames.size(); i++) {
+            if (!sameStructure(typeNames.get(i), sourceTypeNames.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean sameStructure(Optional<TypeName> typeName, Optional<TypeName> sourceTypeName) {
+        if (typeName.isEmpty()) {
+            return true;
+        }
+        return sameStructure(typeName.get(), sourceTypeName.get());
     }
 
     private static void addAnnotationIfAbsent(List<Annotation> annotations, Annotation annotation) {

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 import io.helidon.codegen.spi.AnnotationMapper;
 import io.helidon.codegen.spi.ElementMapper;
 import io.helidon.codegen.spi.TypeMapper;
+import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
@@ -107,6 +108,58 @@ class TypeHierarchyTest {
         assertThat(TypeHierarchy.typeNameAnnotations(upperBoundType), hasItem(notBlank));
         assertThat(TypeHierarchy.typeNameAnnotations(lowerBoundType), hasItem(notBlank));
         assertThat(TypeHierarchy.typeNameAnnotations(arrayType), hasItem(notBlank));
+    }
+
+    @Test
+    void mergeHierarchyAnnotationsIncludesContractTypeUseAnnotations() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName annotatedList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(notBlank)
+                                         .build())
+                .build();
+        TypeName plainList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeNames.STRING)
+                .build();
+        TypedElementInfo contractMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PUBLIC)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(annotatedList)
+                                              .build())
+                .build();
+        TypeInfo contract = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.Contract"))
+                .kind(ElementKind.INTERFACE)
+                .addElementInfo(contractMethod)
+                .build();
+        TypedElementInfo implementationMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PUBLIC)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(plainList)
+                                              .build())
+                .build();
+        TypeInfo implementation = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.Implementation"))
+                .kind(ElementKind.CLASS)
+                .addInterfaceTypeInfo(contract)
+                .addElementInfo(implementationMethod)
+                .build();
+
+        TypedElementInfo merged = TypeHierarchy.mergeHierarchyAnnotations(implementation, implementationMethod);
+
+        TypeName mergedType = merged.parameterArguments().getFirst().typeName();
+        assertThat(mergedType.typeArguments().getFirst().annotations(), hasItem(notBlank));
+        assertThat(TypeHierarchy.nestedAnnotations(CTX, implementation), hasItem(NOT_BLANK));
     }
 
     @Test

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class TypeHierarchyTest {
@@ -149,10 +150,56 @@ class TypeHierarchyTest {
         assertThat(merged.componentType().orElseThrow().annotations(), hasItem(notBlank));
         assertThat(merged.componentType().orElseThrow().annotations(), hasItem(targetAnnotation));
 
+        TypeName lowerBoundTargetType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(targetAnnotation)
+                                                        .build())
+                                         .build())
+                .build();
+        TypeName lowerBoundSourceType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(notBlank)
+                                                        .build())
+                                         .build())
+                .build();
+
+        TypeName lowerBoundMerged = TypeHierarchy.mergeTypeNameAnnotations(lowerBoundTargetType, lowerBoundSourceType);
+
+        assertThat(lowerBoundMerged.typeArguments().getFirst().lowerBounds().getFirst().annotations(), hasItem(notBlank));
+
         TypeName rawList = TypeNames.LIST;
         TypeName mergedRawList = TypeHierarchy.mergeTypeNameAnnotations(rawList, sourceType);
         assertThat(mergedRawList.typeArguments().isEmpty(), is(true));
         assertThat(mergedRawList.componentType().isEmpty(), is(true));
+        assertThat(mergedRawList.annotations(), not(hasItem(notBlank)));
+
+        TypeName mismatchedTargetType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.create("io.helidon.codegen.Foo"))
+                                         .build())
+                .build();
+        TypeName mismatchedSourceType = TypeName.builder(TypeNames.LIST)
+                .addAnnotation(notBlank)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addAnnotation(notBlank)
+                                         .addUpperBound(TypeName.create("io.helidon.codegen.Bar"))
+                                         .build())
+                .build();
+
+        TypeName mismatchedMerged = TypeHierarchy.mergeTypeNameAnnotations(mismatchedTargetType, mismatchedSourceType);
+
+        assertThat(mismatchedMerged.annotations(), not(hasItem(notBlank)));
+        assertThat(mismatchedMerged.typeArguments().getFirst().annotations(), not(hasItem(notBlank)));
     }
 
     private static final class EmptyCodegenContext implements CodegenContext {

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import io.helidon.codegen.spi.AnnotationMapper;
+import io.helidon.codegen.spi.ElementMapper;
+import io.helidon.codegen.spi.TypeMapper;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TypeHierarchyTest {
+    private static final TypeName NOT_BLANK = TypeName.create("io.helidon.validation.Validation.String.NotBlank");
+    private static final CodegenContext CTX = new EmptyCodegenContext();
+
+    @Test
+    void nestedAnnotationsIncludeDeepGenericTypeArgumentAnnotations() {
+        TypeName mapType = TypeName.builder(TypeNames.MAP)
+                .addTypeArgument(TypeNames.STRING)
+                .addTypeArgument(TypeName.builder(TypeNames.LIST)
+                                         .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                                                  .addAnnotation(Annotation.create(NOT_BLANK))
+                                                                  .build())
+                                         .build())
+                .build();
+        TypeInfo typeInfo = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.NestedContract"))
+                .kind(ElementKind.INTERFACE)
+                .addElementInfo(TypedElementInfo.builder()
+                                        .kind(ElementKind.METHOD)
+                                        .elementName("validate")
+                                        .typeName(TypeNames.PRIMITIVE_VOID)
+                                        .addParameterArgument(TypedElementInfo.builder()
+                                                                      .kind(ElementKind.PARAMETER)
+                                                                      .elementName("value")
+                                                                      .typeName(mapType)
+                                                                      .build())
+                                        .build())
+                .build();
+
+        assertThat(TypeHierarchy.nestedAnnotations(CTX, typeInfo), hasItem(NOT_BLANK));
+    }
+
+    @Test
+    void typeNameAnnotationsIncludeWildcardBoundsAndArrayComponents() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName upperBoundType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(notBlank)
+                                                        .build())
+                                         .build())
+                .build();
+        TypeName lowerBoundType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(notBlank)
+                                                        .build())
+                                         .build())
+                .build();
+        TypeName componentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(notBlank)
+                .build();
+        TypeName arrayType = TypeName.builder(componentType)
+                .array(true)
+                .componentType(componentType)
+                .build();
+
+        assertThat(TypeHierarchy.typeNameAnnotations(upperBoundType), hasItem(notBlank));
+        assertThat(TypeHierarchy.typeNameAnnotations(lowerBoundType), hasItem(notBlank));
+        assertThat(TypeHierarchy.typeNameAnnotations(arrayType), hasItem(notBlank));
+    }
+
+    private static final class EmptyCodegenContext implements CodegenContext {
+        @Override
+        public Optional<ModuleInfo> module() {
+            return Optional.empty();
+        }
+
+        @Override
+        public CodegenFiler filer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CodegenLogger logger() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CodegenScope scope() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CodegenOptions options() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<TypeInfo> typeInfo(TypeName typeName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<TypeInfo> typeInfo(TypeName typeName, Predicate<TypedElementInfo> elementPredicate) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<ElementMapper> elementMappers() {
+            return List.of();
+        }
+
+        @Override
+        public List<TypeMapper> typeMappers() {
+            return List.of();
+        }
+
+        @Override
+        public List<AnnotationMapper> annotationMappers() {
+            return List.of();
+        }
+
+        @Override
+        public Set<TypeName> mapperSupportedAnnotations() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<String> mapperSupportedAnnotationPackages() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<Option<?>> supportedOptions() {
+            return Set.of();
+        }
+
+        @Override
+        public String uniqueName(TypeInfo typeInfo, TypedElementInfo elementInfo) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -35,6 +35,7 @@ import io.helidon.common.types.TypedElementInfo;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class TypeHierarchyTest {
@@ -72,6 +73,9 @@ class TypeHierarchyTest {
     @Test
     void typeNameAnnotationsIncludeWildcardBoundsAndArrayComponents() {
         Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName directAnnotatedType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(notBlank)
+                .build();
         TypeName upperBoundType = TypeName.builder(TypeNames.LIST)
                 .addTypeArgument(TypeName.builder()
                                          .className("?")
@@ -93,14 +97,62 @@ class TypeHierarchyTest {
         TypeName componentType = TypeName.builder(TypeNames.STRING)
                 .addAnnotation(notBlank)
                 .build();
-        TypeName arrayType = TypeName.builder(componentType)
+        TypeName arrayType = TypeName.builder(TypeNames.STRING)
                 .array(true)
                 .componentType(componentType)
                 .build();
 
+        assertThat(TypeHierarchy.typeNameAnnotations(directAnnotatedType), hasItem(notBlank));
         assertThat(TypeHierarchy.typeNameAnnotations(upperBoundType), hasItem(notBlank));
         assertThat(TypeHierarchy.typeNameAnnotations(lowerBoundType), hasItem(notBlank));
         assertThat(TypeHierarchy.typeNameAnnotations(arrayType), hasItem(notBlank));
+    }
+
+    @Test
+    void mergeTypeNameAnnotationsPreservesTargetStructure() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        Annotation targetAnnotation = Annotation.create(TypeName.create("io.helidon.TargetAnnotation"));
+        TypeName targetComponentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(targetAnnotation)
+                .build();
+        TypeName sourceComponentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(notBlank)
+                .build();
+        TypeName targetType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(targetAnnotation)
+                                                        .build())
+                                         .build())
+                .array(true)
+                .componentType(targetComponentType)
+                .build();
+        TypeName sourceType = TypeName.builder(TypeNames.LIST)
+                .addAnnotation(notBlank)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(notBlank)
+                                                        .build())
+                                         .build())
+                .array(true)
+                .componentType(sourceComponentType)
+                .build();
+
+        TypeName merged = TypeHierarchy.mergeTypeNameAnnotations(targetType, sourceType);
+
+        assertThat(merged.annotations(), hasItem(notBlank));
+        assertThat(merged.typeArguments().getFirst().upperBounds().getFirst().annotations(), hasItem(notBlank));
+        assertThat(merged.componentType().orElseThrow().annotations(), hasItem(notBlank));
+        assertThat(merged.componentType().orElseThrow().annotations(), hasItem(targetAnnotation));
+
+        TypeName rawList = TypeNames.LIST;
+        TypeName mergedRawList = TypeHierarchy.mergeTypeNameAnnotations(rawList, sourceType);
+        assertThat(mergedRawList.typeArguments().isEmpty(), is(true));
+        assertThat(mergedRawList.componentType().isEmpty(), is(true));
     }
 
     private static final class EmptyCodegenContext implements CodegenContext {

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -163,6 +163,58 @@ class TypeHierarchyTest {
     }
 
     @Test
+    void nestedAnnotationsDoNotMergeHierarchyAnnotationsIntoGeneratedTypes() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName annotatedList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(notBlank)
+                                         .build())
+                .build();
+        TypeName plainList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeNames.STRING)
+                .build();
+        TypedElementInfo serviceMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PACKAGE_PRIVATE)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(annotatedList)
+                                              .build())
+                .build();
+        TypeInfo service = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.ValidatedService"))
+                .kind(ElementKind.CLASS)
+                .addElementInfo(serviceMethod)
+                .build();
+        TypedElementInfo generatedMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PACKAGE_PRIVATE)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(plainList)
+                                              .build())
+                .build();
+        TypeInfo generatedSubtype = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.ValidatedService__Intercepted"))
+                .kind(ElementKind.CLASS)
+                .superTypeInfo(service)
+                .addAnnotation(Annotation.create(TypeNames.GENERATED))
+                .addElementInfo(generatedMethod)
+                .build();
+
+        Set<TypeName> annotations = TypeHierarchy.nestedAnnotations(CTX, generatedSubtype);
+
+        assertThat(annotations, hasItem(TypeNames.GENERATED));
+        assertThat(annotations, not(hasItem(NOT_BLANK)));
+    }
+
+    @Test
     void mergeTypeNameAnnotationsPreservesTargetStructure() {
         Annotation notBlank = Annotation.create(NOT_BLANK);
         Annotation targetAnnotation = Annotation.create(TypeName.create("io.helidon.TargetAnnotation"));

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -173,6 +173,23 @@ class TypeHierarchyTest {
 
         assertThat(lowerBoundMerged.typeArguments().getFirst().lowerBounds().getFirst().annotations(), hasItem(notBlank));
 
+        TypeName varargTargetType = TypeName.builder(TypeNames.STRING)
+                .array(true)
+                .vararg(true)
+                .componentType(TypeNames.STRING)
+                .build();
+        TypeName arraySourceType = TypeName.builder(TypeNames.STRING)
+                .array(true)
+                .componentType(TypeName.builder(TypeNames.STRING)
+                                       .addAnnotation(notBlank)
+                                       .build())
+                .build();
+
+        TypeName varargMerged = TypeHierarchy.mergeTypeNameAnnotations(varargTargetType, arraySourceType);
+
+        assertThat(varargMerged.vararg(), is(true));
+        assertThat(varargMerged.componentType().orElseThrow().annotations(), hasItem(notBlank));
+
         TypeName rawList = TypeNames.LIST;
         TypeName mergedRawList = TypeHierarchy.mergeTypeNameAnnotations(rawList, sourceType);
         assertThat(mergedRawList.typeArguments().isEmpty(), is(true));
@@ -200,6 +217,52 @@ class TypeHierarchyTest {
 
         assertThat(mismatchedMerged.annotations(), not(hasItem(notBlank)));
         assertThat(mismatchedMerged.typeArguments().getFirst().annotations(), not(hasItem(notBlank)));
+    }
+
+    @Test
+    void mergeTypeNameAnnotationsKeepsTargetAnnotationValueForSameAnnotationType() {
+        TypeName annotationType = TypeName.create("io.helidon.codegen.Annotation");
+        Annotation targetAnnotation = Annotation.create(annotationType, "target");
+        Annotation sourceAnnotation = Annotation.create(annotationType, "source");
+        TypeName targetType = TypeName.builder(TypeNames.LIST)
+                .addAnnotation(targetAnnotation)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(targetAnnotation)
+                                         .build())
+                .build();
+        TypeName sourceType = TypeName.builder(TypeNames.LIST)
+                .addAnnotation(sourceAnnotation)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(sourceAnnotation)
+                                         .build())
+                .build();
+
+        TypeName merged = TypeHierarchy.mergeTypeNameAnnotations(targetType, sourceType);
+
+        assertThat(merged.annotations(), hasItem(targetAnnotation));
+        assertThat(merged.annotations(), not(hasItem(sourceAnnotation)));
+        assertThat(merged.typeArguments().getFirst().annotations(), hasItem(targetAnnotation));
+        assertThat(merged.typeArguments().getFirst().annotations(), not(hasItem(sourceAnnotation)));
+    }
+
+    @Test
+    void mergeTypeNameAnnotationsIgnoresFormalTypeParameterNames() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName targetType = TypeName.builder(TypeNames.LIST)
+                .addTypeParameter("T")
+                .addTypeArgument(TypeNames.STRING)
+                .build();
+        TypeName sourceType = TypeName.builder(TypeNames.LIST)
+                .addTypeParameter("E")
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(notBlank)
+                                         .build())
+                .build();
+
+        TypeName merged = TypeHierarchy.mergeTypeNameAnnotations(targetType, sourceType);
+
+        assertThat(merged.typeParameters(), is(List.of("T")));
+        assertThat(merged.typeArguments().getFirst().annotations(), hasItem(notBlank));
     }
 
     private static final class EmptyCodegenContext implements CodegenContext {

--- a/codegen/tests/test-codegen-use/pom.xml
+++ b/codegen/tests/test-codegen-use/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>helidon-codegen-class-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/codegen/tests/test-codegen-use/src/main/java/module-info.java
+++ b/codegen/tests/test-codegen-use/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 module io.helidon.codegen.tests.codegen.use {
+    requires java.compiler;
     requires io.helidon.common;
     requires io.helidon.common.types;
 }

--- a/codegen/tests/test-codegen-use/src/test/java/io/helidon/codegen/test/codegen/use/TypeNameContentCodegenTest.java
+++ b/codegen/tests/test-codegen-use/src/test/java/io/helidon/codegen/test/codegen/use/TypeNameContentCodegenTest.java
@@ -49,7 +49,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TypeNameContentCodegenTest {
     private static final String PACKAGE_NAME = "io.helidon.codegen.test.codegen.use.generated";
     private static final String PACKAGE_PATH = PACKAGE_NAME.replace('.', '/');
-    private static final String TRIGGER_CLASS = "Trigger";
 
     @Test
     void testAnnotatedNestedTypeNameCompiles() throws IOException {
@@ -67,7 +66,26 @@ public class TypeNameContentCodegenTest {
                                          .build())
                 .build();
 
-        var result = compile(typeNameModel("NestedTypeName", typeName));
+        GeneratedModel model = typeNameModel("NestedTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
         String source = generatedSource(result, "NestedTypeName");
 
         assertThat(source, not(containsString("TypeName.create(\"java.util.Map<java.lang.String,")));
@@ -102,7 +120,26 @@ public class TypeNameContentCodegenTest {
                                          .build())
                 .build();
 
-        var result = compile(typeNameModel("BoundTypeName", typeName));
+        GeneratedModel model = typeNameModel("BoundTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
         String source = generatedSource(result, "BoundTypeName");
 
         assertThat(source, not(containsString("TypeName.create(\"java.util.List<? extends")));
@@ -132,7 +169,26 @@ public class TypeNameContentCodegenTest {
                                          .build())
                 .build();
 
-        var result = compile(typeNameModel("LowerBoundTypeName", typeName));
+        GeneratedModel model = typeNameModel("LowerBoundTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
         String source = generatedSource(result, "LowerBoundTypeName");
 
         assertThat(source, not(containsString("TypeName.create(\"java.util.List<? super")));
@@ -160,7 +216,26 @@ public class TypeNameContentCodegenTest {
                 .componentType(componentType)
                 .build();
 
-        var result = compile(typeNameModel("ComponentTypeName", typeName));
+        GeneratedModel model = typeNameModel("ComponentTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
         String source = generatedSource(result, "ComponentTypeName");
 
         assertThat(source, not(containsString("TypeName.create(\"java.lang.String[]")));
@@ -187,7 +262,26 @@ public class TypeNameContentCodegenTest {
                 .enclosingType(enclosingType)
                 .build();
 
-        var result = compile(typedElementModel("ElementInfo", elementInfo));
+        GeneratedModel model = typedElementModel("ElementInfo", elementInfo);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
         String source = generatedSource(result, "ElementInfo");
 
         assertThat(source, containsString(".enclosingType(TypeName.create(\"" + enclosingType.fqName() + "\"))"));
@@ -228,30 +322,6 @@ public class TypeNameContentCodegenTest {
                         .addContentLine(";"))
                 .build();
         return new GeneratedModel(className, classModel);
-    }
-
-    private static TestCompiler.Result compile(GeneratedModel model) {
-        var result = TestCompiler.builder()
-                .currentRelease()
-                .addProcessor(new ContentProcessor(model))
-                .addClasspath(List.of(Builder.class,
-                                      Prototype.class,
-                                      Annotation.class,
-                                      ElementKind.class,
-                                      TypeName.class,
-                                      TypedElementInfo.class))
-                .printDiagnostics(false)
-                .addSource(PACKAGE_PATH + "/" + TRIGGER_CLASS + ".java", """
-                        package %s;
-
-                        final class %s {
-                        }
-                        """.formatted(PACKAGE_NAME, TRIGGER_CLASS))
-                .build()
-                .compile();
-
-        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
-        return result;
     }
 
     private static String generatedSource(TestCompiler.Result result, String className) throws IOException {

--- a/codegen/tests/test-codegen-use/src/test/java/io/helidon/codegen/test/codegen/use/TypeNameContentCodegenTest.java
+++ b/codegen/tests/test-codegen-use/src/test/java/io/helidon/codegen/test/codegen/use/TypeNameContentCodegenTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen.test.codegen.use;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Builder;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TypeNameContentCodegenTest {
+    private static final String PACKAGE_NAME = "io.helidon.codegen.test.codegen.use.generated";
+    private static final String PACKAGE_PATH = PACKAGE_NAME.replace('.', '/');
+    private static final String TRIGGER_CLASS = "Trigger";
+
+    @Test
+    void testAnnotatedNestedTypeNameCompiles() throws IOException {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .property("value", "quoted \" backslash \\ tab \t")
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.MAP)
+                .addTypeArgument(TypeNames.STRING)
+                .addTypeArgument(TypeName.builder(TypeNames.MAP)
+                                         .addTypeArgument(TypeNames.STRING)
+                                         .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                                                  .addAnnotation(annotation)
+                                                                  .build())
+                                         .build())
+                .build();
+
+        var result = compile(typeNameModel("NestedTypeName", typeName));
+        String source = generatedSource(result, "NestedTypeName");
+
+        assertThat(source, not(containsString("TypeName.create(\"java.util.Map<java.lang.String,")));
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"Map\")",
+                              ".addTypeArgument(TypeName.create(\"java.lang.String\"))",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"Map\")",
+                              ".addTypeArgument(TypeName.create(\"java.lang.String\"))",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addAnnotation(Annotation.builder()",
+                              ".typeName(TypeName.create(\"io.helidon.RandomAnnotation\"))",
+                              ".property(\"value\", \"quoted \\\" backslash \\\\ tab \\t\")",
+                              ".build()");
+        assertClassGenerated(result, "NestedTypeName");
+    }
+
+    @Test
+    void testAnnotatedBoundTypeNameCompiles() throws IOException {
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(randomAnnotation())
+                                                        .build())
+                                         .build())
+                .build();
+
+        var result = compile(typeNameModel("BoundTypeName", typeName));
+        String source = generatedSource(result, "BoundTypeName");
+
+        assertThat(source, not(containsString("TypeName.create(\"java.util.List<? extends")));
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"List\")",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".wildcard(true)",
+                              ".addUpperBound(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addAnnotation(Annotation.create(TypeName.create(\"io.helidon.RandomAnnotation\")))",
+                              ".build()");
+        assertClassGenerated(result, "BoundTypeName");
+    }
+
+    @Test
+    void testAnnotatedLowerBoundTypeNameCompiles() throws IOException {
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(randomAnnotation())
+                                                        .build())
+                                         .build())
+                .build();
+
+        var result = compile(typeNameModel("LowerBoundTypeName", typeName));
+        String source = generatedSource(result, "LowerBoundTypeName");
+
+        assertThat(source, not(containsString("TypeName.create(\"java.util.List<? super")));
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"List\")",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".wildcard(true)",
+                              ".addLowerBound(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addAnnotation(Annotation.create(TypeName.create(\"io.helidon.RandomAnnotation\")))",
+                              ".build()");
+        assertClassGenerated(result, "LowerBoundTypeName");
+    }
+
+    @Test
+    void testAnnotatedComponentTypeNameCompiles() throws IOException {
+        TypeName componentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(randomAnnotation())
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.STRING)
+                .array(true)
+                .componentType(componentType)
+                .build();
+
+        var result = compile(typeNameModel("ComponentTypeName", typeName));
+        String source = generatedSource(result, "ComponentTypeName");
+
+        assertThat(source, not(containsString("TypeName.create(\"java.lang.String[]")));
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".array(true)",
+                              ".componentType(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addAnnotation(Annotation.create(TypeName.create(\"io.helidon.RandomAnnotation\")))",
+                              ".build()");
+        assertClassGenerated(result, "ComponentTypeName");
+    }
+
+    @Test
+    void testTypedElementEnclosingTypeCompiles() throws IOException {
+        TypeName enclosingType = TypeName.create("io.helidon.codegen.classmodel.EnclosingType");
+        TypedElementInfo elementInfo = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("method")
+                .typeName(TypeNames.STRING)
+                .enclosingType(enclosingType)
+                .build();
+
+        var result = compile(typedElementModel("ElementInfo", elementInfo));
+        String source = generatedSource(result, "ElementInfo");
+
+        assertThat(source, containsString(".enclosingType(TypeName.create(\"" + enclosingType.fqName() + "\"))"));
+        assertClassGenerated(result, "ElementInfo");
+    }
+
+    private static Annotation randomAnnotation() {
+        return Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+    }
+
+    private static GeneratedModel typeNameModel(String className, TypeName typeName) {
+        ClassModel classModel = ClassModel.builder()
+                .packageName(PACKAGE_NAME)
+                .name(className)
+                .addMethod(method -> method
+                        .isStatic(true)
+                        .name("create")
+                        .returnType(TypeName.create(TypeName.class))
+                        .addContent("return ")
+                        .addContentCreate(typeName)
+                        .addContentLine(";"))
+                .build();
+        return new GeneratedModel(className, classModel);
+    }
+
+    private static GeneratedModel typedElementModel(String className, TypedElementInfo elementInfo) {
+        ClassModel classModel = ClassModel.builder()
+                .packageName(PACKAGE_NAME)
+                .name(className)
+                .addMethod(method -> method
+                        .isStatic(true)
+                        .name("create")
+                        .returnType(TypeName.create(TypedElementInfo.class))
+                        .addContent("return ")
+                        .addContentCreate(elementInfo)
+                        .addContentLine(";"))
+                .build();
+        return new GeneratedModel(className, classModel);
+    }
+
+    private static TestCompiler.Result compile(GeneratedModel model) {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource(PACKAGE_PATH + "/" + TRIGGER_CLASS + ".java", """
+                        package %s;
+
+                        final class %s {
+                        }
+                        """.formatted(PACKAGE_NAME, TRIGGER_CLASS))
+                .build()
+                .compile();
+
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
+        return result;
+    }
+
+    private static String generatedSource(TestCompiler.Result result, String className) throws IOException {
+        Path generatedSource = result.sourceOutput().resolve(PACKAGE_PATH + "/" + className + ".java");
+        assertThat("Generated source should exist: " + generatedSource, Files.exists(generatedSource), is(true));
+        return Files.readString(generatedSource);
+    }
+
+    private static void assertClassGenerated(TestCompiler.Result result, String className) {
+        assertThat(Files.exists(result.classOutput().resolve(PACKAGE_PATH + "/" + className + ".class")), is(true));
+    }
+
+    private static void assertContainsInOrder(String source, String... fragments) {
+        int previous = -1;
+        for (String fragment : fragments) {
+            int current = source.indexOf(fragment, previous + 1);
+            assertThat("Missing fragment after index " + previous + ": " + fragment, current > previous, is(true));
+            previous = current;
+        }
+    }
+
+    private record GeneratedModel(String className, ClassModel classModel) {
+    }
+
+    private static final class ContentProcessor extends AbstractProcessor {
+        private final GeneratedModel model;
+        private boolean processed;
+
+        private ContentProcessor(GeneratedModel model) {
+            this.model = model;
+        }
+
+        @Override
+        public Set<String> getSupportedAnnotationTypes() {
+            return Set.of("*");
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            if (processed || roundEnv.processingOver()) {
+                return false;
+            }
+            processed = true;
+            try {
+                var sourceFile = processingEnv.getFiler()
+                        .createSourceFile(PACKAGE_NAME + "." + model.className());
+                try (Writer writer = sourceFile.openWriter()) {
+                    model.classModel().write(writer);
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            return false;
+        }
+    }
+}

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/DelegatedClassInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/DelegatedClassInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,9 @@ class DelegatedClassInterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.DelegatedClass::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/DelegatingInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/DelegatingInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,9 @@ package io.helidon.service.tests.interception;
 
 import io.helidon.logging.common.LogConfig;
 import io.helidon.service.registry.InterceptionException;
-import io.helidon.service.registry.ServiceRegistry;
-import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -134,7 +131,9 @@ class DelegatingInterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.DelegatedContract::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/ExternallyDelegatedClassInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/ExternallyDelegatedClassInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,9 @@ class ExternallyDelegatedClassInterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.ExternallyDelegatedClass::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/InterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/InterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,9 @@ class InterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.TheService::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/InterfaceInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/InterfaceInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,9 @@ class InterfaceInterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.TheOtherService::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 


### PR DESCRIPTION
Resolves #11868

Fixes codegen core and class-model handling for annotated type names needed by validation:

- preserve nested type-use annotations when creating `TypeName` source
- merge hierarchy type-use annotations for matching method signatures
- include typed-element enclosing type information in generated model source


First of several PRs needed for https://github.com/helidon-io/helidon/issues/11865