### PR TITLE
Fix virtual threads testing module name

### DIFF
--- a/common/testing/virtual-threads/src/main/java/module-info.java
+++ b/common/testing/virtual-threads/src/main/java/module-info.java
@@ -17,7 +17,7 @@
 /**
  * Virtual Thread testing features for Helidon test extensions.
  */
-module io.helidon.common.testing.vitualthreads {
+module io.helidon.common.testing.virtualthreads {
     requires jdk.jfr;
 
     exports io.helidon.common.testing.virtualthreads;

--- a/webserver/testing/junit5/junit5/src/main/java/module-info.java
+++ b/webserver/testing/junit5/junit5/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 module io.helidon.webserver.testing.junit5 {
 
     requires io.helidon.logging.common;
-    requires io.helidon.common.testing.vitualthreads;
+    requires io.helidon.common.testing.virtualthreads;
 
     requires transitive hamcrest.all;
     requires transitive io.helidon.common.testing.http.junit5;


### PR DESCRIPTION
Description
Fixes the misspelled JPMS module name for the virtual-thread testing utilities from io.helidon.common.testing.vitualthreads to io.helidon.common.testing.virtualthreads.

Also updates the WebServer JUnit 5 testing module descriptor to require the corrected module name.

Fixes #11946

Documentation
No documentation impact.
