### PR TITLE
WebServer Accepted socket shutdown race

### DIFF
--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/HttpJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/HttpJmhTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package io.helidon.webserver.benchmark.jmh;
 
+import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -44,11 +48,19 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Benchmark)
 public class HttpJmhTest {
+    private static final String SERVER_HOST = "127.0.0.1";
+    private static final int SOCKET_READ_TIMEOUT_MILLIS = 5_000;
     private static final Header CONTENT_TYPE = HeaderValues.createCached(HeaderNames.CONTENT_TYPE,
                                                                          "text/plain; charset=UTF-8");
     private static final Header CONTENT_LENGTH = HeaderValues.createCached(HeaderNames.CONTENT_LENGTH, "13");
     private static final Header SERVER = HeaderValues.createCached(HeaderNames.SERVER, "Helidon");
     private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] HTTP_1_CLOSE_REQUEST = """
+            GET /plaintext HTTP/1.1\r
+            Host: localhost\r
+            Connection: close\r
+            \r
+            """.getBytes(StandardCharsets.US_ASCII);
     private WebServer server;
     private int serverPort;
     private HttpClient http1Client;
@@ -65,7 +77,7 @@ public class HttpJmhTest {
                         .socketSendBufferSize(64000)
                         .socketReceiveBufferSize(64000))
                 .writeQueueLength(4000)
-                .host("127.0.0.1")
+                .host(SERVER_HOST)
                 .backlog(8192)
                 .routing(router -> router.route(Http1Route.route(Method.GET, "/plaintext", new PlaintextHandler())))
                 .build()
@@ -93,20 +105,79 @@ public class HttpJmhTest {
     public void http1(Blackhole bh) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder()
                 .GET()
-                .uri(URI.create("http://localhost:" + serverPort + "/plaintext"))
+                .uri(URI.create("http://" + SERVER_HOST + ":" + serverPort + "/plaintext"))
                 .build();
         HttpResponse<byte[]> response = http1Client.send(request, HttpResponse.BodyHandlers.ofByteArray());
         bh.consume(response);
     }
 
     @Benchmark
+    public void http1NewConnection(Blackhole bh) throws IOException {
+        byte[] responseBuffer = new byte[1024];
+        try (Socket socket = new Socket(SERVER_HOST, serverPort)) {
+            socket.setTcpNoDelay(true);
+            socket.setSoTimeout(SOCKET_READ_TIMEOUT_MILLIS);
+            OutputStream output = socket.getOutputStream();
+            output.write(HTTP_1_CLOSE_REQUEST);
+            output.flush();
+
+            int bytesRead = readResponse(socket.getInputStream(), responseBuffer);
+            bh.consume(bytesRead);
+            bh.consume(responseBuffer);
+        }
+    }
+
+    @Benchmark
     public void http2(Blackhole bh) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder()
                 .GET()
-                .uri(URI.create("http://localhost:" + serverPort + "/plaintext"))
+                .uri(URI.create("http://" + SERVER_HOST + ":" + serverPort + "/plaintext"))
                 .build();
         HttpResponse<byte[]> response = http2Client.send(request, HttpResponse.BodyHandlers.ofByteArray());
         bh.consume(response);
