### PR TITLE
Support custom JWT groups paths (27.x)

### DIFF
--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -23,13 +23,20 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import io.helidon.common.Errors;
 import io.helidon.common.configurable.Resource;
 import io.helidon.config.Config;
 import io.helidon.config.metadata.Configured;
 import io.helidon.config.metadata.ConfiguredOption;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
+import io.helidon.json.JsonValue;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.Grant;
@@ -66,6 +73,7 @@ import io.helidon.security.util.TokenHandler;
  */
 public final class JwtProvider implements AuthenticationProvider, OutboundSecurityProvider {
     private static final System.Logger LOGGER = System.getLogger(JwtProvider.class.getName());
+    private static final String DEFAULT_JWT_GROUPS_PATH = "groups";
 
     private final boolean optional;
     private final boolean authenticate;
@@ -84,6 +92,8 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
     private final Map<OutboundTarget, JwtOutboundTarget> targetToJwtConfig = new IdentityHashMap<>();
     private final Jwk defaultJwk;
     private final boolean useJwtGroups;
+    private final String jwtGroupsPath;
+    private final String jwtGroupsSeparator;
 
     private JwtProvider(Builder builder) {
         this.optional = builder.optional;
@@ -100,6 +110,8 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         this.expectedIssuer = builder.expectedIssuer;
         this.verifySignature = builder.verifySignature;
         this.useJwtGroups = builder.useJwtGroups;
+        this.jwtGroupsPath = builder.jwtGroupsPath;
+        this.jwtGroupsSeparator = builder.jwtGroupsSeparator;
 
         if (null == atnTokenHandler) {
             defaultTokenHandler = TokenHandler.builder()
@@ -178,7 +190,11 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         if (!validate.isValid()) {
             return failOrAbstain(validate.toString());
         }
-        return AuthenticationResponse.success(buildSubject(jwt, signedJwt));
+        try {
+            return AuthenticationResponse.success(buildSubject(jwt, signedJwt));
+        } catch (JwtException e) {
+            return failOrAbstain(e.getMessage());
+        }
     }
 
     private Errors validateJwt(Jwt jwt) {
@@ -226,8 +242,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
                 .addPublicCredential(TokenCredential.class, builder.build());
 
         if (useJwtGroups) {
-            Optional<List<String>> userGroups = jwt.userGroups();
-            userGroups.ifPresent(groups -> groups.forEach(group -> subjectBuilder.addGrant(Role.create(group))));
+            jwtGroups(jwt).forEach(group -> subjectBuilder.addGrant(Role.create(group)));
         }
 
         Optional<List<String>> scopes = jwt.scopes();
@@ -265,6 +280,50 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         jwt.fullName().ifPresent(value -> builder.addAttribute("full_name", value));
 
         return builder.build();
+    }
+
+    private List<String> jwtGroups(Jwt jwt) {
+        if (DEFAULT_JWT_GROUPS_PATH.equals(jwtGroupsPath)) {
+            return jwt.userGroups().orElse(List.of());
+        }
+        return jwtGroupsClaim(jwt)
+                .map(this::toGroups)
+                .orElse(List.of());
+    }
+
+    private Optional<JsonValue> jwtGroupsClaim(Jwt jwt) {
+        String[] pathSegments = jwtGroupsPath.split("/");
+        Optional<JsonValue> currentValue = jwt.payloadClaimValue(pathSegments[0]);
+        for (int i = 1; i < pathSegments.length; i++) {
+            String pathSegment = pathSegments[i];
+            currentValue = currentValue
+                    .filter(it -> it instanceof JsonObject)
+                    .flatMap(it -> it.asObject().value(pathSegment));
+        }
+        return currentValue;
+    }
+
+    private List<String> toGroups(JsonValue claimValue) {
+        if (claimValue instanceof JsonArray groups) {
+            return groups.values()
+                    .stream()
+                    .map(this::toGroup)
+                    .toList();
+        }
+        String group = toGroup(claimValue);
+        if (jwtGroupsSeparator == null) {
+            return List.of(group);
+        }
+        return Stream.of(group.split(Pattern.quote(jwtGroupsSeparator)))
+                .filter(it -> !it.isBlank())
+                .toList();
+    }
+
+    private String toGroup(JsonValue groupValue) {
+        if (groupValue instanceof JsonString group) {
+            return group.value();
+        }
+        throw new JwtException("Invalid value. Expecting a string or string array for key " + jwtGroupsPath);
     }
 
     @Override
@@ -625,6 +684,8 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         private String expectedAudience;
         private String expectedIssuer;
         private boolean useJwtGroups = true;
+        private String jwtGroupsPath = DEFAULT_JWT_GROUPS_PATH;
+        private String jwtGroupsSeparator;
 
         private Builder() {
         }
@@ -836,6 +897,8 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
             }
             config.get("allow-unsigned").asBoolean().ifPresent(this::allowUnsigned);
             config.get("use-jwt-groups").asBoolean().ifPresent(this::useJwtGroups);
+            config.get("jwt-groups-path").asString().ifPresent(this::jwtGroupsPath);
+            config.get("jwt-groups-separator").asString().ifPresent(this::jwtGroupsSeparator);
 
             return this;
         }
