### PR TITLE
Add missing MDC support to OTel config support [4.x]

### DIFF
--- a/telemetry/opentelemetry-config/pom.xml
+++ b/telemetry/opentelemetry-config/pom.xml
@@ -140,6 +140,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/telemetry/opentelemetry-config/pom.xml
+++ b/telemetry/opentelemetry-config/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.tracing</groupId>
             <artifactId>helidon-tracing</artifactId>
         </dependency>

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/HelidonOpenTelemetryImpl.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/HelidonOpenTelemetryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,14 @@ package io.helidon.telemetry.otelconfig;
 import java.util.Map;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.logging.common.HelidonMdc;
 import io.helidon.tracing.Tracer;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 
 /**
  * Helidon management of OpenTelemetry.
@@ -47,6 +51,22 @@ class HelidonOpenTelemetryImpl implements HelidonOpenTelemetry, RuntimeType.Api<
                                         prototype().service()),
                                 Map.of());
                 Tracer.global(globalHelidonTracer);
+
+                /*
+                Participate in MDC.
+                 */
+                HelidonMdc.set("trace_id", () -> {
+                    var otelSpan = Span.fromContextOrNull(Context.current());
+                    return otelSpan == null ? "none" : otelSpan.getSpanContext().getTraceId();
+                });
+                HelidonMdc.set("span_id", () -> {
+                    var otelSpan = Span.fromContextOrNull(Context.current());
+                    return otelSpan == null ? "none" : otelSpan.getSpanContext().getSpanId();
+                });
+                HelidonMdc.set("baggage", () -> {
+                    var baggage = Baggage.fromContextOrNull(Context.current());
+                    return baggage == null ? "none" : baggage.toString();
+                });
 
 
             } catch (Exception e) {

--- a/telemetry/opentelemetry-config/src/main/java/module-info.java
+++ b/telemetry/opentelemetry-config/src/main/java/module-info.java
@@ -58,6 +58,7 @@ module io.helidon.telemetry.otelconfig {
     requires static io.opentelemetry.exporter.otlp;
     requires static io.opentelemetry.exporter.zipkin;
     requires io.opentelemetry.common;
+    requires io.helidon.logging.common;
 
     exports io.helidon.telemetry.otelconfig;
 

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestMdc.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestMdc.java
@@ -20,19 +20,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
-import io.helidon.common.testing.junit5.InMemoryLoggingHandler;
 import io.helidon.logging.common.LogConfig;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import org.hamcrest.FeatureMatcher;
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -70,9 +65,21 @@ class TestMdc {
             LogConfig.initClass();
             TEST_OUTPUT_STREAM.reset();
 
+            assertThat("Log with no OTel support", logMessage("No OTel"),
+                       allOf(containsString("trace= "),
+                             containsString("span= "),
+                             containsString("baggage= ")));
+
+
             var helidonOtel = HelidonOpenTelemetry.create(OpenTelemetryConfig.builder()
                                                                   .service("log-test-service")
                                                                   .buildPrototype());
+
+            assertThat("Log with Otel support but no current context", logMessage("No context"),
+                       allOf(containsString("trace=none"),
+                             containsString("span=none"),
+                             containsString("baggage=none")));
+
 
             var tracer = GlobalOpenTelemetry.getTracer("test");
             var tracerSpan = tracer.spanBuilder("test").startSpan();
@@ -112,6 +119,9 @@ class TestMdc {
             LOGGER.info(message);
             return TEST_OUTPUT_STREAM.toString();
         } finally {
+            for (var handler : LOGGER.getHandlers()) {
+                handler.flush();
+            }
             TEST_OUTPUT_STREAM.reset();
         }
     }

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestMdc.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestMdc.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.otelconfig;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.common.testing.junit5.InMemoryLoggingHandler;
+import io.helidon.logging.common.LogConfig;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+class TestMdc {
+
+    private static final Logger LOGGER = Logger.getLogger(TestMdc.class.getName());
+    private static final ByteArrayOutputStream TEST_OUTPUT_STREAM = new ByteArrayOutputStream();
+    private static final PrintStream TEST_PRINT_STREAM = new PrintStream(TEST_OUTPUT_STREAM);
+
+
+    @BeforeAll
+    static void init() {
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @AfterAll
+    static void close() {
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void testOtelMdc() {
+
+        var originalPrint = System.out;
+
+        try {
+            System.setOut(TEST_PRINT_STREAM);
+            LogConfig.initClass();
+            TEST_OUTPUT_STREAM.reset();
+
+            var helidonOtel = HelidonOpenTelemetry.create(OpenTelemetryConfig.builder()
+                                                                  .service("log-test-service")
+                                                                  .buildPrototype());
+
+            var tracer = GlobalOpenTelemetry.getTracer("test");
+            var tracerSpan = tracer.spanBuilder("test").startSpan();
+
+            var traceId = tracerSpan.getSpanContext().getTraceId();
+            var spanId = tracerSpan.getSpanContext().getSpanId();
+
+            List<String> output = new ArrayList<>();
+
+            try (var ignoredBaggageContext = Baggage.builder()
+                    .put("b1", "v1")
+                    .build()
+                    .storeInContext(Context.current())
+                    .makeCurrent()) {
+
+                try (Scope ignoredSpanScope = tracerSpan.makeCurrent()) {
+                    output.add(logMessage("Tracer span created"));;
+                }
+
+            }
+            assertThat("Captured log records", output,
+                       hasItem(allOf(containsString("baggage"),
+                                                 containsString("b1"),
+                                                 containsString("v1"),
+                                                 containsString(traceId),
+                                                 containsString(spanId),
+                                                 not(containsString("none")))));
+
+        } finally {
+            System.setOut(originalPrint);
+        }
+
+    }
+
+    private String logMessage(String message) {
+        try {
+            LOGGER.info(message);
+            return TEST_OUTPUT_STREAM.toString();
+        } finally {
+            TEST_OUTPUT_STREAM.reset();
+        }
+    }
+    static Matcher<LogRecord> withMessage(Matcher<? super String> matcher) {
+        return new FeatureMatcher<LogRecord, String>(matcher, "a log record that ", "containsString") {
+            @Override
+            protected String featureValueOf(LogRecord actual) {
+                return actual.getMessage();
+            }
+        };
+    }
+
+}

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestMdc.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestMdc.java
@@ -115,13 +115,4 @@ class TestMdc {
             TEST_OUTPUT_STREAM.reset();
         }
     }
-    static Matcher<LogRecord> withMessage(Matcher<? super String> matcher) {
-        return new FeatureMatcher<LogRecord, String>(matcher, "a log record that ", "containsString") {
-            @Override
-            protected String featureValueOf(LogRecord actual) {
-                return actual.getMessage();
-            }
-        };
-    }
-
 }

--- a/telemetry/opentelemetry-config/src/test/resources/logging.properties
+++ b/telemetry/opentelemetry-config/src/test/resources/logging.properties
@@ -18,7 +18,7 @@
 handlers=io.helidon.logging.jul.HelidonConsoleHandler
 
 # HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s baggage=%X{baggage} trace=%X{trace_id} span=%X{span_id}%n
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s baggage=%X{baggage} trace=%X{trace_id} span=%X{span_id} %n
 
 # Global logging level. Can be overridden by specific loggers
 .level=INFO

--- a/telemetry/opentelemetry-config/src/test/resources/logging.properties
+++ b/telemetry/opentelemetry-config/src/test/resources/logging.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Send messages to the console
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s baggage=%X{baggage} trace=%X{trace_id} span=%X{span_id}%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO


### PR DESCRIPTION
### Description
Resolves #11911

### Release note
_____
Helidon's OpenTelemetry config support now includes MDC logging support for the trace ID, span ID, and baggage with `java.util.logging` logging.
_____

Although Helidon's OpenTelemetry _tracing provider_ participates in MDC (all tracing providers do using common tracing-specific code), the newly-added OpenTelemetry config support does not. This PR adds MDC support for `trace_id`, `span_id`, and `baggage`.

### Documentation
No impact.