### PR TITLE
Fix smart socket writer (main)

### DIFF
--- a/common/socket/src/main/java/io/helidon/common/socket/SmartSocketWriter.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/SmartSocketWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package io.helidon.common.socket;
 
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
 
@@ -24,12 +28,26 @@ import io.helidon.common.buffers.BufferData;
  * A special socket write that starts async but may switch to sync mode if it
  * detects that the async queue size is below {@link #QUEUE_SIZE_THRESHOLD}.
  * If it switches to sync mode, it shall never return back to async mode.
+ *
+ * Regular {@link #write(BufferData)} initially enqueues data so callers usually avoid direct
+ * socket writes while the queue has capacity. If the async queue stays mostly empty, the writer
+ * switches to synchronous writes to avoid the queueing and executor handoff cost on low-contention
+ * connections.
  */
 public class SmartSocketWriter extends SocketWriter {
     private static final long WINDOW_SIZE = 1000;
     private static final double QUEUE_SIZE_THRESHOLD = 2.0;
 
+    // Owned async writer. Smart close must close this writer because the base close is a no-op.
     private final SocketWriterAsync asyncWriter;
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    /*
+     * Serializes SmartSocketWriter entry points. This is required after switching to sync mode
+     * because direct socket writes use mutable staging buffers that must not be entered concurrently.
+     */
+    private final Lock writeLock = new ReentrantLock();
+
     private volatile long windowIndex;
     private volatile boolean asyncMode;
 
@@ -49,14 +67,97 @@ public class SmartSocketWriter extends SocketWriter {
 
     @Override
     public void write(BufferData buffer) {
-        if (asyncMode) {
+        Objects.requireNonNull(buffer);
+        writeLock.lock();
+        try {
+            checkOpen();
+            if (!asyncMode) {
+                // Sync mode intentionally bypasses the async writer, but remains serialized by writeLock.
+                super.writeNow(buffer);       // blocking write
+                return;
+            }
+
             asyncWriter.write(buffer);
             if (++windowIndex % WINDOW_SIZE == 0 && asyncWriter.avgQueueSize() < QUEUE_SIZE_THRESHOLD) {
+                // Drain accepted async writes before publishing the one-way transition to sync mode.
+                asyncWriter.flush();
+                checkOpen();
                 asyncMode = false;
             }
-        } else {
-            asyncWriter.drainQueue();
-            writeNow(buffer);       // blocking write
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void writeNow(BufferData buffer) {
+        Objects.requireNonNull(buffer);
+        writeLock.lock();
+        try {
+            checkOpen();
+            if (!asyncMode) {
+                super.writeNow(buffer);
+                return;
+            }
+
+            // In async mode writeNow waits behind queued/in-flight async writes and preserves ordering.
+            asyncWriter.writeNow(buffer);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void flush() {
+        checkOpen();
+        if (!asyncMode) {
+            return;
+        }
+
+        writeLock.lock();
+        try {
+            checkOpen();
+            if (asyncMode) {
+                // Flush must wait for queued async writes before returning to DataWriter callers.
+                asyncWriter.flush();
+                checkOpen();
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            // Closing the owned async writer wakes blocked producers and attempts to stop the writer thread.
+            asyncWriter.close();
+        }
+    }
+
+    // Intended for deterministic tests of sync-mode close behavior.
+    void switchToSyncMode() {
+        asyncMode = false;
+    }
+
+    // Intended for deterministic tests of full-queue producer sequencing.
+    void beforeWriteQueueAwait(Runnable hook) {
+        asyncWriter.beforeWriteQueueAwait(hook);
+    }
+
+    // Intended for deterministic tests of async flush sequencing.
+    void beforeFlushAwait(Runnable hook) {
+        asyncWriter.beforeFlushAwait(hook);
+    }
+
+    // Intended for deterministic tests of smart-mode transition.
+    boolean asyncMode() {
+        return asyncMode;
+    }
+
+    private void checkOpen() {
+        if (closed.get()) {
+            throw new SocketWriterException();
         }
     }
 }

--- a/common/socket/src/main/java/io/helidon/common/socket/SocketWriterAsync.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/SocketWriterAsync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 
 package io.helidon.common.socket;
 
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.CompositeBufferData;
@@ -29,19 +34,55 @@ import io.helidon.common.buffers.DataWriter;
 /**
  * Socket writer (possibly) used from multiple threads, takes care of writing to a single
  * socket.
+ *
+ * The writer has two write paths:
+ * <ul>
+ *     <li>{@link #write(BufferData)} enqueues data for later draining.</li>
+ *     <li>{@link #writeNow(BufferData)} and {@link #flush()} drain queued data on the caller thread.</li>
+ * </ul>
+ * The caller-thread flush path is intentional: when the caller and writer use the same executor,
+ * waiting for the writer thread to flush could deadlock under saturation or reentrant use.
  */
 class SocketWriterAsync extends SocketWriter implements DataWriter {
-    private static final System.Logger LOGGER = System.getLogger(SocketWriterAsync.class.getName());
-    private static final BufferData CLOSING_TOKEN = BufferData.empty();
+    private static final Runnable EMPTY_RUNNABLE = () -> { };
+    private static final long CLOSE_TIMEOUT_MILLIS = 1000;
+    private static final int MAX_BATCH_SIZE = 1000;
+    private static final long WRITE_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(10);
 
     private final ExecutorService executor;
-    private final ArrayBlockingQueue<BufferData> writeQueue;
+    private final Deque<BufferData> writeQueue;
+    private final BufferData[] writeBatch;
+    private final int writeQueueLength;
     private final CountDownLatch cdl = new CountDownLatch(1);
     private final AtomicBoolean started = new AtomicBoolean(false);
+
+    /*
+     * All queue state is protected by stateLock. The conditions split the common waits:
+     * - notEmpty wakes the writer thread when producers enqueue data.
+     * - notFull wakes blocked producers when a batch is drained.
+     * - idle wakes either side when an active socket write or flush finishes.
+     */
+    private final Lock stateLock = new ReentrantLock();
+    private final Condition notEmpty = stateLock.newCondition();
+    private final Condition notFull = stateLock.newCondition();
+    private final Condition idle = stateLock.newCondition();
+
+    // Test hooks used to block at deterministic points without exposing production state.
+    private volatile Runnable beforeCloseAwait = EMPTY_RUNNABLE;
+    private volatile Runnable beforeFlushAwait = EMPTY_RUNNABLE;
+    private volatile Runnable beforeWriteQueueAwait = EMPTY_RUNNABLE;
+
+    // Failure and lifecycle fields are read from paths that may not hold stateLock.
     private volatile Throwable caught;
     private volatile boolean run = true;
-    private Thread thread;
-    private double avgQueueSize;
+    private volatile Thread thread;
+    private volatile double avgQueueSize;
+
+    // Guarded by stateLock. Exactly one thread may be writing to the socket at a time.
+    private boolean writing;
+
+    // Guarded by stateLock. While true, producers wait so later writes cannot overtake flush/writeNow.
+    private boolean flushing;
 
     /**
      * A new socket writer.
@@ -54,7 +95,9 @@ class SocketWriterAsync extends SocketWriter implements DataWriter {
     SocketWriterAsync(ExecutorService executor, HelidonSocket socket, int writeQueueLength) {
         super(socket);
         this.executor = executor;
-        this.writeQueue = new ArrayBlockingQueue<>(writeQueueLength);
+        this.writeQueue = new ArrayDeque<>(writeQueueLength);
+        this.writeBatch = new BufferData[Math.min(writeQueueLength, MAX_BATCH_SIZE)];
+        this.writeQueueLength = writeQueueLength;
     }
 
     @Override
@@ -66,94 +109,347 @@ class SocketWriterAsync extends SocketWriter implements DataWriter {
 
     @Override
     public void write(BufferData buffer) {
-        checkRunning();
+        Objects.requireNonNull(buffer);
+        long remaining = WRITE_TIMEOUT_NANOS;
+
+        // Start outside stateLock so executor submission cannot block queue state progress.
+        startWriterIfNeeded();
         try {
-            if (!writeQueue.offer(buffer, 10, TimeUnit.SECONDS)) {
+            stateLock.lockInterruptibly();
+            try {
                 checkRunning();
-                throw new IllegalStateException("Failed to write data to queue, timed out");
+
+                // Producers that observe an active flush wait so they do not overtake the flush/writeNow path.
+                while (caught == null && run && flushing) {
+                    idle.await();
+                    checkRunning();
+                }
+
+                // Apply bounded backpressure when the queue is full.
+                while (writeQueue.size() == writeQueueLength) {
+                    checkRunning();
+                    beforeWriteQueueAwait.run();
+                    remaining = notFull.awaitNanos(remaining);
+                    if (remaining > 0) {
+                        continue;
+                    }
+                    checkRunning();
+                    throw new IllegalStateException("Failed to write data to queue, timed out");
+                }
+                checkRunning();
+                writeQueue.add(buffer);
+                notEmpty.signal();
+            } finally {
+                stateLock.unlock();
             }
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted while trying to write to a queue", e);
         }
     }
 
-    /**
-     * Close this writer. Will attempt to write all enqueued buffers and will stop the thread if created.
-     */
-    public void close() {
-        run = false;
-        if (!started.get()) {
-            // thread never started
-            return;
-        }
+    @Override
+    public void writeNow(BufferData buffer) {
+        flush(Objects.requireNonNull(buffer));
+    }
+
+    @Override
+    public void flush() {
+        flush(null);
+    }
+
+    private void flush(BufferData current) {
+        boolean currentPending = current != null;
+        boolean runHook = true;
+        boolean flushStarted = false;
         try {
-            writeQueue.put(CLOSING_TOKEN); // wake up blocked take() operation
-            if (cdl.await(1000, TimeUnit.MILLISECONDS)) {
-                // reads finished because we set run to false
-                BufferData available;
-                while ((available = writeQueue.poll()) != null) {
+            while (true) {
+                int queueSize;
+                stateLock.lockInterruptibly();
+                try {
+                    // Nothing has ever been scheduled and there is no current writeNow buffer.
+                    if (!flushStarted && !currentPending && !started.get() && !writing && writeQueue.isEmpty()) {
+                        return;
+                    }
+                    if (!flushStarted) {
+                        // Only one caller-thread flush can own the queue at a time.
+                        while (caught == null && run && flushing) {
+                            idle.await();
+                        }
+                        checkRunning();
+                        flushing = true;
+                        flushStarted = true;
+                    }
+                    if (runHook) {
+                        beforeFlushAwait.run();
+                        runHook = false;
+                    }
+
+                    // Do not write to the socket concurrently with the writer thread or another flush iteration.
+                    while (caught == null && run && writing) {
+                        idle.await();
+                    }
+                    checkRunning();
+
+                    /*
+                     * Queue contents always go first. For writeNow(current), this preserves FIFO ordering for queued
+                     * data and for producers that were already waiting for queue capacity before this flush started.
+                     */
+                    if (!writeQueue.isEmpty()) {
+                        queueSize = drainBatch(writeBatch.length);
+                    } else if (currentPending) {
+                        writeBatch[0] = current;
+                        currentPending = false;
+                        queueSize = 1;
+                    } else {
+                        return;
+                    }
+
+                    // The lock is released while writing to the socket, but the writing flag keeps other writers out.
+                    writing = true;
+                } finally {
+                    stateLock.unlock();
+                }
+
+                try {
+                    writeBatch(queueSize);
+                } catch (Throwable e) {
+                    fail(e);
+                    throw socketWriterException();
+                } finally {
+                    stateLock.lock();
                     try {
-                        writeNow(available);
-                    } catch (Exception e) {
-                        LOGGER.log(System.Logger.Level.TRACE, "Failed to write last buffers during writer shutdown", e);
-                        // in case we fail to write to socket when closing, it is probably because it is already closed
-                        // we still need to release all buffers
+                        writing = false;
+                        idle.signalAll();
+                    } finally {
+                        stateLock.unlock();
                     }
                 }
             }
-            if (thread != null) {
-                // fail blocked writers
-                thread.interrupt();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while trying to flush queued writes", e);
+        } finally {
+            if (flushStarted) {
+                stateLock.lock();
+                try {
+                    // Release producers and the writer thread after the caller-thread flush is fully done.
+                    flushing = false;
+                    idle.signalAll();
+                } finally {
+                    stateLock.unlock();
+                }
             }
-        } catch (InterruptedException e) {            // failed to get
+        }
+    }
+
+    /**
+     * Close this writer, wake blocked waiters, and stop the writer thread if created.
+     * Queued buffers may be discarded during close.
+     */
+    public void close() {
+        boolean threadStarted;
+        stateLock.lock();
+        try {
+            // Stop accepting new data and wake blocked producers, flushers, and the writer so they can observe close.
+            run = false;
+            threadStarted = started.get();
+            notEmpty.signalAll();
+            notFull.signalAll();
+            idle.signalAll();
+        } finally {
+            stateLock.unlock();
+        }
+        if (!threadStarted) {
+            // thread never started
+            return;
         }
 
+        try {
+            beforeCloseAwait.run();
+            boolean stopped = cdl.await(CLOSE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            if (!stopped) {
+                // The socket may be stuck in I/O; interrupt and discard buffers instead of blocking close forever.
+                interruptWriter();
+                discardQueue();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            interruptWriter();
+            discardQueue();
+        }
+
+    }
+
+    // Intended for deterministic tests of close sequencing.
+    void beforeCloseAwait(Runnable hook) {
+        this.beforeCloseAwait = Objects.requireNonNull(hook);
+    }
+
+    // Intended for deterministic tests of flush sequencing.
+    void beforeFlushAwait(Runnable hook) {
+        this.beforeFlushAwait = Objects.requireNonNull(hook);
+    }
+
+    // Intended for deterministic tests of full-queue producer sequencing.
+    void beforeWriteQueueAwait(Runnable hook) {
+        this.beforeWriteQueueAwait = Objects.requireNonNull(hook);
+    }
+
+    private void interruptWriter() {
+        Thread currentThread = thread;
+        if (currentThread != null) {
+            currentThread.interrupt();
+        }
+    }
+
+    private boolean writeNextQueued() throws InterruptedException {
+        int queueSize;
+
+        stateLock.lockInterruptibly();
+        try {
+            // The background writer yields to caller-thread flush/writeNow so those calls can make progress.
+            while (writeQueue.isEmpty() || writing || flushing) {
+                if (!run) {
+                    return false;
+                }
+                if (writing || flushing) {
+                    idle.await();
+                } else {
+                    notEmpty.await();
+                }
+            }
+
+            queueSize = drainBatch(writeBatch.length);
+
+            // The actual socket write happens outside stateLock; this flag keeps all other writers out.
+            writing = true;
+        } finally {
+            stateLock.unlock();
+        }
+
+        try {
+            writeBatch(queueSize);
+            return true;
+        } catch (Throwable e) {
+            fail(e);
+            return false;
+        } finally {
+            stateLock.lock();
+            try {
+                writing = false;
+                idle.signalAll();
+            } finally {
+                stateLock.unlock();
+            }
+        }
+    }
+
+    private void fail(Throwable e) {
+        stateLock.lock();
+        try {
+            // Record the terminal failure and wake every waiter so they all observe it.
+            this.caught = e;
+            this.run = false;
+            notEmpty.signalAll();
+            notFull.signalAll();
+            idle.signalAll();
+        } finally {
+            stateLock.unlock();
+        }
     }
 
     private void run() {
         this.thread = Thread.currentThread();
         this.thread.setName("[" + socket().socketId() + " " + socket().childSocketId() + "]");
         try {
-            while (run) {
-                CompositeBufferData toWrite = BufferData.createComposite(writeQueue.take());  // wait if the queue is empty
-                // we only want to read a certain amount of data, if somebody writes huge amounts
-                // we could spin here forever and run out of memory
-                int queueSize = 1;
-                for (; queueSize <= 1000; queueSize++) {
-                    BufferData newBuf = writeQueue.poll(); // drain ~all elements from the queue, don't wait.
-                    if (newBuf == null) {
-                        break;
-                    }
-                    toWrite.add(newBuf);
-                }
-                writeNow(toWrite);
-                avgQueueSize = (avgQueueSize + queueSize) / 2.0;
+            // Drain queued writes until close or failure tells writeNextQueued to stop.
+            while (writeNextQueued()) {
             }
-            cdl.countDown();
         } catch (Throwable e) {
-            this.caught = e;
-            this.run = false;
+            fail(e);
+        } finally {
+            // Drop queued buffer references on any terminal exit, including close and failed socket writes.
+            discardQueue();
+            cdl.countDown();
         }
     }
 
     private void checkRunning() {
-        if (started.compareAndSet(false, true)) {
-            // start writer on first asynchronous write
-            executor.submit(this::run);
-        }
         if (!run) {
-            throw new SocketWriterException(caught);
+            throw socketWriterException();
         }
     }
 
-    void drainQueue() {
-        BufferData buffer;
-        while ((buffer = writeQueue.poll()) != null) {
-            writeNow(buffer);
+    private SocketWriterException socketWriterException() {
+        Throwable failure = caught;
+        return failure == null ? new SocketWriterException() : new SocketWriterException(failure);
+    }
+
+    private void startWriterIfNeeded() {
+        if (started.compareAndSet(false, true)) {
+            try {
+                // start writer on first asynchronous write
+                executor.submit(this::run);
+            } catch (RuntimeException e) {
+                fail(e);
+                cdl.countDown();
+                throw e;
+            }
         }
     }
 
     double avgQueueSize() {
         return avgQueueSize;
+    }
+
+    // Intended for deterministic tests of close cleanup.
+    int queuedBufferCount() {
+        stateLock.lock();
+        try {
+            return writeQueue.size();
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    private void signalNotFull(int slots) {
+        for (int i = 0; i < slots; i++) {
+            notFull.signal();
+        }
+    }
+
+    private int drainBatch(int maxSize) {
+        // Caller must hold stateLock.
+        int queueSize = 0;
+        while (queueSize < maxSize && !writeQueue.isEmpty()) {
+            writeBatch[queueSize++] = writeQueue.remove();
+        }
+        signalNotFull(queueSize);
+        return queueSize;
+    }
+
+    private void writeBatch(int queueSize) {
+        // Caller must have reserved the socket write by setting writing=true.
+        CompositeBufferData toWrite = BufferData.createComposite(writeBatch[0]);
+        writeBatch[0] = null;
+        for (int i = 1; i < queueSize; i++) {
+            toWrite.add(writeBatch[i]);
+            writeBatch[i] = null;
+        }
+        super.writeNow(toWrite);
+        avgQueueSize = (avgQueueSize + queueSize) / 2.0;
+    }
+
+    private void discardQueue() {
+        stateLock.lock();
+        try {
+            // Clearing the queue drops references and unblocks producers.
+            writeQueue.clear();
+            notFull.signalAll();
+            idle.signalAll();
+        } finally {
+            stateLock.unlock();
+        }
     }
 }

--- a/common/socket/src/main/java/io/helidon/common/socket/SocketWriterException.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/SocketWriterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,26 @@
 
 package io.helidon.common.socket;
 
+import java.util.Objects;
+
 /**
  * Socket write failed.
  */
 public class SocketWriterException extends RuntimeException {
+    private static final long serialVersionUID = -7500193395790009086L;
+
+    /**
+     * Socket write failed.
+     */
+    public SocketWriterException() {
+    }
+
     /**
      * Socket write failed.
      *
-     * @param cause original throwable
+     * @param cause original throwable, must not be {@code null}
      */
     public SocketWriterException(Throwable cause) {
-        super(cause);
+        super(Objects.requireNonNull(cause));
     }
 }

--- a/common/socket/src/test/java/io/helidon/common/socket/SocketWriterTest.java
+++ b/common/socket/src/test/java/io/helidon/common/socket/SocketWriterTest.java
@@ -1,0 +1,808 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.socket;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import io.helidon.common.buffers.BufferData;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SocketWriterTest {
+
+    @Test
+    void smartWriterCloseStopsAsyncWriter() throws InterruptedException {
+        AtomicReference<Thread> writerThread = new AtomicReference<>();
+        ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "smart-socket-writer-test");
+            writerThread.set(thread);
+            return thread;
+        });
+        TestSocket socket = new TestSocket(false);
+        SocketWriter writer = SocketWriter.create(executor, socket.socket(), 2, true);
+
+        try {
+            writer.write(BufferData.create(new byte[] {1}));
+
+            assertThat("Initial async write did not complete", socket.awaitFirstWrite(), is(true));
+            assertThat(writerThread.get(), notNullValue());
+
+            writer.close();
+            executor.shutdown();
+
+            assertThat("Smart writer close did not stop the async writer",
+                       executor.awaitTermination(1, TimeUnit.SECONDS),
+                       is(true));
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncWriterCloseFlushesQueuedBuffers() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "async-writer-test"));
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "close-test"));
+        TestSocket socket = new TestSocket(true);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+        CountDownLatch closeWaiting = new CountDownLatch(1);
+        Future<?> close;
+
+        try {
+            writer.beforeCloseAwait(closeWaiting::countDown);
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+            writer.write(BufferData.create(new byte[] {2}));
+
+            close = closeExecutor.submit(writer::close);
+            assertThat("Close did not wait for the current async write",
+                       closeWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+
+            socket.releaseFirstWrite();
+            close.get(2, TimeUnit.SECONDS);
+
+            assertThat(socket.writtenBytes(), is(new byte[] {1, 2}));
+            assertThat(socket.writeThreadNames(), contains("[test child]", "[test child]"));
+        } finally {
+            socket.releaseFirstWrite();
+            closeExecutor.shutdownNow();
+            executor.shutdownNow();
+            closeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncWriterCloseDiscardsQueuedBuffersWhenWriterDoesNotStop() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(true);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+
+        try {
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+            writer.write(BufferData.create(new byte[] {2}));
+            writer.write(BufferData.create(new byte[] {3}));
+
+            writer.close();
+
+            assertThat("Close did not discard queued buffers after timeout", writer.queuedBufferCount(), is(0));
+        } finally {
+            socket.releaseFirstWrite();
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncWriterCloseFlushesFullQueueWhenCurrentWriteCompletes() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(true);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+        CountDownLatch closeWaiting = new CountDownLatch(1);
+        Future<?> close;
+
+        try {
+            writer.beforeCloseAwait(closeWaiting::countDown);
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+            writer.write(BufferData.create(new byte[] {2}));
+            writer.write(BufferData.create(new byte[] {3}));
+
+            close = closeExecutor.submit(writer::close);
+            assertThat("Close did not wait for the current async write",
+                       closeWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+
+            socket.releaseFirstWrite();
+            close.get(2, TimeUnit.SECONDS);
+
+            assertThat(socket.writtenBytes(), is(new byte[] {1, 2, 3}));
+        } finally {
+            socket.releaseFirstWrite();
+            closeExecutor.shutdownNow();
+            executor.shutdownNow();
+            closeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void smartWriterCloseDoesNotBlockWhenQueueIsFull() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(true);
+        SocketWriter writer = SocketWriter.create(executor, socket.socket(), 2, true);
+        Future<?> close;
+
+        try {
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+            writer.write(BufferData.create(new byte[] {2}));
+            writer.write(BufferData.create(new byte[] {3}));
+
+            close = closeExecutor.submit(writer::close);
+
+            close.get(2, TimeUnit.SECONDS);
+            executor.shutdown();
+
+            assertThat("Smart writer close did not stop the async writer after a full queue",
+                       executor.awaitTermination(1, TimeUnit.SECONDS),
+                       is(true));
+        } finally {
+            socket.releaseFirstWrite();
+            closeExecutor.shutdownNow();
+            executor.shutdownNow();
+            closeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncWriterWriteFailsWhenCloseWinsBlockedProducerRace() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService producerExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(true);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+        CountDownLatch producerWaiting = new CountDownLatch(1);
+        Future<?> blockedWrite;
+
+        try {
+            writer.beforeWriteQueueAwait(producerWaiting::countDown);
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+            writer.write(BufferData.create(new byte[] {2}));
+            writer.write(BufferData.create(new byte[] {3}));
+
+            blockedWrite = producerExecutor.submit(() -> writer.write(BufferData.create(new byte[] {4})));
+            assertThat("Producer write did not block behind the full queue",
+                       producerWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+
+            closeExecutor.submit(writer::close).get(2, TimeUnit.SECONDS);
+
+            ExecutionException e = assertThrows(ExecutionException.class, () -> blockedWrite.get(2, TimeUnit.SECONDS));
+            assertThat(e.getCause(), instanceOf(SocketWriterException.class));
+            assertThat(socket.writtenBytes(), is(BufferData.EMPTY_BYTES));
+        } finally {
+            socket.releaseFirstWrite();
+            closeExecutor.shutdownNow();
+            producerExecutor.shutdownNow();
+            executor.shutdownNow();
+            closeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            producerExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void smartWriterWriteFailsWhenCloseWinsBlockedProducerRace() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService producerExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(true);
+        SmartSocketWriter writer = new SmartSocketWriter(executor, socket.socket(), 2);
+        CountDownLatch producerWaiting = new CountDownLatch(1);
+        Future<?> blockedWrite;
+
+        try {
+            writer.beforeWriteQueueAwait(producerWaiting::countDown);
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+            writer.write(BufferData.create(new byte[] {2}));
+            writer.write(BufferData.create(new byte[] {3}));
+
+            blockedWrite = producerExecutor.submit(() -> writer.write(BufferData.create(new byte[] {4})));
+            assertThat("Smart producer write did not block behind the full queue",
+                       producerWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+
+            closeExecutor.submit(writer::close).get(2, TimeUnit.SECONDS);
+
+            ExecutionException e = assertThrows(ExecutionException.class, () -> blockedWrite.get(2, TimeUnit.SECONDS));
+            assertThat(e.getCause(), instanceOf(SocketWriterException.class));
+            assertThat(socket.writtenBytes(), is(BufferData.EMPTY_BYTES));
+        } finally {
+            socket.releaseFirstWrite();
+            closeExecutor.shutdownNow();
+            producerExecutor.shutdownNow();
+            executor.shutdownNow();
+            closeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            producerExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncWriterCloseInterruptionStopsAsyncWriter() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(true);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+        CountDownLatch closeWaiting = new CountDownLatch(1);
+        Future<?> close;
+
+        try {
+            writer.beforeCloseAwait(closeWaiting::countDown);
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+
+            close = closeExecutor.submit(writer::close);
+            assertThat("Close did not start waiting for the async writer",
+                       closeWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+
+            close.cancel(true);
+            closeExecutor.shutdown();
+            executor.shutdown();
+
+            assertThat("Interrupted close did not finish",
+                       closeExecutor.awaitTermination(1, TimeUnit.SECONDS),
+                       is(true));
+            assertThat("Interrupted close did not stop the async writer",
+                       executor.awaitTermination(1, TimeUnit.SECONDS),
+                       is(true));
+        } finally {
+            socket.releaseFirstWrite();
+            closeExecutor.shutdownNow();
+            executor.shutdownNow();
+            closeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void smartWriterCloseDoesNotWaitForSyncWrite() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService writeExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(true);
+        SmartSocketWriter writer = new SmartSocketWriter(executor, socket.socket(), 2);
+        Future<?> write;
+        Future<?> close;
+
+        try {
+            writer.switchToSyncMode();
+            write = writeExecutor.submit(() -> writer.write(BufferData.create(new byte[] {1})));
+            assertThat("Sync write did not start", socket.awaitFirstWrite(), is(true));
+
+            close = closeExecutor.submit(writer::close);
+            close.get(2, TimeUnit.SECONDS);
+            assertThrows(SocketWriterException.class, () -> writer.write(BufferData.create(new byte[] {2})));
+
+            socket.releaseFirstWrite();
+            write.get(2, TimeUnit.SECONDS);
+
+            assertThat(socket.writtenBytes(), is(new byte[] {1}));
+        } finally {
+            socket.releaseFirstWrite();
+            closeExecutor.shutdownNow();
+            writeExecutor.shutdownNow();
+            executor.shutdownNow();
+            closeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            writeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void smartWriterSyncWriteFailsAfterClose() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(false);
+        SmartSocketWriter writer = new SmartSocketWriter(executor, socket.socket(), 2);
+
+        try {
+            writer.switchToSyncMode();
+            writer.close();
+
+            assertThrows(SocketWriterException.class, () -> writer.write(BufferData.create(new byte[] {1})));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void smartWriterWriteNowInAsyncModeWaitsForQueuedWrites() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService writeNowExecutor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "write-now-test"));
+        TestSocket socket = new TestSocket(true);
+        SmartSocketWriter writer = new SmartSocketWriter(executor, socket.socket(), 2);
+        CountDownLatch writeNowWaiting = new CountDownLatch(1);
+        Future<?> writeNow;
+
+        try {
+            writer.beforeFlushAwait(writeNowWaiting::countDown);
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+
+            writeNow = writeNowExecutor.submit(() -> writer.writeNow(BufferData.create(new byte[] {2})));
+
+            assertThat("writeNow did not reach the async flush wait",
+                       writeNowWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+            assertThat("writeNow completed before the queued write was released", writeNow.isDone(), is(false));
+            socket.releaseFirstWrite();
+            writeNow.get(2, TimeUnit.SECONDS);
+
+            assertThat(socket.writtenBytes(), is(new byte[] {1, 2}));
+            assertThat(socket.writeThreadNames(), contains("[test child]", "write-now-test"));
+        } finally {
+            socket.releaseFirstWrite();
+            writeNowExecutor.shutdownNow();
+            executor.shutdownNow();
+            writeNowExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void smartWriterFlushInAsyncModeWaitsForQueuedWrites() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService flushExecutor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "flush-test"));
+        TestSocket socket = new TestSocket(true);
+        SmartSocketWriter writer = new SmartSocketWriter(executor, socket.socket(), 2);
+        CountDownLatch flushWaiting = new CountDownLatch(1);
+        Future<?> flush;
+
+        try {
+            writer.beforeFlushAwait(flushWaiting::countDown);
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+            writer.write(BufferData.create(new byte[] {2}));
+
+            flush = flushExecutor.submit(writer::flush);
+
+            assertThat("flush did not reach the async flush wait",
+                       flushWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+            assertThat("flush completed before the queued write was released", flush.isDone(), is(false));
+            socket.releaseFirstWrite();
+            flush.get(2, TimeUnit.SECONDS);
+
+            assertThat(socket.writtenBytes(), is(new byte[] {1, 2}));
+        } finally {
+            socket.releaseFirstWrite();
+            flushExecutor.shutdownNow();
+            executor.shutdownNow();
+            flushExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncWriterWriteNowIsNotOvertakenByLaterWrites() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService writeNowExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService producerExecutor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(true);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+        CountDownLatch flushWaiting = new CountDownLatch(1);
+        Future<?> writeNow;
+        Future<?> producer;
+
+        try {
+            writer.beforeFlushAwait(flushWaiting::countDown);
+            writer.write(BufferData.create(new byte[] {1}));
+            assertThat("Initial async write did not start", socket.awaitFirstWrite(), is(true));
+
+            writeNow = writeNowExecutor.submit(() -> writer.writeNow(BufferData.create(new byte[] {2})));
+            assertThat("writeNow did not reach the async flush wait",
+                       flushWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+
+            producer = producerExecutor.submit(() -> writer.write(BufferData.create(new byte[] {3})));
+
+            socket.releaseFirstWrite();
+            writeNow.get(2, TimeUnit.SECONDS);
+            producer.get(2, TimeUnit.SECONDS);
+            writer.flush();
+
+            assertThat(socket.writtenBytes(), is(new byte[] {1, 2, 3}));
+        } finally {
+            socket.releaseFirstWrite();
+            producerExecutor.shutdownNow();
+            writeNowExecutor.shutdownNow();
+            executor.shutdownNow();
+            producerExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            writeNowExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncAndSmartWritersRejectNullBuffers() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(false);
+        SocketWriterAsync asyncWriter = new SocketWriterAsync(executor, socket.socket(), 2);
+        SmartSocketWriter smartWriter = new SmartSocketWriter(executor, socket.socket(), 2);
+
+        try {
+            assertThrows(NullPointerException.class, () -> asyncWriter.write((BufferData) null));
+            assertThrows(NullPointerException.class, () -> asyncWriter.writeNow((BufferData) null));
+            assertThrows(NullPointerException.class, () -> smartWriter.write((BufferData) null));
+            assertThrows(NullPointerException.class, () -> smartWriter.writeNow((BufferData) null));
+            assertThat(socket.writtenBytes(), is(BufferData.EMPTY_BYTES));
+        } finally {
+            asyncWriter.close();
+            smartWriter.close();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void asyncWriterStartDoesNotHoldStateLockDuringSubmit() throws Exception {
+        BlockingSubmitExecutor executor = new BlockingSubmitExecutor();
+        ExecutorService writeExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(false);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+        CountDownLatch closeWaiting = new CountDownLatch(1);
+        Future<?> write;
+        Future<?> close;
+
+        try {
+            writer.beforeCloseAwait(closeWaiting::countDown);
+            write = writeExecutor.submit(() -> writer.write(BufferData.create(new byte[] {1})));
+
+            assertThat("Writer task submission did not start",
+                       executor.awaitSubmitStarted(),
+                       is(true));
+
+            close = closeExecutor.submit(writer::close);
+            assertThat("Close did not reach its await hook while writer submission was blocked",
+                       closeWaiting.await(10, TimeUnit.SECONDS),
+                       is(true));
+
+            executor.releaseSubmit();
+            close.get(2, TimeUnit.SECONDS);
+
+            ExecutionException e = assertThrows(ExecutionException.class, () -> write.get(2, TimeUnit.SECONDS));
+            assertThat(e.getCause(), instanceOf(SocketWriterException.class));
+        } finally {
+            executor.releaseSubmit();
+            closeExecutor.shutdownNow();
+            writeExecutor.shutdownNow();
+            executor.shutdownNow();
+            closeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            writeExecutor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncWriterFlushOnSameExecutorDrainsQueuedWrites() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(false);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+
+        try {
+            Future<?> flush = executor.submit(() -> {
+                writer.write(BufferData.create(new byte[] {1}));
+                writer.flush();
+            });
+
+            flush.get(2, TimeUnit.SECONDS);
+
+            assertThat(socket.writtenBytes(), is(new byte[] {1}));
+        } finally {
+            writer.close();
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void smartWriterWriteNowOnSameExecutorDoesNotDeadlock() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "same-executor-test"));
+        TestSocket socket = new TestSocket(false);
+        SmartSocketWriter writer = new SmartSocketWriter(executor, socket.socket(), 2);
+
+        try {
+            Future<?> write = executor.submit(() -> {
+                writer.write(BufferData.create(new byte[] {1}));
+                writer.writeNow(BufferData.create(new byte[] {2}));
+            });
+
+            write.get(2, TimeUnit.SECONDS);
+
+            assertThat(socket.writtenBytes(), is(new byte[] {1, 2}));
+            assertThat(socket.writeThreadNames(), contains("same-executor-test", "same-executor-test"));
+        } finally {
+            writer.close();
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void smartWriterWriteNowFailsAfterClose() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(false);
+        SmartSocketWriter writer = new SmartSocketWriter(executor, socket.socket(), 2);
+
+        try {
+            writer.close();
+
+            assertThrows(SocketWriterException.class, () -> writer.writeNow(BufferData.create(new byte[] {1})));
+            assertThat(socket.writtenBytes(), is(BufferData.EMPTY_BYTES));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void smartWriterSwitchesToSyncModeAfterLowQueueWindow() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        TestSocket socket = new TestSocket(false);
+        SmartSocketWriter writer = new SmartSocketWriter(executor, socket.socket(), 2);
+
+        try {
+            for (int i = 1; i <= 1000; i++) {
+                writer.write(BufferData.create(new byte[] {(byte) i}));
+                assertThat("Async write did not complete", socket.awaitWriteCount(i), is(true));
+            }
+
+            assertThat(writer.asyncMode(), is(false));
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void asyncWriterFlushPropagatesWriteFailureWithoutSuccessRace() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        RuntimeException failure = new RuntimeException("boom");
+        TestSocket socket = new TestSocket(false, failure);
+        SocketWriterAsync writer = new SocketWriterAsync(executor, socket.socket(), 2);
+
+        try {
+            writer.write(BufferData.create(new byte[] {1}));
+
+            SocketWriterException flushFailure = assertThrows(SocketWriterException.class, writer::flush);
+            assertThat(flushFailure.getCause(), is(failure));
+
+            SocketWriterException writeFailure = assertThrows(SocketWriterException.class,
+                                                             () -> writer.write(BufferData.create(new byte[] {2})));
+            assertThat(writeFailure.getCause(), is(failure));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static final class BlockingSubmitExecutor extends AbstractExecutorService {
+        private final CountDownLatch submitStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseSubmit = new CountDownLatch(1);
+        private final CountDownLatch terminated = new CountDownLatch(1);
+        private final AtomicBoolean shutdown = new AtomicBoolean();
+        private final AtomicReference<Thread> worker = new AtomicReference<>();
+
+        @Override
+        public void shutdown() {
+            shutdown.set(true);
+            releaseSubmit();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown();
+            Thread thread = worker.get();
+            if (thread != null) {
+                thread.interrupt();
+            }
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown.get();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return terminated.getCount() == 0;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return terminated.await(timeout, unit);
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            submitStarted.countDown();
+            try {
+                releaseSubmit.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                terminated.countDown();
+                return;
+            }
+            if (shutdown.get()) {
+                terminated.countDown();
+                return;
+            }
+            Thread thread = new Thread(() -> {
+                try {
+                    command.run();
+                } finally {
+                    terminated.countDown();
+                }
+            }, "blocking-submit-writer");
+            worker.set(thread);
+            thread.start();
+        }
+
+        private boolean awaitSubmitStarted() throws InterruptedException {
+            return submitStarted.await(10, TimeUnit.SECONDS);
+        }
+
+        private void releaseSubmit() {
+            releaseSubmit.countDown();
+        }
+    }
+
+    private static final class TestSocket {
+        private final HelidonSocket socket = mock(HelidonSocket.class);
+        private final CountDownLatch firstWriteStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseFirstWrite = new CountDownLatch(1);
+        private final ArrayList<String> writeThreadNames = new ArrayList<>();
+        private final ByteArrayOutputStream written = new ByteArrayOutputStream();
+        private final AtomicInteger writeCount = new AtomicInteger();
+        private final AtomicInteger completedWriteCount = new AtomicInteger();
+        private final Lock writtenLock = new ReentrantLock();
+        private final Condition writeCountChanged = writtenLock.newCondition();
+        private final boolean blockFirstWrite;
+        private final RuntimeException firstWriteFailure;
+
+        private TestSocket(boolean blockFirstWrite) {
+            this(blockFirstWrite, null);
+        }
+
+        private TestSocket(boolean blockFirstWrite, RuntimeException firstWriteFailure) {
+            this.blockFirstWrite = blockFirstWrite;
+            this.firstWriteFailure = firstWriteFailure;
+            when(socket.socketId()).thenReturn("test");
+            when(socket.childSocketId()).thenReturn("child");
+            doAnswer(invocation -> {
+                write(invocation.getArgument(0));
+                return null;
+            }).when(socket).write(any(BufferData.class));
+        }
+
+        private HelidonSocket socket() {
+            return socket;
+        }
+
+        private boolean awaitFirstWrite() throws InterruptedException {
+            return firstWriteStarted.await(10, TimeUnit.SECONDS);
+        }
+
+        private boolean awaitWriteCount(int expectedCount) throws InterruptedException {
+            long remaining = TimeUnit.SECONDS.toNanos(10);
+            writtenLock.lock();
+            try {
+                while (completedWriteCount.get() < expectedCount) {
+                    if (remaining <= 0) {
+                        return false;
+                    }
+                    remaining = writeCountChanged.awaitNanos(remaining);
+                }
+                return true;
+            } finally {
+                writtenLock.unlock();
+            }
+        }
+
+        private void releaseFirstWrite() {
+            releaseFirstWrite.countDown();
+        }
+
+        private byte[] writtenBytes() {
+            writtenLock.lock();
+            try {
+                return written.toByteArray();
+            } finally {
+                writtenLock.unlock();
+            }
+        }
+
+        private List<String> writeThreadNames() {
+            writtenLock.lock();
+            try {
+                return List.copyOf(writeThreadNames);
+            } finally {
+                writtenLock.unlock();
+            }
+        }
+
+        private void write(BufferData buffer) {
+            if (writeCount.incrementAndGet() == 1) {
+                firstWriteStarted.countDown();
+                if (firstWriteFailure != null) {
+                    throw firstWriteFailure;
+                }
+                if (blockFirstWrite) {
+                    try {
+                        releaseFirstWrite.await(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException("Interrupted while blocking the first write", e);
+                    }
+                }
+            }
+            writtenLock.lock();
+            try {
+                writeThreadNames.add(Thread.currentThread().getName());
+                written.writeBytes(buffer.readBytes());
+                completedWriteCount.incrementAndGet();
+                writeCountChanged.signalAll();
+            } finally {
+                writtenLock.unlock();
+            }
+        }
+    }
+}

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.common.task.InterruptableTask;
 import io.helidon.common.tls.TlsUtils;
 import io.helidon.http.DateTime;
@@ -176,6 +177,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             state = State.FINISHED;
         } catch (CloseConnectionException
                  | InterruptedException
+                 | SocketWriterException
                  | UncheckedIOException e) {
             throw e;
         } catch (Throwable e) {
@@ -329,7 +331,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     void writeConnectionFrame(Http2FrameData frame) {
         try {
             connectionWriter.write(frame);
-        } catch (UncheckedIOException e) {
+        } catch (SocketWriterException | UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write HTTP/2 connection frame", e);
         }
     }
@@ -904,14 +906,18 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         UNKNOWN
     }
 
-    private record StreamRunnable(Http2ConnectionStreams streams,
-                                  Http2ServerStream stream,
-                                  Thread handlerThread) implements Runnable {
+    // Package-private for deterministic tests of writer-thread failure handling.
+    record StreamRunnable(Http2ConnectionStreams streams,
+                          Http2ServerStream stream,
+                          Thread handlerThread) implements Runnable {
 
         @Override
         public void run() {
             try {
                 stream.run();
+            } catch (SocketWriterException e) {
+                handlerThread.interrupt();
+                LOGGER.log(DEBUG, "Socket writer error on writer thread", e);
             } catch (UncheckedIOException e) {
                 // Broken connection
                 if (e.getCause() instanceof SocketException) {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -262,7 +262,11 @@ class Http2ServerStream implements Runnable, Http2Stream {
             writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
             streams.remove(this.streamId);
             Http2RstStream rst = new Http2RstStream(Http2ErrorCode.PROTOCOL);
-            writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+            try {
+                writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+            } catch (SocketWriterException | UncheckedIOException e) {
+                throw new ServerConnectionException("Failed to write reset stream", e);
+            }
             connectionAttackVectorMetrics.madeYouResetCheck(streamId);
 
             try {
@@ -316,7 +320,9 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                  + ctx.childSocketId() + " ] - " + streamId);
         try {
             handle();
-        } catch (SocketWriterException | CloseConnectionException | UncheckedIOException e) {
+        } catch (SocketWriterException | UncheckedIOException e) {
+            throw e;
+        } catch (CloseConnectionException e) {
             Http2RstStream rst = new Http2RstStream(Http2ErrorCode.STREAM_CLOSED);
             writer.write(rst.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
             // no sense in throwing an exception, as this is invoked from an executor service directly

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Upgrader.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Upgrader.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpPrologue;
@@ -106,7 +107,7 @@ public class Http2Upgrader implements Http1Upgrader {
     private static void writeUpgradeResponse(DataWriter dataWriter) {
         try {
             dataWriter.writeNow(BufferData.create(SWITCHING_PROTOCOLS_BYTES));
-        } catch (UncheckedIOException e) {
+        } catch (SocketWriterException | UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write HTTP/2 upgrade response", e);
         }
     }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -19,11 +19,17 @@ package io.helidon.webserver.http2;
 import java.io.UncheckedIOException;
 import java.net.SocketException;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.SocketWriter;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.http2.Http2Ping;
+import io.helidon.http.http2.Http2StreamState;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
@@ -31,9 +37,10 @@ import io.helidon.webserver.ServerConnectionException;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -50,11 +57,7 @@ class Http2ConnectionTest {
                 .when(writer)
                 .writeNow(any(BufferData.class));
 
-        ConnectionContext ctx = mock(ConnectionContext.class);
-        when(ctx.router()).thenReturn(Router.empty());
-        when(ctx.listenerContext()).thenReturn(mock(ListenerContext.class));
-        when(ctx.dataWriter()).thenReturn(writer);
-        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+        ConnectionContext ctx = http2Context(writer);
 
         Http2Connection connection = new Http2Connection(ctx, Http2Config.create(), List.of());
         connection.pendingPing(Http2Ping.create());
@@ -69,6 +72,61 @@ class Http2ConnectionTest {
     }
 
     @Test
+    void pingAckWrapsSocketWriterExceptionFromSmartWriter() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        HelidonSocket socket = mock(HelidonSocket.class);
+        when(socket.socketId()).thenReturn("test");
+        when(socket.childSocketId()).thenReturn("child");
+        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
+                .when(socket)
+                .write(any(BufferData.class));
+        SocketWriter writer = SocketWriter.create(executor, socket, 2, true);
+        try {
+            ConnectionContext ctx = http2Context(writer);
+            Http2Connection connection = new Http2Connection(ctx, Http2Config.create(), List.of());
+            connection.pendingPing(Http2Ping.create());
+
+            ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                               connection::writePingAck);
+
+            assertAll(
+                    () -> assertThat(exception.getCause(), instanceOf(SocketWriterException.class)),
+                    () -> assertThat(exception.getCause().getCause(), instanceOf(UncheckedIOException.class)),
+                    () -> assertThat(exception.getCause().getCause().getCause(), instanceOf(SocketException.class))
+            );
+        } finally {
+            writer.close();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void streamRunnableInterruptsConnectionThreadOnSocketWriterException() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        doThrow(new SocketWriterException()).when(stream).run();
+        when(stream.streamId()).thenReturn(1);
+        when(stream.streamState()).thenReturn(Http2StreamState.CLOSED);
+        streams.put(new Http2Connection.StreamContext(1, 8192, stream));
+
+        boolean previouslyInterrupted = Thread.interrupted();
+        try {
+            new Http2Connection.StreamRunnable(streams, stream, Thread.currentThread()).run();
+            streams.doMaintenance(0);
+
+            assertAll(
+                    () -> assertThat(Thread.currentThread().isInterrupted(), is(true)),
+                    () -> assertThat(streams.get(1), is(nullValue()))
+            );
+        } finally {
+            Thread.interrupted();
+            if (previouslyInterrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Test
     void closeConnectionWrapsUncheckedIOException() {
         DataWriter writer = mock(DataWriter.class);
         doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
@@ -78,11 +136,7 @@ class Http2ConnectionTest {
         Http2Config config = Http2Config.builder()
                 .maxRapidResets(0)
                 .build();
-        ConnectionContext ctx = mock(ConnectionContext.class);
-        when(ctx.router()).thenReturn(Router.empty());
-        when(ctx.listenerContext()).thenReturn(mock(ListenerContext.class));
-        when(ctx.dataWriter()).thenReturn(writer);
-        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+        ConnectionContext ctx = http2Context(writer);
 
         Http2Connection connection = new Http2Connection(ctx, config, List.of());
         Http2ConnectionChecks checks = new Http2ConnectionChecks(config, connection);
@@ -108,16 +162,21 @@ class Http2ConnectionTest {
     }
 
     private static void closeBeforeHandleDoesNotRequireHandlerThread(boolean interrupt) {
-        ConnectionContext ctx = mock(ConnectionContext.class);
-        when(ctx.router()).thenReturn(Router.empty());
-        when(ctx.listenerContext()).thenReturn(mock(ListenerContext.class));
-        when(ctx.dataWriter()).thenReturn(mock(DataWriter.class));
-        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+        ConnectionContext ctx = http2Context(mock(DataWriter.class));
 
         Http2Connection connection = new Http2Connection(ctx, Http2Config.create(), List.of());
 
         connection.close(interrupt);
 
         assertThat(connection.canInterrupt(), is(true));
+    }
+
+    private static ConnectionContext http2Context(DataWriter writer) {
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.listenerContext()).thenReturn(mock(ListenerContext.class));
+        when(ctx.dataWriter()).thenReturn(writer);
+        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+        return ctx;
     }
 }

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
@@ -16,16 +16,39 @@
 
 package io.helidon.webserver.tests.http2;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataWriter;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2ConnectionWriter;
 import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2Setting;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2Util;
 import io.helidon.logging.common.LogConfig;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.Handler;
 import io.helidon.webserver.http.HttpRouting;
@@ -49,6 +72,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class ContentLengthTest {
 
     private static final Duration TIMEOUT = Duration.ofSeconds(100);
+    private static final Logger CONNECTION_HANDLER_LOGGER = Logger.getLogger("io.helidon.webserver.ConnectionHandler");
     private static final String SHORTER_DATA_PATH = "/shorter-data";
     private static final String LONGER_DATA_PATH = "/longer-data";
     private static final String SECOND_STREAM_OK_PATH = "/second-stream-ok";
@@ -121,6 +145,23 @@ class ContentLengthTest {
     }
 
     @Test
+    void longerDataClosedPeerIsHandledAsServerIo(WebServer server) throws Exception {
+        TestLogHandler logHandler = new TestLogHandler();
+        Level originalLevel = CONNECTION_HANDLER_LOGGER.getLevel();
+        CONNECTION_HANDLER_LOGGER.setLevel(Level.ALL);
+        CONNECTION_HANDLER_LOGGER.addHandler(logHandler);
+        try {
+            sendLongerDataAndResetPeer(server.port());
+
+            assertThat(logHandler.awaitConnectionFailure(Duration.ofSeconds(5)), is(true));
+            assertThat(logHandler.unexpectedException(), is(false));
+        } finally {
+            CONNECTION_HANDLER_LOGGER.removeHandler(logHandler);
+            CONNECTION_HANDLER_LOGGER.setLevel(originalLevel);
+        }
+    }
+
+    @Test
     void longerDataSecondStream(Http2TestClient client) {
         Http2TestConnection h2conn = client.createConnection();
 
@@ -189,9 +230,130 @@ class ContentLengthTest {
         return headers;
     }
 
+    private static void sendLongerDataAndResetPeer(int port) throws IOException {
+        try (Socket socket = new Socket()) {
+            socket.setTcpNoDelay(true);
+            socket.setSoLinger(true, 0);
+            socket.connect(new InetSocketAddress("localhost", port));
+
+            InputStream input = socket.getInputStream();
+            DataWriter rawWriter = new SocketDataWriter(socket.getOutputStream());
+            rawWriter.writeNow(Http2Util.prefaceData());
+            Http2ConnectionWriter h2 = new Http2ConnectionWriter(null, rawWriter, List.of());
+            h2.write(Http2Settings.builder()
+                             .add(Http2Setting.INITIAL_WINDOW_SIZE, 65535L)
+                             .add(Http2Setting.MAX_FRAME_SIZE, 16384L)
+                             .add(Http2Setting.ENABLE_PUSH, false)
+                             .build()
+                             .toFrameData(null, 0, Http2Flag.SettingsFlags.create(0)));
+            assertThat(readFrame(input).header().type(), is(Http2FrameType.SETTINGS));
+            h2.write(new Http2FrameData(Http2FrameHeader.create(0,
+                                                                Http2FrameTypes.SETTINGS,
+                                                                Http2Flag.SettingsFlags.create(Http2Flag.ACK),
+                                                                0),
+                                        BufferData.empty()));
+
+            WritableHeaders<?> headers = WritableHeaders.create();
+            headers.add(HeaderNames.CONTENT_LENGTH, 2);
+            Http2Headers h2Headers = Http2Headers.create(headers);
+            h2Headers.method(POST);
+            h2Headers.path(LONGER_DATA_PATH);
+            h2Headers.scheme("http");
+            h2.writeHeaders(h2Headers,
+                            1,
+                            Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                            FlowControl.Outbound.NOOP);
+
+            BufferData payload = BufferData.create("frank");
+            h2.writeData(new Http2FrameData(Http2FrameHeader.create(payload.available(),
+                                                                    Http2FrameTypes.DATA,
+                                                                    Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                    1),
+                                           payload),
+                         FlowControl.Outbound.NOOP);
+        }
+    }
+
+    private static Http2FrameData readFrame(InputStream input) throws IOException {
+        byte[] frameHeaderBytes = input.readNBytes(Http2FrameHeader.LENGTH);
+        assertThat(frameHeaderBytes.length, is(Http2FrameHeader.LENGTH));
+        Http2FrameHeader header = Http2FrameHeader.create(BufferData.create(frameHeaderBytes));
+        byte[] frameBytes = input.readNBytes(header.length());
+        assertThat(frameBytes.length, is(header.length()));
+        return new Http2FrameData(header, BufferData.create(frameBytes));
+    }
+
     private static void assertNoHandlerExceptions(TestProbe testProbe) {
         assertNull(testProbe.consumeException);
         assertNull(testProbe.sendException);
+    }
+
+    private record SocketDataWriter(OutputStream output) implements DataWriter {
+        @Override
+        public void write(BufferData... buffers) {
+            writeNow(buffers);
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+            writeNow(buffer);
+        }
+
+        @Override
+        public void writeNow(BufferData... buffers) {
+            for (BufferData buffer : buffers) {
+                writeNow(buffer);
+            }
+        }
+
+        @Override
+        public void writeNow(BufferData buffer) {
+            try {
+                buffer.writeTo(output);
+                output.flush();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    private static final class TestLogHandler extends java.util.logging.Handler {
+        private final CountDownLatch connectionFailure = new CountDownLatch(1);
+        private volatile boolean unexpectedException;
+
+        private TestLogHandler() {
+            setLevel(Level.ALL);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            String message = record.getMessage();
+            if (message == null) {
+                return;
+            }
+            if (message.contains("server I/O issue")) {
+                connectionFailure.countDown();
+            }
+            if (message.contains("unexpected exception")) {
+                unexpectedException = true;
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        private boolean awaitConnectionFailure(Duration timeout) throws InterruptedException {
+            return connectionFailure.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        private boolean unexpectedException() {
+            return unexpectedException;
+        }
     }
 
     private static final class TestProbe {

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SimpleSseClient.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SimpleSseClient.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -39,6 +40,7 @@ class SimpleSseClient implements AutoCloseable {
     private final String path;
     private final SocketHttpClient client;
     private String contentEncoding;
+    private boolean chunked;
     private InputStream inputStream;
     private Iterable<String> headers;
 
@@ -122,6 +124,9 @@ class SimpleSseClient implements AutoCloseable {
                 while ((line = readLine(inputStream)) != null) {
                     if (line.isEmpty()) {
                         state = State.HEADERS_READ;
+                        if (chunked) {
+                            inputStream = new ChunkedInputStream(inputStream);
+                        }
                         if (contentEncoding != null) {
                             if ("gzip".equals(contentEncoding)) {
                                 inputStream = new GZIPInputStream(inputStream);
@@ -133,11 +138,13 @@ class SimpleSseClient implements AutoCloseable {
                         }
                         return;
                     }
-                    line = line.toLowerCase();
+                    line = line.toLowerCase(Locale.ROOT);
                     if (line.contains("http/1.1") && !line.contains("200")) {
                         throw new RuntimeException("Invalid status code in response");
                     } else if (line.contains("content-type") && !line.contains("text/event-stream")) {
                         throw new RuntimeException("Invalid content-type in response");
+                    } else if (line.contains("transfer-encoding") && line.contains("chunked")) {
+                        chunked = true;
                     } else if (line.contains("content-encoding")) {
                         contentEncoding = line.substring("content-encoding:".length()).trim();
                     }
@@ -166,5 +173,76 @@ class SimpleSseClient implements AutoCloseable {
             return null;
         }
         return buffer.toString("UTF-8");
+    }
+
+    private static final class ChunkedInputStream extends InputStream {
+        private static final int NO_CHUNK = -1;
+
+        private final InputStream delegate;
+        private int chunkRemaining = NO_CHUNK;
+        private boolean complete;
+
+        private ChunkedInputStream(InputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (!ensureChunk()) {
+                return -1;
+            }
+
+            int b = delegate.read();
+            if (b == -1) {
+                throw new IOException("Unexpected end of chunked stream");
+            }
+
+            chunkRemaining--;
+            if (chunkRemaining == 0) {
+                expectCrlf();
+                chunkRemaining = NO_CHUNK;
+            }
+
+            return b;
+        }
+
+        private boolean ensureChunk() throws IOException {
+            if (complete) {
+                return false;
+            }
+            if (chunkRemaining > 0) {
+                return true;
+            }
+
+            String chunkHeader = readLine(delegate);
+            if (chunkHeader == null) {
+                throw new IOException("Unexpected end of chunked stream");
+            }
+
+            int extension = chunkHeader.indexOf(';');
+            String chunkSize = extension >= 0 ? chunkHeader.substring(0, extension) : chunkHeader;
+            chunkRemaining = Integer.parseInt(chunkSize.trim(), 16);
+
+            if (chunkRemaining == 0) {
+                while (true) {
+                    String trailer = readLine(delegate);
+                    if (trailer == null || trailer.isEmpty()) {
+                        break;
+                    }
+                }
+                complete = true;
+                return false;
+            }
+
+            return true;
+        }
+
+        private void expectCrlf() throws IOException {
+            int cr = delegate.read();
+            int lf = delegate.read();
+            if (cr != '\r' || lf != '\n') {
+                throw new IOException("Invalid chunked stream terminator");
+            }
+        }
     }
 }

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBaseTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBaseTest.java
@@ -18,6 +18,8 @@ package io.helidon.webserver.tests.sse;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.sse.SseEvent;
@@ -34,6 +36,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class SseBaseTest {
+    private static volatile CountDownLatch flushLatch = new CountDownLatch(0);
 
     private final WebServer webServer;
 
@@ -47,6 +50,10 @@ class SseBaseTest {
 
     protected WebServer webServer() {
         return webServer;
+    }
+
+    static void flushLatch(CountDownLatch latch) {
+        flushLatch = latch;
     }
 
     static void sseString1(ServerRequest req, ServerResponse res) {
@@ -63,6 +70,14 @@ class SseBaseTest {
             Thread.sleep(50);      // simulates messages over time
         }
         sseSink.close();
+    }
+
+    static void sseFlush(ServerRequest req, ServerResponse res) throws InterruptedException {
+        try (SseSink sseSink = res.sink(SseSink.TYPE)) {
+            sseSink.emit(SseEvent.create("first"));
+            flushLatch.await(10, TimeUnit.SECONDS);
+            sseSink.emit(SseEvent.create("second"));
+        }
     }
 
     static void sseJson1(ServerRequest req, ServerResponse res) {

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,18 @@
 
 package io.helidon.webserver.tests.sse;
 
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+
 import io.helidon.http.Status;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,10 +46,17 @@ class SseServerTest extends SseBaseTest {
     static void routing(HttpRules rules) {
         rules.get("/sseString1", SseServerTest::sseString1);
         rules.get("/sseString2", SseServerTest::sseString2);
+        rules.get("/sseFlush", SseServerTest::sseFlush);
         rules.get("/sseJson1", SseServerTest::sseJson1);
         rules.get("/sseJson2", SseServerTest::sseJson2);
         rules.get("/sseMixed", SseServerTest::sseMixed);
         rules.get("/sseIdComment", SseServerTest::sseIdComment);
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.writeQueueLength(2);
+        server.smartAsyncWrites(true);
     }
 
     @Test
@@ -55,6 +67,24 @@ class SseServerTest extends SseBaseTest {
     @Test
     void testSseString2() throws Exception {
         testSse("/sseString2", "data:1", "data:2", "data:3");
+    }
+
+    @Test
+    void testSseFlushesEachEvent() throws Exception {
+        CountDownLatch flushLatch = new CountDownLatch(1);
+        SseBaseTest.flushLatch(flushLatch);
+        try (SimpleSseClient sseClient = SimpleSseClient.create("localhost",
+                                                                webServer().port(),
+                                                                "/sseFlush",
+                                                                Duration.ofSeconds(10))) {
+            assertThat(sseClient.nextEvent(), is("data:first"));
+
+            flushLatch.countDown();
+            assertThat(sseClient.nextEvent(), is("data:second"));
+        } finally {
+            flushLatch.countDown();
+            SseBaseTest.flushLatch(new CountDownLatch(0));
+        }
     }
 
     @Test

--- a/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/Http2UpgradeTest.java
+++ b/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/Http2UpgradeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ class Http2UpgradeTest {
 
             // start server and get port
             webServer = WebServer.builder()
+                    .writeQueueLength(2)
+                    .smartAsyncWrites(true)
                     .routing(routing)
                     .build()
                     .start();

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/Continue100ImmediatelyTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/Continue100ImmediatelyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,8 @@ class Continue100ImmediatelyTest {
                                 .build())
                 .build();
 
+        wsb.writeQueueLength(2);
+        wsb.smartAsyncWrites(true);
         wsb.addConnectionSelector(http1);
     }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/Continue100Test.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/Continue100Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,12 @@ import io.helidon.http.Method;
 import io.helidon.http.PathMatchers;
 import io.helidon.http.Status;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.Handler;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -110,6 +112,12 @@ class Continue100Test {
 
     public Continue100Test(WebServer server) {
         defaultPort = server.port();
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.writeQueueLength(2);
+        server.smartAsyncWrites(true);
     }
 
     @Test

--- a/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketTest.java
+++ b/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.WebServer;
-import io.helidon.websocket.WsCloseCodes;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 import io.helidon.webserver.websocket.WsRouting;
+import io.helidon.websocket.WsCloseCodes;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +66,12 @@ class WebSocketTest {
     static void router(Router.RouterBuilder<?> router) {
         service = new EchoService();
         router.addRouting(WsRouting.builder().endpoint("/echo", service));
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.writeQueueLength(2);
+        server.smartAsyncWrites(true);
     }
 
     @BeforeEach

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -285,6 +285,15 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         currentEntitySizeRead = 0;
     }
 
+    // Package-private for deterministic tests of immediate 100-Continue writer failures.
+    void writeContinue() {
+        try {
+            writer.writeNow(BufferData.create(CONTINUE_100));
+        } catch (SocketWriterException | UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write continue", e);
+        }
+    }
+
     /**
      * Only accept protocol upgrades if no entity is present. Otherwise, a successful
      * upgrade may result in the request entity interpreted as part of the new protocol
@@ -550,11 +559,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         // Expect: 100-continue
         if (headers.containsToken(HeaderValues.EXPECT_100)) {
             if (this.http1Config.continueImmediately()) {
-                try {
-                    writer.writeNow(BufferData.create(CONTINUE_100));
-                } catch (UncheckedIOException e) {
-                    throw new ServerConnectionException("Failed to write continue", e);
-                }
+                writeContinue();
             }
             expectContinue = true;
         }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequestWithEntity.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequestWithEntity.java
@@ -17,6 +17,7 @@
 package io.helidon.webserver.http1;
 
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Supplier;
@@ -25,12 +26,14 @@ import java.util.function.UnaryOperator;
 import io.helidon.common.LazyValue;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.concurrency.limits.LimitAlgorithm;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.Status;
 import io.helidon.http.encoding.ContentDecoder;
 import io.helidon.http.media.ReadableEntity;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.HttpSecurity;
 import io.helidon.webserver.http.ServerRequestEntity;
 
@@ -113,7 +116,11 @@ final class Http1ServerRequestWithEntity extends Http1ServerRequest {
                 ctx.log(LOGGER, System.Logger.Level.DEBUG, "send: status %s", Status.CONTINUE_100);
                 ctx.log(LOGGER, System.Logger.Level.DEBUG, "send %n%s", buffer.debugDataHex());
             }
-            ctx.dataWriter().writeNow(buffer);
+            try {
+                ctx.dataWriter().writeNow(buffer);
+            } catch (SocketWriterException | UncheckedIOException e) {
+                throw new ServerConnectionException("Failed to write continue", e);
+            }
             this.continueSent = true;
         }
     }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http1;
+
+import java.io.UncheckedIOException;
+import java.net.SocketException;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.SocketWriter;
+import io.helidon.common.socket.SocketWriterException;
+import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.ServerConnectionException;
+import io.helidon.webserver.WebServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Http1ConnectionTest {
+
+    @Test
+    void continueImmediatelyWrapsSocketWriterExceptionFromSmartWriter() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        SocketWriter writer = smartFailingWriter(executor);
+        try {
+            Http1Connection connection = createConnection(writer);
+
+            ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                               connection::writeContinue);
+
+            assertAll(
+                    () -> assertThat(exception.getCause(), instanceOf(SocketWriterException.class)),
+                    () -> assertThat(exception.getCause().getCause(), instanceOf(UncheckedIOException.class)),
+                    () -> assertThat(exception.getCause().getCause().getCause(), instanceOf(SocketException.class))
+            );
+        } finally {
+            writer.close();
+            executor.shutdownNow();
+        }
+    }
+
+    private static Http1Connection createConnection(DataWriter dataWriter) {
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.contentEncodingContext()).thenReturn(mock(ContentEncodingContext.class));
+        when(listenerContext.config()).thenReturn(WebServer.builder().buildPrototype());
+
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.listenerContext()).thenReturn(listenerContext);
+        when(ctx.dataWriter()).thenReturn(dataWriter);
+        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+        when(ctx.router()).thenReturn(Router.empty());
+
+        return new Http1Connection(ctx,
+                                   Http1Config.builder()
+                                           .continueImmediately(true)
+                                           .build(),
+                                   Map.of());
+    }
+
+    private static SocketWriter smartFailingWriter(ExecutorService executor) {
+        HelidonSocket socket = mock(HelidonSocket.class);
+        when(socket.socketId()).thenReturn("test");
+        when(socket.childSocketId()).thenReturn("child");
+        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
+                .when(socket)
+                .write(any(BufferData.class));
+        return SocketWriter.create(executor, socket, 2, true);
+    }
+}

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
@@ -31,6 +31,7 @@ import io.helidon.common.buffers.DataReader;
 import io.helidon.common.concurrency.limits.Limit;
 import io.helidon.common.concurrency.limits.LimitException;
 import io.helidon.common.socket.SocketContext;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.DateTime;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
@@ -379,7 +380,7 @@ public class WsConnection implements ServerConnection, WsSession {
     private void writeFrame(BufferData frameData) {
         try {
             ctx.dataWriter().writeNow(frameData);
-        } catch (UncheckedIOException e) {
+        } catch (SocketWriterException | UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write websocket frame", e);
         }
     }

--- a/webserver/websocket/src/test/java/io/helidon/webserver/websocket/WsConnectionTest.java
+++ b/webserver/websocket/src/test/java/io/helidon/webserver/websocket/WsConnectionTest.java
@@ -21,6 +21,8 @@ import java.lang.reflect.Field;
 import java.net.SocketException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,6 +30,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.SocketWriter;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
 import io.helidon.webserver.ConnectionContext;
@@ -70,6 +75,27 @@ class WsConnectionTest {
                 () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
                 () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
         );
+    }
+
+    @Test
+    void sendWrapsSocketWriterExceptionFromSmartWriter() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        SocketWriter writer = smartFailingWriter(executor);
+        try {
+            WsConnection connection = createConnection(writer);
+
+            ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                               () -> connection.send("hello", true));
+
+            assertAll(
+                    () -> assertThat(exception.getCause(), instanceOf(SocketWriterException.class)),
+                    () -> assertThat(exception.getCause().getCause(), instanceOf(UncheckedIOException.class)),
+                    () -> assertThat(exception.getCause().getCause().getCause(), instanceOf(SocketException.class))
+            );
+        } finally {
+            writer.close();
+            executor.shutdownNow();
+        }
     }
 
     @Test
@@ -120,6 +146,16 @@ class WsConnectionTest {
                                    mock(Headers.class),
                                    "key",
                                    mock(WsListener.class));
+    }
+
+    private static SocketWriter smartFailingWriter(ExecutorService executor) {
+        HelidonSocket socket = mock(HelidonSocket.class);
+        when(socket.socketId()).thenReturn("test");
+        when(socket.childSocketId()).thenReturn("child");
+        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
+                .when(socket)
+                .write(any(BufferData.class));
+        return SocketWriter.create(executor, socket, 2, true);
     }
 
     private static boolean awaitCloseSent(WsConnection connection) throws ReflectiveOperationException, InterruptedException {


### PR DESCRIPTION
Resolves #11894

Carries forward #11895 from `helidon-4.x` to `main` so the smart socket writer closes its async writer and protocol write failures surface as server I/O failures.

The main-line port preserves the source fix and only adapts conflict areas for existing `main` code and test shape, including chunked SSE test-client support needed by the carried flush regression.