@@ -873,6 +936,43 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         public Builder useJwtGroups(boolean useJwtGroups) {
             this.useJwtGroups = useJwtGroups;
             return this;
+        }
+
+        /**
+         * Path to the JWT payload claim containing the groups to add as role grants.
+         * The default path is {@code groups}. Nested object claims can be configured with slash-separated path segments,
+         * such as {@code realm/groups}.
+         *
+         * @param jwtGroupsPath JWT groups claim path
+         * @return updated builder instance
+         */
+        @ConfiguredOption("groups")
+        public Builder jwtGroupsPath(String jwtGroupsPath) {
+            this.jwtGroupsPath = requireText(jwtGroupsPath, "JWT groups path");
+            return this;
+        }
+
+        /**
+         * Separator used to split a string claim value into multiple groups.
+         * This is used only when {@link #jwtGroupsPath(String)} configures a custom path other than {@code groups}.
+         * The default {@code groups} claim keeps the standard JWT behavior.
+         * Setting this property without changing the JWT groups path has no effect.
+         *
+         * @param jwtGroupsSeparator separator for string-valued custom groups claim
+         * @return updated builder instance
+         */
+        @ConfiguredOption
+        public Builder jwtGroupsSeparator(String jwtGroupsSeparator) {
+            this.jwtGroupsSeparator = requireText(jwtGroupsSeparator, "JWT groups separator");
+            return this;
+        }
+
+        private static String requireText(String value, String description) {
+            Objects.requireNonNull(value, description + " must not be null");
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException(description + " must not be empty");
+            }
+            return value;
         }
 
         private void verifyKeys(Config config) {

--- a/security/providers/jwt/src/test/java/io/helidon/security/providers/jwt/JwtProviderTest.java
+++ b/security/providers/jwt/src/test/java/io/helidon/security/providers/jwt/JwtProviderTest.java
@@ -22,15 +22,19 @@ import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import io.helidon.common.configurable.Resource;
 import io.helidon.config.Config;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.OutboundSecurityResponse;
 import io.helidon.security.Principal;
 import io.helidon.security.ProviderRequest;
+import io.helidon.security.Role;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.SecurityEnvironment;
 import io.helidon.security.SecurityResponse;
@@ -47,6 +51,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -162,6 +167,106 @@ public class JwtProviderTest {
         assertThat(authenticationResponse.service(), is(Optional.empty()));
         assertThat(authenticationResponse.user(), is(Optional.empty()));
         assertThat(authenticationResponse.status(), is(SecurityResponse.SecurityStatus.FAILURE));
+    }
+
+    @Test
+    public void testCustomJwtGroupsPath() {
+        JwtProvider provider = JwtProvider.create(providersConfig.get("jwt-custom-groups"));
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.builder()
+                .subject("user1-id")
+                .preferredUsername("user1")
+                .issuer("jwt.example.com")
+                .algorithm(JwkRSA.ALG_RS256)
+                .keyId("verify-rsa")
+                .issueTime(now)
+                .expirationTime(now.plus(1, ChronoUnit.HOURS))
+                .addAudience("audience.application.id")
+                .addPayloadClaim("permissions", "inventory:read,inventory:write")
+                .build();
+        SignedJwt signedJwt = SignedJwt.sign(jwt, signKeys.forKeyId("sign-rsa").orElseThrow());
+
+        AuthenticationResponse authenticationResponse = provider.authenticate(request(signedJwt.tokenContent()));
+
+        assertThat(authenticationResponse.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
+        Subject subject = authenticationResponse.user().orElseThrow();
+        assertThat(subject.grants(Role.class), hasItems(Role.create("inventory:read"), Role.create("inventory:write")));
+    }
+
+    @Test
+    public void testCustomNestedJwtGroupsPath() {
+        JwtProvider provider = JwtProvider.create(providersConfig.get("jwt-custom-groups-nested"));
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.builder()
+                .subject("user1-id")
+                .preferredUsername("user1")
+                .issuer("jwt.example.com")
+                .algorithm(JwkRSA.ALG_RS256)
+                .keyId("verify-rsa")
+                .issueTime(now)
+                .expirationTime(now.plus(1, ChronoUnit.HOURS))
+                .addAudience("audience.application.id")
+                .addPayloadClaim("realm_access",
+                                 JsonObject.create(Map.of("roles",
+                                                          JsonArray.createStrings(List.of("inventory:read",
+                                                                                          "inventory:write")))))
+                .build();
+        SignedJwt signedJwt = SignedJwt.sign(jwt, signKeys.forKeyId("sign-rsa").orElseThrow());
+
+        AuthenticationResponse authenticationResponse = provider.authenticate(request(signedJwt.tokenContent()));
+
+        assertThat(authenticationResponse.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
+        Subject subject = authenticationResponse.user().orElseThrow();
+        assertThat(subject.grants(Role.class), hasItems(Role.create("inventory:read"), Role.create("inventory:write")));
+    }
+
+    @Test
+    public void testInvalidCustomJwtGroupsPathFailsAuthentication() {
+        JwtProvider provider = JwtProvider.create(providersConfig.get("jwt-custom-groups"));
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.builder()
+                .subject("user1-id")
+                .preferredUsername("user1")
+                .issuer("jwt.example.com")
+                .algorithm(JwkRSA.ALG_RS256)
+                .keyId("verify-rsa")
+                .issueTime(now)
+                .expirationTime(now.plus(1, ChronoUnit.HOURS))
+                .addAudience("audience.application.id")
+                .addPayloadClaim("permissions", 42)
+                .build();
+        SignedJwt signedJwt = SignedJwt.sign(jwt, signKeys.forKeyId("sign-rsa").orElseThrow());
+
+        AuthenticationResponse authenticationResponse = provider.authenticate(request(signedJwt.tokenContent()));
+
+        assertThat(authenticationResponse.status(), is(SecurityResponse.SecurityStatus.FAILURE));
+        assertThat(authenticationResponse.user(), is(Optional.empty()));
+    }
+
+    @Test
+    public void testJwtGroupsSeparatorIgnoredForDefaultGroupsPath() {
+        JwtProvider provider = JwtProvider.builder()
+                .verifySignature(false)
+                .jwtGroupsSeparator(",")
+                .build();
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.builder()
+                .subject("user1-id")
+                .preferredUsername("user1")
+                .issuer("jwt.example.com")
+                .algorithm(JwkRSA.ALG_RS256)
+                .keyId("verify-rsa")
+                .issueTime(now)
+                .expirationTime(now.plus(1, ChronoUnit.HOURS))
+                .addPayloadClaim("groups", "inventory:read,inventory:write")
+                .build();
+        SignedJwt signedJwt = SignedJwt.sign(jwt, signKeys.forKeyId("sign-rsa").orElseThrow());
+
+        AuthenticationResponse authenticationResponse = provider.authenticate(request(signedJwt.tokenContent()));
+
+        assertThat(authenticationResponse.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
+        Subject subject = authenticationResponse.user().orElseThrow();
+        assertThat(subject.grants(Role.class), hasItems(Role.create("inventory:read,inventory:write")));
     }
 
     @Test
@@ -560,5 +665,14 @@ public class JwtProviderTest {
                     assertThat(atnPrincipal.abacAttribute("full_name"), is(Optional.of(fullName)));
                     assertThat(atnPrincipal.abacAttribute("locale"), is(Optional.of(locale)));
                 }, () -> fail("User must be present in response"));
+    }
+
+    private ProviderRequest request(String token) {
+        ProviderRequest atnRequest = mock(ProviderRequest.class);
+        SecurityEnvironment se = SecurityEnvironment.builder()
+                .header("Authorization", "bearer " + token)
+                .build();
+        when(atnRequest.env()).thenReturn(se);
+        return atnRequest;
     }
 }

--- a/security/providers/jwt/src/test/resources/application.yaml
+++ b/security/providers/jwt/src/test/resources/application.yaml
@@ -101,3 +101,24 @@ jwt-no-verification:
         outbound-token:
           header: "Authorization"
           format: "bearer %1$s"
+
+jwt-custom-groups:
+  # Token extraction
+  atn-token:
+    # Expected issuer (if not defined, any issuer is accepted)
+    jwt-issuer: "jwt.example.com"
+    # Expected audience (if not defined, any audience is accepted - security issue...)
+    jwt-audience: "audience.application.id"
+    verify-signature: false
+  jwt-groups-path: "permissions"
+  jwt-groups-separator: ","
+
+jwt-custom-groups-nested:
+  # Token extraction
+  atn-token:
+    # Expected issuer (if not defined, any issuer is accepted)
+    jwt-issuer: "jwt.example.com"
+    # Expected audience (if not defined, any audience is accepted - security issue...)
+    jwt-audience: "audience.application.id"
+    verify-signature: false
+  jwt-groups-path: "realm_access/roles"

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -79,6 +80,7 @@ import static io.helidon.security.providers.oidc.common.spi.TenantConfigFinder.D
  */
 public final class OidcProvider implements AuthenticationProvider, OutboundSecurityProvider {
     private static final System.Logger LOGGER = System.getLogger(OidcProvider.class.getName());
+    static final String DEFAULT_JWT_GROUPS_PATH = "groups";
 
     private final boolean optional;
     private final OidcConfig oidcConfig;
@@ -87,6 +89,8 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
     private final boolean propagate;
     private final OidcOutboundConfig outboundConfig;
     private final boolean useJwtGroups;
+    private final String jwtGroupsPath;
+    private final String jwtGroupsSeparator;
     private final LruCache<String, TenantAuthenticationHandler> tenantAuthHandlers = LruCache.create();
 
     private OidcProvider(Builder builder, OidcOutboundConfig oidcOutboundConfig) {
@@ -94,6 +98,8 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         this.oidcConfig = builder.oidcConfig;
         this.propagate = builder.propagate && (oidcOutboundConfig.hasOutbound());
         this.useJwtGroups = builder.useJwtGroups;
+        this.jwtGroupsPath = builder.jwtGroupsPath;
+        this.jwtGroupsSeparator = builder.jwtGroupsSeparator;
         this.outboundConfig = oidcOutboundConfig;
 
         tenantConfigFinders = List.copyOf(builder.tenantConfigFinders);
@@ -161,6 +167,8 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
             TenantAuthenticationHandler handler = new TenantAuthenticationHandler(oidcConfig,
                                                                                   tenant,
                                                                                   useJwtGroups,
+                                                                                  jwtGroupsPath,
+                                                                                  jwtGroupsSeparator,
                                                                                   optional);
             return tenantAuthHandlers.computeValue(tenantId, () -> Optional.of(handler)).get()
                     .authenticate(tenantId, providerRequest);
@@ -312,6 +320,8 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         // for outbound calls, unless it is the same audience
         private Boolean propagate;
         private boolean useJwtGroups = true;
+        private String jwtGroupsPath = DEFAULT_JWT_GROUPS_PATH;
+        private String jwtGroupsSeparator;
         private OutboundConfig outboundConfig;
         private Config config = Config.empty();
         private TokenHandler defaultOutboundHandler = TokenHandler.builder()
@@ -396,6 +406,8 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
                 }
             }
             config.get("use-jwt-groups").asBoolean().ifPresent(this::useJwtGroups);
+            config.get("jwt-groups-path").asString().ifPresent(this::jwtGroupsPath);
+            config.get("jwt-groups-separator").asString().ifPresent(this::jwtGroupsSeparator);
             config.get("discover-tenant-config-providers").asBoolean().ifPresent(this::discoverTenantConfigProviders);
             config.get("discover-tenant-id-providers").asBoolean().ifPresent(this::discoverTenantIdProviders);
             return this;
@@ -464,6 +476,43 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         public Builder useJwtGroups(boolean useJwtGroups) {
             this.useJwtGroups = useJwtGroups;
             return this;
+        }
+
+        /**
+         * Path to the JWT payload claim containing the groups to add as role grants.
+         * The default path is {@code groups}. Nested object claims can be configured with slash-separated path segments,
+         * such as {@code realm/groups}.
+         *
+         * @param jwtGroupsPath JWT groups claim path
+         * @return updated builder instance
+         */
+        @ConfiguredOption("groups")
+        public Builder jwtGroupsPath(String jwtGroupsPath) {
+            this.jwtGroupsPath = requireText(jwtGroupsPath, "JWT groups path");
+            return this;
+        }
+
+        /**
+         * Separator used to split a string claim value into multiple groups.
+         * This is used only when {@link #jwtGroupsPath(String)} configures a custom path other than {@code groups}.
+         * The default {@code groups} claim keeps the standard OIDC JWT behavior.
+         * Setting this property without changing the JWT groups path has no effect.
+         *
+         * @param jwtGroupsSeparator separator for string-valued custom groups claim
+         * @return updated builder instance
+         */
+        @ConfiguredOption
+        public Builder jwtGroupsSeparator(String jwtGroupsSeparator) {
+            this.jwtGroupsSeparator = requireText(jwtGroupsSeparator, "JWT groups separator");
+            return this;
+        }
+
+        private static String requireText(String value, String description) {
+            Objects.requireNonNull(value, description + " must not be null");
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException(description + " must not be empty");
+            }
+            return value;
         }
 
         /**

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -34,6 +34,7 @@ import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.helidon.common.Errors;
 import io.helidon.common.LazyValue;
@@ -43,8 +44,11 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.SetCookie;
 import io.helidon.http.Status;
+import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
+import io.helidon.json.JsonString;
+import io.helidon.json.JsonValue;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.Grant;
@@ -95,15 +99,28 @@ class TenantAuthenticationHandler {
     private final TenantConfig tenantConfig;
     private final Tenant tenant;
     private final boolean useJwtGroups;
+    private final String jwtGroupsPath;
+    private final String jwtGroupsSeparator;
     private final BiFunction<SignedJwt, Errors.Collector, Errors.Collector> jwtValidator;
     private final BiConsumer<StringBuilder, String> scopeAppender;
     private final Pattern attemptPattern;
 
     TenantAuthenticationHandler(OidcConfig oidcConfig, Tenant tenant, boolean useJwtGroups, boolean optional) {
+        this(oidcConfig, tenant, useJwtGroups, OidcProvider.DEFAULT_JWT_GROUPS_PATH, null, optional);
+    }
+
+    TenantAuthenticationHandler(OidcConfig oidcConfig,
+                                Tenant tenant,
+                                boolean useJwtGroups,
+                                String jwtGroupsPath,
+                                String jwtGroupsSeparator,
+                                boolean optional) {
         this.oidcConfig = oidcConfig;
         this.tenant = tenant;
         this.tenantConfig = tenant.tenantConfig();
         this.useJwtGroups = useJwtGroups;
+        this.jwtGroupsPath = jwtGroupsPath;
+        this.jwtGroupsSeparator = jwtGroupsSeparator;
         this.optional = optional;
 
         attemptPattern = Pattern.compile(".*?" + oidcConfig.redirectAttemptParam() + "=(\\d+).*");
@@ -784,7 +801,16 @@ class TenantAuthenticationHandler {
         if (errors.isValid() && validationErrors.isValid()) {
 
             errors.log(LOGGER);
-            Subject subject = buildSubject(jwt, signedJwt, idToken);
+            Subject subject;
+            try {
+                subject = buildSubject(jwt, signedJwt, idToken);
+            } catch (JwtException e) {
+                return errorResponse(providerRequest,
+                                     Status.UNAUTHORIZED_401,
+                                     "invalid_token",
+                                     e.getMessage(),
+                                     tenantId);
+            }
 
             Set<String> scopes = subject.grantsByType("scope")
                     .stream()
@@ -833,7 +859,8 @@ class TenantAuthenticationHandler {
         }
     }
 
-    private Subject buildSubject(Jwt jwt, SignedJwt signedJwt, Jwt idToken) {
+    // Package-private to allow focused tests to exercise subject construction without invoking remote OIDC flows.
+    Subject buildSubject(Jwt jwt, SignedJwt signedJwt, Jwt idToken) {
         Principal principal = buildPrincipal(jwt, idToken);
 
         TokenCredential.Builder builder = TokenCredential.builder();
@@ -849,8 +876,7 @@ class TenantAuthenticationHandler {
                 .addPublicCredential(TokenCredential.class, builder.build());
 
         if (useJwtGroups) {
-            Optional<List<String>> userGroups = jwt.userGroups();
-            userGroups.ifPresent(groups -> groups.forEach(group -> subjectBuilder.addGrant(Role.create(group))));
+            jwtGroups(jwt).forEach(group -> subjectBuilder.addGrant(Role.create(group)));
         }
 
         Optional<List<String>> scopes = jwt.scopes();
@@ -861,6 +887,50 @@ class TenantAuthenticationHandler {
 
         return subjectBuilder.build();
 
+    }
+
+    private List<String> jwtGroups(Jwt jwt) {
+        if (OidcProvider.DEFAULT_JWT_GROUPS_PATH.equals(jwtGroupsPath)) {
+            return jwt.userGroups().orElse(List.of());
+        }
+        return jwtGroupsClaim(jwt)
+                .map(this::toGroups)
+                .orElse(List.of());
+    }
+
+    private Optional<JsonValue> jwtGroupsClaim(Jwt jwt) {
+        String[] pathSegments = jwtGroupsPath.split("/");
+        Optional<JsonValue> currentValue = jwt.payloadClaimValue(pathSegments[0]);
+        for (int i = 1; i < pathSegments.length; i++) {
+            String pathSegment = pathSegments[i];
+            currentValue = currentValue
+                    .filter(it -> it instanceof JsonObject)
+                    .flatMap(it -> it.asObject().value(pathSegment));
+        }
+        return currentValue;
+    }
+
+    private List<String> toGroups(JsonValue claimValue) {
+        if (claimValue instanceof JsonArray groups) {
+            return groups.values()
+                    .stream()
+                    .map(this::toGroup)
+                    .toList();
+        }
+        String group = toGroup(claimValue);
+        if (jwtGroupsSeparator == null) {
+            return List.of(group);
+        }
+        return Stream.of(group.split(Pattern.quote(jwtGroupsSeparator)))
+                .filter(it -> !it.isBlank())
+                .toList();
+    }
+
+    private String toGroup(JsonValue groupValue) {
+        if (groupValue instanceof JsonString group) {
+            return group.value();
+        }
+        throw new JwtException("Invalid value. Expecting a string or string array for key " + jwtGroupsPath);
     }
 
     private Principal buildPrincipal(Jwt accessToken, Jwt idToken) {

--- a/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/TenantAuthenticationHandlerTest.java
+++ b/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/TenantAuthenticationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,32 @@
 package io.helidon.security.providers.oidc;
 
 import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
 
+import io.helidon.config.Config;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
+import io.helidon.security.AuthenticationResponse;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.ProviderRequest;
+import io.helidon.security.Role;
 import io.helidon.security.Security;
 import io.helidon.security.SecurityEnvironment;
+import io.helidon.security.SecurityResponse;
+import io.helidon.security.Subject;
+import io.helidon.security.jwt.Jwt;
+import io.helidon.security.jwt.SignedJwt;
+import io.helidon.security.jwt.jwk.Jwk;
 import io.helidon.security.providers.oidc.common.OidcConfig;
 import io.helidon.security.providers.oidc.common.Tenant;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -35,6 +52,67 @@ import static org.mockito.Mockito.when;
  * Unit test for {@link TenantAuthenticationHandler}.
  */
 class TenantAuthenticationHandlerTest {
+
+    @Test
+    public void testCustomJwtGroupsPath() {
+        OidcConfig oidcConfig = OidcConfig.builder()
+                .clientId("test")
+                .clientSecret("123")
+                .identityUri(URI.create("http://localhost:1234"))
+                .build();
+
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.tenantConfig()).thenReturn(oidcConfig);
+
+        TenantAuthenticationHandler authenticationHandler = new TenantAuthenticationHandler(oidcConfig,
+                                                                                            tenant,
+                                                                                            true,
+                                                                                            "realm_access/roles",
+                                                                                            null,
+                                                                                            true);
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.builder()
+                .subject("user1-id")
+                .preferredUsername("user1")
+                .algorithm("none")
+                .issueTime(now)
+                .expirationTime(now.plus(1, ChronoUnit.HOURS))
+                .addPayloadClaim("realm_access",
+                                 JsonObject.create(Map.of("roles",
+                                                          JsonArray.createStrings(List.of("inventory:read",
+                                                                                          "inventory:write")))))
+                .build();
+        SignedJwt signedJwt = SignedJwt.sign(jwt, Jwk.NONE_JWK);
+
+        Subject subject = authenticationHandler.buildSubject(jwt, signedJwt, null);
+
+        assertThat(subject.grants(Role.class), hasItems(Role.create("inventory:read"), Role.create("inventory:write")));
+    }
+
+    @Test
+    public void testConfiguredCustomJwtGroupsPathWithSeparator() {
+        OidcProvider provider = OidcProvider.create(Config.create().get("security.oidc-custom-groups"));
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.builder()
+                .subject("user1-id")
+                .preferredUsername("user1")
+                .algorithm("none")
+                .issueTime(now)
+                .expirationTime(now.plus(1, ChronoUnit.HOURS))
+                .addPayloadClaim("realm_access",
+                                 JsonObject.create(Map.of("roles",
+                                                          JsonString.create("inventory:read,inventory:write"))))
+                .build();
+        SignedJwt signedJwt = SignedJwt.sign(jwt, Jwk.NONE_JWK);
+
+        AuthenticationResponse authenticationResponse = provider.authenticate(request(signedJwt.tokenContent()));
+
+        assertThat(authenticationResponse.description().orElse("Unexpected authentication response"),
+                   authenticationResponse.status(),
+                   is(SecurityResponse.SecurityStatus.SUCCESS));
+        Subject subject = authenticationResponse.user().orElseThrow();
+        assertThat(subject.grants(Role.class), hasItems(Role.create("inventory:read"), Role.create("inventory:write")));
+    }
 
     @Test
     public void testOriginalUri() {
@@ -92,6 +170,21 @@ class TenantAuthenticationHandlerTest {
         when(providerRequest.env()).thenReturn(securityEnvironment);
 
         assertThat(authenticationHandler.origUri(providerRequest), is("/noQuery"));
+    }
+
+    private ProviderRequest request(String token) {
+        ProviderRequest providerRequest = mock(ProviderRequest.class);
+        SecurityEnvironment securityEnvironment = SecurityEnvironment.builder()
+                .header("Authorization", "bearer " + token)
+                .targetUri(URI.create("http://localhost:1234/test"))
+                .build();
+        when(providerRequest.env()).thenReturn(securityEnvironment);
+
+        EndpointConfig endpointConfig = mock(EndpointConfig.class);
+        when(endpointConfig.securityLevels()).thenReturn(List.of());
+        when(providerRequest.endpointConfig()).thenReturn(endpointConfig);
+
+        return providerRequest;
     }
 
 }

--- a/security/providers/oidc/src/test/resources/application.yaml
+++ b/security/providers/oidc/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,3 +28,18 @@ security:
     token-endpoint-uri: "http://identity.oracle.com/tokens"
     authorization-endpoint-uri: "http://identity.oracle.com/authorization"
     introspect-endpoint-uri: "http://identity.oracle.com/introspect"
+  oidc-custom-groups:
+    identity-uri: "https://identity.oracle.com"
+    client-id: "client-id-value"
+    client-secret: "client-secret-value"
+    frontend-uri: "http://something:7001"
+    oidc-metadata-well-known: false
+    token-endpoint-uri: "http://identity.oracle.com/tokens"
+    authorization-endpoint-uri: "http://identity.oracle.com/authorization"
+    validate-jwt-with-jwk: true
+    token-signature-validation: false
+    check-audience: false
+    header-use: true
+    cookie-use: false
+    jwt-groups-path: "realm_access/roles"
+    jwt-groups-separator: ","


### PR DESCRIPTION
Resolves #11962

Carries custom JWT groups path support from #11961 to main for the SE JWT and OIDC providers. The main branch no longer contains the 4.x MicroProfile JWT module, so this carry-forward applies only to the provider modules that still live in this repository line.
