### PR TITLE
3.x netty 4.1.133.final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -128,7 +128,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.132.Final</version.lib.netty>
+        <version.lib.netty>4.1.133.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.76.0</version.lib.oci>
         <version.lib.ojdbc8>21.15.0.0</version.lib.ojdbc8>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -56,6 +56,55 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
    <cve>CVE-2025-15599</cve>
 </suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-3.13.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <cve>CVE-2026-41240</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-3.13.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>CVE-2026-41238</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-3.13.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>CVE-2026-41239</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-3.13.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>GHSA-39q2-94rc-95cp</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-3.13.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>GHSA-cj63-jhhr-wcxv</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-3.13.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>GHSA-cjmm-f4jc-qw8r</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-3.13.0.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>GHSA-h8r8-wccr-v5f2</vulnerabilityName>
+</suppress>
 
 
 <!--
@@ -413,6 +462,24 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib.*$</packageUrl>
    <cve>CVE-2020-29582</cve>
+</suppress>
+
+<!-- False Positive.
+     This CVE is against Prometheus server, not simple client
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: simpleclient-0.9.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient@.*$</packageUrl>
+   <cve>CVE-2026-42154</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient_common-0.9.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_common@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
 </suppress>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <version.plugin.source>3.3.0</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.2.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.2.2</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

- Upgrade Netty to 4.1.133.Final
- Upgrade dependency check to 12.2.2
- Suppress Prometheus false positive and swagger_ui noise.