### PR TITLE
2.x: Upgrade Netty to 4.1.133.Final, postgresql driver to 42.7.11

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -123,7 +123,7 @@
         <version.lib.hibernate-validator>6.2.5.Final</version.lib.hibernate-validator>
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
-        <version.lib.netty>4.1.132.Final</version.lib.netty>
+        <version.lib.netty>4.1.133.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.76.0</version.lib.oci>
         <version.lib.oci-java-sdk-objectstorage>${version.lib.oci}</version.lib.oci-java-sdk-objectstorage>
@@ -138,7 +138,7 @@
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.perfmark-api>0.25.0</version.lib.perfmark-api>
         <version.lib.persistence-api>2.2.3</version.lib.persistence-api>
-        <version.lib.postgresql>42.4.4</version.lib.postgresql>
+        <version.lib.postgresql>42.7.11</version.lib.postgresql>
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>2.0.9</version.lib.slf4j>
         <version.lib.smallrye-openapi>2.0.26</version.lib.smallrye-openapi>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -25,18 +25,83 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
 </suppress>
 
 <!--
-    This CVE is against DOMPurify brought in by javascript in the smallrye UI component.
+    These CVEs are against DOMPurify brought in by javascript in the smallrye UI component.
     In 4.x we made this component "provided". We can't do that in 2.x and 3.x due to compatiblity concerns.
     Also, this is primarily a developer feature and not intended for a production runtime.
 -->
-
 <suppress>
-   <notes><![CDATA[
-   file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
-   ]]></notes>
-   <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
-   <vulnerabilityName>CVE-2024-45801</vulnerabilityName>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <cve>CVE-2024-48910</cve>
 </suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <cve>CVE-2024-47875</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <cve>CVE-2024-45801</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <cve>CVE-2025-26791</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <cve>CVE-2026-41240</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>GHSA-39q2-94rc-95cp</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>GHSA-cj63-jhhr-wcxv</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>GHSA-cjmm-f4jc-qw8r</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>GHSA-h8r8-wccr-v5f2</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: smallrye-open-api-ui-2.0.26.jar: swagger-ui-bundle.js
+    ]]></notes>
+    <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+    <vulnerabilityName>CVE-2026-41239</vulnerabilityName>
+</suppress>
+
+
+
 
 <!-- This CVE is against the etcd server. We ship a Java client -->
 <suppress>
@@ -236,6 +301,24 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*@.*$</packageUrl>
    <cve>CVE-2024-11407</cve>
 </suppress>
+<!-- False Positive.
+     This CVE is against gRPC-Go servers not gRPC Java
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-core-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*@.*$</packageUrl>
+   <cve>CVE-2026-33186</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-protobuf-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc-protobuf@.*$</packageUrl>
+   <cve>CVE-2026-33186</cve>
+</suppress>
+
 
 
 <!-- False Positive.
@@ -305,6 +388,18 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib.*$</packageUrl>
    <cve>CVE-2020-29582</cve>
 </suppress>
+
+<!-- False Positive.
+     Another FP against prometheus server (not prometheus simple client)
+ -->
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient-0.16.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient.*@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
+</suppress>
+
 
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.2.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.2.2</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0-M5</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

- Upgrade Netty to 4.1.133.Final
- Upgrade postgresql driver to 42.7.11
- Upgrade dependency check to 12.2.2
- Suppress false positives