### PR TITLE
Fix WebServer suspend and resume failure rollback

### DIFF
--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -317,6 +317,8 @@ In this example, the `GET` handler matches requests to `/hello/subpath`.
 Your `HttpService` can interpose on the server lifecycle by overriding the `beforeStart`, `afterStart`, and `afterStop` methods.
 Failures from `beforeStart` or `afterStart` fail `WebServer.start()` after startup cleanup, and failures from
 `afterStop` fail `WebServer.stop()` after listener cleanup. Cleanup failures may be attached as suppressed exceptions.
+If `afterStop` runs during suspend or resume failure cleanup, its failure may be suppressed on the original suspend or resume
+failure.
 [source,java]
 .Helidon 4.x server lifecycle
 ----

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -483,12 +483,18 @@ class LoomServer implements WebServer, Resumable {
         try {
             lifecycleLock.lockInterruptibly();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted during snapshot checkpoint.", e);
         }
         try {
             if (running.get()) {
-                for (ServerListener listener : listeners.values()) {
-                    listener.suspend();
+                try {
+                    for (ServerListener listener : listeners.values()) {
+                        listener.suspend();
+                    }
+                } catch (RuntimeException | Error e) {
+                    stopAfterResumableFailure(e);
+                    throw e;
                 }
             }
         } finally {
@@ -502,12 +508,18 @@ class LoomServer implements WebServer, Resumable {
         try {
             lifecycleLock.lockInterruptibly();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted during snapshot restore.", e);
         }
         try {
             if (running.get()) {
-                for (ServerListener listener : listeners.values()) {
-                    listener.resume();
+                try {
+                    for (ServerListener listener : listeners.values()) {
+                        listener.resume();
+                    }
+                } catch (RuntimeException | Error e) {
+                    stopAfterResumableFailure(e);
+                    throw e;
                 }
             }
         } finally {
@@ -518,6 +530,16 @@ class LoomServer implements WebServer, Resumable {
                 + now + " milliseconds. "
                 + ResumableSupport.get().uptimeSinceResume() + " milliseconds since JVM snapshot restore. "
                 + "Java " + Runtime.version());
+    }
+
+    private void stopAfterResumableFailure(Throwable failure) {
+        try {
+            stopIt();
+        } catch (RuntimeException | Error e) {
+            if (failure != e) {
+                failure.addSuppressed(e);
+            }
+        }
     }
 
     private static final class ListenerFuture {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerLifecycle.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerLifecycle.java
@@ -40,6 +40,8 @@ public interface ServerLifecycle {
      * After server stop.
      * Exceptions thrown by this method fail {@link WebServer#stop()} after listener cleanup has been attempted.
      * If this method is invoked during startup cleanup, exceptions may fail {@link WebServer#start()}.
+     * If this method is invoked during suspend or resume failure cleanup, exceptions may be suppressed on the original
+     * suspend or resume failure.
      */
     default void afterStop() {
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -252,10 +252,11 @@ class ServerListener implements ListenerContext {
     }
 
     void stop() {
-        if (!running) {
+        if (!running && !inCheckpoint) {
             return;
         }
         running = false;
+        inCheckpoint = false;
         Throwable failure = stopResources();
         try {
             router.afterStop();
@@ -267,23 +268,8 @@ class ServerListener implements ListenerContext {
 
     private Throwable stopResources() {
         Throwable failure = null;
-        try {
-            // Stop listening for connections
-            ServerSocketChannel localServerSocket = serverSocket;
-            if (localServerSocket != null) {
-                localServerSocket.close();
-                if (configuredAddress instanceof UnixDomainSocketAddress udsa) {
-                    try {
-                        // UNIX socket files are created automatically, but they are not deleted when the channel is closed
-                        Files.deleteIfExists(udsa.getPath());
-                    } catch (IOException e) {
-                        LOGGER.log(WARNING, "Failed to delete UNIX socket file " + udsa.getPath().toAbsolutePath(), e);
-                    }
-                }
-            }
-        } catch (IOException e) {
-            LOGGER.log(INFO, "Exception thrown on socket close", e);
-        }
+        // Stop listening for connections
+        closeServerSocketForStop();
 
         try {
             // Stop handling any new requests on all active connections
@@ -314,10 +300,13 @@ class ServerListener implements ListenerContext {
         }
 
         Thread localServerThread = serverThread;
+        CompletableFuture<Void> localCloseFuture = closeFuture;
         if (localServerThread != null) {
             localServerThread.interrupt();
+            if (localServerThread.getState() == Thread.State.NEW && localCloseFuture != null) {
+                localCloseFuture.complete(null);
+            }
         }
-        CompletableFuture<Void> localCloseFuture = closeFuture;
         if (localCloseFuture != null) {
             try {
                 localCloseFuture.join();
@@ -501,12 +490,7 @@ class ServerListener implements ListenerContext {
         if (localServerSocket == null) {
             return;
         }
-        boolean bound = false;
-        try {
-            bound = localServerSocket.getLocalAddress() != null;
-        } catch (IOException e) {
-            LOGGER.log(DEBUG, "Failed to check server socket binding after failed start", e);
-        }
+        boolean bound = serverSocketBound(localServerSocket, "Failed to check server socket binding after failed start");
         try {
             localServerSocket.close();
         } catch (IOException e) {
@@ -515,7 +499,41 @@ class ServerListener implements ListenerContext {
             serverSocket = null;
             connectedPort = -1;
         }
-        if (bound && configuredAddress instanceof UnixDomainSocketAddress udsa) {
+        if (bound) {
+            deleteUnixSocketFile();
+        }
+    }
+
+    private void closeServerSocketForStop() {
+        ServerSocketChannel localServerSocket = serverSocket;
+        if (localServerSocket == null) {
+            return;
+        }
+        boolean bound = serverSocketBound(localServerSocket, "Failed to check server socket binding before stop");
+        try {
+            localServerSocket.close();
+        } catch (IOException e) {
+            LOGGER.log(INFO, "Exception thrown on socket close", e);
+        } finally {
+            serverSocket = null;
+            connectedPort = -1;
+        }
+        if (bound) {
+            deleteUnixSocketFile();
+        }
+    }
+
+    private boolean serverSocketBound(ServerSocketChannel localServerSocket, String debugMessage) {
+        try {
+            return localServerSocket.getLocalAddress() != null;
+        } catch (IOException e) {
+            LOGGER.log(DEBUG, debugMessage, e);
+            return false;
+        }
+    }
+
+    private void deleteUnixSocketFile() {
+        if (configuredAddress instanceof UnixDomainSocketAddress udsa) {
             try {
                 Files.deleteIfExists(udsa.getPath());
             } catch (IOException e) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -546,6 +546,82 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
+    void webServerSuspendFailureStopsAllListenersAndPreservesCleanupFailure() {
+        LifecycleService defaultService = new LifecycleService("default");
+        LifecycleService adminService = new LifecycleService("admin", true);
+        LifecycleService monitorService = new LifecycleService("monitor");
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .routing(routing -> routing.register(defaultService))
+                .putSocket("admin", listener -> listener.port(0)
+                        .routing(routing -> routing.register(adminService)))
+                .putSocket("monitor", listener -> listener.port(0)
+                        .routing(routing -> routing.register(monitorService)))
+                .build()
+                .start();
+
+        try {
+            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
+            assertThat(listener, notNullValue());
+            listener.activeConnection("failing",
+                                      new ThrowingCloseConnection(new AtomicInteger(), "suspend close failed"));
+
+            RuntimeException failure = assertThrows(RuntimeException.class, server::suspend);
+
+            assertThat(failure.getMessage(), is("suspend close failed"));
+            assertThat(server.isRunning(), is(false));
+            assertThat(suppressedContainsMessage(failure, "afterStop failed admin"), is(true));
+            assertThat(defaultService.afterStops(), is(1));
+            assertThat(adminService.afterStops(), is(1));
+            assertThat(monitorService.afterStops(), is(1));
+        } finally {
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void webServerResumeFailureStopsAllListenersAndPreservesCleanupFailure(@TempDir Path tempDir) throws Exception {
+        LifecycleService defaultService = new LifecycleService("default");
+        LifecycleService adminService = new LifecycleService("admin");
+        LifecycleService monitorService = new LifecycleService("monitor", true);
+        Path socketPath = tempDir.resolve("admin.sock");
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .routing(routing -> routing.register(defaultService))
+                .putSocket("admin", listener -> listener
+                        .bindAddress(UnixDomainSocketAddress.of(socketPath))
+                        .routing(routing -> routing.register(adminService)))
+                .putSocket("monitor", listener -> listener
+                        .address(InetAddress.getLoopbackAddress())
+                        .port(0)
+                        .routing(routing -> routing.register(monitorService)))
+                .build()
+                .start();
+
+        try {
+            server.suspend();
+            Files.writeString(socketPath, "existing");
+
+            RuntimeException failure = assertThrows(RuntimeException.class, server::resume);
+
+            assertThat(failure, instanceOf(UncheckedIOException.class));
+            assertThat(containsMessage(failure, "Failed to start server"), is(true));
+            assertThat(server.isRunning(), is(false));
+            assertThat(suppressedContainsMessage(failure, "afterStop failed monitor"), is(true));
+            assertThat(defaultService.afterStops(), is(1));
+            assertThat(adminService.afterStops(), is(1));
+            assertThat(monitorService.afterStops(), is(1));
+            assertThat(Files.readString(socketPath), is("existing"));
+        } finally {
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
     void shutdownHandlerStopFailureStopsAllListeners() {
         LifecycleService defaultService = new LifecycleService("default", true);
         LifecycleService adminService = new LifecycleService("admin", true);
@@ -600,6 +676,15 @@ class ServerListenerLifecycleTest {
         return cause != null && containsMessage(cause, message);
     }
 
+    private static boolean suppressedContainsMessage(Throwable failure, String message) {
+        for (Throwable suppressed : failure.getSuppressed()) {
+            if (containsMessage(suppressed, message)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static void stopUntilStopped(WebServer server) {
         for (int i = 0; i < 3 && server.isRunning(); i++) {
             try {
@@ -647,7 +732,11 @@ class ServerListenerLifecycleTest {
         }
     }
 
-    private record ThrowingCloseConnection(AtomicInteger closeCalls) implements ServerConnection {
+    private record ThrowingCloseConnection(AtomicInteger closeCalls, String message) implements ServerConnection {
+        private ThrowingCloseConnection(AtomicInteger closeCalls) {
+            this(closeCalls, "connection close failed");
+        }
+
         @Override
         public void handle(io.helidon.common.concurrency.limits.Limit limit) {
         }
@@ -660,7 +749,7 @@ class ServerListenerLifecycleTest {
         @Override
         public void close(boolean interrupt) {
             closeCalls.incrementAndGet();
-            throw new IllegalStateException("connection close failed");
+            throw new IllegalStateException(message);
         }
     }
 


### PR DESCRIPTION
Resolves #11937

Stops the WebServer after suspend or resume listener failures, preserves the original lifecycle failure, and keeps cleanup failures suppressed on it. Also keeps Unix-domain socket cleanup limited to listener-owned bound sockets during rollback.
