### PR TITLE
Enable logging Javadoc fail on warning

### DIFF
--- a/logging/jul/src/main/java/io/helidon/logging/jul/JulMdcPropagator.java
+++ b/logging/jul/src/main/java/io/helidon/logging/jul/JulMdcPropagator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,12 @@ import io.helidon.common.context.spi.DataPropagationProvider;
  * This class is loaded and used via SPI.
  */
 public class JulMdcPropagator implements DataPropagationProvider<Map<String, String>> {
+
+    /**
+     * Default constructor required by {@link java.util.ServiceLoader}.
+     */
+    public JulMdcPropagator() {
+    }
 
     @Override
     public Map<String, String> data() {

--- a/logging/jul/src/main/java/io/helidon/logging/jul/JulMdcProvider.java
+++ b/logging/jul/src/main/java/io/helidon/logging/jul/JulMdcProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,13 @@ import io.helidon.logging.common.spi.MdcProvider;
  * This class is loaded and used via SPI.
  */
 public class JulMdcProvider implements MdcProvider {
+
+    /**
+     * Default constructor required by {@link java.util.ServiceLoader}.
+     */
+    public JulMdcProvider() {
+    }
+
     @Override
     public void put(String key, String value) {
         JulMdc.put(key, value);

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -29,6 +29,10 @@
     <packaging>pom</packaging>
     <name>Helidon Logging Project</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>common</module>
         <module>jul</module>

--- a/logging/slf4j/src/main/java/io/helidon/logging/slf4j/Slf4jMdcPropagator.java
+++ b/logging/slf4j/src/main/java/io/helidon/logging/slf4j/Slf4jMdcPropagator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,12 @@ import org.slf4j.MDC;
  * This class is loaded and used via SPI.
  */
 public class Slf4jMdcPropagator implements DataPropagationProvider<Map<String, String>> {
+
+    /**
+     * Default constructor required by {@link java.util.ServiceLoader}.
+     */
+    public Slf4jMdcPropagator() {
+    }
 
     @Override
     public Map<String, String> data() {

--- a/logging/slf4j/src/main/java/io/helidon/logging/slf4j/Slf4jMdcProvider.java
+++ b/logging/slf4j/src/main/java/io/helidon/logging/slf4j/Slf4jMdcProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ import org.slf4j.MDC;
  * This class is loaded and used via SPI.
  */
 public class Slf4jMdcProvider implements MdcProvider {
+
+    /**
+     * Default constructor required by {@link java.util.ServiceLoader}.
+     */
+    public Slf4jMdcProvider() {
+    }
 
     @Override
     public void put(String key, String value) {

--- a/logging/slf4j/src/main/java/io/helidon/logging/slf4j/Slf4jProvider.java
+++ b/logging/slf4j/src/main/java/io/helidon/logging/slf4j/Slf4jProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,13 @@ import org.slf4j.LoggerFactory;
  * Slf4j logging provider.
  */
 public class Slf4jProvider implements LoggingProvider {
+
+    /**
+     * Default constructor required by {@link java.util.ServiceLoader}.
+     */
+    public Slf4jProvider() {
+    }
+
     @Override
     public void initialization() {
         LoggerFactory.getLogger(Slf4jProvider.class)


### PR DESCRIPTION
Part of #9356

Enable Javadoc fail-on-warning for logging modules and document service-provider constructors that surfaced as warnings.
