### PR TITLE
Fix invalid feature flavor metadata

### DIFF
--- a/common/features/codegen/pom.xml
+++ b/common/features/codegen/pom.xml
@@ -28,6 +28,11 @@
     <artifactId>helidon-common-features-codegen</artifactId>
     <name>Helidon Common Features Codegen</name>
 
+    <properties>
+        <!-- TestCompiler module-path setup is incorrectly reported as compile-scope test-only dependencies. -->
+        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.metadata</groupId>
@@ -49,5 +54,54 @@
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-metadata</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-apt</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <proc>none</proc>
+                            <compilerArgs combine.children="append">
+                                <compilerArg>--add-modules</compilerArg>
+                                <compilerArg>java.compiler</compilerArg>
+                                <compilerArg>--add-reads</compilerArg>
+                                <compilerArg>io.helidon.common.features.codegen=java.compiler</compilerArg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/features/codegen/src/main/java/io/helidon/common/features/codegen/FeatureCodegenExtension.java
+++ b/common/features/codegen/src/main/java/io/helidon/common/features/codegen/FeatureCodegenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ class FeatureCodegenExtension implements CodegenExtension {
                 .stream()
                 .flatMap(List::stream)
                 .map(Flavor::valueOf)
-                .forEach(builder::addFlavor);
+                .forEach(builder::addInvalidFlavor);
 
         if (module.hasAnnotation(FeatureCodegenTypes.INCUBATING)) {
             builder.status(FeatureStatus.INCUBATING);

--- a/common/features/codegen/src/test/java/io/helidon/common/features/codegen/FeatureCodegenExtensionTest.java
+++ b/common/features/codegen/src/test/java/io/helidon/common/features/codegen/FeatureCodegenExtensionTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.features.codegen;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.features.api.Features;
+import io.helidon.common.features.metadata.FeatureMetadata;
+import io.helidon.common.features.metadata.FeatureRegistry;
+import io.helidon.common.features.metadata.Flavor;
+import io.helidon.metadata.MetadataConstants;
+import io.helidon.metadata.hson.Hson;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+class FeatureCodegenExtensionTest {
+
+    @Test
+    void invalidFlavorIsGeneratedAsInvalidFlavor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addModulepath(Features.class)
+                .addModulepath(FeatureMetadata.class)
+                .addModulepath(io.helidon.common.Builder.class)
+                .addModulepath(MetadataConstants.class)
+                .addModulepath(Hson.class)
+                .addModulepath(BufferData.class)
+                .addProcessor(AptProcessor::new)
+                .printDiagnostics(false)
+                .addSource("module-info.java", """
+                        import io.helidon.common.features.api.Features;
+                        import io.helidon.common.features.api.HelidonFlavor;
+
+                        @Features.Name("Test Feature")
+                        @Features.InvalidFlavor(HelidonFlavor.MP)
+                        module test.module {
+                            requires io.helidon.common.features.api;
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat("Compilation diagnostics: " + diagnostics, result.success(), is(true));
+
+        var registry = result.classOutput()
+                .resolve(MetadataConstants.LOCATION)
+                .resolve("test.module")
+                .resolve(MetadataConstants.FEATURE_REGISTRY_FILE);
+        assertThat(Files.exists(registry), is(true));
+
+        FeatureMetadata metadata;
+        try (var input = Files.newInputStream(registry)) {
+            metadata = FeatureRegistry.metadata("test", Hson.parse(input).asArray())
+                    .getFirst();
+        }
+        assertThat(metadata.flavors(), not(hasItem(Flavor.MP)));
+        assertThat(metadata.invalidFlavors(), contains(Flavor.MP));
+    }
+}


### PR DESCRIPTION
Resolves #11897

Carries forward #11898 to `main`. Feature codegen now records `@Features.InvalidFlavor` values as invalid flavors in generated feature metadata instead of supported flavors. The regression compiles an annotated module descriptor with `TestCompiler` and verifies the generated registry through `FeatureRegistry`.
