### PR TITLE
Preserve UDS address across WebClient redirects (27.x)

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -149,6 +149,8 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
 
         // this must be after we set clientUri, as it is used from the method
         clientConfig.baseAddress()
+                .filter(it -> !(it instanceof UnixDomainSocketAddress)
+                        || this.redirectSourceUri == null)
                 .ifPresent(this::address);
     }
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -94,6 +94,9 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
         tls(request.tls());
+        if (sameOrigin(request.resolvedUri(), clientUri)) {
+            request.address().ifPresent(this::address);
+        }
         outputStreamRedirect(request.outputStreamRedirect());
     }
 
@@ -221,6 +224,12 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
 
     Http1ClientImpl http1Client() {
         return http1Client;
+    }
+
+    private static boolean sameOrigin(ClientUri sourceUri, ClientUri targetUri) {
+        return sourceUri.scheme().equalsIgnoreCase(targetUri.scheme())
+                && sourceUri.host().equalsIgnoreCase(targetUri.host())
+                && sourceUri.port() == targetUri.port();
     }
 
     void sanitizeRedirectHeaders(ClientUri requestUri, ClientRequestHeaders requestHeaders) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -77,6 +77,9 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
         tls(request.tls());
+        if (sameOrigin(request.resolvedUri(), clientUri)) {
+            request.address().ifPresent(this::address);
+        }
 
         this.priority(request.priority);
         this.priorKnowledge(request.priorKnowledge);
