### PR TITLE
Fix Content-Location header constant (3.x)

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/Http.java
+++ b/common/http/src/main/java/io/helidon/common/http/Http.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -949,7 +949,7 @@ public final class Http {
          * The <code>{@value}</code> header name.
          * An alternate location for the returned data.
          */
-        public static final String CONTENT_LOCATION = "aa";
+        public static final String CONTENT_LOCATION = "Content-Location";
         /**
          * The <code>{@value}</code> header name.
          * Where in a full body message this partial message belongs.

--- a/common/http/src/test/java/io/helidon/common/http/HttpTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/HttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,5 +49,10 @@ class HttpTest {
         assertThat(rs.reasonPhrase(), is("Custom reason phrase"));
         assertThat(rs.code(), is(TEMPORARY_REDIRECT_307.code()));
         assertThat(rs.family(), is(TEMPORARY_REDIRECT_307.family()));
+    }
+
+    @Test
+    void testContentLocationHeaderName() {
+        assertThat(Http.Header.CONTENT_LOCATION, is("Content-Location"));
     }
 }


### PR DESCRIPTION
Resolves #11917

Fixes the public `Content-Location` header constant so it uses the standard header name and adds focused coverage for the constant.
