### PR TITLE
Fix BufferData lastIndexOf index handling (main)

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/CompositeArrayBufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/CompositeArrayBufferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,16 +218,35 @@ class CompositeArrayBufferData extends ReadOnlyBufferData implements CompositeBu
     public int lastIndexOf(byte aByte, int length) {
         int index;
         int lengthRemaining = length;
+        int indexPrefix = 0;
+        int lastFullIndex = -1;
 
-        for (int i = data.length - 1; i >= 0; i--) {
-            BufferData datum = data[i];
-            index = datum.lastIndexOf(aByte, Math.min(lengthRemaining, datum.available()));
-            if (index > -1) {
-                return index;
-            }
-            lengthRemaining -= datum.available();
+        for (int i = 0; i < data.length; i++) {
             if (lengthRemaining <= 0) {
                 break;
+            }
+            BufferData datum = data[i];
+            int available = datum.available();
+            if (lengthRemaining <= available) {
+                index = datum.lastIndexOf(aByte, lengthRemaining);
+                if (index > -1) {
+                    return indexPrefix + index;
+                }
+                lastFullIndex = i - 1;
+                break;
+            }
+            lengthRemaining -= available;
+            indexPrefix += available;
+            lastFullIndex = i;
+        }
+
+        for (int i = lastFullIndex; i >= 0; i--) {
+            BufferData datum = data[i];
+            int available = datum.available();
+            indexPrefix -= available;
+            index = datum.lastIndexOf(aByte, available);
+            if (index > -1) {
+                return indexPrefix + index;
             }
         }
         return -1;

--- a/common/buffers/src/main/java/io/helidon/common/buffers/CompositeListBufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/CompositeListBufferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 
 class CompositeListBufferData extends ReadOnlyBufferData implements CompositeBufferData {
     private final List<BufferData> data;
@@ -223,16 +224,34 @@ class CompositeListBufferData extends ReadOnlyBufferData implements CompositeBuf
     public int lastIndexOf(byte aByte, int length) {
         int index;
         int lengthRemaining = length;
+        int indexPrefix = 0;
 
-        for (int i = data.size() - 1; i >= 0; i--) {
-            BufferData datum = data.get(i);
-            index = datum.lastIndexOf(aByte, Math.min(lengthRemaining, datum.available()));
-            if (index > -1) {
-                return index;
-            }
-            lengthRemaining -= datum.available();
+        ListIterator<BufferData> iterator = data.listIterator();
+        while (iterator.hasNext()) {
             if (lengthRemaining <= 0) {
                 break;
+            }
+            BufferData datum = iterator.next();
+            int available = datum.available();
+            if (lengthRemaining <= available) {
+                index = datum.lastIndexOf(aByte, lengthRemaining);
+                if (index > -1) {
+                    return indexPrefix + index;
+                }
+                iterator.previous();
+                break;
+            }
+            lengthRemaining -= available;
+            indexPrefix += available;
+        }
+
+        while (iterator.hasPrevious()) {
+            BufferData datum = iterator.previous();
+            int available = datum.available();
+            indexPrefix -= available;
+            index = datum.lastIndexOf(aByte, available);
+            if (index > -1) {
+                return indexPrefix + index;
             }
         }
         return -1;

--- a/common/buffers/src/main/java/io/helidon/common/buffers/FixedBufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/FixedBufferData.java
@@ -205,7 +205,11 @@ class FixedBufferData implements BufferData {
 
     @Override
     public int lastIndexOf(byte aByte, int length) {
-        for (int i = (readPosition + length) - 1; i >= readPosition; i--) {
+        if (length <= 0) {
+            return -1;
+        }
+        int searchLength = Math.min(length, available());
+        for (int i = (readPosition + searchLength) - 1; i >= readPosition; i--) {
             byte b = bytes[i];
             if (b == aByte) {
                 return i - readPosition;

--- a/common/buffers/src/main/java/io/helidon/common/buffers/GrowingBufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/GrowingBufferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,7 +198,11 @@ class GrowingBufferData implements BufferData {
 
     @Override
     public int lastIndexOf(byte aByte, int length) {
-        for (int i = length - 1; i >= readPosition; i--) {
+        if (length <= 0) {
+            return -1;
+        }
+        int searchLength = Math.min(length, available());
+        for (int i = (readPosition + searchLength) - 1; i >= readPosition; i--) {
             byte b = bytes[i];
             if (b == aByte) {
                 return i - readPosition;

--- a/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
@@ -145,7 +145,11 @@ class ReadOnlyArrayData extends ReadOnlyBufferData {
 
     @Override
     public int lastIndexOf(byte aByte, int length) {
-        for (int i = length - 1; i >= position; i--) {
+        if (length <= 0) {
+            return -1;
+        }
+        int searchLength = Math.min(length, available());
+        for (int i = (position + searchLength) - 1; i >= position; i--) {
             byte b = bytes[offset + i];
             if (b == aByte) {
                 return i - position;

--- a/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataTest.java
@@ -67,6 +67,36 @@ class BufferDataTest {
 
     @ParameterizedTest
     @MethodSource("initParams")
+    void lastIndexOfWithLengthAfterPartialRead(TestContext context) {
+        BufferData b = context.bufferData();
+        b.writeAscii("01abcy");
+        b.skip(2);
+
+        assertThat(b.lastIndexOf((byte) 'y', 4), is(3));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void lastIndexOfClampsLengthToAvailable(TestContext context) {
+        BufferData b = context.bufferData();
+        b.writeAscii("01abcy");
+        b.skip(2);
+
+        assertThat(b.lastIndexOf((byte) 'y', 5), is(3));
+        assertThat(b.lastIndexOf((byte) 0, 5), is(-1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void lastIndexOfIgnoresNegativeLength(TestContext context) {
+        BufferData b = context.bufferData();
+        b.writeAscii("abc");
+
+        assertThat(b.lastIndexOf((byte) 'a', Integer.MIN_VALUE), is(-1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
     void testWriteHpackInt(TestContext context) {
         int value = 10;
 

--- a/common/buffers/src/test/java/io/helidon/common/buffers/CompositeBufferDataTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/CompositeBufferDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,30 @@ class CompositeBufferDataTest {
         combined.read();
         String result = combined.readString(combined.indexOf((byte) '0'));
         assertThat(result, is("123456789"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void lastIndexOfReturnsCompositeRelativeIndex(TestContext context) {
+        BufferData combined = context.bufferData();
+
+        assertThat(combined.lastIndexOf((byte) '0', combined.available()), is(10));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void lastIndexOfSearchesOnlyRequestedLength(TestContext context) {
+        BufferData combined = context.bufferData();
+
+        assertThat(combined.lastIndexOf((byte) '8', 7), is(-1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void lastIndexOfSearchesPreviousBuffersWithinRequestedLength(TestContext context) {
+        BufferData combined = context.bufferData();
+
+        assertThat(combined.lastIndexOf((byte) '6', 8), is(6));
     }
 
     private record TestContext(String name, BufferData bufferData) {

--- a/common/buffers/src/test/java/io/helidon/common/buffers/ReadOnlyArrayDataTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/ReadOnlyArrayDataTest.java
@@ -45,6 +45,35 @@ class ReadOnlyArrayDataTest {
     }
 
     @Test
+    void lastIndexOfWithLengthAfterPartialRead() {
+        byte[] data = "01abcy".getBytes(StandardCharsets.UTF_8);
+        ReadOnlyArrayData buf = new ReadOnlyArrayData(data, 0, data.length);
+
+        buf.skip(2);
+
+        assertThat(buf.lastIndexOf((byte) 'y', 4), is(3));
+    }
+
+    @Test
+    void lastIndexOfClampsLengthToAvailable() {
+        byte[] data = "01abcy".getBytes(StandardCharsets.UTF_8);
+        ReadOnlyArrayData buf = new ReadOnlyArrayData(data, 0, data.length);
+
+        buf.skip(2);
+
+        assertThat(buf.lastIndexOf((byte) 'y', 5), is(3));
+        assertThat(buf.lastIndexOf((byte) 0, 5), is(-1));
+    }
+
+    @Test
+    void lastIndexOfIgnoresNegativeLength() {
+        byte[] data = "abc".getBytes(StandardCharsets.UTF_8);
+        ReadOnlyArrayData buf = new ReadOnlyArrayData(data, 0, data.length);
+
+        assertThat(buf.lastIndexOf((byte) 'a', Integer.MIN_VALUE), is(-1));
+    }
+
+    @Test
     void testDebugData() {
         byte[] test = "Hello World!".getBytes(StandardCharsets.UTF_8);
         ReadOnlyArrayData rad = new ReadOnlyArrayData(test, 1, test.length - 1);


### PR DESCRIPTION
Resolves #11902

Carries forward #11903 to `main`. `BufferData.lastIndexOf(byte, int)` implementations now search relative to the current read position, clamp the requested length to the readable window, and return composite-relative indexes for composite buffers. Adds focused regression coverage for composite buffers and partial-read array-backed buffers.