@@ -176,6 +179,12 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
 
     void sanitizeRedirectHeaders(ClientUri requestUri, ClientRequestHeaders requestHeaders) {
         super.sanitizeRedirectSensitiveHeaders(requestUri, requestHeaders);
+    }
+
+    private static boolean sameOrigin(ClientUri sourceUri, ClientUri targetUri) {
+        return sourceUri.scheme().equalsIgnoreCase(targetUri.scheme())
+                && sourceUri.host().equalsIgnoreCase(targetUri.host())
+                && sourceUri.port() == targetUri.port();
     }
 
     Http2ClientResponseImpl invokeEntity(Object entity) {

--- a/webserver/tests/unix-domain-socket/src/test/java/io/helidon/webserver/tests/unix/domain/socket/UnixDomainSocketTest.java
+++ b/webserver/tests/unix-domain-socket/src/test/java/io/helidon/webserver/tests/unix/domain/socket/UnixDomainSocketTest.java
@@ -42,6 +42,7 @@ import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.Keys;
 import io.helidon.common.socket.TlsNioSocket;
 import io.helidon.common.tls.Tls;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.webclient.api.ClientResponseTyped;
@@ -79,6 +80,8 @@ public class UnixDomainSocketTest {
     private static final String LOGICAL_HOST = "service.example";
     private static final String LOGICAL_AUTHORITY = LOGICAL_HOST + ":443";
     private static final String LOGICAL_BASE_URI = "https://" + LOGICAL_HOST;
+    private static final String LOGICAL_PLAIN_BASE_URI = "http://127.0.0.1:1";
+    private static final String LOGICAL_PLAIN_AUTHORITY = "127.0.0.1:1";
 
     private static Path socketPath;
 
@@ -92,6 +95,20 @@ public class UnixDomainSocketTest {
     @SetUpRoute
     public static void setUpRoute(HttpRules rules) {
         rules.get("/test", (req, res) -> res.send("Hello World!"));
+        rules.get("/redirect-http1", (req, res) -> res.status(Status.FOUND_302)
+                .header(HeaderNames.LOCATION, "/redirected-http1")
+                .send());
+        rules.get("/redirected-http1", (req, res) -> res.send(req.authority()));
+        rules.get("/redirect-http1-cross-origin", (req, res) -> res.status(Status.FOUND_302)
+                .header(HeaderNames.LOCATION, req.query().get("target"))
+                .send());
+        rules.route(Http2Route.route(Method.GET, "/redirect-http2", (req, res) -> res.status(Status.FOUND_302)
+                .header(HeaderNames.LOCATION, "/redirected-http2")
+                .send()));
+        rules.route(Http2Route.route(Method.GET, "/redirected-http2", (req, res) -> res.send(req.authority())));
+        rules.route(Http2Route.route(Method.GET, "/redirect-http2-cross-origin", (req, res) -> res.status(Status.FOUND_302)
+                .header(HeaderNames.LOCATION, req.query().get("target"))
+                .send()));
     }
 
     @Test
@@ -105,6 +122,174 @@ public class UnixDomainSocketTest {
 
         assertThat(response.status(), is(Status.OK_200));
         assertThat(response.entity(), is("Hello World!"));
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http1UnixSocketSameOriginRedirectPreservesTransportAddress() {
+        var address = UnixDomainSocketAddress.of(socketPath);
+        Http1Client http1Client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(LOGICAL_PLAIN_BASE_URI)
+                .build();
+        try {
+            assertResponse(http1Client.get()
+                                   .address(address)
+                                   .path("/redirect-http1")
+                                   .request(String.class),
+                           LOGICAL_PLAIN_AUTHORITY);
+        } finally {
+            http1Client.closeResource();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http2UnixSocketSameOriginRedirectPreservesTransportAddress() {
+        var address = UnixDomainSocketAddress.of(socketPath);
+        Http2Client http2Client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(LOGICAL_PLAIN_BASE_URI)
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .build();
+        try {
+            assertResponse(http2Client.get()
+                                   .address(address)
+                                   .path("/redirect-http2")
+                                   .request(String.class),
+                           LOGICAL_PLAIN_AUTHORITY);
+        } finally {
+            http2Client.closeResource();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http1UnixSocketBaseAddressSameOriginRedirectPreservesTransportAddress() {
+        var address = UnixDomainSocketAddress.of(socketPath);
+        Http1Client http1Client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(LOGICAL_PLAIN_BASE_URI)
+                .baseAddress(address)
+                .build();
+        try {
+            assertResponse(http1Client.get()
+                                   .path("/redirect-http1")
+                                   .request(String.class),
+                           LOGICAL_PLAIN_AUTHORITY);
+        } finally {
+            http1Client.closeResource();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http2UnixSocketBaseAddressSameOriginRedirectPreservesTransportAddress() {
+        var address = UnixDomainSocketAddress.of(socketPath);
+        Http2Client http2Client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(LOGICAL_PLAIN_BASE_URI)
+                .baseAddress(address)
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .build();
+        try {
+            assertResponse(http2Client.get()
+                                   .path("/redirect-http2")
+                                   .request(String.class),
+                           LOGICAL_PLAIN_AUTHORITY);
+        } finally {
+            http2Client.closeResource();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http1UnixSocketCrossOriginRedirectDropsTransportAddress() {
+        var address = UnixDomainSocketAddress.of(socketPath);
+        WebServer targetServer = startPlainServer("HTTP/1 TCP target", false);
+        Http1Client http1Client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(LOGICAL_PLAIN_BASE_URI)
+                .build();
+        try {
+            assertResponse(http1Client.get()
+                                   .address(address)
+                                   .path("/redirect-http1-cross-origin")
+                                   .queryParam("target", "http://127.0.0.1:" + targetServer.port() + "/target")
+                                   .request(String.class),
+                           "HTTP/1 TCP target");
+        } finally {
+            http1Client.closeResource();
+            targetServer.stop();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http1UnixSocketBaseAddressCrossOriginRedirectDropsTransportAddress() {
+        var address = UnixDomainSocketAddress.of(socketPath);
+        WebServer targetServer = startPlainServer("HTTP/1 TCP target", false);
+        Http1Client http1Client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(LOGICAL_PLAIN_BASE_URI)
+                .baseAddress(address)
+                .build();
+        try {
+            assertResponse(http1Client.get()
+                                   .path("/redirect-http1-cross-origin")
+                                   .queryParam("target", "http://127.0.0.1:" + targetServer.port() + "/redirect-again")
+                                   .request(String.class),
+                           "HTTP/1 TCP target");
+        } finally {
+            http1Client.closeResource();
+            targetServer.stop();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http2UnixSocketBaseAddressCrossOriginRedirectDropsTransportAddress() {
+        var address = UnixDomainSocketAddress.of(socketPath);
+        WebServer targetServer = startPlainServer("HTTP/2 TCP target", true);
+        Http2Client http2Client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(LOGICAL_PLAIN_BASE_URI)
+                .baseAddress(address)
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .build();
+        try {
+            assertResponse(http2Client.get()
+                                   .path("/redirect-http2-cross-origin")
+                                   .queryParam("target", "http://127.0.0.1:" + targetServer.port() + "/redirect-again")
+                                   .request(String.class),
+                           "HTTP/2 TCP target");
+        } finally {
+            http2Client.closeResource();
+            targetServer.stop();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http2UnixSocketCrossOriginRedirectDropsTransportAddress() {
+        var address = UnixDomainSocketAddress.of(socketPath);
+        WebServer targetServer = startPlainServer("HTTP/2 TCP target", true);
+        Http2Client http2Client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(LOGICAL_PLAIN_BASE_URI)
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .build();
+        try {
+            assertResponse(http2Client.get()
+                                   .address(address)
+                                   .path("/redirect-http2-cross-origin")
+                                   .queryParam("target", "http://127.0.0.1:" + targetServer.port() + "/target")
+                                   .request(String.class),
+                           "HTTP/2 TCP target");
+        } finally {
+            http2Client.closeResource();
+            targetServer.stop();
+        }
     }
 
     @Test
@@ -451,6 +636,27 @@ public class UnixDomainSocketTest {
                 .routing(rules -> {
                     rules.get("/test", (req, res) -> res.send(http1Response));
                     rules.route(Http2Route.route(Method.GET, "/h2", (req, res) -> res.send(http2Response)));
+                })
+                .build()
+                .start();
+    }
+
+    private static WebServer startPlainServer(String response, boolean http2) {
+        return WebServer.builder()
+                .host("127.0.0.1")
+                .port(http2 ? -1 : 0)
+                .routing(rules -> {
+                    if (http2) {
+                        rules.route(Http2Route.route(Method.GET, "/redirect-again", (req, res) -> res.status(Status.FOUND_302)
+                                .header(HeaderNames.LOCATION, "/target")
+                                .send()));
+                        rules.route(Http2Route.route(Method.GET, "/target", (req, res) -> res.send(response)));
+                    } else {
+                        rules.get("/redirect-again", (req, res) -> res.status(Status.FOUND_302)
+                                .header(HeaderNames.LOCATION, "/target")
+                                .send());
+                        rules.get("/target", (req, res) -> res.send(response));
+                    }
                 })
                 .build()
                 .start();


### PR DESCRIPTION
Resolves #11934

Preserves Unix-domain-socket transport addresses for same-origin WebClient redirects in HTTP/1 and HTTP/2, while dropping UDS transport overrides when redirects cross to a different logical origin.

Adds UDS redirect regressions for per-request addresses and configured base addresses.
