### PR TITLE
Document max-tcp-connections admission semantics (27.x)

### DIFF
--- a/docs/src/main/asciidoc/includes/guides/performance-tuning.adoc
+++ b/docs/src/main/asciidoc/includes/guides/performance-tuning.adoc
@@ -45,7 +45,9 @@ server:
   idle-connection-timeout: PT5M # Close connections that have been idle for 5 minutes
   max-concurrent-requests: NNNN # Maximum number of concurrent requests. 0 or -1 is unlimited.
   # For throughput limiting, use server.concurrency-limit.throughput.amount (0 is unlimited) with a matching duration.
-  max-tcp-connections: NNNN     # Max number of concurrent tcp connections. 0 or -1 is unlimited.
+  # Pre-accept connection admission capacity. A permit is reserved before accept and
+  # released after handling, or if configuring/submitting the accepted socket fails.
+  max-tcp-connections: NNNN     # 0 or -1 is unlimited.
   max-in-memory-entity: NNNNNN  # Entities smaller than this are buffered in memory vs streamed (bytes)
   max-payload-size: NNNNNNN     # Reject requests with payload sizes greater than this. -1 is unlimited (bytes)
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -239,11 +239,13 @@ interface ListenerConfigBlueprint {
     SocketOptions connectionOptions();
 
     /**
-     * Limits the number of connections that can be opened at a single point in time.
+     * Limits the number of connection permits that this listener may reserve before accepting sockets.
+     * A permit is acquired before each accept attempt and released after the accepted connection finishes,
+     * or immediately if the accepted socket cannot be configured or submitted to the connection executor.
      * Defaults to {@code -1}, meaning "unlimited" - what the system allows.
      * {@code 0} has the same meaning as {@code -1} - unlimited number of connections.
      *
-     * @return number of TCP connections that can be opened to this listener, regardless of protocol
+     * @return pre-accept TCP connection admission capacity for this listener, regardless of protocol
      */
     @Option.Configured
     @Option.DefaultInt(-1)


### PR DESCRIPTION
Resolves #11943

Clarifies that WebServer `max-tcp-connections` is a pre-accept admission capacity and aligns the performance tuning snippet with the listener Javadocs.
