### PR TITLE
Allow telemetry to be disabled without startup exception

### DIFF
--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
@@ -116,6 +116,6 @@ interface OpenTelemetryConfigBlueprint extends Prototype.Factory<HelidonOpenTele
      * @return the SDK
      */
     @Option.Access("")
-    Optional<OpenTelemetrySdk> openTelemetrySdk();
+    OpenTelemetrySdk openTelemetrySdk();
 
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
@@ -116,6 +116,6 @@ interface OpenTelemetryConfigBlueprint extends Prototype.Factory<HelidonOpenTele
      * @return the SDK
      */
     @Option.Access("")
-    OpenTelemetrySdk openTelemetrySdk();
+    Optional<OpenTelemetrySdk> openTelemetrySdk();
 
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigSupport.java
@@ -35,6 +35,10 @@ final class OpenTelemetryConfigSupport {
     private OpenTelemetryConfigSupport() {
     }
 
+    private static OpenTelemetrySdk noopOpenTelemetrySdk() {
+        return OpenTelemetrySdk.builder().build();
+    }
+
     private static OpenTelemetry openTelemetry(OpenTelemetryConfig.BuilderBase<?, ?> target) {
         var openTelemetrySdkBuilder = OpenTelemetrySdk.builder();
 
@@ -100,12 +104,21 @@ final class OpenTelemetryConfigSupport {
             derive from the settings.
              */
             if (target.openTelemetry().isPresent()) {
+                if (target.openTelemetrySdk().isEmpty()) {
+                    var openTelemetry = target.openTelemetry().get();
+                    target.openTelemetrySdk(openTelemetry instanceof OpenTelemetrySdk sdk
+                                                    ? sdk
+                                                    : noopOpenTelemetrySdk());
+                }
                 return;
             }
 
-            target.openTelemetry(target.enabled()
-                                         ? openTelemetry(target)
-                                         : OpenTelemetry.noop());
+            if (target.enabled()) {
+                target.openTelemetry(openTelemetry(target));
+            } else {
+                target.openTelemetrySdk(noopOpenTelemetrySdk())
+                        .openTelemetry(OpenTelemetry.noop());
+            }
         }
 
     }
@@ -149,4 +162,3 @@ final class OpenTelemetryConfigSupport {
     }
 
 }
-

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
@@ -24,6 +24,7 @@ import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -102,11 +103,8 @@ class TestBasicConfig {
                          iterableWithSize(2)));
 
         assertThat("Sampler",
-                   openTelemetryConfig.openTelemetrySdk()
-                           .map(OpenTelemetrySdk::getSdkTracerProvider)
-                           .map(SdkTracerProvider::getSampler)
-                           .map(Sampler::toString),
-                   OptionalMatcher.optionalValue(is("AlwaysOffSampler")));
+                   openTelemetryConfig.openTelemetrySdk().getSdkTracerProvider().getSampler().toString(),
+                   is("AlwaysOffSampler"));
 
     }
 
@@ -141,6 +139,10 @@ class TestBasicConfig {
 
         OpenTelemetryConfig openTelemetry = OpenTelemetryConfig.create(config.get("telemetry"));
         assertThat("OpenTelemetry with config disabled", openTelemetry.openTelemetry(), is(equalTo(OpenTelemetry.noop())));
+        assertThat("OpenTelemetry SDK with config disabled", openTelemetry.openTelemetrySdk(), is(notNullValue()));
+        assertThat("OpenTelemetry SDK propagators with config disabled",
+                   openTelemetry.openTelemetrySdk().getPropagators(),
+                   is(equalTo(ContextPropagators.noop())));
 
     }
 

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
@@ -23,12 +23,17 @@ import io.helidon.common.testing.junit5.OptionalMatcher;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -97,8 +102,11 @@ class TestBasicConfig {
                          iterableWithSize(2)));
 
         assertThat("Sampler",
-                   openTelemetryConfig.openTelemetrySdk().getSdkTracerProvider().getSampler().toString(),
-                   is("AlwaysOffSampler"));
+                   openTelemetryConfig.openTelemetrySdk()
+                           .map(OpenTelemetrySdk::getSdkTracerProvider)
+                           .map(SdkTracerProvider::getSampler)
+                           .map(Sampler::toString),
+                   OptionalMatcher.optionalValue(is("AlwaysOffSampler")));
 
     }
 
@@ -115,6 +123,25 @@ class TestBasicConfig {
 
         assertThat("Global", openTelemetry.global(), is(true));
         assertThat("Enabled", openTelemetry.enabled(), is(true));
+    }
+
+    @Test
+    void testDisabled() {
+        /*
+        The main point of this test is to make sure that we can build the OpenTelemetryConfig object without errors when
+        telemetry is disabled.
+         */
+        var config = Config.just(ConfigSources.create(
+                """
+                        telemetry:
+                          service: test
+                          enabled: false
+                        """,
+                MediaTypes.APPLICATION_YAML));
+
+        OpenTelemetryConfig openTelemetry = OpenTelemetryConfig.create(config.get("telemetry"));
+        assertThat("OpenTelemetry with config disabled", openTelemetry.openTelemetry(), is(equalTo(OpenTelemetry.noop())));
+
     }
 
     @Test


### PR DESCRIPTION
### Description
Resolves #11964 

### Release Note
____
Helidon no longer throws an exception about a required `OpenTelemetrySdk` setting when `telemetry.enabled` is `false`.
____

The PR changes the `openTelemetrySdk` blueprint setting to an `Optional` but it has always had package-private access so there is no change to the public surface area.

The `openTelemetrySdk` setting is used only internally within the module and is not needed if the user has disabled telemetry.

A new test makes sure that disabling telemetry does not cause a failure wrt `openTelemetrySdk`.

### Documentation
No impact.