### PR TITLE
4.x: Upgrade Netty to 4.1.133.Final, Handlebars to 4.5.1, Opennlp to 2.5.9

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -108,7 +108,7 @@
         <version.lib.kotlin>1.9.10</version.lib.kotlin>
         <version.lib.langchain4j>1.12.1</version.lib.langchain4j>
         <version.lib.langchain4j-community>1.12.1-beta21</version.lib.langchain4j-community>
-        <!-- Force upgrade opennlp-tools transient dependency of langchain4j. Remove once langchain4j upgrades -->
+        <!-- Force upgrade opennlp-tools transitive dependency of langchain4j. Remove once langchain4j upgrades -->
         <version.lib.opennlp-tools>2.5.9</version.lib.opennlp-tools>
         <version.lib.log4j>2.25.4</version.lib.log4j>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
@@ -1271,7 +1271,7 @@
                 <artifactId>jsr305</artifactId>
                 <version>${version.lib.google-findbugs-jsr305}</version>
             </dependency>
-            <!-- For upgrade. Transient dependency of langchain4j -->
+            <!-- For upgrade. Transitive dependency of langchain4j -->
             <dependency>
                 <groupId>org.apache.opennlp</groupId>
                 <artifactId>opennlp-tools</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -67,7 +67,7 @@
         <version.lib.guava>33.3.1-jre</version.lib.guava>
         <version.lib.h2>2.4.240</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
-        <version.lib.handlebars>4.4.0</version.lib.handlebars>
+        <version.lib.handlebars>4.5.1</version.lib.handlebars>
         <version.lib.hibernate.family>6.3</version.lib.hibernate.family>
         <version.lib.hibernate>${version.lib.hibernate.family}.1.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
@@ -108,6 +108,8 @@
         <version.lib.kotlin>1.9.10</version.lib.kotlin>
         <version.lib.langchain4j>1.12.1</version.lib.langchain4j>
         <version.lib.langchain4j-community>1.12.1-beta21</version.lib.langchain4j-community>
+        <!-- Force upgrade opennlp-tools transient dependency of langchain4j. Remove once langchain4j upgrades -->
+        <version.lib.opennlp-tools>2.5.9</version.lib.opennlp-tools>
         <version.lib.log4j>2.25.4</version.lib.log4j>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
@@ -138,7 +140,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.132.Final</version.lib.netty>
+        <version.lib.netty>4.1.133.Final</version.lib.netty>
         <version.lib.oci>3.78.1</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>
@@ -1268,6 +1270,12 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${version.lib.google-findbugs-jsr305}</version>
+            </dependency>
+            <!-- For upgrade. Transient dependency of langchain4j -->
+            <dependency>
+                <groupId>org.apache.opennlp</groupId>
+                <artifactId>opennlp-tools</artifactId>
+                <version>${version.lib.opennlp-tools}</version>
             </dependency>
             <!-- END OF Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
 

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -210,6 +210,17 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <cve>CVE-2019-3826</cve>
 </suppress>
 
+<!-- False Positive.
+     Another FP against prometheus server (not prometheus simple client)
+ -->
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient-0.16.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient.*@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
+</suppress>
+
 <!-- False Positives.
      This CVE is against the XML Database component of Oracle Database Server.
      The below are client libraries for XML and XML JDBC support.

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.2.1</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.2.2</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

- Upgrades Netty to 4.1.133.Final. Why does 4.x manage Netty version? See #9645
- Upgrades Handlebars to 4.5.1
- Force upgrades opennlp to 2.5.9. This is a transitive dependency of langchain4j. 
- Upgrade owasp dependency check to 12.2.2
- Suppress prometheus simple-client false positive



