### PR TITLE
Fix Configured config key Javadoc (4.x)

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Option.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Option.java
@@ -39,7 +39,7 @@ public final class Option {
     public @interface Configured {
         /**
          * Override "guessed" configuration key.
-         * The configuration key is the method name converted to snake case by default.
+         * The configuration key is the method name converted to kebab-case by default.
          *
          * @return custom configuration key
          */


### PR DESCRIPTION
Resolves #11876

Updates the `Option.Configured#value()` Javadoc so it describes the generated default configuration key as kebab-case, matching the builder codegen behavior.
