### PR TITLE
Fix service registry codegen for interface-contract validation (4.x)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -17,7 +17,10 @@
 package io.helidon.declarative.codegen.validation;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -74,8 +77,16 @@ class InterceptorGenerator {
             // ignore annotations, these are good
             return;
         }
+        if (factoryInterceptionWrapper(type)) {
+            // The original factory provider owns the element interceptors used by the generated wrapper.
+            return;
+        }
 
         if (!isService(type)) {
+            if (hasOnlyNonPrivateInterfaceMethodValidation(type)) {
+                // Interface method constraints are validated by interceptors generated for service implementations.
+                return;
+            }
             if (!type.hasAnnotation(VALIDATION_VALIDATED)) {
                 throw new CodegenException(VALIDATION_VALIDATED.fqName()
                                                    + " annotation is required on non-service type that has constraints "
@@ -123,14 +134,50 @@ class InterceptorGenerator {
         }
 
         // and finally annotated methods
+        Set<String> generatedMethodTargets = new HashSet<>();
         type.elementInfo()
                 .stream()
                 .filter(ElementInfoPredicates::isMethod)
                 .filter(Predicate.not(ElementInfoPredicates::isPrivate))
                 .filter(Predicate.not(ElementInfoPredicates::isStatic))
                 .forEach(element -> {
-                    generateInterceptor(type, interceptorCounter, element, "METHOD");
+                    String target = type.typeName().fqName() + "." + element.signature().text();
+                    if (generatedMethodTargets.contains(target)) {
+                        return;
+                    }
+                    if (generateInterceptor(type, interceptorCounter, element, "METHOD")) {
+                        generatedMethodTargets.add(target);
+                    }
                 });
+    }
+
+    private boolean factoryInterceptionWrapper(TypeInfo type) {
+        return type.superTypeInfo()
+                .map(TypeInfo::typeName)
+                .map(TypeName::genericTypeName)
+                .filter(it -> it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY)
+                        || it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY)
+                        || it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SERVICES_FACTORY)
+                        || it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_IP_FACTORY)
+                        || it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_QUALIFIED_FACTORY))
+                .isPresent();
+    }
+
+    private boolean hasOnlyNonPrivateInterfaceMethodValidation(TypeInfo type) {
+        if (type.kind() != ElementKind.INTERFACE) {
+            return false;
+        }
+
+        List<TypedElementInfo> elementsWithValidation = type.elementInfo()
+                .stream()
+                .filter(it -> ValidationHelper.needsWork(constraintAnnotations, it))
+                .toList();
+
+        return !elementsWithValidation.isEmpty()
+                && elementsWithValidation.stream()
+                .allMatch(it -> ElementInfoPredicates.isMethod(it)
+                        && !ElementInfoPredicates.isPrivate(it)
+                        && !ElementInfoPredicates.isStatic(it));
     }
 
     private boolean isService(TypeInfo type) {
@@ -138,7 +185,15 @@ class InterceptorGenerator {
         if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER)) {
             return true;
         }
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE)) {
+            return true;
+        }
         if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE)) {
+            return true;
+        }
+        if (type.elementInfo()
+                .stream()
+                .anyMatch(ElementInfoPredicates.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT))) {
             return true;
         }
         for (Annotation annotation : type.annotations()) {
@@ -152,12 +207,12 @@ class InterceptorGenerator {
         return false;
     }
 
-    private void generateInterceptor(TypeInfo interceptedType,
-                                     AtomicInteger interceptorCounter,
-                                     TypedElementInfo element,
-                                     String location) {
+    private boolean generateInterceptor(TypeInfo interceptedType,
+                                        AtomicInteger interceptorCounter,
+                                        TypedElementInfo element,
+                                        String location) {
         if (!ValidationHelper.needsWork(constraintAnnotations, element)) {
-            return;
+            return false;
         }
 
         TypeName typeName = interceptedType.typeName();
@@ -285,6 +340,7 @@ class InterceptorGenerator {
         classModel.addConstructor(constructor);
         classModel.addMethod(proceedMethod.addContentLine());
         roundContext.addGeneratedType(generatedType, classModel, GENERATOR);
+        return true;
     }
 
     private void addValidators(TypeName generatedType,

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -141,7 +141,7 @@ class InterceptorGenerator {
                 .filter(Predicate.not(ElementInfoPredicates::isPrivate))
                 .filter(Predicate.not(ElementInfoPredicates::isStatic))
                 .forEach(element -> {
-                    String target = type.typeName().fqName() + "." + element.signature().text();
+                    String target = elementTarget(type, element);
                     if (generatedMethodTargets.contains(target)) {
                         return;
                     }
@@ -167,6 +167,9 @@ class InterceptorGenerator {
         if (type.kind() != ElementKind.INTERFACE) {
             return false;
         }
+        if (!type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_CONTRACT)) {
+            return false;
+        }
 
         List<TypedElementInfo> elementsWithValidation = type.elementInfo()
                 .stream()
@@ -183,6 +186,9 @@ class InterceptorGenerator {
     private boolean isService(TypeInfo type) {
         // must be annotated with @Service.Provider, or @Service.Scope
         if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER)) {
+            return true;
+        }
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_DESCRIBE)) {
             return true;
         }
         if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE)) {
@@ -229,7 +235,7 @@ class InterceptorGenerator {
                 .addAnnotation(DeclarativeTypes.SINGLETON_ANNOTATION)
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                 .addAnnotation(Annotation.create(ServiceCodegenTypes.SERVICE_ANNOTATION_NAMED,
-                                                 typeName.fqName() + "." + element.signature().text()))
+                                                 elementTarget(interceptedType, element)))
                 .addInterface(ServiceCodegenTypes.INTERCEPTION_ELEMENT_INTERCEPTOR);
 
         Constructor.Builder constructor = Constructor.builder()
@@ -384,5 +390,11 @@ class InterceptorGenerator {
                                      localVariableName);
 
         proceedMethod.addContentLine("}");
+    }
+
+    private String elementTarget(TypeInfo type, TypedElementInfo element) {
+        return element.enclosingType()
+                .orElse(type.typeName())
+                .fqName() + "." + element.signature().text();
     }
 }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.declarative.codegen.validation;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
@@ -40,7 +41,10 @@ class ValidationExtension implements RegistryCodegenExtension {
         // we want both, as we must not add interceptors to types that are marked as validated
         // also constraints are valid (outside validated types) only on interceptable services
         Collection<TypeInfo> validated = roundContext.annotatedTypes(ValidationTypes.VALIDATION_VALIDATED);
-        Collection<TypeName> constraintAnnotations = roundContext.annotatedAnnotations(VALIDATION_CONSTRAINT);
+        Collection<TypeName> constraintAnnotations = roundContext.annotatedAnnotations(VALIDATION_CONSTRAINT)
+                .stream()
+                .filter(this::isConstraintAnnotation)
+                .toList();
 
         var validatedGenerator = new ValidatedTypeGenerator(roundContext, constraintAnnotations);
         for (TypeInfo validate : validated) {
@@ -51,5 +55,16 @@ class ValidationExtension implements RegistryCodegenExtension {
         for (TypeInfo type : roundContext.types()) {
             interceptorGenerator.process(type);
         }
+    }
+
+    private boolean isConstraintAnnotation(TypeName typeName) {
+        return roundContextTypeInfo(typeName)
+                .map(it -> it.hasAnnotation(VALIDATION_CONSTRAINT))
+                .orElse(true);
+    }
+
+    private Optional<TypeInfo> roundContextTypeInfo(TypeName typeName) {
+        return ctx.typeInfo(typeName)
+                .or(() -> ctx.typeInfo(typeName.genericTypeName()));
     }
 }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtensionProvider.java
@@ -56,6 +56,11 @@ public class ValidationExtensionProvider implements RegistryCodegenExtensionProv
     }
 
     @Override
+    public boolean supportsServiceContractAnnotations() {
+        return true;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new ValidationExtension(codegenContext);
     }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -122,6 +122,96 @@ public class ValidationCodegenTest {
     }
 
     @Test
+    void testServiceContractConstraintGeneratesInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        assertThat(Files.exists(result.sourceOutput().resolve("com/example/DefaultApiImpl__Validated.java")),
+                   is(false));
+
+        var content = Files.readString(interceptor, StandardCharsets.UTF_8);
+        assertThat(content, containsString("\"com.example.DefaultApiImpl.validate(java.lang.String)\""));
+        assertThat(content, containsString("validation__ctx.check("));
+    }
+
+    @Test
+    void testValidatedServiceContractDoesNotMarkImplementationAsValidated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        @Validation.Validated
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java")),
+                   is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApiImpl__Validated.java")),
+                   is(false));
+    }
+
+    @Test
     void testPrivateFieldValidation() throws IOException {
         var result = TestCompiler.builder()
                 .currentRelease()

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -24,8 +24,11 @@ import java.util.List;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.apt.AptProcessor;
 import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.GenericType;
 import io.helidon.common.Generated;
 import io.helidon.common.types.Annotation;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
@@ -42,6 +45,9 @@ public class ValidationCodegenTest {
             Generated.class,
             Validation.Constraint.class,
             Annotation.class,
+            GenericType.class,
+            Lookup.class,
+            Qualifier.class,
             Service.class,
             Prototype.class
     );
@@ -168,6 +174,225 @@ public class ValidationCodegenTest {
     }
 
     @Test
+    void testDescribeServiceContractConstraintGeneratesInterceptor() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DescribedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Describe
+                        class DescribedApi implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DescribedApi__ValidationInterceptor_0.java")),
+                   is(true));
+    }
+
+    @Test
+    void testSupplierProvidedContractSameSignatureGeneratesInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface ProvidedApi {
+                            @Validation.String.NotBlank
+                            String get();
+                        }
+                        """)
+                .addSource("ProvidedApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class ProvidedApiSupplier implements Supplier<ProvidedApi> {
+                            @Override
+                            public ProvidedApi get() {
+                                return () -> "value";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/ProvidedApiSupplier__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        assertThat(Files.readString(interceptor, StandardCharsets.UTF_8),
+                   containsString("\"com.example.ProvidedApi.get()\""));
+    }
+
+    @Test
+    void testInjectionPointFactoryDelegateKeepsCustomizedFirst() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("IpProvidedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface IpProvidedApi {
+                            @Validation.String.NotBlank
+                            String value();
+                        }
+                        """)
+                .addSource("IpProvider.java", """
+                        package com.example;
+
+                        import java.util.List;
+                        import java.util.Optional;
+
+                        import io.helidon.service.registry.Lookup;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        class IpProvider implements Service.InjectionPointFactory<IpProvidedApi> {
+                            @Override
+                            public Optional<Service.QualifiedInstance<IpProvidedApi>> first(Lookup lookup) {
+                                return Optional.of(Service.QualifiedInstance.create(() -> "first"));
+                            }
+
+                            @Override
+                            @Validation.Collection.Size(min = 1)
+                            public List<Service.QualifiedInstance<IpProvidedApi>> list(Lookup lookup) {
+                                return List.of(Service.QualifiedInstance.create(() -> "list"));
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var wrapper = result.sourceOutput().resolve("com/example/IpProvider__Interception_Wrapper.java");
+        assertThat(Files.exists(wrapper), is(true));
+        assertThat(Files.readString(wrapper, StandardCharsets.UTF_8),
+                   containsString("return helidonInject__delegate.first(lookup);"));
+    }
+
+    @Test
+    void testQualifiedFactoryDelegateKeepsCustomizedFirst() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("TestQualifier.java", """
+                        package com.example;
+
+                        import java.lang.annotation.ElementType;
+                        import java.lang.annotation.Retention;
+                        import java.lang.annotation.RetentionPolicy;
+                        import java.lang.annotation.Target;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Qualifier
+                        @Retention(RetentionPolicy.CLASS)
+                        @Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.FIELD})
+                        public @interface TestQualifier {
+                            String value() default "";
+                        }
+                        """)
+                .addSource("QualifiedProvidedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface QualifiedProvidedApi {
+                            @Validation.String.NotBlank
+                            String value();
+                        }
+                        """)
+                .addSource("QualifiedProvider.java", """
+                        package com.example;
+
+                        import java.util.List;
+                        import java.util.Optional;
+
+                        import io.helidon.common.GenericType;
+                        import io.helidon.service.registry.Lookup;
+                        import io.helidon.service.registry.Qualifier;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        @TestQualifier("first")
+                        class QualifiedProvider implements Service.QualifiedFactory<QualifiedProvidedApi, TestQualifier> {
+                            @Override
+                            public Optional<Service.QualifiedInstance<QualifiedProvidedApi>> first(
+                                    Qualifier qualifier,
+                                    Lookup lookup,
+                                    GenericType<QualifiedProvidedApi> type) {
+                                return Optional.of(Service.QualifiedInstance.create(() -> "first", qualifier));
+                            }
+
+                            @Override
+                            @Validation.Collection.Size(min = 1)
+                            public List<Service.QualifiedInstance<QualifiedProvidedApi>> list(
+                                    Qualifier qualifier,
+                                    Lookup lookup,
+                                    GenericType<QualifiedProvidedApi> type) {
+                                return List.of(Service.QualifiedInstance.create(() -> "list", qualifier));
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var wrapper = result.sourceOutput().resolve("com/example/QualifiedProvider__Interception_Wrapper.java");
+        assertThat(Files.exists(wrapper), is(true));
+        assertThat(Files.readString(wrapper, StandardCharsets.UTF_8),
+                   containsString("return helidonInject__delegate.first(qualifier, lookup, type);"));
+    }
+
+    @Test
     void testValidatedServiceContractDoesNotMarkImplementationAsValidated() {
         var result = TestCompiler.builder()
                 .currentRelease()
@@ -209,6 +434,30 @@ public class ValidationCodegenTest {
         assertThat(Files.exists(result.sourceOutput()
                                         .resolve("com/example/DefaultApiImpl__Validated.java")),
                    is(false));
+    }
+
+    @Test
+    void testNonServiceInterfaceMethodConstraintRequiresValidated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString(ValidationTypes.VALIDATION_VALIDATED.fqName()
+                                                      + " annotation is required on non-service type"));
     }
 
     @Test

--- a/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,9 @@ package io.helidon.service.codegen;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.helidon.codegen.CodegenException;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.ResolvedType;
@@ -33,6 +31,7 @@ import io.helidon.common.types.TypeNames;
 
 import static io.helidon.service.codegen.ServiceCodegenAnnotations.WILDCARD_NAMED;
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_IP_FACTORY;
+import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_QUALIFIED_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SERVICES_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY;
@@ -53,9 +52,14 @@ class DescribedService {
 
     /*
      the following is only relevant on service itself (not on provided type)
-     */
+    */
     // type of provider (if this is a provider at all)
     private final FactoryType providerType;
+    // generic provider interface implemented by the service, such as Supplier<Optional<MyContract>>
+    private final TypeName factoryTypeName;
+    private final Set<ResolvedType> directProviderContracts;
+    private final Set<ResolvedType> providerFactoryContracts;
+    private final boolean factoryInterceptionWrapper;
     // qualifiers of provided type are inherited from service
     private final Set<Annotation> qualifiers;
     // provided type does not have a descriptor, only service does
@@ -74,6 +78,10 @@ class DescribedService {
                              TypeName descriptorType,
                              Set<Annotation> qualifiers,
                              FactoryType providerType,
+                             TypeName factoryTypeName,
+                             Set<ResolvedType> directProviderContracts,
+                             Set<ResolvedType> providerFactoryContracts,
+                             boolean factoryInterceptionWrapper,
                              TypeName qualifiedProviderQualifier) {
 
         this.serviceType = serviceType;
@@ -83,6 +91,10 @@ class DescribedService {
         this.scope = scope;
         this.qualifiers = Set.copyOf(qualifiers);
         this.providerType = providerType;
+        this.factoryTypeName = factoryTypeName;
+        this.directProviderContracts = Set.copyOf(directProviderContracts);
+        this.providerFactoryContracts = Set.copyOf(providerFactoryContracts);
+        this.factoryInterceptionWrapper = factoryInterceptionWrapper;
         this.qualifiedProviderQualifier = qualifiedProviderQualifier;
     }
 
@@ -96,6 +108,7 @@ class DescribedService {
         TypeName descriptorType = ctx.descriptorType(serviceType);
 
         Set<ResolvedType> directContracts = new HashSet<>();
+        Set<ResolvedType> serviceElementContracts = new HashSet<>();
         Set<ResolvedType> providedContracts = new HashSet<>();
         FactoryType providerType = FactoryType.SERVICE;
         TypeName qualifiedProviderQualifier = null;
@@ -105,73 +118,20 @@ class DescribedService {
         ServiceContracts serviceContracts = roundContext.serviceContracts(serviceInfo);
         if (serviceInfo.kind() == ElementKind.INTERFACE) {
             directContracts.add(ResolvedType.create(serviceInfo.typeName()));
+            serviceElementContracts.add(ResolvedType.create(serviceInfo.typeName()));
         }
 
-        // now we know which contracts are OK to use, and we can check the service types and real contracts
-        // service is a factory only if it implements the interface directly; this is never inherited
-        List<TypeInfo> typeInfos = serviceInfo.interfaceTypeInfo();
-        Map<TypeName, TypeInfo> implementedInterfaceTypes = new HashMap<>();
-        typeInfos.forEach(it -> implementedInterfaceTypes.put(it.typeName(), it));
-
-        /*
-        For each service type we support, gather contracts
-         */
-        var response = serviceContracts.analyseFactory(TypeNames.SUPPLIER);
-        if (response.valid()) {
-            providerType = FactoryType.SUPPLIER;
-            directContracts.add(ResolvedType.create(response.factoryType()));
-            providedContracts.addAll(response.providedContracts());
-            providedTypeName = response.providedType();
-            providedTypeInfo = response.providedTypeInfo();
-            implementedInterfaceTypes.remove(TypeNames.SUPPLIER);
-        }
-        response = serviceContracts.analyseFactory(SERVICE_SERVICES_FACTORY);
-        if (response.valid()) {
-            // if this is not a service type, throw
-            if (providerType != FactoryType.SERVICE) {
-                throw new CodegenException("Service implements more than one provider type: "
-                                                   + providerType + ", and services provider.",
-                                           serviceInfo.originatingElementValue());
-            }
-            providerType = FactoryType.SERVICES;
-            directContracts.add(ResolvedType.create(response.providedType()));
-            providedContracts.addAll(response.providedContracts());
-            providedTypeName = response.providedType();
-            providedTypeInfo = response.providedTypeInfo();
-            implementedInterfaceTypes.remove(SERVICE_SERVICES_FACTORY);
-        }
-        response = serviceContracts.analyseFactory(SERVICE_INJECTION_POINT_FACTORY);
-        if (response.valid()) {
-            // if this is not a service type, throw
-            if (providerType != FactoryType.SERVICE) {
-                throw new CodegenException("Service implements more than one provider type: "
-                                                   + providerType + ", and injection point provider.",
-                                           serviceInfo.originatingElementValue());
-            }
-            providerType = FactoryType.INJECTION_POINT;
-            directContracts.add(ResolvedType.create(response.providedType()));
-            providedContracts.addAll(response.providedContracts());
-            providedTypeName = response.providedType();
-            providedTypeInfo = response.providedTypeInfo();
-            implementedInterfaceTypes.remove(SERVICE_INJECTION_POINT_FACTORY);
-        }
-        response = serviceContracts.analyseFactory(SERVICE_QUALIFIED_FACTORY);
-        if (response.valid()) {
-            // if this is not a service type, throw
-            if (providerType != FactoryType.SERVICE) {
-                throw new CodegenException("Service implements more than one provider type: "
-                                                   + providerType + ", and qualified provider.",
-                                           serviceInfo.originatingElementValue());
-            }
-            providerType = FactoryType.QUALIFIED;
-            directContracts.add(ResolvedType.create(response.providedType()));
-            providedContracts.addAll(response.providedContracts());
-            qualifiedProviderQualifier = ServiceContracts
-                    .requiredTypeArgument(implementedInterfaceTypes.remove(SERVICE_QUALIFIED_FACTORY), 1);
-            providedTypeName = response.providedType();
-            providedTypeInfo = response.providedTypeInfo();
-            implementedInterfaceTypes.remove(SERVICE_QUALIFIED_FACTORY);
-        }
+        ServiceTypes.FactoryInfo factoryInfo = ServiceTypes.factoryInfo(serviceContracts, serviceInfo);
+        providerType = factoryInfo.providerType();
+        TypeName factoryTypeName = factoryInfo.factoryTypeName();
+        Set<ResolvedType> providerFactoryContracts = new HashSet<>(factoryInfo.directContracts());
+        directContracts.addAll(providerFactoryContracts);
+        providedContracts.addAll(factoryInfo.providedContracts());
+        qualifiedProviderQualifier = factoryInfo.qualifiedProviderQualifier();
+        providedTypeName = factoryInfo.providedTypeName();
+        providedTypeInfo = factoryInfo.providedTypeInfo();
+        providerFactoryContracts.removeAll(providedContracts);
+        Map<TypeName, TypeInfo> implementedInterfaceTypes = new HashMap<>(factoryInfo.remainingImplementedInterfaces());
 
         // add direct contracts
         HashSet<ResolvedType> processedDirectContracts = new HashSet<>();
@@ -179,11 +139,19 @@ class DescribedService {
             serviceContracts.addContracts(directContracts,
                                           processedDirectContracts,
                                           typeInfo);
+            serviceContracts.addContracts(serviceElementContracts,
+                                          new HashSet<>(),
+                                          typeInfo);
         });
         // add contracts from super type(s)
-        serviceInfo.superTypeInfo().ifPresent(it -> serviceContracts.addContracts(directContracts,
-                                                                                  processedDirectContracts,
-                                                                                  it));
+        serviceInfo.superTypeInfo().ifPresent(it -> {
+            serviceContracts.addContracts(directContracts,
+                                          processedDirectContracts,
+                                          it);
+            serviceContracts.addContracts(serviceElementContracts,
+                                          new HashSet<>(),
+                                          it);
+        });
 
         Map<ResolvedType, Set<ResolvedType>> contractMap = new HashMap<>();
         directContracts.forEach(directContract -> addContractToMap(roundContext,
@@ -195,11 +163,15 @@ class DescribedService {
                                                                        contractMap,
                                                                        providedContract));
 
+        Set<ResolvedType> directProviderContracts = new HashSet<>(directContracts);
+        directProviderContracts.removeAll(providerFactoryContracts);
+        directProviderContracts.removeAll(providedContracts);
+
         DescribedType serviceDescriptor;
         DescribedType providedDescriptor;
 
         if (providerType == FactoryType.SERVICE) {
-            var serviceElements = DescribedElements.create(ctx, interception, directContracts, serviceInfo);
+            var serviceElements = DescribedElements.create(ctx, interception, serviceElementContracts, serviceInfo);
             serviceDescriptor = new DescribedType(serviceInfo,
                                                   serviceInfo.typeName(),
                                                   directContracts,
@@ -208,7 +180,7 @@ class DescribedService {
 
             providedDescriptor = null;
         } else {
-            var serviceElements = DescribedElements.create(ctx, interception, Set.of(), serviceInfo);
+            var serviceElements = DescribedElements.create(ctx, interception, serviceElementContracts, serviceInfo);
             serviceDescriptor = new DescribedType(serviceInfo,
                                                   serviceInfo.typeName(),
                                                   directContracts,
@@ -231,8 +203,24 @@ class DescribedService {
                 descriptorType,
                 gatherQualifiers(serviceInfo),
                 providerType,
+                factoryTypeName,
+                directProviderContracts,
+                providerFactoryContracts,
+                factoryInterceptionWrapper(serviceInfo),
                 qualifiedProviderQualifier
         );
+    }
+
+    private static boolean factoryInterceptionWrapper(TypeInfo serviceInfo) {
+        return serviceInfo.superTypeInfo()
+                .map(TypeInfo::typeName)
+                .map(TypeName::genericTypeName)
+                .filter(it -> it.equals(INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY)
+                        || it.equals(INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY)
+                        || it.equals(INTERCEPT_G_WRAPPER_SERVICES_FACTORY)
+                        || it.equals(INTERCEPT_G_WRAPPER_IP_FACTORY)
+                        || it.equals(INTERCEPT_G_WRAPPER_QUALIFIED_FACTORY))
+                .isPresent();
     }
 
     private static void addContractToMap(RegistryRoundContext ctx,
@@ -261,7 +249,9 @@ class DescribedService {
     TypeName interceptionWrapperSuperType() {
         return switch (providerType()) {
             case NONE, SERVICE -> serviceType.typeName();
-            case SUPPLIER -> createType(INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY, providedType.typeName());
+            case SUPPLIER -> optionalSupplier()
+                    ? createType(INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY, providedType.typeName())
+                    : createType(INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY, providedType.typeName());
             case SERVICES -> createType(INTERCEPT_G_WRAPPER_SERVICES_FACTORY, providedType.typeName());
             case INJECTION_POINT -> createType(INTERCEPT_G_WRAPPER_IP_FACTORY, providedType.typeName());
             case QUALIFIED ->
@@ -272,11 +262,20 @@ class DescribedService {
     TypeName providerInterface() {
         return switch (providerType()) {
             case NONE, SERVICE -> serviceType.typeName();
-            case SUPPLIER -> createType(TypeNames.SUPPLIER, providedType.typeName());
+            case SUPPLIER -> optionalSupplier()
+                    ? createType(TypeNames.SUPPLIER, createType(TypeNames.OPTIONAL, providedType.typeName()))
+                    : createType(TypeNames.SUPPLIER, providedType.typeName());
             case SERVICES -> createType(SERVICE_SERVICES_FACTORY, providedType.typeName());
             case INJECTION_POINT -> createType(SERVICE_INJECTION_POINT_FACTORY, providedType.typeName());
             case QUALIFIED -> createType(SERVICE_QUALIFIED_FACTORY, providedType.typeName(), qualifiedProviderQualifier);
         };
+    }
+
+    private boolean optionalSupplier() {
+        return providerType == FactoryType.SUPPLIER
+                && factoryTypeName != null
+                && !factoryTypeName.typeArguments().isEmpty()
+                && factoryTypeName.typeArguments().getFirst().isOptional();
     }
 
     boolean isFactory() {
@@ -289,6 +288,18 @@ class DescribedService {
 
     DescribedType serviceDescriptor() {
         return serviceType;
+    }
+
+    Set<ResolvedType> directProviderContracts() {
+        return directProviderContracts;
+    }
+
+    Set<ResolvedType> providerFactoryContracts() {
+        return providerFactoryContracts;
+    }
+
+    boolean factoryInterceptionWrapper() {
+        return factoryInterceptionWrapper;
     }
 
     ServiceSuperType superType() {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/InterceptedTypeGenerator.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/InterceptedTypeGenerator.java
@@ -113,7 +113,8 @@ class InterceptedTypeGenerator {
                         String invokeLine = invoker
                                 + ".invoke("
                                 + info.parameterArguments()
-                                .stream().map(TypedElementInfo::elementName)
+                                .stream()
+                                .map(InterceptedTypeGenerator::invokerArgument)
                                 .collect(Collectors.joining(", "))
                                 + ");";
                         // body of the method
@@ -146,6 +147,42 @@ class InterceptedTypeGenerator {
 
                     }));
 
+        }
+    }
+
+    static void generateDelegateMethods(ClassModel.Builder classModel, List<MethodDefinition> interceptedMethods) {
+        for (MethodDefinition interceptedMethod : interceptedMethods) {
+            TypedElementInfo info = interceptedMethod.info();
+
+            classModel.addMethod(method -> method
+                    .accessModifier(AccessModifier.PACKAGE_PRIVATE)
+                    .name(interceptedMethod.delegateName())
+                    .returnType(info.typeName())
+                    .update(it -> info.parameterArguments().forEach(arg -> it.addParameter(param -> param.type(arg.typeName())
+                            .name(arg.elementName()))))
+                    .update(it -> {
+                        if (!interceptedMethod.exceptionTypes().isEmpty()) {
+                            for (TypeName exceptionType : interceptedMethod.exceptionTypes()) {
+                                it.addThrows(exceptionType, "thrown by intercepted method");
+                            }
+                        }
+                    })
+                    .update(it -> {
+                        String invokeLine = "super."
+                                + info.elementName()
+                                + "("
+                                + info.parameterArguments()
+                                .stream()
+                                .map(TypedElementInfo::elementName)
+                                .collect(Collectors.joining(", "))
+                                + ");";
+                        if (interceptedMethod.isVoid()) {
+                            it.addContentLine(invokeLine);
+                        } else {
+                            it.addContent("return ")
+                                    .addContentLine(invokeLine);
+                        }
+                    }));
         }
     }
 
@@ -257,6 +294,7 @@ class InterceptedTypeGenerator {
 
         generateConstructor(classModel);
 
+        generateDelegateMethods(classModel, interceptedMethods);
         generateInterceptedMethods(classModel, interceptedMethods);
 
         return classModel;
@@ -266,6 +304,13 @@ class InterceptedTypeGenerator {
         return TypeName.builder(INTERCEPT_INVOKER)
                 .addTypeArgument(type.boxed())
                 .build();
+    }
+
+    private static String invokerArgument(TypedElementInfo arg) {
+        if (arg.typeName().array()) {
+            return "(Object) " + arg.elementName();
+        }
+        return arg.elementName();
     }
 
     private void generateConstructor(ClassModel.Builder classModel) {
@@ -328,13 +373,8 @@ class InterceptedTypeGenerator {
             for (int i = 0; i < sortedMethods.size(); i++) {
                 TypedElements.ElementMeta elementMeta = sortedMethods.get(i);
 
-                List<Annotation> elementAnnotations = new ArrayList<>(elementMeta.element().annotations());
-                addInterfaceAnnotations(elementAnnotations, elementMeta.abstractMethods());
-
-                TypedElementInfo typedElementInfo = TypedElementInfo.builder()
-                        .from(elementMeta.element())
-                        .annotations(elementAnnotations)
-                        .build();
+                TypedElementInfo typedElementInfo = TypedElements.mergeAbstractMethods(elementMeta.element(),
+                                                                                       elementMeta.abstractMethods());
 
                 String constantName = "METHOD_" + toConstantName(ctx.uniqueName(typeInfo, elementMeta.element()));
                 String invokerName = typedElementInfo.elementName() + "_" + i + "_invoker";
@@ -349,21 +389,9 @@ class InterceptedTypeGenerator {
             return result;
         }
 
-        private static void addInterfaceAnnotations(List<Annotation> elementAnnotations,
-                                                    List<TypedElements.DeclaredElement> declaredElements) {
-
-            for (TypedElements.DeclaredElement declaredElement : declaredElements) {
-                declaredElement.element()
-                        .annotations()
-                        .forEach(it -> addInterfaceAnnotation(elementAnnotations, it));
-            }
+        String delegateName() {
+            return "helidonInject__" + invokerName.substring(0, invokerName.length() - "_invoker".length());
         }
 
-        private static void addInterfaceAnnotation(List<Annotation> elementAnnotations, Annotation annotation) {
-            // only add if not already there
-            if (!elementAnnotations.contains(annotation)) {
-                elementAnnotations.add(annotation);
-            }
-        }
     }
 }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/Interception.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/Interception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,7 +152,9 @@ final class Interception {
             return true;
         }
         for (TypedElements.DeclaredElement interfaceMethod : methodMeta.abstractMethods()) {
-            return hasInterceptTrigger(interfaceMethod.abstractType(), interfaceMethod.element());
+            if (hasInterceptTrigger(interfaceMethod.abstractType(), interfaceMethod.element())) {
+                return true;
+            }
         }
 
         return false;
@@ -174,12 +176,10 @@ final class Interception {
     }
 
     private boolean hasInterceptTriggerOnParams(TypeInfo typeInfo, TypedElementInfo tei) {
-        // we currently cannot retrieve annotations on generics, i.e. List<@NotBlank String>
         if (hasInterceptTriggerOnTypeArguments(typeInfo, tei.typeName())) {
             return true;
         }
 
-        // so for now, just support direct annotations on parameters
         for (TypedElementInfo parameter : tei.parameterArguments()) {
             if (hasInterceptTrigger(typeInfo, parameter)) {
                 return true;
@@ -200,6 +200,21 @@ final class Interception {
             if (hasInterceptTriggerOnTypeArguments(typeInfo, typeArgument)) {
                 return true;
             }
+        }
+        for (TypeName lowerBound : typeName.lowerBounds()) {
+            if (hasInterceptTriggerOnTypeArguments(typeInfo, lowerBound)) {
+                return true;
+            }
+        }
+        for (TypeName upperBound : typeName.upperBounds()) {
+            if (hasInterceptTriggerOnTypeArguments(typeInfo, upperBound)) {
+                return true;
+            }
+        }
+        if (typeName.componentType()
+                .map(componentType -> hasInterceptTriggerOnTypeArguments(typeInfo, componentType))
+                .orElse(false)) {
+            return true;
         }
         return false;
     }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/RegistryRoundContext.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/RegistryRoundContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/codegen/src/main/java/io/helidon/service/codegen/RoundContextImpl.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/RoundContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 
 import io.helidon.codegen.ClassCode;
 import io.helidon.codegen.RoundContext;
+import io.helidon.codegen.TypeHierarchy;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
@@ -96,9 +97,10 @@ class RoundContextImpl implements RegistryRoundContext {
         }
 
         List<TypeInfo> result = new ArrayList<>();
-
         for (TypeInfo typeInfo : typeInfos) {
-            if (typeInfo.hasAnnotation(annotationType)) {
+            if (typeInfo.hasAnnotation(annotationType) || TypeHierarchy.hierarchyAnnotations(ctx, typeInfo)
+                    .stream()
+                    .anyMatch(it -> it.typeName().equals(annotationType))) {
                 result.add(typeInfo);
             }
         }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -323,6 +323,12 @@ public final class ServiceCodegenTypes {
      */
     public static final TypeName INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY =
             TypeName.create("io.helidon.service.registry.GeneratedService.SupplierFactoryInterceptionWrapper");
+    /**
+     * {@link io.helidon.common.types.TypeName} for
+     * {@code io.helidon.service.registry.GeneratedService.OptionalSupplierFactoryInterceptionWrapper}.
+     */
+    public static final TypeName INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY =
+            TypeName.create("io.helidon.service.registry.GeneratedService.OptionalSupplierFactoryInterceptionWrapper");
     /**
      * {@link io.helidon.common.types.TypeName} for
      * {@code io.helidon.service.registry.GeneratedService.ServicesFactoryInterceptionWrapper}.

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
@@ -2797,21 +2797,6 @@ public class ServiceDescriptorCodegen {
         return true;
     }
 
-    private boolean hasParameters(TypedElementInfo method, TypeName... parameterTypes) {
-        List<TypedElementInfo> parameterArguments = method.parameterArguments();
-        if (parameterArguments.size() != parameterTypes.length) {
-            return false;
-        }
-
-        for (int i = 0; i < parameterTypes.length; i++) {
-            if (!parameterArguments.get(i).typeName().equals(parameterTypes[i])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     private boolean hasFactoryParameters(TypedElementInfo method, TypeName... parameterTypes) {
         List<TypedElementInfo> parameterArguments = method.parameterArguments();
         if (parameterArguments.size() != parameterTypes.length) {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
@@ -87,6 +87,11 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_DEPENDENC
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_PER_INSTANCE_DESCRIPTOR;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_QUALIFIED_FACTORY_DESCRIPTOR;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_SCOPE_HANDLER_DESCRIPTOR;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_LOOKUP;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIED_INSTANCE;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIER;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_SCOPE_HANDLER;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_SERVICE_INSTANCE;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SET_OF_QUALIFIERS;
@@ -214,9 +219,9 @@ public class ServiceDescriptorCodegen {
         Set<ResolvedType> factoryContracts;
 
         if (service.isFactory()) {
-            if (serviceTypeName.className().endsWith("__Interception_Wrapper")) {
+            if (service.factoryInterceptionWrapper()) {
                 contracts = service.providedDescriptor().contracts();
-                factoryContracts = service.serviceDescriptor().contracts();
+                factoryContracts = service.providerFactoryContracts();
             } else {
                 // check if contracts are intercepted
                 var providedElements = service.providedDescriptor().elements();
@@ -224,7 +229,7 @@ public class ServiceDescriptorCodegen {
                 if (providedElements.methodsIntercepted()) {
                     // remove contracts from the original service, service descriptor will only be used to instantiate provider
                     contracts = Set.of();
-                    factoryContracts = Set.of();
+                    factoryContracts = service.directProviderContracts();
                     // generate delegate injection (unless already generated) in current package
                     TypeName delegateType = generateProvidedInterceptionDelegate(roundCtx, service);
                     // then generate a service that injects the original service, and wraps provider method(s) using delegation
@@ -448,23 +453,6 @@ public class ServiceDescriptorCodegen {
         contentBuilder.addContent(enumValue.getDeclaringClass())
                 .addContent(".")
                 .addContent(enumValue.name());
-    }
-
-    private static void addInterfaceAnnotations(List<Annotation> elementAnnotations,
-                                                List<TypedElements.DeclaredElement> declaredElements) {
-
-        for (TypedElements.DeclaredElement declaredElement : declaredElements) {
-            declaredElement.element()
-                    .annotations()
-                    .forEach(it -> addInterfaceAnnotation(elementAnnotations, it));
-        }
-    }
-
-    private static void addInterfaceAnnotation(List<Annotation> elementAnnotations, Annotation annotation) {
-        // only add if not already there
-        if (!elementAnnotations.contains(annotation)) {
-            elementAnnotations.add(annotation);
-        }
     }
 
     private static List<ParamDefinition> declareCtrParamsAndGetThem(Method.Builder method, List<ParamDefinition> params) {
@@ -1768,7 +1756,7 @@ public class ServiceDescriptorCodegen {
                 .decreaseContentPadding()
                 .addContent(".invoke(")
                 .addContent(constructorParams.stream()
-                                    .map(ParamDefinition::ipParamName)
+                                    .map(ServiceDescriptorCodegen::invokerArgument)
                                     .collect(Collectors.joining(", ")))
                 .addContentLine(");")
                 .decreaseContentPadding()
@@ -2056,8 +2044,10 @@ public class ServiceDescriptorCodegen {
             // assign the instance
             methodBuilder.addContent("instance__helidonInject.")
                     .addContent(field.ipParamName())
-                    .addContent(" = config__invoker.invoke(")
-                    .addContent(field.ipParamName())
+                    .addContent(" = ")
+                    .addContent(invokerName)
+                    .addContent(".invoke(")
+                    .addContent(invokerArgument(field))
                     .addContentLine(");")
                     .decreaseContentPadding();
             // end try/catch block
@@ -2327,6 +2317,10 @@ public class ServiceDescriptorCodegen {
                                            DescribedService service,
                                            TypeName delegateType) {
         TypeName typeName = service.serviceDescriptor().typeName();
+        TypeName descriptorType = service.descriptorType();
+        List<InterceptedTypeGenerator.MethodDefinition> factoryMethods = factoryMethods(service);
+        List<InterceptedTypeGenerator.MethodDefinition> interceptedFactoryMethods = interceptedFactoryMethods(service,
+                                                                                                             factoryMethods);
 
         String typeNameSuffix = "__Interception_Wrapper";
         TypeName wrapperType = TypeName.builder()
@@ -2351,12 +2345,20 @@ public class ServiceDescriptorCodegen {
 
         service.qualifiers()
                 .forEach(classModel::addAnnotation);
+        serviceOrderAnnotations(service.serviceDescriptor().typeInfo())
+                .forEach(classModel::addAnnotation);
 
         classModel.addField(interceptMeta -> interceptMeta
                 .type(INTERCEPT_METADATA)
                 .name("interceptMeta")
                 .isFinal(true)
                 .accessModifier(AccessModifier.PRIVATE));
+
+        if (!interceptedFactoryMethods.isEmpty()) {
+            Qualifiers.generateQualifiersConstant(classModel, service.qualifiers());
+            annotationsField(classModel, service.serviceDescriptor().typeInfo());
+            InterceptedTypeGenerator.generateInvokerFields(classModel, interceptedFactoryMethods);
+        }
 
         classModel.addConstructor(ctr -> ctr
                 .addAnnotation(Annotation.create(SERVICE_ANNOTATION_INJECT))
@@ -2367,11 +2369,21 @@ public class ServiceDescriptorCodegen {
                 .addParameter(interceptMeta -> interceptMeta
                         .type(INTERCEPT_METADATA)
                         .name("interceptMeta"))
-                .addContentLine("super(delegate);")
+                .addContent("super(")
+                .update(it -> factoryDelegate(it, service))
+                .addContentLine(");")
                 .addContentLine("this.interceptMeta = interceptMeta;")
+                .update(it -> InterceptedTypeGenerator.createInvokers(it,
+                                                                       descriptorType,
+                                                                       interceptedFactoryMethods,
+                                                                       true,
+                                                                       "interceptMeta",
+                                                                       descriptorType.fqName() + ".INSTANCE",
+                                                                       "QUALIFIERS",
+                                                                       "ANNOTATIONS",
+                                                                       "super"))
         );
 
-        TypeName descriptorType = service.descriptorType();
         classModel.addMethod(wrap -> wrap
                 .addAnnotation(Annotations.OVERRIDE)
                 .accessModifier(AccessModifier.PROTECTED)
@@ -2391,10 +2403,437 @@ public class ServiceDescriptorCodegen {
                 .addContentLine("instance);")
         );
 
+        InterceptedTypeGenerator.generateInterceptedMethods(classModel, interceptedFactoryMethods);
+
         roundContext.addGeneratedType(wrapperType,
                                       classModel,
                                       typeName,
                                       service.serviceDescriptor().typeInfo().originatingElementValue());
+    }
+
+    private List<Annotation> serviceOrderAnnotations(TypeInfo typeInfo) {
+        List<Annotation> annotations = new ArrayList<>();
+        typeInfo.findAnnotation(TypeName.create(Weight.class))
+                .ifPresent(annotations::add);
+        typeInfo.findAnnotation(SERVICE_ANNOTATION_RUN_LEVEL)
+                .ifPresent(annotations::add);
+        return annotations;
+    }
+
+    private void factoryDelegate(ContentBuilder<?> content, DescribedService service) {
+        List<InterceptedTypeGenerator.MethodDefinition> factoryMethods = factoryMethods(service);
+        if (factoryMethods.isEmpty()) {
+            content.addContent("delegate");
+            return;
+        }
+
+        TypeName interceptedType = interceptedTypeName(service.serviceDescriptor().typeName());
+        switch (service.providerType()) {
+        case INJECTION_POINT -> injectionPointFactoryDelegate(content, service, interceptedType, factoryMethods);
+        case QUALIFIED -> qualifiedFactoryDelegate(content, service, interceptedType, factoryMethods);
+        default -> methodReferenceFactoryDelegate(content, service, interceptedType, factoryMethods);
+        }
+    }
+
+    private List<InterceptedTypeGenerator.MethodDefinition> interceptedFactoryMethods(
+            DescribedService service,
+            List<InterceptedTypeGenerator.MethodDefinition> factoryMethods) {
+        List<InterceptedTypeGenerator.MethodDefinition> result = new ArrayList<>();
+        switch (service.providerType()) {
+        case SUPPLIER -> factoryMethod(factoryMethods, "get")
+                .ifPresent(result::add);
+        case SERVICES -> factoryMethod(factoryMethods, "services")
+                .ifPresent(result::add);
+        case INJECTION_POINT -> {
+            factoryMethod(factoryMethods, "first", SERVICE_LOOKUP)
+                    .ifPresent(result::add);
+            factoryMethod(factoryMethods, "list", SERVICE_LOOKUP)
+                    .ifPresent(result::add);
+        }
+        case QUALIFIED -> {
+            TypeName genericProvidedType = TypeName.builder(TypeNames.GENERIC_TYPE)
+                    .addTypeArgument(service.providedDescriptor().typeName())
+                    .build();
+            factoryMethod(factoryMethods,
+                          "first",
+                          SERVICE_QUALIFIER,
+                          SERVICE_LOOKUP,
+                          genericProvidedType)
+                    .ifPresent(result::add);
+            factoryMethod(factoryMethods,
+                          "list",
+                          SERVICE_QUALIFIER,
+                          SERVICE_LOOKUP,
+                          genericProvidedType)
+                    .ifPresent(result::add);
+        }
+        default -> {
+        }
+        }
+        return List.copyOf(result);
+    }
+
+    private void methodReferenceFactoryDelegate(ContentBuilder<?> content,
+                                                DescribedService service,
+                                                TypeName interceptedType,
+                                                List<InterceptedTypeGenerator.MethodDefinition> factoryMethods) {
+        String factoryMethodName = switch (service.providerType()) {
+            case SUPPLIER -> "get";
+            case SERVICES -> "services";
+            case NONE, SERVICE, INJECTION_POINT, QUALIFIED -> "";
+        };
+        if (factoryMethodName.isEmpty()) {
+            content.addContent("delegate");
+            return;
+        }
+
+        Optional<InterceptedTypeGenerator.MethodDefinition> factoryMethod =
+                factoryMethod(factoryMethods, factoryMethodName);
+        if (factoryMethod.isEmpty()) {
+            content.addContent("delegate");
+            return;
+        }
+
+        content.addContent("delegate instanceof ")
+                .addContent(interceptedType)
+                .addContent(" helidonInject__delegate ? helidonInject__delegate::")
+                .addContent(factoryMethod.get().delegateName())
+                .addContent(" : delegate");
+    }
+
+    private void injectionPointFactoryDelegate(ContentBuilder<?> content,
+                                               DescribedService service,
+                                               TypeName interceptedType,
+                                               List<InterceptedTypeGenerator.MethodDefinition> factoryMethods) {
+        Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod = factoryMethod(factoryMethods,
+                                                                                       "first",
+                                                                                       SERVICE_LOOKUP);
+        Optional<InterceptedTypeGenerator.MethodDefinition> listMethod = factoryMethod(factoryMethods,
+                                                                                      "list",
+                                                                                      SERVICE_LOOKUP);
+
+        factoryDelegateHeader(content, service, interceptedType);
+        content.addContentLine(" {")
+                .increaseContentPadding();
+
+        TypeName optionalQualifiedInstance = optionalQualifiedInstanceType(service);
+        content.addContentLine("@Override")
+                .addContent("public ")
+                .addContent(optionalQualifiedInstance)
+                .addContentLine(" first(")
+                .increaseContentPadding()
+                .addContent(SERVICE_LOOKUP)
+                .addContentLine(" lookup) {");
+        injectionPointFactoryFirstBody(content, service, firstMethod, listMethod);
+        content.addContentLine("}")
+                .decreaseContentPadding()
+                .addContentLine();
+
+        TypeName listQualifiedInstance = listQualifiedInstanceType(service);
+        content.addContentLine("@Override")
+                .addContent("public ")
+                .addContent(listQualifiedInstance)
+                .addContentLine(" list(")
+                .increaseContentPadding()
+                .addContent(SERVICE_LOOKUP)
+                .addContentLine(" lookup) {");
+        injectionPointFactoryListBody(content, service, firstMethod, listMethod);
+        content.addContentLine("}")
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .addContent("} : delegate");
+    }
+
+    private void injectionPointFactoryFirstBody(ContentBuilder<?> content,
+                                                DescribedService service,
+                                                Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
+                                                Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
+        if (listMethod.isPresent()) {
+            // Raw first(...) may still dispatch to the intercepted list(...) override from the provider implementation.
+            content.addContent(listQualifiedInstanceType(service))
+                    .addContent(" helidonInject__list = helidonInject__delegate.")
+                    .addContent(listMethod.get().delegateName())
+                    .addContentLine("(lookup);")
+                    .addContent("return helidonInject__list.isEmpty() ? ")
+                    .addContent(Optional.class)
+                    .addContent(".empty() : ")
+                    .addContent(Optional.class)
+                    .addContentLine(".of(helidonInject__list.getFirst());");
+            return;
+        }
+        content.addContent("return helidonInject__delegate.")
+                .addContent(firstMethod.map(InterceptedTypeGenerator.MethodDefinition::delegateName).orElse("first"))
+                .addContentLine("(lookup);");
+    }
+
+    private void injectionPointFactoryListBody(ContentBuilder<?> content,
+                                               DescribedService service,
+                                               Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
+                                               Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
+        if (listMethod.isPresent()) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(listMethod.get().delegateName())
+                    .addContentLine("(lookup);");
+            return;
+        }
+        if (firstMethod.isPresent() && !factoryMethodCustomized(service, "list", SERVICE_LOOKUP)) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(firstMethod.get().delegateName())
+                    .addContentLine("(lookup).map(List::of).orElseGet(List::of);");
+            return;
+        }
+        content.addContentLine("return helidonInject__delegate.list(lookup);");
+    }
+
+    private void qualifiedFactoryDelegate(ContentBuilder<?> content,
+                                          DescribedService service,
+                                          TypeName interceptedType,
+                                          List<InterceptedTypeGenerator.MethodDefinition> factoryMethods) {
+        TypeName genericProvidedType = TypeName.builder(TypeNames.GENERIC_TYPE)
+                .addTypeArgument(service.providedDescriptor().typeName())
+                .build();
+        Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod = factoryMethod(factoryMethods,
+                                                                                       "first",
+                                                                                       SERVICE_QUALIFIER,
+                                                                                       SERVICE_LOOKUP,
+                                                                                       genericProvidedType);
+        Optional<InterceptedTypeGenerator.MethodDefinition> listMethod = factoryMethod(factoryMethods,
+                                                                                      "list",
+                                                                                      SERVICE_QUALIFIER,
+                                                                                      SERVICE_LOOKUP,
+                                                                                      genericProvidedType);
+
+        factoryDelegateHeader(content, service, interceptedType);
+        content.addContentLine(" {")
+                .increaseContentPadding();
+
+        TypeName optionalQualifiedInstance = optionalQualifiedInstanceType(service);
+        content.addContentLine("@Override")
+                .addContent("public ")
+                .addContent(optionalQualifiedInstance)
+                .addContentLine(" first(")
+                .increaseContentPadding()
+                .addContent(SERVICE_QUALIFIER)
+                .addContentLine(" qualifier,")
+                .addContent(SERVICE_LOOKUP)
+                .addContentLine(" lookup,")
+                .addContent(genericProvidedType)
+                .addContentLine(" type) {");
+        qualifiedFactoryFirstBody(content, service, firstMethod, listMethod);
+        content.addContentLine("}")
+                .decreaseContentPadding()
+                .addContentLine();
+
+        TypeName listQualifiedInstance = listQualifiedInstanceType(service);
+        content.addContentLine("@Override")
+                .addContent("public ")
+                .addContent(listQualifiedInstance)
+                .addContentLine(" list(")
+                .increaseContentPadding()
+                .addContent(SERVICE_QUALIFIER)
+                .addContentLine(" qualifier,")
+                .addContent(SERVICE_LOOKUP)
+                .addContentLine(" lookup,")
+                .addContent(genericProvidedType)
+                .addContentLine(" type) {");
+        qualifiedFactoryListBody(content, service, genericProvidedType, firstMethod, listMethod);
+        content.addContentLine("}")
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .addContent("} : delegate");
+    }
+
+    private void qualifiedFactoryFirstBody(ContentBuilder<?> content,
+                                           DescribedService service,
+                                           Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
+                                           Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
+        if (listMethod.isPresent()) {
+            // Raw first(...) may still dispatch to the intercepted list(...) override from the provider implementation.
+            content.addContent(listQualifiedInstanceType(service))
+                    .addContent(" helidonInject__list = helidonInject__delegate.")
+                    .addContent(listMethod.get().delegateName())
+                    .addContentLine("(qualifier, lookup, type);")
+                    .addContent("return helidonInject__list.isEmpty() ? ")
+                    .addContent(Optional.class)
+                    .addContent(".empty() : ")
+                    .addContent(Optional.class)
+                    .addContentLine(".of(helidonInject__list.getFirst());");
+            return;
+        }
+        content.addContent("return helidonInject__delegate.")
+                .addContent(firstMethod.map(InterceptedTypeGenerator.MethodDefinition::delegateName).orElse("first"))
+                .addContentLine("(qualifier, lookup, type);");
+    }
+
+    private void qualifiedFactoryListBody(ContentBuilder<?> content,
+                                          DescribedService service,
+                                          TypeName genericProvidedType,
+                                          Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
+                                          Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
+        if (listMethod.isPresent()) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(listMethod.get().delegateName())
+                    .addContentLine("(qualifier, lookup, type);");
+            return;
+        }
+        if (firstMethod.isPresent()
+                && !factoryMethodCustomized(service, "list", SERVICE_QUALIFIER, SERVICE_LOOKUP, genericProvidedType)) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(firstMethod.get().delegateName())
+                    .addContentLine("(qualifier, lookup, type).map(List::of).orElseGet(List::of);");
+            return;
+        }
+        content.addContentLine("return helidonInject__delegate.list(qualifier, lookup, type);");
+    }
+
+    private void factoryDelegateHeader(ContentBuilder<?> content,
+                                       DescribedService service,
+                                       TypeName interceptedType) {
+        content.addContent("delegate instanceof ")
+                .addContent(interceptedType)
+                .addContent(" helidonInject__delegate ? new ")
+                .addContent(service.providerInterface())
+                .addContent("()");
+    }
+
+    private TypeName optionalQualifiedInstanceType(DescribedService service) {
+        return TypeName.builder(TypeNames.OPTIONAL)
+                .addTypeArgument(qualifiedInstanceType(service))
+                .build();
+    }
+
+    private TypeName listQualifiedInstanceType(DescribedService service) {
+        return TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(qualifiedInstanceType(service))
+                .build();
+    }
+
+    private TypeName qualifiedInstanceType(DescribedService service) {
+        return TypeName.builder(SERVICE_QUALIFIED_INSTANCE)
+                .addTypeArgument(service.providedDescriptor().typeName())
+                .build();
+    }
+
+    private List<InterceptedTypeGenerator.MethodDefinition> factoryMethods(DescribedService service) {
+        if (!service.serviceDescriptor().elements().methodsIntercepted()) {
+            return List.of();
+        }
+
+        return InterceptedTypeGenerator.MethodDefinition.toDefinitions(
+                        ctx,
+                        service.serviceDescriptor().typeInfo(),
+                        service.serviceDescriptor()
+                                .elements()
+                                .interceptedElements()
+                                .stream()
+                                .filter(it -> it.element().kind() == ElementKind.METHOD)
+                                .toList());
+    }
+
+    private boolean factoryMethodCustomized(DescribedService service, String factoryMethodName, TypeName... parameterTypes) {
+        return factoryMethodCustomized(service.serviceDescriptor().typeInfo(),
+                                       new HashSet<>(),
+                                       factoryMethodName,
+                                       parameterTypes);
+    }
+
+    private boolean factoryMethodCustomized(TypeInfo typeInfo,
+                                            Set<TypeName> processedTypes,
+                                            String factoryMethodName,
+                                            TypeName... parameterTypes) {
+        if (!processedTypes.add(typeInfo.typeName().genericTypeName())) {
+            return false;
+        }
+        if (!defaultFactoryInterface(typeInfo)
+                && typeInfo.elementInfo()
+                        .stream()
+                        .filter(it -> it.kind() == ElementKind.METHOD)
+                        .filter(not(ElementInfoPredicates::isPrivate))
+                        .filter(not(ElementInfoPredicates::isStatic))
+                        .filter(it -> it.elementName().equals(factoryMethodName))
+                        .anyMatch(it -> hasFactoryParameters(it, parameterTypes))) {
+            return true;
+        }
+
+        if (typeInfo.superTypeInfo()
+                .map(it -> factoryMethodCustomized(it, processedTypes, factoryMethodName, parameterTypes))
+                .orElse(false)) {
+            return true;
+        }
+
+        return typeInfo.interfaceTypeInfo()
+                .stream()
+                .anyMatch(it -> factoryMethodCustomized(it, processedTypes, factoryMethodName, parameterTypes));
+    }
+
+    private boolean defaultFactoryInterface(TypeInfo typeInfo) {
+        TypeName genericType = typeInfo.typeName().genericTypeName();
+        return genericType.equals(SERVICE_INJECTION_POINT_FACTORY) || genericType.equals(SERVICE_QUALIFIED_FACTORY);
+    }
+
+    private Optional<InterceptedTypeGenerator.MethodDefinition> factoryMethod(
+            List<InterceptedTypeGenerator.MethodDefinition> factoryMethods,
+            String factoryMethodName,
+            TypeName... parameterTypes) {
+        return factoryMethods
+                .stream()
+                .filter(it -> it.info().elementName().equals(factoryMethodName))
+                .filter(it -> hasParameters(it, parameterTypes))
+                .findFirst();
+    }
+
+    private boolean hasParameters(InterceptedTypeGenerator.MethodDefinition method, TypeName... parameterTypes) {
+        List<TypedElementInfo> parameterArguments = method.info().parameterArguments();
+        if (parameterArguments.size() != parameterTypes.length) {
+            return false;
+        }
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            if (!parameterArguments.get(i).typeName().equals(parameterTypes[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean hasParameters(TypedElementInfo method, TypeName... parameterTypes) {
+        List<TypedElementInfo> parameterArguments = method.parameterArguments();
+        if (parameterArguments.size() != parameterTypes.length) {
+            return false;
+        }
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            if (!parameterArguments.get(i).typeName().equals(parameterTypes[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean hasFactoryParameters(TypedElementInfo method, TypeName... parameterTypes) {
+        List<TypedElementInfo> parameterArguments = method.parameterArguments();
+        if (parameterArguments.size() != parameterTypes.length) {
+            return false;
+        }
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            TypeName actualType = parameterArguments.get(i).typeName();
+            TypeName expectedType = parameterTypes[i];
+            if (!actualType.equals(expectedType) && !actualType.genericTypeName().equals(expectedType.genericTypeName())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static String invokerArgument(ParamDefinition param) {
+        if (param.declaredType().array()) {
+            return "(Object) " + param.ipParamName();
+        }
+        return param.ipParamName();
     }
 
     private void factoryType(ClassModel.Builder classModel, DescribedService service, FactoryType factoryType) {
@@ -2454,10 +2893,7 @@ public class ServiceDescriptorCodegen {
         if (ElementInfoPredicates.isStatic(method)) {
             return false;
         }
-        List<Annotation> elementAnnotations = new ArrayList<>(method.annotations());
-        addInterfaceAnnotations(elementAnnotations, element.abstractMethods());
-
-        for (Annotation elementAnnotation : elementAnnotations) {
+        for (Annotation elementAnnotation : element.effectiveElement().annotations()) {
             if (elementAnnotation.hasMetaAnnotation(SERVICE_ANNOTATION_ENTRY_POINT)) {
                 return true;
             }
@@ -2473,13 +2909,6 @@ public class ServiceDescriptorCodegen {
         String uniqueName = ctx.uniqueName(typeInfo, method);
         String constantName = "METHOD_" + toConstantName(uniqueName);
 
-        // add inherited annotations from interfaces
-        List<Annotation> elementAnnotations = new ArrayList<>(method.annotations());
-        addInterfaceAnnotations(elementAnnotations, element.abstractMethods());
-        TypedElementInfo typedElementInfo = TypedElementInfo.builder()
-                .from(method)
-                .annotations(elementAnnotations)
-                .build();
         classModel.addField(constant -> constant
                 .description("Element info for method: {@code " + method.signature() + "}.")
                 .accessModifier(AccessModifier.PUBLIC)
@@ -2487,7 +2916,7 @@ public class ServiceDescriptorCodegen {
                 .isFinal(true)
                 .type(TypeNames.TYPED_ELEMENT_INFO)
                 .name(constantName)
-                .addContentCreate(typedElementInfo));
+                .addContentCreate(element.effectiveElement()));
     }
 
     private void generateInterceptedType(RegistryRoundContext roundContext,

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
@@ -2548,7 +2548,13 @@ public class ServiceDescriptorCodegen {
                                                 DescribedService service,
                                                 Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
                                                 Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
-        if (listMethod.isPresent()) {
+        if (firstMethod.isPresent()) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(firstMethod.get().delegateName())
+                    .addContentLine("(lookup);");
+            return;
+        }
+        if (listMethod.isPresent() && !factoryMethodCustomized(service, "first", SERVICE_LOOKUP)) {
             // Raw first(...) may still dispatch to the intercepted list(...) override from the provider implementation.
             content.addContent(listQualifiedInstanceType(service))
                     .addContent(" helidonInject__list = helidonInject__delegate.")
@@ -2562,8 +2568,7 @@ public class ServiceDescriptorCodegen {
             return;
         }
         content.addContent("return helidonInject__delegate.")
-                .addContent(firstMethod.map(InterceptedTypeGenerator.MethodDefinition::delegateName).orElse("first"))
-                .addContentLine("(lookup);");
+                .addContentLine("first(lookup);");
     }
 
     private void injectionPointFactoryListBody(ContentBuilder<?> content,
@@ -2619,7 +2624,7 @@ public class ServiceDescriptorCodegen {
                 .addContentLine(" lookup,")
                 .addContent(genericProvidedType)
                 .addContentLine(" type) {");
-        qualifiedFactoryFirstBody(content, service, firstMethod, listMethod);
+        qualifiedFactoryFirstBody(content, service, genericProvidedType, firstMethod, listMethod);
         content.addContentLine("}")
                 .decreaseContentPadding()
                 .addContentLine();
@@ -2645,9 +2650,17 @@ public class ServiceDescriptorCodegen {
 
     private void qualifiedFactoryFirstBody(ContentBuilder<?> content,
                                            DescribedService service,
+                                           TypeName genericProvidedType,
                                            Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
                                            Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
-        if (listMethod.isPresent()) {
+        if (firstMethod.isPresent()) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(firstMethod.get().delegateName())
+                    .addContentLine("(qualifier, lookup, type);");
+            return;
+        }
+        if (listMethod.isPresent()
+                && !factoryMethodCustomized(service, "first", SERVICE_QUALIFIER, SERVICE_LOOKUP, genericProvidedType)) {
             // Raw first(...) may still dispatch to the intercepted list(...) override from the provider implementation.
             content.addContent(listQualifiedInstanceType(service))
                     .addContent(" helidonInject__list = helidonInject__delegate.")
@@ -2661,8 +2674,7 @@ public class ServiceDescriptorCodegen {
             return;
         }
         content.addContent("return helidonInject__delegate.")
-                .addContent(firstMethod.map(InterceptedTypeGenerator.MethodDefinition::delegateName).orElse("first"))
-                .addContentLine("(qualifier, lookup, type);");
+                .addContentLine("first(qualifier, lookup, type);");
     }
 
     private void qualifiedFactoryListBody(ContentBuilder<?> content,

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,8 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                     return new ExtensionInfo(extension,
                                              discoveryPredicate(it.supportedAnnotations(),
                                                                 it.supportedAnnotationPackages()),
-                                             it.supportedMetaAnnotations());
+                                             it.supportedMetaAnnotations(),
+                                             it.supportsServiceContractAnnotations());
                 })
                 .toList();
     }
@@ -216,15 +217,26 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
 
         Set<TypeName> availableAnnotations = new HashSet<>();
         Map<TypeName, List<TypeInfo>> annotationToTypes = new HashMap<>();
+        Map<TypeName, Set<TypeName>> supportedAnnotationsCache = new HashMap<>();
+        Map<TypeName, Set<TypeName>> metaAnnotationsCache = new HashMap<>();
+        Map<TypeName, Boolean> metaAnnotatedCache = new HashMap<>();
+        Map<TypeName, Set<TypeName>> metaAnnotated = new HashMap<>();
         Map<TypeName, TypeInfo> processedTypes = new HashMap<>();
+
+        for (TypeName typeName : extension.supportedMetaAnnotations()) {
+            metaAnnotated.put(typeName, new HashSet<>(roundContext.annotatedAnnotations(typeName)));
+        }
 
         for (TypeInfoAndAnnotations annotatedType : annotatedTypes) {
             for (TypeName annotationType : annotatedType.annotations()) {
                 // first check if directly supported
                 if (extension.supportedAnnotationsPredicate.test(annotationType)
-                        || isMetaAnnotated(roundContext, extension, annotationType)) {
+                        || isMetaAnnotated(roundContext, extension, annotationType, metaAnnotationsCache, metaAnnotatedCache)) {
 
                     availableAnnotations.add(annotationType);
+                    addMetaAnnotated(metaAnnotated,
+                                     annotationType,
+                                     metaAnnotations(roundContext, extension, annotationType, metaAnnotationsCache));
                     processedTypes.put(annotatedType.typeInfo().typeName(), annotatedType.typeInfo());
                     annotationToTypes.computeIfAbsent(annotationType, k -> new ArrayList<>())
                             .add(annotatedType.typeInfo());
@@ -232,12 +244,26 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                     // or we support the annotation type, or it is prefixed by the package prefix
                 }
             }
+            Set<TypeName> contractAnnotations = supportedServiceContractAnnotations(roundContext,
+                                                                                    extension,
+                                                                                    annotatedType.typeInfo(),
+                                                                                    supportedAnnotationsCache,
+                                                                                    metaAnnotationsCache,
+                                                                                    metaAnnotatedCache);
+            if (!contractAnnotations.isEmpty()) {
+                processedTypes.put(annotatedType.typeInfo().typeName(), annotatedType.typeInfo());
+                availableAnnotations.addAll(contractAnnotations);
+                contractAnnotations.forEach(it -> addMetaAnnotated(metaAnnotated,
+                                                                    it,
+                                                                    metaAnnotations(roundContext,
+                                                                                    extension,
+                                                                                    it,
+                                                                                    metaAnnotationsCache)));
+            }
         }
 
-        Map<TypeName, Set<TypeName>> metaAnnotated = new HashMap<>();
-        for (TypeName typeName : extension.supportedMetaAnnotations()) {
-            metaAnnotated.put(typeName, Set.copyOf(roundContext.annotatedAnnotations(typeName)));
-        }
+        Map<TypeName, Set<TypeName>> metaAnnotatedCopy = new HashMap<>();
+        metaAnnotated.forEach((key, value) -> metaAnnotatedCopy.put(key, Set.copyOf(value)));
 
         return new RoundContextImpl(
                 ctx,
@@ -245,17 +271,166 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                 newDescriptors::add,
                 Set.copyOf(availableAnnotations),
                 Map.copyOf(annotationToTypes),
-                Map.copyOf(metaAnnotated),
+                Map.copyOf(metaAnnotatedCopy),
                 List.copyOf(processedTypes.values()));
     }
 
-    private boolean isMetaAnnotated(RoundContext roundContext, ExtensionInfo extension, TypeName annotationType) {
+    private Set<TypeName> supportedServiceContractAnnotations(RoundContext roundContext,
+                                                              ExtensionInfo extension,
+                                                              TypeInfo serviceType,
+                                                              Map<TypeName, Set<TypeName>> supportedAnnotationsCache,
+                                                              Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                                              Map<TypeName, Boolean> metaAnnotatedCache) {
+        if (!extension.supportsServiceContractAnnotations() || !ServiceTypes.isService(serviceType)) {
+            return Set.of();
+        }
+
+        ServiceContracts serviceContracts = ServiceContracts.create(ctx.options(), roundContext::typeInfo, serviceType);
+        Set<ResolvedType> contracts = new HashSet<>();
+        serviceContracts.addContracts(contracts, new HashSet<>(), serviceType);
+
+        Set<TypeName> result = new HashSet<>(supportedAnnotationsOnContracts(roundContext,
+                                                                             extension,
+                                                                             contracts,
+                                                                             supportedAnnotationsCache,
+                                                                             metaAnnotationsCache,
+                                                                             metaAnnotatedCache));
+        result.addAll(supportedAnnotationsOnContracts(roundContext,
+                                                      extension,
+                                                      ServiceTypes.factoryProvidedContracts(serviceContracts, serviceType),
+                                                      supportedAnnotationsCache,
+                                                      metaAnnotationsCache,
+                                                      metaAnnotatedCache));
+
+        return Set.copyOf(result);
+    }
+
+    private Set<TypeName> supportedAnnotationsOnContracts(RoundContext roundContext,
+                                                          ExtensionInfo extension,
+                                                          Set<ResolvedType> contracts,
+                                                          Map<TypeName, Set<TypeName>> supportedAnnotationsCache,
+                                                          Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                                          Map<TypeName, Boolean> metaAnnotatedCache) {
+        Set<TypeName> result = new HashSet<>();
+        for (ResolvedType contract : contracts) {
+            TypeName contractType = contract.type();
+            result.addAll(supportedAnnotationsCache.computeIfAbsent(contractType,
+                                                                    it -> supportedAnnotations(roundContext,
+                                                                                               extension,
+                                                                                               contractType,
+                                                                                               metaAnnotationsCache,
+                                                                                               metaAnnotatedCache)));
+        }
+
+        return result;
+    }
+
+    private Set<TypeName> supportedAnnotations(RoundContext roundContext,
+                                               ExtensionInfo extension,
+                                               TypeName typeName,
+                                               Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                               Map<TypeName, Boolean> metaAnnotatedCache) {
+        Optional<TypeInfo> typeInfo = roundContext.typeInfo(typeName)
+                .or(() -> roundContext.typeInfo(typeName.genericTypeName()));
+        return typeInfo.map(it -> supportedAnnotations(roundContext,
+                                                       extension,
+                                                       it,
+                                                       metaAnnotationsCache,
+                                                       metaAnnotatedCache))
+                .orElseGet(Set::of);
+    }
+
+    private Set<TypeName> supportedAnnotations(RoundContext roundContext,
+                                               ExtensionInfo extension,
+                                               TypeInfo typeInfo,
+                                               Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                               Map<TypeName, Boolean> metaAnnotatedCache) {
+        Set<TypeName> result = new HashSet<>();
+        for (TypeName annotationType : TypeHierarchy.nestedAnnotations(ctx, typeInfo)) {
+            if (extension.supportedAnnotationsPredicate.test(annotationType)
+                    || isMetaAnnotated(roundContext,
+                                       extension,
+                                       annotationType,
+                                       metaAnnotationsCache,
+                                       metaAnnotatedCache)) {
+                result.add(annotationType);
+            }
+        }
+
+        return result;
+    }
+
+    private boolean isMetaAnnotated(RoundContext roundContext,
+                                    ExtensionInfo extension,
+                                    TypeName annotationType,
+                                    Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                    Map<TypeName, Boolean> metaAnnotatedCache) {
+        return metaAnnotatedCache.computeIfAbsent(annotationType,
+                                                  it -> !metaAnnotations(roundContext,
+                                                                         extension,
+                                                                         annotationType,
+                                                                         metaAnnotationsCache).isEmpty());
+    }
+
+    private Set<TypeName> metaAnnotations(RoundContext roundContext,
+                                          ExtensionInfo extension,
+                                          TypeName annotationType,
+                                          Map<TypeName, Set<TypeName>> metaAnnotationsCache) {
+        return metaAnnotationsCache.computeIfAbsent(annotationType,
+                                                    it -> metaAnnotations(roundContext, extension, annotationType));
+    }
+
+    private Set<TypeName> metaAnnotations(RoundContext roundContext, ExtensionInfo extension, TypeName annotationType) {
+        Set<TypeName> result = new HashSet<>();
         for (TypeName typeName : extension.supportedMetaAnnotations()) {
-            if (roundContext.annotatedAnnotations(typeName)
-                    .contains(annotationType)) {
+            if (roundContext.annotatedAnnotations(typeName).contains(annotationType)) {
+                result.add(typeName);
+            }
+        }
+        Optional<TypeInfo> annotationInfo = ctx.typeInfo(annotationType);
+        if (annotationInfo.isEmpty()) {
+            return Set.copyOf(result);
+        }
+        for (TypeName supportedMetaAnnotation : extension.supportedMetaAnnotations()) {
+            if (!result.contains(supportedMetaAnnotation)
+                    && isMetaAnnotated(annotationInfo.get(), Set.of(supportedMetaAnnotation), new HashSet<>())) {
+                result.add(supportedMetaAnnotation);
+            }
+        }
+
+        return Set.copyOf(result);
+    }
+
+    private void addMetaAnnotated(Map<TypeName, Set<TypeName>> metaAnnotated,
+                                  TypeName annotationType,
+                                  Set<TypeName> metaAnnotations) {
+        for (TypeName metaAnnotation : metaAnnotations) {
+            metaAnnotated.computeIfAbsent(metaAnnotation, ignored -> new HashSet<>())
+                    .add(annotationType);
+        }
+    }
+
+    private boolean isMetaAnnotated(TypeInfo annotationType, Set<TypeName> supportedMetaAnnotations, Set<TypeName> processed) {
+        if (!processed.add(annotationType.typeName())) {
+            return false;
+        }
+
+        for (Annotation annotation : annotationType.annotations()) {
+            if (supportedMetaAnnotations.contains(annotation.typeName())) {
+                return true;
+            }
+            for (TypeName supportedMetaAnnotation : supportedMetaAnnotations) {
+                if (annotation.hasMetaAnnotation(supportedMetaAnnotation)) {
+                    return true;
+                }
+            }
+            if (ctx.typeInfo(annotation.typeName())
+                    .map(it -> isMetaAnnotated(it, supportedMetaAnnotations, processed))
+                    .orElse(false)) {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -277,6 +452,7 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
 
     private record ExtensionInfo(RegistryCodegenExtension extension,
                                  Predicate<TypeName> supportedAnnotationsPredicate,
-                                 Set<TypeName> supportedMetaAnnotations) {
+                                 Set<TypeName> supportedMetaAnnotations,
+                                 boolean supportsServiceContractAnnotations) {
     }
 }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
@@ -36,10 +36,13 @@ import io.helidon.codegen.TypeHierarchy;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.ElementSignature;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
 import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 import io.helidon.service.metadata.DescriptorMetadata;
@@ -251,7 +254,8 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                                                                                     metaAnnotationsCache,
                                                                                     metaAnnotatedCache);
             if (!contractAnnotations.isEmpty()) {
-                processedTypes.put(annotatedType.typeInfo().typeName(), annotatedType.typeInfo());
+                processedTypes.put(annotatedType.typeInfo().typeName(),
+                                   effectiveServiceType(roundContext, annotatedType.typeInfo()));
                 availableAnnotations.addAll(contractAnnotations);
                 contractAnnotations.forEach(it -> addMetaAnnotated(metaAnnotated,
                                                                     it,
@@ -273,6 +277,51 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                 Map.copyOf(annotationToTypes),
                 Map.copyOf(metaAnnotatedCopy),
                 List.copyOf(processedTypes.values()));
+    }
+
+    private TypeInfo effectiveServiceType(RoundContext roundContext, TypeInfo serviceType) {
+        ServiceContracts serviceContracts = ServiceContracts.create(ctx.options(), roundContext::typeInfo, serviceType);
+        Set<ResolvedType> contracts = new HashSet<>();
+        serviceContracts.addContracts(contracts, new HashSet<>(), serviceType);
+
+        List<TypedElementInfo> elements = new ArrayList<>();
+        Set<ElementSignature> signatures = new HashSet<>();
+        addEffectiveElements(elements, signatures, TypedElements.gatherElements(ctx, contracts, serviceType));
+
+        ServiceTypes.FactoryInfo factoryInfo = ServiceTypes.factoryInfo(serviceContracts, serviceType);
+        if (factoryInfo.providerType() != FactoryType.SERVICE && factoryInfo.providedTypeInfo() != null) {
+            addEffectiveMethodElements(elements,
+                                       signatures,
+                                       TypedElements.gatherElements(ctx,
+                                                                    factoryInfo.providedContracts(),
+                                                                    factoryInfo.providedTypeInfo()));
+        }
+
+        return TypeInfo.builder(serviceType)
+                .elementInfo(elements)
+                .build();
+    }
+
+    private void addEffectiveElements(List<TypedElementInfo> elements,
+                                      Set<ElementSignature> signatures,
+                                      List<TypedElements.ElementMeta> elementMetas) {
+        for (TypedElements.ElementMeta elementMeta : elementMetas) {
+            TypedElementInfo element = elementMeta.effectiveElement();
+            if (signatures.add(element.signature())) {
+                elements.add(element);
+            }
+        }
+    }
+
+    private void addEffectiveMethodElements(List<TypedElementInfo> elements,
+                                            Set<ElementSignature> signatures,
+                                            List<TypedElements.ElementMeta> elementMetas) {
+        for (TypedElements.ElementMeta elementMeta : elementMetas) {
+            TypedElementInfo element = elementMeta.effectiveElement();
+            if (element.kind() == ElementKind.METHOD && signatures.add(element.signature())) {
+                elements.add(element);
+            }
+        }
     }
 
     private Set<TypeName> supportedServiceContractAnnotations(RoundContext roundContext,

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
@@ -285,7 +285,7 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
         serviceContracts.addContracts(contracts, new HashSet<>(), serviceType);
 
         List<TypedElementInfo> elements = new ArrayList<>();
-        Set<ElementSignature> signatures = new HashSet<>();
+        Set<ElementKey> signatures = new HashSet<>();
         addEffectiveElements(elements, signatures, TypedElements.gatherElements(ctx, contracts, serviceType));
 
         ServiceTypes.FactoryInfo factoryInfo = ServiceTypes.factoryInfo(serviceContracts, serviceType);
@@ -303,22 +303,22 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
     }
 
     private void addEffectiveElements(List<TypedElementInfo> elements,
-                                      Set<ElementSignature> signatures,
+                                      Set<ElementKey> signatures,
                                       List<TypedElements.ElementMeta> elementMetas) {
         for (TypedElements.ElementMeta elementMeta : elementMetas) {
             TypedElementInfo element = elementMeta.effectiveElement();
-            if (signatures.add(element.signature())) {
+            if (signatures.add(ElementKey.create(element))) {
                 elements.add(element);
             }
         }
     }
 
     private void addEffectiveMethodElements(List<TypedElementInfo> elements,
-                                            Set<ElementSignature> signatures,
+                                            Set<ElementKey> signatures,
                                             List<TypedElements.ElementMeta> elementMetas) {
         for (TypedElements.ElementMeta elementMeta : elementMetas) {
             TypedElementInfo element = elementMeta.effectiveElement();
-            if (element.kind() == ElementKind.METHOD && signatures.add(element.signature())) {
+            if (element.kind() == ElementKind.METHOD && signatures.add(ElementKey.create(element))) {
                 elements.add(element);
             }
         }
@@ -503,5 +503,14 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                                  Predicate<TypeName> supportedAnnotationsPredicate,
                                  Set<TypeName> supportedMetaAnnotations,
                                  boolean supportsServiceContractAnnotations) {
+    }
+
+    private record ElementKey(TypeName owner, ElementSignature signature) {
+        static ElementKey create(TypedElementInfo element) {
+            return new ElementKey(element.enclosingType()
+                                          .map(TypeName::genericTypeName)
+                                          .orElse(TypeNames.OBJECT),
+                                  element.signature());
+        }
     }
 }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceTypes.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.codegen;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.helidon.codegen.CodegenException;
+import io.helidon.codegen.ElementInfoPredicates;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+
+final class ServiceTypes {
+    private static final List<TypeName> FACTORY_TYPES = List.of(TypeNames.SUPPLIER,
+                                                                ServiceCodegenTypes.SERVICE_SERVICES_FACTORY,
+                                                                ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY,
+                                                                ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY);
+
+    private ServiceTypes() {
+    }
+
+    /**
+     * Whether the type is a Helidon service type.
+     *
+     * @param type type to check
+     * @return whether the type is a service
+     */
+    static boolean isService(TypeInfo type) {
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER)) {
+            return true;
+        }
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE)) {
+            return true;
+        }
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE)) {
+            return true;
+        }
+        if (type.elementInfo()
+                .stream()
+                .anyMatch(ElementInfoPredicates.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT))) {
+            return true;
+        }
+        for (Annotation annotation : type.annotations()) {
+            if (annotation.hasMetaAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER)) {
+                return true;
+            }
+            if (annotation.hasMetaAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Analyze all supported service factory contracts.
+     *
+     * @param serviceContracts service contracts
+     * @param serviceInfo      service type
+     * @return full factory analysis
+     */
+    static FactoryInfo factoryInfo(ServiceContracts serviceContracts, TypeInfo serviceInfo) {
+        List<TypeInfo> typeInfos = serviceInfo.interfaceTypeInfo();
+        Map<TypeName, TypeInfo> implementedInterfaceTypes = new HashMap<>();
+        typeInfos.forEach(it -> implementedInterfaceTypes.put(it.typeName(), it));
+
+        Set<ResolvedType> directContracts = new HashSet<>();
+        Set<ResolvedType> providedContracts = new HashSet<>();
+        FactoryType providerType = FactoryType.SERVICE;
+        TypeName factoryTypeName = null;
+        TypeName qualifiedProviderQualifier = null;
+        TypeInfo providedTypeInfo = null;
+        TypeName providedTypeName = null;
+
+        for (TypeName factoryType : FACTORY_TYPES) {
+            var response = serviceContracts.analyseFactory(factoryType);
+            if (!response.valid()) {
+                continue;
+            }
+
+            if (factoryType.equals(TypeNames.SUPPLIER)) {
+                if (providerType != FactoryType.SERVICE) {
+                    throw new CodegenException("Service implements more than one provider type: "
+                                                       + providerType + ", and supplier.",
+                                               serviceInfo.originatingElementValue());
+                }
+                providerType = FactoryType.SUPPLIER;
+                factoryTypeName = response.factoryType();
+                directContracts.add(ResolvedType.create(response.factoryType()));
+                providedContracts.addAll(response.providedContracts());
+                providedTypeName = response.providedType();
+                providedTypeInfo = response.providedTypeInfo();
+                implementedInterfaceTypes.remove(TypeNames.SUPPLIER);
+            } else if (factoryType.equals(ServiceCodegenTypes.SERVICE_SERVICES_FACTORY)) {
+                if (providerType != FactoryType.SERVICE) {
+                    throw new CodegenException("Service implements more than one provider type: "
+                                                       + providerType + ", and services provider.",
+                                               serviceInfo.originatingElementValue());
+                }
+                providerType = FactoryType.SERVICES;
+                factoryTypeName = response.factoryType();
+                directContracts.add(ResolvedType.create(response.providedType()));
+                providedContracts.addAll(response.providedContracts());
+                providedTypeName = response.providedType();
+                providedTypeInfo = response.providedTypeInfo();
+                implementedInterfaceTypes.remove(ServiceCodegenTypes.SERVICE_SERVICES_FACTORY);
+            } else if (factoryType.equals(ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY)) {
+                if (providerType != FactoryType.SERVICE) {
+                    throw new CodegenException("Service implements more than one provider type: "
+                                                       + providerType + ", and injection point provider.",
+                                               serviceInfo.originatingElementValue());
+                }
+                providerType = FactoryType.INJECTION_POINT;
+                factoryTypeName = response.factoryType();
+                directContracts.add(ResolvedType.create(response.providedType()));
+                providedContracts.addAll(response.providedContracts());
+                providedTypeName = response.providedType();
+                providedTypeInfo = response.providedTypeInfo();
+                implementedInterfaceTypes.remove(ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY);
+            } else if (factoryType.equals(ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY)) {
+                if (providerType != FactoryType.SERVICE) {
+                    throw new CodegenException("Service implements more than one provider type: "
+                                                       + providerType + ", and qualified provider.",
+                                               serviceInfo.originatingElementValue());
+                }
+                providerType = FactoryType.QUALIFIED;
+                factoryTypeName = response.factoryType();
+                directContracts.add(ResolvedType.create(response.providedType()));
+                providedContracts.addAll(response.providedContracts());
+                qualifiedProviderQualifier = ServiceContracts
+                        .requiredTypeArgument(implementedInterfaceTypes.remove(ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY),
+                                              1);
+                providedTypeName = response.providedType();
+                providedTypeInfo = response.providedTypeInfo();
+            }
+        }
+
+        return new FactoryInfo(providerType,
+                               factoryTypeName,
+                               providedTypeName,
+                               providedTypeInfo,
+                               qualifiedProviderQualifier,
+                               Set.copyOf(directContracts),
+                               Set.copyOf(providedContracts),
+                               Map.copyOf(implementedInterfaceTypes));
+    }
+
+    /**
+     * Contracts provided by the service factory interface implemented by a service.
+     *
+     * @param serviceContracts service contracts
+     * @param serviceInfo      service type
+     * @return provided contracts
+     */
+    static Set<ResolvedType> factoryProvidedContracts(ServiceContracts serviceContracts, TypeInfo serviceInfo) {
+        return factoryInfo(serviceContracts, serviceInfo).providedContracts();
+    }
+
+    record FactoryInfo(FactoryType providerType,
+                       TypeName factoryTypeName,
+                       TypeName providedTypeName,
+                       TypeInfo providedTypeInfo,
+                       TypeName qualifiedProviderQualifier,
+                       Set<ResolvedType> directContracts,
+                       Set<ResolvedType> providedContracts,
+                       Map<TypeName, TypeInfo> remainingImplementedInterfaces) {
+    }
+}

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceTypes.java
@@ -49,6 +49,9 @@ final class ServiceTypes {
         if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER)) {
             return true;
         }
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_DESCRIBE)) {
+            return true;
+        }
         if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE)) {
             return true;
         }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/TypedElements.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/TypedElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,24 @@ package io.helidon.service.codegen;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.ElementInfoPredicates;
+import io.helidon.codegen.TypeHierarchy;
 import io.helidon.common.types.AccessModifier;
+import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.ElementSignature;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
@@ -37,10 +43,10 @@ import static java.util.function.Predicate.not;
 
 final class TypedElements {
     static final ElementMeta DEFAULT_CONSTRUCTOR = new ElementMeta(TypedElementInfo.builder()
-                                                                           .typeName(TypeNames.OBJECT)
-                                                                           .accessModifier(AccessModifier.PUBLIC)
-                                                                           .kind(ElementKind.CONSTRUCTOR)
-                                                                           .build());
+                                                                          .typeName(TypeNames.OBJECT)
+                                                                          .accessModifier(AccessModifier.PUBLIC)
+                                                                          .kind(ElementKind.CONSTRUCTOR)
+                                                                          .build());
 
     private TypedElements() {
     }
@@ -53,6 +59,7 @@ final class TypedElements {
                 .toList();
 
         for (TypedElementInfo declaredElement : declaredElements) {
+            declaredElement = withTargetEnclosingType(declaredElement, typeInfo.typeName());
             List<TypedElements.DeclaredElement> abstractMethods = new ArrayList<>();
 
             if (declaredElement.kind() == ElementKind.METHOD) {
@@ -77,24 +84,30 @@ final class TypedElements {
     static List<TypedElements.ElementMeta> gatherElements(CodegenContext ctx,
                                                           Collection<ResolvedType> contracts,
                                                           TypeInfo typeInfo) {
+        return gatherElements(ctx::typeInfo, contracts, typeInfo);
+    }
+
+    private static List<TypedElements.ElementMeta> gatherElements(TypeInfoFactory typeInfoFactory,
+                                                                  Collection<ResolvedType> contracts,
+                                                                  TypeInfo typeInfo) {
         List<TypedElements.ElementMeta> result = new ArrayList<>();
         Set<ElementSignature> processedSignatures = new HashSet<>();
+        List<ContractInfo> contractInfos = contractInfos(typeInfoFactory, contracts);
 
         typeInfo.elementInfo()
                 .stream()
                 .filter(it -> it.kind() != ElementKind.CLASS)
                 .forEach(declaredElement -> {
+                    declaredElement = withTargetEnclosingType(declaredElement, typeInfo.typeName());
                     List<TypedElements.DeclaredElement> abstractMethods = new ArrayList<>();
 
                     if (declaredElement.kind() == ElementKind.METHOD) {
                         // now find the same method on any interface (if declared there)
-                        for (TypeInfo info : typeInfo.interfaceTypeInfo()) {
-                            if (!contracts.contains(ResolvedType.create(info.typeName()))) {
-                                // only interested in contracts
-                                continue;
-                            }
-
-                            findAbstractMethod(info, declaredElement, abstractMethods);
+                        for (ContractInfo contractInfo : contractInfos) {
+                            findAbstractMethod(contractInfo.typeInfo(),
+                                               contractInfo.resolvedType().type(),
+                                               declaredElement,
+                                               abstractMethods);
                         }
 
                         // and on any super class (must be abstract)
@@ -110,33 +123,160 @@ final class TypedElements {
                 });
 
         // we have gathered all the declared elements, now let's gather inherited elements (default methods etc.)
-        for (ResolvedType contract : contracts) {
-            Optional<TypeInfo> contractTypeInfo = ctx.typeInfo(contract.type());
-            if (contractTypeInfo.isPresent()) {
-                TypeInfo inheritedContract = contractTypeInfo.get();
-                inheritedContract.elementInfo()
-                        .stream()
-                        .filter(it -> it.kind() != ElementKind.CLASS)
-                        .forEach(superElement -> {
-                            if (!processedSignatures.add(superElement.signature())) {
-                                // already processed
-                                return;
-                            }
-                            List<TypedElements.DeclaredElement> interfaceMethods = new ArrayList<>();
-                            if (superElement.kind() == ElementKind.METHOD) {
-                                interfaceMethods.add(new DeclaredElement(inheritedContract, superElement));
-                            }
-                            result.add(new TypedElements.ElementMeta(superElement, interfaceMethods));
-                        });
-            }
+        Map<ElementSignature, List<DeclaredElement>> inheritedMethods = new LinkedHashMap<>();
+        for (ContractInfo contract : contractInfos) {
+            TypeInfo inheritedContract = contract.typeInfo();
+            Map<String, TypeName> typeArguments = typeArgumentMapping(inheritedContract, contract.resolvedType().type());
+            inheritedContract.elementInfo()
+                    .stream()
+                    .filter(it -> it.kind() != ElementKind.CLASS)
+                    .filter(it -> it.kind() != ElementKind.METHOD
+                            || (!ElementInfoPredicates.isStatic(it) && !ElementInfoPredicates.isPrivate(it)))
+                    .map(it -> withEnclosingType(resolveTypeArguments(it, typeArguments), inheritedContract.typeName()))
+                    .forEach(superElement -> {
+                        TypedElementInfo targetElement = withTargetEnclosingType(superElement, typeInfo.typeName());
+                        if (processedSignatures.contains(targetElement.signature())) {
+                            // already processed
+                            return;
+                        }
+                        if (targetElement.kind() == ElementKind.METHOD) {
+                            inheritedMethods.computeIfAbsent(targetElement.signature(), ignored -> new ArrayList<>())
+                                    .add(new DeclaredElement(inheritedContract, superElement));
+                            return;
+                        }
+                        processedSignatures.add(targetElement.signature());
+                        result.add(new TypedElements.ElementMeta(targetElement, List.of()));
+                    });
+        }
+        for (List<DeclaredElement> abstractMethods : inheritedMethods.values()) {
+            TypedElementInfo element = withTargetEnclosingType(abstractMethods.getFirst().element(), typeInfo.typeName());
+            element = mergeAbstractMethods(element,
+                                           abstractMethods.subList(1, abstractMethods.size()));
+            result.add(new TypedElements.ElementMeta(element, abstractMethods));
+            processedSignatures.add(element.signature());
         }
 
         return result;
     }
 
+    private static List<ContractInfo> contractInfos(TypeInfoFactory typeInfoFactory, Collection<ResolvedType> contracts) {
+        List<ContractInfo> contractInfos = contracts.stream()
+                .sorted(Comparator.comparing(it -> it.type().toString()))
+                .flatMap(it -> {
+                    TypeName resolvedType = resolveContractType(typeInfoFactory, contracts, it.type());
+                    return typeInfoFactory.typeInfo(resolvedType)
+                            .or(() -> typeInfoFactory.typeInfo(it.type()))
+                            .map(typeInfo -> new ContractInfo(ResolvedType.create(resolvedType), typeInfo))
+                            .stream();
+                })
+                .toList();
+
+        Map<TypeName, ContractInfo> result = new LinkedHashMap<>();
+        contractInfos.stream()
+                .filter(it -> !lessSpecificGenericContract(contractInfos, it))
+                .forEach(it -> result.putIfAbsent(it.resolvedType().type(), it));
+
+        return List.copyOf(result.values());
+    }
+
+    private static boolean lessSpecificGenericContract(Collection<ContractInfo> contracts, ContractInfo contract) {
+        TypeName typeName = contract.resolvedType().type();
+        if (!genericContract(contract.typeInfo())) {
+            return false;
+        }
+        if (!typeName.typeArguments().isEmpty() && !hasGenericTypeArgument(typeName)) {
+            return false;
+        }
+
+        return contracts.stream()
+                .map(it -> it.resolvedType().type())
+                .anyMatch(it -> typeName.genericTypeName().equals(it.genericTypeName())
+                        && !it.typeArguments().isEmpty()
+                        && !hasGenericTypeArgument(it));
+    }
+
+    private static boolean genericContract(TypeInfo info) {
+        return !info.typeName().typeParameters().isEmpty()
+                || !typeParameterNames(info.declaredType().typeArguments()).isEmpty();
+    }
+
+    private static boolean rawGenericContract(TypeInfoFactory typeInfoFactory, TypeName typeName) {
+        if (!typeName.typeArguments().isEmpty()) {
+            return false;
+        }
+
+        return typeInfoFactory.typeInfo(typeName)
+                .map(TypedElements::genericContract)
+                .orElse(false);
+    }
+
+    private static TypeName resolveContractType(TypeInfoFactory typeInfoFactory,
+                                                Collection<ResolvedType> contracts,
+                                                TypeName typeName) {
+        if (!hasGenericTypeArgument(typeName) && !rawGenericContract(typeInfoFactory, typeName)) {
+            return typeName;
+        }
+
+        for (ResolvedType candidate : contracts) {
+            TypeName candidateType = candidate.type();
+            if (candidateType.typeArguments().isEmpty()
+                    || hasGenericTypeArgument(candidateType)
+                    || candidateType.genericTypeName().equals(typeName.genericTypeName())) {
+                continue;
+            }
+
+            Optional<TypeName> resolvedType = typeInfoFactory.typeInfo(candidateType)
+                    .flatMap(it -> resolveInheritedType(it, candidateType, typeName.genericTypeName(), new HashSet<>()));
+            if (resolvedType.isPresent() && !hasGenericTypeArgument(resolvedType.get())) {
+                return resolvedType.get();
+            }
+        }
+
+        return typeName;
+    }
+
+    private static Optional<TypeName> resolveInheritedType(TypeInfo info,
+                                                           TypeName resolvedInfoType,
+                                                           TypeName targetType,
+                                                           Set<TypeName> processed) {
+        if (!processed.add(resolvedInfoType)) {
+            return Optional.empty();
+        }
+
+        Map<String, TypeName> typeArguments = typeArgumentMapping(info, resolvedInfoType);
+        for (TypeInfo interfaceInfo : info.interfaceTypeInfo()) {
+            TypeName interfaceType = resolveTypeArguments(interfaceInfo.typeName(), typeArguments);
+            if (interfaceType.genericTypeName().equals(targetType)) {
+                return Optional.of(interfaceType);
+            }
+            Optional<TypeName> resolvedType = resolveInheritedType(interfaceInfo, interfaceType, targetType, processed);
+            if (resolvedType.isPresent()) {
+                return resolvedType;
+            }
+        }
+
+        return info.superTypeInfo()
+                .flatMap(superInfo -> {
+                    TypeName superType = resolveTypeArguments(superInfo.typeName(), typeArguments);
+                    if (superType.genericTypeName().equals(targetType)) {
+                        return Optional.of(superType);
+                    }
+                    return resolveInheritedType(superInfo, superType, targetType, processed);
+                });
+    }
+
     private static void findAbstractMethod(TypeInfo info,
                                            TypedElementInfo declaredElement,
                                            List<DeclaredElement> abstractMethods) {
+        findAbstractMethod(info, info.typeName(), declaredElement, abstractMethods);
+    }
+
+    private static void findAbstractMethod(TypeInfo info,
+                                           TypeName resolvedType,
+                                           TypedElementInfo declaredElement,
+                                           List<DeclaredElement> abstractMethods) {
+        Map<String, TypeName> typeArguments = typeArgumentMapping(info, resolvedType);
+
         info.elementInfo()
                 .stream()
                 .filter(ElementInfoPredicates::isMethod)
@@ -144,22 +284,211 @@ final class TypedElements {
                 .filter(not(ElementInfoPredicates::isPrivate))
                 // we want all methods from interfaces, but only abstract methods from abstract classes
                 .filter(it -> ElementInfoPredicates.isAbstract(it) || ElementInfoPredicates.isDefault(it))
+                .map(it -> withEnclosingType(resolveTypeArguments(it, typeArguments), resolvedType))
                 .filter(it -> declaredElement.signature().equals(it.signature()))
                 .findFirst()
                 .ifPresent(it -> abstractMethods.add(new TypedElements.DeclaredElement(info, it)));
+    }
+
+    private static TypedElementInfo withEnclosingType(TypedElementInfo element, TypeName enclosingType) {
+        if (element.enclosingType().isPresent()) {
+            return element;
+        }
+        return TypedElementInfo.builder(element)
+                .enclosingType(enclosingType.genericTypeName())
+                .build();
+    }
+
+    private static TypedElementInfo withTargetEnclosingType(TypedElementInfo element, TypeName enclosingType) {
+        TypeName targetType = enclosingType.genericTypeName();
+        if (element.enclosingType()
+                .map(targetType::equals)
+                .orElse(false)) {
+            return element;
+        }
+        return TypedElementInfo.builder(element)
+                .enclosingType(targetType)
+                .build();
+    }
+
+    private static TypedElementInfo resolveTypeArguments(TypedElementInfo element,
+                                                         Map<String, TypeName> typeArguments) {
+        if (typeArguments.isEmpty()) {
+            return element;
+        }
+
+        List<TypedElementInfo> parameters = element.parameterArguments()
+                .stream()
+                .map(it -> TypedElementInfo.builder(it)
+                        .typeName(resolveTypeArguments(it.typeName(), typeArguments))
+                        .build())
+                .toList();
+
+        return TypedElementInfo.builder(element)
+                .typeName(resolveTypeArguments(element.typeName(), typeArguments))
+                .parameterArguments(parameters)
+                .build();
+    }
+
+    static TypedElementInfo mergeAbstractMethods(TypedElementInfo element, List<DeclaredElement> abstractMethods) {
+        if (abstractMethods.isEmpty()) {
+            return element;
+        }
+
+        List<TypedElementInfo> contractMethods = abstractMethods.stream()
+                .map(DeclaredElement::element)
+                .toList();
+
+        List<Annotation> annotations = new ArrayList<>(element.annotations());
+        contractMethods.stream()
+                .map(TypedElementInfo::annotations)
+                .flatMap(List::stream)
+                .forEach(it -> addAnnotationIfAbsent(annotations, it));
+
+        List<TypedElementInfo> parameters = new ArrayList<>();
+        List<TypedElementInfo> elementParameters = element.parameterArguments();
+        for (int i = 0; i < elementParameters.size(); i++) {
+            TypedElementInfo parameter = elementParameters.get(i);
+            List<Annotation> parameterAnnotations = new ArrayList<>(parameter.annotations());
+            TypeName parameterType = parameter.typeName();
+            for (TypedElementInfo contractMethod : contractMethods) {
+                List<TypedElementInfo> contractParameters = contractMethod.parameterArguments();
+                if (contractParameters.size() > i) {
+                    TypedElementInfo contractParameter = contractParameters.get(i);
+                    contractParameter.annotations().forEach(it -> addAnnotationIfAbsent(parameterAnnotations, it));
+                    parameterType = mergeTypeName(parameterType, contractParameter.typeName());
+                }
+            }
+            parameters.add(TypedElementInfo.builder(parameter)
+                                   .annotations(parameterAnnotations)
+                                   .typeName(parameterType)
+                                   .build());
+        }
+
+        TypeName returnType = element.typeName();
+        for (TypedElementInfo contractMethod : contractMethods) {
+            returnType = mergeTypeName(returnType, contractMethod.typeName());
+        }
+
+        return TypedElementInfo.builder(element)
+                .annotations(annotations)
+                .typeName(returnType)
+                .parameterArguments(parameters)
+                .build();
+    }
+
+    private static TypeName resolveTypeArguments(TypeName typeName, Map<String, TypeName> typeArguments) {
+        if (typeName.generic()) {
+            TypeName resolved = typeArguments.get(typeName.className().trim());
+            if (resolved != null) {
+                return mergeTypeName(resolved, typeName);
+            }
+        }
+
+        List<TypeName> resolvedTypeArguments = typeName.typeArguments()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        List<TypeName> resolvedLowerBounds = typeName.lowerBounds()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        List<TypeName> resolvedUpperBounds = typeName.upperBounds()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        Optional<TypeName> resolvedComponentType = typeName.componentType()
+                .map(it -> resolveTypeArguments(it, typeArguments));
+
+        if (resolvedTypeArguments.equals(typeName.typeArguments())
+                && resolvedLowerBounds.equals(typeName.lowerBounds())
+                && resolvedUpperBounds.equals(typeName.upperBounds())
+                && resolvedComponentType.equals(typeName.componentType())) {
+            return typeName;
+        }
+
+        TypeName.Builder builder = TypeName.builder(typeName)
+                .typeArguments(resolvedTypeArguments)
+                .lowerBounds(resolvedLowerBounds)
+                .upperBounds(resolvedUpperBounds);
+        resolvedComponentType.ifPresent(builder::componentType);
+        return builder.build();
+    }
+
+    private static TypeName mergeTypeName(TypeName typeName, TypeName contractTypeName) {
+        return TypeHierarchy.mergeTypeNameAnnotations(typeName, contractTypeName);
+    }
+
+    private static void addAnnotationIfAbsent(List<Annotation> annotations, Annotation annotation) {
+        if (!annotations.contains(annotation)) {
+            annotations.add(annotation);
+        }
+    }
+
+    private static Map<String, TypeName> typeArgumentMapping(TypeInfo info, TypeName resolvedType) {
+        TypeName typeName = info.typeName();
+        List<String> typeParameters = typeName.typeParameters();
+        List<TypeName> typeArguments = resolvedType.typeArguments();
+        if (typeArguments.isEmpty()) {
+            typeArguments = typeName.typeArguments();
+        }
+        if (typeParameters.isEmpty()) {
+            typeParameters = typeParameterNames(info.declaredType().typeArguments());
+        }
+        if (typeParameters.isEmpty() || typeArguments.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, TypeName> result = new LinkedHashMap<>();
+        for (int i = 0; i < Math.min(typeParameters.size(), typeArguments.size()); i++) {
+            result.put(genericTypeName(typeParameters.get(i)), typeArguments.get(i));
+        }
+        return result;
+    }
+
+    private static List<String> typeParameterNames(List<TypeName> typeParameters) {
+        return typeParameters.stream()
+                .filter(TypeName::generic)
+                .filter(not(TypeName::wildcard))
+                .map(TypeName::className)
+                .map(TypedElements::genericTypeName)
+                .toList();
+    }
+
+    private static String genericTypeName(String typeParameter) {
+        String name = typeParameter.trim();
+        int index = name.indexOf(' ');
+        return index == -1 ? name : name.substring(0, index);
+    }
+
+    private static boolean hasGenericTypeArgument(TypeName typeName) {
+        for (TypeName typeArgument : typeName.typeArguments()) {
+            if (typeArgument.generic() || typeArgument.wildcard() || hasGenericTypeArgument(typeArgument)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
      * Metadata of an element (field, constructor, method).
      *
      * @param element         element declared on a type
-     * @param abstractMethods if the element is a method, this list contains all interface / abstract class abstract methods that
-     *                        define the contract of the method
+     * @param abstractMethods interface or abstract class methods that define the contract of this method
      */
     record ElementMeta(TypedElementInfo element,
                        List<DeclaredElement> abstractMethods) {
         ElementMeta(TypedElementInfo element) {
             this(element, List.of());
+        }
+
+        /**
+         * Element with annotations and type-use annotations merged from matching service-contract methods.
+         *
+         * @return effective element
+         */
+        TypedElementInfo effectiveElement() {
+            return mergeAbstractMethods(element, abstractMethods);
         }
     }
 
@@ -171,5 +500,13 @@ final class TypedElements {
      */
     record DeclaredElement(TypeInfo abstractType,
                            TypedElementInfo element) {
+    }
+
+    private record ContractInfo(ResolvedType resolvedType,
+                                TypeInfo typeInfo) {
+    }
+
+    private interface TypeInfoFactory {
+        Optional<TypeInfo> typeInfo(TypeName typeName);
     }
 }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/spi/RegistryCodegenExtensionProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/spi/RegistryCodegenExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,26 @@ import io.helidon.service.codegen.RegistryCodegenContext;
  * this provider has access to {@link io.helidon.service.codegen.RegistryCodegenContext}.
  */
 public interface RegistryCodegenExtensionProvider extends CodegenProvider {
+    /**
+     * Whether this extension should also process services whose service contracts contain annotations
+     * supported by this extension.
+     * <p>
+     * Service contracts include direct service contracts and contracts provided by factory services. Contract annotations
+     * are discovered from nested contract metadata, including annotations on the contract type, methods, method parameters,
+     * parameter and return type arguments, and annotations matched through {@link #supportedMetaAnnotations()}.
+     * <p>
+     * Matching services are passed to the extension through {@link io.helidon.service.codegen.RegistryRoundContext#types()}.
+     * <p>
+     * Contract annotations do not make the implementation itself appear from
+     * {@link io.helidon.service.codegen.RegistryRoundContext#annotatedTypes(io.helidon.common.types.TypeName)} unless the
+     * implementation also has that annotation directly or through normal annotation inheritance.
+     *
+     * @return whether services with supported service-contract annotations should be processed
+     */
+    default boolean supportsServiceContractAnnotations() {
+        return false;
+    }
+
     /**
      * Create a new extension based on the context.
      *

--- a/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public interface DescriptorMetadata {
     Set<ResolvedType> contracts();
 
     /**
-     * Contracts of the factory service, if this describes a factory, empty otherwise.
+     * Contracts that identify the factory provider itself, if this describes a factory, empty otherwise.
      *
      * @return factory contracts
      */

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -332,26 +332,7 @@ final class Activators {
          * @return whether the provider itself should be returned
          */
         protected boolean requestedProvider(Lookup lookup, FactoryType providerType) {
-            if (lookup.factoryTypes().contains(providerType)) {
-                return true;
-            }
-            if (lookup.contracts().size() == 1) {
-                ResolvedType requestedContract = lookup.contracts().iterator().next();
-                if (requestedContract.equals(ResolvedType.create(descriptor().serviceType()))) {
-                    // requested actual service
-                    return true;
-                }
-                if (descriptor().factoryContracts().contains(requestedContract)
-                        && !descriptor().contracts().contains(requestedContract)) {
-                    // requested a contract satisfied by the factory only
-                    return true;
-                }
-            }
-            if (lookup.serviceType().isPresent() && lookup.serviceType().get().equals(descriptor().serviceType())) {
-                return true;
-            }
-
-            return false;
+            return Contracts.requestedProvider(lookup, descriptor(), providerType);
         }
 
         private void stateTransitionStart(ActivationResult.Builder res, ActivationPhase phase) {
@@ -624,6 +605,11 @@ final class Activators {
         protected Optional<List<QualifiedInstance<T>>> targetInstances(Lookup lookup) {
             if (serviceInstance == null) {
                 return Optional.empty();
+            }
+
+            if (requestedProvider(lookup, FactoryType.QUALIFIED)) {
+                T instance = serviceInstance.get();
+                return Optional.of(List.of(QualifiedInstance.create(instance, provider.descriptor().qualifiers())));
             }
 
             return lookup.qualifiers()

--- a/service/registry/src/main/java/io/helidon/service/registry/ActivatorsPerLookup.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ActivatorsPerLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,6 +148,11 @@ final class ActivatorsPerLookup {
         protected Optional<List<QualifiedInstance<T>>> targetInstances(Lookup lookup) {
             if (serviceInstance == null) {
                 return Optional.empty();
+            }
+
+            if (requestedProvider(lookup, FactoryType.QUALIFIED)) {
+                T instance = serviceInstance.get(currentPhase);
+                return Optional.of(List.of(QualifiedInstance.create(instance, provider.descriptor().qualifiers())));
             }
 
             return lookup.qualifiers()

--- a/service/registry/src/main/java/io/helidon/service/registry/Contracts.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Contracts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 package io.helidon.service.registry;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
 
 /*
 Management of contracts, to return correct contracts for services created from other services,
@@ -33,8 +35,42 @@ final class Contracts {
 
         return switch (descriptor.factoryType()) {
             case NONE, SERVICE -> new FixedContracts(contracts);
-            default -> new ProviderContracts(contracts, descriptor.factoryContracts());
+            default -> new ProviderContracts(descriptor.serviceType(),
+                                             descriptor.factoryType(),
+                                             contracts,
+                                             descriptor.factoryContracts());
         };
+    }
+
+    static boolean requestedProvider(Lookup lookup, ServiceInfo descriptor, FactoryType factoryType) {
+        return requestedProvider(lookup,
+                                 descriptor.serviceType(),
+                                 factoryType,
+                                 descriptor.contracts(),
+                                 descriptor.factoryContracts());
+    }
+
+    private static boolean requestedProvider(Lookup lookup,
+                                             TypeName serviceType,
+                                             FactoryType factoryType,
+                                             Set<ResolvedType> contracts,
+                                             Set<ResolvedType> factoryContracts) {
+        if (lookup.factoryTypes().contains(factoryType)) {
+            return true;
+        }
+        if (lookup.contracts().size() == 1) {
+            ResolvedType requestedContract = lookup.contracts().iterator().next();
+            if (requestedContract.equals(ResolvedType.create(serviceType))) {
+                return true;
+            }
+            if (factoryContracts.contains(requestedContract)
+                    && !contracts.contains(requestedContract)) {
+                return true;
+            }
+        }
+        return lookup.serviceType()
+                .map(serviceType::equals)
+                .orElse(false);
     }
 
     interface ContractLookup {
@@ -55,16 +91,30 @@ final class Contracts {
     }
 
     private static final class ProviderContracts implements ContractLookup {
+        private final TypeName serviceType;
+        private final FactoryType factoryType;
         private final Set<ResolvedType> contracts;
         private final Set<ResolvedType> factoryContracts;
+        private final Set<ResolvedType> providerContracts;
 
-        ProviderContracts(Set<ResolvedType> contracts, Set<ResolvedType> factoryContracts) {
+        ProviderContracts(TypeName serviceType,
+                          FactoryType factoryType,
+                          Set<ResolvedType> contracts,
+                          Set<ResolvedType> factoryContracts) {
+            this.serviceType = serviceType;
+            this.factoryType = factoryType;
             this.contracts = contracts;
             this.factoryContracts = factoryContracts;
+            HashSet<ResolvedType> providerContracts = new HashSet<>(factoryContracts);
+            providerContracts.add(ResolvedType.create(serviceType));
+            this.providerContracts = Set.copyOf(providerContracts);
         }
 
         @Override
         public Set<ResolvedType> contracts(Lookup lookup) {
+            if (requestedProvider(lookup, serviceType, factoryType, contracts, factoryContracts)) {
+                return providerContracts;
+            }
             return contracts;
         }
     }

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -899,7 +899,6 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
         }
         return actualContracts;
     }
-
 
     private record ScopeImpl(TypeName scopeType,
                              Service.ScopeHandler handler,

--- a/service/registry/src/main/java/io/helidon/service/registry/GeneratedService.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/GeneratedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@ package io.helidon.service.registry;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.helidon.common.GenericType;
+import io.helidon.common.LazyValue;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
 
@@ -143,7 +145,7 @@ public final class GeneratedService {
          * @return qualified instance with wrapped instance
          */
         protected Service.QualifiedInstance<T> wrapQualifiedInstance(Service.QualifiedInstance<T> qualifiedInstance) {
-            return Service.QualifiedInstance.create(wrap(qualifiedInstance.get()), qualifiedInstance.qualifiers());
+            return new LazyQualifiedInstance<>(qualifiedInstance, this);
         }
 
         /**
@@ -154,6 +156,26 @@ public final class GeneratedService {
          * @return wrapped instance
          */
         protected abstract T wrap(T originalInstance);
+
+        private static final class LazyQualifiedInstance<T> implements Service.QualifiedInstance<T> {
+            private final Service.QualifiedInstance<T> delegate;
+            private final LazyValue<T> instance;
+
+            private LazyQualifiedInstance(Service.QualifiedInstance<T> delegate, InterceptionWrapper<T> wrapper) {
+                this.delegate = delegate;
+                this.instance = LazyValue.create(() -> wrapper.wrap(delegate.get()));
+            }
+
+            @Override
+            public Set<Qualifier> qualifiers() {
+                return delegate.qualifiers();
+            }
+
+            @Override
+            public T get() {
+                return instance.get();
+            }
+        }
     }
 
     /**
@@ -177,6 +199,31 @@ public final class GeneratedService {
         @Override
         public T get() {
             return wrap(delegate.get());
+        }
+    }
+
+    /**
+     * Wrapper for generated Service factories that implement a {@link java.util.function.Supplier} of an optional service.
+     *
+     * @param <T> type of the provided contract
+     */
+    public abstract static class OptionalSupplierFactoryInterceptionWrapper<T> extends InterceptionWrapper<T>
+            implements Supplier<Optional<T>> {
+        private final Supplier<Optional<T>> delegate;
+
+        /**
+         * Creates a new instance delegating service instantiation to the provided supplier.
+         *
+         * @param delegate used to obtain optional service instance that will be {@link #wrap(Object) wrapped} for interception
+         */
+        protected OptionalSupplierFactoryInterceptionWrapper(Supplier<Optional<T>> delegate) {
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
+        }
+
+        @Override
+        public Optional<T> get() {
+            return delegate.get()
+                    .map(this::wrap);
         }
     }
 
@@ -229,7 +276,7 @@ public final class GeneratedService {
 
         @Override
         public List<Service.QualifiedInstance<T>> list(Lookup lookup) {
-            return delegate.first(lookup)
+            return delegate.list(lookup)
                     .stream()
                     .map(this::wrapQualifiedInstance)
                     .collect(Collectors.toUnmodifiableList());

--- a/service/registry/src/main/java/io/helidon/service/registry/GeneratedService.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/GeneratedService.java
@@ -191,9 +191,10 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided supplier.
          *
          * @param delegate used to obtain service instance that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected SupplierFactoryInterceptionWrapper(Supplier<T> delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override
@@ -215,6 +216,7 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided supplier.
          *
          * @param delegate used to obtain optional service instance that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected OptionalSupplierFactoryInterceptionWrapper(Supplier<Optional<T>> delegate) {
             this.delegate = Objects.requireNonNull(delegate, "delegate");
@@ -241,9 +243,10 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided services factory.
          *
          * @param delegate used to obtain service instances that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected ServicesFactoryInterceptionWrapper(Service.ServicesFactory<T> delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override
@@ -269,9 +272,10 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided injection point factory.
          *
          * @param delegate used to obtain service instances that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected IpFactoryInterceptionWrapper(Service.InjectionPointFactory<T> delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override
@@ -304,9 +308,10 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided qualified factory.
          *
          * @param delegate used to obtain service instances that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected QualifiedFactoryInterceptionWrapper(Service.QualifiedFactory<T, A> delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override

--- a/service/registry/src/main/java/io/helidon/service/registry/InterceptionMetadataImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/InterceptionMetadataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,13 +112,13 @@ class InterceptionMetadataImpl implements InterceptionMetadata {
                                                                   TypedElementInfo element) {
         // need to find all interceptors for the providers (ordered by weight)
         List<ServiceManager<Interception.Interceptor>> allInterceptors = registry.interceptors();
+        String elementSignature = descriptor.serviceType().fqName() + "." + element.signature().text();
 
         List<Supplier<Interception.Interceptor>> result = new ArrayList<>();
 
         for (ServiceManager<Interception.Interceptor> interceptor : allInterceptors) {
             if (interceptor.descriptor().contracts().contains(ELEMENT_INTERCEPTOR)) {
                 // interceptors of specific elements (methods, constructors)
-                String elementSignature = descriptor.serviceType().fqName() + "." + element.signature().text();
                 if (applicableElement(elementSignature, interceptor.descriptor())) {
                     result.add(new ServiceSupply<>(Lookup.EMPTY, List.of(interceptor)));
                 }

--- a/service/registry/src/main/java/io/helidon/service/registry/InterceptionMetadataImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/InterceptionMetadataImpl.java
@@ -112,7 +112,9 @@ class InterceptionMetadataImpl implements InterceptionMetadata {
                                                                   TypedElementInfo element) {
         // need to find all interceptors for the providers (ordered by weight)
         List<ServiceManager<Interception.Interceptor>> allInterceptors = registry.interceptors();
-        String elementSignature = descriptor.serviceType().fqName() + "." + element.signature().text();
+        String elementSignature = element.enclosingType()
+                .orElse(descriptor.serviceType())
+                .fqName() + "." + element.signature().text();
 
         List<Supplier<Interception.Interceptor>> result = new ArrayList<>();
 

--- a/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
@@ -116,6 +116,8 @@ interface LookupBlueprint {
      * If configured, the lookup will return service factories of the
      * chosen types.
      * If no factory types are defined, service instances are returned.
+     * Factory types alone do not expose hidden raw factory-provider descriptors; use a service type or a contract when
+     * the factory provider itself is requested.
      * <p>
      * Otherwise only service factories of the chosen types are returned, as follows:
      * <ul>
@@ -168,7 +170,7 @@ interface LookupBlueprint {
 
         boolean matches = matches(serviceInfo.serviceType(), this.serviceType());
         if (matches && this.serviceType().isEmpty() && hiddenFactoryProviderDescriptor(serviceInfo)) {
-            matches = !this.contracts().isEmpty() || hasFactoryTypeFilter(this.factoryTypes());
+            matches = !this.contracts().isEmpty();
         }
         if (matches && this.serviceType().isEmpty()) {
             matches = serviceInfo.contracts().containsAll(this.contracts())
@@ -254,15 +256,6 @@ interface LookupBlueprint {
             return true;
         }
         return providerTypes.contains(providerType);
-    }
-
-    private boolean hasFactoryTypeFilter(Set<FactoryType> providerTypes) {
-        for (FactoryType providerType : providerTypes) {
-            if (providerType != FactoryType.NONE) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private boolean matchesTypes(Set<TypeName> scopes, Set<TypeName> criteria) {

--- a/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
@@ -168,7 +168,7 @@ interface LookupBlueprint {
 
         boolean matches = matches(serviceInfo.serviceType(), this.serviceType());
         if (matches && this.serviceType().isEmpty() && hiddenFactoryProviderDescriptor(serviceInfo)) {
-            matches = !this.contracts().isEmpty() || !this.factoryTypes().isEmpty();
+            matches = !this.contracts().isEmpty() || hasFactoryTypeFilter(this.factoryTypes());
         }
         if (matches && this.serviceType().isEmpty()) {
             matches = serviceInfo.contracts().containsAll(this.contracts())
@@ -254,6 +254,15 @@ interface LookupBlueprint {
             return true;
         }
         return providerTypes.contains(providerType);
+    }
+
+    private boolean hasFactoryTypeFilter(Set<FactoryType> providerTypes) {
+        for (FactoryType providerType : providerTypes) {
+            if (providerType != FactoryType.NONE) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean matchesTypes(Set<TypeName> scopes, Set<TypeName> criteria) {

--- a/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,13 +163,16 @@ interface LookupBlueprint {
      */
     default boolean matches(ServiceInfo serviceInfo) {
         if (this == LookupSupport.CustomMethods.EMPTY) {
-            return !serviceInfo.isAbstract();
+            return !serviceInfo.isAbstract() && !hiddenFactoryProviderDescriptor(serviceInfo);
         }
 
         boolean matches = matches(serviceInfo.serviceType(), this.serviceType());
+        if (matches && this.serviceType().isEmpty() && hiddenFactoryProviderDescriptor(serviceInfo)) {
+            matches = !this.contracts().isEmpty() || !this.factoryTypes().isEmpty();
+        }
         if (matches && this.serviceType().isEmpty()) {
             matches = serviceInfo.contracts().containsAll(this.contracts())
-                    || this.contracts().contains(ResolvedType.create(serviceInfo.serviceType()))
+                    || matchesConcreteServiceType(serviceInfo)
                     || serviceInfo.factoryContracts().containsAll(this.contracts());
         }
         matches = matches
@@ -208,6 +211,12 @@ interface LookupBlueprint {
         return matches;
     }
 
+    private boolean hiddenFactoryProviderDescriptor(ServiceInfo serviceInfo) {
+        return serviceInfo.contracts().isEmpty()
+                && serviceInfo.factoryType() != FactoryType.NONE
+                && serviceInfo.factoryType() != FactoryType.SERVICE;
+    }
+
     /**
      * Determines whether the provided qualifiers are matched by this lookup criteria.
      *
@@ -234,6 +243,10 @@ interface LookupBlueprint {
             return true;
         }
         return Objects.equals(src, criteria.get());
+    }
+
+    private boolean matchesConcreteServiceType(ServiceInfo serviceInfo) {
+        return this.contracts().contains(ResolvedType.create(serviceInfo.serviceType()));
     }
 
     private boolean matchesProviderTypes(Set<FactoryType> providerTypes, FactoryType providerType) {

--- a/service/registry/src/main/java/io/helidon/service/registry/LookupSupport.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/LookupSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ final class LookupSupport {
 
     static final class CustomMethods {
         /**
-         * Empty lookup matches anything and everything except for abstract types.
+         * Empty lookup matches anything and everything except for abstract types and hidden raw factory providers.
          */
         @Prototype.Constant
         static final Lookup EMPTY = createEmpty();

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceInfo.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,8 @@ public interface ServiceInfo extends Weighted {
     }
 
     /**
-     * Set of contracts the described service implements directly. If the service is not a factory,
-     * this set is empty.
+     * Set of contracts that identify the factory provider itself. These contracts are distinct from contracts of services
+     * provided by the factory. If the service is not a factory, this set is empty.
      *
      * @return set of factory contracts
      */

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceInstance.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,11 @@ public interface ServiceInstance<T> extends Service.QualifiedInstance<T> {
     TypeName TYPE = TypeName.create(ServiceInstance.class);
 
     /**
-     * Contracts of the service instance.
+     * Contracts associated with this service instance for the lookup that produced it.
+     * For factory-backed services, provided-service lookups return the provided service contracts, while provider-targeted
+     * lookups return the provider or factory contracts.
      *
-     * @return contracts the service instance implements
+     * @return contracts associated with this service instance for the current lookup
      */
     Set<ResolvedType> contracts();
 

--- a/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
+++ b/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,6 +176,8 @@ class ServiceCodegenTypesTest {
         // generated interception types
         checkField(toCheck, checked, fields, "INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY",
                    GeneratedService.SupplierFactoryInterceptionWrapper.class);
+        checkField(toCheck, checked, fields, "INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY",
+                   GeneratedService.OptionalSupplierFactoryInterceptionWrapper.class);
         checkField(toCheck, checked, fields, "INTERCEPT_G_WRAPPER_SERVICES_FACTORY",
                    GeneratedService.ServicesFactoryInterceptionWrapper.class);
         checkField(toCheck, checked, fields, "INTERCEPT_G_WRAPPER_IP_FACTORY",

--- a/service/tests/interception/src/main/java/io/helidon/service/tests/interception/AbstractClassTypes.java
+++ b/service/tests/interception/src/main/java/io/helidon/service/tests/interception/AbstractClassTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,16 @@ import io.helidon.service.registry.Service;
  * An example that illustrates usages of {@link io.helidon.service.registry.Interception.Interceptor}.
  */
 class AbstractClassTypes {
+    static final String ABSTRACT_DIRECT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.MyAbstractClassContract.sayHelloDirect(java.lang.String)";
+    static final String IMPL_DIRECT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.MyAbstractClassContractImpl.sayHelloDirect(java.lang.String)";
+    static final String DEFAULT_CONTRACT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.DefaultMethodContract.sayHelloDefault(java.lang.String)";
+    static final String FIRST_DEFAULT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.FirstDefaultMethodService.sayHelloDefault(java.lang.String)";
+    static final String SECOND_DEFAULT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.SecondDefaultMethodService.sayHelloDefault(java.lang.String)";
 
     /**
      * An annotation to mark methods to be intercepted.
@@ -73,6 +83,96 @@ class AbstractClassTypes {
     }
 
     /**
+     * Element interceptor named after the abstract class method. This must not match the subtype service.
+     */
+    @Service.Singleton
+    @Service.Named(ABSTRACT_DIRECT_METHOD)
+    static class AbstractDirectMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
+     * Element interceptor named after the concrete subtype service method.
+     */
+    @Service.Singleton
+    @Service.Named(IMPL_DIRECT_METHOD)
+    static class ImplDirectMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
+     * Element interceptor named after the default interface method. This must not match implementing services.
+     */
+    @Service.Singleton
+    @Service.Named(DEFAULT_CONTRACT_METHOD)
+    static class DefaultContractMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
+     * Element interceptor named after the first default-method service.
+     */
+    @Service.Singleton
+    @Service.Named(FIRST_DEFAULT_METHOD)
+    static class FirstDefaultMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
+     * Element interceptor named after the second default-method service.
+     */
+    @Service.Singleton
+    @Service.Named(SECOND_DEFAULT_METHOD)
+    static class SecondDefaultMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
      * A service that extends an abstract class contract with an intercepted method.
      */
     @Service.Singleton
@@ -82,5 +182,30 @@ class AbstractClassTypes {
         public String sayHello(String name) {
             return "Hello %s!".formatted(name);
         }
+    }
+
+    /**
+     * A service contract with an intercepted default method.
+     */
+    @Service.Contract
+    interface DefaultMethodContract {
+        @Traced
+        default String sayHelloDefault(String name) {
+            return "Hello %s!".formatted(name);
+        }
+    }
+
+    /**
+     * First service that inherits the default method.
+     */
+    @Service.Singleton
+    static class FirstDefaultMethodService implements DefaultMethodContract {
+    }
+
+    /**
+     * Second service that inherits the default method.
+     */
+    @Service.Singleton
+    static class SecondDefaultMethodService implements DefaultMethodContract {
     }
 }

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/AbstractClassInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/AbstractClassInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,16 @@ import java.util.List;
 
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.tests.interception.AbstractClassTypes.AbstractDirectMethodInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.DefaultContractMethodInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.FirstDefaultMethodInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.FirstDefaultMethodService;
+import io.helidon.service.tests.interception.AbstractClassTypes.ImplDirectMethodInterceptor;
 import io.helidon.service.tests.interception.AbstractClassTypes.MyAbstractClassContract;
 import io.helidon.service.tests.interception.AbstractClassTypes.MyAbstractClassContractImpl;
 import io.helidon.service.tests.interception.AbstractClassTypes.MyServiceInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.SecondDefaultMethodInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.SecondDefaultMethodService;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -52,15 +59,32 @@ class AbstractClassInterceptionTest {
     @Test
     void testInterceptor() {
         MyServiceInterceptor.INVOKED.clear();
+        AbstractDirectMethodInterceptor.INVOKED.clear();
+        ImplDirectMethodInterceptor.INVOKED.clear();
+        DefaultContractMethodInterceptor.INVOKED.clear();
+        FirstDefaultMethodInterceptor.INVOKED.clear();
+        SecondDefaultMethodInterceptor.INVOKED.clear();
 
         var myAbstractClassContract = registry.get(MyAbstractClassContract.class);
         assertThat(myAbstractClassContract.sayHello("Jessica"), is("Hello Jessica!"));
         assertThat(myAbstractClassContract.sayHello("Juliet"), is("Hello Juliet!"));
         assertThat(myAbstractClassContract.sayHelloDirect("John"), is("Hello John!"));
+        assertThat(registry.get(FirstDefaultMethodService.class).sayHelloDefault("Jane"), is("Hello Jane!"));
+        assertThat(registry.get(SecondDefaultMethodService.class).sayHelloDefault("Jill"), is("Hello Jill!"));
 
         assertThat(MyServiceInterceptor.INVOKED, is(List.of(
                 "%s.sayHello: [Jessica]".formatted(MyAbstractClassContractImpl.class.getName()),
                 "%s.sayHello: [Juliet]".formatted(MyAbstractClassContractImpl.class.getName()),
+                "%s.sayHelloDirect: [John]".formatted(MyAbstractClassContractImpl.class.getName()),
+                "%s.sayHelloDefault: [Jane]".formatted(FirstDefaultMethodService.class.getName()),
+                "%s.sayHelloDefault: [Jill]".formatted(SecondDefaultMethodService.class.getName()))));
+        assertThat(AbstractDirectMethodInterceptor.INVOKED, is(List.of()));
+        assertThat(ImplDirectMethodInterceptor.INVOKED, is(List.of(
                 "%s.sayHelloDirect: [John]".formatted(MyAbstractClassContractImpl.class.getName()))));
+        assertThat(DefaultContractMethodInterceptor.INVOKED, is(List.of()));
+        assertThat(FirstDefaultMethodInterceptor.INVOKED, is(List.of(
+                "%s.sayHelloDefault: [Jane]".formatted(FirstDefaultMethodService.class.getName()))));
+        assertThat(SecondDefaultMethodInterceptor.INVOKED, is(List.of(
+                "%s.sayHelloDefault: [Jill]".formatted(SecondDefaultMethodService.class.getName()))));
     }
 }

--- a/service/tests/qualified-providers/src/main/java/io/helidon/service/tests/qualified/providers/SecondQualifiedProvider.java
+++ b/service/tests/qualified-providers/src/main/java/io/helidon/service/tests/qualified/providers/SecondQualifiedProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import io.helidon.service.registry.Service;
 import io.helidon.service.registry.Service.QualifiedFactory;
 import io.helidon.service.registry.Service.QualifiedInstance;
 
-@Service.Singleton
+@Service.PerLookup
 class SecondQualifiedProvider implements QualifiedFactory<QualifiedContract, SecondQualifier> {
     private final Map<String, QualifiedContract> values = Map.of("first", new QualifiedContractImpl("first"),
                                                                  "second", new QualifiedContractImpl("second"));

--- a/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
+++ b/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 package io.helidon.service.tests.qualified.providers;
 
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
@@ -23,6 +26,9 @@ import io.helidon.service.registry.ServiceRegistryManager;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class QualifiedProvidersTest {
@@ -57,5 +63,21 @@ public class QualifiedProvidersTest {
         assertThat(theService.second(), is(49));
         assertThat(theService.firstContract().name(), is("first"));
         assertThat(theService.secondContract().name(), is("second"));
+
+        Lookup singletonProviderLookup = Lookup.builder()
+                .serviceType(FirstQualifiedProvider.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        Service.QualifiedFactory<?, ?> singletonProvider = registry.get(singletonProviderLookup);
+        assertThat(singletonProvider, instanceOf(FirstQualifiedProvider.class));
+        assertThat(registry.get(singletonProviderLookup), sameInstance(singletonProvider));
+
+        Lookup perLookupProviderLookup = Lookup.builder()
+                .serviceType(SecondQualifiedProvider.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        Service.QualifiedFactory<?, ?> perLookupProvider = registry.get(perLookupProviderLookup);
+        assertThat(perLookupProvider, instanceOf(SecondQualifiedProvider.class));
+        assertThat(registry.get(perLookupProviderLookup), not(sameInstance(perLookupProvider)));
     }
 }

--- a/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
+++ b/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
@@ -16,9 +16,15 @@
 
 package io.helidon.service.tests.qualified.providers;
 
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.types.ResolvedType;
 import io.helidon.service.registry.FactoryType;
 import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInstance;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
@@ -30,6 +36,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 public class QualifiedProvidersTest {
     @Test
@@ -71,6 +78,13 @@ public class QualifiedProvidersTest {
         Service.QualifiedFactory<?, ?> singletonProvider = registry.get(singletonProviderLookup);
         assertThat(singletonProvider, instanceOf(FirstQualifiedProvider.class));
         assertThat(registry.get(singletonProviderLookup), sameInstance(singletonProvider));
+        List<ServiceInstance<Service.QualifiedFactory<?, ?>>> singletonProviderInstances =
+                registry.lookupInstances(singletonProviderLookup);
+        assertThat(singletonProviderInstances, hasSize(1));
+        assertThat(singletonProviderInstances.getFirst().get(), sameInstance(singletonProvider));
+        assertThat(singletonProviderInstances.getFirst().contracts(),
+                   is(Set.of(ResolvedType.create(Object.class),
+                             ResolvedType.create(FirstQualifiedProvider.class))));
 
         Lookup perLookupProviderLookup = Lookup.builder()
                 .serviceType(SecondQualifiedProvider.class)
@@ -79,5 +93,21 @@ public class QualifiedProvidersTest {
         Service.QualifiedFactory<?, ?> perLookupProvider = registry.get(perLookupProviderLookup);
         assertThat(perLookupProvider, instanceOf(SecondQualifiedProvider.class));
         assertThat(registry.get(perLookupProviderLookup), not(sameInstance(perLookupProvider)));
+        List<ServiceInstance<Service.QualifiedFactory<?, ?>>> perLookupProviderInstances =
+                registry.lookupInstances(perLookupProviderLookup);
+        assertThat(perLookupProviderInstances, hasSize(1));
+        assertThat(perLookupProviderInstances.getFirst().get(), instanceOf(SecondQualifiedProvider.class));
+        assertThat(perLookupProviderInstances.getFirst().contracts(),
+                   is(Set.of(ResolvedType.create(QualifiedContract.class),
+                             ResolvedType.create(SecondQualifiedProvider.class))));
+
+        Lookup providedLookup = Lookup.builder()
+                .addContract(QualifiedContract.class)
+                .addQualifier(Qualifier.create(SecondQualifier.class, "first"))
+                .build();
+        List<ServiceInstance<QualifiedContract>> providedInstances = registry.lookupInstances(providedLookup);
+        assertThat(providedInstances, hasSize(1));
+        assertThat(providedInstances.getFirst().get().name(), is("first"));
+        assertThat(providedInstances.getFirst().contracts(), is(Set.of(ResolvedType.create(QualifiedContract.class))));
     }
 }

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/GeneratedServiceTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/GeneratedServiceTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.service.test.registry;
 
+import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -49,6 +50,14 @@ class GeneratedServiceTest {
     }
 
     @Test
+    void factoryInterceptionWrappersRejectNullDelegates() {
+        assertNullDelegate(() -> new TestSupplierWrapper(null));
+        assertNullDelegate(() -> new TestServicesFactoryWrapper(null, new AtomicInteger()));
+        assertNullDelegate(() -> new TestIpFactoryWrapper(null));
+        assertNullDelegate(() -> new TestQualifiedFactoryWrapper(null));
+    }
+
+    @Test
     void broadLookupsSkipHiddenFactoryProviderDescriptors() {
         var descriptor = new HiddenFactoryProviderInfo();
 
@@ -61,6 +70,11 @@ class GeneratedServiceTest {
                    is(false));
         assertThat(Lookup.builder()
                            .addFactoryType(FactoryType.NONE)
+                           .build()
+                           .matches(descriptor),
+                   is(false));
+        assertThat(Lookup.builder()
+                           .addFactoryType(FactoryType.SUPPLIER)
                            .build()
                            .matches(descriptor),
                    is(false));
@@ -167,9 +181,49 @@ class GeneratedServiceTest {
         assertThat(wraps.get(), is(1));
     }
 
+    private static void assertNullDelegate(Runnable runnable) {
+        NullPointerException e = assertThrows(NullPointerException.class, runnable::run);
+
+        assertThat(e.getMessage(), is("delegate"));
+    }
+
+    private static final class TestSupplierWrapper extends GeneratedService.SupplierFactoryInterceptionWrapper<String> {
+        private TestSupplierWrapper(Supplier<String> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            return originalInstance;
+        }
+    }
+
     private static final class TestOptionalSupplierWrapper
             extends GeneratedService.OptionalSupplierFactoryInterceptionWrapper<String> {
         private TestOptionalSupplierWrapper(Supplier<Optional<String>> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            return originalInstance;
+        }
+    }
+
+    private static final class TestIpFactoryWrapper extends GeneratedService.IpFactoryInterceptionWrapper<String> {
+        private TestIpFactoryWrapper(Service.InjectionPointFactory<String> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            return originalInstance;
+        }
+    }
+
+    private static final class TestQualifiedFactoryWrapper
+            extends GeneratedService.QualifiedFactoryInterceptionWrapper<String, Annotation> {
+        private TestQualifiedFactoryWrapper(Service.QualifiedFactory<String, Annotation> delegate) {
             super(delegate);
         }
 

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/GeneratedServiceTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/GeneratedServiceTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.GeneratedService;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GeneratedServiceTest {
+    @Test
+    void optionalSupplierFactoryInterceptionWrapperRejectsNullDelegate() {
+        NullPointerException e = assertThrows(NullPointerException.class, () -> new TestOptionalSupplierWrapper(null));
+
+        assertThat(e.getMessage(), is("delegate"));
+    }
+
+    @Test
+    void broadLookupsSkipHiddenFactoryProviderDescriptors() {
+        var descriptor = new HiddenFactoryProviderInfo();
+
+        assertThat(Lookup.EMPTY.matches(descriptor), is(false));
+        assertThat(Lookup.builder()
+                           .addScope(Service.Singleton.TYPE)
+                           .runLevel(Service.RunLevel.NORMAL)
+                           .build()
+                           .matches(descriptor),
+                   is(false));
+        assertThat(Lookup.builder()
+                           .addContract(HiddenFactoryProviderInfo.PROVIDER_CONTRACT)
+                           .addFactoryType(FactoryType.SUPPLIER)
+                           .build()
+                           .matches(descriptor),
+                   is(true));
+        assertThat(Lookup.builder()
+                           .serviceType(HiddenFactoryProviderInfo.SERVICE_TYPE)
+                           .build()
+                           .matches(descriptor),
+                   is(true));
+    }
+
+    @Test
+    void servicesFactoryInterceptionWrapperWrapsQualifiedInstanceLazily() {
+        Qualifier qualifier = Qualifier.createNamed("test");
+        Set<Qualifier> qualifiers = Set.of(qualifier);
+        AtomicInteger gets = new AtomicInteger();
+        AtomicInteger wraps = new AtomicInteger();
+        Service.QualifiedInstance<String> qualifiedInstance = new Service.QualifiedInstance<>() {
+            @Override
+            public String get() {
+                gets.incrementAndGet();
+                return "value";
+            }
+
+            @Override
+            public Set<Qualifier> qualifiers() {
+                return qualifiers;
+            }
+        };
+        TestServicesFactoryWrapper wrapper = new TestServicesFactoryWrapper(() -> List.of(qualifiedInstance), wraps);
+
+        List<Service.QualifiedInstance<String>> wrappedInstances = wrapper.services();
+
+        assertThat(wrappedInstances, is(List.of(wrappedInstances.getFirst())));
+        assertThat(wrappedInstances.getFirst().qualifiers(), is(qualifiers));
+        assertThat(gets.get(), is(0));
+        assertThat(wraps.get(), is(0));
+
+        assertThat(wrappedInstances.getFirst().get(), is("wrapped-value"));
+        assertThat(wrappedInstances.getFirst().get(), is("wrapped-value"));
+        assertThat(gets.get(), is(1));
+        assertThat(wraps.get(), is(1));
+    }
+
+    @Test
+    void servicesFactoryInterceptionWrapperWrapsQualifiedInstanceOnceUnderContention() throws Exception {
+        AtomicInteger gets = new AtomicInteger();
+        AtomicInteger wraps = new AtomicInteger();
+        CountDownLatch delegateEntered = new CountDownLatch(1);
+        CountDownLatch releaseDelegate = new CountDownLatch(1);
+        Service.QualifiedInstance<String> qualifiedInstance = new Service.QualifiedInstance<>() {
+            @Override
+            public String get() {
+                gets.incrementAndGet();
+                try {
+                    delegateEntered.countDown();
+                    assertThat(releaseDelegate.await(5, TimeUnit.SECONDS), is(true));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+                return "value";
+            }
+
+            @Override
+            public Set<Qualifier> qualifiers() {
+                return Set.of();
+            }
+        };
+        TestServicesFactoryWrapper wrapper = new TestServicesFactoryWrapper(() -> List.of(qualifiedInstance), wraps);
+        Service.QualifiedInstance<String> wrappedInstance = wrapper.services().getFirst();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(2);
+        try {
+            var first = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                return wrappedInstance.get();
+            });
+            var second = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                return wrappedInstance.get();
+            });
+
+            assertThat(ready.await(5, TimeUnit.SECONDS), is(true));
+            start.countDown();
+            assertThat(delegateEntered.await(5, TimeUnit.SECONDS), is(true));
+            releaseDelegate.countDown();
+
+            assertThat(first.get(5, TimeUnit.SECONDS), is("wrapped-value"));
+            assertThat(second.get(5, TimeUnit.SECONDS), is("wrapped-value"));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(gets.get(), is(1));
+        assertThat(wraps.get(), is(1));
+    }
+
+    private static final class TestOptionalSupplierWrapper
+            extends GeneratedService.OptionalSupplierFactoryInterceptionWrapper<String> {
+        private TestOptionalSupplierWrapper(Supplier<Optional<String>> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            return originalInstance;
+        }
+    }
+
+    private static final class HiddenFactoryProviderInfo implements ServiceInfo {
+        private static final TypeName SERVICE_TYPE = TypeName.create("io.helidon.service.test.registry.HiddenProvider");
+        private static final TypeName DESCRIPTOR_TYPE =
+                TypeName.create("io.helidon.service.test.registry.HiddenProvider__ServiceDescriptor");
+        private static final ResolvedType PROVIDER_CONTRACT = ResolvedType.create(Supplier.class);
+
+        @Override
+        public TypeName serviceType() {
+            return SERVICE_TYPE;
+        }
+
+        @Override
+        public TypeName descriptorType() {
+            return DESCRIPTOR_TYPE;
+        }
+
+        @Override
+        public Set<ResolvedType> factoryContracts() {
+            return Set.of(PROVIDER_CONTRACT);
+        }
+
+        @Override
+        public Optional<Double> runLevel() {
+            return Optional.of(Service.RunLevel.NORMAL);
+        }
+
+        @Override
+        public FactoryType factoryType() {
+            return FactoryType.SUPPLIER;
+        }
+
+        @Override
+        public TypeName scope() {
+            return Service.Singleton.TYPE;
+        }
+    }
+
+    private static final class TestServicesFactoryWrapper
+            extends GeneratedService.ServicesFactoryInterceptionWrapper<String> {
+        private final AtomicInteger wraps;
+
+        private TestServicesFactoryWrapper(Service.ServicesFactory<String> delegate, AtomicInteger wraps) {
+            super(delegate);
+            this.wraps = wraps;
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            wraps.incrementAndGet();
+            return "wrapped-" + originalInstance;
+        }
+    }
+}

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/GeneratedServiceTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/GeneratedServiceTest.java
@@ -60,6 +60,11 @@ class GeneratedServiceTest {
                            .matches(descriptor),
                    is(false));
         assertThat(Lookup.builder()
+                           .addFactoryType(FactoryType.NONE)
+                           .build()
+                           .matches(descriptor),
+                   is(false));
+        assertThat(Lookup.builder()
                            .addContract(HiddenFactoryProviderInfo.PROVIDER_CONTRACT)
                            .addFactoryType(FactoryType.SUPPLIER)
                            .build()

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Contract
+interface InterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class InterfaceConstrainedServiceImpl implements InterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/IpFactoryProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/IpFactoryProvidedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Contract
+interface IpFactoryProvidedService {
+    @Validation.String.NotBlank
+    String value();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/IpFactoryProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/IpFactoryProvidedServiceProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Singleton
+class IpFactoryProvidedServiceProvider implements Service.InjectionPointFactory<IpFactoryProvidedService> {
+    @Override
+    public Optional<Service.QualifiedInstance<IpFactoryProvidedService>> first(Lookup lookup) {
+        return Optional.of(Service.QualifiedInstance.create(() -> "first"));
+    }
+
+    @Override
+    @Validation.Collection.Size(min = 1)
+    public List<Service.QualifiedInstance<IpFactoryProvidedService>> list(Lookup lookup) {
+        return List.of(Service.QualifiedInstance.create(() -> "list"));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Contract
+interface QualifiedFactoryProvidedService {
+    @Validation.String.NotBlank
+    String value();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedServiceProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Singleton
+class QualifiedFactoryProvidedServiceProvider
+        implements Service.QualifiedFactory<QualifiedFactoryProvidedService, QualifiedFactoryQualifier> {
+    @Override
+    public Optional<Service.QualifiedInstance<QualifiedFactoryProvidedService>> first(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryProvidedService> type) {
+        return Optional.of(Service.QualifiedInstance.create(() -> "first", qualifier));
+    }
+
+    @Override
+    @Validation.Collection.Size(min = 1)
+    public List<Service.QualifiedInstance<QualifiedFactoryProvidedService>> list(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryProvidedService> type) {
+        return List.of(Service.QualifiedInstance.create(() -> "list", qualifier));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryQualifier.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryQualifier.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.helidon.service.registry.Service;
+
+@Service.Qualifier
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@interface QualifiedFactoryQualifier {
+    String value();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Contract
+interface SupplierProvidedService {
+    @Validation.String.NotBlank
+    String get();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedServiceProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class SupplierProvidedServiceProvider implements Supplier<SupplierProvidedService> {
+    @Override
+    public SupplierProvidedService get() {
+        return () -> "";
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
@@ -40,9 +40,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Testing.Test
 public class ValidationTest {
     private final ValidatedService service;
+    private final InterfaceConstrainedService interfaceConstrainedService;
 
-    public ValidationTest(ValidatedService service) {
+    public ValidationTest(ValidatedService service, InterfaceConstrainedService interfaceConstrainedService) {
         this.service = service;
+        this.interfaceConstrainedService = interfaceConstrainedService;
     }
 
     @Test
@@ -50,6 +52,18 @@ public class ValidationTest {
         var response = service.process(new ValidatedType("good_test_value", 42, new BigDecimal("1.10")));
 
         assertThat(response, is("Good"));
+    }
+
+    @Test
+    public void testInterfaceMethodConstraint() {
+        var response = interfaceConstrainedService.validate("value");
+
+        assertThat(response, is("value"));
+
+        var result = assertThrows(ValidationException.class, () -> interfaceConstrainedService.validate(""));
+
+        assertThat(result.violations(), hasSize(1));
+        assertThat(result.violations().getFirst().message(), containsString("is blank"));
     }
 
     @Test

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
@@ -20,7 +20,13 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.GenericType;
 import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.testing.junit5.Testing;
 import io.helidon.validation.ConstraintViolation.Location;
 import io.helidon.validation.ConstraintViolation.PathElement;
@@ -41,10 +47,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class ValidationTest {
     private final ValidatedService service;
     private final InterfaceConstrainedService interfaceConstrainedService;
+    private final SupplierProvidedService supplierProvidedService;
+    private final ServiceRegistry registry;
 
-    public ValidationTest(ValidatedService service, InterfaceConstrainedService interfaceConstrainedService) {
+    public ValidationTest(ValidatedService service,
+                          InterfaceConstrainedService interfaceConstrainedService,
+                          SupplierProvidedService supplierProvidedService,
+                          ServiceRegistry registry) {
         this.service = service;
         this.interfaceConstrainedService = interfaceConstrainedService;
+        this.supplierProvidedService = supplierProvidedService;
+        this.registry = registry;
     }
 
     @Test
@@ -64,6 +77,53 @@ public class ValidationTest {
 
         assertThat(result.violations(), hasSize(1));
         assertThat(result.violations().getFirst().message(), containsString("is blank"));
+    }
+
+    @Test
+    public void testSupplierProvidedSameSignatureConstraint() {
+        var result = assertThrows(ValidationException.class, supplierProvidedService::get);
+
+        assertThat(result.violations(), hasSize(1));
+        assertThat(result.violations().getFirst().message(), containsString("is blank"));
+    }
+
+    @Test
+    public void testInjectionPointFactoryUsesCustomizedFirst() {
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(IpFactoryProvidedService.class)
+                .addFactoryType(FactoryType.INJECTION_POINT)
+                .build();
+        @SuppressWarnings("unchecked")
+        Service.InjectionPointFactory<IpFactoryProvidedService> factory = registry.get(factoryLookup);
+
+        Lookup providedLookup = Lookup.builder()
+                .addContract(IpFactoryProvidedService.class)
+                .build();
+
+        assertThat(factory.first(providedLookup).orElseThrow().get().value(), is("first"));
+        assertThat(factory.list(providedLookup).getFirst().get().value(), is("list"));
+    }
+
+    @Test
+    public void testQualifiedFactoryUsesCustomizedFirst() {
+        Lookup factoryLookup = Lookup.builder()
+                .serviceType(QualifiedFactoryProvidedServiceProvider.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        @SuppressWarnings("unchecked")
+        Service.QualifiedFactory<QualifiedFactoryProvidedService, QualifiedFactoryQualifier> factory =
+                registry.get(factoryLookup);
+
+        Qualifier qualifier = Qualifier.create(QualifiedFactoryQualifier.class, "test");
+        Lookup providedLookup = Lookup.builder()
+                .addContract(QualifiedFactoryProvidedService.class)
+                .addQualifier(qualifier)
+                .build();
+        GenericType<QualifiedFactoryProvidedService> providedType =
+                GenericType.create(QualifiedFactoryProvidedService.class);
+
+        assertThat(factory.first(qualifier, providedLookup, providedType).orElseThrow().get().value(), is("first"));
+        assertThat(factory.list(qualifier, providedLookup, providedType).getFirst().get().value(), is("list"));
     }
 
     @Test


### PR DESCRIPTION
Resolves #11872

Fixes service registry/codegen handling for services whose validation constraints are discovered through implemented service contracts.

The change updates service codegen and registry metadata so generated interception wrappers preserve service/factory contract information, route factory-provided services through the correct wrappers, and keep element interceptor qualifiers exact for each generated service type and method signature.

