### PR TITLE
Apply declarative validation constraints from service interfaces (4.x)

### DIFF
--- a/declarative/README.md
+++ b/declarative/README.md
@@ -65,7 +65,7 @@ For each Helidon feature, we need a namespace class to contain the annotations a
 | LRA              | `LRA`                                | `Lra` cannot be freed                                     |
 | Transactions     | `Tx`                                 | `Transaction` is the interface                            |
 | Service Registry | `Service`, `Interception`            | OK                                                        |
-| Validation       | `Validation`, `Check`                | OK                                                        |
+| Validation       | `Validation`                         | OK                                                        |
 
 ## Integrations
 
@@ -357,14 +357,16 @@ Both features require code-generation.
 Type validation code-generation of type validators is triggered by the presence of the `@Validation.Validated` annotation on a type.
 
 Method validation code-generation of interceptors is triggered by the presence of an annotation "meta-annotated"
-with `@Validation.Constraint` on a method, its parameter, or type arguments of its parameters or return type.
-In addition the `Check.Valid` annotation also triggers code-generation, and can be used to validate against a type validator
+with `@Validation.Constraint` on a service method, its implemented service-contract method, its parameter, or type
+arguments of its parameters or return type.
+In addition the `@Validation.Valid` annotation also triggers code-generation, and can be used to validate against a type validator
 mentioned above.
 
 ### Declaration
 
 Annotations:
-- All annotations from `io.helidon.validation.Check` class to trigger validation using an interceptor
+- All built-in constraint annotations from `io.helidon.validation.Validation` to trigger validation using an interceptor
+- `@Validation.Valid` - to trigger validation against a generated type validator
 - `@Validation.Validated` - on a type to generate type validator for a type
 
 ### Configuration
@@ -388,8 +390,7 @@ The type validation works as follows:
 3. the type validator validates the type and returns response with possible constraint violations
 
 Important types:
-- `Check` - a container class for all constraint annotations
-- `Validation` - a container class for validation annotations that are not constraints
+- `Validation` - a container class for validation annotations and built-in constraint annotations
 - `ValidationException` - throws when validation fails in an interceptor
 - `Validator` - programmatic API to validate instances and their properties (only for validated types), can be obtained from service registry
 - `ConstraintValidatorProvider` - service registry service that validates a single constraint annotation type
@@ -399,10 +400,16 @@ Important types:
 Supported concepts:
 - any service method annotated with a constraint annotation will be intercepted and validated
 - any service method that has parameters with at least one constraint annotation will be intercepted and validated
-- for identification of "what to validate", `@Check.Valid` is a constraint annotation
-- annotations on type arguments of method parameters and method return type are supported, as long as they are on 
-    `Optional`, `Map`, `Collection` - i.e. `List<@Check.Valid String>` will trigger an interceptor and will be validated
-- types annotated with `@Validation.Validated` will be validated when used in a method or constructor that uses `@Check.Valid` on the typed parameter
+- any service method that implements a non-private service-contract method with constraint annotations or `@Validation.Valid`
+    will be intercepted and validated
+- services returned by registry-managed factories such as `Supplier`, `Service.ServicesFactory`,
+    `Service.InjectionPointFactory`, and `Service.QualifiedFactory` follow the same service-contract validation rules
+- `@Validation.Valid` identifies what to validate using a generated type validator
+- annotations on method parameter and return types are supported on nested `Optional`, `Collection`, `List`, `Set`, `Map`
+    key/value types, array component types, and wildcard bounds - i.e. `List<@Validation.Valid MyType>` will trigger an
+    interceptor and will be validated
+- types annotated with `@Validation.Validated` will be validated when used in a method or constructor that uses
+    `@Validation.Valid` on the typed parameter
 - same rules as for generation of interceptors apply for type validation: constraints are honored, including getters,
     fields, and type arguments
 - a user may create a "compound annotation" - an annotation that has one or more constraint annotations, these will be honored as

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -167,9 +167,6 @@ class InterceptorGenerator {
         if (type.kind() != ElementKind.INTERFACE) {
             return false;
         }
-        if (!type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_CONTRACT)) {
-            return false;
-        }
 
         List<TypedElementInfo> elementsWithValidation = type.elementInfo()
                 .stream()
@@ -332,7 +329,7 @@ class InterceptorGenerator {
                           fieldHandler,
                           element,
                           "RETURN_VALUE",
-                          "interception__res");
+                          returnValueLocal(proceedMethod, element));
             // leave method on response
             proceedMethod.addContentLine("}");
         }
@@ -349,12 +346,48 @@ class InterceptorGenerator {
         return true;
     }
 
