### PR TITLE
Preserve response Connection close header (3.x)

### DIFF
--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,6 +105,15 @@ public class JerseyExampleResource {
     @Path("noentity")
     public Response noEntity() {
         return Response.ok().build();
+    }
+
+    @GET
+    @Path("response/connection-close")
+    public Response responseConnectionClose() {
+        return Response.ok("close")
+                .header("Connection", "close")
+                .header("X-My_Header", "foo")
+                .build();
     }
 
     @GET

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,17 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.URI;
+import java.net.Socket;
+import java.net.SocketException;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.helidon.common.http.HttpRequest;
 import jakarta.ws.rs.ProcessingException;
@@ -41,7 +48,9 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
 /**
  * The JerseySupportTest.
@@ -239,6 +248,26 @@ public class JerseySupportTest {
     }
 
     @Test
+    public void responseConnectionClose() throws Exception {
+        try (Socket socket = new Socket("localhost", JerseyExampleMain.INSTANCE.webServer(true).port())) {
+            socket.setSoTimeout(10000);
+            PrintWriter writer = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(),
+                                                                        StandardCharsets.UTF_8));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                                                                             StandardCharsets.UTF_8));
+
+            sendRequest(writer, "/jersey/first/response/connection-close");
+
+            String response = receive(reader);
+            Map<String, String> headers = headersFromResponse(response);
+            assertThat(headers, hasEntry(equalToIgnoringCase("Connection"), is("close")));
+            assertThat(headers, hasEntry(equalToIgnoringCase("X-My_Header"), is("foo")));
+            assertThat(entityFromResponse(response), is("close"));
+            assertConnectionIsClosed(writer, reader);
+        }
+    }
+
+    @Test
     public void simpleGetNotFound() {
         Response response = get("jersey/first/non-existent-resource");
 
@@ -423,5 +452,75 @@ public class JerseySupportTest {
             }
         }
     }
-}
 
+    private static void sendRequest(PrintWriter writer, String path) {
+        writer.print("GET " + path + " HTTP/1.1\r\n");
+        writer.print("Host: 127.0.0.1\r\n");
+        writer.print("\r\n");
+        writer.flush();
+    }
+
+    private static void assertConnectionIsClosed(PrintWriter writer, BufferedReader reader) throws IOException {
+        sendRequest(writer, "/jersey/first/hello");
+        try {
+            assertThat(receive(reader), is(""));
+        } catch (SocketException e) {
+            // The socket can close before or during the second read.
+        }
+    }
+
+    private static Map<String, String> headersFromResponse(String response) {
+        int index = response.indexOf("\n\n");
+        if (index < 0) {
+            throw new AssertionError("Missing end of headers in response!");
+        }
+        String[] lines = response.substring(0, index).split("\\n");
+        Map<String, String> result = new HashMap<>(lines.length - 1);
+        for (int i = 1; i < lines.length; i++) {
+            int headerSeparator = lines[i].indexOf(':');
+            if (headerSeparator < 0) {
+                throw new AssertionError("Header without colon: " + lines[i]);
+            }
+            result.put(lines[i].substring(0, headerSeparator).trim(),
+                       lines[i].substring(headerSeparator + 1).trim());
+        }
+        return result;
+    }
+
+    private static String entityFromResponse(String response) {
+        int index = response.indexOf("\n\n");
+        if (index < 0) {
+            throw new AssertionError("Missing end of headers in response!");
+        }
+        return response.substring(index + 2);
+    }
+
+    private static String receive(BufferedReader reader) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        String line;
+        boolean ending = false;
+        int contentLength = -1;
+        while ((line = reader.readLine()) != null) {
+            if (line.toLowerCase().startsWith("content-length")) {
+                int colon = line.indexOf(':');
+                contentLength = Integer.parseInt(line.substring(colon + 1).trim());
+            }
+            sb.append(line).append("\n");
+            if ("".equals(line) && contentLength >= 0) {
+                char[] content = new char[contentLength];
+                int read = reader.read(content);
+                if (read > 0) {
+                    sb.append(content, 0, read);
+                }
+                break;
+            }
+            if (ending && "".equals(line)) {
+                break;
+            }
+            if (!ending && "0".equals(line)) {
+                ending = true;
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ class BareResponseImpl implements BareResponse {
     private CompletableFuture<ChannelFutureListener> requestEntityAnalyzed;
     private BackpressureStrategy backpressureStrategy;
     private final long backpressureBufferSize;
+    private volatile boolean closeAfterResponse;
 
     // Accessed by writeStatusHeaders(status, headers) method
     /*
@@ -220,9 +221,12 @@ class BareResponseImpl implements BareResponse {
 
         // Add keep alive header as per:
         // http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
-        // if response Connection header is set explicitly to close, we can ignore the following
-        if (!keepAlive || HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(response.headers().get(HttpHeaderNames.CONNECTION))) {
+        if (HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(response.headers().get(HttpHeaderNames.CONNECTION))) {
+            closeAfterResponse = true;
+            originalEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
+        } else if (!keepAlive) {
             response.headers().remove(HttpHeaderNames.CONNECTION);
+            closeAfterResponse = true;
             originalEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
         } else {
             if (!requestContext.requestCompleted()) {
@@ -322,8 +326,9 @@ class BareResponseImpl implements BareResponse {
             return;
         }
         requestEntityAnalyzed = requestEntityAnalyzed.thenApply(listener -> {
+            ChannelFutureListener closeAction = closeAfterResponse ? ChannelFutureListener.CLOSE : listener;
             requestContext.runInScope(() -> {
-                if (ChannelFutureListener.CLOSE.equals(listener)) {
+                if (ChannelFutureListener.CLOSE.equals(closeAction)) {
                     if (LOGGER.isLoggable(Level.FINEST)) {
                         LOGGER.finest(log("Closing with an empty buffer; keep-alive: false", channel));
                     }
@@ -333,9 +338,9 @@ class BareResponseImpl implements BareResponse {
                     }
                     channel.read();
                 }
-                writeLastContent(throwable, listener);
+                writeLastContent(throwable, closeAction);
             });
-            return listener;
+            return closeAction;
         });
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,6 +147,11 @@ public class PlainTest {
                             } else {
                                 res.send("abcd");
                             }
+                        })
+                        .get("/response-connection-close", (req, res) -> {
+                            res.headers().put(Http.Header.CONNECTION, "close");
+                            res.headers().put("X-My_Header", "foo");
+                            res.send("close");
                         })
                         .get("/multi", (req, res) -> {
                             res.send(Multi.just("test 1", "test 2", "test 3")
@@ -465,6 +470,20 @@ public class PlainTest {
         Map<String, String> headers = headersFromResponse(s);
         assertThat(headers, not(hasKey(equalToIgnoringCase("connection"))));
         assertThat(entityFromResponse(s, false), is("9\nIt works!\n0\n\n"));
+    }
+
+    @Test
+    public void testResponseConnectionCloseHeader() throws Exception {
+        try (SocketHttpClient s = new SocketHttpClient(webServer)) {
+            s.request(Http.Method.GET, "/response-connection-close", null);
+
+            String response = s.receive();
+            Map<String, String> headers = headersFromResponse(response);
+            assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.CONNECTION), is("close")));
+            assertThat(headers, hasEntry(equalToIgnoringCase("X-My_Header"), is("foo")));
+            assertThat(entityFromResponse(response, false), is("5\nclose\n0\n\n"));
+            SocketHttpClient.assertConnectionIsClosed(s);
+        }
     }
 
     @Test


### PR DESCRIPTION
Resolves #11916

Preserves explicit response-side `Connection: close` headers while still closing the connection after the response is written. Adds wire-level regression coverage for WebServer and MP/Jersey responses.