### PR TITLE
Enable Javadoc fail-on-warning for config modules (27.x)

### DIFF
--- a/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,6 +228,15 @@ public final class EncryptionFilter implements ConfigFilter {
         private char[] masterPassword;
         private Keys privateKeyConfig;
         private boolean requireEncryption = true;
+
+        /**
+         * Create a new builder.
+         *
+         * @deprecated use {@link EncryptionFilter#builder()} instead
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public Builder() {
+        }
 
         private Builder fromConfig() {
             fromConfig = true;

--- a/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilterService.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ import io.helidon.config.spi.ConfigFilter;
  */
 public class EncryptionFilterService implements ConfigFilter {
     private ConfigFilter filter;
+
+    /**
+     * Service provider constructor.
+     */
+    public EncryptionFilterService() {
+    }
 
     @Override
     public String apply(Config.Key key, String stringValue) {

--- a/config/object-mapping/src/main/java/io/helidon/config/objectmapping/ObjectConfigMapperProvider.java
+++ b/config/object-mapping/src/main/java/io/helidon/config/objectmapping/ObjectConfigMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,12 @@ public class ObjectConfigMapperProvider implements ConfigMapperProvider {
     private static final String METHOD_FROM_STRING = "fromString";
     private static final String METHOD_PARSE = "parse";
     private static final String METHOD_CREATE = "create";
+
+    /**
+     * Service provider constructor.
+     */
+    public ObjectConfigMapperProvider() {
+    }
 
     @Override
     public Map<Class<?>, Function<Config, ?>> mappers() {

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -35,6 +35,10 @@
         Configuration API
     </description>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>config</module>
         <module>object-mapping</module>

--- a/config/testing/src/main/java/module-info.java
+++ b/config/testing/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ module io.helidon.config.testing {
 
     requires hamcrest.all;
     requires io.helidon.config;
+    requires transitive io.helidon.common.testing.junit5;
     requires org.junit.jupiter.api;
 
 }


### PR DESCRIPTION
Part of #9356

Enables Javadoc fail-on-warning for the config reactor and fixes the config object-mapping and encryption Javadoc warnings found by that stricter check.
