### PR TITLE
Remove incorrect double-setting of OTel baggage context in MP

### DIFF
--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -29,9 +29,6 @@ import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
 
-import io.opentelemetry.api.baggage.Baggage;
-import io.opentelemetry.api.baggage.BaggageEntryMetadata;
-import io.opentelemetry.context.Context;
 import io.opentelemetry.semconv.ServerAttributes;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -162,9 +159,6 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         requestContext.setProperty(SPAN, helidonSpan);
         requestContext.setProperty(SPAN_SCOPE, helidonScope);
 
-        // Handle OpenTelemetry Baggage from the current OpenTelemetry Context.
-        handleBaggage(requestContext, Context.current());
-
     }
 
     @Override
@@ -277,30 +271,6 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
             return path + "?" + rawQuery;
         }
         return path;
-    }
-
-    // Extract OpenTelemetry Baggage from Request Headers.
-    private void handleBaggage(ContainerRequestContext containerRequestContext, Context context) {
-        List<String> baggageProperties = containerRequestContext.getHeaders().get("baggage");
-        if (baggageProperties != null) {
-            var baggageBuilder = Baggage.builder();
-            for (String b : baggageProperties) {
-                String[] assignments = b.split(",");
-                for (String assignment : assignments) {
-                    String[] split = assignment.split("=");
-                    if (split.length == 2) {
-                        String[] valueAndMetadata = split[1].split(";");
-                        String value = valueAndMetadata.length > 0 ? valueAndMetadata[0] : "";
-                        String metadata = valueAndMetadata.length > 1 ? valueAndMetadata[1] : "";
-                        baggageBuilder
-                                .put(split[0], value, BaggageEntryMetadata.create(metadata));
-                    }
-                }
-            }
-            baggageBuilder.build()
-                    .storeInContext(context)
-                    .makeCurrent();
-        }
     }
 
     private static Class<?> getRealClass(Class<?> object) {

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestPropagatedBaggageCleared.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestPropagatedBaggageCleared.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.microprofile.testing.AddBean;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+
+@HelidonTest
+@AddBean(BaggageCheckingResource.class)
+class TestPropagatedBaggageCleared {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void testPropagatedBaggageCleared() {
+
+        Response response = webTarget.path("/baggage")
+                .request()
+                .header("baggage", "xx=2")
+                .get();
+
+        assertThat("Response status", response.getStatus(), is(200));
+        assertThat("Baggage during request with header", response.readEntity(String.class), is("xx=2"));
+
+        response = webTarget.path("/baggage")
+                .request()
+                .get();
+
+        assertThat("Response status", response.getStatus(), is(200));
+        assertThat("Baggage during request without header", response.readEntity(String.class), isEmptyString());
+
+    }
+}


### PR DESCRIPTION
### Description
Resolves #11882 

### Release note
____
Helidon MP Telemetry no longer incorrectly adds an additional OpenTelemetry `Context` for propagated baggage.
____

The `HelidonTelemetryContainerFilter` detects propagated context on an incoming request(tracer, span, baggage) and re-establishes the equivalent in-memory context, executes the request, then "pops" the in-memory context.

Originally, the MP Telemetry implementation used only OTel APIs. Part of its work was to explicitly establish the span context and the baggage context in memory.

Later, once Helidon had a full-fledged OTel-based provider for the neutral tracing API, we updated the MP code to use it. That provider included logic to re-establish propagated context for incoming requests.

But the code to explicitly set the baggage was incorrectly left in the MP filter. This caused an extra OTel context to be set. Further, when the response part of the filter closes the Helidon `Scope` (which would normally pop the OTel context), the current context--set by the request part of the filter adding the baggage again--did not match the context represented by the `Scope` so the scope did not pop the OTel context.

This left the OTel context in place. A later request with no context propagation of its own would incorrectly "inherit" this left-over context.

The PR removes the code which adds the extra baggage context and adds a test.

### Documentation
Bug fix No impact.