### PR TITLE
Fix TLS reload without initial managers (4.x)

### DIFF
--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.net.ssl.CertPathTrustManagerParameters;
 import javax.net.ssl.KeyManager;
@@ -60,12 +61,9 @@ public class ConfiguredTlsManager implements TlsManager {
     private static final LazyValue<SecureRandom> RANDOM = LazyValue.create(SecureRandom::new);
     private final String name;
     private final String type;
+    private final ReentrantLock stateLock = new ReentrantLock();
 
-    private volatile X509KeyManager keyManager;
-    private volatile TlsReloadableX509KeyManager reloadableKeyManager;
-    private volatile X509TrustManager trustManager;
-    private volatile TlsReloadableX509TrustManager reloadableTrustManager;
-    private volatile SSLContext sslContext;
+    private volatile TlsManagerState state = new TlsManagerState();
 
     ConfiguredTlsManager() {
         this("@default", "tls-manager");
@@ -95,7 +93,7 @@ public class ConfiguredTlsManager implements TlsManager {
 
     @Override // TlsManager
     public SSLContext sslContext() {
-        return sslContext;
+        return state.sslContext;
     }
 
     @Override // TlsManager
@@ -110,12 +108,12 @@ public class ConfiguredTlsManager implements TlsManager {
 
     @Override // TlsManager
     public Optional<X509KeyManager> keyManager() {
-        return Optional.ofNullable(keyManager);
+        return Optional.ofNullable(state.keyManager);
     }
 
     @Override // TlsManager
     public Optional<X509TrustManager> trustManager() {
-        return Optional.ofNullable(trustManager);
+        return Optional.ofNullable(state.trustManager);
     }
 
     /**
@@ -127,8 +125,36 @@ public class ConfiguredTlsManager implements TlsManager {
     // for extensibility it is more suitable to have a single method for reloading, hence the optional parameters,
     // if we need even one more, create an object with a builder
     protected void reload(Optional<X509KeyManager> keyManager, Optional<X509TrustManager> trustManager) {
-        keyManager.ifPresent(reloadableKeyManager::reload);
-        trustManager.ifPresent(reloadableTrustManager::reload);
+        stateLock.lock();
+        try {
+            TlsManagerState current = state;
+            X509KeyManager keyManagerToReload = keyManager.orElse(null);
+            X509TrustManager trustManagerToReload = trustManager.orElse(null);
+
+            if (keyManagerToReload != null) {
+                validateReload(current.reloadableKeyManager, keyManagerToReload);
+            }
+            if (trustManagerToReload != null) {
+                validateReload(current.reloadableTrustManager, trustManagerToReload);
+            }
+
+            if (keyManagerToReload != null) {
+                current.reloadableKeyManager.reload(keyManagerToReload);
+            }
+            if (trustManagerToReload != null) {
+                current.reloadableTrustManager.reload(trustManagerToReload);
+            }
+
+            if (keyManagerToReload != null || trustManagerToReload != null) {
+                state = new TlsManagerState(current.sslContext,
+                                            keyManagerToReload == null ? current.keyManager : keyManagerToReload,
+                                            current.reloadableKeyManager,
+                                            trustManagerToReload == null ? current.trustManager : trustManagerToReload,
+                                            current.reloadableTrustManager);
+            }
+        } finally {
+            stateLock.unlock();
+        }
     }
 
     /**
@@ -143,45 +169,13 @@ public class ConfiguredTlsManager implements TlsManager {
                                   SecureRandom secureRandom,
                                   KeyManager[] keyManagers,
                                   TrustManager[] trustManagers) {
+        stateLock.lock();
         try {
-            TrustManager[] tm;
-            KeyManager[] km;
-
-            if (keyManagers.length == 0) {
-                km = null;
-            } else {
-                km = wrapX509KeyManagers(keyManagers);
-            }
-
-            if (trustManagers.length == 0) {
-                tm = null;
-            } else {
-                tm = wrapX509TrustManagers(trustManagers);
-            }
-
-            SSLContext sslContext;
-
-            if (tlsConfig.provider().isPresent()) {
-                sslContext = SSLContext.getInstance(tlsConfig.protocol(), tlsConfig.provider().get());
-            } else {
-                sslContext = SSLContext.getInstance(tlsConfig.protocol());
-            }
-            sslContext.init(km, tm, secureRandom);
-
-            SSLSessionContext serverSessionContext = sslContext.getServerSessionContext();
-            if (serverSessionContext != null) {
-                if (tlsConfig.sessionCacheSize() != TlsConfig.DEFAULT_SESSION_CACHE_SIZE) {
-                    // To allow javax.net.ssl.sessionCacheSize system property usage
-                    // see javax.net.ssl.SSLSessionContext.getSessionCacheSize doc
-                    serverSessionContext.setSessionCacheSize(tlsConfig.sessionCacheSize());
-                }
-                // seconds
-                serverSessionContext.setSessionTimeout((int) tlsConfig.sessionTimeout().toSeconds());
-            }
-
-            this.sslContext = sslContext;
+            initSslContextLocked(tlsConfig, secureRandom, keyManagers, trustManagers);
         } catch (GeneralSecurityException e) {
             throw new IllegalArgumentException("Failed to create SSLContext", e);
+        } finally {
+            stateLock.unlock();
         }
     }
 
@@ -219,9 +213,9 @@ public class ConfiguredTlsManager implements TlsManager {
     /**
      * Build the key manager factory.
      *
-     * @param target        the tls configuration
-     * @param secureRandom  the secure random
-     * @param privateKey    the private key for the key store
+     * @param target       the tls configuration
+     * @param secureRandom the secure random
+     * @param privateKey   the private key for the key store
      * @param certificates the certificates for the keystore
      * @return a key manager factory instance
      */
@@ -302,8 +296,8 @@ public class ConfiguredTlsManager implements TlsManager {
     /**
      * Perform initialization of the {@link TrustManagerFactory} based on the provided TLS configuration.
      *
-     * @param tmf trust manager factory to be initialized
-     * @param keyStore keystore
+     * @param tmf       trust manager factory to be initialized
+     * @param keyStore  keystore
      * @param tlsConfig tls configuration
      */
     protected void initializeTmf(TrustManagerFactory tmf, KeyStore keyStore, TlsConfig tlsConfig) {
@@ -350,6 +344,74 @@ public class ConfiguredTlsManager implements TlsManager {
         return new TrustAllManagerFactory();
     }
 
+    // for tests
+    TlsReloadableX509KeyManager reloadableKeyManager() {
+        return state.reloadableKeyManager;
+    }
+
+    private static void validateReload(TlsReloadableX509KeyManager reloadableKeyManager, X509KeyManager keyManager) {
+        if (reloadableKeyManager instanceof TlsReloadableX509KeyManager.NotReloadableKeyManager) {
+            reloadableKeyManager.reload(keyManager);
+        }
+        TlsReloadableX509KeyManager.assertValid(keyManager);
+    }
+
+    private static void validateReload(TlsReloadableX509TrustManager reloadableTrustManager,
+                                       X509TrustManager trustManager) {
+        if (reloadableTrustManager instanceof TlsReloadableX509TrustManager.NotReloadableTrustManager) {
+            reloadableTrustManager.reload(trustManager);
+        }
+        TlsReloadableX509TrustManager.assertValid(trustManager);
+    }
+
+    private void initSslContextLocked(TlsConfig tlsConfig,
+                                      SecureRandom secureRandom,
+                                      KeyManager[] keyManagers,
+                                      TrustManager[] trustManagers) throws GeneralSecurityException {
+        TrustManager[] tm;
+        KeyManager[] km;
+        KeyManagerState keyManagerState;
+        TrustManagerState trustManagerState;
+
+        if (keyManagers.length == 0) {
+            keyManagerState = noReloadableKeyManagerState(null);
+            km = null;
+        } else {
+            keyManagerState = wrapX509KeyManagers(keyManagers);
+            km = keyManagerState.keyManagers;
+        }
+
+        if (trustManagers.length == 0) {
+            trustManagerState = noReloadableTrustManagerState(null);
+            tm = null;
+        } else {
+            trustManagerState = wrapX509TrustManagers(trustManagers);
+            tm = trustManagerState.trustManagers;
+        }
+
+        SSLContext sslContext;
+
+        if (tlsConfig.provider().isPresent()) {
+            sslContext = SSLContext.getInstance(tlsConfig.protocol(), tlsConfig.provider().get());
+        } else {
+            sslContext = SSLContext.getInstance(tlsConfig.protocol());
+        }
+        sslContext.init(km, tm, secureRandom);
+
+        SSLSessionContext serverSessionContext = sslContext.getServerSessionContext();
+        if (serverSessionContext != null) {
+            if (tlsConfig.sessionCacheSize() != TlsConfig.DEFAULT_SESSION_CACHE_SIZE) {
+                // To allow javax.net.ssl.sessionCacheSize system property usage
+                // see javax.net.ssl.SSLSessionContext.getSessionCacheSize doc
+                serverSessionContext.setSessionCacheSize(tlsConfig.sessionCacheSize());
+            }
+            // seconds
+            serverSessionContext.setSessionTimeout((int) tlsConfig.sessionTimeout().toSeconds());
+        }
+
+        setSslContext(sslContext, keyManagerState, trustManagerState);
+    }
+
     // creates an internal keystore and initializes it with certificates discovered from configuration, then gets the trust
     // manager factory using tmf(TlsConfig)
     private TrustManagerFactory initTmf(TlsConfig tlsConfig) throws KeyStoreException {
@@ -379,7 +441,14 @@ public class ConfiguredTlsManager implements TlsManager {
 
     private void sslContext(TlsConfig tlsConfig) {
         if (tlsConfig.sslContext().isPresent()) {
-            this.sslContext = tlsConfig.sslContext().get();
+            stateLock.lock();
+            try {
+                setSslContext(tlsConfig.sslContext().get(),
+                              noReloadableKeyManagerState(null),
+                              noReloadableTrustManagerState(null));
+            } finally {
+                stateLock.unlock();
+            }
             return;
         }
 
@@ -428,20 +497,18 @@ public class ConfiguredTlsManager implements TlsManager {
      * @param keyManagers used key managers
      * @return the same managers, except the first X509 one is wrapped
      */
-    private KeyManager[] wrapX509KeyManagers(KeyManager[] keyManagers) {
+    private KeyManagerState wrapX509KeyManagers(KeyManager[] keyManagers) {
         KeyManager[] toReturn = new KeyManager[keyManagers.length];
         System.arraycopy(keyManagers, 0, toReturn, 0, toReturn.length);
         for (int i = 0; i < keyManagers.length; i++) {
             KeyManager keyManager = keyManagers[i];
             if (keyManager instanceof X509KeyManager x509KeyManager) {
-                this.keyManager = x509KeyManager;
-                this.reloadableKeyManager = TlsReloadableX509KeyManager.create(x509KeyManager);
+                TlsReloadableX509KeyManager reloadableKeyManager = TlsReloadableX509KeyManager.create(x509KeyManager);
                 toReturn[i] = reloadableKeyManager;
-                return toReturn;
+                return new KeyManagerState(toReturn, x509KeyManager, reloadableKeyManager);
             }
         }
-        this.reloadableKeyManager = new TlsReloadableX509KeyManager.NotReloadableKeyManager();
-        return toReturn;
+        return noReloadableKeyManagerState(toReturn);
     }
 
     /**
@@ -450,19 +517,91 @@ public class ConfiguredTlsManager implements TlsManager {
      * @param trustManagers used trust managers
      * @return the same managers, except the first X509 one is wrapped
      */
-    private TrustManager[] wrapX509TrustManagers(TrustManager[] trustManagers) {
+    private TrustManagerState wrapX509TrustManagers(TrustManager[] trustManagers) {
         TrustManager[] toReturn = new TrustManager[trustManagers.length];
         System.arraycopy(trustManagers, 0, toReturn, 0, toReturn.length);
         for (int i = 0; i < trustManagers.length; i++) {
             TrustManager trustManager = trustManagers[i];
             if (trustManager instanceof X509TrustManager x509TrustManager) {
-                this.trustManager = x509TrustManager;
-                this.reloadableTrustManager = TlsReloadableX509TrustManager.create(x509TrustManager);
+                TlsReloadableX509TrustManager reloadableTrustManager = TlsReloadableX509TrustManager.create(x509TrustManager);
                 toReturn[i] = reloadableTrustManager;
-                return toReturn;
+                return new TrustManagerState(toReturn, x509TrustManager, reloadableTrustManager);
             }
         }
-        this.reloadableTrustManager = new TlsReloadableX509TrustManager.NotReloadableTrustManager();
-        return toReturn;
+        return noReloadableTrustManagerState(toReturn);
+    }
+
+    private KeyManagerState noReloadableKeyManagerState(KeyManager[] keyManagers) {
+        return new KeyManagerState(keyManagers, null, new TlsReloadableX509KeyManager.NotReloadableKeyManager());
+    }
+
+    private TrustManagerState noReloadableTrustManagerState(TrustManager[] trustManagers) {
+        return new TrustManagerState(trustManagers, null, new TlsReloadableX509TrustManager.NotReloadableTrustManager());
+    }
+
+    private void setSslContext(SSLContext sslContext,
+                               KeyManagerState keyManagerState,
+                               TrustManagerState trustManagerState) {
+        this.state = new TlsManagerState(sslContext,
+                                         keyManagerState.keyManager,
+                                         keyManagerState.reloadableKeyManager,
+                                         trustManagerState.trustManager,
+                                         trustManagerState.reloadableTrustManager);
+    }
+
+    private static final class TlsManagerState {
+        private final SSLContext sslContext;
+        private final X509KeyManager keyManager;
+        private final TlsReloadableX509KeyManager reloadableKeyManager;
+        private final X509TrustManager trustManager;
+        private final TlsReloadableX509TrustManager reloadableTrustManager;
+
+        private TlsManagerState() {
+            this(null,
+                 null,
+                 new TlsReloadableX509KeyManager.NotReloadableKeyManager(),
+                 null,
+                 new TlsReloadableX509TrustManager.NotReloadableTrustManager());
+        }
+
+        private TlsManagerState(SSLContext sslContext,
+                                X509KeyManager keyManager,
+                                TlsReloadableX509KeyManager reloadableKeyManager,
+                                X509TrustManager trustManager,
+                                TlsReloadableX509TrustManager reloadableTrustManager) {
+            this.sslContext = sslContext;
+            this.keyManager = keyManager;
+            this.reloadableKeyManager = reloadableKeyManager;
+            this.trustManager = trustManager;
+            this.reloadableTrustManager = reloadableTrustManager;
+        }
+    }
+
+    private static final class KeyManagerState {
+        private final KeyManager[] keyManagers;
+        private final X509KeyManager keyManager;
+        private final TlsReloadableX509KeyManager reloadableKeyManager;
+
+        private KeyManagerState(KeyManager[] keyManagers,
+                                X509KeyManager keyManager,
+                                TlsReloadableX509KeyManager reloadableKeyManager) {
+            this.keyManagers = keyManagers;
+            this.keyManager = keyManager;
+            this.reloadableKeyManager = reloadableKeyManager;
+        }
+    }
+
+    private static final class TrustManagerState {
+        private final TrustManager[] trustManagers;
+        private final X509TrustManager trustManager;
+        private final TlsReloadableX509TrustManager reloadableTrustManager;
+
+        private TrustManagerState(TrustManager[] trustManagers,
+                                  X509TrustManager trustManager,
+                                  TlsReloadableX509TrustManager reloadableTrustManager) {
+            this.trustManagers = trustManagers;
+            this.trustManager = trustManager;
+            this.reloadableTrustManager = reloadableTrustManager;
+        }
     }
 }

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsReloadableX509KeyManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsReloadableX509KeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,10 @@ import javax.net.ssl.X509KeyManager;
 class TlsReloadableX509KeyManager extends X509ExtendedKeyManager implements TlsReloadableComponent {
     private static final System.Logger LOGGER = System.getLogger(TlsReloadableX509KeyManager.class.getName());
 
-    private volatile X509KeyManager keyManager;
-    private volatile X509ExtendedKeyManager extended;
+    private volatile KeyManagerState state;
 
     private TlsReloadableX509KeyManager(X509KeyManager keyManager) {
-        this.keyManager = keyManager;
-        extended(keyManager);
+        this.state = new KeyManagerState(keyManager);
     }
 
     static TlsReloadableX509KeyManager create(X509KeyManager keyManager) {
@@ -53,42 +51,42 @@ class TlsReloadableX509KeyManager extends X509ExtendedKeyManager implements TlsR
 
     @Override
     public String[] getClientAliases(String s, Principal[] principals) {
-        return keyManager.getClientAliases(s, principals);
+        return state.keyManager.getClientAliases(s, principals);
     }
 
     @Override
     public String chooseClientAlias(String[] strings, Principal[] principals, Socket socket) {
-        return keyManager.chooseClientAlias(strings, principals, socket);
+        return state.keyManager.chooseClientAlias(strings, principals, socket);
     }
 
     @Override
     public String[] getServerAliases(String s, Principal[] principals) {
-        return keyManager.getServerAliases(s, principals);
+        return state.keyManager.getServerAliases(s, principals);
     }
 
     @Override
     public String chooseServerAlias(String s, Principal[] principals, Socket socket) {
-        return keyManager.chooseServerAlias(s, principals, socket);
+        return state.keyManager.chooseServerAlias(s, principals, socket);
     }
 
     @Override
     public X509Certificate[] getCertificateChain(String s) {
-        return keyManager.getCertificateChain(s);
+        return state.keyManager.getCertificateChain(s);
     }
 
     @Override
     public PrivateKey getPrivateKey(String s) {
-        return keyManager.getPrivateKey(s);
+        return state.keyManager.getPrivateKey(s);
     }
 
     @Override
     public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
-        return extended.chooseEngineClientAlias(keyType, issuers, engine);
+        return state.extended.chooseEngineClientAlias(keyType, issuers, engine);
     }
 
     @Override
     public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
-        return extended.chooseEngineServerAlias(keyType, issuers, engine);
+        return state.extended.chooseEngineServerAlias(keyType, issuers, engine);
     }
 
     @Override
@@ -100,16 +98,14 @@ class TlsReloadableX509KeyManager extends X509ExtendedKeyManager implements TlsR
         Objects.requireNonNull(keyManager, "Cannot unset key manager");
         assertValid(keyManager);
         LOGGER.log(System.Logger.Level.DEBUG, "Reloading TLS X509KeyManager");
-        this.keyManager = keyManager;
-        extended(keyManager);
+        this.state = new KeyManagerState(keyManager);
     }
 
-    private void extended(X509KeyManager keyManager) {
+    private static X509ExtendedKeyManager extended(X509KeyManager keyManager) {
         if (keyManager instanceof X509ExtendedKeyManager ekm) {
-            this.extended = ekm;
-            return;
+            return ekm;
         }
-        this.extended = new X509ExtendedKeyManager() {
+        return new X509ExtendedKeyManager() {
             @Override
             public String[] getClientAliases(String s, Principal[] principals) {
                 return keyManager.getClientAliases(s, principals);
@@ -150,6 +146,16 @@ class TlsReloadableX509KeyManager extends X509ExtendedKeyManager implements TlsR
                 return keyManager.chooseServerAlias(keyType, issuers, null);
             }
         };
+    }
+
+    private static final class KeyManagerState {
+        private final X509KeyManager keyManager;
+        private final X509ExtendedKeyManager extended;
+
+        private KeyManagerState(X509KeyManager keyManager) {
+            this.keyManager = keyManager;
+            this.extended = extended(keyManager);
+        }
     }
 
     static class NotReloadableKeyManager extends TlsReloadableX509KeyManager {

--- a/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls;
+
+import java.net.Socket;
+import java.security.GeneralSecurityException;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConfiguredTlsManagerTest {
+    @Test
+    void reloadCannotAddTrustManagerAfterStartingWithoutOne() {
+        Tls tls = Tls.create(it -> { });
+        Tls reload = Tls.create(it -> it.trustAll(true));
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                                                               () -> tls.reload(reload));
+
+        assertThat(exception.getMessage(), is("Cannot set trust manager if one was not set during server start"));
+    }
+
+    @Test
+    void reloadCannotAddKeyManagerAfterStartingWithoutOne() {
+        Tls tls = Tls.create(it -> { });
+        Tls reload = Tls.create(it -> it.manager(new KeyManagerOnlyTlsManager()));
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                                                               () -> tls.reload(reload));
+
+        assertThat(exception.getMessage(), is("Cannot reload key manager if one was not set during server start"));
+    }
+
+    @Test
+    void reloadCannotAddTrustManagerAfterStartingWithExplicitSslContext() {
+        SSLContext sslContext = createSslContext();
+        Tls tls = Tls.create(it -> it.sslContext(sslContext));
+        Tls reload = Tls.create(it -> it.trustAll(true));
+
+        assertThat(tls.sslContext(), sameInstance(sslContext));
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                                                               () -> tls.reload(reload));
+
+        assertThat(exception.getMessage(), is("Cannot set trust manager if one was not set during server start"));
+    }
+
+    @Test
+    void reloadCannotAddKeyManagerAfterStartingWithExplicitSslContext() {
+        SSLContext sslContext = createSslContext();
+        Tls tls = Tls.create(it -> it.sslContext(sslContext));
+        Tls reload = Tls.create(it -> it.manager(new KeyManagerOnlyTlsManager()));
+
+        assertThat(tls.sslContext(), sameInstance(sslContext));
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                                                               () -> tls.reload(reload));
+
+        assertThat(exception.getMessage(), is("Cannot reload key manager if one was not set during server start"));
+    }
+
+    @Test
+    void failedReinitializationDoesNotClearReloadableManagers() {
+        ConfiguredTlsManager manager = new ConfiguredTlsManager();
+        X509KeyManager keyManager = new TestKeyManager();
+        X509TrustManager trustManager = new TestTrustManager();
+        TlsConfig initialConfig = Tls.builder().buildPrototype();
+        TlsConfig failingConfig = Tls.builder()
+                .provider("missing-provider")
+                .buildPrototype();
+
+        manager.initSslContext(initialConfig,
+                               new SecureRandom(),
+                               new KeyManager[] {keyManager},
+                               new TrustManager[] {trustManager});
+        SSLContext sslContext = manager.sslContext();
+
+        assertThat(manager.sslContext(), sameInstance(sslContext));
+        assertThat(manager.keyManager().orElseThrow(), sameInstance(keyManager));
+        assertThat(manager.trustManager().orElseThrow(), sameInstance(trustManager));
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> manager.initSslContext(failingConfig,
+                                                  new SecureRandom(),
+                                                  new KeyManager[] {new TestKeyManager()},
+                                                  new TrustManager[] {new TestTrustManager()}));
+
+        assertThat(manager.sslContext(), sameInstance(sslContext));
+        assertThat(manager.keyManager().orElseThrow(), sameInstance(keyManager));
+        assertThat(manager.trustManager().orElseThrow(), sameInstance(trustManager));
+
+        X509KeyManager reloadedKeyManager = new TestKeyManager();
+        X509TrustManager reloadedTrustManager = new TestTrustManager();
+        manager.reload(Optional.of(reloadedKeyManager), Optional.of(reloadedTrustManager));
+
+        assertThat(manager.keyManager().orElseThrow(), sameInstance(reloadedKeyManager));
+        assertThat(manager.trustManager().orElseThrow(), sameInstance(reloadedTrustManager));
+    }
+
+    @Test
+    void reloadDoesNotChangeKeyManagerWhenTrustManagerCannotReload() {
+        ConfiguredTlsManager manager = new ConfiguredTlsManager();
+        PrivateKey initialPrivateKey = new TestPrivateKey("initial");
+        PrivateKey reloadPrivateKey = new TestPrivateKey("reload");
+
+        manager.initSslContext(Tls.builder().buildPrototype(),
+                               new SecureRandom(),
+                               new KeyManager[] {new TestKeyManager(initialPrivateKey)},
+                               new TrustManager[0]);
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                                                               () -> manager.reload(
+                                                                       Optional.of(new TestKeyManager(reloadPrivateKey)),
+                                                                       Optional.of(new TestTrustManager())));
+
+        assertThat(exception.getMessage(), is("Cannot set trust manager if one was not set during server start"));
+        assertThat(manager.reloadableKeyManager().getPrivateKey("test"), sameInstance(initialPrivateKey));
+    }
+
+    private static SSLContext createSslContext() {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, null, null);
+            return sslContext;
+        } catch (GeneralSecurityException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static final class KeyManagerOnlyTlsManager implements TlsManager {
+        private SSLContext sslContext;
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public String type() {
+            return "test";
+        }
+
+        @Override
+        public void init(TlsConfig tls) {
+            this.sslContext = createSslContext();
+        }
+
+        @Override
+        public void reload(Tls tls) {
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            return sslContext;
+        }
+
+        @Override
+        public Optional<X509KeyManager> keyManager() {
+            return Optional.of(new TestKeyManager());
+        }
+
+        @Override
+        public Optional<X509TrustManager> trustManager() {
+            return Optional.empty();
+        }
+    }
+
+    private static final class TestKeyManager implements X509KeyManager {
+        private final PrivateKey privateKey;
+
+        private TestKeyManager() {
+            this(new TestPrivateKey("test"));
+        }
+
+        private TestKeyManager(PrivateKey privateKey) {
+            this.privateKey = privateKey;
+        }
+
+        @Override
+        public String[] getClientAliases(String keyType, Principal[] issuers) {
+            return new String[0];
+        }
+
+        @Override
+        public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+            return null;
+        }
+
+        @Override
+        public String[] getServerAliases(String keyType, Principal[] issuers) {
+            return new String[0];
+        }
+
+        @Override
+        public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+            return null;
+        }
+
+        @Override
+        public X509Certificate[] getCertificateChain(String alias) {
+            return new X509Certificate[0];
+        }
+
+        @Override
+        public PrivateKey getPrivateKey(String alias) {
+            return privateKey;
+        }
+    }
+
+    private static final class TestPrivateKey implements PrivateKey {
+        private static final long serialVersionUID = 1L;
+
+        private final String algorithm;
+
+        private TestPrivateKey(String algorithm) {
+            this.algorithm = algorithm;
+        }
+
+        @Override
+        public String getAlgorithm() {
+            return algorithm;
+        }
+
+        @Override
+        public String getFormat() {
+            return "RAW";
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return new byte[0];
+        }
+    }
+
+    private static final class TestTrustManager implements X509TrustManager {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+}


### PR DESCRIPTION
Resolves #11884

Fixes reload handling for configured TLS managers that started without key or trust managers. The reload path now uses controlled not-reloadable sentinels, validates both sides before mutating either manager, and keeps TLS manager state publication consistent across reload and failed reinitialization.
