### PR TITLE
Fix codegen TypeName annotation handling (27.x)

### DIFF
--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
@@ -17,6 +17,7 @@
 package io.helidon.codegen.classmodel;
 
 import java.util.List;
+import java.util.Objects;
 
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ResolvedType;
@@ -75,23 +76,13 @@ public interface ContentBuilder<T extends ContentBuilder<T>> {
     /**
      * Adds the provided literal as content, enclosed in double quotes.
      * <p>
-     * In case the {@code literal} contains an end of line character, the output will be a text-block (multiline string),
-     * otherwise it will be a quotes string, with escaped tabs, quotes, and backslashes.
+     * The output is a quoted string with escaped tabs, line endings, quotes, and backslashes.
      *
      * @param literal the literal string to be added as content
      * @return updated builder instance
      */
     default T addContentLiteral(String literal) {
-        if (literal.contains("\n")) {
-            // the simplest solution is to use multiline string
-            return addContent("\"\"\"\n" + literal + "\"\"\"");
-        }
-        // escape tabs, double quote, and backslashes
-        String toWrite = literal;
-        toWrite = toWrite.replace("\\", "\\\\");
-        toWrite = toWrite.replace("\"", "\\\"");
-        toWrite = toWrite.replace("\t", "\\t");
-        return addContent("\"" + toWrite + "\"");
+        return addContent("\"" + escapedContentLiteral(literal) + "\"");
     }
 
     /**
@@ -132,7 +123,9 @@ public interface ContentBuilder<T extends ContentBuilder<T>> {
      * To create a type name without type arguments (such as when used with {@code .class}), use
      * {@link io.helidon.common.types.TypeName#genericTypeName()}.
      * <p>
-     * The generated content will be similar to: {@code TypeName.create("some.type.Name")}
+     * Simple type names use generated content similar to: {@code TypeName.create("some.type.Name")}.
+     * Type names with direct or inherited type-use annotations use generated builder content to preserve annotations
+     * on the root type, type arguments, wildcard bounds, and array component types.
      *
      * @param typeName type name to code generate
      * @return updated builder instance
@@ -235,4 +228,30 @@ public interface ContentBuilder<T extends ContentBuilder<T>> {
      * @return updated builder instance
      */
     T clearContent();
+
+    private static String escapedContentLiteral(String literal) {
+        Objects.requireNonNull(literal, "literal is null");
+
+        StringBuilder result = new StringBuilder(literal.length());
+        for (int i = 0; i < literal.length(); i++) {
+            char ch = literal.charAt(i);
+            switch (ch) {
+            case '\b' -> result.append("\\b");
+            case '\t' -> result.append("\\t");
+            case '\n' -> result.append("\\n");
+            case '\f' -> result.append("\\f");
+            case '\r' -> result.append("\\r");
+            case '"' -> result.append("\\\"");
+            case '\\' -> result.append("\\\\");
+            default -> {
+                if (ch < ' ') {
+                    result.append(String.format("\\u%04x", (int) ch));
+                } else {
+                    result.append(ch);
+                }
+            }
+            }
+        }
+        return result.toString();
+    }
 }

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentSupport.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentSupport.java
@@ -62,6 +62,11 @@ final class ContentSupport {
                     .addContentLine("\")");
         }
 
