### PR TITLE
Enable Javadoc fail-on-warning for health modules (27.x)

### DIFF
--- a/health/health/src/main/java/io/helidon/health/HealthCheckResponse.java
+++ b/health/health/src/main/java/io/helidon/health/HealthCheckResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,15 @@ public interface HealthCheckResponse {
         // Use a TreeMap to preserve stability of the details in JSON output.
         private final Map<String, Object> details = new TreeMap<>();
         private Status status = Status.UP;
+
+        /**
+         * Create a new builder.
+         *
+         * @deprecated use {@link HealthCheckResponse#builder()} instead
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public Builder() {
+        }
 
         @Override
         public HealthCheckResponse build() {

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -32,6 +32,10 @@
 
     <description>Health check support for Helidon SE</description>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>health</module>
         <module>health-checks</module>


### PR DESCRIPTION
Part of #9356

Enables Javadoc fail-on-warning for the health reactor and fixes the health Javadoc warning found by that stricter check.