+    }
+
+    private static int readResponse(InputStream input, byte[] responseBuffer) throws IOException {
+        int bytesRead = 0;
+        int bodyStart = -1;
+        while (bytesRead < responseBuffer.length) {
+            int read = input.read(responseBuffer, bytesRead, responseBuffer.length - bytesRead);
+            if (read == -1) {
+                throw new EOFException("Response ended before complete body was received");
+            }
+            bytesRead += read;
+            if (bodyStart == -1) {
+                bodyStart = bodyStart(responseBuffer, bytesRead);
+            }
+            if (bodyStart != -1 && bytesRead >= bodyStart + RESPONSE_BYTES.length) {
+                if (!bodyMatches(responseBuffer, bodyStart)) {
+                    throw new IOException("Unexpected response body");
+                }
+                return bytesRead;
+            }
+        }
+        throw new IOException("Response exceeded benchmark buffer before complete body was received");
+    }
+
+    private static int bodyStart(byte[] responseBuffer, int bytesRead) {
+        for (int i = 3; i < bytesRead; i++) {
+            if (responseBuffer[i - 3] == '\r'
+                    && responseBuffer[i - 2] == '\n'
+                    && responseBuffer[i - 1] == '\r'
+                    && responseBuffer[i] == '\n') {
+                return i + 1;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean bodyMatches(byte[] responseBuffer, int bodyStart) {
+        for (int i = 0; i < RESPONSE_BYTES.length; i++) {
+            if (responseBuffer[bodyStart + i] != RESPONSE_BYTES[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static class PlaintextHandler implements Handler {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -154,20 +154,6 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         this.initConnectionHeaders = true;
     }
 
-    private static void settingsUpdate(Http2Config config, Http2Settings.Builder builder) {
-        applySetting(builder, config.maxFrameSize(), Http2Setting.MAX_FRAME_SIZE);
-        applySetting(builder, config.maxHeaderListSize(), Http2Setting.MAX_HEADER_LIST_SIZE);
-        applySetting(builder, config.maxConcurrentStreams(), Http2Setting.MAX_CONCURRENT_STREAMS);
-        applySetting(builder, config.initialWindowSize(), Http2Setting.INITIAL_WINDOW_SIZE);
-    }
-
-    // Add value to the builder only when differs from default
-    private static void applySetting(Http2Settings.Builder builder, long value, Http2Setting<Long> settings) {
-        if (value != settings.defaultValue()) {
-            builder.add(settings, value);
-        }
-    }
-
     @Override
     public void handle(Limit limit) throws InterruptedException {
         try {
@@ -253,19 +239,6 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         }
     }
 
-    private static void validateMaxFrameSize(Http2Settings http2Settings) {
-        if (!http2Settings.hasValue(Http2Setting.MAX_FRAME_SIZE)) {
-            return;
-        }
-
-        Long maxFrameSize = http2Settings.value(Http2Setting.MAX_FRAME_SIZE);
-        // specification defines, that the frame size must be between the initial size (16384) and 2^24-1
-        if (maxFrameSize < WindowSize.DEFAULT_MAX_FRAME_SIZE || maxFrameSize > WindowSize.MAX_MAX_FRAME_SIZE) {
-            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
-                                     "Frame size must be between 2^14 and 2^24-1, but is: " + maxFrameSize);
-        }
-    }
-
     /**
      * Connection headers from an upgrade request from HTTP/1.1.
      *
@@ -299,10 +272,6 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         return Duration.between(lastRequestTimestamp, DateTime.timestamp());
     }
 
-    void finish() {
-        this.state = State.FINISHED;
-    }
-
     @Override
     public void close(boolean interrupt) {
         // either way, finish
@@ -316,8 +285,15 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         } else if (canInterrupt()) {
             // only interrupt when not processing a request (there is a chance of a race condition, this edge case
             // is ignored
-            myThread.interrupt();
+            Thread localThread = myThread;
+            if (localThread != null) {
+                localThread.interrupt();
+            }
         }
+    }
+
+    void finish() {
+        this.state = State.FINISHED;
     }
 
     // jUnit Http2Config pkg only visible test accessor.
@@ -333,6 +309,56 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     // jUnit Http2Settings pkg only visible test accessor.
     Http2Settings clientSettings() {
         return clientSettings;
+    }
+
+    void pendingPing(Http2Ping ping) {
+        this.ping = ping;
+    }
+
+    void writePingAck() {
+        BufferData frame = ping.data();
+        Http2FrameHeader header = Http2FrameHeader.create(frame.available(),
+                                                          Http2FrameTypes.PING,
+                                                          Http2Flag.PingFlags.create(Http2Flag.ACK),
+                                                          0);
+        ping = null;
+        writeConnectionFrame(new Http2FrameData(header, frame));
+        state = State.READ_FRAME;
+    }
+
+    void writeConnectionFrame(Http2FrameData frame) {
+        try {
+            connectionWriter.write(frame);
+        } catch (UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write HTTP/2 connection frame", e);
+        }
+    }
+
+    private static void settingsUpdate(Http2Config config, Http2Settings.Builder builder) {
+        applySetting(builder, config.maxFrameSize(), Http2Setting.MAX_FRAME_SIZE);
+        applySetting(builder, config.maxHeaderListSize(), Http2Setting.MAX_HEADER_LIST_SIZE);
+        applySetting(builder, config.maxConcurrentStreams(), Http2Setting.MAX_CONCURRENT_STREAMS);
+        applySetting(builder, config.initialWindowSize(), Http2Setting.INITIAL_WINDOW_SIZE);
+    }
+
+    // Add value to the builder only when differs from default
+    private static void applySetting(Http2Settings.Builder builder, long value, Http2Setting<Long> settings) {
+        if (value != settings.defaultValue()) {
+            builder.add(settings, value);
+        }
+    }
+
+    private static void validateMaxFrameSize(Http2Settings http2Settings) {
+        if (!http2Settings.hasValue(Http2Setting.MAX_FRAME_SIZE)) {
+            return;
+        }
+
+        Long maxFrameSize = http2Settings.value(Http2Setting.MAX_FRAME_SIZE);
+        // specification defines, that the frame size must be between the initial size (16384) and 2^24-1
+        if (maxFrameSize < WindowSize.DEFAULT_MAX_FRAME_SIZE || maxFrameSize > WindowSize.MAX_MAX_FRAME_SIZE) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                     "Frame size must be between 2^14 and 2^24-1, but is: " + maxFrameSize);
+        }
     }
 
     private void doHandle(Limit limit) throws InterruptedException {
@@ -746,29 +772,6 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             state = State.READ_FRAME;
         } else {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received priority while processing headers");
-        }
-    }
-
-    void pendingPing(Http2Ping ping) {
-        this.ping = ping;
-    }
-
-    void writePingAck() {
-        BufferData frame = ping.data();
-        Http2FrameHeader header = Http2FrameHeader.create(frame.available(),
-                                                          Http2FrameTypes.PING,
-                                                          Http2Flag.PingFlags.create(Http2Flag.ACK),
-                                                          0);
-        ping = null;
-        writeConnectionFrame(new Http2FrameData(header, frame));
-        state = State.READ_FRAME;
-    }
-
-    void writeConnectionFrame(Http2FrameData frame) {
-        try {
-            connectionWriter.write(frame);
-        } catch (UncheckedIOException e) {
-            throw new ServerConnectionException("Failed to write HTTP/2 connection frame", e);
         }
     }
 

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -31,6 +31,7 @@ import io.helidon.webserver.ServerConnectionException;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -94,5 +95,29 @@ class Http2ConnectionTest {
                 () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
                 () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
         );
+    }
+
+    @Test
+    void gracefulCloseBeforeHandleDoesNotRequireHandlerThread() {
+        closeBeforeHandleDoesNotRequireHandlerThread(false);
+    }
+
+    @Test
+    void forcedCloseBeforeHandleDoesNotRequireHandlerThread() {
+        closeBeforeHandleDoesNotRequireHandlerThread(true);
+    }
+
+    private static void closeBeforeHandleDoesNotRequireHandlerThread(boolean interrupt) {
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.listenerContext()).thenReturn(mock(ListenerContext.class));
+        when(ctx.dataWriter()).thenReturn(mock(DataWriter.class));
+        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+
+        Http2Connection connection = new Http2Connection(ctx, Http2Config.create(), List.of());
+
+        connection.close(interrupt);
+
+        assertThat(connection.canInterrupt(), is(true));
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -21,12 +21,15 @@ import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.nio.channels.SocketChannel;
+import java.time.Duration;
 import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import javax.net.ssl.SSLEngine;
@@ -77,12 +80,24 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     private final Router router;
     private final Tls tls;
     private final ListenerConfig listenerConfig;
+    private final String channelId;
+    private final Consumer<ConnectionHandler> activeHandlerRemoveListener;
+    private final ReentrantLock closeLock = new ReentrantLock();
 
-    private ServerConnection connection;
-    private HelidonSocket helidonSocket;
+    private String socketIds;
+    private boolean closeRequested;
+    private boolean closeInterrupt;
+    private boolean handlingStarted;
     private DataReader reader;
     private SocketWriter writer;
     private ProxyProtocolData proxyProtocolData;
+
+    // Published from the handler thread so lifecycle close/interrupt paths do not miss a created delegate.
+    private volatile ServerConnection connection;
+    // Published for listener-side deduplication of handler-owned active connections.
+    private volatile ServerConnection activeConnection;
+    // Published so concurrent close uses the wrapped socket once setup reaches that stage.
+    private volatile HelidonSocket helidonSocket;
 
     ConnectionHandler(ListenerContext listenerContext,
                       LimitAlgorithm.Token limitToken,
@@ -92,7 +107,8 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
                       SocketChannel socket,
                       String serverChannelId,
                       Router router,
-                      Tls tls) {
+                      Tls tls,
+                      Consumer<ConnectionHandler> activeHandlerRemoveListener) {
         this.listenerContext = listenerContext;
         this.limitToken = limitToken;
         this.requestLimit = requestLimit;
@@ -104,6 +120,8 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         this.router = router;
         this.tls = tls;
         this.listenerConfig = listenerContext.config();
+        this.activeHandlerRemoveListener = activeHandlerRemoveListener;
+        this.channelId = "0x" + HexFormat.of().toHexDigits(System.identityHashCode(socket));
     }
 
     @Override
@@ -113,104 +131,22 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
 
     @Override
     public final void run() {
-        String channelId = "0x" + HexFormat.of().toHexDigits(System.identityHashCode(socket));
-
-        // proxy protocol before SSL handshake
-        if (listenerConfig.enableProxyProtocol()) {
-            ProxyProtocolHandler handler = new ProxyProtocolHandler(socket, channelId);
-            try {
-                proxyProtocolData = handler.get();
-            } catch (RuntimeException e) {
-                if (LOGGER.isLoggable(TRACE)) {
-                    LOGGER.log(TRACE, "[" + channelId + "] Failed to retrieve Proxy Protocol data", e);
-                }
-                closeChannel(channelId);
-                return;
-            }
-        }
-
-        // handle SSL and init helidonSocket, reader and writer
         try {
-            helidonSocket = createSocket(tls, socket, channelId);
-
-            reader = DataReader.create(new MapExceptionDataSupplier(helidonSocket));
-            writer = SocketWriter.create(listenerContext.executor(),
-                                         helidonSocket,
-                                         listenerConfig.writeQueueLength(),
-                                         listenerConfig.smartAsyncWrites());
-        } catch (RuntimeException e) {
-            // these exceptions are thrown to the executor service
-            if (LOGGER.isLoggable(TRACE)) {
-                LOGGER.log(TRACE, "[" + channelId + "] Failed to establish connection", e);
-            }
-            closeChannel(channelId);
-            return;
-        } catch (Exception e) {
-            if (LOGGER.isLoggable(TRACE)) {
-                LOGGER.log(TRACE, "[" + channelId + "] Failed to establish connection", e);
-            }
-            closeChannel(channelId);
-            return;
-        }
-
-        // connection handling
-        String socketsId = helidonSocket.socketId() + " " + helidonSocket.childSocketId();
-        Thread.currentThread().setName("[" + socketsId + "] WebServer socket");
-        if (LOGGER.isLoggable(DEBUG)) {
-            helidonSocket.log(LOGGER,
-                       DEBUG,
-                       "accepted socket from %s:%d",
-                       helidonSocket.remotePeer().host(),
-                       helidonSocket.remotePeer().port());
-        }
-
-        try {
-            if (helidonSocket.protocolNegotiated()) {
-                this.connection = connectionProviders.byApplicationProtocol(helidonSocket.protocol())
-                        .connection(this);
-            }
-
-            if (connection == null) {
-                this.connection = identifyConnection();
-            }
-
-            if (connection == null) {
-                if (isHttp10Connection(reader)) {
-                    // cannot easily return 505, so log better message instead
-                    throw new CloseConnectionException("HTTP 1.0 is not supported, consider using HTTP 1.1");
-                }
-                throw new CloseConnectionException("No suitable connection provider");
-            }
-            activeConnections.put(socketsId, connection);
-            connection.handle(requestLimit);
-        } catch (RequestException e) {
-            helidonSocket.log(LOGGER, WARNING, "escaped Request exception", e);
-        } catch (HttpException e) {
-            helidonSocket.log(LOGGER, WARNING, "escaped HTTP exception", e);
-        } catch (ServerConnectionException e) {
-            // socket exception - the socket failed, probably killed by OS, proxy or client
-            helidonSocket.log(LOGGER, TRACE, "server I/O issue", e);
-        } catch (CloseConnectionException e) {
-            // end of request stream - safe to close the connection, as it was requested by our client
-            helidonSocket.log(LOGGER, TRACE, "connection close requested", e);
-        } catch (UncheckedIOException e) {
-            if (e.getCause() instanceof SocketException) {
-                // socket exception - the socket failed, probably killed by OS, proxy or client
-                helidonSocket.log(LOGGER, TRACE, "server I/O issue", e);
-            } else {
-                helidonSocket.log(LOGGER, WARNING, "unexpected I/O exception", e);
-            }
-        } catch (Exception e) {
-            helidonSocket.log(LOGGER, WARNING, "unexpected exception", e);
+            run(channelId);
         } finally {
-            // connection has finished the loop of handling, release the semaphore
-            limitToken.success();
-            activeConnections.remove(socketsId);
-            writer.close();
+            releaseConnectionLimit(handlingStarted);
+            if (socketIds != null) {
+                activeConnections.remove(socketIds);
+            }
+            if (writer != null) {
+                writer.close();
+            }
             closeChannel(channelId);
+            if (helidonSocket != null) {
+                helidonSocket.log(LOGGER, DEBUG, "socket closed");
+            }
+            activeHandlerRemoveListener.accept(this);
         }
-
-        helidonSocket.log(LOGGER, DEBUG, "socket closed");
     }
 
     @Override
@@ -271,6 +207,176 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     @Override
     public HelidonSocket serverSocket() {
         return helidonSocket;
+    }
+
+    ServerConnection connection() {
+        ServerConnection localActiveConnection = activeConnection;
+        return localActiveConnection == null ? connection : localActiveConnection;
+    }
+
+    void close(boolean interrupt) {
+        ServerConnection localConnection;
+        boolean localCloseInterrupt;
+        boolean closeChannel;
+        closeLock.lock();
+        try {
+            if (interrupt) {
+                closeInterrupt = true;
+            }
+            closeRequested = true;
+            localConnection = connection;
+            localCloseInterrupt = closeInterrupt;
+            closeChannel = !handlingStarted;
+        } finally {
+            closeLock.unlock();
+        }
+        if (closeChannel) {
+            closeChannel("0x" + HexFormat.of().toHexDigits(System.identityHashCode(socket)));
+        }
+        if (localConnection != null) {
+            localConnection.close(localCloseInterrupt);
+        }
+    }
+
+    static boolean isHttp10Connection(DataReader reader) {
+        try {
+            reader.ensureAvailable();
+        } catch (DataReader.InsufficientDataAvailableException e) {
+            throw new CloseConnectionException("No data available", e);
+        }
+        BufferData request = reader.getBuffer(reader.available());
+        int lf = request.indexOf(Bytes.LF_BYTE);
+        return lf != -1 && request.readString(lf).endsWith(HTTP_1_0);
+    }
+
+    // extracted run method to make the run method clean (a single try/finally block)
+    private void run(String channelId) {
+        // proxy protocol before SSL handshake
+        if (listenerConfig.enableProxyProtocol()) {
+            ProxyProtocolHandler handler = new ProxyProtocolHandler(socket, channelId);
+            try {
+                proxyProtocolData = handler.get();
+            } catch (RuntimeException e) {
+                if (LOGGER.isLoggable(TRACE)) {
+                    LOGGER.log(TRACE, "[" + channelId + "] Failed to retrieve Proxy Protocol data", e);
+                }
+                return;
+            }
+        }
+
+        // handle SSL and init helidonSocket, reader and writer
+        try {
+            helidonSocket = createSocket(tls, socket, channelId);
+
+            reader = DataReader.create(new MapExceptionDataSupplier(helidonSocket));
+            writer = SocketWriter.create(listenerContext.executor(),
+                                         helidonSocket,
+                                         listenerConfig.writeQueueLength(),
+                                         listenerConfig.smartAsyncWrites());
+        } catch (RuntimeException e) {
+            // these exceptions are thrown to the executor service
+            if (LOGGER.isLoggable(TRACE)) {
+                LOGGER.log(TRACE, "[" + channelId + "] Failed to establish connection", e);
+            }
+            return;
+        } catch (Exception e) {
+            if (LOGGER.isLoggable(TRACE)) {
+                LOGGER.log(TRACE, "[" + channelId + "] Failed to establish connection", e);
+            }
+            return;
+        }
+
+        // connection handling
+        socketIds = helidonSocket.socketId() + " " + helidonSocket.childSocketId();
+        Thread.currentThread().setName("[" + socketIds + "] WebServer socket");
+        if (LOGGER.isLoggable(DEBUG)) {
+            helidonSocket.log(LOGGER,
+                              DEBUG,
+                              "accepted socket from %s:%d",
+                              helidonSocket.remotePeer().host(),
+                              helidonSocket.remotePeer().port());
+        }
+
+        try {
+            if (helidonSocket.protocolNegotiated()) {
+                this.connection = connectionProviders.byApplicationProtocol(helidonSocket.protocol())
+                        .connection(this);
+            }
+
+            if (connection == null) {
+                this.connection = identifyConnection();
+            }
+
+            if (connection == null) {
+                if (isHttp10Connection(reader)) {
+                    // cannot easily return 505, so log better message instead
+                    throw new CloseConnectionException("HTTP 1.0 is not supported, consider using HTTP 1.1");
+                }
+                throw new CloseConnectionException("No suitable connection provider");
+            }
+            if (!registerActiveConnection(socketIds)) {
+                return;
+            }
+            activeHandlerRemoveListener.accept(this);
+            if (!startHandling()) {
+                return;
+            }
+            connection.handle(requestLimit);
+        } catch (RequestException e) {
+            helidonSocket.log(LOGGER, WARNING, "escaped Request exception", e);
+        } catch (HttpException e) {
+            helidonSocket.log(LOGGER, WARNING, "escaped HTTP exception", e);
+        } catch (ServerConnectionException e) {
+            // socket exception - the socket failed, probably killed by OS, proxy or client
+            helidonSocket.log(LOGGER, TRACE, "server I/O issue", e);
+        } catch (CloseConnectionException e) {
+            // end of request stream - safe to close the connection, as it was requested by our client
+            helidonSocket.log(LOGGER, TRACE, "connection close requested", e);
+        } catch (UncheckedIOException e) {
+            if (e.getCause() instanceof SocketException) {
+                // socket exception - the socket failed, probably killed by OS, proxy or client
+                helidonSocket.log(LOGGER, TRACE, "server I/O issue", e);
+            } else {
+                helidonSocket.log(LOGGER, WARNING, "unexpected I/O exception", e);
+            }
+        } catch (Exception e) {
+            helidonSocket.log(LOGGER, WARNING, "unexpected exception", e);
+        }
+    }
+
+    private void releaseConnectionLimit(boolean handlingStarted) {
+        if (handlingStarted) {
+            limitToken.success();
+        } else {
+            limitToken.ignore();
+        }
+    }
+
+    private boolean registerActiveConnection(String socketsId) {
+        closeLock.lock();
+        try {
+            if (closeRequested) {
+                return false;
+            }
+            activeConnection = new ActiveConnection(connection);
+            activeConnections.put(socketsId, activeConnection);
+            return true;
+        } finally {
+            closeLock.unlock();
+        }
+    }
+
+    private boolean startHandling() {
+        closeLock.lock();
+        try {
+            if (closeRequested) {
+                return false;
+            }
+            handlingStarted = true;
+            return true;
+        } finally {
+            closeLock.unlock();
+        }
     }
 
     private HelidonSocket createSocket(Tls tls, SocketChannel socket, String channelId) throws IOException {
@@ -425,15 +531,28 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         }
     }
 
-    static boolean isHttp10Connection(DataReader reader) {
-        try {
-            reader.ensureAvailable();
-        } catch (DataReader.InsufficientDataAvailableException e) {
-            throw new CloseConnectionException("No data available", e);
+    // we need to call close on ConnectionHandler, instead on the connection, when invoked from ServerListener
+    private final class ActiveConnection implements ServerConnection {
+        private final ServerConnection delegate;
+
+        private ActiveConnection(ServerConnection delegate) {
+            this.delegate = delegate;
         }
-        BufferData request = reader.getBuffer(reader.available());
-        int lf = request.indexOf(Bytes.LF_BYTE);
-        return lf != -1 && request.readString(lf).endsWith(HTTP_1_0);
+
+        @Override
+        public void handle(Limit limit) throws InterruptedException {
+            delegate.handle(limit);
+        }
+
+        @Override
+        public Duration idleTime() {
+            return delegate.idleTime();
+        }
+
+        @Override
+        public void close(boolean interrupt) {
+            ConnectionHandler.this.close(interrupt);
+        }
     }
 
     private static class MapExceptionDataSupplier implements Supplier<byte[]> {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -90,7 +90,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     private SocketWriter writer;
     private ProxyProtocolData proxyProtocolData;
 
-    // Published from the handler thread so lifecycle close/interrupt paths do not miss a created delegate.
+    // Published before handling starts so lifecycle close/interrupt paths do not miss the delegate.
     private volatile ServerConnection connection;
     // Published so concurrent close uses the wrapped socket once setup reaches that stage.
     private volatile HelidonSocket helidonSocket;
@@ -302,26 +302,28 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         }
 
         try {
+            ServerConnection selectedConnection = null;
             if (helidonSocket.protocolNegotiated()) {
-                this.connection = connectionProviders.byApplicationProtocol(helidonSocket.protocol())
+                selectedConnection = connectionProviders.byApplicationProtocol(helidonSocket.protocol())
                         .connection(this);
             }
 
-            if (connection == null) {
-                this.connection = identifyConnection();
+            if (selectedConnection == null) {
+                selectedConnection = identifyConnection();
             }
 
-            if (connection == null) {
+            if (selectedConnection == null) {
                 if (isHttp10Connection(reader)) {
                     // cannot easily return 505, so log better message instead
                     throw new CloseConnectionException("HTTP 1.0 is not supported, consider using HTTP 1.1");
                 }
                 throw new CloseConnectionException("No suitable connection provider");
             }
-            if (!startHandling()) {
+            if (!startHandling(selectedConnection)) {
+                close(false);
                 return;
             }
-            connection.handle(requestLimit);
+            selectedConnection.handle(requestLimit);
         } catch (RequestException e) {
             helidonSocket.log(LOGGER, WARNING, "escaped Request exception", e);
         } catch (HttpException e) {
@@ -352,9 +354,10 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         }
     }
 
-    private boolean startHandling() {
+    private boolean startHandling(ServerConnection selectedConnection) {
         closeLock.lock();
         try {
+            connection = selectedConnection;
             if (closeRequested) {
                 return false;
             }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -25,7 +25,6 @@ import java.time.Duration;
 import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.ReentrantLock;
@@ -74,14 +73,13 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     private final Limit requestLimit;
     private final ConnectionProviders connectionProviders;
     private final List<ServerConnectionSelector> providerCandidates;
-    private final Map<String, ServerConnection> activeConnections;
     private final SocketChannel socket;
     private final String serverChannelId;
     private final Router router;
     private final Tls tls;
     private final ListenerConfig listenerConfig;
     private final String channelId;
-    private final Consumer<ConnectionHandler> activeHandlerRemoveListener;
+    private final Consumer<ConnectionHandler> connectionHandlerRemoveListener;
     private final ReentrantLock closeLock = new ReentrantLock();
 
     private String socketIds;
@@ -94,8 +92,6 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
 
     // Published from the handler thread so lifecycle close/interrupt paths do not miss a created delegate.
     private volatile ServerConnection connection;
-    // Published for listener-side deduplication of handler-owned active connections.
-    private volatile ServerConnection activeConnection;
     // Published so concurrent close uses the wrapped socket once setup reaches that stage.
     private volatile HelidonSocket helidonSocket;
 
@@ -103,24 +99,22 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
                       LimitAlgorithm.Token limitToken,
                       Limit requestLimit,
                       ConnectionProviders connectionProviders,
-                      Map<String, ServerConnection> activeConnections,
                       SocketChannel socket,
                       String serverChannelId,
                       Router router,
                       Tls tls,
-                      Consumer<ConnectionHandler> activeHandlerRemoveListener) {
+                      Consumer<ConnectionHandler> connectionHandlerRemoveListener) {
         this.listenerContext = listenerContext;
         this.limitToken = limitToken;
         this.requestLimit = requestLimit;
         this.connectionProviders = connectionProviders;
         this.providerCandidates = connectionProviders.providerCandidates();
-        this.activeConnections = activeConnections;
         this.socket = socket;
         this.serverChannelId = serverChannelId;
         this.router = router;
         this.tls = tls;
         this.listenerConfig = listenerContext.config();
-        this.activeHandlerRemoveListener = activeHandlerRemoveListener;
+        this.connectionHandlerRemoveListener = connectionHandlerRemoveListener;
         this.channelId = "0x" + HexFormat.of().toHexDigits(System.identityHashCode(socket));
     }
 
@@ -135,9 +129,6 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
             run(channelId);
         } finally {
             releaseConnectionLimit(handlingStarted);
-            if (socketIds != null) {
-                activeConnections.remove(socketIds);
-            }
             if (writer != null) {
                 writer.close();
             }
@@ -145,7 +136,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
             if (helidonSocket != null) {
                 helidonSocket.log(LOGGER, DEBUG, "socket closed");
             }
-            activeHandlerRemoveListener.accept(this);
+            connectionHandlerRemoveListener.accept(this);
         }
     }
 
@@ -209,11 +200,6 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         return helidonSocket;
     }
 
-    ServerConnection connection() {
-        ServerConnection localActiveConnection = activeConnection;
-        return localActiveConnection == null ? connection : localActiveConnection;
-    }
-
     void close(boolean interrupt) {
         ServerConnection localConnection;
         boolean localCloseInterrupt;
@@ -235,6 +221,24 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         }
         if (localConnection != null) {
             localConnection.close(localCloseInterrupt);
+        }
+    }
+
+    void closeIfIdle(Duration timeout) {
+        ServerConnection localConnection;
+        closeLock.lock();
+        try {
+            if (!handlingStarted || closeRequested) {
+                return;
+            }
+            localConnection = connection;
+        } finally {
+            closeLock.unlock();
+        }
+        if (localConnection != null && localConnection.idleTime().compareTo(timeout) > 0) {
+            // this should be a graceful shutdown, in case a request is received in parallel, we want to handle
+            // it, and yes, then it would be closed (and it must not accept another request)
+            close(false);
         }
     }
 
@@ -314,10 +318,6 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
                 }
                 throw new CloseConnectionException("No suitable connection provider");
             }
-            if (!registerActiveConnection(socketIds)) {
-                return;
-            }
-            activeHandlerRemoveListener.accept(this);
             if (!startHandling()) {
                 return;
             }
@@ -349,20 +349,6 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
             limitToken.success();
         } else {
             limitToken.ignore();
-        }
-    }
-
-    private boolean registerActiveConnection(String socketsId) {
-        closeLock.lock();
-        try {
-            if (closeRequested) {
-                return false;
-            }
-            activeConnection = new ActiveConnection(connection);
-            activeConnections.put(socketsId, activeConnection);
-            return true;
-        } finally {
-            closeLock.unlock();
         }
     }
 
@@ -528,30 +514,6 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
             } catch (Throwable e) {
                 helidonSocket.log(LOGGER, TRACE, "Failed to close socket on connection close", e);
             }
-        }
-    }
-
-    // we need to call close on ConnectionHandler, instead on the connection, when invoked from ServerListener
-    private final class ActiveConnection implements ServerConnection {
-        private final ServerConnection delegate;
-
-        private ActiveConnection(ServerConnection delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void handle(Limit limit) throws InterruptedException {
-            delegate.handle(limit);
-        }
-
-        @Override
-        public Duration idleTime() {
-            return delegate.idleTime();
-        }
-
-        @Override
-        public void close(boolean interrupt) {
-            ConnectionHandler.this.close(interrupt);
         }
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -132,7 +132,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
             if (writer != null) {
                 writer.close();
             }
-            closeChannel(channelId);
+            closeChannel();
             if (helidonSocket != null) {
                 helidonSocket.log(LOGGER, DEBUG, "socket closed");
             }
@@ -217,7 +217,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
             closeLock.unlock();
         }
         if (closeChannel) {
-            closeChannel("0x" + HexFormat.of().toHexDigits(System.identityHashCode(socket)));
+            closeChannel();
         }
         if (localConnection != null) {
             localConnection.close(localCloseInterrupt);
@@ -502,7 +502,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         }
     }
 
-    private void closeChannel(String channelId) {
+    private void closeChannel() {
         if (helidonSocket == null) {
             try {
                 socket.close();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/IdleTimeoutHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/IdleTimeoutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,20 +22,18 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.function.Supplier;
 
-import io.helidon.webserver.spi.ServerConnection;
-
 class IdleTimeoutHandler extends TimerTask {
     private final Timer timer;
-    private final Supplier<List<ServerConnection>> connectionSupplier;
+    private final Supplier<List<ConnectionHandler>> handlerSupplier;
     private final Duration timeout;
     private final Duration period;
     private final String taskName;
 
     IdleTimeoutHandler(Timer timer,
                        ListenerConfig listenerConfig,
-                       Supplier<List<ServerConnection>> connectionSupplier) {
+                       Supplier<List<ConnectionHandler>> handlerSupplier) {
         this.timer = timer;
-        this.connectionSupplier = connectionSupplier;
+        this.handlerSupplier = handlerSupplier;
         this.timeout = listenerConfig.idleConnectionTimeout();
         this.period = listenerConfig.idleConnectionPeriod();
 
@@ -47,17 +45,13 @@ class IdleTimeoutHandler extends TimerTask {
     public void run() {
         String name = Thread.currentThread().getName();
         Thread.currentThread().setName(taskName);
-        List<ServerConnection> serverConnections = connectionSupplier.get();
-        for (ServerConnection serverConnection : serverConnections) {
-            if (serverConnection.idleTime().compareTo(timeout) > 0) {
-                // this should be a graceful shutdown, in case a request is received in parallel, we want to handle
-                // it, and yes, then it would be closed (and it must not accept another request)
-                try {
-                    serverConnection.close(false);
-                } catch (Throwable t) {
-                    System.getLogger(IdleTimeoutHandler.class.getName() + "." + taskName)
-                            .log(System.Logger.Level.TRACE, "Failed to close an idle connection", t);
-                }
+        List<ConnectionHandler> connectionHandlers = handlerSupplier.get();
+        for (ConnectionHandler connectionHandler : connectionHandlers) {
+            try {
+                connectionHandler.closeIfIdle(timeout);
+            } catch (Throwable t) {
+                System.getLogger(IdleTimeoutHandler.class.getName() + "." + taskName)
+                        .log(System.Logger.Level.TRACE, "Failed to close an idle connection", t);
             }
         }
         Thread.currentThread().setName(name);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -208,6 +208,60 @@ class LoomServer implements WebServer, Resumable {
         return context;
     }
 
+    @Override
+    public void suspend() {
+        try {
+            lifecycleLock.lockInterruptibly();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted during snapshot checkpoint.", e);
+        }
+        try {
+            if (running.get()) {
+                try {
+                    for (ServerListener listener : listeners.values()) {
+                        listener.suspend();
+                    }
+                } catch (RuntimeException | Error e) {
+                    stopAfterResumableFailure(e);
+                    throw e;
+                }
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    @Override
+    public void resume() {
+        long now = System.currentTimeMillis();
+        try {
+            lifecycleLock.lockInterruptibly();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted during snapshot restore.", e);
+        }
+        try {
+            if (running.get()) {
+                try {
+                    for (ServerListener listener : listeners.values()) {
+                        listener.resume();
+                    }
+                } catch (RuntimeException | Error e) {
+                    stopAfterResumableFailure(e);
+                    throw e;
+                }
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+        now = System.currentTimeMillis() - now;
+        LOGGER.log(System.Logger.Level.INFO, "Restored all channels in "
+                + now + " milliseconds. "
+                + ResumableSupport.get().uptimeSinceResume() + " milliseconds since JVM snapshot restore. "
+                + "Java " + Runtime.version());
+    }
+
     private static void validateRoutingsHaveNamedListener(WebServerConfig serverConfig, Set<String> namedListeners) {
         var routingNames = serverConfig.namedRoutings()
                 .keySet();
@@ -233,24 +287,6 @@ class LoomServer implements WebServer, Resumable {
             } else {
                 throw new IllegalStateException(message);
             }
-        }
-    }
-
-    // Intended for testing. May return null!
-    ServerListener listener(String socketName) {
-        return listeners.get(socketName);
-    }
-
-    // Intended for testing.
-    void shutdownFromShutdownHook() {
-        HelidonShutdownHandler localShutdownHandler = shutdownHandler;
-        if (localShutdownHandler == null) {
-            throw new IllegalStateException("Shutdown handler is not registered");
-        }
-        try {
-            localShutdownHandler.shutdown();
-        } finally {
-            deregisterShutdownHook();
         }
     }
 
@@ -476,60 +512,6 @@ class LoomServer implements WebServer, Resumable {
             }
         }
         return failure;
-    }
-
-    @Override
-    public void suspend() {
-        try {
-            lifecycleLock.lockInterruptibly();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted during snapshot checkpoint.", e);
-        }
-        try {
-            if (running.get()) {
-                try {
-                    for (ServerListener listener : listeners.values()) {
-                        listener.suspend();
-                    }
-                } catch (RuntimeException | Error e) {
-                    stopAfterResumableFailure(e);
-                    throw e;
-                }
-            }
-        } finally {
-            lifecycleLock.unlock();
-        }
-    }
-
-    @Override
-    public void resume() {
-        long now = System.currentTimeMillis();
-        try {
-            lifecycleLock.lockInterruptibly();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted during snapshot restore.", e);
-        }
-        try {
-            if (running.get()) {
-                try {
-                    for (ServerListener listener : listeners.values()) {
-                        listener.resume();
-                    }
-                } catch (RuntimeException | Error e) {
-                    stopAfterResumableFailure(e);
-                    throw e;
-                }
-            }
-        } finally {
-            lifecycleLock.unlock();
-        }
-        now = System.currentTimeMillis() - now;
-        LOGGER.log(System.Logger.Level.INFO, "Restored all channels in "
-                + now + " milliseconds. "
-                + ResumableSupport.get().uptimeSinceResume() + " milliseconds since JVM snapshot restore. "
-                + "Java " + Runtime.version());
     }
 
     private void stopAfterResumableFailure(Throwable failure) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -262,6 +262,11 @@ class LoomServer implements WebServer, Resumable {
                 + "Java " + Runtime.version());
     }
 
+    Thread.State listenerThreadState(String socketName) {
+        ServerListener listener = listeners.get(socketName);
+        return listener == null ? null : listener.serverThreadState();
+    }
+
     private static void validateRoutingsHaveNamedListener(WebServerConfig serverConfig, Set<String> namedListeners) {
         var routingNames = serverConfig.namedRoutings()
                 .keySet();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -262,6 +262,7 @@ class LoomServer implements WebServer, Resumable {
                 + "Java " + Runtime.version());
     }
 
+    // Intended for tests that need listener state without stack walking.
     Thread.State listenerThreadState(String socketName) {
         ServerListener listener = listeners.get(socketName);
         return listener == null ? null : listener.serverThreadState();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -271,6 +271,7 @@ class ServerListener implements ListenerContext {
         return tls.enabled();
     }
 
+    // Intended for tests that need listener state without stack walking.
     Thread.State serverThreadState() {
         Thread localServerThread = serverThread;
         return localServerThread == null ? null : localServerThread.getState();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -30,11 +30,8 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HexFormat;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.Timer;
@@ -60,7 +57,6 @@ import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webserver.http.DirectHandlers;
 import io.helidon.webserver.spi.ProtocolConfig;
-import io.helidon.webserver.spi.ServerConnection;
 import io.helidon.webserver.spi.ServerConnectionSelector;
 import io.helidon.webserver.spi.ServerConnectionSelectorProvider;
 
@@ -94,8 +90,7 @@ class ServerListener implements ListenerContext {
     private final Context context;
     private final Limit connectionLimit;
     private final Limit requestLimit;
-    private final Set<ConnectionHandler> activeHandlers = ConcurrentHashMap.newKeySet();
-    private final Map<String, ServerConnection> activeConnections = new ConcurrentHashMap<>();
+    private final Set<ConnectionHandler> connectionHandlers = ConcurrentHashMap.newKeySet();
 
     private volatile boolean running;
     private volatile boolean inCheckpoint;
@@ -188,7 +183,7 @@ class ServerListener implements ListenerContext {
         // handle idle connection timeout
         IdleTimeoutHandler ith = new IdleTimeoutHandler(idleConnectionTimer,
                                                         listenerConfig,
-                                                        this::activeConnections);
+                                                        this::connectionHandlers);
         ith.start();
     }
 
@@ -633,38 +628,37 @@ class ServerListener implements ListenerContext {
                                                                       token,
                                                                       requestLimit,
                                                                       connectionProviders,
-                                                                      activeConnections,
                                                                       socket,
                                                                       serverChannelId,
                                                                       router,
                                                                       tls,
-                                                                      activeHandlers::remove);
-                    activeHandlers.add(handler);
+                                                                      connectionHandlers::remove);
+                    connectionHandlers.add(handler);
 
                     try {
                         if (!running) {
-                            activeHandlers.remove(handler);
+                            connectionHandlers.remove(handler);
                             closeAcceptedSocket(socket, null);
                             token.ignore();
                             continue;
                         }
                         connectionOptions.configureSocket(socket);
                         if (!running) {
-                            activeHandlers.remove(handler);
+                            connectionHandlers.remove(handler);
                             closeAcceptedSocket(socket, null);
                             token.ignore();
                             continue;
                         }
                         readerExecutor.execute(handler);
                     } catch (RejectedExecutionException e) {
-                        activeHandlers.remove(handler);
+                        connectionHandlers.remove(handler);
                         LOGGER.log(ERROR, "Executor rejected handler for new connection", e);
                         closeAcceptedSocket(socket, e);
 
                         // we never started the handler, so we must release the semaphore here
                         token.dropped();
                     } catch (Exception e) {
-                        activeHandlers.remove(handler);
+                        connectionHandlers.remove(handler);
                         // we may get an SSL handshake errors, which should only fail one socket, not the listener
                         LOGGER.log(TRACE, "Failed to handle accepted socket", e);
                         closeAcceptedSocket(socket, e);
@@ -714,36 +708,13 @@ class ServerListener implements ListenerContext {
         }
     }
 
-    private List<ConnectionHandler> activeHandlers() {
-        return new ArrayList<>(activeHandlers);
-    }
-
-    private List<ServerConnection> activeConnections() {
-        return new ArrayList<>(activeConnections.values());
-    }
-
-    private List<ServerConnection> activeConnectionsExcludingActiveHandlers(List<ConnectionHandler> activeHandlers) {
-        List<ServerConnection> result = new ArrayList<>();
-        Set<ServerConnection> handledConnections = activeHandlerConnections(activeHandlers);
-        for (ServerConnection connection : activeConnections()) {
-            if (!handledConnections.contains(connection)) {
-                result.add(connection);
-            }
-        }
-        return result;
+    private List<ConnectionHandler> connectionHandlers() {
+        return new ArrayList<>(connectionHandlers);
     }
 
     private Throwable closeOpenConnections(boolean interrupt) {
         Throwable failure = null;
-        List<ConnectionHandler> handlers = activeHandlers();
-        failure = LifecycleFailures.add(failure, closeActiveHandlers(handlers, interrupt));
-        failure = LifecycleFailures.add(failure, closeActiveConnections(handlers, interrupt));
-        return failure;
-    }
-
-    private Throwable closeActiveHandlers(List<ConnectionHandler> activeHandlers, boolean interrupt) {
-        Throwable failure = null;
-        for (ConnectionHandler handler : activeHandlers) {
+        for (ConnectionHandler handler : connectionHandlers()) {
             try {
                 handler.close(interrupt);
             } catch (RuntimeException | Error e) {
@@ -751,29 +722,6 @@ class ServerListener implements ListenerContext {
             }
         }
         return failure;
-    }
-
-    private Throwable closeActiveConnections(List<ConnectionHandler> activeHandlers, boolean interrupt) {
-        Throwable failure = null;
-        for (ServerConnection connection : activeConnectionsExcludingActiveHandlers(activeHandlers)) {
-            try {
-                connection.close(interrupt);
-            } catch (RuntimeException | Error e) {
-                failure = LifecycleFailures.add(failure, e);
-            }
-        }
-        return failure;
-    }
-
-    private Set<ServerConnection> activeHandlerConnections(List<ConnectionHandler> activeHandlers) {
-        Set<ServerConnection> connections = Collections.newSetFromMap(new IdentityHashMap<>());
-        for (ConnectionHandler handler : activeHandlers) {
-            ServerConnection connection = handler.connection();
-            if (connection != null) {
-                connections.add(connection);
-            }
-        }
-        return connections;
     }
 
     private static void throwIfCheckpointSuspendFailed(Throwable failure) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -271,6 +271,11 @@ class ServerListener implements ListenerContext {
         return tls.enabled();
     }
 
+    Thread.State serverThreadState() {
+        Thread localServerThread = serverThread;
+        return localServerThread == null ? null : localServerThread.getState();
+    }
+
     void reloadTls(Tls tls) {
         if (!this.tls.enabled()) {
             throw new IllegalArgumentException("TLS is not enabled on the socket " + socketName

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -30,16 +30,17 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HexFormat;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -54,7 +55,6 @@ import io.helidon.common.concurrency.limits.LimitAlgorithm;
 import io.helidon.common.context.Context;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.task.HelidonTaskExecutor;
-import io.helidon.common.task.InterruptableTask;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
@@ -94,6 +94,7 @@ class ServerListener implements ListenerContext {
     private final Context context;
     private final Limit connectionLimit;
     private final Limit requestLimit;
+    private final Set<ConnectionHandler> activeHandlers = ConcurrentHashMap.newKeySet();
     private final Map<String, ServerConnection> activeConnections = new ConcurrentHashMap<>();
 
     private volatile boolean running;
@@ -102,10 +103,6 @@ class ServerListener implements ListenerContext {
     private volatile ServerSocketChannel serverSocket;
     private volatile Thread serverThread;
     private volatile CompletableFuture<Void> closeFuture;
-    private volatile Runnable beforeReaderExecutorTerminate = () -> {
-    };
-    private volatile Runnable beforeSharedExecutorAwait = () -> {
-    };
 
     @SuppressWarnings("unchecked")
     ServerListener(String socketName,
@@ -195,15 +192,6 @@ class ServerListener implements ListenerContext {
         ith.start();
     }
 
-    private void initServerThread() {
-        this.closeFuture = new CompletableFuture<>();
-        this.serverThread = Thread.ofPlatform()
-                .inheritInheritableThreadLocals(true)
-                .daemon(false)
-                .name("server-" + socketName + "-listener")
-                .unstarted(this::listen);
-    }
-
     @Override
     public MediaContext mediaContext() {
         return mediaContext;
@@ -266,14 +254,73 @@ class ServerListener implements ListenerContext {
         LifecycleFailures.throwIfFailed(failure, "Failed to stop listener " + socketName);
     }
 
+    void start() {
+        start(() -> false);
+    }
+
+    void start(BooleanSupplier cancelled) {
+        boolean lifecycleStarted = false;
+        try {
+            checkCancelledStartup(cancelled);
+            router.beforeStart();
+            lifecycleStarted = true;
+            checkCancelledStartup(cancelled);
+            startIt(cancelled);
+        } catch (RuntimeException | Error e) {
+            rollbackFailedStart(e, lifecycleStarted);
+            throw e;
+        }
+    }
+
+    boolean hasTls() {
+        return tls.enabled();
+    }
+
+    void reloadTls(Tls tls) {
+        if (!this.tls.enabled()) {
+            throw new IllegalArgumentException("TLS is not enabled on the socket " + socketName
+                                                       + " and therefore cannot be reloaded");
+        }
+        if (!tls.enabled()) {
+            throw new UnsupportedOperationException("TLS cannot be disabled by reloading on the socket " + socketName);
+        }
+        this.tls.reload(tls);
+    }
+
+    void suspend() {
+        inCheckpoint = true;
+        // Checkpoint suspend is expected to stop the listener thread. The connection-limit wait path
+        // converts interrupts into a rejected outcome, so clear the loop condition first to avoid
+        // re-entering the wait after the interrupt is consumed.
+        running = false;
+        suspendForCheckpoint();
+        serverThread = null;
+        closeFuture = null;
+    }
+
+    void resume() {
+        initServerThread();
+        startIt();
+        inCheckpoint = false;
+    }
+
+    private void initServerThread() {
+        this.closeFuture = new CompletableFuture<>();
+        this.serverThread = Thread.ofPlatform()
+                .inheritInheritableThreadLocals(true)
+                .daemon(false)
+                .name("server-" + socketName + "-listener")
+                .unstarted(this::listen);
+    }
+
     private Throwable stopResources() {
         Throwable failure = null;
         // Stop listening for connections
         closeServerSocketForStop();
 
         try {
-            // Stop handling any new requests on all active connections
-            failure = LifecycleFailures.add(failure, closeActiveConnections(false));
+            // Stop handling any new requests on all accepted and active connections
+            failure = LifecycleFailures.add(failure, closeOpenConnections(false));
         } catch (RuntimeException | Error e) {
             failure = LifecycleFailures.add(failure, e);
         }
@@ -293,8 +340,8 @@ class ServerListener implements ListenerContext {
         }
 
         try {
-            // Interrupt and close any active connections
-            failure = LifecycleFailures.add(failure, closeActiveConnections(true));
+            // Interrupt and close any accepted and active connections
+            failure = LifecycleFailures.add(failure, closeOpenConnections(true));
         } catch (RuntimeException | Error e) {
             failure = LifecycleFailures.add(failure, e);
         }
@@ -319,6 +366,7 @@ class ServerListener implements ListenerContext {
     }
 
     private void suspendForCheckpoint() {
+        Throwable failure = null;
         try {
             // Stop listening for connections
             serverSocket.close();
@@ -330,33 +378,27 @@ class ServerListener implements ListenerContext {
                     LOGGER.log(WARNING, "Failed to delete UNIX socket file " + udsa.getPath().toAbsolutePath(), e);
                 }
             }
-            // Stop handling any new requests on all active connections
-            activeConnections().forEach(connection -> connection.close(false));
-            // Interrupt and close any active connections
-            activeConnections().forEach(connection -> connection.close(true));
         } catch (IOException e) {
             LOGGER.log(INFO, "Exception thrown on socket close", e);
         }
-        serverThread.interrupt();
-        closeFuture.join();
-    }
+        // Stop handling any new requests on all accepted and active connections
+        failure = LifecycleFailures.add(failure, closeOpenConnections(false));
+        // Interrupt and close any accepted and active connections
+        failure = LifecycleFailures.add(failure, closeOpenConnections(true));
 
-    void start() {
-        start(() -> false);
-    }
-
-    void start(BooleanSupplier cancelled) {
-        boolean lifecycleStarted = false;
-        try {
-            checkCancelledStartup(cancelled);
-            router.beforeStart();
-            lifecycleStarted = true;
-            checkCancelledStartup(cancelled);
-            startIt(cancelled);
-        } catch (RuntimeException | Error e) {
-            rollbackFailedStart(e, lifecycleStarted);
-            throw e;
+        Thread localServerThread = serverThread;
+        if (localServerThread != null) {
+            localServerThread.interrupt();
         }
+        CompletableFuture<Void> localCloseFuture = closeFuture;
+        if (localCloseFuture != null) {
+            try {
+                localCloseFuture.join();
+            } catch (RuntimeException | Error e) {
+                failure = LifecycleFailures.add(failure, e);
+            }
+        }
+        throwIfCheckpointSuspendFailed(failure);
     }
 
     private void startIt() {
@@ -436,21 +478,6 @@ class ServerListener implements ListenerContext {
         if (cancelled.getAsBoolean()) {
             throw new IllegalStateException("Listener startup cancelled " + socketName);
         }
-    }
-
-    boolean hasTls() {
-        return tls.enabled();
-    }
-
-    void reloadTls(Tls tls) {
-        if (!this.tls.enabled()) {
-            throw new IllegalArgumentException("TLS is not enabled on the socket " + socketName
-                                                       + " and therefore cannot be reloaded");
-        }
-        if (!tls.enabled()) {
-            throw new UnsupportedOperationException("TLS cannot be disabled by reloading on the socket " + socketName);
-        }
-        this.tls.reload(tls);
     }
 
     private void debugTls(String serverChannelId, Tls tls) {
@@ -544,11 +571,6 @@ class ServerListener implements ListenerContext {
 
     private void shutdownReaderExecutor() {
         Throwable failure = null;
-        try {
-            beforeReaderExecutorTerminate.run();
-        } catch (RuntimeException | Error e) {
-            failure = LifecycleFailures.add(failure, e);
-        }
         readerExecutor.terminate(gracePeriod.toMillis(), TimeUnit.MILLISECONDS);
         if (Thread.currentThread().isInterrupted()) {
             failure = LifecycleFailures.add(failure,
@@ -569,11 +591,6 @@ class ServerListener implements ListenerContext {
     private void shutdownSharedExecutor() {
         Throwable failure = null;
         sharedExecutor.shutdown();
-        try {
-            beforeSharedExecutorAwait.run();
-        } catch (RuntimeException | Error e) {
-            failure = LifecycleFailures.add(failure, e);
-        }
         try {
             boolean done = sharedExecutor.awaitTermination(gracePeriod.toMillis(), TimeUnit.MILLISECONDS);
             if (!done) {
@@ -612,42 +629,45 @@ class ServerListener implements ListenerContext {
 
                     // if accept fails itself, we consider it end of story, the listener is broken
                     SocketChannel socket = serverSocket.accept();
+                    ConnectionHandler handler = new ConnectionHandler(this,
+                                                                      token,
+                                                                      requestLimit,
+                                                                      connectionProviders,
+                                                                      activeConnections,
+                                                                      socket,
+                                                                      serverChannelId,
+                                                                      router,
+                                                                      tls,
+                                                                      activeHandlers::remove);
+                    activeHandlers.add(handler);
 
                     try {
+                        if (!running) {
+                            activeHandlers.remove(handler);
+                            closeAcceptedSocket(socket, null);
+                            token.ignore();
+                            continue;
+                        }
                         connectionOptions.configureSocket(socket);
-                        ConnectionHandler handler = new ConnectionHandler(this,
-                                                                          token,
-                                                                          requestLimit,
-                                                                          connectionProviders,
-                                                                          activeConnections,
-                                                                          socket,
-                                                                          serverChannelId,
-                                                                          router,
-                                                                          tls);
+                        if (!running) {
+                            activeHandlers.remove(handler);
+                            closeAcceptedSocket(socket, null);
+                            token.ignore();
+                            continue;
+                        }
                         readerExecutor.execute(handler);
                     } catch (RejectedExecutionException e) {
+                        activeHandlers.remove(handler);
                         LOGGER.log(ERROR, "Executor rejected handler for new connection", e);
-
-                        // the socket was never handled
-                        try {
-                            socket.close();
-                        } catch (IOException ex) {
-                            LOGGER.log(TRACE, "Failed to close socket that was rejected for execution", e);
-                        }
+                        closeAcceptedSocket(socket, e);
 
                         // we never started the handler, so we must release the semaphore here
                         token.dropped();
                     } catch (Exception e) {
+                        activeHandlers.remove(handler);
                         // we may get an SSL handshake errors, which should only fail one socket, not the listener
                         LOGGER.log(TRACE, "Failed to handle accepted socket", e);
-                        // the socket was never handled
-                        try {
-                            socket.close();
-                        } catch (IOException ex) {
-                            LOGGER.log(TRACE,
-                                       "Failed to close socket that failed start execution (see previous trace for reason)",
-                                       e);
-                        }
+                        closeAcceptedSocket(socket, e);
 
                         // we never started the handler, so we must release the semaphore here
                         token.ignore();
@@ -682,13 +702,60 @@ class ServerListener implements ListenerContext {
         closeFuture.complete(null);
     }
 
+    private static void closeAcceptedSocket(SocketChannel socket, Throwable cause) {
+        // the socket was never handled
+        try {
+            socket.close();
+        } catch (IOException e) {
+            if (cause != null && cause != e) {
+                e.addSuppressed(cause);
+            }
+            LOGGER.log(TRACE, "Failed to close socket that was not handled", e);
+        }
+    }
+
+    private List<ConnectionHandler> activeHandlers() {
+        return new ArrayList<>(activeHandlers);
+    }
+
     private List<ServerConnection> activeConnections() {
         return new ArrayList<>(activeConnections.values());
     }
 
-    private Throwable closeActiveConnections(boolean interrupt) {
-        Throwable failure = null;
+    private List<ServerConnection> activeConnectionsExcludingActiveHandlers(List<ConnectionHandler> activeHandlers) {
+        List<ServerConnection> result = new ArrayList<>();
+        Set<ServerConnection> handledConnections = activeHandlerConnections(activeHandlers);
         for (ServerConnection connection : activeConnections()) {
+            if (!handledConnections.contains(connection)) {
+                result.add(connection);
+            }
+        }
+        return result;
+    }
+
+    private Throwable closeOpenConnections(boolean interrupt) {
+        Throwable failure = null;
+        List<ConnectionHandler> handlers = activeHandlers();
+        failure = LifecycleFailures.add(failure, closeActiveHandlers(handlers, interrupt));
+        failure = LifecycleFailures.add(failure, closeActiveConnections(handlers, interrupt));
+        return failure;
+    }
+
+    private Throwable closeActiveHandlers(List<ConnectionHandler> activeHandlers, boolean interrupt) {
+        Throwable failure = null;
+        for (ConnectionHandler handler : activeHandlers) {
+            try {
+                handler.close(interrupt);
+            } catch (RuntimeException | Error e) {
+                failure = LifecycleFailures.add(failure, e);
+            }
+        }
+        return failure;
+    }
+
+    private Throwable closeActiveConnections(List<ConnectionHandler> activeHandlers, boolean interrupt) {
+        Throwable failure = null;
+        for (ServerConnection connection : activeConnectionsExcludingActiveHandlers(activeHandlers)) {
             try {
                 connection.close(interrupt);
             } catch (RuntimeException | Error e) {
@@ -698,45 +765,29 @@ class ServerListener implements ListenerContext {
         return failure;
     }
 
-    // Intended for testing.
-    Thread serverThreads() {
-        return serverThread;
+    private Set<ServerConnection> activeHandlerConnections(List<ConnectionHandler> activeHandlers) {
+        Set<ServerConnection> connections = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ConnectionHandler handler : activeHandlers) {
+            ServerConnection connection = handler.connection();
+            if (connection != null) {
+                connections.add(connection);
+            }
+        }
+        return connections;
     }
 
-    // Intended for testing.
-    void activeConnection(String id, ServerConnection connection) {
-        activeConnections.put(id, connection);
+    private static void throwIfCheckpointSuspendFailed(Throwable failure) {
+        if (failure == null) {
+            return;
+        }
+        Throwable unwrapped = LifecycleFailures.unwrap(failure);
+        if (unwrapped instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (unwrapped instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException("Failed to suspend listener for checkpoint", unwrapped);
     }
 
-    // Intended for testing.
-    Future<?> readerTask(InterruptableTask<?> task) {
-        return readerExecutor.execute(task);
-    }
-
-    // Intended for testing.
-    void beforeReaderExecutorTerminate(Runnable beforeReaderExecutorTerminate) {
-        this.beforeReaderExecutorTerminate = Objects.requireNonNull(beforeReaderExecutorTerminate);
-    }
-
-    // Intended for testing.
-    void beforeSharedExecutorAwait(Runnable beforeSharedExecutorAwait) {
-        this.beforeSharedExecutorAwait = Objects.requireNonNull(beforeSharedExecutorAwait);
-    }
-
-    void suspend() {
-        inCheckpoint = true;
-        // Checkpoint suspend is expected to stop the listener thread. The connection-limit wait path
-        // converts interrupts into a rejected outcome, so clear the loop condition first to avoid
-        // re-entering the wait after the interrupt is consumed.
-        running = false;
-        suspendForCheckpoint();
-        serverThread = null;
-        closeFuture = null;
-    }
-
-    void resume() {
-        initServerThread();
-        startIt();
-        inCheckpoint = false;
-    }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -22,6 +22,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketOption;
+import java.net.SocketTimeoutException;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
@@ -536,6 +537,61 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
+    void idleTimeoutIgnoresAcceptedSocketBeforeConnectionHandling() throws Exception {
+        PreRegistrationConnectionSelector selector = new PreRegistrationConnectionSelector();
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .idleConnectionTimeout(Duration.ofMillis(1))
+                .idleConnectionPeriod(Duration.ofMillis(10))
+                .addConnectionSelector(selector)
+                .build()
+                .start();
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.setSoTimeout(250);
+            socket.getOutputStream().write('x');
+            assertThat(selector.awaitSupports(), is(true));
+            TimeUnit.MILLISECONDS.sleep(200);
+
+            assertThrows(SocketTimeoutException.class, () -> socket.getInputStream().read());
+            assertThat(selector.connection().handlingStarted(), is(false));
+            assertThat(selector.connection().gracefulCloses(), is(0));
+            assertThat(selector.connection().forcedCloses(), is(0));
+        } finally {
+            selector.release();
+            selector.connection().release();
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void idleTimeoutClosesHandledConnection() throws Exception {
+        IdleBlockingConnection connection = new IdleBlockingConnection();
+        QueueingConnectionSelector selector = new QueueingConnectionSelector(connection);
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .idleConnectionTimeout(Duration.ofMillis(1))
+                .idleConnectionPeriod(Duration.ofMillis(10))
+                .addConnectionSelector(selector)
+                .build()
+                .start();
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.getOutputStream().write('x');
+            assertThat(connection.awaitHandling(), is(true));
+            assertThat(connection.awaitGracefulClose(), is(true));
+            assertThat(connection.forcedCloses(), is(0));
+        } finally {
+            connection.release();
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
     void webServerStopFailureThrowsAfterStoppingAllListeners() {
         LifecycleService defaultService = new LifecycleService("default", true);
         LifecycleService adminService = new LifecycleService("admin", true);
@@ -927,6 +983,55 @@ class ServerListenerLifecycleTest {
 
         private int gracefulCloses() {
             return gracefulCloses.get();
+        }
+
+        private int forcedCloses() {
+            return forcedCloses.get();
+        }
+
+        private void release() {
+            release.countDown();
+        }
+    }
+
+    private static final class IdleBlockingConnection implements ServerConnection {
+        private final CountDownLatch handling = new CountDownLatch(1);
+        private final CountDownLatch gracefulClose = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+        private final AtomicInteger forcedCloses = new AtomicInteger();
+
+        @Override
+        public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+            handling.countDown();
+            while (release.getCount() != 0) {
+                try {
+                    release.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts so shutdown must close the connection.
+                }
+            }
+        }
+
+        @Override
+        public Duration idleTime() {
+            return Duration.ofMinutes(1);
+        }
+
+        @Override
+        public void close(boolean interrupt) {
+            if (interrupt) {
+                forcedCloses.incrementAndGet();
+            } else {
+                gracefulClose.countDown();
+            }
+        }
+
+        private boolean awaitHandling() throws InterruptedException {
+            return handling.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean awaitGracefulClose() throws InterruptedException {
+            return gracefulClose.await(5, TimeUnit.SECONDS);
         }
 
         private int forcedCloses() {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -569,11 +569,12 @@ class ServerListenerLifecycleTest {
             assertSocketClosed(socket);
             assertThat(selector.connection().handlingStarted(), is(false));
 
-            selector.release();
             suspendThread.join(TimeUnit.SECONDS.toMillis(5));
 
             assertThat(suspendThread.isAlive(), is(false));
             assertThat(suspendFailure.get(), nullValue());
+
+            selector.release();
             waitFor(Duration.ofSeconds(5),
                     () -> selector.connection().forcedCloses() == 1,
                     "accepted connection was not force closed");

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 import io.helidon.common.buffers.BufferData;
@@ -454,12 +455,59 @@ class ServerListenerLifecycleTest {
 
             assertThat(stopThread.isAlive(), is(false));
             assertThat(stopFailure.get(), nullValue());
-            assertThat(selector.connection().gracefulCloses(), is(0));
+            assertThat(selector.connection().gracefulCloses(), is(1));
             assertThat(selector.connection().forcedCloses(), is(0));
             assertThat(selector.connection().handlingStarted(), is(false));
         } finally {
             selector.release();
-            selector.connection().release();
+            BlockingConnection connection = selector.connection();
+            if (connection != null) {
+                connection.release();
+            }
+            if (stopThread != null && stopThread.isAlive()) {
+                stopThread.interrupt();
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void gracefulShutdownClosesConnectionCreatedAfterCloseRequest() throws Exception {
+        ConnectionCreationBlockingSelector selector = new ConnectionCreationBlockingSelector();
+        AtomicReference<Throwable> stopFailure = new AtomicReference<>();
+        LoomServer server = startServer(selector, Duration.ofMinutes(1));
+        Thread stopThread = null;
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.setSoTimeout(5_000);
+            socket.getOutputStream().write('x');
+            assertThat(selector.awaitConnectionCreation(), is(true));
+
+            stopThread = Thread.ofPlatform()
+                    .name("test-graceful-connection-created-after-close")
+                    .start(() -> {
+                        try {
+                            server.stop();
+                        } catch (RuntimeException | Error e) {
+                            stopFailure.set(e);
+                        }
+                    });
+
+            assertSocketClosed(socket);
+            selector.release();
+            stopThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(stopThread.isAlive(), is(false));
+            assertThat(stopFailure.get(), nullValue());
+            assertThat(selector.connection().handlingStarted(), is(false));
+            assertThat(selector.connection().gracefulCloses(), is(1));
+            assertThat(selector.connection().forcedCloses(), is(0));
+        } finally {
+            selector.release();
+            BlockingConnection connection = selector.connection();
+            if (connection != null) {
+                connection.release();
+            }
             if (stopThread != null && stopThread.isAlive()) {
                 stopThread.interrupt();
             }
@@ -483,8 +531,11 @@ class ServerListenerLifecycleTest {
             assertThat(selector.connection().handlingStarted(), is(false));
 
             selector.release();
+            waitFor(Duration.ofSeconds(5),
+                    () -> selector.connection().forcedCloses() == 1,
+                    "accepted connection was not force closed");
             assertThat(selector.connection().gracefulCloses(), is(0));
-            assertThat(selector.connection().forcedCloses(), is(0));
+            assertThat(selector.connection().forcedCloses(), is(1));
             assertThat(selector.connection().handlingStarted(), is(false));
         } finally {
             selector.release();
@@ -524,7 +575,7 @@ class ServerListenerLifecycleTest {
             assertThat(suspendThread.isAlive(), is(false));
             assertThat(suspendFailure.get(), nullValue());
             assertThat(selector.connection().gracefulCloses(), is(0));
-            assertThat(selector.connection().forcedCloses(), is(0));
+            assertThat(selector.connection().forcedCloses(), is(1));
             assertThat(selector.connection().handlingStarted(), is(false));
         } finally {
             selector.release();
@@ -538,7 +589,7 @@ class ServerListenerLifecycleTest {
 
     @Test
     void idleTimeoutIgnoresAcceptedSocketBeforeConnectionHandling() throws Exception {
-        PreRegistrationConnectionSelector selector = new PreRegistrationConnectionSelector();
+        PreRegistrationThenIdleConnectionSelector selector = new PreRegistrationThenIdleConnectionSelector();
         LoomServer server = (LoomServer) WebServer.builder()
                 .shutdownHook(false)
                 .address(InetAddress.getLoopbackAddress())
@@ -549,19 +600,25 @@ class ServerListenerLifecycleTest {
                 .build()
                 .start();
 
-        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
-            socket.setSoTimeout(250);
-            socket.getOutputStream().write('x');
+        try (Socket blockedSocket = new Socket(InetAddress.getLoopbackAddress(), server.port());
+                Socket idleSocket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            blockedSocket.setSoTimeout(250);
+            blockedSocket.getOutputStream().write('x');
             assertThat(selector.awaitSupports(), is(true));
-            TimeUnit.MILLISECONDS.sleep(200);
 
-            assertThrows(SocketTimeoutException.class, () -> socket.getInputStream().read());
-            assertThat(selector.connection().handlingStarted(), is(false));
-            assertThat(selector.connection().gracefulCloses(), is(0));
-            assertThat(selector.connection().forcedCloses(), is(0));
+            idleSocket.getOutputStream().write('x');
+            assertThat(selector.idleConnection().awaitHandling(), is(true));
+            assertThat(selector.idleConnection().awaitGracefulClose(), is(true));
+
+            assertThrows(SocketTimeoutException.class, () -> blockedSocket.getInputStream().read());
+            assertThat(selector.preRegistrationConnection().handlingStarted(), is(false));
+            assertThat(selector.preRegistrationConnection().gracefulCloses(), is(0));
+            assertThat(selector.preRegistrationConnection().forcedCloses(), is(0));
+            assertThat(selector.idleConnection().forcedCloses(), is(0));
         } finally {
             selector.release();
-            selector.connection().release();
+            selector.preRegistrationConnection().release();
+            selector.idleConnection().release();
             stopUntilStopped(server);
         }
     }
@@ -761,6 +818,17 @@ class ServerListenerLifecycleTest {
         }
     }
 
+    private static void waitFor(Duration timeout, BooleanSupplier condition, String message) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(10);
+        }
+        throw new AssertionError(message);
+    }
+
     private static int awaitPort(WebServer server, String socketName) throws Exception {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
         int port;
@@ -896,6 +964,114 @@ class ServerListenerLifecycleTest {
                 return connections[connections.length - 1];
             }
             return connections[current];
+        }
+    }
+
+    private static final class PreRegistrationThenIdleConnectionSelector implements ServerConnectionSelector {
+        private final AtomicBoolean preRegistrationSelected = new AtomicBoolean();
+        private final ThreadLocal<Boolean> preRegistrationHandler = ThreadLocal.withInitial(() -> false);
+        private final CountDownLatch supportsEntered = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+        private final BlockingConnection preRegistrationConnection = new BlockingConnection();
+        private final IdleBlockingConnection idleConnection = new IdleBlockingConnection();
+
+        @Override
+        public int bytesToIdentifyConnection() {
+            return 0;
+        }
+
+        @Override
+        public Support supports(BufferData data) {
+            if (preRegistrationSelected.compareAndSet(false, true)) {
+                preRegistrationHandler.set(true);
+                supportsEntered.countDown();
+                while (release.getCount() != 0) {
+                    try {
+                        release.await(1, TimeUnit.SECONDS);
+                    } catch (InterruptedException _) {
+                        // Deliberately ignore interrupts to prove idle timeout does not close the accepted socket.
+                    }
+                }
+            }
+            return Support.SUPPORTED;
+        }
+
+        @Override
+        public Set<String> supportedApplicationProtocols() {
+            return Set.of("test-pre-registration-then-idle");
+        }
+
+        @Override
+        public ServerConnection connection(ConnectionContext ctx) {
+            if (preRegistrationHandler.get()) {
+                preRegistrationHandler.remove();
+                return preRegistrationConnection;
+            }
+            return idleConnection;
+        }
+
+        private boolean awaitSupports() throws InterruptedException {
+            return supportsEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        private void release() {
+            release.countDown();
+        }
+
+        private BlockingConnection preRegistrationConnection() {
+            return preRegistrationConnection;
+        }
+
+        private IdleBlockingConnection idleConnection() {
+            return idleConnection;
+        }
+    }
+
+    private static final class ConnectionCreationBlockingSelector implements ServerConnectionSelector {
+        private final CountDownLatch connectionCreationEntered = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+        private final AtomicReference<BlockingConnection> connection = new AtomicReference<>();
+
+        @Override
+        public int bytesToIdentifyConnection() {
+            return 0;
+        }
+
+        @Override
+        public Support supports(BufferData data) {
+            return Support.SUPPORTED;
+        }
+
+        @Override
+        public Set<String> supportedApplicationProtocols() {
+            return Set.of("test-connection-creation-blocking");
+        }
+
+        @Override
+        public ServerConnection connection(ConnectionContext ctx) {
+            BlockingConnection newConnection = new BlockingConnection();
+            connection.set(newConnection);
+            connectionCreationEntered.countDown();
+            while (release.getCount() != 0) {
+                try {
+                    release.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts to prove shutdown closes the just-created connection.
+                }
+            }
+            return newConnection;
+        }
+
+        private boolean awaitConnectionCreation() throws InterruptedException {
+            return connectionCreationEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        private void release() {
+            release.countDown();
+        }
+
+        private BlockingConnection connection() {
+            return connection.get();
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -19,23 +19,31 @@ package io.helidon.webserver;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketOption;
 import java.net.UnixDomainSocketAddress;
+import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import io.helidon.common.task.InterruptableTask;
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.socket.SocketOptions;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.spi.ServerConnection;
+import io.helidon.webserver.spi.ServerConnectionSelector;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -45,6 +53,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -310,211 +319,218 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
-    void interruptedExecutorShutdownStillFinishesListenerCleanup() throws Exception {
-        CountDownLatch sharedTaskStarted = new CountDownLatch(1);
-        CountDownLatch releaseSharedTask = new CountDownLatch(1);
-        CountDownLatch sharedTaskInterrupted = new CountDownLatch(1);
-        CountDownLatch sharedExecutorAwaitStarted = new CountDownLatch(1);
-        CountDownLatch forceCloseInvoked = new CountDownLatch(1);
-        AtomicReference<Throwable> stopFailure = new AtomicReference<>();
+    void activeConnectionCloseFailuresDoNotSkipRemainingConnections() throws Exception {
+        AtomicInteger firstCloseCalls = new AtomicInteger();
+        AtomicInteger secondCloseCalls = new AtomicInteger();
+        ThrowingBlockingConnection first = new ThrowingBlockingConnection(firstCloseCalls, "connection close failed");
+        ThrowingBlockingConnection second = new ThrowingBlockingConnection(secondCloseCalls, "connection close failed");
+        QueueingConnectionSelector selector = new QueueingConnectionSelector(first, second);
         LifecycleService service = new LifecycleService("default");
 
-        LoomServer server = (LoomServer) WebServer.builder()
-                .shutdownHook(false)
-                .port(0)
-                .shutdownGracePeriod(Duration.ofSeconds(30))
-                .routing(routing -> routing.register(service))
-                .build()
-                .start();
+        LoomServer server = startServer(selector, Duration.ZERO, service);
 
-        Future<?> sharedTask = null;
-        Thread stopThread = null;
-        try {
-            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
-            assertThat(listener, notNullValue());
-            listener.activeConnection("test", new CloseTrackingConnection(forceCloseInvoked));
-            listener.beforeSharedExecutorAwait(sharedExecutorAwaitStarted::countDown);
-            sharedTask = listener.executor().submit(() -> {
-                sharedTaskStarted.countDown();
-                try {
-                    releaseSharedTask.await();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    sharedTaskInterrupted.countDown();
-                    throw new IllegalStateException("shared task interrupted", e);
-                }
-            });
-            assertThat(sharedTaskStarted.await(5, TimeUnit.SECONDS), is(true));
-
-            stopThread = Thread.ofPlatform()
-                    .name("test-interrupted-stop")
-                    .start(() -> {
-                        try {
-                            server.stop();
-                        } catch (RuntimeException | Error e) {
-                            stopFailure.set(e);
-                        }
-                    });
-
-            assertThat(sharedExecutorAwaitStarted.await(5, TimeUnit.SECONDS), is(true));
-
-            stopThread.interrupt();
-            assertThat(forceCloseInvoked.await(5, TimeUnit.SECONDS), is(true));
-            assertThat(sharedTaskInterrupted.await(5, TimeUnit.SECONDS), is(true));
-            stopThread.join(TimeUnit.SECONDS.toMillis(5));
-
-            assertThat(stopThread.isAlive(), is(false));
-            assertThat(stopFailure.get(), notNullValue());
-            assertThat(containsMessage(stopFailure.get(), "Interrupted while shutting down listener executor"), is(true));
-            assertThat(server.isRunning(), is(false));
-            assertThat(service.afterStops(), is(1));
-        } finally {
-            releaseSharedTask.countDown();
-            if (sharedTask != null) {
-                sharedTask.cancel(true);
-            }
-            if (stopThread != null && stopThread.isAlive()) {
-                stopThread.interrupt();
-            }
-            stopUntilStopped(server);
-        }
-    }
-
-    @Test
-    void interruptedReaderExecutorShutdownFailsStopAndForcesShutdown() throws Exception {
-        CountDownLatch readerTaskStarted = new CountDownLatch(1);
-        CountDownLatch releaseReaderTask = new CountDownLatch(1);
-        CountDownLatch readerTaskInterrupted = new CountDownLatch(1);
-        CountDownLatch readerExecutorTerminateStarted = new CountDownLatch(1);
-        AtomicReference<Throwable> stopFailure = new AtomicReference<>();
-        LifecycleService service = new LifecycleService("default");
-
-        LoomServer server = (LoomServer) WebServer.builder()
-                .shutdownHook(false)
-                .port(0)
-                .shutdownGracePeriod(Duration.ofSeconds(30))
-                .routing(routing -> routing.register(service))
-                .build()
-                .start();
-
-        Future<?> readerTask = null;
-        Thread stopThread = null;
-        try {
-            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
-            assertThat(listener, notNullValue());
-            listener.beforeReaderExecutorTerminate(readerExecutorTerminateStarted::countDown);
-            readerTask = listener.readerTask(new BlockingReaderTask(readerTaskStarted,
-                                                                    releaseReaderTask,
-                                                                    readerTaskInterrupted));
-            assertThat(readerTaskStarted.await(5, TimeUnit.SECONDS), is(true));
-
-            stopThread = Thread.ofPlatform()
-                    .name("test-interrupted-reader-stop")
-                    .start(() -> {
-                        try {
-                            server.stop();
-                        } catch (RuntimeException | Error e) {
-                            stopFailure.set(e);
-                        }
-                    });
-
-            assertThat(readerExecutorTerminateStarted.await(5, TimeUnit.SECONDS), is(true));
-
-            stopThread.interrupt();
-            assertThat(readerTaskInterrupted.await(5, TimeUnit.SECONDS), is(true));
-            stopThread.join(TimeUnit.SECONDS.toMillis(5));
-
-            assertThat(stopThread.isAlive(), is(false));
-            assertThat(stopFailure.get(), notNullValue());
-            assertThat(containsMessage(stopFailure.get(), "Interrupted while shutting down listener reader executor"), is(true));
-            assertThat(server.isRunning(), is(false));
-            assertThat(service.afterStops(), is(1));
-        } finally {
-            releaseReaderTask.countDown();
-            if (readerTask != null) {
-                readerTask.cancel(true);
-            }
-            if (stopThread != null && stopThread.isAlive()) {
-                stopThread.interrupt();
-            }
-            stopUntilStopped(server);
-        }
-    }
-
-    @Test
-    void executorShutdownTestHookFailureDoesNotSkipForcedShutdown() throws Exception {
-        CountDownLatch sharedTaskStarted = new CountDownLatch(1);
-        CountDownLatch releaseSharedTask = new CountDownLatch(1);
-        CountDownLatch sharedTaskInterrupted = new CountDownLatch(1);
-        LifecycleService service = new LifecycleService("default");
-
-        LoomServer server = (LoomServer) WebServer.builder()
-                .shutdownHook(false)
-                .port(0)
-                .shutdownGracePeriod(Duration.ofMillis(1))
-                .routing(routing -> routing.register(service))
-                .build()
-                .start();
-
-        Future<?> sharedTask = null;
-        try {
-            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
-            assertThat(listener, notNullValue());
-            listener.beforeSharedExecutorAwait(() -> {
-                throw new IllegalStateException("before await failed");
-            });
-            sharedTask = listener.executor().submit(() -> {
-                sharedTaskStarted.countDown();
-                try {
-                    releaseSharedTask.await();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    sharedTaskInterrupted.countDown();
-                    throw new IllegalStateException("shared task interrupted", e);
-                }
-            });
-            assertThat(sharedTaskStarted.await(5, TimeUnit.SECONDS), is(true));
-
-            RuntimeException failure = assertThrows(RuntimeException.class, server::stop);
-
-            assertThat(containsMessage(failure, "before await failed"), is(true));
-            assertThat(sharedTaskInterrupted.await(5, TimeUnit.SECONDS), is(true));
-            assertThat(server.isRunning(), is(false));
-            assertThat(service.afterStops(), is(1));
-        } finally {
-            releaseSharedTask.countDown();
-            if (sharedTask != null) {
-                sharedTask.cancel(true);
-            }
-            stopUntilStopped(server);
-        }
-    }
-
-    @Test
-    void activeConnectionCloseFailuresDoNotSkipRemainingConnections() {
-        AtomicInteger closeCalls = new AtomicInteger();
-        LifecycleService service = new LifecycleService("default");
-
-        LoomServer server = (LoomServer) WebServer.builder()
-                .shutdownHook(false)
-                .port(0)
-                .routing(routing -> routing.register(service))
-                .build()
-                .start();
-
-        try {
-            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
-            assertThat(listener, notNullValue());
-            listener.activeConnection("first", new ThrowingCloseConnection(closeCalls));
-            listener.activeConnection("second", new ThrowingCloseConnection(closeCalls));
+        try (Socket firstSocket = new Socket(InetAddress.getLoopbackAddress(), server.port());
+             Socket secondSocket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            firstSocket.getOutputStream().write('x');
+            secondSocket.getOutputStream().write('x');
+            assertThat(first.awaitHandling(), is(true));
+            assertThat(second.awaitHandling(), is(true));
 
             RuntimeException failure = assertThrows(RuntimeException.class, server::stop);
 
             assertThat(containsMessage(failure, "connection close failed"), is(true));
-            assertThat(closeCalls.get(), is(4));
+            assertThat(firstCloseCalls.get(), is(2));
+            assertThat(secondCloseCalls.get(), is(2));
             assertThat(service.afterStops(), is(1));
             assertThat(server.isRunning(), is(false));
         } finally {
+            first.release();
+            second.release();
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void checkpointSuspendCloseFailuresDoNotSkipRemainingConnections() throws Exception {
+        AtomicInteger firstCloseCalls = new AtomicInteger();
+        AtomicInteger secondCloseCalls = new AtomicInteger();
+        ThrowingBlockingConnection first = new ThrowingBlockingConnection(firstCloseCalls, "connection close failed");
+        ThrowingBlockingConnection second = new ThrowingBlockingConnection(secondCloseCalls, "connection close failed");
+        QueueingConnectionSelector selector = new QueueingConnectionSelector(first, second);
+        LifecycleService service = new LifecycleService("default");
+
+        LoomServer server = startServer(selector, Duration.ZERO, service);
+
+        try (Socket firstSocket = new Socket(InetAddress.getLoopbackAddress(), server.port());
+             Socket secondSocket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            firstSocket.getOutputStream().write('x');
+            secondSocket.getOutputStream().write('x');
+            assertThat(first.awaitHandling(), is(true));
+            assertThat(second.awaitHandling(), is(true));
+
+            RuntimeException failure = assertThrows(RuntimeException.class, server::suspend);
+
+            assertThat(containsMessage(failure, "connection close failed"), is(true));
+            assertThat(firstCloseCalls.get() >= 2, is(true));
+            assertThat(secondCloseCalls.get() >= 2, is(true));
+        } finally {
+            first.release();
+            second.release();
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void gracefulShutdownClosesAcceptedSocketDuringSocketConfiguration() throws Exception {
+        BlockingSocketOptions socketOptions = new BlockingSocketOptions();
+        AtomicReference<Throwable> stopFailure = new AtomicReference<>();
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .shutdownGracePeriod(Duration.ofMinutes(1))
+                .connectionOptions(socketOptions)
+                .build()
+                .start();
+        Thread stopThread = null;
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.setSoTimeout(5_000);
+            assertThat(socketOptions.awaitConfigure(), is(true));
+
+            stopThread = Thread.ofPlatform()
+                    .name("test-graceful-socket-config-stop")
+                    .start(() -> {
+                        try {
+                            server.stop();
+                        } catch (RuntimeException | Error e) {
+                            stopFailure.set(e);
+                        }
+                    });
+
+            assertSocketClosed(socket);
+            socketOptions.release();
+            stopThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(stopThread.isAlive(), is(false));
+            assertThat(stopFailure.get(), nullValue());
+        } finally {
+            socketOptions.release();
+            if (stopThread != null && stopThread.isAlive()) {
+                stopThread.interrupt();
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void gracefulShutdownClosesAcceptedSocketBeforeConnectionRegistration() throws Exception {
+        PreRegistrationConnectionSelector selector = new PreRegistrationConnectionSelector();
+        AtomicReference<Throwable> stopFailure = new AtomicReference<>();
+        LoomServer server = startServer(selector, Duration.ofMinutes(1));
+        Thread stopThread = null;
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.setSoTimeout(5_000);
+            socket.getOutputStream().write('x');
+            assertThat(selector.awaitSupports(), is(true));
+
+            stopThread = Thread.ofPlatform()
+                    .name("test-graceful-pre-registration-stop")
+                    .start(() -> {
+                        try {
+                            server.stop();
+                        } catch (RuntimeException | Error e) {
+                            stopFailure.set(e);
+                        }
+                    });
+
+            assertSocketClosed(socket);
+            assertThat(selector.connection().handlingStarted(), is(false));
+
+            selector.release();
+            stopThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(stopThread.isAlive(), is(false));
+            assertThat(stopFailure.get(), nullValue());
+            assertThat(selector.connection().gracefulCloses(), is(0));
+            assertThat(selector.connection().forcedCloses(), is(0));
+            assertThat(selector.connection().handlingStarted(), is(false));
+        } finally {
+            selector.release();
+            selector.connection().release();
+            if (stopThread != null && stopThread.isAlive()) {
+                stopThread.interrupt();
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void forcedShutdownClosesAcceptedSocketBeforeConnectionRegistration() throws Exception {
+        PreRegistrationConnectionSelector selector = new PreRegistrationConnectionSelector();
+        LoomServer server = startServer(selector, Duration.ZERO);
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.setSoTimeout(5_000);
+            socket.getOutputStream().write('x');
+            assertThat(selector.awaitSupports(), is(true));
+
+            server.stop();
+
+            assertSocketClosed(socket);
+            assertThat(selector.connection().handlingStarted(), is(false));
+
+            selector.release();
+            assertThat(selector.connection().gracefulCloses(), is(0));
+            assertThat(selector.connection().forcedCloses(), is(0));
+            assertThat(selector.connection().handlingStarted(), is(false));
+        } finally {
+            selector.release();
+            selector.connection().release();
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void suspendClosesAcceptedSocketBeforeConnectionRegistration() throws Exception {
+        PreRegistrationConnectionSelector selector = new PreRegistrationConnectionSelector();
+        AtomicReference<Throwable> suspendFailure = new AtomicReference<>();
+        LoomServer server = startServer(selector, Duration.ZERO);
+        Thread suspendThread = null;
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.setSoTimeout(5_000);
+            socket.getOutputStream().write('x');
+            assertThat(selector.awaitSupports(), is(true));
+
+            suspendThread = Thread.ofPlatform()
+                    .name("test-suspend-pre-registration")
+                    .start(() -> {
+                        try {
+                            server.suspend();
+                        } catch (RuntimeException | Error e) {
+                            suspendFailure.set(e);
+                        }
+                    });
+
+            assertSocketClosed(socket);
+            assertThat(selector.connection().handlingStarted(), is(false));
+
+            selector.release();
+            suspendThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(suspendThread.isAlive(), is(false));
+            assertThat(suspendFailure.get(), nullValue());
+            assertThat(selector.connection().gracefulCloses(), is(0));
+            assertThat(selector.connection().forcedCloses(), is(0));
+            assertThat(selector.connection().handlingStarted(), is(false));
+        } finally {
+            selector.release();
+            selector.connection().release();
+            if (suspendThread != null && suspendThread.isAlive()) {
+                suspendThread.interrupt();
+            }
             stopUntilStopped(server);
         }
     }
@@ -546,13 +562,17 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
-    void webServerSuspendFailureStopsAllListenersAndPreservesCleanupFailure() {
+    void webServerSuspendFailureStopsAllListenersAndPreservesCleanupFailure() throws Exception {
+        ThrowingBlockingConnection connection = new ThrowingBlockingConnection(new AtomicInteger(), "suspend close failed");
+        QueueingConnectionSelector selector = new QueueingConnectionSelector(connection);
         LifecycleService defaultService = new LifecycleService("default");
         LifecycleService adminService = new LifecycleService("admin", true);
         LifecycleService monitorService = new LifecycleService("monitor");
         LoomServer server = (LoomServer) WebServer.builder()
                 .shutdownHook(false)
                 .port(0)
+                .shutdownGracePeriod(Duration.ZERO)
+                .addConnectionSelector(selector)
                 .routing(routing -> routing.register(defaultService))
                 .putSocket("admin", listener -> listener.port(0)
                         .routing(routing -> routing.register(adminService)))
@@ -561,11 +581,9 @@ class ServerListenerLifecycleTest {
                 .build()
                 .start();
 
-        try {
-            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
-            assertThat(listener, notNullValue());
-            listener.activeConnection("failing",
-                                      new ThrowingCloseConnection(new AtomicInteger(), "suspend close failed"));
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.getOutputStream().write('x');
+            assertThat(connection.awaitHandling(), is(true));
 
             RuntimeException failure = assertThrows(RuntimeException.class, server::suspend);
 
@@ -576,6 +594,7 @@ class ServerListenerLifecycleTest {
             assertThat(adminService.afterStops(), is(1));
             assertThat(monitorService.afterStops(), is(1));
         } finally {
+            connection.release();
             stopUntilStopped(server);
         }
     }
@@ -616,29 +635,6 @@ class ServerListenerLifecycleTest {
             assertThat(adminService.afterStops(), is(1));
             assertThat(monitorService.afterStops(), is(1));
             assertThat(Files.readString(socketPath), is("existing"));
-        } finally {
-            stopUntilStopped(server);
-        }
-    }
-
-    @Test
-    void shutdownHandlerStopFailureStopsAllListeners() {
-        LifecycleService defaultService = new LifecycleService("default", true);
-        LifecycleService adminService = new LifecycleService("admin", true);
-        LoomServer server = (LoomServer) WebServer.builder()
-                .port(0)
-                .routing(routing -> routing.register(defaultService))
-                .putSocket("admin", listener -> listener.port(0)
-                        .routing(routing -> routing.register(adminService)))
-                .build()
-                .start();
-
-        try {
-            server.shutdownFromShutdownHook();
-
-            assertThat(server.isRunning(), is(false));
-            assertThat(defaultService.afterStops(), is(1));
-            assertThat(adminService.afterStops(), is(1));
         } finally {
             stopUntilStopped(server);
         }
@@ -701,6 +697,14 @@ class ServerListenerLifecycleTest {
         }
     }
 
+    private static void assertSocketClosed(Socket socket) throws Exception {
+        try {
+            assertThat(socket.getInputStream().read(), is(-1));
+        } catch (SocketException _) {
+            // A reset socket is closed from the client perspective.
+        }
+    }
+
     private static int awaitPort(WebServer server, String socketName) throws Exception {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
         int port;
@@ -714,9 +718,193 @@ class ServerListenerLifecycleTest {
         return port;
     }
 
-    private record CloseTrackingConnection(CountDownLatch forceCloseInvoked) implements ServerConnection {
+    private static LoomServer startServer(ServerConnectionSelector selector, Duration shutdownGracePeriod) {
+        return (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .shutdownGracePeriod(shutdownGracePeriod)
+                .addConnectionSelector(selector)
+                .build()
+                .start();
+    }
+
+    private static LoomServer startServer(ServerConnectionSelector selector,
+                                          Duration shutdownGracePeriod,
+                                          LifecycleService service) {
+        return (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .shutdownGracePeriod(shutdownGracePeriod)
+                .addConnectionSelector(selector)
+                .routing(routing -> routing.register(service))
+                .build()
+                .start();
+    }
+
+    private static final class BlockingSocketOptions implements SocketOptions {
+        private final SocketOptions delegate = SocketOptions.create();
+        private final CountDownLatch configureEntered = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+
+        @Override
+        public void configureSocket(SocketChannel socket) {
+            configureEntered.countDown();
+            while (release.getCount() != 0) {
+                try {
+                    release.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts to prove shutdown closes the accepted socket.
+                }
+            }
+            delegate.configureSocket(socket);
+        }
+
+        @Override
+        public Map<SocketOption<?>, Object> socketOptions() {
+            return delegate.socketOptions();
+        }
+
+        @Override
+        public Duration connectTimeout() {
+            return delegate.connectTimeout();
+        }
+
+        @Override
+        public Duration readTimeout() {
+            return delegate.readTimeout();
+        }
+
+        @Override
+        public Optional<Integer> socketReceiveBufferSize() {
+            return delegate.socketReceiveBufferSize();
+        }
+
+        @Override
+        public Optional<Integer> socketSendBufferSize() {
+            return delegate.socketSendBufferSize();
+        }
+
+        @Override
+        public boolean socketReuseAddress() {
+            return delegate.socketReuseAddress();
+        }
+
+        @Override
+        public boolean socketKeepAlive() {
+            return delegate.socketKeepAlive();
+        }
+
+        @Override
+        public boolean tcpNoDelay() {
+            return delegate.tcpNoDelay();
+        }
+
+        private boolean awaitConfigure() throws InterruptedException {
+            return configureEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        private void release() {
+            release.countDown();
+        }
+    }
+
+    private static final class QueueingConnectionSelector implements ServerConnectionSelector {
+        private final ServerConnection[] connections;
+        private final AtomicInteger index = new AtomicInteger();
+
+        private QueueingConnectionSelector(ServerConnection... connections) {
+            this.connections = connections;
+        }
+
+        @Override
+        public int bytesToIdentifyConnection() {
+            return 0;
+        }
+
+        @Override
+        public Support supports(BufferData data) {
+            return Support.SUPPORTED;
+        }
+
+        @Override
+        public Set<String> supportedApplicationProtocols() {
+            return Set.of("test-queueing");
+        }
+
+        @Override
+        public ServerConnection connection(ConnectionContext ctx) {
+            int current = index.getAndIncrement();
+            if (current >= connections.length) {
+                return connections[connections.length - 1];
+            }
+            return connections[current];
+        }
+    }
+
+    private static final class PreRegistrationConnectionSelector implements ServerConnectionSelector {
+        private final CountDownLatch supportsEntered = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+        private final BlockingConnection connection = new BlockingConnection();
+
+        @Override
+        public int bytesToIdentifyConnection() {
+            return 0;
+        }
+
+        @Override
+        public Support supports(BufferData data) {
+            supportsEntered.countDown();
+            while (release.getCount() != 0) {
+                try {
+                    release.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts to prove shutdown closes the accepted socket.
+                }
+            }
+            return Support.SUPPORTED;
+        }
+
+        @Override
+        public Set<String> supportedApplicationProtocols() {
+            return Set.of("test-pre-registration");
+        }
+
+        @Override
+        public ServerConnection connection(ConnectionContext ctx) {
+            return connection;
+        }
+
+        private boolean awaitSupports() throws InterruptedException {
+            return supportsEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        private void release() {
+            release.countDown();
+        }
+
+        private BlockingConnection connection() {
+            return connection;
+        }
+    }
+
+    private static final class BlockingConnection implements ServerConnection {
+        private final CountDownLatch handling = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+        private final AtomicInteger gracefulCloses = new AtomicInteger();
+        private final AtomicInteger forcedCloses = new AtomicInteger();
+
         @Override
         public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+            handling.countDown();
+            while (release.getCount() != 0) {
+                try {
+                    release.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts so shutdown must close the connection.
+                }
+            }
         }
 
         @Override
@@ -727,18 +915,50 @@ class ServerListenerLifecycleTest {
         @Override
         public void close(boolean interrupt) {
             if (interrupt) {
-                forceCloseInvoked.countDown();
+                forcedCloses.incrementAndGet();
+            } else {
+                gracefulCloses.incrementAndGet();
             }
+        }
+
+        private boolean handlingStarted() {
+            return handling.getCount() == 0;
+        }
+
+        private int gracefulCloses() {
+            return gracefulCloses.get();
+        }
+
+        private int forcedCloses() {
+            return forcedCloses.get();
+        }
+
+        private void release() {
+            release.countDown();
         }
     }
 
-    private record ThrowingCloseConnection(AtomicInteger closeCalls, String message) implements ServerConnection {
-        private ThrowingCloseConnection(AtomicInteger closeCalls) {
-            this(closeCalls, "connection close failed");
+    private static final class ThrowingBlockingConnection implements ServerConnection {
+        private final CountDownLatch handling = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+        private final AtomicInteger closeCalls;
+        private final String message;
+
+        private ThrowingBlockingConnection(AtomicInteger closeCalls, String message) {
+            this.closeCalls = closeCalls;
+            this.message = message;
         }
 
         @Override
         public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+            handling.countDown();
+            while (release.getCount() != 0) {
+                try {
+                    release.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts so shutdown must close the connection.
+                }
+            }
         }
 
         @Override
@@ -751,27 +971,13 @@ class ServerListenerLifecycleTest {
             closeCalls.incrementAndGet();
             throw new IllegalStateException(message);
         }
-    }
 
-    private record BlockingReaderTask(CountDownLatch started,
-                                      CountDownLatch release,
-                                      CountDownLatch interrupted) implements InterruptableTask<Void> {
-        @Override
-        public boolean canInterrupt() {
-            return false;
+        private boolean awaitHandling() throws InterruptedException {
+            return handling.await(5, TimeUnit.SECONDS);
         }
 
-        @Override
-        public Void call() throws Exception {
-            started.countDown();
-            try {
-                release.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                interrupted.countDown();
-                throw e;
-            }
-            return null;
+        private void release() {
+            release.countDown();
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -574,6 +574,9 @@ class ServerListenerLifecycleTest {
 
             assertThat(suspendThread.isAlive(), is(false));
             assertThat(suspendFailure.get(), nullValue());
+            waitFor(Duration.ofSeconds(5),
+                    () -> selector.connection().forcedCloses() == 1,
+                    "accepted connection was not force closed");
             assertThat(selector.connection().gracefulCloses(), is(0));
             assertThat(selector.connection().forcedCloses(), is(1));
             assertThat(selector.connection().handlingStarted(), is(false));

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerSuspendTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerSuspendTest.java
@@ -17,12 +17,14 @@
 package io.helidon.webserver;
 
 import java.net.Socket;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +48,10 @@ class ServerListenerSuspendTest {
         try {
             stalledConnection = new Socket("127.0.0.1", server.port());
             queuedConnection = new Socket("127.0.0.1", server.port());
+
+            waitFor(Duration.ofSeconds(5),
+                    () -> server.listenerThreadState(WebServer.DEFAULT_SOCKET_NAME) == Thread.State.TIMED_WAITING,
+                    "listener did not block on the TCP connection limit");
 
             Future<?> suspendFuture = executor.submit(server::suspend);
             try {
@@ -88,6 +94,17 @@ class ServerListenerSuspendTest {
             throw error;
         }
         return e;
+    }
+
+    private static void waitFor(Duration timeout, BooleanSupplier condition, String message) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        fail(message);
     }
 
     private static void closeQuietly(Socket socket) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerSuspendTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerSuspendTest.java
@@ -17,14 +17,12 @@
 package io.helidon.webserver;
 
 import java.net.Socket;
-import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.BooleanSupplier;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,14 +44,8 @@ class ServerListenerSuspendTest {
         boolean suspended = false;
 
         try {
-            ServerListener listener = server.listener(WebServer.DEFAULT_SOCKET_NAME);
-            Thread listenerThread = listener.serverThreads();
             stalledConnection = new Socket("127.0.0.1", server.port());
             queuedConnection = new Socket("127.0.0.1", server.port());
-
-            waitFor(Duration.ofSeconds(5),
-                    () -> listenerThread.getState() == Thread.State.TIMED_WAITING,
-                    "listener did not block on the TCP connection limit");
 
             Future<?> suspendFuture = executor.submit(server::suspend);
             try {
@@ -96,17 +88,6 @@ class ServerListenerSuspendTest {
             throw error;
         }
         return e;
-    }
-
-    private static void waitFor(Duration timeout, BooleanSupplier condition, String message) throws InterruptedException {
-        long deadline = System.nanoTime() + timeout.toNanos();
-        while (System.nanoTime() < deadline) {
-            if (condition.getAsBoolean()) {
-                return;
-            }
-            Thread.sleep(10);
-        }
-        fail(message);
     }
 
     private static void closeQuietly(Socket socket) {


### PR DESCRIPTION
Resolves #11938

Fixes shutdown handling for sockets accepted by WebServer before protocol connection registration, routing listener lifecycle and idle-timeout handling through the connection handler.
