### PR TITLE
Propagate WebServer lifecycle failures

### DIFF
--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -314,7 +314,9 @@ In this example, the `GET` handler matches requests to `/hello/subpath`.
 
 === Server Lifecycle
 
-In Helidon 4 your `HttpService` can interpose on the server lifecycle by overriding the `beforeStart` and `afterStop` methods:
+Your `HttpService` can interpose on the server lifecycle by overriding the `beforeStart`, `afterStart`, and `afterStop` methods.
+Failures from `beforeStart` or `afterStart` fail `WebServer.start()` after startup cleanup, and failures from
+`afterStop` fail `WebServer.stop()` after listener cleanup. Cleanup failures may be attached as suppressed exceptions.
 [source,java]
 .Helidon 4.x server lifecycle
 ----

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/WebServerIsRunningTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/WebServerIsRunningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class WebServerIsRunningTest {
 
@@ -48,7 +49,8 @@ class WebServerIsRunningTest {
         WebServerConfig.Builder builder = WebServer.builder()
                 .routing(rb -> rb.get("/", (req, res) -> { }));
         builder.tls(tls);
-        WebServer server = builder.build().start();
+        WebServer server = builder.build();
+        assertThrows(IllegalStateException.class, server::start);
         assertThat(server.isRunning(), is(false));
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LifecycleFailures.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LifecycleFailures.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.concurrent.CompletionException;
+
+final class LifecycleFailures {
+    private LifecycleFailures() {
+    }
+
+    static Throwable add(Throwable failure, Throwable next) {
+        if (next == null) {
+            return normalize(failure);
+        }
+        Throwable unwrapped = normalize(next);
+        if (failure == null) {
+            return unwrapped;
+        }
+        failure = normalize(failure);
+        if (failure == unwrapped) {
+            return failure;
+        }
+        failure.addSuppressed(unwrapped);
+        return failure;
+    }
+
+    static void throwIfFailed(Throwable failure, String message) {
+        if (failure == null) {
+            return;
+        }
+        throwIfFailedAsIllegalState(failure, message);
+    }
+
+    static void throwIfFailedAsIllegalState(Throwable failure, String message) {
+        if (failure == null) {
+            return;
+        }
+        Throwable unwrapped = normalize(failure);
+        if (unwrapped instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException(message, unwrapped);
+    }
+
+    static Throwable unwrap(Throwable failure) {
+        if (failure instanceof CompletionException completionException && completionException.getCause() != null) {
+            return completionException.getCause();
+        }
+        return failure;
+    }
+
+    private static Throwable normalize(Throwable failure) {
+        if (failure == null) {
+            return null;
+        }
+        Throwable unwrapped = unwrap(failure);
+        if (unwrapped == failure) {
+            return failure;
+        }
+        for (Throwable suppressed : failure.getSuppressed()) {
+            add(unwrapped, suppressed);
+        }
+        return unwrapped;
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -23,14 +23,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
 
 import io.helidon.Main;
 import io.helidon.common.SerializationConfig;
@@ -132,7 +134,8 @@ class LoomServer implements WebServer, Resumable {
         try {
             lifecycleLock.lockInterruptibly();
         } catch (InterruptedException e) {
-            throw new IllegalStateException("Webserver start was interrupted");
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Webserver start was interrupted", e);
         }
         try {
             if (running.compareAndSet(false, true)) {
@@ -155,6 +158,7 @@ class LoomServer implements WebServer, Resumable {
         try {
             lifecycleLock.lockInterruptibly();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IllegalStateException("Webserver stop was interrupted", e);
         }
         try {
@@ -237,34 +241,61 @@ class LoomServer implements WebServer, Resumable {
         return listeners.get(socketName);
     }
 
-    private void stopIt() {
-        // We may be in a shutdown hook and new threads may not be created
-        for (ServerListener listener : listeners.values()) {
-            listener.stop();
+    // Intended for testing.
+    void shutdownFromShutdownHook() {
+        HelidonShutdownHandler localShutdownHandler = shutdownHandler;
+        if (localShutdownHandler == null) {
+            throw new IllegalStateException("Shutdown handler is not registered");
         }
+        try {
+            localShutdownHandler.shutdown();
+        } finally {
+            deregisterShutdownHook();
+        }
+    }
 
+    private void stopIt() {
+        Throwable failure = stopListeners();
         running.set(false);
-
         LOGGER.log(System.Logger.Level.INFO, "Helidon WebServer stopped all channels.");
-        deregisterShutdownHook();
+        try {
+            deregisterShutdownHook();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+        LifecycleFailures.throwIfFailed(failure, "Failed to stop Helidon WebServer");
+    }
+
+    private Throwable stopAfterLifecycleFailure(Throwable failure) {
+        Throwable result = LifecycleFailures.add(null, failure);
+        try {
+            stopIt();
+        } catch (RuntimeException | Error e) {
+            result = LifecycleFailures.add(result, e);
+        }
+        return result;
     }
 
     private void startIt() {
         long now = System.currentTimeMillis();
         // make sure we do not allow runtime without JEP-290 enforcement
         SerializationConfig.configureRuntime();
-        boolean result = parallel("start", ServerListener::start);
-        if (!result) {
+        Throwable failure = startListeners();
+        if (failure != null) {
             LOGGER.log(System.Logger.Level.ERROR, "Helidon WebServer failed to start, shutting down");
-            parallel("stop", ServerListener::stop);
-            if (startFutures != null) {
-                startFutures.forEach(future -> future.future().cancel(true));
-            }
+            cancelStartFutures();
+            failure = LifecycleFailures.add(failure, stopListeners());
             running.set(false);
-            return;
+            LifecycleFailures.throwIfFailedAsIllegalState(failure, "Failed to start Helidon WebServer");
         }
-        if (registerShutdownHook) {
-            registerShutdownHook();
+        try {
+            if (registerShutdownHook) {
+                registerShutdownHook();
+            }
+            fireAfterStart();
+        } catch (RuntimeException | Error e) {
+            Throwable startupFailure = stopAfterLifecycleFailure(e);
+            LifecycleFailures.throwIfFailedAsIllegalState(startupFailure, "Failed to start Helidon WebServer");
         }
         now = System.currentTimeMillis() - now;
         // JVM uptime or since restore
@@ -274,8 +305,6 @@ class LoomServer implements WebServer, Resumable {
                 + now + " milliseconds. "
                 + uptime + " milliseconds since JVM startup. "
                 + "Java " + Runtime.version());
-
-        fireAfterStart();
 
         if ("!".equals(System.getProperty(EXIT_ON_STARTED_KEY))) {
             LOGGER.log(System.Logger.Level.INFO, String.format("Exiting, -D%s set.", EXIT_ON_STARTED_KEY));
@@ -307,35 +336,146 @@ class LoomServer implements WebServer, Resumable {
         }
     }
 
-    // return false if anything fails
-    private boolean parallel(String taskName, Consumer<ServerListener> task) {
-        boolean result = true;
+    private Throwable startListeners() {
+        Throwable failure = null;
+        boolean interrupted = false;
+        AtomicBoolean cancelled = new AtomicBoolean();
+        ExecutorCompletionService<ListenerFuture> completedStarts = new ExecutorCompletionService<>(executorService);
 
         List<ListenerFuture> futures = new LinkedList<>();
 
         for (ServerListener listener : listeners.values()) {
-            futures.add(new ListenerFuture(listener, executorService.submit(() -> {
+            ListenerFuture listenerFuture = new ListenerFuture(listener, cancelled);
+            listenerFuture.future = completedStarts.submit(() -> {
                 Contexts.runInContext(context, () -> {
-                    Thread.currentThread().setName(taskName + " " + listener);
-                    task.accept(listener);
+                    Thread currentThread = Thread.currentThread();
+                    listenerFuture.thread.set(currentThread);
+                    currentThread.setName("start " + listener);
+                    listener.start(cancelled::get);
                 });
-            })));
-        }
-        for (ListenerFuture listenerFuture : futures) {
-            try {
-                listenerFuture.future().get();
-            } catch (InterruptedException e) {
-                LOGGER.log(System.Logger.Level.ERROR, "Failed to start listener, interrupted: "
-                        + listenerFuture.listener.configuredAddress(), e);
-                result = false;
-            } catch (ExecutionException e) {
-                LOGGER.log(System.Logger.Level.ERROR, "Failed to start listener: "
-                        + listenerFuture.listener.configuredAddress(), e);
-                result = false;
-            }
+                return listenerFuture;
+            });
+            futures.add(listenerFuture);
         }
         this.startFutures = futures;
-        return result;
+        int remaining = futures.size();
+        Future<ListenerFuture> failedFuture = null;
+        while (remaining > 0) {
+            try {
+                Future<ListenerFuture> future = completedStarts.take();
+                remaining--;
+                try {
+                    future.get();
+                } catch (CancellationException _) {
+                    // Cancelled by another listener startup failure.
+                } catch (ExecutionException e) {
+                    ListenerFuture listenerFuture = listenerFuture(futures, future);
+                    LOGGER.log(System.Logger.Level.ERROR, "Failed to start listener: "
+                            + listenerFuture.listener.configuredAddress(), e);
+                    failure = LifecycleFailures.add(failure, e.getCause() == null ? e : e.getCause());
+                    cancelled.set(true);
+                    cancelStartFutures(futures);
+                    failedFuture = future;
+                    break;
+                }
+            } catch (InterruptedException e) {
+                LOGGER.log(System.Logger.Level.ERROR, "Failed to start listener, interrupted", e);
+                failure = LifecycleFailures.add(failure,
+                                                new IllegalStateException("Interrupted while waiting for listener startup", e));
+                cancelled.set(true);
+                cancelStartFutures(futures);
+                interrupted = true;
+                break;
+            }
+        }
+        if (failure != null) {
+            failure = awaitStartFutures(futures, failedFuture, failure);
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        return failure;
+    }
+
+    private static ListenerFuture listenerFuture(List<ListenerFuture> futures, Future<ListenerFuture> future) {
+        for (ListenerFuture listenerFuture : futures) {
+            if (listenerFuture.future == future) {
+                return listenerFuture;
+            }
+        }
+        throw new IllegalStateException("Unknown listener startup future");
+    }
+
+    private Throwable awaitStartFutures(List<ListenerFuture> futures, Future<ListenerFuture> failedFuture, Throwable failure) {
+        boolean interrupted = false;
+        for (ListenerFuture listenerFuture : futures) {
+            Future<ListenerFuture> future = listenerFuture.future;
+            if (future == failedFuture) {
+                continue;
+            }
+            boolean done = false;
+            while (!done) {
+                try {
+                    future.get();
+                    done = true;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    failure = LifecycleFailures.add(failure,
+                                                    new IllegalStateException("Interrupted while waiting for listener "
+                                                                                      + listenerFuture.listener, e));
+                } catch (CancellationException _) {
+                    done = true;
+                } catch (ExecutionException e) {
+                    failure = LifecycleFailures.add(failure, e.getCause() == null ? e : e.getCause());
+                    done = true;
+                }
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        return failure;
+    }
+
+    private void cancelStartFutures() {
+        List<ListenerFuture> localStartFutures = startFutures;
+        if (localStartFutures != null) {
+            cancelStartFutures(localStartFutures);
+        }
+    }
+
+    private static void cancelStartFutures(List<ListenerFuture> futures) {
+        for (ListenerFuture listenerFuture : futures) {
+            listenerFuture.cancelled.set(true);
+            Future<ListenerFuture> future = listenerFuture.future;
+            if (future.isDone()) {
+                continue;
+            }
+            Thread thread = listenerFuture.thread.get();
+            if (thread == null) {
+                if (!future.cancel(false)) {
+                    thread = listenerFuture.thread.get();
+                    if (thread != null) {
+                        thread.interrupt();
+                    }
+                }
+            } else {
+                thread.interrupt();
+            }
+        }
+    }
+
+    private Throwable stopListeners() {
+        Throwable failure = null;
+        // We may be in a shutdown hook and new threads may not be created
+        for (ServerListener listener : listeners.values()) {
+            try {
+                listener.stop();
+            } catch (RuntimeException | Error e) {
+                failure = LifecycleFailures.add(failure, e);
+            }
+        }
+        return failure;
     }
 
     @Override
@@ -380,7 +520,16 @@ class LoomServer implements WebServer, Resumable {
                 + "Java " + Runtime.version());
     }
 
-    private record ListenerFuture(ServerListener listener, Future<?> future) {
+    private static final class ListenerFuture {
+        private final ServerListener listener;
+        private final AtomicBoolean cancelled;
+        private final AtomicReference<Thread> thread = new AtomicReference<>();
+        private Future<ListenerFuture> future;
+
+        private ListenerFuture(ServerListener listener, AtomicBoolean cancelled) {
+            this.listener = listener;
+            this.cancelled = cancelled;
+        }
     }
 
     private static final class ServerShutdownHandler implements HelidonShutdownHandler {
@@ -401,12 +550,22 @@ class LoomServer implements WebServer, Resumable {
 
         @Override
         public void shutdown() {
-            listeners.values().forEach(ServerListener::stop);
+            Throwable failure = null;
+            for (ServerListener listener : listeners.values()) {
+                try {
+                    listener.stop();
+                } catch (RuntimeException | Error e) {
+                    failure = LifecycleFailures.add(failure, e);
+                }
+            }
             if (startFutures != null) {
-                startFutures.forEach(future -> future.future().cancel(true));
+                cancelStartFutures(startFutures);
             }
 
             running.set(false);
+            if (failure != null) {
+                LOGGER.log(System.Logger.Level.ERROR, "Failed to stop Helidon WebServer from shutdown hook", failure);
+            }
         }
 
         @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerLifecycle.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,14 @@ package io.helidon.webserver;
 public interface ServerLifecycle {
     /**
      * Before server start.
+     * If this method throws an exception, server startup fails and the server attempts startup cleanup.
      */
     default void beforeStart() {
     }
 
     /**
      * After server start.
+     * If this method throws an exception, server startup fails and the server attempts startup cleanup.
      *
      * @param webServer the {@link WebServer} that was started
      */
@@ -36,6 +38,8 @@ public interface ServerLifecycle {
 
     /**
      * After server stop.
+     * Exceptions thrown by this method fail {@link WebServer#stop()} after listener cleanup has been attempted.
+     * If this method is invoked during startup cleanup, exceptions may fail {@link WebServer#start()}.
      */
     default void afterStop() {
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -33,13 +33,16 @@ import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Timer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 
 import javax.net.ssl.SSLParameters;
 
@@ -51,6 +54,7 @@ import io.helidon.common.concurrency.limits.LimitAlgorithm;
 import io.helidon.common.context.Context;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.task.HelidonTaskExecutor;
+import io.helidon.common.task.InterruptableTask;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
@@ -98,6 +102,10 @@ class ServerListener implements ListenerContext {
     private volatile ServerSocketChannel serverSocket;
     private volatile Thread serverThread;
     private volatile CompletableFuture<Void> closeFuture;
+    private volatile Runnable beforeReaderExecutorTerminate = () -> {
+    };
+    private volatile Runnable beforeSharedExecutorAwait = () -> {
+    };
 
     @SuppressWarnings("unchecked")
     ServerListener(String socketName,
@@ -248,11 +256,80 @@ class ServerListener implements ListenerContext {
             return;
         }
         running = false;
-        suspend(true);
-        router.afterStop();
+        Throwable failure = stopResources();
+        try {
+            router.afterStop();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+        LifecycleFailures.throwIfFailed(failure, "Failed to stop listener " + socketName);
     }
 
-    private void suspend(boolean shutdownExecutors) {
+    private Throwable stopResources() {
+        Throwable failure = null;
+        try {
+            // Stop listening for connections
+            ServerSocketChannel localServerSocket = serverSocket;
+            if (localServerSocket != null) {
+                localServerSocket.close();
+                if (configuredAddress instanceof UnixDomainSocketAddress udsa) {
+                    try {
+                        // UNIX socket files are created automatically, but they are not deleted when the channel is closed
+                        Files.deleteIfExists(udsa.getPath());
+                    } catch (IOException e) {
+                        LOGGER.log(WARNING, "Failed to delete UNIX socket file " + udsa.getPath().toAbsolutePath(), e);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.log(INFO, "Exception thrown on socket close", e);
+        }
+
+        try {
+            // Stop handling any new requests on all active connections
+            failure = LifecycleFailures.add(failure, closeActiveConnections(false));
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+
+        try {
+            // Shutdown reader executor
+            shutdownReaderExecutor();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+
+        try {
+            // Shutdown shared executor
+            shutdownSharedExecutor();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+
+        try {
+            // Interrupt and close any active connections
+            failure = LifecycleFailures.add(failure, closeActiveConnections(true));
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+
+        Thread localServerThread = serverThread;
+        if (localServerThread != null) {
+            localServerThread.interrupt();
+        }
+        CompletableFuture<Void> localCloseFuture = closeFuture;
+        if (localCloseFuture != null) {
+            try {
+                localCloseFuture.join();
+            } catch (RuntimeException | Error e) {
+                failure = LifecycleFailures.add(failure, e);
+            }
+        }
+
+        return failure;
+    }
+
+    private void suspendForCheckpoint() {
         try {
             // Stop listening for connections
             serverSocket.close();
@@ -266,28 +343,6 @@ class ServerListener implements ListenerContext {
             }
             // Stop handling any new requests on all active connections
             activeConnections().forEach(connection -> connection.close(false));
-            if (shutdownExecutors) {
-                // Shutdown reader executor
-                readerExecutor.terminate(gracePeriod.toMillis(), TimeUnit.MILLISECONDS);
-                if (!readerExecutor.isTerminated()) {
-                    LOGGER.log(DEBUG, "Some tasks in reader executor did not terminate gracefully");
-                    readerExecutor.forceTerminate();
-                }
-
-                // Shutdown shared executor
-                try {
-                    sharedExecutor.shutdown();
-                    boolean done = sharedExecutor.awaitTermination(gracePeriod.toMillis(), TimeUnit.MILLISECONDS);
-                    if (!done) {
-                        List<Runnable> running = sharedExecutor.shutdownNow();
-                        if (!running.isEmpty()) {
-                            LOGGER.log(DEBUG, running.size() + " tasks in shared executor did not terminate gracefully");
-                        }
-                    }
-                } catch (InterruptedException e) {
-                    // falls through
-                }
-            }
             // Interrupt and close any active connections
             activeConnections().forEach(connection -> connection.close(true));
         } catch (IOException e) {
@@ -298,11 +353,29 @@ class ServerListener implements ListenerContext {
     }
 
     void start() {
-        router.beforeStart();
-        startIt();
+        start(() -> false);
+    }
+
+    void start(BooleanSupplier cancelled) {
+        boolean lifecycleStarted = false;
+        try {
+            checkCancelledStartup(cancelled);
+            router.beforeStart();
+            lifecycleStarted = true;
+            checkCancelledStartup(cancelled);
+            startIt(cancelled);
+        } catch (RuntimeException | Error e) {
+            rollbackFailedStart(e, lifecycleStarted);
+            throw e;
+        }
     }
 
     private void startIt() {
+        startIt(() -> false);
+    }
+
+    private void startIt(BooleanSupplier cancelled) {
+        checkCancelledStartup(cancelled);
         try {
             if (configuredAddress instanceof UnixDomainSocketAddress) {
                 serverSocket = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
@@ -316,56 +389,64 @@ class ServerListener implements ListenerContext {
             listenerConfig.configureSocket(serverSocket);
 
             serverSocket.bind(configuredAddress, listenerConfig.backlog());
+            checkCancelledStartup(cancelled);
             this.connectedPort = serverSocket.getLocalAddress() instanceof InetSocketAddress ias ? ias.getPort() : -1;
+
+            String serverChannelId = "0x" + HexFormat.of().toHexDigits(System.identityHashCode(serverSocket));
+
+            running = true;
+
+            if (LOGGER.isLoggable(INFO)) {
+                if (configuredAddress instanceof InetSocketAddress inetAddress) {
+                    String format;
+                    if (tls.enabled()) {
+                        format = "[%s] https://%s:%s bound for socket '%s'";
+                    } else {
+                        format = "[%s] http://%s:%s bound for socket '%s'";
+                    }
+                    LOGGER.log(INFO, String.format(format,
+                                                   serverChannelId,
+                                                   inetAddress.getHostString(),
+                                                   connectedPort,
+                                                   socketName));
+                } else {
+                    String format;
+                    if (tls.enabled()) {
+                        format = "[%s] %s bound for secure socket '%s'";
+                    } else {
+                        format = "[%s] %s bound for socket '%s'";
+                    }
+                    LOGGER.log(INFO, String.format(format,
+                                                   serverChannelId,
+                                                   configuredAddress,
+                                                   socketName));
+                }
+
+
+                if (LOGGER.isLoggable(TRACE)) {
+                    if (listenerConfig.writeQueueLength() <= 1) {
+                        LOGGER.log(System.Logger.Level.TRACE, "[" + serverChannelId + "] direct writes");
+                    } else {
+                        LOGGER.log(System.Logger.Level.TRACE,
+                                   "[" + serverChannelId + "] async writes, queue length: "
+                                           + listenerConfig.writeQueueLength());
+                    }
+                    if (tls.enabled()) {
+                        debugTls(serverChannelId, tls);
+                    }
+                }
+            }
+
+            serverThread.start();
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to start server", e);
         }
+    }
 
-        String serverChannelId = "0x" + HexFormat.of().toHexDigits(System.identityHashCode(serverSocket));
-
-        running = true;
-
-        if (LOGGER.isLoggable(INFO)) {
-            if (configuredAddress instanceof InetSocketAddress inetAddress) {
-                String format;
-                if (tls.enabled()) {
-                    format = "[%s] https://%s:%s bound for socket '%s'";
-                } else {
-                    format = "[%s] http://%s:%s bound for socket '%s'";
-                }
-                LOGGER.log(INFO, String.format(format,
-                                               serverChannelId,
-                                               inetAddress.getHostString(),
-                                               connectedPort,
-                                               socketName));
-            } else {
-                String format;
-                if (tls.enabled()) {
-                    format = "[%s] %s bound for secure socket '%s'";
-                } else {
-                    format = "[%s] %s bound for socket '%s'";
-                }
-                LOGGER.log(INFO, String.format(format,
-                                               serverChannelId,
-                                               configuredAddress,
-                                               socketName));
-            }
-
-
-            if (LOGGER.isLoggable(TRACE)) {
-                if (listenerConfig.writeQueueLength() <= 1) {
-                    LOGGER.log(System.Logger.Level.TRACE, "[" + serverChannelId + "] direct writes");
-                } else {
-                    LOGGER.log(System.Logger.Level.TRACE,
-                               "[" + serverChannelId + "] async writes, queue length: " + listenerConfig.writeQueueLength());
-                }
-                if (tls.enabled()) {
-                    debugTls(serverChannelId, tls);
-                }
-            }
+    private void checkCancelledStartup(BooleanSupplier cancelled) {
+        if (cancelled.getAsBoolean()) {
+            throw new IllegalStateException("Listener startup cancelled " + socketName);
         }
-
-        serverThread.start();
     }
 
     boolean hasTls() {
@@ -395,6 +476,110 @@ class ServerListener implements ListenerContext {
                 + "Want client auth: " + sslParameters.getWantClientAuth();
 
         LOGGER.log(TRACE, message);
+    }
+
+    private void rollbackFailedStart(Throwable startupFailure, boolean lifecycleStarted) {
+        running = false;
+        suppressCleanupFailure(startupFailure, this::closeServerSocketOnFailure);
+        suppressCleanupFailure(startupFailure, this::shutdownReaderExecutor);
+        suppressCleanupFailure(startupFailure, this::shutdownSharedExecutor);
+        if (lifecycleStarted) {
+            suppressCleanupFailure(startupFailure, router::afterStop);
+        }
+    }
+
+    private static void suppressCleanupFailure(Throwable startupFailure, Runnable cleanup) {
+        try {
+            cleanup.run();
+        } catch (RuntimeException | Error e) {
+            LifecycleFailures.add(startupFailure, e);
+        }
+    }
+
+    private void closeServerSocketOnFailure() {
+        ServerSocketChannel localServerSocket = serverSocket;
+        if (localServerSocket == null) {
+            return;
+        }
+        boolean bound = false;
+        try {
+            bound = localServerSocket.getLocalAddress() != null;
+        } catch (IOException e) {
+            LOGGER.log(DEBUG, "Failed to check server socket binding after failed start", e);
+        }
+        try {
+            localServerSocket.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to close server socket after failed start", e);
+        } finally {
+            serverSocket = null;
+            connectedPort = -1;
+        }
+        if (bound && configuredAddress instanceof UnixDomainSocketAddress udsa) {
+            try {
+                Files.deleteIfExists(udsa.getPath());
+            } catch (IOException e) {
+                LOGGER.log(WARNING, "Failed to delete UNIX socket file " + udsa.getPath().toAbsolutePath(), e);
+            }
+        }
+    }
+
+    private void shutdownReaderExecutor() {
+        Throwable failure = null;
+        try {
+            beforeReaderExecutorTerminate.run();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+        readerExecutor.terminate(gracePeriod.toMillis(), TimeUnit.MILLISECONDS);
+        if (Thread.currentThread().isInterrupted()) {
+            failure = LifecycleFailures.add(failure,
+                                            new IllegalStateException("Interrupted while shutting down listener reader executor "
+                                                                              + "for " + socketName));
+        }
+        if (!readerExecutor.isTerminated()) {
+            LOGGER.log(DEBUG, "Some tasks in reader executor did not terminate gracefully");
+            try {
+                readerExecutor.forceTerminate();
+            } catch (RuntimeException | Error e) {
+                failure = LifecycleFailures.add(failure, e);
+            }
+        }
+        LifecycleFailures.throwIfFailed(failure, "Failed to shut down listener reader executor for " + socketName);
+    }
+
+    private void shutdownSharedExecutor() {
+        Throwable failure = null;
+        sharedExecutor.shutdown();
+        try {
+            beforeSharedExecutorAwait.run();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+        try {
+            boolean done = sharedExecutor.awaitTermination(gracePeriod.toMillis(), TimeUnit.MILLISECONDS);
+            if (!done) {
+                forceShutdownSharedExecutor();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            IllegalStateException interrupted =
+                    new IllegalStateException("Interrupted while shutting down listener executor for " + socketName, e);
+            try {
+                forceShutdownSharedExecutor();
+            } catch (RuntimeException | Error shutdownFailure) {
+                interrupted.addSuppressed(shutdownFailure);
+            }
+            failure = LifecycleFailures.add(failure, interrupted);
+        }
+        LifecycleFailures.throwIfFailed(failure, "Failed to shut down listener executor for " + socketName);
+    }
+
+    private void forceShutdownSharedExecutor() {
+        List<Runnable> running = sharedExecutor.shutdownNow();
+        if (!running.isEmpty()) {
+            LOGGER.log(DEBUG, running.size() + " tasks in shared executor did not terminate gracefully");
+        }
     }
 
     private void listen() {
@@ -483,9 +668,41 @@ class ServerListener implements ListenerContext {
         return new ArrayList<>(activeConnections.values());
     }
 
+    private Throwable closeActiveConnections(boolean interrupt) {
+        Throwable failure = null;
+        for (ServerConnection connection : activeConnections()) {
+            try {
+                connection.close(interrupt);
+            } catch (RuntimeException | Error e) {
+                failure = LifecycleFailures.add(failure, e);
+            }
+        }
+        return failure;
+    }
+
     // Intended for testing.
     Thread serverThreads() {
         return serverThread;
+    }
+
+    // Intended for testing.
+    void activeConnection(String id, ServerConnection connection) {
+        activeConnections.put(id, connection);
+    }
+
+    // Intended for testing.
+    Future<?> readerTask(InterruptableTask<?> task) {
+        return readerExecutor.execute(task);
+    }
+
+    // Intended for testing.
+    void beforeReaderExecutorTerminate(Runnable beforeReaderExecutorTerminate) {
+        this.beforeReaderExecutorTerminate = Objects.requireNonNull(beforeReaderExecutorTerminate);
+    }
+
+    // Intended for testing.
+    void beforeSharedExecutorAwait(Runnable beforeSharedExecutorAwait) {
+        this.beforeSharedExecutorAwait = Objects.requireNonNull(beforeSharedExecutorAwait);
     }
 
     void suspend() {
@@ -494,7 +711,7 @@ class ServerListener implements ListenerContext {
         // converts interrupts into a rejected outcome, so clear the loop condition first to avoid
         // re-entering the wait after the interrupt is consumed.
         running = false;
-        suspend(false);
+        suspendForCheckpoint();
         serverThread = null;
         closeFuture = null;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ThreadPerTaskExecutor.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ThreadPerTaskExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ class ThreadPerTaskExecutor implements HelidonTaskExecutor {
                 boolean result = terminationSignal.await(timeout, unit);
                 return result && state.compareAndSet(SHUTDOWN, TERMINATED);
             } catch (InterruptedException e) {
-                // falls through
+                Thread.currentThread().interrupt();
             }
         }
         return false;
@@ -260,4 +260,3 @@ class ThreadPerTaskExecutor implements HelidonTaskExecutor {
         }
     }
 }
-

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,15 +70,21 @@ public interface WebServer extends RuntimeType.Api<WebServerConfig> {
      * The start will fail on a server that is shut down, or that failed to start.
      * In such cases, create a new instance of WebServer.
      *
+     * If startup fails, all started channels are shut down before the failure is propagated.
+     * Additional cleanup failures may be attached as suppressed exceptions.
+     *
      * @return a started server
-     * @throws IllegalStateException when startup fails, in such a case all channels are shut down
+     * @throws IllegalStateException if startup or startup cleanup fails
      */
     WebServer start();
 
     /**
      * Attempt to gracefully shutdown the server.
+     * All channels are asked to stop even when one fails. If shutdown fails, the server is marked as stopped before
+     * the failure is propagated. Additional shutdown failures may be attached as suppressed exceptions.
      *
      * @return a stopped server
+     * @throws RuntimeException if shutdown cleanup fails
      * @see #start()
      */
     WebServer stop();

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -1,0 +1,821 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.UnixDomainSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import io.helidon.common.task.InterruptableTask;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.spi.ServerConnection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ServerListenerLifecycleTest {
+    @Test
+    void webServerStartFailureThrowsAndRunsCleanup() throws Exception {
+        LifecycleService service = new LifecycleService("default");
+        try (ServerSocket blocker = new ServerSocket(0, 50, InetAddress.getLoopbackAddress())) {
+            WebServer server = WebServer.builder()
+                    .shutdownHook(false)
+                    .address(InetAddress.getLoopbackAddress())
+                    .port(blocker.getLocalPort())
+                    .routing(routing -> routing.register(service))
+                    .build();
+
+            IllegalStateException failure = assertThrows(IllegalStateException.class, server::start);
+
+            assertThat(server.isRunning(), is(false));
+            assertThat(failure.getCause(), instanceOf(UncheckedIOException.class));
+            assertThat(service.beforeStarts(), is(1));
+            assertThat(service.afterStops(), is(1));
+        }
+    }
+
+    @Test
+    void webServerBeforeStartFailureThrowsAndRunsCleanup() {
+        LifecycleService service = new LifecycleService("default", true, false, false);
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .routing(routing -> routing.register(service))
+                .build();
+
+        RuntimeException failure = assertThrows(RuntimeException.class, server::start);
+
+        assertThat(server.isRunning(), is(false));
+        assertThat(service.beforeStarts(), is(1));
+        assertThat(service.afterStops(), is(0));
+        assertThat(containsMessage(failure, "beforeStart failed default"), is(true));
+    }
+
+    @Test
+    void interruptedStartWaitFailsStartupAndRunsCleanup() throws Exception {
+        CountDownLatch beforeStartEntered = new CountDownLatch(2);
+        CountDownLatch releaseBeforeStart = new CountDownLatch(1);
+        CountDownLatch afterStopInvoked = new CountDownLatch(2);
+        CountDownLatch beforeStartExited = new CountDownLatch(2);
+        AtomicReference<Throwable> startFailure = new AtomicReference<>();
+        AtomicBoolean startThreadInterrupted = new AtomicBoolean();
+        AtomicBoolean blockedStartupExitedBeforeFailure = new AtomicBoolean();
+        LifecycleService defaultService = new LifecycleService("default");
+        BlockingBeforeStartService adminService = new BlockingBeforeStartService(beforeStartEntered,
+                                                                                 releaseBeforeStart,
+                                                                                 afterStopInvoked,
+                                                                                 beforeStartExited);
+        BlockingBeforeStartService monitorService = new BlockingBeforeStartService(beforeStartEntered,
+                                                                                   releaseBeforeStart,
+                                                                                   afterStopInvoked,
+                                                                                   beforeStartExited);
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .routing(routing -> routing.register(defaultService))
+                .putSocket("admin", listener -> listener
+                        .address(InetAddress.getLoopbackAddress())
+                        .port(0)
+                        .routing(routing -> routing.register(adminService)))
+                .putSocket("monitor", listener -> listener
+                        .address(InetAddress.getLoopbackAddress())
+                        .port(0)
+                        .routing(routing -> routing.register(monitorService)))
+                .build();
+
+        Thread startThread = Thread.ofPlatform()
+                .name("test-interrupted-start")
+                .start(() -> {
+                    try {
+                        server.start();
+                    } catch (RuntimeException | Error e) {
+                        blockedStartupExitedBeforeFailure.set(beforeStartExited.getCount() == 0);
+                        startFailure.set(e);
+                        startThreadInterrupted.set(Thread.currentThread().isInterrupted());
+                    }
+                });
+
+        try {
+            assertThat(beforeStartEntered.await(5, TimeUnit.SECONDS), is(true));
+            int defaultPort = awaitPort(server, WebServer.DEFAULT_SOCKET_NAME);
+
+            startThread.interrupt();
+            startThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(startThread.isAlive(), is(false));
+            assertThat(startFailure.get(), notNullValue());
+            assertThat(containsMessage(startFailure.get(), "Interrupted while waiting for listener"), is(true));
+            assertThat(startThreadInterrupted.get(), is(true));
+            assertThat(blockedStartupExitedBeforeFailure.get(), is(true));
+            assertThat(server.isRunning(), is(false));
+            assertThat(defaultService.afterStops(), is(1));
+            assertThat(afterStopInvoked.getCount(), is(2L));
+            assertPortCanBind(defaultPort);
+        } finally {
+            releaseBeforeStart.countDown();
+            if (startThread.isAlive()) {
+                startThread.interrupt();
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void webServerStartFailureThrowsAndStopsAlreadyStartedListeners() throws Exception {
+        CountDownLatch adminBeforeStartEntered = new CountDownLatch(1);
+        CountDownLatch releaseAdminBeforeStart = new CountDownLatch(1);
+        CountDownLatch adminAfterStopInvoked = new CountDownLatch(1);
+        AtomicReference<Throwable> startFailure = new AtomicReference<>();
+        LifecycleService defaultService = new LifecycleService("default");
+        BlockingBeforeStartService adminService = new BlockingBeforeStartService(adminBeforeStartEntered,
+                                                                                 releaseAdminBeforeStart,
+                                                                                 adminAfterStopInvoked);
+        try (ServerSocket blocker = new ServerSocket(0, 50, InetAddress.getLoopbackAddress())) {
+            WebServer server = WebServer.builder()
+                    .shutdownHook(false)
+                    .address(InetAddress.getLoopbackAddress())
+                    .port(0)
+                    .routing(routing -> routing.register(defaultService))
+                    .putSocket("admin", listener -> listener
+                            .address(InetAddress.getLoopbackAddress())
+                            .port(blocker.getLocalPort())
+                            .routing(routing -> routing.register(adminService)))
+                    .build();
+
+            Thread startThread = Thread.ofPlatform()
+                    .name("test-partial-start-cleanup")
+                    .start(() -> {
+                        try {
+                            server.start();
+                        } catch (RuntimeException | Error e) {
+                            startFailure.set(e);
+                        }
+            });
+
+            try {
+                assertThat(adminBeforeStartEntered.await(5, TimeUnit.SECONDS), is(true));
+                int defaultPort = awaitPort(server, WebServer.DEFAULT_SOCKET_NAME);
+                assertThat(defaultPort > 0, is(true));
+
+                releaseAdminBeforeStart.countDown();
+                startThread.join(TimeUnit.SECONDS.toMillis(5));
+
+                assertThat(startThread.isAlive(), is(false));
+                assertThat(startFailure.get(), instanceOf(IllegalStateException.class));
+                assertThat(server.isRunning(), is(false));
+                assertThat(containsMessage(startFailure.get(), "Failed to start server"), is(true));
+                assertThat(defaultService.beforeStarts(), is(1));
+                assertThat(defaultService.afterStops(), is(1));
+                assertThat(adminAfterStopInvoked.await(5, TimeUnit.SECONDS), is(true));
+                assertPortCanBind(defaultPort);
+            } finally {
+                releaseAdminBeforeStart.countDown();
+                if (startThread.isAlive()) {
+                    startThread.interrupt();
+                }
+                stopUntilStopped(server);
+            }
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void unixSocketBindFailureDoesNotDeleteExistingPath(@TempDir Path tempDir) throws Exception {
+        Path socketPath = tempDir.resolve("server.sock");
+        Files.writeString(socketPath, "existing");
+
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .bindAddress(UnixDomainSocketAddress.of(socketPath))
+                .routing(routing -> routing.register(new LifecycleService("default")))
+                .build();
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, server::start);
+
+        assertThat(containsMessage(failure, "Failed to start server"), is(true));
+        assertThat(Files.readString(socketPath), is("existing"));
+    }
+
+    @Test
+    void webServerAfterStartFailureThrowsAndRunsCleanup() {
+        LifecycleService service = new LifecycleService("default", false, true);
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .routing(routing -> routing.register(service))
+                .build();
+
+        try {
+            RuntimeException failure = assertThrows(RuntimeException.class, server::start);
+
+            assertThat(server.isRunning(), is(false));
+            assertThat(service.beforeStarts(), is(1));
+            assertThat(service.afterStarts(), is(1));
+            assertThat(service.afterStops(), is(1));
+            assertThat(containsMessage(failure, "afterStart failed default"), is(true));
+        } finally {
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void webServerAfterStartFailureStopsAllListeners() throws Exception {
+        AtomicInteger defaultPort = new AtomicInteger(-1);
+        AtomicInteger adminPort = new AtomicInteger(-1);
+        LifecycleService defaultService = new LifecycleService("default");
+        LifecycleService adminService = new LifecycleService("admin", false, false, true, webServer -> {
+            defaultPort.set(webServer.port(WebServer.DEFAULT_SOCKET_NAME));
+            adminPort.set(webServer.port("admin"));
+        });
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .routing(routing -> routing.register(defaultService))
+                .putSocket("admin", listener -> listener
+                        .address(InetAddress.getLoopbackAddress())
+                        .port(0)
+                        .routing(routing -> routing.register(adminService)))
+                .build();
+
+        try {
+            RuntimeException failure = assertThrows(RuntimeException.class, server::start);
+
+            assertThat(server.isRunning(), is(false));
+            assertThat(adminService.afterStarts(), is(1));
+            assertThat(defaultService.afterStops(), is(1));
+            assertThat(adminService.afterStops(), is(1));
+            assertThat(containsMessage(failure, "afterStart failed admin"), is(true));
+            assertPortCanBind(defaultPort.get());
+            assertPortCanBind(adminPort.get());
+        } finally {
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void completionExceptionAfterStartPreservesCleanupFailure() {
+        LifecycleService service = new LifecycleService("default", false, true, false, _ -> {
+            throw new CompletionException(new IllegalStateException("afterStart wrapped default"));
+        });
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .routing(routing -> routing.register(service))
+                .build();
+
+        RuntimeException failure = assertThrows(RuntimeException.class, server::start);
+
+        assertThat(server.isRunning(), is(false));
+        assertThat(service.afterStarts(), is(1));
+        assertThat(service.afterStops(), is(1));
+        assertThat(containsMessage(failure, "afterStart wrapped default"), is(true));
+        assertThat(containsMessage(failure, "afterStop failed default"), is(true));
+    }
+
+    @Test
+    void interruptedExecutorShutdownStillFinishesListenerCleanup() throws Exception {
+        CountDownLatch sharedTaskStarted = new CountDownLatch(1);
+        CountDownLatch releaseSharedTask = new CountDownLatch(1);
+        CountDownLatch sharedTaskInterrupted = new CountDownLatch(1);
+        CountDownLatch sharedExecutorAwaitStarted = new CountDownLatch(1);
+        CountDownLatch forceCloseInvoked = new CountDownLatch(1);
+        AtomicReference<Throwable> stopFailure = new AtomicReference<>();
+        LifecycleService service = new LifecycleService("default");
+
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .shutdownGracePeriod(Duration.ofSeconds(30))
+                .routing(routing -> routing.register(service))
+                .build()
+                .start();
+
+        Future<?> sharedTask = null;
+        Thread stopThread = null;
+        try {
+            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
+            assertThat(listener, notNullValue());
+            listener.activeConnection("test", new CloseTrackingConnection(forceCloseInvoked));
+            listener.beforeSharedExecutorAwait(sharedExecutorAwaitStarted::countDown);
+            sharedTask = listener.executor().submit(() -> {
+                sharedTaskStarted.countDown();
+                try {
+                    releaseSharedTask.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    sharedTaskInterrupted.countDown();
+                    throw new IllegalStateException("shared task interrupted", e);
+                }
+            });
+            assertThat(sharedTaskStarted.await(5, TimeUnit.SECONDS), is(true));
+
+            stopThread = Thread.ofPlatform()
+                    .name("test-interrupted-stop")
+                    .start(() -> {
+                        try {
+                            server.stop();
+                        } catch (RuntimeException | Error e) {
+                            stopFailure.set(e);
+                        }
+                    });
+
+            assertThat(sharedExecutorAwaitStarted.await(5, TimeUnit.SECONDS), is(true));
+
+            stopThread.interrupt();
+            assertThat(forceCloseInvoked.await(5, TimeUnit.SECONDS), is(true));
+            assertThat(sharedTaskInterrupted.await(5, TimeUnit.SECONDS), is(true));
+            stopThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(stopThread.isAlive(), is(false));
+            assertThat(stopFailure.get(), notNullValue());
+            assertThat(containsMessage(stopFailure.get(), "Interrupted while shutting down listener executor"), is(true));
+            assertThat(server.isRunning(), is(false));
+            assertThat(service.afterStops(), is(1));
+        } finally {
+            releaseSharedTask.countDown();
+            if (sharedTask != null) {
+                sharedTask.cancel(true);
+            }
+            if (stopThread != null && stopThread.isAlive()) {
+                stopThread.interrupt();
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void interruptedReaderExecutorShutdownFailsStopAndForcesShutdown() throws Exception {
+        CountDownLatch readerTaskStarted = new CountDownLatch(1);
+        CountDownLatch releaseReaderTask = new CountDownLatch(1);
+        CountDownLatch readerTaskInterrupted = new CountDownLatch(1);
+        CountDownLatch readerExecutorTerminateStarted = new CountDownLatch(1);
+        AtomicReference<Throwable> stopFailure = new AtomicReference<>();
+        LifecycleService service = new LifecycleService("default");
+
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .shutdownGracePeriod(Duration.ofSeconds(30))
+                .routing(routing -> routing.register(service))
+                .build()
+                .start();
+
+        Future<?> readerTask = null;
+        Thread stopThread = null;
+        try {
+            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
+            assertThat(listener, notNullValue());
+            listener.beforeReaderExecutorTerminate(readerExecutorTerminateStarted::countDown);
+            readerTask = listener.readerTask(new BlockingReaderTask(readerTaskStarted,
+                                                                    releaseReaderTask,
+                                                                    readerTaskInterrupted));
+            assertThat(readerTaskStarted.await(5, TimeUnit.SECONDS), is(true));
+
+            stopThread = Thread.ofPlatform()
+                    .name("test-interrupted-reader-stop")
+                    .start(() -> {
+                        try {
+                            server.stop();
+                        } catch (RuntimeException | Error e) {
+                            stopFailure.set(e);
+                        }
+                    });
+
+            assertThat(readerExecutorTerminateStarted.await(5, TimeUnit.SECONDS), is(true));
+
+            stopThread.interrupt();
+            assertThat(readerTaskInterrupted.await(5, TimeUnit.SECONDS), is(true));
+            stopThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(stopThread.isAlive(), is(false));
+            assertThat(stopFailure.get(), notNullValue());
+            assertThat(containsMessage(stopFailure.get(), "Interrupted while shutting down listener reader executor"), is(true));
+            assertThat(server.isRunning(), is(false));
+            assertThat(service.afterStops(), is(1));
+        } finally {
+            releaseReaderTask.countDown();
+            if (readerTask != null) {
+                readerTask.cancel(true);
+            }
+            if (stopThread != null && stopThread.isAlive()) {
+                stopThread.interrupt();
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void executorShutdownTestHookFailureDoesNotSkipForcedShutdown() throws Exception {
+        CountDownLatch sharedTaskStarted = new CountDownLatch(1);
+        CountDownLatch releaseSharedTask = new CountDownLatch(1);
+        CountDownLatch sharedTaskInterrupted = new CountDownLatch(1);
+        LifecycleService service = new LifecycleService("default");
+
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .shutdownGracePeriod(Duration.ofMillis(1))
+                .routing(routing -> routing.register(service))
+                .build()
+                .start();
+
+        Future<?> sharedTask = null;
+        try {
+            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
+            assertThat(listener, notNullValue());
+            listener.beforeSharedExecutorAwait(() -> {
+                throw new IllegalStateException("before await failed");
+            });
+            sharedTask = listener.executor().submit(() -> {
+                sharedTaskStarted.countDown();
+                try {
+                    releaseSharedTask.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    sharedTaskInterrupted.countDown();
+                    throw new IllegalStateException("shared task interrupted", e);
+                }
+            });
+            assertThat(sharedTaskStarted.await(5, TimeUnit.SECONDS), is(true));
+
+            RuntimeException failure = assertThrows(RuntimeException.class, server::stop);
+
+            assertThat(containsMessage(failure, "before await failed"), is(true));
+            assertThat(sharedTaskInterrupted.await(5, TimeUnit.SECONDS), is(true));
+            assertThat(server.isRunning(), is(false));
+            assertThat(service.afterStops(), is(1));
+        } finally {
+            releaseSharedTask.countDown();
+            if (sharedTask != null) {
+                sharedTask.cancel(true);
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void activeConnectionCloseFailuresDoNotSkipRemainingConnections() {
+        AtomicInteger closeCalls = new AtomicInteger();
+        LifecycleService service = new LifecycleService("default");
+
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .routing(routing -> routing.register(service))
+                .build()
+                .start();
+
+        try {
+            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
+            assertThat(listener, notNullValue());
+            listener.activeConnection("first", new ThrowingCloseConnection(closeCalls));
+            listener.activeConnection("second", new ThrowingCloseConnection(closeCalls));
+
+            RuntimeException failure = assertThrows(RuntimeException.class, server::stop);
+
+            assertThat(containsMessage(failure, "connection close failed"), is(true));
+            assertThat(closeCalls.get(), is(4));
+            assertThat(service.afterStops(), is(1));
+            assertThat(server.isRunning(), is(false));
+        } finally {
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void webServerStopFailureThrowsAfterStoppingAllListeners() {
+        LifecycleService defaultService = new LifecycleService("default", true);
+        LifecycleService adminService = new LifecycleService("admin", true);
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .routing(routing -> routing.register(defaultService))
+                .putSocket("admin", listener -> listener.port(0)
+                        .routing(routing -> routing.register(adminService)))
+                .build()
+                .start();
+
+        try {
+            RuntimeException failure = assertThrows(RuntimeException.class, server::stop);
+
+            assertThat(server.isRunning(), is(false));
+            assertThat(defaultService.afterStops(), is(1));
+            assertThat(adminService.afterStops(), is(1));
+            assertThat(containsMessage(failure, "afterStop failed default"), is(true));
+            assertThat(containsMessage(failure, "afterStop failed admin"), is(true));
+        } finally {
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void shutdownHandlerStopFailureStopsAllListeners() {
+        LifecycleService defaultService = new LifecycleService("default", true);
+        LifecycleService adminService = new LifecycleService("admin", true);
+        LoomServer server = (LoomServer) WebServer.builder()
+                .port(0)
+                .routing(routing -> routing.register(defaultService))
+                .putSocket("admin", listener -> listener.port(0)
+                        .routing(routing -> routing.register(adminService)))
+                .build()
+                .start();
+
+        try {
+            server.shutdownFromShutdownHook();
+
+            assertThat(server.isRunning(), is(false));
+            assertThat(defaultService.afterStops(), is(1));
+            assertThat(adminService.afterStops(), is(1));
+        } finally {
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void duplicateLifecycleFailureInstanceDoesNotAbortStopCleanup() {
+        CachedFailureLifecycleService service = new CachedFailureLifecycleService();
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .routing(routing -> routing.register(service))
+                .putSocket("admin", listener -> listener.port(0)
+                        .routing(routing -> routing.register(service)))
+                .build()
+                .start();
+
+        RuntimeException failure = assertThrows(RuntimeException.class, server::stop);
+
+        assertThat(server.isRunning(), is(false));
+        assertThat(service.afterStops(), is(2));
+        assertThat(containsMessage(failure, "cached afterStop failure"), is(true));
+    }
+
+    private static boolean containsMessage(Throwable failure, String message) {
+        if (failure.getMessage() != null && failure.getMessage().contains(message)) {
+            return true;
+        }
+        for (Throwable suppressed : failure.getSuppressed()) {
+            if (containsMessage(suppressed, message)) {
+                return true;
+            }
+        }
+        Throwable cause = failure.getCause();
+        return cause != null && containsMessage(cause, message);
+    }
+
+    private static void stopUntilStopped(WebServer server) {
+        for (int i = 0; i < 3 && server.isRunning(); i++) {
+            try {
+                server.stop();
+            } catch (RuntimeException _) {
+            }
+        }
+    }
+
+    private static void assertPortCanBind(int port) throws Exception {
+        assertThat(port > 0, is(true));
+        try (ServerSocket _ = new ServerSocket(port, 50, InetAddress.getLoopbackAddress())) {
+            // validates that failed startup cleanup released the socket
+        }
+    }
+
+    private static int awaitPort(WebServer server, String socketName) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        int port;
+        do {
+            port = server.port(socketName);
+            if (port > 0) {
+                return port;
+            }
+            TimeUnit.MILLISECONDS.sleep(10);
+        } while (System.nanoTime() < deadline);
+        return port;
+    }
+
+    private record CloseTrackingConnection(CountDownLatch forceCloseInvoked) implements ServerConnection {
+        @Override
+        public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+        }
+
+        @Override
+        public Duration idleTime() {
+            return Duration.ZERO;
+        }
+
+        @Override
+        public void close(boolean interrupt) {
+            if (interrupt) {
+                forceCloseInvoked.countDown();
+            }
+        }
+    }
+
+    private record ThrowingCloseConnection(AtomicInteger closeCalls) implements ServerConnection {
+        @Override
+        public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+        }
+
+        @Override
+        public Duration idleTime() {
+            return Duration.ZERO;
+        }
+
+        @Override
+        public void close(boolean interrupt) {
+            closeCalls.incrementAndGet();
+            throw new IllegalStateException("connection close failed");
+        }
+    }
+
+    private record BlockingReaderTask(CountDownLatch started,
+                                      CountDownLatch release,
+                                      CountDownLatch interrupted) implements InterruptableTask<Void> {
+        @Override
+        public boolean canInterrupt() {
+            return false;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            started.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                interrupted.countDown();
+                throw e;
+            }
+            return null;
+        }
+    }
+
+    private record BlockingBeforeStartService(CountDownLatch beforeStartEntered,
+                                              CountDownLatch releaseBeforeStart,
+                                              CountDownLatch afterStopInvoked,
+                                              CountDownLatch beforeStartExited) implements HttpService {
+        private BlockingBeforeStartService(CountDownLatch beforeStartEntered,
+                                           CountDownLatch releaseBeforeStart,
+                                           CountDownLatch afterStopInvoked) {
+            this(beforeStartEntered, releaseBeforeStart, afterStopInvoked, new CountDownLatch(0));
+        }
+
+        @Override
+        public void routing(HttpRules rules) {
+        }
+
+        @Override
+        public void beforeStart() {
+            beforeStartEntered.countDown();
+            try {
+                releaseBeforeStart.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("beforeStart interrupted", e);
+            } finally {
+                beforeStartExited.countDown();
+            }
+        }
+
+        @Override
+        public void afterStop() {
+            afterStopInvoked.countDown();
+        }
+    }
+
+    private static final class CachedFailureLifecycleService implements HttpService {
+        private final RuntimeException failure = new IllegalStateException("cached afterStop failure");
+        private final AtomicInteger afterStops = new AtomicInteger();
+
+        @Override
+        public void routing(HttpRules rules) {
+        }
+
+        @Override
+        public void afterStop() {
+            afterStops.incrementAndGet();
+            throw failure;
+        }
+
+        private int afterStops() {
+            return afterStops.get();
+        }
+    }
+
+    private static final class LifecycleService implements HttpService {
+        private final String name;
+        private final boolean failBeforeStart;
+        private final boolean failAfterStop;
+        private final boolean failAfterStart;
+        private final Consumer<WebServer> afterStartAction;
+        private final AtomicInteger beforeStarts = new AtomicInteger();
+        private final AtomicInteger afterStarts = new AtomicInteger();
+        private final AtomicInteger afterStops = new AtomicInteger();
+
+        private LifecycleService(String name) {
+            this(name, false);
+        }
+
+        private LifecycleService(String name, boolean failAfterStop) {
+            this(name, failAfterStop, false);
+        }
+
+        private LifecycleService(String name, boolean failAfterStop, boolean failAfterStart) {
+            this(name, false, failAfterStop, failAfterStart);
+        }
+
+        private LifecycleService(String name, boolean failBeforeStart, boolean failAfterStop, boolean failAfterStart) {
+            this(name, failBeforeStart, failAfterStop, failAfterStart, _ -> {
+            });
+        }
+
+        private LifecycleService(String name,
+                                 boolean failBeforeStart,
+                                 boolean failAfterStop,
+                                 boolean failAfterStart,
+                                 Consumer<WebServer> afterStartAction) {
+            this.name = name;
+            this.failBeforeStart = failBeforeStart;
+            this.failAfterStop = failAfterStop;
+            this.failAfterStart = failAfterStart;
+            this.afterStartAction = afterStartAction;
+        }
+
+        @Override
+        public void routing(HttpRules rules) {
+        }
+
+        @Override
+        public void beforeStart() {
+            beforeStarts.incrementAndGet();
+            if (failBeforeStart) {
+                throw new IllegalStateException("beforeStart failed " + name);
+            }
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            afterStarts.incrementAndGet();
+            afterStartAction.accept(webServer);
+            if (failAfterStart) {
+                throw new IllegalStateException("afterStart failed " + name);
+            }
+        }
+
+        @Override
+        public void afterStop() {
+            afterStops.incrementAndGet();
+            if (failAfterStop) {
+                throw new IllegalStateException("afterStop failed " + name);
+            }
+        }
+
+        private int beforeStarts() {
+            return beforeStarts.get();
+        }
+
+        private int afterStarts() {
+            return afterStarts.get();
+        }
+
+        private int afterStops() {
+            return afterStops.get();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #11936

Propagates WebServer startup and shutdown lifecycle failures after attempting cleanup across all listeners.