+        element.enclosingType()
+                .ifPresent(it -> contentBuilder.addContent(".enclosingType(")
+                        .addContentCreate(it)
+                        .addContentLine(")"));
+
         for (Annotation annotation : element.annotations()) {
             contentBuilder.addContent(".addAnnotation(")
                     .addContentCreate(annotation)
@@ -153,6 +158,74 @@ final class ContentSupport {
     }
 
     static void addCreateTypeName(ContentBuilder<?> builder, TypeName typeName) {
+        if (hasNestedAnnotations(typeName)) {
+            builder.addContent(TypeNames.TYPE_NAME)
+                    .addContentLine(".builder()")
+                    .increaseContentPadding()
+                    .increaseContentPadding();
+
+            addBuilderString(builder, "packageName", typeName.packageName());
+            addBuilderString(builder, "className", typeName.className());
+            typeName.enclosingNames().forEach(it -> addBuilderString(builder, "addEnclosingName", it));
+            if (typeName.primitive()) {
+                builder.addContentLine(".primitive(true)");
+            }
+            if (typeName.array()) {
+                builder.addContentLine(".array(true)");
+            }
+            if (typeName.vararg()) {
+                builder.addContentLine(".vararg(true)");
+            }
+            if (typeName.generic()) {
+                builder.addContentLine(".generic(true)");
+            }
+            if (typeName.wildcard()) {
+                builder.addContentLine(".wildcard(true)");
+            }
+
+            for (Annotation annotation : typeName.annotations()) {
+                builder.addContent(".addAnnotation(")
+                        .addContentCreate(annotation)
+                        .addContentLine(")");
+            }
+
+            for (Annotation annotation : typeName.inheritedAnnotations()) {
+                builder.addContent(".addInheritedAnnotation(")
+                        .addContentCreate(annotation)
+                        .addContentLine(")");
+            }
+
+            for (TypeName typeArgument : typeName.typeArguments()) {
+                builder.addContent(".addTypeArgument(")
+                        .addContentCreate(typeArgument)
+                        .addContentLine(")");
+            }
+
+            typeName.typeParameters().forEach(it -> addBuilderString(builder, "addTypeParameter", it));
+
+            for (TypeName lowerBound : typeName.lowerBounds()) {
+                builder.addContent(".addLowerBound(")
+                        .addContentCreate(lowerBound)
+                        .addContentLine(")");
+            }
+
+            for (TypeName upperBound : typeName.upperBounds()) {
+                builder.addContent(".addUpperBound(")
+                        .addContentCreate(upperBound)
+                        .addContentLine(")");
+            }
+
+            typeName.componentType()
+                    .ifPresent(componentType -> builder.addContent(".componentType(")
+                            .addContentCreate(componentType)
+                            .addContentLine(")"));
+
+            builder.addContentLine(".build()")
+                    .decreaseContentPadding()
+                    .decreaseContentPadding();
+            return;
+        }
+
         // TypeName.create("my.type.Name<my.type.TypeArgument>")
         builder.addContent(TypeNames.TYPE_NAME)
                 .addContent(".create(\"")
@@ -160,9 +233,38 @@ final class ContentSupport {
                 .addContent("\")");
     }
 
+    private static void addBuilderString(ContentBuilder<?> builder, String method, String value) {
+        if (value.isEmpty()) {
+            return;
+        }
+        builder.addContent(".")
+                .addContent(method)
+                .addContent("(")
+                .addContentLiteral(value)
+                .addContentLine(")");
+    }
+
+    private static boolean hasNestedAnnotations(TypeName typeName) {
+        if (!typeName.annotations().isEmpty() || !typeName.inheritedAnnotations().isEmpty()) {
+            return true;
+        }
+        if (typeName.typeArguments().stream().anyMatch(ContentSupport::hasNestedAnnotations)) {
+            return true;
+        }
+        if (typeName.lowerBounds().stream().anyMatch(ContentSupport::hasNestedAnnotations)) {
+            return true;
+        }
+        if (typeName.upperBounds().stream().anyMatch(ContentSupport::hasNestedAnnotations)) {
+            return true;
+        }
+        return typeName.componentType()
+                .map(ContentSupport::hasNestedAnnotations)
+                .orElse(false);
+    }
+
     private static void addAnnotationValue(ContentBuilder<?> contentBuilder, Object objectValue) {
         switch (objectValue) {
-        case String value -> contentBuilder.addContent("\"" + value + "\"");
+        case String value -> contentBuilder.addContentLiteral(value);
         case Boolean value -> contentBuilder.addContent(String.valueOf(value));
         case Long value -> contentBuilder.addContent(String.valueOf(value) + 'L');
         case Double value -> contentBuilder.addContent(String.valueOf(value) + 'D');

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/ContentBuilderTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/ContentBuilderTest.java
@@ -47,10 +47,27 @@ class ContentBuilderTest {
     }
 
     @Test
+    void testAddContentLiteralBackslash() {
+        var c = new TestContentBuilder();
+        c.addContentLiteral("test string with \\ backslash");
+
+        assertThat(c.generatedString(), is("    \"test string with \\\\ backslash\""));
+    }
+
+    @Test
     void testAddContentLiteralNewLine() {
         var c = new TestContentBuilder();
         c.addContentLiteral("test string with\n lines");
 
-        assertThat(c.generatedString(), is("    \"\"\"\ntest string with\n lines\"\"\""));
+        assertThat(c.generatedString(), is("    \"test string with\\n lines\""));
+    }
+
+    @Test
+    void testAddContentLiteralMultilineEscapes() {
+        var c = new TestContentBuilder();
+        c.addContentLiteral("first\npath \\ tab \t quote \" delimiter \"\"\" return\rnext");
+
+        assertThat(c.generatedString(),
+                   is("    \"first\\npath \\\\ tab \\t quote \\\" delimiter \\\"\\\"\\\" return\\rnext\""));
     }
 }

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypesCodegenTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypesCodegenTest.java
@@ -20,11 +20,16 @@ import java.lang.annotation.ElementType;
 import java.util.List;
 
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class TypesCodegenTest {
@@ -92,5 +97,130 @@ class TypesCodegenTest {
                               .property("ltype", @java.util.List@.of(@io.helidon.common.types.TypeName@.create("io.helidon.codegen.classmodel.TypesCodegenTest"),@io.helidon.common.types.TypeName@.create("io.helidon.codegen.classmodel.TypesCodegenTest")))
                               .property("lenum", @java.util.List@.of(@io.helidon.common.types.EnumValue@.create(@io.helidon.common.types.TypeName@.create("java.lang.annotation.ElementType"),"FIELD"),@io.helidon.common.types.EnumValue@.create(@io.helidon.common.types.TypeName@.create("java.lang.annotation.ElementType"),"MODULE")))
                               .build()"""));
+    }
+
+    @Test
+    void testAnnotatedNestedTypeName() {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .property("value", "quoted \" backslash \\ tab \t")
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.MAP)
+                .addTypeArgument(TypeNames.STRING)
+                .addTypeArgument(TypeName.builder(TypeNames.MAP)
+                                         .addTypeArgument(TypeNames.STRING)
+                                         .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                                                  .addAnnotation(annotation)
+                                                                  .build())
+                                         .build())
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateTypeName(contentBuilder, typeName);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString,
+                   not(containsString("@io.helidon.common.types.TypeName@.create(\"java.util.Map<java.lang.String,")));
+        assertThat(createString, containsString(".className(\"Map\")"));
+        assertThat(createString, containsString(".addTypeArgument(@io.helidon.common.types.TypeName@.builder()"));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.builder()"));
+        assertThat(createString, containsString(".property(\"value\", \"quoted \\\" backslash \\\\ tab \\t\")"));
+    }
+
+    @Test
+    void testAnnotatedBoundTypeName() {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(annotation)
+                                                        .build())
+                                         .build())
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateTypeName(contentBuilder, typeName);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString,
+                   not(containsString("@io.helidon.common.types.TypeName@.create(\"java.util.List<? extends")));
+        assertThat(createString, containsString(".wildcard(true)"));
+        assertThat(createString, containsString(".addUpperBound(@io.helidon.common.types.TypeName@.builder()"));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
+    }
+
+    @Test
+    void testAnnotatedLowerBoundTypeName() {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(annotation)
+                                                        .build())
+                                         .build())
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateTypeName(contentBuilder, typeName);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString,
+                   not(containsString("@io.helidon.common.types.TypeName@.create(\"java.util.List<? super")));
+        assertThat(createString, containsString(".wildcard(true)"));
+        assertThat(createString, containsString(".addLowerBound(@io.helidon.common.types.TypeName@.builder()"));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
+    }
+
+    @Test
+    void testAnnotatedComponentTypeName() {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+        TypeName componentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(annotation)
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.STRING)
+                .array(true)
+                .componentType(componentType)
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateTypeName(contentBuilder, typeName);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString,
+                   not(containsString("@io.helidon.common.types.TypeName@.create(\"java.lang.String[]")));
+        assertThat(createString, containsString(".array(true)"));
+        assertThat(createString, containsString(".componentType(@io.helidon.common.types.TypeName@.builder()"));
+        assertThat(createString, containsString(".addAnnotation(@io.helidon.common.types.Annotation@.create("));
+    }
+
+    @Test
+    void testTypedElementEnclosingType() {
+        TypeName enclosingType = TypeName.create("io.helidon.codegen.classmodel.EnclosingType");
+        TypedElementInfo elementInfo = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("method")
+                .typeName(TypeNames.STRING)
+                .enclosingType(enclosingType)
+                .build();
+
+        TestContentBuilder contentBuilder = new TestContentBuilder();
+        ContentSupport.addCreateElement(contentBuilder, elementInfo);
+        String createString = contentBuilder.generatedString();
+
+        assertThat(createString, containsString(".enclosingType("));
+        assertThat(createString,
+                   containsString(".enclosingType(@io.helidon.common.types.TypeName@.create(\""
+                                          + enclosingType.fqName()
+                                          + "\"))"));
     }
 }

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,6 +33,7 @@ import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
 
+import static io.helidon.common.types.TypeNames.GENERATED;
 import static io.helidon.common.types.TypeNames.INHERITED;
 import static java.util.function.Predicate.not;
 
@@ -212,14 +214,26 @@ public final class TypeHierarchy {
     }
 
     /**
-     * Annotations on the {@code typeInfo}, it's methods, and method parameters.
+     * Annotations on the {@code typeInfo}, its methods, method parameters, and the type-use positions nested in their
+     * {@link TypeName}s.
+     * <p>
+     * Type-use positions include type arguments, wildcard bounds, and array component types of the type itself,
+     * element return or field types, and parameter types.
      *
      * @param ctx context
      * @param typeInfo type info to check
      * @return a set of all annotation types on any of the elements, including inherited annotations
      */
     public static Set<TypeName> nestedAnnotations(CodegenContext ctx, TypeInfo typeInfo) {
+        Objects.requireNonNull(ctx, "ctx is null");
+        Objects.requireNonNull(typeInfo, "typeInfo is null");
         Set<TypeName> result = new HashSet<>();
+        List<TypedElementInfo> elements = typeInfo.hasAnnotation(GENERATED)
+                ? typeInfo.elementInfo()
+                : typeInfo.elementInfo()
+                        .stream()
+                        .map(it -> mergeHierarchyAnnotations(typeInfo, it))
+                        .toList();
 
         // on type
         typeInfo.annotations()
@@ -230,45 +244,40 @@ public final class TypeHierarchy {
                 .stream()
                 .map(Annotation::typeName)
                 .forEach(result::add);
-        genericTypeAnnotations(typeInfo.typeName())
+        typeNameAnnotations(typeInfo.typeName())
                 .stream()
                 .map(Annotation::typeName)
                 .forEach(result::add);
 
         // on fields, methods etc.
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::annotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
 
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::inheritedAnnotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
 
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::typeName)
-                .map(TypeHierarchy::genericTypeAnnotations)
+                .map(TypeHierarchy::typeNameAnnotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
 
         // on parameters
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::parameterArguments)
                 .flatMap(List::stream)
                 .map(TypedElementInfo::annotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::parameterArguments)
                 .flatMap(List::stream)
                 .map(TypedElementInfo::inheritedAnnotations)
@@ -276,12 +285,11 @@ public final class TypeHierarchy {
                 .map(Annotation::typeName)
                 .forEach(result::add);
 
-        typeInfo.elementInfo()
-                .stream()
+        elements.stream()
                 .map(TypedElementInfo::parameterArguments)
                 .flatMap(List::stream)
                 .map(TypedElementInfo::typeName)
-                .map(TypeHierarchy::genericTypeAnnotations)
+                .map(TypeHierarchy::typeNameAnnotations)
                 .flatMap(List::stream)
                 .map(Annotation::typeName)
                 .forEach(result::add);
@@ -289,14 +297,208 @@ public final class TypeHierarchy {
         return result;
     }
 
-    private static List<Annotation> genericTypeAnnotations(TypeName typeName) {
-        // annotations on type arguments (i.e. Set<@Valid SomeType>)
-        List<Annotation> result = new ArrayList<>();
-        for (TypeName typeArgument : typeName.typeArguments()) {
-            result.addAll(typeArgument.annotations());
-            genericTypeAnnotations(typeArgument);
+    /**
+     * Merge method and parameter annotations, and return and parameter type-use annotations, from overridden methods and
+     * interface methods into the provided method element. Non-method elements are returned unchanged.
+     * <p>
+     * When the same annotation type exists on both the target method and an inherited method, the target method annotation
+     * is preserved. Type-use annotations are merged using {@link #mergeTypeNameAnnotations(TypeName, TypeName)}.
+     *
+     * @param type    type declaring the element
+     * @param element element to merge
+     * @return element with matching hierarchy annotations merged in
+     */
+    static TypedElementInfo mergeHierarchyAnnotations(TypeInfo type, TypedElementInfo element) {
+        if (element.kind() != ElementKind.METHOD) {
+            return element;
         }
+
+        List<TypedElementInfo> prototypes = new ArrayList<>();
+        Set<TypeName> processedTypes = new HashSet<>();
+        String packageName = type.typeName().packageName();
+
+        type.superTypeInfo().ifPresent(it -> collectInheritedMethods(
+                processedTypes,
+                prototypes,
+                it,
+                element,
+                packageName));
+        type.interfaceTypeInfo().forEach(it -> collectInheritedMethods(
+                processedTypes,
+                prototypes,
+                it,
+                element,
+                packageName));
+
+        if (prototypes.isEmpty()) {
+            return element;
+        }
+
+        Map<TypeName, Annotation> annotations = new LinkedHashMap<>();
+        element.annotations().forEach(it -> annotations.put(it.typeName(), it));
+        prototypes.stream()
+                .map(TypedElementInfo::annotations)
+                .flatMap(List::stream)
+                .forEach(it -> annotations.putIfAbsent(it.typeName(), it));
+
+        TypeName returnType = element.typeName();
+        for (TypedElementInfo prototype : prototypes) {
+            returnType = mergeTypeNameAnnotations(returnType, prototype.typeName());
+        }
+
+        List<TypedElementInfo> parameters = new ArrayList<>();
+        List<TypedElementInfo> elementParameters = element.parameterArguments();
+        for (int i = 0; i < elementParameters.size(); i++) {
+            TypedElementInfo parameter = elementParameters.get(i);
+            Map<TypeName, Annotation> parameterAnnotations = new LinkedHashMap<>();
+            parameter.annotations().forEach(it -> parameterAnnotations.put(it.typeName(), it));
+
+            TypeName parameterType = parameter.typeName();
+            for (TypedElementInfo prototype : prototypes) {
+                List<TypedElementInfo> prototypeParameters = prototype.parameterArguments();
+                if (prototypeParameters.size() > i) {
+                    TypedElementInfo prototypeParameter = prototypeParameters.get(i);
+                    prototypeParameter.annotations()
+                            .forEach(it -> parameterAnnotations.putIfAbsent(it.typeName(), it));
+                    parameterType = mergeTypeNameAnnotations(parameterType, prototypeParameter.typeName());
+                }
+            }
+
+            parameters.add(TypedElementInfo.builder(parameter)
+                                   .annotations(List.copyOf(parameterAnnotations.values()))
+                                   .typeName(parameterType)
+                                   .build());
+        }
+
+        return TypedElementInfo.builder(element)
+                .annotations(List.copyOf(annotations.values()))
+                .typeName(returnType)
+                .parameterArguments(parameters)
+                .build();
+    }
+
+    /**
+     * Annotation instances nested inside a type name.
+     * This includes annotations declared directly on the provided type name and annotations declared on nested
+     * type arguments, wildcard bounds, and array component types.
+     *
+     * @param typeName type name to scan
+     * @return nested annotation instances
+     */
+    static List<Annotation> typeNameAnnotations(TypeName typeName) {
+        List<Annotation> result = new ArrayList<>();
+        result.addAll(typeName.annotations());
+        result.addAll(typeName.inheritedAnnotations());
+        for (TypeName typeArgument : typeName.typeArguments()) {
+            result.addAll(typeNameAnnotations(typeArgument));
+        }
+        for (TypeName lowerBound : typeName.lowerBounds()) {
+            result.addAll(typeNameAnnotations(lowerBound));
+        }
+        for (TypeName upperBound : typeName.upperBounds()) {
+            result.addAll(typeNameAnnotations(upperBound));
+        }
+        typeName.componentType()
+                .map(TypeHierarchy::typeNameAnnotations)
+                .ifPresent(result::addAll);
         return result;
+    }
+
+    /**
+     * Merge type-use annotations from a source type name into a target type name.
+     * If the type names do not have the same structure, the target type name is returned unchanged.
+     * <p>
+     * Matching type names merge direct and inherited annotations on the root type, type arguments, wildcard bounds,
+     * and array component types. When both type names contain the same annotation type at a matching position, the
+     * target annotation is preserved. Formal type parameter names do not block merging.
+     *
+     * @param typeName       target type name
+     * @param sourceTypeName source type name
+     * @return type name with annotations merged from the source
+     */
+    static TypeName mergeTypeNameAnnotations(TypeName typeName, TypeName sourceTypeName) {
+        if (!sameStructure(typeName, sourceTypeName)) {
+            return typeName;
+        }
+
+        List<Annotation> annotations = new ArrayList<>(typeName.annotations());
+        sourceTypeName.annotations().forEach(it -> addAnnotationIfAbsent(annotations, it));
+        List<Annotation> inheritedAnnotations = new ArrayList<>(typeName.inheritedAnnotations());
+        sourceTypeName.inheritedAnnotations().forEach(it -> addAnnotationIfAbsent(inheritedAnnotations, it));
+
+        TypeName.Builder builder = TypeName.builder(typeName)
+                .annotations(annotations)
+                .inheritedAnnotations(inheritedAnnotations)
+                .typeArguments(mergeTypeNameLists(typeName.typeArguments(), sourceTypeName.typeArguments()))
+                .lowerBounds(mergeTypeNameLists(typeName.lowerBounds(), sourceTypeName.lowerBounds()))
+                .upperBounds(mergeTypeNameLists(typeName.upperBounds(), sourceTypeName.upperBounds()));
+
+        if (typeName.componentType().isPresent() && sourceTypeName.componentType().isPresent()) {
+            builder.componentType(mergeTypeNameAnnotations(typeName.componentType().get(),
+                                                          sourceTypeName.componentType().get()));
+        }
+
+        return builder.build();
+    }
+
+    private static List<TypeName> mergeTypeNameLists(List<TypeName> typeNames, List<TypeName> sourceTypeNames) {
+        if (sourceTypeNames.isEmpty()) {
+            return typeNames;
+        }
+        if (typeNames.isEmpty()) {
+            return typeNames;
+        }
+        if (typeNames.size() != sourceTypeNames.size()) {
+            return typeNames;
+        }
+
+        List<TypeName> merged = new ArrayList<>(typeNames.size());
+        for (int i = 0; i < typeNames.size(); i++) {
+            merged.add(mergeTypeNameAnnotations(typeNames.get(i), sourceTypeNames.get(i)));
+        }
+        return merged;
+    }
+
+    private static boolean sameStructure(TypeName typeName, TypeName sourceTypeName) {
+        if (typeName.primitive() != sourceTypeName.primitive()
+                || typeName.array() != sourceTypeName.array()
+                || typeName.generic() != sourceTypeName.generic()
+                || typeName.wildcard() != sourceTypeName.wildcard()
+                || typeName.typeArguments().size() != sourceTypeName.typeArguments().size()
+                || typeName.lowerBounds().size() != sourceTypeName.lowerBounds().size()
+                || typeName.upperBounds().size() != sourceTypeName.upperBounds().size()
+                || typeName.componentType().isPresent() != sourceTypeName.componentType().isPresent()) {
+            return false;
+        }
+        return typeName.packageName().equals(sourceTypeName.packageName())
+                && typeName.className().equals(sourceTypeName.className())
+                && typeName.enclosingNames().equals(sourceTypeName.enclosingNames())
+                && sameStructure(typeName.typeArguments(), sourceTypeName.typeArguments())
+                && sameStructure(typeName.lowerBounds(), sourceTypeName.lowerBounds())
+                && sameStructure(typeName.upperBounds(), sourceTypeName.upperBounds())
+                && sameStructure(typeName.componentType(), sourceTypeName.componentType());
+    }
+
+    private static boolean sameStructure(List<TypeName> typeNames, List<TypeName> sourceTypeNames) {
+        for (int i = 0; i < typeNames.size(); i++) {
+            if (!sameStructure(typeNames.get(i), sourceTypeNames.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean sameStructure(Optional<TypeName> typeName, Optional<TypeName> sourceTypeName) {
+        if (typeName.isEmpty()) {
+            return true;
+        }
+        return sameStructure(typeName.get(), sourceTypeName.get());
+    }
+
+    private static void addAnnotationIfAbsent(List<Annotation> annotations, Annotation annotation) {
+        if (annotations.stream().noneMatch(it -> it.typeName().equals(annotation.typeName()))) {
+            annotations.add(annotation);
+        }
     }
 
     private static void processMetaAnnotations(CodegenContext ctx,

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -35,7 +35,6 @@ import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.common.types.TypeNames.GENERATED;
 import static io.helidon.common.types.TypeNames.INHERITED;
-import static java.util.function.Predicate.not;
 
 /**
  * Utilities for type hierarchy.
@@ -555,6 +554,27 @@ public final class TypeHierarchy {
             return;
         }
 
+        Map<String, TypeName> substitutions = new LinkedHashMap<>();
+        List<TypeName> typeArguments = type.typeName().typeArguments();
+        if (!typeArguments.isEmpty()) {
+            List<String> typeParameters = type.declaredType().typeParameters();
+            if (typeParameters.isEmpty()) {
+                typeParameters = type.declaredType()
+                        .typeArguments()
+                        .stream()
+                        .filter(TypeName::generic)
+                        .map(TypeName::className)
+                        .toList();
+            }
+
+            for (int i = 0; i < typeArguments.size() && i < typeParameters.size(); i++) {
+                String typeParameter = typeParameters.get(i);
+                int boundStart = typeParameter.indexOf(' ');
+                substitutions.put(boundStart > 0 ? typeParameter.substring(0, boundStart) : typeParameter,
+                                  typeArguments.get(i));
+            }
+        }
+
         inherited(
                 type,
                 method,
@@ -562,12 +582,19 @@ public final class TypeHierarchy {
                         .stream()
                         .map(TypedElementInfo::typeName)
                         .collect(Collectors.toUnmodifiableList()),
-                currentPackage)
+                currentPackage,
+                substitutions)
                 .ifPresent(collected::add);
 
-        type.superTypeInfo().ifPresent(it -> collectInheritedMethods(processed, collected, it, method, currentPackage));
+        type.superTypeInfo()
+                .map(it -> substituteTypeParameters(it, substitutions))
+                .ifPresent(it -> collectInheritedMethods(processed, collected, it, method, currentPackage));
         for (TypeInfo typeInfo : type.interfaceTypeInfo()) {
-            collectInheritedMethods(processed, collected, typeInfo, method, currentPackage);
+            collectInheritedMethods(processed,
+                                    collected,
+                                    substituteTypeParameters(typeInfo, substitutions),
+                                    method,
+                                    currentPackage);
         }
     }
 
@@ -583,20 +610,47 @@ public final class TypeHierarchy {
     private static Optional<TypedElementInfo> inherited(TypeInfo type,
                                                         TypedElementInfo method,
                                                         List<TypeName> arguments,
-                                                        String currentPackage) {
+                                                        String currentPackage,
+                                                        Map<String, TypeName> substitutions) {
 
         String methodName = method.elementName();
-        // we look only for exact match (including types)
-        Optional<TypedElementInfo> found = type.elementInfo()
-                .stream()
-                .filter(ElementInfoPredicates::isMethod)
-                .filter(not(ElementInfoPredicates::isPrivate))
-                .filter(ElementInfoPredicates.elementName(methodName))
-                .filter(ElementInfoPredicates.hasParams(arguments))
-                .findFirst();
+        for (TypedElementInfo superMethod : type.elementInfo()) {
+            if (!ElementInfoPredicates.isMethod(superMethod)
+                    || ElementInfoPredicates.isPrivate(superMethod)
+                    || !methodName.equals(superMethod.elementName())) {
+                continue;
+            }
 
-        if (found.isPresent()) {
-            TypedElementInfo superMethod = found.get();
+            List<TypedElementInfo> parameters = superMethod.parameterArguments();
+            if (parameters.size() != arguments.size()) {
+                continue;
+            }
+
+            Map<String, TypeName> methodSubstitutions = substitutions;
+            if (!superMethod.typeParameters().isEmpty() && !substitutions.isEmpty()) {
+                methodSubstitutions = new LinkedHashMap<>(substitutions);
+                superMethod.typeParameters()
+                        .stream()
+                        .map(TypeName::className)
+                        .forEach(methodSubstitutions::remove);
+            }
+
+            List<TypedElementInfo> substitutedParameters = new ArrayList<>(parameters.size());
+            boolean sameSignature = true;
+            for (int i = 0; i < parameters.size(); i++) {
+                TypedElementInfo parameter = parameters.get(i);
+                TypeName parameterType = substituteTypeParameters(parameter.typeName(), methodSubstitutions);
+                if (!arguments.get(i).equals(parameterType)) {
+                    sameSignature = false;
+                    break;
+                }
+                substitutedParameters.add(TypedElementInfo.builder(parameter)
+                                                  .typeName(parameterType)
+                                                  .build());
+            }
+            if (!sameSignature) {
+                continue;
+            }
 
             // method has same signature, but is package local and is in a different package
             boolean realOverride = superMethod.accessModifier() != AccessModifier.PACKAGE_PRIVATE
@@ -604,11 +658,68 @@ public final class TypeHierarchy {
 
             if (realOverride) {
                 // this is a valid method that the type overrides
-                return Optional.of(superMethod);
+                return Optional.of(TypedElementInfo.builder(superMethod)
+                                           .typeName(substituteTypeParameters(superMethod.typeName(), methodSubstitutions))
+                                           .parameterArguments(substitutedParameters)
+                                           .build());
             }
         }
 
         return Optional.empty();
+    }
+
+    private static TypeInfo substituteTypeParameters(TypeInfo type, Map<String, TypeName> substitutions) {
+        if (substitutions.isEmpty()) {
+            return type;
+        }
+        return TypeInfo.builder(type)
+                .typeName(substituteTypeParameters(type.typeName(), substitutions))
+                .build();
+    }
+
+    private static TypeName substituteTypeParameters(TypeName typeName, Map<String, TypeName> substitutions) {
+        if (substitutions.isEmpty()) {
+            return typeName;
+        }
+
+        TypeName replacement = typeName.generic()
+                && !typeName.array()
+                && typeName.typeArguments().isEmpty()
+                && typeName.lowerBounds().isEmpty()
+                && typeName.upperBounds().isEmpty()
+                && typeName.componentType().isEmpty()
+                ? substitutions.get(typeName.className())
+                : null;
+        if (replacement != null) {
+            List<Annotation> annotations = new ArrayList<>(replacement.annotations());
+            typeName.annotations().forEach(it -> addAnnotationIfAbsent(annotations, it));
+            List<Annotation> inheritedAnnotations = new ArrayList<>(replacement.inheritedAnnotations());
+            typeName.inheritedAnnotations().forEach(it -> addAnnotationIfAbsent(inheritedAnnotations, it));
+            return TypeName.builder(replacement)
+                    .annotations(annotations)
+                    .inheritedAnnotations(inheritedAnnotations)
+                    .build();
+        }
+
+        TypeName.Builder builder = TypeName.builder(typeName)
+                .typeArguments(typeName.typeArguments()
+                                       .stream()
+                                       .map(it -> substituteTypeParameters(it, substitutions))
+                                       .toList())
+                .lowerBounds(typeName.lowerBounds()
+                                     .stream()
+                                     .map(it -> substituteTypeParameters(it, substitutions))
+                                     .toList())
+                .upperBounds(typeName.upperBounds()
+                                     .stream()
+                                     .map(it -> substituteTypeParameters(it, substitutions))
+                                     .toList());
+
+        typeName.componentType()
+                .map(it -> substituteTypeParameters(it, substitutions))
+                .ifPresent(builder::componentType);
+
+        return builder.build();
     }
 
 }

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import io.helidon.codegen.spi.AnnotationMapper;
+import io.helidon.codegen.spi.ElementMapper;
+import io.helidon.codegen.spi.TypeMapper;
+import io.helidon.common.types.AccessModifier;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TypeHierarchyTest {
+    private static final TypeName NOT_BLANK = TypeName.create("io.helidon.validation.Validation.String.NotBlank");
+    private static final CodegenContext CTX = new EmptyCodegenContext();
+
+    @Test
+    void nestedAnnotationsIncludeDeepGenericTypeArgumentAnnotations() {
+        TypeName mapType = TypeName.builder(TypeNames.MAP)
+                .addTypeArgument(TypeNames.STRING)
+                .addTypeArgument(TypeName.builder(TypeNames.LIST)
+                                         .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                                                  .addAnnotation(Annotation.create(NOT_BLANK))
+                                                                  .build())
+                                         .build())
+                .build();
+        TypeInfo typeInfo = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.NestedContract"))
+                .kind(ElementKind.INTERFACE)
+                .addElementInfo(TypedElementInfo.builder()
+                                        .kind(ElementKind.METHOD)
+                                        .elementName("validate")
+                                        .typeName(TypeNames.PRIMITIVE_VOID)
+                                        .addParameterArgument(TypedElementInfo.builder()
+                                                                      .kind(ElementKind.PARAMETER)
+                                                                      .elementName("value")
+                                                                      .typeName(mapType)
+                                                                      .build())
+                                        .build())
+                .build();
+
+        assertThat(TypeHierarchy.nestedAnnotations(CTX, typeInfo), hasItem(NOT_BLANK));
+    }
+
+    @Test
+    void typeNameAnnotationsIncludeWildcardBoundsAndArrayComponents() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName directAnnotatedType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(notBlank)
+                .build();
+        TypeName upperBoundType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(notBlank)
+                                                        .build())
+                                         .build())
+                .build();
+        TypeName lowerBoundType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(notBlank)
+                                                        .build())
+                                         .build())
+                .build();
+        TypeName componentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(notBlank)
+                .build();
+        TypeName arrayType = TypeName.builder(TypeNames.STRING)
+                .array(true)
+                .componentType(componentType)
+                .build();
+
+        assertThat(TypeHierarchy.typeNameAnnotations(directAnnotatedType), hasItem(notBlank));
+        assertThat(TypeHierarchy.typeNameAnnotations(upperBoundType), hasItem(notBlank));
+        assertThat(TypeHierarchy.typeNameAnnotations(lowerBoundType), hasItem(notBlank));
+        assertThat(TypeHierarchy.typeNameAnnotations(arrayType), hasItem(notBlank));
+    }
+
+    @Test
+    void mergeHierarchyAnnotationsIncludesContractTypeUseAnnotations() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName annotatedList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(notBlank)
+                                         .build())
+                .build();
+        TypeName plainList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeNames.STRING)
+                .build();
+        TypedElementInfo contractMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PUBLIC)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(annotatedList)
+                                              .build())
+                .build();
+        TypeInfo contract = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.Contract"))
+                .kind(ElementKind.INTERFACE)
+                .addElementInfo(contractMethod)
+                .build();
+        TypedElementInfo implementationMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PUBLIC)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(plainList)
+                                              .build())
+                .build();
+        TypeInfo implementation = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.Implementation"))
+                .kind(ElementKind.CLASS)
+                .addInterfaceTypeInfo(contract)
+                .addElementInfo(implementationMethod)
+                .build();
+
+        TypedElementInfo merged = TypeHierarchy.mergeHierarchyAnnotations(implementation, implementationMethod);
+
+        TypeName mergedType = merged.parameterArguments().getFirst().typeName();
+        assertThat(mergedType.typeArguments().getFirst().annotations(), hasItem(notBlank));
+        assertThat(TypeHierarchy.nestedAnnotations(CTX, implementation), hasItem(NOT_BLANK));
+    }
+
+    @Test
+    void nestedAnnotationsDoNotMergeHierarchyAnnotationsIntoGeneratedTypes() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName annotatedList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(notBlank)
+                                         .build())
+                .build();
+        TypeName plainList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeNames.STRING)
+                .build();
+        TypedElementInfo serviceMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PACKAGE_PRIVATE)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(annotatedList)
+                                              .build())
+                .build();
+        TypeInfo service = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.ValidatedService"))
+                .kind(ElementKind.CLASS)
+                .addElementInfo(serviceMethod)
+                .build();
+        TypedElementInfo generatedMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PACKAGE_PRIVATE)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(plainList)
+                                              .build())
+                .build();
+        TypeInfo generatedSubtype = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.ValidatedService__Intercepted"))
+                .kind(ElementKind.CLASS)
+                .superTypeInfo(service)
+                .addAnnotation(Annotation.create(TypeNames.GENERATED))
+                .addElementInfo(generatedMethod)
+                .build();
+
+        Set<TypeName> annotations = TypeHierarchy.nestedAnnotations(CTX, generatedSubtype);
+
+        assertThat(annotations, hasItem(TypeNames.GENERATED));
+        assertThat(annotations, not(hasItem(NOT_BLANK)));
+    }
+
+    @Test
+    void mergeTypeNameAnnotationsPreservesTargetStructure() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        Annotation targetAnnotation = Annotation.create(TypeName.create("io.helidon.TargetAnnotation"));
+        TypeName targetComponentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(targetAnnotation)
+                .build();
+        TypeName sourceComponentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(notBlank)
+                .build();
+        TypeName targetType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(targetAnnotation)
+                                                        .build())
+                                         .build())
+                .array(true)
+                .componentType(targetComponentType)
+                .build();
+        TypeName sourceType = TypeName.builder(TypeNames.LIST)
+                .addAnnotation(notBlank)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(notBlank)
+                                                        .build())
+                                         .build())
+                .array(true)
+                .componentType(sourceComponentType)
+                .build();
+
+        TypeName merged = TypeHierarchy.mergeTypeNameAnnotations(targetType, sourceType);
+
+        assertThat(merged.annotations(), hasItem(notBlank));
+        assertThat(merged.typeArguments().getFirst().upperBounds().getFirst().annotations(), hasItem(notBlank));
+        assertThat(merged.componentType().orElseThrow().annotations(), hasItem(notBlank));
+        assertThat(merged.componentType().orElseThrow().annotations(), hasItem(targetAnnotation));
+
+        TypeName lowerBoundTargetType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(targetAnnotation)
+                                                        .build())
+                                         .build())
+                .build();
+        TypeName lowerBoundSourceType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(notBlank)
+                                                        .build())
+                                         .build())
+                .build();
+
+        TypeName lowerBoundMerged = TypeHierarchy.mergeTypeNameAnnotations(lowerBoundTargetType, lowerBoundSourceType);
+
+        assertThat(lowerBoundMerged.typeArguments().getFirst().lowerBounds().getFirst().annotations(), hasItem(notBlank));
+
+        TypeName varargTargetType = TypeName.builder(TypeNames.STRING)
+                .array(true)
+                .vararg(true)
+                .componentType(TypeNames.STRING)
+                .build();
+        TypeName arraySourceType = TypeName.builder(TypeNames.STRING)
+                .array(true)
+                .componentType(TypeName.builder(TypeNames.STRING)
+                                       .addAnnotation(notBlank)
+                                       .build())
+                .build();
+
+        TypeName varargMerged = TypeHierarchy.mergeTypeNameAnnotations(varargTargetType, arraySourceType);
+
+        assertThat(varargMerged.vararg(), is(true));
+        assertThat(varargMerged.componentType().orElseThrow().annotations(), hasItem(notBlank));
+
+        TypeName rawList = TypeNames.LIST;
+        TypeName mergedRawList = TypeHierarchy.mergeTypeNameAnnotations(rawList, sourceType);
+        assertThat(mergedRawList.typeArguments().isEmpty(), is(true));
+        assertThat(mergedRawList.componentType().isEmpty(), is(true));
+        assertThat(mergedRawList.annotations(), not(hasItem(notBlank)));
+
+        TypeName mismatchedTargetType = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.create("io.helidon.codegen.Foo"))
+                                         .build())
+                .build();
+        TypeName mismatchedSourceType = TypeName.builder(TypeNames.LIST)
+                .addAnnotation(notBlank)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addAnnotation(notBlank)
+                                         .addUpperBound(TypeName.create("io.helidon.codegen.Bar"))
+                                         .build())
+                .build();
+
+        TypeName mismatchedMerged = TypeHierarchy.mergeTypeNameAnnotations(mismatchedTargetType, mismatchedSourceType);
+
+        assertThat(mismatchedMerged.annotations(), not(hasItem(notBlank)));
+        assertThat(mismatchedMerged.typeArguments().getFirst().annotations(), not(hasItem(notBlank)));
+    }
+
+    @Test
+    void mergeTypeNameAnnotationsKeepsTargetAnnotationValueForSameAnnotationType() {
+        TypeName annotationType = TypeName.create("io.helidon.codegen.Annotation");
+        Annotation targetAnnotation = Annotation.create(annotationType, "target");
+        Annotation sourceAnnotation = Annotation.create(annotationType, "source");
+        TypeName targetType = TypeName.builder(TypeNames.LIST)
+                .addAnnotation(targetAnnotation)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(targetAnnotation)
+                                         .build())
+                .build();
+        TypeName sourceType = TypeName.builder(TypeNames.LIST)
+                .addAnnotation(sourceAnnotation)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(sourceAnnotation)
+                                         .build())
+                .build();
+
+        TypeName merged = TypeHierarchy.mergeTypeNameAnnotations(targetType, sourceType);
+
+        assertThat(merged.annotations(), hasItem(targetAnnotation));
+        assertThat(merged.annotations(), not(hasItem(sourceAnnotation)));
+        assertThat(merged.typeArguments().getFirst().annotations(), hasItem(targetAnnotation));
+        assertThat(merged.typeArguments().getFirst().annotations(), not(hasItem(sourceAnnotation)));
+    }
+
+    @Test
+    void mergeTypeNameAnnotationsIgnoresFormalTypeParameterNames() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName targetType = TypeName.builder(TypeNames.LIST)
+                .addTypeParameter("T")
+                .addTypeArgument(TypeNames.STRING)
+                .build();
+        TypeName sourceType = TypeName.builder(TypeNames.LIST)
+                .addTypeParameter("E")
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addAnnotation(notBlank)
+                                         .build())
+                .build();
+
+        TypeName merged = TypeHierarchy.mergeTypeNameAnnotations(targetType, sourceType);
+
+        assertThat(merged.typeParameters(), is(List.of("T")));
+        assertThat(merged.typeArguments().getFirst().annotations(), hasItem(notBlank));
+    }
+
+    private static final class EmptyCodegenContext implements CodegenContext {
+        @Override
+        public Optional<ModuleInfo> module() {
+            return Optional.empty();
+        }
+
+        @Override
+        public CodegenFiler filer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CodegenLogger logger() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CodegenScope scope() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CodegenOptions options() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<TypeInfo> typeInfo(TypeName typeName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<TypeInfo> typeInfo(TypeName typeName, Predicate<TypedElementInfo> elementPredicate) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<ElementMapper> elementMappers() {
+            return List.of();
+        }
+
+        @Override
+        public List<TypeMapper> typeMappers() {
+            return List.of();
+        }
+
+        @Override
+        public List<AnnotationMapper> annotationMappers() {
+            return List.of();
+        }
+
+        @Override
+        public Set<TypeName> mapperSupportedAnnotations() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<String> mapperSupportedAnnotationPackages() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<Option<?>> supportedOptions() {
+            return Set.of();
+        }
+
+        @Override
+        public String uniqueName(TypeInfo typeInfo, TypedElementInfo elementInfo) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -163,6 +163,68 @@ class TypeHierarchyTest {
     }
 
     @Test
+    void mergeHierarchyAnnotationsIncludesGenericContractTypeUseAnnotations() {
+        Annotation notBlank = Annotation.create(NOT_BLANK);
+        TypeName typeVariable = TypeName.createFromGenericDeclaration("T");
+        TypeName contractType = TypeName.create("io.helidon.codegen.test.GenericContract");
+        TypeName declaredContract = TypeName.builder(contractType)
+                .addTypeParameter("T")
+                .addTypeArgument(typeVariable)
+                .build();
+        TypeName implementedContract = TypeName.builder(contractType)
+                .addTypeArgument(TypeNames.STRING)
+                .build();
+        TypeName annotatedList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder(typeVariable)
+                                         .addAnnotation(notBlank)
+                                         .build())
+                .build();
+        TypeName plainList = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeNames.STRING)
+                .build();
+        TypedElementInfo contractMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PUBLIC)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(annotatedList)
+                                              .build())
+                .build();
+        TypeInfo contract = TypeInfo.builder()
+                .typeName(implementedContract)
+                .declaredType(declaredContract)
+                .kind(ElementKind.INTERFACE)
+                .addElementInfo(contractMethod)
+                .build();
+        TypedElementInfo implementationMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PUBLIC)
+                .elementName("validate")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(plainList)
+                                              .build())
+                .build();
+        TypeInfo implementation = TypeInfo.builder()
+                .typeName(TypeName.create("io.helidon.codegen.test.GenericImplementation"))
+                .kind(ElementKind.CLASS)
+                .addInterfaceTypeInfo(contract)
+                .addElementInfo(implementationMethod)
+                .build();
+
+        TypedElementInfo merged = TypeHierarchy.mergeHierarchyAnnotations(implementation, implementationMethod);
+
+        TypeName mergedType = merged.parameterArguments().getFirst().typeName();
+        assertThat(mergedType.typeArguments().getFirst().annotations(), hasItem(notBlank));
+        assertThat(TypeHierarchy.nestedAnnotations(CTX, implementation), hasItem(NOT_BLANK));
+    }
+
+    @Test
     void nestedAnnotationsDoNotMergeHierarchyAnnotationsIntoGeneratedTypes() {
         Annotation notBlank = Annotation.create(NOT_BLANK);
         TypeName annotatedList = TypeName.builder(TypeNames.LIST)

--- a/codegen/tests/test-codegen-use/pom.xml
+++ b/codegen/tests/test-codegen-use/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>helidon-codegen-class-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/codegen/tests/test-codegen-use/src/main/java/module-info.java
+++ b/codegen/tests/test-codegen-use/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 module io.helidon.codegen.tests.codegen.use {
+    requires java.compiler;
     requires io.helidon.common;
     requires io.helidon.common.types;
 }

--- a/codegen/tests/test-codegen-use/src/test/java/io/helidon/codegen/test/codegen/use/TypeNameContentCodegenTest.java
+++ b/codegen/tests/test-codegen-use/src/test/java/io/helidon/codegen/test/codegen/use/TypeNameContentCodegenTest.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen.test.codegen.use;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Builder;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TypeNameContentCodegenTest {
+    private static final String PACKAGE_NAME = "io.helidon.codegen.test.codegen.use.generated";
+    private static final String PACKAGE_PATH = PACKAGE_NAME.replace('.', '/');
+
+    @Test
+    void testAnnotatedNestedTypeNameCompiles() throws IOException, ReflectiveOperationException {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .property("value", "quoted \" backslash \\ tab \t\nblock \"\"\" end")
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.MAP)
+                .addTypeArgument(TypeNames.STRING)
+                .addTypeArgument(TypeName.builder(TypeNames.MAP)
+                                         .addTypeArgument(TypeNames.STRING)
+                                         .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                                                  .addAnnotation(annotation)
+                                                                  .build())
+                                         .build())
+                .build();
+
+        GeneratedModel model = typeNameModel("NestedTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
+        String source = generatedSource(result, "NestedTypeName");
+
+        assertThat(source, not(containsString("TypeName.create(\"java.util.Map<java.lang.String,")));
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"Map\")",
+                              ".addTypeArgument(TypeName.create(\"java.lang.String\"))",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"Map\")",
+                              ".addTypeArgument(TypeName.create(\"java.lang.String\"))",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addAnnotation(Annotation.builder()",
+                              ".typeName(TypeName.create(\"io.helidon.RandomAnnotation\"))",
+                              ".property(\"value\", \"quoted \\\" backslash \\\\ tab \\t\\nblock \\\"\\\"\\\" end\")",
+                              ".build()");
+        assertClassGenerated(result, "NestedTypeName");
+
+        TypeName generatedTypeName = generatedTypeName(result, "NestedTypeName");
+        assertThat(generatedTypeName.typeArguments()
+                           .get(1)
+                           .typeArguments()
+                           .get(1)
+                           .annotations(),
+                   hasItem(annotation));
+    }
+
+    @Test
+    void testAnnotatedBoundTypeNameCompiles() throws IOException, ReflectiveOperationException {
+        Annotation annotation = randomAnnotation();
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addUpperBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(annotation)
+                                                        .build())
+                                         .build())
+                .build();
+
+        GeneratedModel model = typeNameModel("BoundTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
+        String source = generatedSource(result, "BoundTypeName");
+
+        assertThat(source, not(containsString("TypeName.create(\"java.util.List<? extends")));
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"List\")",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".wildcard(true)",
+                              ".addUpperBound(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addAnnotation(Annotation.create(TypeName.create(\"io.helidon.RandomAnnotation\")))",
+                              ".build()");
+        assertClassGenerated(result, "BoundTypeName");
+
+        TypeName generatedTypeName = generatedTypeName(result, "BoundTypeName");
+        assertThat(generatedTypeName.typeArguments()
+                           .getFirst()
+                           .upperBounds()
+                           .getFirst()
+                           .annotations(),
+                   hasItem(annotation));
+    }
+
+    @Test
+    void testAnnotatedLowerBoundTypeNameCompiles() throws IOException, ReflectiveOperationException {
+        Annotation annotation = randomAnnotation();
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder()
+                                         .className("?")
+                                         .wildcard(true)
+                                         .addLowerBound(TypeName.builder(TypeNames.STRING)
+                                                        .addAnnotation(annotation)
+                                                        .build())
+                                         .build())
+                .build();
+
+        GeneratedModel model = typeNameModel("LowerBoundTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
+        String source = generatedSource(result, "LowerBoundTypeName");
+
+        assertThat(source, not(containsString("TypeName.create(\"java.util.List<? super")));
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"List\")",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".wildcard(true)",
+                              ".addLowerBound(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addAnnotation(Annotation.create(TypeName.create(\"io.helidon.RandomAnnotation\")))",
+                              ".build()");
+        assertClassGenerated(result, "LowerBoundTypeName");
+
+        TypeName generatedTypeName = generatedTypeName(result, "LowerBoundTypeName");
+        assertThat(generatedTypeName.typeArguments()
+                           .getFirst()
+                           .lowerBounds()
+                           .getFirst()
+                           .annotations(),
+                   hasItem(annotation));
+    }
+
+    @Test
+    void testAnnotatedComponentTypeNameCompiles() throws IOException, ReflectiveOperationException {
+        Annotation annotation = randomAnnotation();
+        TypeName componentType = TypeName.builder(TypeNames.STRING)
+                .addAnnotation(annotation)
+                .build();
+        TypeName typeName = TypeName.builder(TypeNames.STRING)
+                .array(true)
+                .componentType(componentType)
+                .build();
+
+        GeneratedModel model = typeNameModel("ComponentTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
+        String source = generatedSource(result, "ComponentTypeName");
+
+        assertThat(source, not(containsString("TypeName.create(\"java.lang.String[]")));
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".array(true)",
+                              ".componentType(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addAnnotation(Annotation.create(TypeName.create(\"io.helidon.RandomAnnotation\")))",
+                              ".build()");
+        assertClassGenerated(result, "ComponentTypeName");
+
+        TypeName generatedTypeName = generatedTypeName(result, "ComponentTypeName");
+        assertThat(generatedTypeName.componentType().orElseThrow().annotations(), hasItem(annotation));
+    }
+
+    @Test
+    void testInheritedAnnotatedTypeNameCompiles() throws IOException, ReflectiveOperationException {
+        Annotation annotation = randomAnnotation();
+        TypeName typeName = TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(TypeName.builder(TypeNames.STRING)
+                                         .addInheritedAnnotation(annotation)
+                                         .build())
+                .build();
+
+        GeneratedModel model = typeNameModel("InheritedTypeName", typeName);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
+        String source = generatedSource(result, "InheritedTypeName");
+
+        assertContainsInOrder(source,
+                              "return TypeName.builder()",
+                              ".packageName(\"java.util\")",
+                              ".className(\"List\")",
+                              ".addTypeArgument(TypeName.builder()",
+                              ".packageName(\"java.lang\")",
+                              ".className(\"String\")",
+                              ".addInheritedAnnotation(Annotation.create(TypeName.create(\"io.helidon.RandomAnnotation\")))",
+                              ".build()");
+        assertClassGenerated(result, "InheritedTypeName");
+
+        TypeName generatedTypeName = generatedTypeName(result, "InheritedTypeName");
+        TypeName generatedTypeArgument = generatedTypeName.typeArguments().getFirst();
+        assertThat(generatedTypeArgument.annotations(), not(hasItem(annotation)));
+        assertThat(generatedTypeArgument.inheritedAnnotations(), hasItem(annotation));
+    }
+
+    @Test
+    void testTypedElementEnclosingTypeCompiles() throws IOException {
+        TypeName enclosingType = TypeName.create("io.helidon.codegen.classmodel.EnclosingType");
+        TypedElementInfo elementInfo = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("method")
+                .typeName(TypeNames.STRING)
+                .enclosingType(enclosingType)
+                .build();
+
+        GeneratedModel model = typedElementModel("ElementInfo", elementInfo);
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(new ContentProcessor(model))
+                .addClasspath(List.of(Builder.class,
+                                      Prototype.class,
+                                      Annotation.class,
+                                      ElementKind.class,
+                                      TypeName.class,
+                                      TypedElementInfo.class))
+                .printDiagnostics(false)
+                .addSource("io/helidon/codegen/test/codegen/use/generated/Trigger.java", """
+                        package io.helidon.codegen.test.codegen.use.generated;
+
+                        final class Trigger {
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(String.join("\n", result.diagnostics()), result.success(), is(true));
+        String source = generatedSource(result, "ElementInfo");
+
+        assertThat(source, containsString(".enclosingType(TypeName.create(\"" + enclosingType.fqName() + "\"))"));
+        assertClassGenerated(result, "ElementInfo");
+    }
+
+    private static Annotation randomAnnotation() {
+        return Annotation.builder()
+                .typeName(TypeName.create("io.helidon.RandomAnnotation"))
+                .build();
+    }
+
+    private static GeneratedModel typeNameModel(String className, TypeName typeName) {
+        ClassModel classModel = ClassModel.builder()
+                .packageName(PACKAGE_NAME)
+                .name(className)
+                .addMethod(method -> method
+                        .isStatic(true)
+                        .name("create")
+                        .returnType(TypeName.create(TypeName.class))
+                        .addContent("return ")
+                        .addContentCreate(typeName)
+                        .addContentLine(";"))
+                .build();
+        return new GeneratedModel(className, classModel);
+    }
+
+    private static GeneratedModel typedElementModel(String className, TypedElementInfo elementInfo) {
+        ClassModel classModel = ClassModel.builder()
+                .packageName(PACKAGE_NAME)
+                .name(className)
+                .addMethod(method -> method
+                        .isStatic(true)
+                        .name("create")
+                        .returnType(TypeName.create(TypedElementInfo.class))
+                        .addContent("return ")
+                        .addContentCreate(elementInfo)
+                        .addContentLine(";"))
+                .build();
+        return new GeneratedModel(className, classModel);
+    }
+
+    private static String generatedSource(TestCompiler.Result result, String className) throws IOException {
+        Path generatedSource = result.sourceOutput().resolve(PACKAGE_PATH + "/" + className + ".java");
+        assertThat("Generated source should exist: " + generatedSource, Files.exists(generatedSource), is(true));
+        return Files.readString(generatedSource);
+    }
+
+    private static void assertClassGenerated(TestCompiler.Result result, String className) {
+        assertThat(Files.exists(result.classOutput().resolve(PACKAGE_PATH + "/" + className + ".class")), is(true));
+    }
+
+    private static TypeName generatedTypeName(TestCompiler.Result result, String className)
+            throws IOException, ReflectiveOperationException {
+        URL[] urls = {result.classOutput().toUri().toURL()};
+        try (URLClassLoader classLoader = new URLClassLoader(urls, TypeNameContentCodegenTest.class.getClassLoader())) {
+            Class<?> generatedClass = Class.forName(PACKAGE_NAME + "." + className, true, classLoader);
+            return (TypeName) generatedClass.getMethod("create").invoke(null);
+        }
+    }
+
+    private static void assertContainsInOrder(String source, String... fragments) {
+        int previous = -1;
+        for (String fragment : fragments) {
+            int current = source.indexOf(fragment, previous + 1);
+            assertThat("Missing fragment after index " + previous + ": " + fragment, current > previous, is(true));
+            previous = current;
+        }
+    }
+
+    private record GeneratedModel(String className, ClassModel classModel) {
+    }
+
+    private static final class ContentProcessor extends AbstractProcessor {
+        private final GeneratedModel model;
+        private boolean processed;
+
+        private ContentProcessor(GeneratedModel model) {
+            this.model = model;
+        }
+
+        @Override
+        public Set<String> getSupportedAnnotationTypes() {
+            return Set.of("*");
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            if (processed || roundEnv.processingOver()) {
+                return false;
+            }
+            processed = true;
+            try {
+                var sourceFile = processingEnv.getFiler()
+                        .createSourceFile(PACKAGE_NAME + "." + model.className());
+                try (Writer writer = sourceFile.openWriter()) {
+                    model.classModel().write(writer);
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            return false;
+        }
+    }
+}

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/DelegatedClassInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/DelegatedClassInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,9 @@ class DelegatedClassInterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.DelegatedClass::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/DelegatingInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/DelegatingInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,9 @@ class DelegatingInterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.DelegatedContract::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/ExternallyDelegatedClassInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/ExternallyDelegatedClassInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,9 @@ class ExternallyDelegatedClassInterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.ExternallyDelegatedClass::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/InterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/InterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,9 @@ class InterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.TheService::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/InterfaceInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/InterfaceInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,9 @@ class InterfaceInterceptionTest {
     void testRepeatWithNoExceptionThrownFromTarget() {
         InterceptionException e = assertThrows(InterceptionException.class,
                                                () -> service.intercepted("hello", false, true, false));
-        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: java.lang.String intercepted"));
+        assertThat(e.getMessage(), startsWith("Duplicate invocation, or unknown call type: "
+                                                      + "io.helidon.service.tests.interception.TheOtherService::"
+                                                      + "java.lang.String intercepted"));
         assertThat(e.targetWasCalled(), is(true));
     }
 


### PR DESCRIPTION
Resolves #11869

Forward-port of #11870 from the 4.x line.

Summary:
- preserve nested type-use annotations when discovering and merging TypeName metadata across type arguments, wildcard bounds, and array component types
- emit builder-based TypeName construction when nested annotations must be preserved
- use faithful string literal escaping for generated annotation values and include typed-element enclosing type metadata
- add focused TypeHierarchy and compile-through TypeName codegen coverage
