### PR TITLE
Fix Content-Location header constant (4.x)

### DIFF
--- a/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ enum HeaderNameEnum implements HeaderName {
         static final String CONTENT_ENCODING_NAME = "Content-Encoding";
         static final String CONTENT_LANGUAGE_NAME = "Content-Language";
         static final String CONTENT_LENGTH_NAME = "Content-Length";
-        static final String CONTENT_LOCATION_NAME = "aa";
+        static final String CONTENT_LOCATION_NAME = "Content-Location";
         static final String CONTENT_RANGE_NAME = "Content-Range";
         static final String CONTENT_TYPE_NAME = "Content-Type";
         static final String DATE_NAME = "Date";

--- a/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
+++ b/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,6 +120,18 @@ class HeaderNamesTest {
         assertThat(custom1.defaultCase(), is("My-Custom-Header"));
         assertThat(custom2.lowerCase(), is("my-custom-header"));
         assertThat(custom2.defaultCase(), is("my-custom-header"));
+    }
+
+    @Test
+    void testContentLocationHeaderName() {
+        HeaderName contentLocation = HeaderNames.CONTENT_LOCATION;
+
+        assertAll(
+                () -> assertThat(HeaderNames.CONTENT_LOCATION_NAME, is("Content-Location")),
+                () -> assertThat(contentLocation.defaultCase(), is("Content-Location")),
+                () -> assertThat(contentLocation.lowerCase(), is("content-location")),
+                () -> assertThat(HeaderNames.create("Content-Location"), equalTo(contentLocation))
+        );
     }
 
     @Test

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -795,7 +795,7 @@ public class Http2Headers {
         MAX_FORWARDS(47, HeaderNames.MAX_FORWARDS),
         PROXY_AUTHENTICATE(48, HeaderNames.PROXY_AUTHENTICATE),
         PROXY_AUTHORIZATION(49, HeaderNames.PROXY_AUTHORIZATION),
-        RANGE(50, HeaderNames.CONTENT_LOCATION),
+        RANGE(50, HeaderNames.RANGE),
         REFERER(51, HeaderNames.REFERER),
         REFRESH(52, HeaderNames.REFRESH),
         RETRY_AFTER(53, HeaderNames.RETRY_AFTER),

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,6 +249,15 @@ class Http2HeadersTest {
         headerRecord = dynamicTable.get(Http2Headers.StaticHeader.MAX_INDEX + 3);
         assertThat(headerRecord.headerName(), is(Http2Headers.AUTHORITY_NAME));
         assertThat(headerRecord.value(), is("www.example.com"));
+    }
+
+    @Test
+    void testStaticRangeHeaderName() {
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        Headers requestHeaders = headers("b2", dynamicTable).httpHeaders();
+
+        assertThat(requestHeaders.contains(HeaderNames.RANGE), is(true));
+        assertThat(requestHeaders.contains(HeaderNames.CONTENT_LOCATION), is(false));
     }
 
     private Http2Headers headers(String hexEncoded, DynamicTable dynamicTable) {


### PR DESCRIPTION
Resolves #11918

Fixes the public `Content-Location` header constants, corrects the HTTP/2 static table `Range` entry, and adds focused coverage for both header mappings.
