### PR TITLE
Fix timeout current-thread completion logging (4.x)

### DIFF
--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -133,8 +133,9 @@ public final class FaultTolerance {
             try {
                 Thread.sleep(millis);
             } catch (InterruptedException e) {
-                // should never be interrupted
-                LOGGER.log(ERROR, "Delayed runnable was unexpectedly interrupted");
+                // Future.cancel(true) interrupts the sleeping task to cancel the delayed action.
+                Thread.currentThread().interrupt();
+                return;
             }
             runnable.run();
         };

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -18,6 +18,7 @@ package io.helidon.faulttolerance;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
@@ -129,6 +130,7 @@ public final class FaultTolerance {
      */
     @Deprecated(forRemoval = true, since = "4.3.0")
     public static Runnable toDelayedRunnable(Runnable runnable, long millis) {
+        Objects.requireNonNull(runnable, "runnable");
         return () -> {
             try {
                 Thread.sleep(millis);

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutThreadsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutThreadsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,20 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.helidon.common.testing.junit5.InMemoryLoggingHandler;
+import io.helidon.common.testing.junit5.LogRecordMatcher;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
 /**
@@ -58,6 +67,57 @@ class TimeoutThreadTest {
         for (Thread thread : threads) {
             assertThat(thread.getState(), is(not(Thread.State.TIMED_WAITING)));
         }
+    }
+
+    @Test
+    void testCurrentThreadCompletionDoesNotLogInterruptedMonitor() {
+        Logger logger = Logger.getLogger(FaultTolerance.class.getName());
+        Level originalLevel = logger.getLevel();
+        logger.setLevel(Level.ALL);
+
+        TestThreadFactory threadFactory = new TestThreadFactory();
+        try (ExecutorService executor = Executors.newThreadPerTaskExecutor(threadFactory);
+                InMemoryLoggingHandler handler = InMemoryLoggingHandler.create(logger)) {
+            String status = Timeout.builder()
+                    .timeout(Duration.ofSeconds(10))
+                    .currentThread(true)
+                    .executor(executor)
+                    .build()
+                    .invoke(() -> {
+                        Thread monitorThread = awaitMonitorThread(threadFactory);
+                        awaitThreadState(monitorThread, Thread.State.TIMED_WAITING);
+                        return "done";
+                    });
+            assertThat(status, is("done"));
+            assertThat(handler.logRecords(),
+                       not(hasItem(LogRecordMatcher.withMessage(
+                               containsString("Delayed runnable was unexpectedly interrupted")))));
+        } finally {
+            logger.setLevel(originalLevel);
+        }
+    }
+
+    private static Thread awaitMonitorThread(TestThreadFactory threadFactory) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            List<Thread> threads = threadFactory.threads();
+            if (!threads.isEmpty()) {
+                return threads.get(0);
+            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
+        }
+        throw new AssertionError("Timed out waiting for the timeout monitor thread to start");
+    }
+
+    private static void awaitThreadState(Thread thread, Thread.State expectedState) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            if (thread.getState() == expectedState) {
+                return;
+            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
+        }
+        throw new AssertionError("Timed out waiting for thread state " + expectedState + ", last state was " + thread.getState());
     }
 
     static class TestThreadFactory implements ThreadFactory {

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutThreadsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutThreadsTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Check that all threads created by timeout instances are properly
@@ -78,23 +79,30 @@ class TimeoutThreadTest {
         TestThreadFactory threadFactory = new TestThreadFactory();
         try (ExecutorService executor = Executors.newThreadPerTaskExecutor(threadFactory);
                 InMemoryLoggingHandler handler = InMemoryLoggingHandler.create(logger)) {
+            Thread[] monitorThread = new Thread[1];
             String status = Timeout.builder()
                     .timeout(Duration.ofSeconds(10))
                     .currentThread(true)
                     .executor(executor)
                     .build()
                     .invoke(() -> {
-                        Thread monitorThread = awaitMonitorThread(threadFactory);
-                        awaitThreadState(monitorThread, Thread.State.TIMED_WAITING);
+                        monitorThread[0] = awaitMonitorThread(threadFactory);
+                        awaitThreadState(monitorThread[0], Thread.State.TIMED_WAITING);
                         return "done";
                     });
             assertThat(status, is("done"));
+            awaitThreadTerminated(monitorThread[0]);
             assertThat(handler.logRecords(),
                        not(hasItem(LogRecordMatcher.withMessage(
                                containsString("Delayed runnable was unexpectedly interrupted")))));
         } finally {
             logger.setLevel(originalLevel);
         }
+    }
+
+    @Test
+    void testDelayedRunnableRequiresRunnable() {
+        assertThrows(NullPointerException.class, () -> FaultTolerance.toDelayedRunnable(null, 1));
     }
 
     private static Thread awaitMonitorThread(TestThreadFactory threadFactory) {
@@ -118,6 +126,22 @@ class TimeoutThreadTest {
             LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
         }
         throw new AssertionError("Timed out waiting for thread state " + expectedState + ", last state was " + thread.getState());
+    }
+
+    private static void awaitThreadTerminated(Thread thread) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            try {
+                thread.join(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("Interrupted while waiting for thread to terminate", e);
+            }
+            if (!thread.isAlive()) {
+                return;
+            }
+        }
+        throw new AssertionError("Timed out waiting for thread to terminate, last state was " + thread.getState());
     }
 
     static class TestThreadFactory implements ThreadFactory {


### PR DESCRIPTION
Resolves #11560

Backports #11790 to `helidon-4.x`.

This avoids logging an error when a `currentThread(true)` timeout monitor is interrupted by normal cancellation after the protected invocation completes. It also tightens the 4.x regression test so the canceled monitor thread has finished before captured logs are checked.
