### PR TITLE
Defensively copy TLS SSL parameters (main)

### DIFF
--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -69,7 +69,7 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
         // at this time, the TlsConfigDecorator should have created SSL parameters; the SSL context is the responsibility
         // of the manager to provide
         this.tlsConfig = Objects.requireNonNull(config);
-        this.sslParameters = config.sslParameters().orElseThrow();
+        this.sslParameters = copySslParameters(config.sslParameters().orElseThrow());
         this.enabled = config.enabled();
 
         if (config.enabled()) {
@@ -140,7 +140,7 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
     public final SSLEngine newEngine() {
         checkEnabled();
         SSLEngine sslEngine = sslContext.createSSLEngine();
-        sslEngine.setSSLParameters(sslParameters);
+        sslEngine.setSSLParameters(copySslParameters(sslParameters));
         return sslEngine;
     }
 
@@ -177,9 +177,7 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
         try {
             SSLServerSocket socket = (SSLServerSocket) sslServerSocketFactory.createServerSocket();
 
-            // create a copy of SSLParameters, as otherwise we may use wrong endpoint identification algorithm for server
-            SSLParameters parameters = copySslParameters();
-            parameters.setApplicationProtocols(this.sslParameters.getApplicationProtocols());
+            SSLParameters parameters = copySslParameters(sslParameters);
             parameters.setEndpointIdentificationAlgorithm("");
 
             socket.setSSLParameters(parameters);
@@ -203,10 +201,8 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
             SSLSocket sslSocket = (SSLSocket) sslSocketFactory
                     .createSocket(socket, address.getHostName(), address.getPort(), true);
 
-            // create a copy of SSLParameters, as otherwise we may overwrite alpnProtocols of requests in parallel
-            SSLParameters parameters = copySslParameters();
+            SSLParameters parameters = copySslParameters(sslParameters);
             parameters.setApplicationProtocols(alpnProtocols.toArray(new String[0]));
-            parameters.setEndpointIdentificationAlgorithm(this.sslParameters.getEndpointIdentificationAlgorithm());
 
             sslSocket.setSSLParameters(parameters);
             return sslSocket;
@@ -226,12 +222,12 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
     }
 
     /**
-     * SSL parameters.
+     * SSL parameters. The returned parameters are a copy, and changing them does not modify this TLS configuration.
      *
-     * @return SSL parameters
+     * @return SSL parameters copy
      */
     public SSLParameters sslParameters() {
-        return sslParameters;
+        return copySslParameters(sslParameters);
     }
 
     /**
@@ -262,25 +258,25 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
         return tlsManager.trustManager();
     }
 
-    private SSLParameters copySslParameters() {
-        // this copy does not set application protocols (each client request may have different ones)
-        // this copy does not set endpoint identification algorithm, server must not set it
+    private static SSLParameters copySslParameters(SSLParameters source) {
         SSLParameters parameters = new SSLParameters();
-        parameters.setServerNames(this.sslParameters.getServerNames());
-        parameters.setCipherSuites(this.sslParameters.getCipherSuites());
-        parameters.setAlgorithmConstraints(this.sslParameters.getAlgorithmConstraints());
-        parameters.setEnableRetransmissions(this.sslParameters.getEnableRetransmissions());
-        parameters.setMaximumPacketSize(this.sslParameters.getMaximumPacketSize());
-        parameters.setNamedGroups(this.sslParameters.getNamedGroups());
-        parameters.setProtocols(this.sslParameters.getProtocols());
-        parameters.setSignatureSchemes(this.sslParameters.getSignatureSchemes());
-        parameters.setSNIMatchers(this.sslParameters.getSNIMatchers());
-        parameters.setUseCipherSuitesOrder(this.sslParameters.getUseCipherSuitesOrder());
-        if (this.sslParameters.getNeedClientAuth()) {
-            parameters.setNeedClientAuth(this.sslParameters.getNeedClientAuth());
+        parameters.setServerNames(source.getServerNames());
+        parameters.setCipherSuites(source.getCipherSuites());
+        parameters.setAlgorithmConstraints(source.getAlgorithmConstraints());
+        parameters.setApplicationProtocols(source.getApplicationProtocols());
+        parameters.setEndpointIdentificationAlgorithm(source.getEndpointIdentificationAlgorithm());
+        parameters.setEnableRetransmissions(source.getEnableRetransmissions());
+        parameters.setMaximumPacketSize(source.getMaximumPacketSize());
+        parameters.setNamedGroups(source.getNamedGroups());
+        parameters.setProtocols(source.getProtocols());
+        parameters.setSignatureSchemes(source.getSignatureSchemes());
+        parameters.setSNIMatchers(source.getSNIMatchers());
+        parameters.setUseCipherSuitesOrder(source.getUseCipherSuitesOrder());
+        if (source.getNeedClientAuth()) {
+            parameters.setNeedClientAuth(source.getNeedClientAuth());
         }
-        if (this.sslParameters.getWantClientAuth()) {
-            parameters.setWantClientAuth(this.sslParameters.getWantClientAuth());
+        if (source.getWantClientAuth()) {
+            parameters.setWantClientAuth(source.getWantClientAuth());
         }
         return parameters;
     }

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.common.tls;
 
+import java.io.IOException;
 import java.security.AlgorithmConstraints;
 import java.security.AlgorithmParameters;
 import java.security.CryptoPrimitive;
@@ -24,11 +25,13 @@ import java.util.List;
 import java.util.Set;
 
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
 
 public class TlsTest {
     @Test
@@ -67,5 +70,49 @@ public class TlsTest {
 
         first.setSNIMatchers(List.of());
         second.setSNIMatchers(List.of());
+    }
+
+    @Test
+    public void testSslParametersCannotMutateTls() throws IOException {
+        Tls tls = Tls.create(it -> it.addApplicationProtocol("h2")
+                .endpointIdentificationAlgorithm(Tls.ENDPOINT_IDENTIFICATION_HTTPS));
+
+        SSLParameters parameters = tls.sslParameters();
+        parameters.setApplicationProtocols(new String[] {"http/1.1"});
+        parameters.setEndpointIdentificationAlgorithm("");
+
+        SSLParameters freshParameters = tls.sslParameters();
+        assertThat(freshParameters.getApplicationProtocols(), arrayContaining("h2"));
+        assertThat(freshParameters.getEndpointIdentificationAlgorithm(), is(Tls.ENDPOINT_IDENTIFICATION_HTTPS));
+
+        SSLParameters engineParameters = tls.newEngine().getSSLParameters();
+        assertThat(engineParameters.getApplicationProtocols(), arrayContaining("h2"));
+        assertThat(engineParameters.getEndpointIdentificationAlgorithm(), is(Tls.ENDPOINT_IDENTIFICATION_HTTPS));
+
+        try (SSLServerSocket serverSocket = tls.createServerSocket()) {
+            SSLParameters serverParameters = serverSocket.getSSLParameters();
+            assertThat(serverParameters.getApplicationProtocols(), arrayContaining("h2"));
+            assertThat(serverParameters.getEndpointIdentificationAlgorithm(), is(""));
+        }
+    }
+
+    @Test
+    public void testConfiguredSslParametersCannotMutateTls() {
+        SSLParameters configured = new SSLParameters();
+        configured.setApplicationProtocols(new String[] {"h2"});
+        configured.setEndpointIdentificationAlgorithm(Tls.ENDPOINT_IDENTIFICATION_HTTPS);
+
+        Tls tls = Tls.create(it -> it.sslParameters(configured));
+
+        configured.setApplicationProtocols(new String[] {"http/1.1"});
+        configured.setEndpointIdentificationAlgorithm("");
+
+        SSLParameters freshParameters = tls.sslParameters();
+        assertThat(freshParameters.getApplicationProtocols(), arrayContaining("h2"));
+        assertThat(freshParameters.getEndpointIdentificationAlgorithm(), is(Tls.ENDPOINT_IDENTIFICATION_HTTPS));
+
+        SSLParameters engineParameters = tls.newEngine().getSSLParameters();
+        assertThat(engineParameters.getApplicationProtocols(), arrayContaining("h2"));
+        assertThat(engineParameters.getEndpointIdentificationAlgorithm(), is(Tls.ENDPOINT_IDENTIFICATION_HTTPS));
     }
 }


### PR DESCRIPTION
Resolves #11889

Carries forward #11890 to `main`, defensively copying TLS `SSLParameters` when storing, exposing, and applying them so external mutation cannot alter later TLS engines or sockets.