+    private String returnValueLocal(Method.Builder proceedMethod, TypedElementInfo element) {
+        if (!returnValueNeedsWork(element)) {
+            return "interception__res";
+        }
+        if (ElementInfoPredicates.isVoid(element)) {
+            throw new CodegenException("Validation annotations cannot constrain a void method return value.",
+                                       element.originatingElementValue());
+        }
+
+        proceedMethod.addContent("var validation__return = (")
+                .addContent(element.typeName())
+                .addContentLine(") interception__res;");
+        return "validation__return";
+    }
+
+    private boolean returnValueNeedsWork(TypedElementInfo element) {
+        if (element.hasAnnotation(VALIDATION_VALID) || metaAnnotated(element, VALIDATION_VALID)) {
+            return true;
+        }
+        if (ValidationHelper.needsWork(constraintAnnotations, element.annotations())) {
+            return true;
+        }
+        for (TypeName constraintAnnotation : constraintAnnotations) {
+            if (element.hasAnnotation(constraintAnnotation)) {
+                return true;
+            }
+        }
+
+        return ValidationHelper.needsWork(constraintAnnotations, element.typeName());
+    }
+
     private void addValidators(TypeName generatedType,
                                Method.Builder proceedMethod,
                                FieldHandler fieldHandler,
                                TypedElementInfo element,
                                String location,
                                String localVariableName) {
+        var validationContext = ValidationHelper.validationContext(generatedType,
+                                                                   constraintAnnotations,
+                                                                   proceedMethod,
+                                                                   fieldHandler,
+                                                                   element);
         proceedMethod.addContent("try (var scope__" + location.toLowerCase(Locale.ROOT) + " = validation__ctx.scope(")
                 .addContent(CONSTRAINT_VIOLATION_LOCATION)
                 .addContent(".")
@@ -373,21 +406,14 @@ class InterceptorGenerator {
 
         // we must honor order of declaration on the element
         for (Annotation annotation : ValidationHelper.findConstraintAnnotations(constraintAnnotations, element)) {
-            addValidationOfConstraint(generatedType,
-                                      fieldHandler,
-                                      proceedMethod,
+            addValidationOfConstraint(validationContext,
                                       annotation,
                                       location,
-                                      element,
+                                      element.typeName(),
                                       localVariableName);
         }
 
-        addValidationOfTypeArguments(generatedType,
-                                     constraintAnnotations,
-                                     proceedMethod,
-                                     fieldHandler,
-                                     element,
-                                     localVariableName);
+        addValidationOfTypeArguments(validationContext, localVariableName);
 
         proceedMethod.addContentLine("}");
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidatedTypeGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidatedTypeGenerator.java
@@ -474,13 +474,13 @@ class ValidatedTypeGenerator {
                 .addContentLine(")) {");
 
         TypeName typeName = element.typeName();
+        var validationContext = ValidationHelper.validationContext(generatedType,
+                                                                   constraintAnnotations,
+                                                                   checkMethod,
+                                                                   fieldHandler,
+                                                                   element);
 
-        addValidationOfTypeArguments(generatedType,
-                                     constraintAnnotations,
-                                     checkMethod,
-                                     fieldHandler,
-                                     element,
-                                     "value");
+        addValidationOfTypeArguments(validationContext, "value");
 
         if (element.hasAnnotation(VALIDATION_VALID)) {
 
@@ -491,12 +491,10 @@ class ValidatedTypeGenerator {
 
         // we must honor order of declaration on the element
         for (Annotation annotation : ValidationHelper.findConstraintAnnotations(constraintAnnotations, element)) {
-            addValidationOfConstraint(generatedType,
-                                      fieldHandler,
-                                      checkMethod,
+            addValidationOfConstraint(validationContext,
                                       annotation,
                                       location,
-                                      element,
+                                      typeName,
                                       "value");
         }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java
@@ -59,7 +59,10 @@ class ValidationExtension implements RegistryCodegenExtension {
 
     private boolean isConstraintAnnotation(TypeName typeName) {
         return roundContextTypeInfo(typeName)
-                .map(it -> it.hasAnnotation(VALIDATION_CONSTRAINT))
+                .map(it -> it.hasAnnotation(VALIDATION_CONSTRAINT)
+                        || it.annotations()
+                                .stream()
+                                .anyMatch(annotation -> annotation.hasMetaAnnotation(VALIDATION_CONSTRAINT)))
                 .orElse(true);
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
@@ -20,12 +20,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.codegen.TypeHierarchy;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.AnnotationProperty;
+import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
@@ -85,85 +89,67 @@ final class ValidationHelper {
                 .addContentLine(");");
     }
 
-    static void addValidationOfTypeArguments(TypeName generatedType,
-                                             Collection<TypeName> constraintAnnotations,
-                                             ContentBuilder<?> contentBuilder,
-                                             FieldHandler fieldHandler,
-                                             TypedElementInfo element,
-                                             String localVariableName) {
-        TypeName typeName = element.typeName();
+    static ValidationContext validationContext(TypeName generatedType,
+                                               Collection<TypeName> constraintAnnotations,
+                                               ContentBuilder<?> contentBuilder,
+                                               FieldHandler fieldHandler,
+                                               TypedElementInfo element) {
+        return new ValidationContext(generatedType, constraintAnnotations, contentBuilder, fieldHandler, element);
+    }
 
-        // check for types that we support that
-        if (typeName.equals(TypeNames.SET)
-                || typeName.equals(TypeNames.LIST)
-                || typeName.equals(TypeNames.COLLECTION)
-                || typeName.equals(TypeNames.OPTIONAL)) {
-            addValidationForSingleTypeArgument(generatedType,
-                                               constraintAnnotations,
-                                               contentBuilder,
-                                               fieldHandler,
-                                               element,
-                                               localVariableName,
-                                               typeName);
-        } else if (typeName.equals(TypeNames.MAP)) {
-            addValidationOfMap(generatedType,
-                               constraintAnnotations,
-                               contentBuilder,
-                               fieldHandler,
-                               element,
-                               localVariableName,
-                               typeName);
-        }
+    static void addValidationOfTypeArguments(ValidationContext context, String localVariableName) {
+        addValidationOfContainerType(context,
+                                     context.element().typeName(),
+                                     localVariableName,
+                                     0);
     }
 
     /**
      *
-     * @param generatedType  type of the generated class
-     * @param fieldHandler   field handler for the processed type
-     * @param contentBuilder content where we should add the constraint validation code
-     * @param constraint     the constraint - must be an annotation of the element or its type parameters
-     * @param location       location of the check (i.e. parameter, return value etc.)
-     * @param element        the element that is annotated, or contains this annotation
-     * @param varName        name of the variable to check using the constraint validator
+     * @param context       validation code generation context
+     * @param constraint    the constraint - must be an annotation of the element or its type parameters
+     * @param location      location of the check (i.e. parameter, return value etc.)
+     * @param annotatedType type that carries the constraint annotation
+     * @param varName       name of the variable to check using the constraint validator
      */
-    static void addValidationOfConstraint(TypeName generatedType,
-                                          FieldHandler fieldHandler,
-                                          ContentBuilder<?> contentBuilder,
+    static void addValidationOfConstraint(ValidationContext context,
                                           Annotation constraint,
                                           String location,
-                                          TypedElementInfo element,
+                                          TypeName annotatedType,
                                           String varName) {
 
         // create a constant with the fully qualified name of the constraint
-        String constraintType = fieldHandler.constant("CONSTRAINT",
-                                                      TypeNames.STRING,
-                                                      constraint.typeName(),
-                                                      it -> it.addContentLiteral(constraint.typeName().fqName()));
+        String constraintType = context.fieldHandler()
+                .constant("CONSTRAINT",
+                          TypeNames.STRING,
+                          constraint.typeName(),
+                          it -> it.addContentLiteral(constraint.typeName().fqName()));
 
-        String validator = fieldHandler.field(CONSTRAINT_VALIDATOR,
-                                              "constraintValidator",
-                                              AccessModifier.PRIVATE,
-                                              constraint,
-                                              it -> {
-                                              },
-                                              (ctr, name) -> {
-                                                  ctr.addParameter(param -> param
-                                                                  .name(name + "_provider")
-                                                                  .addAnnotation(namedByConstant(generatedType,
-                                                                                                 constraintType))
-                                                                  .type(CONSTRAINT_VALIDATOR_PROVIDER))
-                                                          .addContent("this.")
-                                                          .addContent(name)
-                                                          .addContent(" = ")
-                                                          .addContent(name + "_provider")
-                                                          .addContent(".create(")
-                                                          .addContentCreate(element.typeName())
-                                                          .addContent(", ")
-                                                          .addContentCreate(constraint)
-                                                          .addContentLine(");");
-                                              });
+        String validator = context.fieldHandler()
+                .field(CONSTRAINT_VALIDATOR,
+                       "constraintValidator",
+                       AccessModifier.PRIVATE,
+                       new ValidatorKey(ResolvedType.create(annotatedType), constraint),
+                       it -> {
+                       },
+                       (ctr, name) -> {
+                           ctr.addParameter(param -> param
+                                           .name(name + "_provider")
+                                           .addAnnotation(namedByConstant(context.generatedType(), constraintType))
+                                           .type(CONSTRAINT_VALIDATOR_PROVIDER))
+                                   .addContent("this.")
+                                   .addContent(name)
+                                   .addContent(" = ")
+                                   .addContent(name + "_provider")
+                                   .addContent(".create(")
+                                   .addContentCreate(annotatedType)
+                                   .addContent(", ")
+                                   .addContentCreate(constraint)
+                                   .addContentLine(");");
+                       });
 
-        contentBuilder.addContent("validation__ctx.check(")
+        context.contentBuilder()
+                .addContent("validation__ctx.check(")
                 .addContent(validator)
                 .addContent(", ")
                 .addContent(varName)
@@ -181,9 +167,19 @@ final class ValidationHelper {
         return result;
     }
 
+    private static List<Annotation> findConstraintAnnotations(Collection<TypeName> constraintAnnotations,
+                                                              List<Annotation> annotations) {
+        List<Annotation> result = new ArrayList<>();
+        Set<Annotation> processed = new HashSet<>();
+
+        findConstraintAnnotations(constraintAnnotations, annotations, result, processed);
+
+        return result;
+    }
+
     static boolean needsWork(Collection<TypeName> constraintAnnotations, TypedElementInfo element) {
         // the element itself is annotated either with valid or one of the constraints
-        // a type parameter is annotated in the same way (only first level)
+        // a type parameter is annotated in the same way
 
         if (element.hasAnnotation(VALIDATION_VALID)) {
             return true;
@@ -197,21 +193,8 @@ final class ValidationHelper {
             return true;
         }
 
-        // now type parameters of the element itself, or its parameters
-        // (valid only for methods, but not present on fields so no problem to check)
-        TypeName elementType = element.typeName();
-        for (TypeName typeName : elementType.typeArguments()) {
-            if (typeName.hasAnnotation(VALIDATION_VALID)) {
-                return true;
-            }
-            for (TypeName constraintAnnotation : constraintAnnotations) {
-                if (typeName.hasAnnotation(constraintAnnotation)) {
-                    return true;
-                }
-            }
-            if (needsWork(constraintAnnotations, typeName.annotations())) {
-                return true;
-            }
+        if (needsWork(constraintAnnotations, element.typeName())) {
+            return true;
         }
 
         for (TypedElementInfo param : element.parameterArguments()) {
@@ -223,8 +206,20 @@ final class ValidationHelper {
         return false;
     }
 
+    static boolean needsWork(Collection<TypeName> constraintAnnotations, TypeName typeName) {
+        return needsWork(constraintAnnotations, TypeHierarchy.typeNameAnnotations(typeName));
+    }
+
     static boolean needsWork(Collection<TypeName> constraintAnnotations, List<Annotation> annotations) {
         for (Annotation annotation : annotations) {
+            if (annotation.typeName().equals(VALIDATION_VALID)) {
+                return true;
+            }
+            for (TypeName constraintAnnotation : constraintAnnotations) {
+                if (annotation.typeName().equals(constraintAnnotation)) {
+                    return true;
+                }
+            }
             if (annotation.hasMetaAnnotation(VALIDATION_VALID)) {
                 return true;
             }
@@ -279,8 +274,8 @@ final class ValidationHelper {
         for (Annotation annotation : annotations) {
             if (processed.add(annotation)) {
                 // a constraint itself
-                if (constraintAnnotations.contains(annotation.typeName())) {
-
+                if (constraintAnnotations.contains(annotation.typeName())
+                        && isConstraintAnnotation(annotation)) {
                     result.add(annotation);
                 }
                 // maybe meta-annotated with a constraint
@@ -289,171 +284,308 @@ final class ValidationHelper {
         }
     }
 
-    private static void addValidationOfMap(TypeName generatedType,
-                                           Collection<TypeName> constraintAnnotations,
-                                           ContentBuilder<?> contentBuilder,
-                                           FieldHandler fieldHandler,
-                                           TypedElementInfo element,
-                                           String localVariableName,
-                                           TypeName typeName) {
-        // handle map keys and values
-        if (typeName.typeArguments().size() == 2) {
-            TypeName keyType = typeName.typeArguments().get(0);
-            TypeName valueType = typeName.typeArguments().get(1);
+    private static boolean isConstraintAnnotation(Annotation annotation) {
+        return annotation.metaAnnotations().isEmpty()
+                || annotation.metaAnnotations()
+                        .stream()
+                        .anyMatch(it -> it.typeName().equals(ValidationTypes.VALIDATION_CONSTRAINT));
+    }
 
-            boolean keyHasValid = keyType.hasAnnotation(VALIDATION_VALID);
-            List<Annotation> keyConstraints = new ArrayList<>();
-            boolean valueHasValid = valueType.hasAnnotation(VALIDATION_VALID);
-            List<Annotation> valueConstraints = new ArrayList<>();
-
-            // now for each constraint annotation...
-            // we must honor order of declaration on the element
-            for (Annotation annotation : keyType.annotations()) {
-                if (constraintAnnotations.contains(annotation.typeName())) {
-                    keyConstraints.add(annotation);
-                }
-            }
-            // we must honor order of declaration on the element
-            for (Annotation annotation : valueType.annotations()) {
-                if (constraintAnnotations.contains(annotation.typeName())) {
-                    valueConstraints.add(annotation);
-                }
-            }
-
-            if (keyHasValid || valueHasValid || !keyConstraints.isEmpty() || !valueConstraints.isEmpty()) {
-                // need to go through the collection/optional
-                contentBuilder.addContent("if (")
-                        .addContent(localVariableName)
-                        .addContentLine(" != null) {");
-
-                contentBuilder.addContent("for (var validation__entry : ")
-                        .addContent(localVariableName)
-                        .addContentLine(".entrySet()) {")
-                        .addContentLine("var validation__key = validation__entry.getKey();")
-                        .addContentLine("var validation__value = validation__entry.getValue();");
-
-                if (keyHasValid || !keyConstraints.isEmpty()) {
-                    contentBuilder.addContent("try (var scope__mapkey = validation__ctx.scope(")
-                            .addContent(CONSTRAINT_VIOLATION_LOCATION)
-                            .addContent(".KEY, ")
-                            .addContentLiteral("key")
-                            .addContentLine(")) {");
-                }
-                if (keyHasValid) {
-                    String validatorField = addTypeValidator(fieldHandler, keyType);
-                    addValidationOfValid(contentBuilder, validatorField, "validation__key");
-                }
-                for (Annotation constraint : keyConstraints) {
-                    addValidationOfConstraint(generatedType,
-                                              fieldHandler,
-                                              contentBuilder,
-                                              constraint,
-                                              "KEY",
-                                              element,
-                                              "validation__key");
-                }
-
-                if (keyHasValid || !keyConstraints.isEmpty()) {
-                    contentBuilder.addContentLine("}");
-                }
-
-                if (valueHasValid || !valueConstraints.isEmpty()) {
-                    contentBuilder.addContent("try (var scope__mapelement = validation__ctx.scope(")
-                            .addContent(CONSTRAINT_VIOLATION_LOCATION)
-                            .addContent(".ELEMENT, ")
-                            .addContentLiteral("value")
-                            .addContentLine(")) {");
-                }
-                if (valueHasValid) {
-                    String validatorField = addTypeValidator(fieldHandler, valueType);
-                    addValidationOfValid(contentBuilder, validatorField, "validation__value");
-                }
-
-                for (Annotation constraint : valueConstraints) {
-                    addValidationOfConstraint(generatedType,
-                                              fieldHandler,
-                                              contentBuilder,
-                                              constraint,
-                                              "ELEMENT",
-                                              element,
-                                              "validation__value");
-                }
-
-                if (valueHasValid || !valueConstraints.isEmpty()) {
-                    contentBuilder.addContentLine("}");
-                }
-
-                contentBuilder.addContentLine("}");
-                contentBuilder.addContentLine("}");
-            }
+    private static void addValidationOfContainerType(ValidationContext context,
+                                                     TypeName typeName,
+                                                     String localVariableName,
+                                                     int depth) {
+        if (typeName.equals(TypeNames.SET)
+                || typeName.equals(TypeNames.LIST)
+                || typeName.equals(TypeNames.COLLECTION)
+                || typeName.equals(TypeNames.OPTIONAL)) {
+            addValidationOfSingleTypeArgument(context,
+                                              typeName,
+                                              localVariableName,
+                                              depth);
+        } else if (typeName.equals(TypeNames.MAP)) {
+            addValidationOfMap(context,
+                               typeName,
+                               localVariableName,
+                               depth);
+        } else if (typeName.array()) {
+            addValidationOfArrayComponent(context,
+                                          typeName,
+                                          localVariableName,
+                                          depth);
         }
     }
 
-    private static void addValidationForSingleTypeArgument(TypeName generatedType,
-                                                           Collection<TypeName> constraintAnnotations,
-                                                           ContentBuilder<?> contentBuilder,
-                                                           FieldHandler fieldHandler,
-                                                           TypedElementInfo element,
-                                                           String localVariableName,
-                                                           TypeName typeName) {
-        // handle collection type argument annotations
-        if (!typeName.typeArguments().isEmpty()) {
-            boolean isOptional = typeName.equals(TypeNames.OPTIONAL);
-            TypeName maybeAnnotated = typeName.typeArguments().getFirst();
-            boolean hasValid = maybeAnnotated.hasAnnotation(VALIDATION_VALID)
-                    || !findMetaAnnotations(maybeAnnotated.annotations(), VALIDATION_VALID).isEmpty();
-            List<Annotation> constraints = new ArrayList<>();
+    private static void addValidationOfArrayComponent(ValidationContext context,
+                                                      TypeName typeName,
+                                                      String localVariableName,
+                                                      int depth) {
+        Optional<TypeName> componentType = typeName.componentType();
+        if (componentType.isEmpty() || !needsWork(context.constraintAnnotations(), componentType.get())) {
+            return;
+        }
 
-            // now for each constraint annotation...
-            // we must honor order of declaration on the element
-            for (Annotation annotation : maybeAnnotated.annotations()) {
-                if (constraintAnnotations.contains(annotation.typeName())) {
-                    constraints.add(annotation);
-                }
-            }
+        String elementVar = "validation__element" + depth;
+        context.contentBuilder()
+                .addContent("if (")
+                .addContent(localVariableName)
+                .addContentLine(" != null) {");
+        context.contentBuilder()
+                .addContent("for (var ")
+                .addContent(elementVar)
+                .addContent(" : ")
+                .addContent(localVariableName)
+                .addContentLine(") {");
+        addValidationOfTypeName(context,
+                                new TypeValidation(componentType.get(),
+                                                   elementVar,
+                                                   "ELEMENT",
+                                                   "element",
+                                                   depth + 1,
+                                                   false,
+                                                   false));
+        context.contentBuilder().addContentLine("}");
+        context.contentBuilder().addContentLine("}");
+    }
 
-            if (hasValid || !constraints.isEmpty()) {
-                // need to go through the collection/optional
-                contentBuilder.addContent("if (")
-                        .addContent(localVariableName)
-                        .addContentLine(" != null) {");
-                if (isOptional) {
-                    contentBuilder.addContent("if (")
-                            .addContent(localVariableName)
-                            .addContentLine(".isPresent()) {")
-                            .addContent("var validation__element = ")
-                            .addContent(localVariableName)
-                            .addContentLine(".get();");
-                } else {
-                    contentBuilder.addContent("for (var validation__element : ")
-                            .addContent(localVariableName)
-                            .addContentLine(") {");
-                }
-                contentBuilder.addContent("try (var scope__element = validation__ctx.scope(")
-                        .addContent(CONSTRAINT_VIOLATION_LOCATION)
-                        .addContent(".")
-                        .addContent("ELEMENT")
-                        .addContentLine(", \"element\")) {");
+    private static void addValidationOfMap(ValidationContext context,
+                                           TypeName typeName,
+                                           String localVariableName,
+                                           int depth) {
+        if (typeName.typeArguments().size() != 2) {
+            return;
+        }
 
-                if (hasValid) {
-                    String validatorField = addTypeValidator(fieldHandler, maybeAnnotated);
-                    addValidationOfValid(contentBuilder, validatorField, "validation__element");
-                }
+        TypeName keyType = typeName.typeArguments().get(0);
+        TypeName valueType = typeName.typeArguments().get(1);
+        boolean keyNeedsWork = needsWork(context.constraintAnnotations(), keyType);
+        boolean valueNeedsWork = needsWork(context.constraintAnnotations(), valueType);
+        if (!keyNeedsWork && !valueNeedsWork) {
+            return;
+        }
 
-                for (Annotation constraint : constraints) {
-                    addValidationOfConstraint(generatedType,
-                                              fieldHandler,
-                                              contentBuilder,
-                                              constraint,
-                                              "ELEMENT",
-                                              element,
-                                              "validation__element");
-                }
+        String entryVar = "validation__entry" + depth;
+        String keyVar = "validation__key" + depth;
+        String valueVar = "validation__value" + depth;
 
-                contentBuilder.addContentLine("}");
-                contentBuilder.addContentLine("}");
-                contentBuilder.addContentLine("}");
+        context.contentBuilder()
+                .addContent("if (")
+                .addContent(localVariableName)
+                .addContentLine(" != null) {");
+        context.contentBuilder()
+                .addContent("for (var ")
+                .addContent(entryVar)
+                .addContent(" : ")
+                .addContent(localVariableName)
+                .addContentLine(".entrySet()) {")
+                .addContent("var ")
+                .addContent(keyVar)
+                .addContent(" = ")
+                .addContent(entryVar)
+                .addContentLine(".getKey();")
+                .addContent("var ")
+                .addContent(valueVar)
+                .addContent(" = ")
+                .addContent(entryVar)
+                .addContentLine(".getValue();");
+
+        if (keyNeedsWork) {
+            addValidationOfTypeName(context,
+                                    new TypeValidation(keyType,
+                                                       keyVar,
+                                                       "KEY",
+                                                       "key",
+                                                       depth + 1,
+                                                       false,
+                                                       true));
+        }
+        if (valueNeedsWork) {
+            addValidationOfTypeName(context,
+                                    new TypeValidation(valueType,
+                                                       valueVar,
+                                                       "ELEMENT",
+                                                       "value",
+                                                       depth + 1,
+                                                       false,
+                                                       true));
+        }
+
+        context.contentBuilder().addContentLine("}");
+        context.contentBuilder().addContentLine("}");
+    }
+
+    private static void addValidationOfSingleTypeArgument(ValidationContext context,
+                                                          TypeName typeName,
+                                                          String localVariableName,
+                                                          int depth) {
+        if (typeName.typeArguments().isEmpty()) {
+            return;
+        }
+
+        TypeName typeArgument = typeName.typeArguments().getFirst();
+        if (!needsWork(context.constraintAnnotations(), typeArgument)) {
+            return;
+        }
+
+        String elementVar = "validation__element" + depth;
+
+        context.contentBuilder()
+                .addContent("if (")
+                .addContent(localVariableName)
+                .addContentLine(" != null) {");
+        if (typeName.equals(TypeNames.OPTIONAL)) {
+            context.contentBuilder()
+                    .addContent("if (")
+                    .addContent(localVariableName)
+                    .addContentLine(".isPresent()) {")
+                    .addContent("var ")
+                    .addContent(elementVar)
+                    .addContent(" = ")
+                    .addContent(localVariableName)
+                    .addContentLine(".get();");
+        } else {
+            context.contentBuilder()
+                    .addContent("for (var ")
+                    .addContent(elementVar)
+                    .addContent(" : ")
+                    .addContent(localVariableName)
+                    .addContentLine(") {");
+        }
+
+        addValidationOfTypeName(context,
+                                new TypeValidation(typeArgument,
+                                                   elementVar,
+                                                   "ELEMENT",
+                                                   "element",
+                                                   depth + 1,
+                                                   false,
+                                                   false));
+
+        context.contentBuilder().addContentLine("}");
+        context.contentBuilder().addContentLine("}");
+    }
+
+    private static void addValidationOfTypeName(ValidationContext context, TypeValidation validation) {
+        List<Annotation> annotations = directTypeAnnotations(validation.typeName());
+        boolean hasValid = annotations.stream()
+                .anyMatch(it -> it.typeName().equals(VALIDATION_VALID) || it.hasMetaAnnotation(VALIDATION_VALID));
+        List<Annotation> constraints = findConstraintAnnotations(context.constraintAnnotations(), annotations);
+        boolean currentNeedsWork = hasValid || !constraints.isEmpty();
+
+        if (validation.forceScope() && needsWork(context.constraintAnnotations(), validation.typeName())) {
+            scope(context.contentBuilder(), validation.location(), validation.locationName(), validation.depth());
+            addCurrentTypeValidation(context, validation, hasValid, constraints);
+            addNestedTypeValidation(context, validation);
+            context.contentBuilder().addContentLine("}");
+            return;
+        }
+
+        if (currentNeedsWork) {
+            scope(context.contentBuilder(), validation.location(), validation.locationName(), validation.depth());
+            addCurrentTypeValidation(context, validation, hasValid, constraints);
+            context.contentBuilder().addContentLine("}");
+        }
+
+        addNestedTypeValidation(context, validation);
+    }
+
+    private static void scope(ContentBuilder<?> contentBuilder, String location, String locationName, int depth) {
+        contentBuilder.addContent("try (var scope__")
+                .addContent(location.toLowerCase(Locale.ROOT))
+                .addContent(String.valueOf(depth))
+                .addContent(" = validation__ctx.scope(")
+                .addContent(CONSTRAINT_VIOLATION_LOCATION)
+                .addContent(".")
+                .addContent(location)
+                .addContent(", ")
+                .addContentLiteral(locationName)
+                .addContentLine(")) {");
+    }
+
+    private static void addCurrentTypeValidation(ValidationContext context,
+                                                 TypeValidation validation,
+                                                 boolean hasValid,
+                                                 List<Annotation> constraints) {
+        if (hasValid) {
+            String validatorField = addTypeValidator(context.fieldHandler(), validation.typeName());
+            if (validation.guardValidType()) {
+                String validVar = "validation__valid" + validation.depth();
+                context.contentBuilder()
+                        .addContent("if (")
+                        .addContent(validation.localVariableName())
+                        .addContent(" instanceof ")
+                        .addContent(validation.typeName().genericTypeName())
+                        .addContent(" ")
+                        .addContent(validVar)
+                        .addContentLine(") {");
+                addValidationOfValid(context.contentBuilder(), validatorField, validVar);
+                context.contentBuilder().addContentLine("}");
+            } else {
+                addValidationOfValid(context.contentBuilder(), validatorField, validation.localVariableName());
             }
         }
+
+        for (Annotation constraint : constraints) {
+            addValidationOfConstraint(context,
+                                      constraint,
+                                      validation.location(),
+                                      validation.typeName(),
+                                      validation.localVariableName());
+        }
+    }
+
+    private static void addNestedTypeValidation(ValidationContext context, TypeValidation validation) {
+        addValidationOfContainerType(context,
+                                     validation.typeName(),
+                                     validation.localVariableName(),
+                                     validation.depth());
+        for (TypeName lowerBound : validation.typeName().lowerBounds()) {
+            addValidationOfTypeName(context,
+                                    new TypeValidation(lowerBound,
+                                                       validation.localVariableName(),
+                                                       validation.location(),
+                                                       validation.locationName(),
+                                                       validation.depth() + 1,
+                                                       true,
+                                                       false));
+        }
+        for (TypeName upperBound : validation.typeName().upperBounds()) {
+            addValidationOfTypeName(context,
+                                    new TypeValidation(upperBound,
+                                                       validation.localVariableName(),
+                                                       validation.location(),
+                                                       validation.locationName(),
+                                                       validation.depth() + 1,
+                                                       false,
+                                                       false));
+        }
+    }
+
+    private static List<Annotation> directTypeAnnotations(TypeName typeName) {
+        if (typeName.inheritedAnnotations().isEmpty()) {
+            return typeName.annotations();
+        }
+        List<Annotation> annotations = new ArrayList<>(typeName.annotations());
+        annotations.addAll(typeName.inheritedAnnotations());
+        return annotations;
+    }
+
+    private record ValidatorKey(ResolvedType annotatedType, Annotation constraint) {
+    }
+
+    record ValidationContext(TypeName generatedType,
+                             Collection<TypeName> constraintAnnotations,
+                             ContentBuilder<?> contentBuilder,
+                             FieldHandler fieldHandler,
+                             TypedElementInfo element) {
+    }
+
+    private record TypeValidation(TypeName typeName,
+                                  String localVariableName,
+                                  String location,
+                                  String locationName,
+                                  int depth,
+                                  boolean guardValidType,
+                                  boolean forceScope) {
     }
 }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -27,6 +27,7 @@ import io.helidon.codegen.testing.TestCompiler;
 import io.helidon.common.GenericType;
 import io.helidon.common.Generated;
 import io.helidon.common.types.Annotation;
+import io.helidon.service.codegen.ServiceCodegenTypes;
 import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
@@ -51,6 +52,17 @@ public class ValidationCodegenTest {
             Service.class,
             Prototype.class
     );
+
+    @Test
+    void testValidationProviderUsesServiceContractTrigger() {
+        var provider = new ValidationExtensionProvider();
+
+        assertThat(provider.supportsServiceContractAnnotations(), is(true));
+        assertThat(provider.supportedAnnotations().contains(ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER), is(false));
+        assertThat(provider.supportedAnnotations().contains(ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE), is(false));
+        assertThat(provider.supportedAnnotations().contains(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT), is(false));
+        assertThat(provider.supportedMetaAnnotations().contains(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE), is(false));
+    }
 
     @Test
     void testFieldValidation() throws IOException {
@@ -437,7 +449,7 @@ public class ValidationCodegenTest {
     }
 
     @Test
-    void testNonServiceInterfaceMethodConstraintRequiresValidated() {
+    void testPlainInterfaceMethodConstraintDoesNotRequireValidated() {
         var result = TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(CLASSPATH)
@@ -455,9 +467,270 @@ public class ValidationCodegenTest {
                 .compile();
 
         String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApi__ValidationInterceptor_0.java")),
+                   is(false));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApi__Validated.java")),
+                   is(false));
+    }
+
+    @Test
+    void testInterfaceStaticMethodParameterConstraintRequiresValidated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            static String validate(@Validation.String.NotBlank String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
         assertThat(diagnostics, result.success(), is(false));
         assertThat(diagnostics, containsString(ValidationTypes.VALIDATION_VALIDATED.fqName()
                                                       + " annotation is required on non-service type"));
+    }
+
+    @Test
+    void testInterfacePrivateMethodParameterConstraintRequiresValidated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            private String validate(@Validation.String.NotBlank String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString(ValidationTypes.VALIDATION_VALIDATED.fqName()
+                                                      + " annotation is required on non-service type"));
+    }
+
+    @Test
+    void testMetaAnnotatedContractConstraintTriggersServiceProcessing() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("CustomConstraint.java", """
+                        package com.example;
+
+                        import java.lang.annotation.ElementType;
+                        import java.lang.annotation.Target;
+
+                        import io.helidon.validation.Validation;
+
+                        @Target(ElementType.PARAMETER)
+                        @Validation.String.NotBlank
+                        public @interface CustomConstraint {
+                        }
+                        """)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        public interface DefaultApi {
+                            String validate(@CustomConstraint String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java")),
+                   is(true));
+    }
+
+    @Test
+    void testNestedConstraintUsesAnnotatedTypeForValidatorProvider() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import java.util.List;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        class DefaultApiImpl {
+                            void validate(@Validation.Integer.Min(10) Long count,
+                                          List<@Validation.Integer.Min(10) Integer> values) {
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        var interceptor = result.sourceOutput()
+                .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        var content = Files.readString(interceptor, StandardCharsets.UTF_8);
+        assertThat(content, containsString(".packageName(\"java.lang\")"));
+        assertThat(content, containsString(".className(\"Long\")"));
+        assertThat(content, containsString(".className(\"Integer\")"));
+    }
+
+    @Test
+    void testVoidMethodReturnConstraintFailsClearly() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        class DefaultApi {
+                            @Validation.NotNull
+                            void reset() {
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString("Validation annotations cannot constrain a void method return value."));
+        assertThat(diagnostics, not(containsString("(void)")));
+    }
+
+    @Test
+    void testLowerBoundValidTypeUseCompiles() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ValidatedType.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        record ValidatedType(@Validation.String.NotBlank String name) {
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import java.util.List;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        class DefaultApiImpl {
+                            void validate(List<? super @Validation.Valid ValidatedType> values) {
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        var interceptor = result.sourceOutput()
+                .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        var content = Files.readString(interceptor, StandardCharsets.UTF_8);
+        assertThat(content, containsString("instanceof ValidatedType validation__valid"));
+        assertThat(content, containsString(".check(validation__ctx, validation__valid"));
+        assertThat(content, not(containsString(".check(validation__ctx, validation__element")));
+    }
+
+    @Test
+    void testSameSignatureInterfaceConstraintsAreMerged() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("LowApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        interface LowApi {
+                            String validate(@Validation.Integer.Min(1) int count);
+                        }
+                        """)
+                .addSource("HighApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        interface HighApi {
+                            String validate(@Validation.Integer.Min(10) int count);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements LowApi, HighApi {
+                            @Override
+                            public String validate(int count) {
+                                return String.valueOf(count);
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+
+        var content = Files.readString(interceptor, StandardCharsets.UTF_8);
+        assertThat(content.lines().filter(it -> it.contains("validation__ctx.check(")).count(), is(2L));
     }
 
     @Test

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -268,7 +268,7 @@ Helidon validation module:
 
 ==== Constraint Annotations
 
-A "Constraint Annotation" is any annotation directly annotated with `io.helidon.validation.Validation`.
+A "Constraint Annotation" is any annotation directly annotated with `io.helidon.validation.Validation.Constraint`.
 Helidon Validation provides a set of built-in validation constraints, though custom constraints can be created, or existing constraints can be combined.
 
 Existing constraints:
@@ -355,6 +355,8 @@ A type annotated with `@Validation.Validated` will have validation code generate
 `@Validation.Valid` - if such an annotation is present, and it is on a field of another validated type, or it is a parameter,
 return type, or a type argument of a parameter/return type of a service method, the object instance will be validated using
 a generated interceptor.
+Type-use validation is supported on nested `Optional`, `Collection`, `List`, `Set`, `Map` key/value types, array component
+types, and wildcard bounds.
 
 ==== Usage
 
@@ -368,6 +370,19 @@ include::{sourcedir}/se/ValidationSnippets.java[tag=snippet_1, indent=0]
 .Example of a validated method call using a validated type
 ----
 include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_7, indent=0]
+----
+
+Constraint annotations and `@Validation.Valid` can also be declared on non-private instance methods of service interfaces.
+They are applied when the service instance is obtained from the service registry.
+The same applies to instances returned by registry-managed service factories, including `Supplier`,
+`Service.ServicesFactory`, `Service.InjectionPointFactory`, and `Service.QualifiedFactory` services.
+This can change runtime behavior for services that already declared interface validation: invalid calls through
+registry-obtained services may now fail with a `ValidationException`, while directly constructed objects are not intercepted.
+
+[source,java]
+.Example of a validated service contract
+----
+include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_7b, indent=0]
 ----
 
 A custom "compound" annotation can be created to simplify usage.

--- a/docs/src/main/asciidoc/se/injection/injection.adoc
+++ b/docs/src/main/asciidoc/se/injection/injection.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -570,6 +570,9 @@ link:{service-registry-base-url}/io/helidon/service/registry/Interception.Delega
 However, keep in mind that usage of this annotation doesn’t add the ability to intercept constructor calls.
 To enable interception, this annotation must be present on the class that the factory produces.
 While it is not required on interfaces, it will still work correctly if applied there.
+If the produced type is an interface, Helidon can generate the required delegation wrapper for registry-managed factories
+without `@Interception.Delegate` on the produced implementation class. This is the path used by declarative validation
+when method constraints are declared on service interfaces.
 
 If you need to enable interception for classes using delegation, you should make sure about the following:
 

--- a/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
+++ b/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
@@ -146,6 +146,20 @@ public class DeclarativeExample {
     }
     // end::snippet_7[]
 
+    // tag::snippet_7b[]
+    interface ValidatedServiceContract {
+        String process(@Validation.String.NotBlank String value);
+    }
+
+    @Service.Singleton
+    static class ContractValidatedService implements ValidatedServiceContract {
+        @Override
+        public String process(String value) {
+            return value;
+        }
+    }
+    // end::snippet_7b[]
+
     // tag::snippet_8[]
     @Validation.NotNull
     @Validation.String.NotBlank

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ChildGenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ChildGenericInterfaceConstrainedService.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+interface ChildGenericInterfaceConstrainedService<T> extends ParentGenericInterfaceConstrainedService<T> {
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ConstrainedDefaultInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ConstrainedDefaultInterfaceConstrainedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface ConstrainedDefaultInterfaceConstrainedService extends UnconstrainedDefaultInterfaceConstrainedService {
+    @Override
+    default String validateInheritedDefault(@Validation.String.NotBlank String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/CustomConstraintValidatorProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/CustomConstraintValidatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.validation.tests.validation;
 
+import java.util.List;
+
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.registry.Service;
@@ -29,13 +31,15 @@ import io.helidon.validation.spi.ConstraintValidatorProvider;
 public class CustomConstraintValidatorProvider implements ConstraintValidatorProvider {
     @Override
     public ConstraintValidator create(TypeName typeName, Annotation constraintAnnotation) {
-        return new CustomValidator(constraintAnnotation);
+        return new CustomValidator(typeName, constraintAnnotation);
     }
 
     private static class CustomValidator implements ConstraintValidator {
+        private final TypeName typeName;
         private final Annotation annotation;
 
-        private CustomValidator(Annotation annotation) {
+        private CustomValidator(TypeName typeName, Annotation annotation) {
+            this.typeName = typeName;
             this.annotation = annotation;
         }
 
@@ -47,6 +51,15 @@ public class CustomConstraintValidatorProvider implements ConstraintValidatorPro
 
             if (value instanceof String str) {
                 if (str.equals("good")) {
+                    return ValidatorResponse.create();
+                }
+            }
+            if (value instanceof List<?> values) {
+                String resolvedName = typeName.resolvedName();
+                if (resolvedName.equals("java.util.List<java.lang.String>") && values.equals(List.of("good"))) {
+                    return ValidatorResponse.create();
+                }
+                if (resolvedName.equals("java.util.List<java.lang.Integer>") && values.equals(List.of(42))) {
                     return ValidatorResponse.create();
                 }
             }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/DefaultInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/DefaultInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class DefaultInterfaceConstrainedServiceImpl implements ConstrainedDefaultInterfaceConstrainedService {
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/FactoryProviderGetInterceptor.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/FactoryProviderGetInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.service.registry.Interception;
+import io.helidon.service.registry.InterceptionContext;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Named("io.helidon.validation.tests.validation.SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.get()")
+class FactoryProviderGetInterceptor implements Interception.ElementInterceptor {
+    private static final AtomicInteger CALLS = new AtomicInteger();
+
+    static void reset() {
+        CALLS.set(0);
+    }
+
+    static int count() {
+        return CALLS.get();
+    }
+
+    @Override
+    public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+        CALLS.incrementAndGet();
+        return chain.proceed(args);
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/FactoryProviderLegacyValidateInterceptor.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/FactoryProviderLegacyValidateInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.service.registry.Interception;
+import io.helidon.service.registry.InterceptionContext;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Named("io.helidon.validation.tests.validation.QualifiedFactoryProvidedInterfaceConstrainedServiceProvider"
+        + ".validate(java.lang.String)")
+class FactoryProviderLegacyValidateInterceptor implements Interception.ElementInterceptor {
+    private static final AtomicInteger CALLS = new AtomicInteger();
+
+    static void reset() {
+        CALLS.set(0);
+    }
+
+    static int count() {
+        return CALLS.get();
+    }
+
+    @Override
+    public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+        CALLS.incrementAndGet();
+        return chain.proceed(args);
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/GenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/GenericInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface GenericInterfaceConstrainedService<T> {
+    T validateGeneric(@Validation.String.NotBlank T value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface InjectOnlyInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+class InjectOnlyInterfaceConstrainedServiceImpl implements InjectOnlyInterfaceConstrainedService {
+    @Service.Inject
+    InjectOnlyInterfaceConstrainedServiceImpl() {
+    }
+
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryDirectContract.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryDirectContract {
+    @Validation.NotNull
+    Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(
+            @Validation.NotNull Lookup lookup);
+
+    @Validation.NotNull
+    @Validation.Collection.Size(2)
+    List<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> list(
+            @Validation.NotNull Lookup lookup);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyBaseProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyBaseProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+
+abstract class InjectionPointFactoryFirstOnlyBaseProvider
+        implements Service.InjectionPointFactory<InjectionPointFactoryFirstOnlyProvidedService> {
+    @Override
+    public List<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> list(Lookup lookup) {
+        return List.of(Service.QualifiedInstance.create(new InjectionPointFactoryFirstOnlyProvidedServiceImpl()),
+                       Service.QualifiedInstance.create(new InjectionPointFactoryFirstOnlyProvidedServiceImpl()));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyDirectContract.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryFirstOnlyDirectContract {
+    @Validation.NotNull
+    Optional<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> first(Lookup lookup);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryFirstOnlyProvidedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class InjectionPointFactoryFirstOnlyProvidedServiceImpl implements InjectionPointFactoryFirstOnlyProvidedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedServiceProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class InjectionPointFactoryFirstOnlyProvidedServiceProvider
+        extends InjectionPointFactoryFirstOnlyBaseProvider
+        implements Service.InjectionPointFactory<InjectionPointFactoryFirstOnlyProvidedService>,
+                   InjectionPointFactoryFirstOnlyDirectContract {
+    @Override
+    public Optional<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> first(Lookup lookup) {
+        return Optional.of(list(lookup).getFirst());
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryOverloadedDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryOverloadedDirectContract.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryOverloadedDirectContract {
+    Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(
+            @Validation.NotNull String name);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl
+        implements InjectionPointFactoryProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider
+        implements Service.InjectionPointFactory<InjectionPointFactoryProvidedInterfaceConstrainedService>,
+                   InjectionPointFactoryDirectContract,
+                   InjectionPointFactoryOverloadedDirectContract {
+    @Override
+    public Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(String name) {
+        return Optional.of(Service.QualifiedInstance.create(new InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl(),
+                                                           Qualifier.createNamed(name)));
+    }
+
+    @Override
+    public Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(
+            Lookup lookup) {
+        return Optional.of(list(lookup).getFirst());
+    }
+
+    @Override
+    public List<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> list(Lookup lookup) {
+        return List.of(Service.QualifiedInstance.create(new InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl()),
+                       Service.QualifiedInstance.create(new InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl()));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
@@ -16,10 +16,44 @@
 
 package io.helidon.validation.tests.validation;
 
-import io.helidon.service.registry.Service;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import io.helidon.validation.Validation;
 
-@Service.Contract
 interface InterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
+
+    default String validateDefault(@Validation.String.NotBlank String value) {
+        return value;
+    }
+
+    List<String> validateList(List<@Validation.String.NotBlank String> values);
+
+    List<List<String>> validateNestedList(List<List<@Validation.String.NotBlank String>> values);
+
+    Map<String, String> validateMap(Map<@Validation.String.NotBlank String, @Validation.String.NotBlank String> values);
+
+    Map<List<String>, String> validateNestedMapKey(Map<List<@Validation.String.NotBlank String>, String> values);
+
+    Map<String, List<String>> validateNestedMapValue(Map<String, List<@Validation.String.NotBlank String>> values);
+
+    Optional<String> validateOptional(Optional<@Validation.String.NotBlank String> value);
+
+    @TypeUseNotBlank String[] validateArray(@TypeUseNotBlank String[] values);
+
+    List<Integer> validateIntegerList(List<@Validation.Integer.Min(10) Integer> values);
+
+    List<@Validation.String.NotBlank String> invalidNames();
+
+    int validateMinimum(@Validation.Integer.Min(10) int value);
+
+    String validateShared(@Validation.String.NotBlank String value);
+
+    String validateDuplicate(@Validation.String.NotBlank String value);
+
+    List<String> validateCustomStringList(@CustomConstraint List<String> values);
+
+    List<Integer> validateCustomIntegerList(@CustomConstraint List<Integer> values);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
@@ -16,12 +16,108 @@
 
 package io.helidon.validation.tests.validation;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
 
 @Service.Singleton
-class InterfaceConstrainedServiceImpl implements InterfaceConstrainedService {
+class InterfaceConstrainedServiceImpl
+        implements UnconstrainedInterfaceConstrainedService,
+                   InterfaceConstrainedService,
+                   LowerMinimumInterfaceConstrainedService,
+                   GenericInterfaceConstrainedService<String>,
+                   OrderedGenericInterfaceConstrainedService<String, Integer>,
+                   ChildGenericInterfaceConstrainedService<String> {
     @Override
     public String validate(String value) {
+        return value;
+    }
+
+    @Override
+    public List<String> validateList(List<String> values) {
+        return values;
+    }
+
+    @Override
+    public List<List<String>> validateNestedList(List<List<String>> values) {
+        return values;
+    }
+
+    @Override
+    public Map<String, String> validateMap(Map<String, String> values) {
+        return values;
+    }
+
+    @Override
+    public Map<List<String>, String> validateNestedMapKey(Map<List<String>, String> values) {
+        return values;
+    }
+
+    @Override
+    public Map<String, List<String>> validateNestedMapValue(Map<String, List<String>> values) {
+        return values;
+    }
+
+    @Override
+    public Optional<String> validateOptional(Optional<String> value) {
+        return value;
+    }
+
+    @Override
+    public String[] validateArray(String[] values) {
+        return values;
+    }
+
+    @Override
+    public List<Integer> validateIntegerList(List<Integer> values) {
+        return values;
+    }
+
+    @Override
+    public List<String> invalidNames() {
+        return List.of("");
+    }
+
+    @Override
+    public int validateMinimum(@Validation.Integer.Min(1) int value) {
+        return value;
+    }
+
+    @Override
+    public String validateShared(String value) {
+        return value;
+    }
+
+    @Override
+    public String validateDuplicate(@Validation.String.NotBlank String value) {
+        return value;
+    }
+
+    @Override
+    public List<String> validateCustomStringList(List<String> values) {
+        return values;
+    }
+
+    @Override
+    public List<Integer> validateCustomIntegerList(List<Integer> values) {
+        return values;
+    }
+
+    @Override
+    public String validateGeneric(String value) {
+        return value;
+    }
+
+    @Override
+    public Integer validateOrderedGeneric(String key, Integer value) {
+        return value;
+    }
+
+    @Override
+    public String validateInheritedGeneric(String value) {
         return value;
     }
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceMethodValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceMethodValidationTest.java
@@ -1,0 +1,988 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInstance;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.testing.junit5.Testing;
+import io.helidon.validation.ConstraintViolation.Location;
+import io.helidon.validation.ConstraintViolation.PathElement;
+import io.helidon.validation.Validation;
+import io.helidon.validation.ValidationException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Testing.Test
+class InterfaceMethodValidationTest {
+    private final ServiceRegistry registry;
+
+    InterfaceMethodValidationTest(ServiceRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Test
+    void interfaceParameterConstraintIsAppliedFromRegistryService() {
+        assertThat(new InterfaceConstrainedServiceImpl().validate(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateDefault(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateList(List.of("")), is(List.of("")));
+        assertThat(new InterfaceConstrainedServiceImpl().validateNestedList(List.of(List.of(""))), is(List.of(List.of(""))));
+        assertThat(new InterfaceConstrainedServiceImpl().validateMap(Map.of("", "valid")), is(Map.of("", "valid")));
+        assertThat(new InterfaceConstrainedServiceImpl().validateNestedMapKey(Map.of(List.of(""), "valid")),
+                   is(Map.of(List.of(""), "valid")));
+        assertThat(new InterfaceConstrainedServiceImpl().validateNestedMapValue(Map.of("key", List.of(""))),
+                   is(Map.of("key", List.of(""))));
+        assertThat(new InterfaceConstrainedServiceImpl().validateOptional(Optional.of("")), is(Optional.of("")));
+        String[] array = {""};
+        assertThat(new InterfaceConstrainedServiceImpl().validateArray(array), sameInstance(array));
+        assertThat(new InterfaceConstrainedServiceImpl().validateIntegerList(List.of(5)), is(List.of(5)));
+        assertThat(new InterfaceConstrainedServiceImpl().invalidNames(), is(List.of("")));
+        assertThat(new InterfaceConstrainedServiceImpl().validateMinimum(5), is(5));
+        assertThat(new InterfaceConstrainedServiceImpl().validateShared(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateDuplicate(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateGeneric(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateOrderedGeneric("", 42), is(42));
+        assertThat(new InterfaceConstrainedServiceImpl().validateInheritedGeneric(""), is(""));
+        assertThat(new DefaultInterfaceConstrainedServiceImpl().validateInheritedDefault(""), is(""));
+
+        InterfaceConstrainedService service = registry.get(InterfaceConstrainedService.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        GenericInterfaceConstrainedService<String> genericService =
+                (GenericInterfaceConstrainedService) registry.get(GenericInterfaceConstrainedService.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        OrderedGenericInterfaceConstrainedService<String, Integer> orderedGenericService =
+                (OrderedGenericInterfaceConstrainedService) registry.get(OrderedGenericInterfaceConstrainedService.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ParentGenericInterfaceConstrainedService<String> parentGenericService =
+                (ParentGenericInterfaceConstrainedService) registry.get(ParentGenericInterfaceConstrainedService.class);
+        ConstrainedDefaultInterfaceConstrainedService defaultMethodService =
+                registry.get(ConstrainedDefaultInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+        LegacyValidateDefaultInterceptor.reset();
+        assertThat(service.validateDefault("valid"), is("valid"));
+        assertThat(LegacyValidateDefaultInterceptor.count(), is(1));
+        assertThat(service.validateList(List.of("valid")), is(List.of("valid")));
+        assertThat(service.validateNestedList(List.of(List.of("valid"))), is(List.of(List.of("valid"))));
+        assertThat(service.validateMap(Map.of("key", "valid")), is(Map.of("key", "valid")));
+        assertThat(service.validateNestedMapKey(Map.of(List.of("valid"), "valid")),
+                   is(Map.of(List.of("valid"), "valid")));
+        assertThat(service.validateNestedMapValue(Map.of("key", List.of("valid"))),
+                   is(Map.of("key", List.of("valid"))));
+        assertThat(service.validateOptional(Optional.of("valid")), is(Optional.of("valid")));
+        array = new String[] {"valid"};
+        assertThat(service.validateArray(array), sameInstance(array));
+        assertThat(service.validateIntegerList(List.of(10)), is(List.of(10)));
+        assertThat(service.validateMinimum(10), is(10));
+        assertThat(service.validateShared("valid"), is("valid"));
+        assertThat(service.validateDuplicate("valid"), is("valid"));
+        assertThat(service.validateCustomStringList(List.of("good")), is(List.of("good")));
+        assertThat(service.validateCustomIntegerList(List.of(42)), is(List.of(42)));
+        assertThat(genericService.validateGeneric("valid"), is("valid"));
+        assertThat(orderedGenericService.validateOrderedGeneric("valid", 42), is(42));
+        assertThat(parentGenericService.validateInheritedGeneric("valid"), is("valid"));
+        assertThat(defaultMethodService.validateInheritedDefault("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateCustomStringList(List.of("bad")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateCustomStringList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values")),
+                        "Must be \"good\" string",
+                        List.of("bad"),
+                        TypeName.create(CustomConstraint.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateCustomIntegerList(List.of(41)));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateCustomIntegerList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values")),
+                        "Must be \"good\" string",
+                        List.of(41),
+                        TypeName.create(CustomConstraint.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateDefault(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateDefault(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateList(List.of("")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateNestedList(List.of(List.of(""))));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateNestedList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateMap(Map.of("", "valid")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateMap(java.util.Map)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.KEY, "key")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateMap(Map.of("key", "")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateMap(java.util.Map)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateNestedMapKey(Map.of(List.of(""), "valid")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateNestedMapKey(java.util.Map)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.KEY, "key"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class,
+                              () -> service.validateNestedMapValue(Map.of("key", List.of(""))));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateNestedMapValue(java.util.Map)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "value"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateOptional(Optional.of("")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateOptional(java.util.Optional)"),
+                                PathElement.create(Location.PARAMETER, "value"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateArray(new String[] {""}));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateArray(java.lang.String[])"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateIntegerList(List.of(5)));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateIntegerList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is less than 10",
+                        5,
+                        TypeName.create(Validation.Integer.Min.class));
+
+        result = assertThrows(ValidationException.class, service::invalidNames);
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "invalidNames()"),
+                                PathElement.create(Location.RETURN_VALUE, "List"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateMinimum(5));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateMinimum(int)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is less than 10",
+                        5,
+                        TypeName.create(Validation.Integer.Min.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateShared(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateShared(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateDuplicate(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateDuplicate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> genericService.validateGeneric(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateGeneric(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> orderedGenericService.validateOrderedGeneric("", 42));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD,
+                                                   "validateOrderedGeneric(java.lang.String,java.lang.Integer)"),
+                                PathElement.create(Location.PARAMETER, "key")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> parentGenericService.validateInheritedGeneric(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateInheritedGeneric(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> defaultMethodService.validateInheritedDefault(""));
+        assertViolation(result,
+                        DefaultInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, DefaultInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateInheritedDefault(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void injectOnlyServiceUsesInterfaceParameterConstraint() {
+        assertThat(new InjectOnlyInterfaceConstrainedServiceImpl().validate(""), is(""));
+
+        InjectOnlyInterfaceConstrainedService service = registry.get(InjectOnlyInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        InjectOnlyInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectOnlyInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void supplierProvidedServiceUsesInterfaceParameterConstraint() {
+        assertThat(new SupplierProvidedInterfaceConstrainedServiceProvider().get().validate(""), is(""));
+
+        SupplierProvidedInterfaceConstrainedService service =
+                registry.get(SupplierProvidedInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        SupplierProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProvidedInterfaceConstrainedServiceProvider.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void supplierProvidedServiceUsesInterfaceReturnConstraintOnSameSignatureMethod() {
+        assertThat(new SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider().get().get(), is(""));
+
+        SupplierProvidedSameSignatureInterfaceConstrainedService service =
+                registry.get(SupplierProvidedSameSignatureInterfaceConstrainedService.class);
+
+        var result = assertThrows(ValidationException.class, service::get);
+        assertViolation(result,
+                        SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "get()"),
+                                PathElement.create(Location.RETURN_VALUE, "String")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        Lookup supplierLookup = Lookup.builder()
+                .addContract(SupplierProvidedSameSignatureInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.SUPPLIER)
+                .build();
+        Supplier<SupplierProvidedSameSignatureInterfaceConstrainedService> supplier = registry.get(supplierLookup);
+
+        FactoryProviderGetInterceptor.reset();
+        SupplierProvidedSameSignatureInterfaceConstrainedService suppliedService = supplier.get();
+        assertThat(FactoryProviderGetInterceptor.count(), is(1));
+
+        result = assertThrows(ValidationException.class, suppliedService::get);
+        assertViolation(result,
+                        SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "get()"),
+                                PathElement.create(Location.RETURN_VALUE, "String")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        SupplierProvidedSameSignatureProviderContract providerContract =
+                registry.get(SupplierProvidedSameSignatureProviderContract.class);
+
+        FactoryProviderGetInterceptor.reset();
+        assertThat(providerContract.get(), instanceOf(SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl.class));
+        assertThat(FactoryProviderGetInterceptor.count(), is(1));
+    }
+
+    @Test
+    void supplierProviderDirectContractAndProvidedContractUseIndependentSameSignatureConstraints() {
+        assertThat(new SupplierProviderSameSignatureConstrainedServiceProvider().get().validate(""), is(""));
+        assertThat(new SupplierProviderSameSignatureConstrainedServiceProvider().validate("abc"), is("abc"));
+
+        SupplierProviderSameSignatureConstrainedService service =
+                registry.get(SupplierProviderSameSignatureConstrainedService.class);
+
+        assertThat(service.validate("abc"), is("abc"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        SupplierProviderSameSignatureConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProviderSameSignatureConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        SupplierProviderSameSignatureConstrainedServiceProvider provider =
+                registry.get(SupplierProviderSameSignatureConstrainedServiceProvider.class);
+
+        assertThat(provider.validate("123"), is("123"));
+
+        result = assertThrows(ValidationException.class, () -> provider.validate("abc"));
+        assertViolation(result,
+                        SupplierProviderSameSignatureConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProviderSameSignatureConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "pattern",
+                        "abc",
+                        TypeName.create(Validation.String.Pattern.class));
+
+        SupplierProviderSameSignatureDirectService directService =
+                registry.get(SupplierProviderSameSignatureDirectService.class);
+        List<ServiceInstance<SupplierProviderSameSignatureDirectService>> directInstances =
+                registry.lookupInstances(Lookup.create(SupplierProviderSameSignatureDirectService.class));
+
+        assertThat(directService.validate("123"), is("123"));
+        assertThat(directInstances, hasSize(1));
+        assertThat(directInstances.getFirst()
+                           .contracts()
+                           .contains(ResolvedType.create(SupplierProviderSameSignatureDirectService.class)),
+                   is(true));
+
+        result = assertThrows(ValidationException.class, () -> directService.validate("abc"));
+        assertViolation(result,
+                        SupplierProviderSameSignatureConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProviderSameSignatureConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "pattern",
+                        "abc",
+                        TypeName.create(Validation.String.Pattern.class));
+    }
+
+    @Test
+    void optionalSupplierProvidedServiceUsesInterfaceParameterConstraint() {
+        assertThat(new OptionalSupplierProvidedInterfaceConstrainedServiceProvider()
+                           .get()
+                           .orElseThrow()
+                           .validate(""),
+                   is(""));
+
+        OptionalSupplierProvidedInterfaceConstrainedService service =
+                registry.get(OptionalSupplierProvidedInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        Lookup supplierLookup = Lookup.builder()
+                .addContract(OptionalSupplierProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.SUPPLIER)
+                .build();
+        Supplier<Optional<OptionalSupplierProvidedInterfaceConstrainedService>> supplier = registry.get(supplierLookup);
+
+        assertThat(supplier.get().orElseThrow().validate("valid"), is("valid"));
+
+        result = assertThrows(ValidationException.class, () -> supplier.get().orElseThrow().validate(""));
+        assertViolation(result,
+                        OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void concreteFactoryProviderLookupRemainsAvailable() {
+        assertConcreteProviderIsAvailable(SupplierProvidedInterfaceConstrainedServiceProvider.class, FactoryType.SUPPLIER);
+        assertConcreteProviderIsAvailable(OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class,
+                                          FactoryType.SUPPLIER);
+        assertConcreteProviderIsAvailable(ServicesFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                                          FactoryType.SERVICES);
+        assertConcreteProviderIsAvailable(InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                                          FactoryType.INJECTION_POINT);
+        assertConcreteProviderIsAvailable(QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                                          FactoryType.QUALIFIED);
+
+        Lookup supplierLookup = Lookup.builder()
+                .addContract(SupplierProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.SUPPLIER)
+                .build();
+        Supplier<SupplierProvidedInterfaceConstrainedService> supplier = registry.get(supplierLookup);
+        assertThrows(ValidationException.class, () -> supplier.get().validate(""));
+    }
+
+    @Test
+    void servicesFactoryProvidedServiceUsesInterfaceParameterConstraint() {
+        assertThat(new ServicesFactoryProvidedInterfaceConstrainedServiceProvider()
+                           .services()
+                           .getFirst()
+                           .get()
+                           .validate(""),
+                   is(""));
+
+        ServicesFactoryProvidedInterfaceConstrainedService service =
+                registry.get(ServicesFactoryProvidedInterfaceConstrainedService.class);
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(ServicesFactoryProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.SERVICES)
+                .build();
+        Service.ServicesFactory<ServicesFactoryProvidedInterfaceConstrainedService> factory = registry.get(factoryLookup);
+        List<Service.QualifiedInstance<ServicesFactoryProvidedInterfaceConstrainedService>> factoryServices =
+                factory.services();
+
+        assertThat(service.validate("valid"), is("valid"));
+        assertThat(factoryServices, hasSize(1));
+        assertThat(factoryServices.getFirst().get().validate("valid"), is("valid"));
+        assertThrows(ValidationException.class, () -> factoryServices.getFirst().get().validate(""));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        ServicesFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   ServicesFactoryProvidedInterfaceConstrainedServiceProvider.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void broadLookupDoesNotBypassFactoryInterceptionWrappers() {
+        List<Object> allServices = registry.all(Lookup.EMPTY);
+        List<SupplierProvidedInterfaceConstrainedService> supplierServices =
+                allServices.stream()
+                        .filter(SupplierProvidedInterfaceConstrainedService.class::isInstance)
+                        .map(SupplierProvidedInterfaceConstrainedService.class::cast)
+                        .toList();
+        List<OptionalSupplierProvidedInterfaceConstrainedService> optionalSupplierServices =
+                allServices.stream()
+                        .filter(OptionalSupplierProvidedInterfaceConstrainedService.class::isInstance)
+                        .map(OptionalSupplierProvidedInterfaceConstrainedService.class::cast)
+                        .toList();
+        List<ServicesFactoryProvidedInterfaceConstrainedService> servicesFactoryServices =
+                allServices.stream()
+                        .filter(ServicesFactoryProvidedInterfaceConstrainedService.class::isInstance)
+                        .map(ServicesFactoryProvidedInterfaceConstrainedService.class::cast)
+                        .toList();
+
+        assertThat(supplierServices.isEmpty(), is(false));
+        assertThat(optionalSupplierServices.isEmpty(), is(false));
+        assertThat(servicesFactoryServices.isEmpty(), is(false));
+        supplierServices.forEach(it -> assertThrows(ValidationException.class, () -> it.validate("")));
+        optionalSupplierServices.forEach(it -> assertThrows(ValidationException.class, () -> it.validate("")));
+        servicesFactoryServices.forEach(it -> assertThrows(ValidationException.class, () -> it.validate("")));
+    }
+
+    @Test
+    void injectionPointFactoryProvidedServiceUsesInterfaceParameterConstraint() {
+        assertThat(new InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider()
+                           .first(Lookup.create(InjectionPointFactoryProvidedInterfaceConstrainedService.class))
+                           .orElseThrow()
+                           .get()
+                           .validate(""),
+                   is(""));
+
+        InjectionPointFactoryProvidedInterfaceConstrainedService service =
+                registry.get(InjectionPointFactoryProvidedInterfaceConstrainedService.class);
+        List<InjectionPointFactoryProvidedInterfaceConstrainedService> services =
+                registry.all(InjectionPointFactoryProvidedInterfaceConstrainedService.class);
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(InjectionPointFactoryProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.INJECTION_POINT)
+                .build();
+        Service.InjectionPointFactory<InjectionPointFactoryProvidedInterfaceConstrainedService> factory =
+                registry.get(factoryLookup);
+        InjectionPointFactoryDirectContract directFactory = registry.get(InjectionPointFactoryDirectContract.class);
+        Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService> factoryFirst =
+                factory.first(Lookup.create(InjectionPointFactoryProvidedInterfaceConstrainedService.class))
+                        .orElseThrow();
+        List<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> factoryServices =
+                factory.list(Lookup.create(InjectionPointFactoryProvidedInterfaceConstrainedService.class));
+        InjectionPointFactoryOverloadedDirectContract overloadedFactory = registry.get(
+                InjectionPointFactoryOverloadedDirectContract.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+        assertThat(services, hasSize(2));
+        assertThat(factoryFirst.get().validate("valid"), is("valid"));
+        assertThat(factoryServices, hasSize(2));
+        assertThat(overloadedFactory.first("overloaded").orElseThrow().get().validate("valid"), is("valid"));
+        for (InjectionPointFactoryProvidedInterfaceConstrainedService listedService : services) {
+            assertThat(listedService.validate("valid"), is("valid"));
+            assertThrows(ValidationException.class, () -> listedService.validate(""));
+        }
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> factory.list(null));
+        assertViolation(result,
+                        InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "list(io.helidon.service.registry.Lookup)"),
+                                PathElement.create(Location.PARAMETER, "lookup")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+
+        result = assertThrows(ValidationException.class, () -> directFactory.list(null));
+        assertViolation(result,
+                        InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "list(io.helidon.service.registry.Lookup)"),
+                                PathElement.create(Location.PARAMETER, "lookup")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+
+        result = assertThrows(ValidationException.class, () -> overloadedFactory.first(null));
+        assertViolation(result,
+                        InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "first(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "name")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+    }
+
+    @Test
+    void injectionPointFactoryListPreservesCustomListWhenOnlyFirstIsIntercepted() {
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(InjectionPointFactoryFirstOnlyProvidedService.class)
+                .addFactoryType(FactoryType.INJECTION_POINT)
+                .build();
+        Service.InjectionPointFactory<InjectionPointFactoryFirstOnlyProvidedService> factory = registry.get(factoryLookup);
+
+        List<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> factoryServices =
+                factory.list(Lookup.create(InjectionPointFactoryFirstOnlyProvidedService.class));
+
+        assertThat(factoryServices, hasSize(2));
+        for (Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService> factoryService : factoryServices) {
+            assertThat(factoryService.get().validate("valid"), is("valid"));
+            assertThrows(ValidationException.class, () -> factoryService.get().validate(""));
+        }
+    }
+
+    @Test
+    void qualifiedFactoryListPreservesCustomListWhenOnlyFirstIsIntercepted() {
+        Qualifier qualifier = Qualifier.createNamed("qualified-first-only");
+        Lookup lookup = Lookup.builder()
+                .addQualifier(qualifier)
+                .addContract(QualifiedFactoryFirstOnlyProvidedService.class)
+                .build();
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(QualifiedFactoryFirstOnlyProvidedService.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        Service.QualifiedFactory<QualifiedFactoryFirstOnlyProvidedService, Service.Named> factory =
+                registry.get(factoryLookup);
+        GenericType<QualifiedFactoryFirstOnlyProvidedService> contractType =
+                GenericType.create(QualifiedFactoryFirstOnlyProvidedService.class);
+
+        List<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> factoryServices =
+                factory.list(qualifier, lookup, contractType);
+
+        assertThat(factoryServices, hasSize(2));
+        for (Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService> factoryService : factoryServices) {
+            assertThat(factoryService.get().validate("valid"), is("valid"));
+            assertThrows(ValidationException.class, () -> factoryService.get().validate(""));
+        }
+    }
+
+    @Test
+    void qualifiedFactoryProvidedServiceUsesInterfaceParameterConstraint() {
+        Qualifier qualifier = Qualifier.createNamed("qualified");
+        Lookup lookup = Lookup.builder()
+                .addQualifier(qualifier)
+                .addContract(QualifiedFactoryProvidedInterfaceConstrainedService.class)
+                .build();
+        GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> contractType =
+                GenericType.create(QualifiedFactoryProvidedInterfaceConstrainedService.class);
+        assertThat(new QualifiedFactoryProvidedInterfaceConstrainedServiceProvider()
+                           .first(qualifier,
+                                  lookup,
+                                  contractType)
+                           .orElseThrow()
+                           .get()
+                           .validate(""),
+                   is(""));
+
+        QualifiedFactoryProvidedInterfaceConstrainedService service = registry.get(lookup);
+        var serviceInfo = registry.lookupServices(lookup).getFirst();
+        Lookup factoryLookup = Lookup.builder()
+                .addQualifier(qualifier)
+                .addContract(QualifiedFactoryProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        Service.QualifiedFactory<QualifiedFactoryProvidedInterfaceConstrainedService, Service.Named> factory =
+                registry.get(factoryLookup);
+        QualifiedFactoryDirectContract directFactory = registry.get(QualifiedFactoryDirectContract.class);
+        Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService> factoryFirst =
+                factory.first(qualifier, lookup, contractType).orElseThrow();
+        List<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> factoryServices =
+                factory.list(qualifier, lookup, contractType);
+
+        FactoryProviderLegacyValidateInterceptor.reset();
+        assertThat(service.validate("valid"), is("valid"));
+        assertThat(FactoryProviderLegacyValidateInterceptor.count(), is(0));
+        assertThat(serviceInfo.weight(), is(42.0));
+        assertThat(serviceInfo.runLevel(), is(Optional.of(43.0)));
+        assertThat(factoryFirst.get().validate("valid"), is("valid"));
+        assertThat(factoryServices, hasSize(2));
+        assertThat(factoryServices.getFirst().get().validate("valid"), is("valid"));
+        assertThrows(ValidationException.class, () -> factoryFirst.get().validate(""));
+        assertThrows(ValidationException.class, () -> factoryServices.getFirst().get().validate(""));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> factory.list(null, lookup, contractType));
+        assertViolation(result,
+                        QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD,
+                                                   "list(io.helidon.service.registry.Qualifier,"
+                                                           + "io.helidon.service.registry.Lookup,"
+                                                           + "io.helidon.common.GenericType)"),
+                                PathElement.create(Location.PARAMETER, "qualifier")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+
+        result = assertThrows(ValidationException.class, () -> directFactory.list(null, lookup, contractType));
+        assertViolation(result,
+                        QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD,
+                                                   "list(io.helidon.service.registry.Qualifier,"
+                                                           + "io.helidon.service.registry.Lookup,"
+                                                           + "io.helidon.common.GenericType)"),
+                                PathElement.create(Location.PARAMETER, "qualifier")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+    }
+
+    @Test
+    void perInstanceServiceUsesInterfaceParameterConstraint() {
+        var directService = new PerInstanceInterfaceConstrainedServiceImpl(new PerInstanceInterfaceConstrainedConfig());
+        assertThat(directService.validate(""),
+                   is(""));
+
+        PerInstanceInterfaceConstrainedService service = registry.get(PerInstanceInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        PerInstanceInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   PerInstanceInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void validInterfaceParameterTriggersValidation() {
+        ValidatedType invalidValue = new ValidatedType("invalid_text", 42, new BigDecimal("1.10"));
+        assertThat(new ValidInterfaceConstrainedServiceImpl().validate(invalidValue), is("ok"));
+        assertThat(new ValidInterfaceConstrainedServiceImpl().validateAll(List.of(invalidValue)), is("ok"));
+
+        ValidInterfaceConstrainedService service = registry.get(ValidInterfaceConstrainedService.class);
+
+        assertThat(service.validate(new ValidatedType("good_test_value", 42, new BigDecimal("1.10"))), is("ok"));
+        assertThat(service.validateAll(List.of(new ValidatedType("good_test_value", 42, new BigDecimal("1.10")))), is("ok"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(invalidValue));
+        assertViolation(result,
+                        ValidInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, ValidInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD,
+                                                   "validate(io.helidon.validation.tests.validation.ValidatedType)"),
+                                PathElement.create(Location.PARAMETER, "value"),
+                                PathElement.create(Location.TYPE, ValidatedType.class.getName()),
+                                PathElement.create(Location.RECORD_COMPONENT, "first")),
+                        "pattern",
+                        "invalid_text",
+                        TypeName.create(Validation.String.Pattern.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateAll(List.of(invalidValue)));
+        assertViolation(result,
+                        ValidInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, ValidInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateAll(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element"),
+                                PathElement.create(Location.TYPE, ValidatedType.class.getName()),
+                                PathElement.create(Location.RECORD_COMPONENT, "first")),
+                        "pattern",
+                        "invalid_text",
+                        TypeName.create(Validation.String.Pattern.class));
+    }
+
+    @Test
+    void serviceDescriptorMetadataIncludesInterfaceMethodConstraints() {
+        TypeName notBlank = TypeName.create(Validation.String.NotBlank.class);
+        TypeName min = TypeName.create(Validation.Integer.Min.class);
+
+        var validateParameter = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_VALIDATE
+                .parameterArguments()
+                .getFirst();
+        assertThat(validateParameter.hasAnnotation(notBlank), is(true));
+
+        var validateListElementType = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_VALIDATE_LIST
+                .parameterArguments()
+                .getFirst()
+                .typeName()
+                .typeArguments()
+                .getFirst();
+        assertThat(validateListElementType.hasAnnotation(notBlank), is(true));
+
+        var invalidNamesElementType = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_INVALID_NAMES
+                .typeName()
+                .typeArguments()
+                .getFirst();
+        assertThat(invalidNamesElementType.hasAnnotation(notBlank), is(true));
+
+        var inheritedGenericParameter = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_VALIDATE_INHERITED_GENERIC
+                .parameterArguments()
+                .getFirst();
+        assertThat(inheritedGenericParameter.typeName(), is(TypeName.create(String.class)));
+        assertThat(inheritedGenericParameter.hasAnnotation(notBlank), is(true));
+
+        var validateMinimumParameter = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_VALIDATE_MINIMUM
+                .parameterArguments()
+                .getFirst();
+        assertThat(validateMinimumParameter.annotation(min).objectValue(), is(Optional.of(1)));
+        assertThat(validateMinimumParameter.annotations()
+                           .stream()
+                           .filter(it -> it.typeName().equals(min))
+                           .map(it -> it.objectValue().orElseThrow())
+                           .toList(),
+                   contains(1, 10));
+    }
+
+    private void assertConcreteProviderIsAvailable(Class<?> providerType, FactoryType factoryType) {
+        assertThat(providerType.isInstance(registry.first(providerType).orElseThrow()), is(true));
+
+        Lookup serviceTypeLookup = Lookup.builder()
+                .serviceType(providerType)
+                .build();
+        assertThat(providerType.isInstance(registry.first(serviceTypeLookup).orElseThrow()), is(true));
+
+        Lookup factoryServiceTypeLookup = Lookup.builder()
+                .serviceType(providerType)
+                .addFactoryType(factoryType)
+                .build();
+        assertThat(providerType.isInstance(registry.first(factoryServiceTypeLookup).orElseThrow()), is(true));
+        List<ServiceInstance<Object>> factoryServiceTypeInstances = registry.lookupInstances(factoryServiceTypeLookup);
+        assertThat(factoryServiceTypeInstances, hasSize(1));
+        assertThat(providerType.isInstance(factoryServiceTypeInstances.getFirst().get()), is(true));
+        assertThat(factoryServiceTypeInstances.getFirst()
+                           .contracts()
+                           .contains(ResolvedType.create(providerType)),
+                   is(true));
+    }
+
+    private static void assertViolation(ValidationException result,
+                                        Class<?> serviceType,
+                                        List<PathElement> expectedLocation,
+                                        String expectedMessage,
+                                        Object expectedInvalidValue,
+                                        TypeName expectedAnnotation) {
+        var violations = result.violations();
+
+        assertThat(violations, hasSize(1));
+        var violation = violations.getFirst();
+
+        assertThat(violation.location(), contains(expectedLocation.toArray(PathElement[]::new)));
+        assertThat(violation.message(), containsString(expectedMessage));
+        assertThat(violation.invalidValue(), is(expectedInvalidValue));
+        assertThat(violation.rootType(), sameInstance(serviceType));
+        assertThat(violation.annotation().typeName(), is(expectedAnnotation));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LegacyValidateDefaultInterceptor.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LegacyValidateDefaultInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.service.registry.Interception;
+import io.helidon.service.registry.InterceptionContext;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Named("io.helidon.validation.tests.validation.InterfaceConstrainedServiceImpl.validateDefault(java.lang.String)")
+class LegacyValidateDefaultInterceptor implements Interception.ElementInterceptor {
+    private static final AtomicInteger CALLS = new AtomicInteger();
+
+    static void reset() {
+        CALLS.set(0);
+    }
+
+    static int count() {
+        return CALLS.get();
+    }
+
+    @Override
+    public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+        CALLS.incrementAndGet();
+        return chain.proceed(args);
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LowerMinimumInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LowerMinimumInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface LowerMinimumInterfaceConstrainedService {
+    int validateMinimum(@Validation.Integer.Min(1) int value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface OptionalSupplierProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class OptionalSupplierProvidedInterfaceConstrainedServiceImpl
+        implements OptionalSupplierProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Provider
+class OptionalSupplierProvidedInterfaceConstrainedServiceProvider
+        implements Supplier<Optional<OptionalSupplierProvidedInterfaceConstrainedService>> {
+    @Override
+    public Optional<OptionalSupplierProvidedInterfaceConstrainedService> get() {
+        return Optional.of(new OptionalSupplierProvidedInterfaceConstrainedServiceImpl());
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OrderedGenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OrderedGenericInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface OrderedGenericInterfaceConstrainedService<K, V> {
+    V validateOrderedGeneric(@Validation.String.NotBlank K key, V value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ParentGenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ParentGenericInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface ParentGenericInterfaceConstrainedService<T> {
+    T validateInheritedGeneric(@Validation.String.NotBlank T value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedConfig.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class PerInstanceInterfaceConstrainedConfig {
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface PerInstanceInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.PerInstance(PerInstanceInterfaceConstrainedConfig.class)
+class PerInstanceInterfaceConstrainedServiceImpl implements PerInstanceInterfaceConstrainedService {
+    @Service.Inject
+    PerInstanceInterfaceConstrainedServiceImpl(PerInstanceInterfaceConstrainedConfig config) {
+    }
+
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryDirectContract.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface QualifiedFactoryDirectContract {
+    Optional<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> first(
+            @Validation.NotNull Qualifier qualifier,
+            @Validation.NotNull Lookup lookup,
+            @Validation.NotNull GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> type);
+
+    @Validation.Collection.Size(2)
+    List<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> list(
+            @Validation.NotNull Qualifier qualifier,
+            @Validation.NotNull Lookup lookup,
+            @Validation.NotNull GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> type);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyBaseProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyBaseProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+abstract class QualifiedFactoryFirstOnlyBaseProvider
+        implements Service.QualifiedFactory<QualifiedFactoryFirstOnlyProvidedService, Service.Named> {
+    @Override
+    public List<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> list(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryFirstOnlyProvidedService> type) {
+        return List.of(Service.QualifiedInstance.create(new QualifiedFactoryFirstOnlyProvidedServiceImpl(), qualifier),
+                       Service.QualifiedInstance.create(new QualifiedFactoryFirstOnlyProvidedServiceImpl(), qualifier));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyDirectContract.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface QualifiedFactoryFirstOnlyDirectContract {
+    @Validation.NotNull
+    Optional<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> first(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryFirstOnlyProvidedService> type);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface QualifiedFactoryFirstOnlyProvidedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class QualifiedFactoryFirstOnlyProvidedServiceImpl implements QualifiedFactoryFirstOnlyProvidedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedServiceProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class QualifiedFactoryFirstOnlyProvidedServiceProvider
+        extends QualifiedFactoryFirstOnlyBaseProvider
+        implements Service.QualifiedFactory<QualifiedFactoryFirstOnlyProvidedService, Service.Named>,
+                   QualifiedFactoryFirstOnlyDirectContract {
+    @Override
+    public Optional<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> first(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryFirstOnlyProvidedService> type) {
+        return Optional.of(list(qualifier, lookup, type).getFirst());
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface QualifiedFactoryProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class QualifiedFactoryProvidedInterfaceConstrainedServiceImpl
+        implements QualifiedFactoryProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.Weight;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.RunLevel(43.0)
+@Weight(42.0)
+class QualifiedFactoryProvidedInterfaceConstrainedServiceProvider
+        implements Service.QualifiedFactory<QualifiedFactoryProvidedInterfaceConstrainedService, Service.Named>,
+                   QualifiedFactoryDirectContract {
+    @Override
+    public Optional<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> first(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> type) {
+        return Optional.of(list(qualifier, lookup, type).getFirst());
+    }
+
+    @Override
+    public List<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> list(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> type) {
+        return List.of(Service.QualifiedInstance.create(new QualifiedFactoryProvidedInterfaceConstrainedServiceImpl(),
+                                                        qualifier),
+                       Service.QualifiedInstance.create(new QualifiedFactoryProvidedInterfaceConstrainedServiceImpl(),
+                                                        qualifier));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface ServicesFactoryProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class ServicesFactoryProvidedInterfaceConstrainedServiceImpl
+        implements ServicesFactoryProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class ServicesFactoryProvidedInterfaceConstrainedServiceProvider
+        implements Service.ServicesFactory<ServicesFactoryProvidedInterfaceConstrainedService> {
+    @Override
+    public List<Service.QualifiedInstance<ServicesFactoryProvidedInterfaceConstrainedService>> services() {
+        return List.of(Service.QualifiedInstance.create(new ServicesFactoryProvidedInterfaceConstrainedServiceImpl()));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class SupplierProvidedInterfaceConstrainedServiceImpl implements SupplierProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Provider
+class SupplierProvidedInterfaceConstrainedServiceProvider
+        implements Supplier<SupplierProvidedInterfaceConstrainedService> {
+    @Override
+    public SupplierProvidedInterfaceConstrainedService get() {
+        return new SupplierProvidedInterfaceConstrainedServiceImpl();
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProvidedSameSignatureInterfaceConstrainedService {
+    @Validation.String.NotBlank
+    String get();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl
+        implements SupplierProvidedSameSignatureInterfaceConstrainedService {
+    @Override
+    public String get() {
+        return "";
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Provider
+class SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider
+        implements Supplier<SupplierProvidedSameSignatureInterfaceConstrainedService>,
+                   SupplierProvidedSameSignatureProviderContract {
+    @Override
+    public SupplierProvidedSameSignatureInterfaceConstrainedService get() {
+        return new SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl();
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureProviderContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureProviderContract.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProvidedSameSignatureProviderContract {
+    @Validation.NotNull
+    SupplierProvidedSameSignatureInterfaceConstrainedService get();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProviderSameSignatureConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class SupplierProviderSameSignatureConstrainedServiceImpl implements SupplierProviderSameSignatureConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedServiceProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Provider
+class SupplierProviderSameSignatureConstrainedServiceProvider
+        implements Supplier<SupplierProviderSameSignatureConstrainedService>, SupplierProviderSameSignatureDirectService {
+    @Override
+    public SupplierProviderSameSignatureConstrainedService get() {
+        return new SupplierProviderSameSignatureConstrainedServiceImpl();
+    }
+
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureDirectService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureDirectService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProviderSameSignatureDirectService {
+    String validate(@Validation.String.Pattern("[0-9]+") String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeUseNotBlank.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeUseNotBlank.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import io.helidon.validation.Validation;
+
+@Target(ElementType.TYPE_USE)
+@Validation.String.NotBlank
+@interface TypeUseNotBlank {
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/UnconstrainedDefaultInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/UnconstrainedDefaultInterfaceConstrainedService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+interface UnconstrainedDefaultInterfaceConstrainedService {
+    String validateInheritedDefault(String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/UnconstrainedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/UnconstrainedInterfaceConstrainedService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+interface UnconstrainedInterfaceConstrainedService {
+    String validateShared(String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.validation.Validation;
+
+interface ValidInterfaceConstrainedService {
+    String validate(@Validation.Valid ValidatedType value);
+
+    String validateAll(List<? super @Validation.Valid ValidatedType> values);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class ValidInterfaceConstrainedServiceImpl implements ValidInterfaceConstrainedService {
+    @Override
+    public String validate(ValidatedType value) {
+        return "ok";
+    }
+
+    @Override
+    public String validateAll(List<? super ValidatedType> values) {
+        return "ok";
+    }
+}

--- a/validation/validation/src/main/java/module-info.java
+++ b/validation/validation/src/main/java/module-info.java
@@ -35,7 +35,9 @@ import io.helidon.common.features.api.HelidonFlavor;
  * <p>
  * To enable interception of validated methods, the method, its parameter, or a generic type argument must be annotated with
  * one of the constraints in {@link io.helidon.validation.Validation} class, or the {@link io.helidon.validation.Validation.Valid}
- * annotation, and the same codegen module must be on the annotation processor path.
+ * annotation, and the same codegen module must be on the annotation processor path. For registry-managed services and
+ * service factories, these annotations may also be declared on non-private instance methods of implemented service contracts.
+ * Validation is applied to instances obtained from the service registry; directly constructed instances are not intercepted.
  * <p>
  * The constraints are grouped (through container classes) based on types that can be constrained.
  * Some constraints are for convenience - such as {@link io.helidon.validation.Validation.Integer.Max} and


### PR DESCRIPTION
Resolves #11865

Applies declarative validation constraints declared on service interfaces to registry-managed services, including factory-provided services. Also extends generated validation handling for nested type-use constraints and documents the supported service-interface behavior.

Production source files changed:

- `declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java`
- `declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidatedTypeGenerator.java`
- `declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java`
- `declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java`
- `validation/validation/src/main/java/module-info.java`

Also changed non-test docs/snippet files:
- `declarative/README.md`
- `docs/src/main/asciidoc/se/injection/declarative.adoc`
- `docs/src/main/asciidoc/se/injection/injection.adoc`
- `docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java`