### PR TITLE
4.x: Suppress neo4j false positives

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -289,6 +289,21 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <packageUrl regex="true">^pkg:maven/io\.helidon\.integrations\.neo4j/helidon-integrations-neo4j.*$</packageUrl>
    <cve>CVE-2026-1337</cve>
 </suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: io.helidon.integrations.neo4j:helidon-integrations-neo4j-health:4.5.0-SNAPSHOT
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.helidon\.integrations\.neo4j/helidon-integrations-neo4j.*@.*$</packageUrl>
+    <cve>CVE-2026-1497</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: neo4j-bolt-connection-1.0.0.jar
+    file name: neo4j-bolt-connection-netty-1.0.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.neo4j\.bolt/neo4j-bolt-connection.*@.*$</packageUrl>
+    <cve>CVE-2026-1497</cve>
+</suppress>
 
 <!-- 
      This CVE is old and was fixed in Kotlin 1.4.21. The CPE recently changed in NVD.


### PR DESCRIPTION
### Description

Suppress neo4j false positives

1. Mis-identified helidon neo4j integration artifacts as neo4j
2. CVE is against neo4j enterprise server, not driver
