### PR TITLE
1.x:  Upgrade Netty to 4.1.133.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -87,7 +87,7 @@
         <version.lib.mockito>2.23.4</version.lib.mockito>
         <version.lib.mysql-connector-java>8.0.29</version.lib.mysql-connector-java>
         <version.lib.narayana>5.9.3.Final</version.lib.narayana>
-        <version.lib.netty>4.1.132.Final</version.lib.netty>
+        <version.lib.netty>4.1.133.Final</version.lib.netty>
         <version.lib.oci-java-sdk-objectstorage>2.81.0</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>19.3.0.0</version.lib.ojdbc8>
         <version.lib.opentracing>0.32.0</version.lib.opentracing>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -130,6 +130,24 @@
    <cpe>cpe:/a:sun:openjdk</cpe>
 </suppress>
 
+<!-- False Positive.
+     This CVE is against gRPC-Go servers not gRPC Java
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-core-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*@.*$</packageUrl>
+   <cve>CVE-2026-33186</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-protobuf-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc-protobuf@.*$</packageUrl>
+   <cve>CVE-2026-33186</cve>
+</suppress>
+
 <!-- grpc -->
 <!-- This was applying the version of opentracing-grpc to grpc
      which triggered CVEs for older versions of grpc and grpc-js
@@ -292,6 +310,18 @@
    <cve>CVE-2023-4759</cve>
 </suppress>
 
+<!-- False Positive.
+     jgit-6.10.1 has the fix for CVE-2025-4949. See
+     https://projects.eclipse.org/projects/technology.jgit/releases/6.10.1
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: org.eclipse.jgit-6.10.1.202505221210-r.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jgit/org\.eclipse\.jgit@.*$</packageUrl>
+   <cve>CVE-2025-4949</cve>
+</suppress>
+
 <!--
     False Positives. These CVEs are against the Brave web browser, not brave-opentracing.
 -->
@@ -336,6 +366,18 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
    <cve>CVE-2023-28360</cve>
+</suppress>
+
+
+<!-- False Positive.
+     FP against prometheus server (not prometheus simple client)
+ -->
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient-0.9.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
 </suppress>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.plugin.spotbugs>3.1.12</version.plugin.spotbugs>
         <version.plugin.surefire.provider.junit>1.0.3</version.plugin.surefire.provider.junit>
         <version.plugin.surefire>2.19.1</version.plugin.surefire>
-        <version.plugin.dependency-check>12.2.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.2.2</version.plugin.dependency-check>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>


### PR DESCRIPTION
### Description
- Upgrade Netty to 4.1.133.Final
- Upgrade dependency check to 12.2.2
- Suppress some false positives
