### PR TITLE
Apply container semantics to TypeHandlerOptional (4.x)

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import io.helidon.builder.codegen.spi.BuilderCodegenExtension;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Constructor;
+import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.codegen.classmodel.InnerClass;
 import io.helidon.codegen.classmodel.Javadoc;
 import io.helidon.codegen.classmodel.Method;
@@ -578,6 +579,69 @@ final class GenerateAbstractBuilder {
                 .anyMatch(it -> it.provider().isPresent());
     }
 
+    private static boolean optionalProviderContainer(TypeName typeName) {
+        return typeName.isOptional()
+                && !typeName.typeArguments().isEmpty()
+                && (typeName.typeArguments().getFirst().isList() || typeName.typeArguments().getFirst().isSet());
+    }
+
+    private static boolean optionalProviderSet(TypeName typeName) {
+        return typeName.isOptional()
+                && !typeName.typeArguments().isEmpty()
+                && typeName.typeArguments().getFirst().isSet();
+    }
+
+    private static TypeName providerContainerType(TypeName typeName) {
+        if (typeName.isOptional()) {
+            return typeName.typeArguments().getFirst();
+        }
+        return typeName;
+    }
+
+    private static TypeName providerValueType(OptionHandler optionHandler) {
+        TypeName providerContainerType = providerContainerType(optionHandler.option().declaredType());
+        if (providerContainerType.isList() || providerContainerType.isSet()) {
+            return providerContainerType.typeArguments().getFirst();
+        }
+        return optionHandler.typeHandler().type();
+    }
+
+    private static void optionalProviderExisting(ContentBuilder<?> content, OptionInfo option, boolean optionalSet) {
+        content.addContent(option.name())
+                .addContent(" == null ? ")
+                .addContent(List.class)
+                .addContent(".of() : ");
+        if (optionalSet) {
+            content.addContent(List.class)
+                    .addContent(".copyOf(")
+                    .addContent(option.name())
+                    .addContent(")");
+        } else {
+            content.addContent(option.name());
+        }
+    }
+
+    private static void optionalProviderEmpty(ContentBuilder<?> content, TypeName providerValueType) {
+        content.addContent(List.class)
+                .addContent(".<")
+                .addContent(providerValueType.genericTypeName())
+                .addContent(">of()");
+    }
+
+    private static void addOptionalProviderDiscovered(Method.Builder preBuildBuilder, OptionInfo option, boolean optionalSet) {
+        preBuildBuilder.addContent("this.add")
+                .addContent(capitalize(option.name()))
+                .addContent("(");
+        if (optionalSet) {
+            preBuildBuilder.addContent("new ")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("<>(discovered)");
+        } else {
+            preBuildBuilder.addContent("discovered");
+        }
+        preBuildBuilder.addContentLine(");");
+    }
+
     private static void serviceLoaderPropertyDiscovery(Method.Builder preBuildBuilder,
                                                        OptionHandler optionHandler,
                                                        boolean propertyConfigured,
@@ -586,11 +650,47 @@ final class GenerateAbstractBuilder {
         TypeHandler typeHandler = optionHandler.typeHandler();
         OptionInfo option = optionHandler.option();
         TypeName typeName = option.declaredType();
+        TypeName providerValueType = providerValueType(optionHandler);
 
         if (propertyConfigured) {
             OptionConfigured configured = option.configured().get();
 
-            if (typeName.isList() || typeName.isSet()) {
+            if (optionalProviderContainer(typeName)) {
+                boolean optionalSet = optionalProviderSet(typeName);
+                preBuildBuilder.addContentLine("{")
+                        .addContent("var optionConfig = config.get(\"")
+                        .addContent(configured.configKey())
+                        .addContentLine("\");")
+                        .addContent("var discovered = optionConfig.exists() && optionConfig.asNodeList().orElseGet(")
+                        .addContent(List.class)
+                        .addContentLine("::of).isEmpty()")
+                        .increaseContentPadding()
+                        .increaseContentPadding()
+                        .addContent("? ")
+                        .update(it -> optionalProviderEmpty(it, providerValueType))
+                        .addContentLine("")
+                        .addContent(": ")
+                        .addContent(CONFIG_BUILDER_SUPPORT)
+                        .addContent(".discoverServices(config, \"")
+                        .addContent(configured.configKey())
+                        .addContent("\", ")
+                        .addContent(providerType.genericTypeName())
+                        .addContent(".class, ")
+                        .addContent(providerValueType.genericTypeName())
+                        .addContent(".class, ")
+                        .addContent(option.name())
+                        .addContent("DiscoverServices, ")
+                        .update(it -> optionalProviderExisting(it, option, optionalSet))
+                        .addContentLine(");")
+                        .decreaseContentPadding()
+                        .decreaseContentPadding()
+                        .addContent("if (optionConfig.exists() || ")
+                        .addContent(option.name())
+                        .addContentLine(" != null || !discovered.isEmpty()) {");
+                addOptionalProviderDiscovered(preBuildBuilder, option, optionalSet);
+                preBuildBuilder.addContentLine("}")
+                        .addContentLine("}");
+            } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
                         .addContent(capitalize(option.name()))
                         .addContent("(")
@@ -600,7 +700,7 @@ final class GenerateAbstractBuilder {
                         .addContent("\", ")
                         .addContent(providerType.genericTypeName())
                         .addContent(".class, ")
-                        .addContent(typeHandler.type().genericTypeName())
+                        .addContent(providerValueType.genericTypeName())
                         .addContent(".class, ")
                         .addContent(option.name())
                         .addContent("DiscoverServices, ")
@@ -626,7 +726,25 @@ final class GenerateAbstractBuilder {
                         .addContentLine(");");
             }
         } else {
-            if (typeName.isList() || typeName.isSet()) {
+            if (optionalProviderContainer(typeName)) {
+                boolean optionalSet = optionalProviderSet(typeName);
+                preBuildBuilder.addContentLine("{")
+                        .addContent("var discovered = ")
+                        .addContent(BUILDER_SUPPORT)
+                        .addContent(".discoverServices(")
+                        .addContent(providerType.genericTypeName())
+                        .addContent(".class, ")
+                        .addContent(option.name())
+                        .addContent("DiscoverServices, ")
+                        .update(it -> optionalProviderExisting(it, option, optionalSet))
+                        .addContentLine(");")
+                        .addContent("if (")
+                        .addContent(option.name())
+                        .addContentLine(" != null || !discovered.isEmpty()) {");
+                addOptionalProviderDiscovered(preBuildBuilder, option, optionalSet);
+                preBuildBuilder.addContentLine("}")
+                        .addContentLine("}");
+            } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
                         .addContent(capitalize(option.name()))
                         .addContent("(")
@@ -786,11 +904,19 @@ final class GenerateAbstractBuilder {
         TypeHandler typeHandler = optionHandler.typeHandler();
         OptionInfo option = optionHandler.option();
         TypeName typeName = option.declaredType();
+        TypeName providerValueType = providerValueType(optionHandler);
 
         if (propertyConfigured) {
             OptionConfigured configured = option.configured().get();
 
-            if (typeName.isList() || typeName.isSet()) {
+            if (optionalProviderContainer(typeName)) {
+                serviceRegistryConfiguredOptionalProviderContainer(preBuildBuilder,
+                                                                   option,
+                                                                   configured,
+                                                                   providerType,
+                                                                   providerValueType,
+                                                                   optionalProviderSet(typeName));
+            } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
                         .addContent(capitalize(option.name()))
                         .addContent("(")
@@ -805,7 +931,7 @@ final class GenerateAbstractBuilder {
                         .addContentLine("registry,")
                         .addContent(providerType.genericTypeName())
                         .addContentLine(".class,")
-                        .addContent(typeHandler.type().genericTypeName())
+                        .addContent(providerValueType.genericTypeName())
                         .addContentLine(".class,")
                         .addContent(option.name())
                         .addContentLine("DiscoverServices,")
@@ -843,7 +969,33 @@ final class GenerateAbstractBuilder {
                         .decreaseContentPadding();
             }
         } else {
-            if (typeName.isList()) {
+            if (optionalProviderContainer(typeName)) {
+                boolean optionalSet = optionalProviderSet(typeName);
+                preBuildBuilder.addContentLine("{")
+                        .addContent("var discovered = ")
+                        .addContent(REGISTRY_BUILDER_SUPPORT);
+                if (optionalSet) {
+                    preBuildBuilder.addContent(".<")
+                            .addContent(providerValueType.genericTypeName())
+                            .addContent(">serviceSet(registry, ")
+                            .addContentCreate(providerValueType)
+                            .addContent(", ");
+                } else {
+                    preBuildBuilder.addContent(".<")
+                            .addContent(providerValueType.genericTypeName())
+                            .addContent(">serviceList(registry, ")
+                            .addContentCreate(providerValueType)
+                            .addContent(", ");
+                }
+                preBuildBuilder.addContent(option.name())
+                        .addContentLine("DiscoverServices);")
+                        .addContent("if (")
+                        .addContent(option.name())
+                        .addContentLine(" != null || !discovered.isEmpty()) {");
+                addOptionalProviderDiscovered(preBuildBuilder, option, false);
+                preBuildBuilder.addContentLine("}")
+                        .addContentLine("}");
+            } else if (typeName.isList()) {
                 preBuildBuilder
                         .addContent("this.add")
                         .addContent(capitalize(option.name()))
@@ -881,6 +1033,55 @@ final class GenerateAbstractBuilder {
                         .addContentLine(");");
             }
         }
+    }
+
+    private static void serviceRegistryConfiguredOptionalProviderContainer(Method.Builder preBuildBuilder,
+                                                                          OptionInfo option,
+                                                                          OptionConfigured configured,
+                                                                          TypeName providerType,
+                                                                          TypeName providerValueType,
+                                                                          boolean optionalSet) {
+        preBuildBuilder.addContentLine("{")
+                .addContent("var optionConfig = config.get(\"")
+                .addContent(configured.configKey())
+                .addContentLine("\");")
+                .addContent("var discovered = optionConfig.exists() && optionConfig.asNodeList().orElseGet(")
+                .addContent(List.class)
+                .addContentLine("::of).isEmpty()")
+                .increaseContentPadding()
+                .increaseContentPadding()
+                .addContent("? ")
+                .update(it -> optionalProviderEmpty(it, providerValueType))
+                .addContentLine("")
+                .addContent(": ")
+                .addContent(CONFIG_BUILDER_SUPPORT)
+                .addContentLine(".discoverServices(config,")
+                .increaseContentPadding()
+                .increaseContentPadding()
+                .increaseContentPadding()
+                .addContent("\"")
+                .addContent(configured.configKey())
+                .addContentLine("\",")
+                .addContentLine("registry,")
+                .addContent(providerType.genericTypeName())
+                .addContentLine(".class,")
+                .addContent(providerValueType.genericTypeName())
+                .addContentLine(".class,")
+                .addContent(option.name())
+                .addContentLine("DiscoverServices,")
+                .update(it -> optionalProviderExisting(it, option, optionalSet))
+                .addContentLine(");")
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .addContent("if (optionConfig.exists() || ")
+                .addContent(option.name())
+                .addContentLine(" != null || !discovered.isEmpty()) {");
+        addOptionalProviderDiscovered(preBuildBuilder, option, optionalSet);
+        preBuildBuilder.addContentLine("}")
+                .addContentLine("}");
     }
 
     private static void validatePrototypeMethod(List<BuilderCodegenExtension> extensions, InnerClass.Builder classBuilder,
@@ -1291,7 +1492,23 @@ final class GenerateAbstractBuilder {
             constructor.addContent("this." + option.name() + " = ");
             TypeName declaredType = option.declaredType();
 
-            if (declaredType.isOptional() || declaredType.equals(OPTIONAL_COMMON_CONFIG)) {
+            if (declaredType.isOptional() && optionHandler.typeHandler().type().isList()) {
+                constructor.addContent("builder." + getterName + "().map(")
+                        .addContent(List.class)
+                        .addContentLine("::copyOf);");
+            } else if (declaredType.isOptional() && optionHandler.typeHandler().type().isSet()) {
+                constructor.addContent("builder." + getterName + "().map(it -> ")
+                        .addContent(Collections.class)
+                        .addContent(".unmodifiableSet(new ")
+                        .addContent(LinkedHashSet.class)
+                        .addContentLine("<>(it)));");
+            } else if (declaredType.isOptional() && optionHandler.typeHandler().type().isMap()) {
+                constructor.addContent("builder." + getterName + "().map(it -> ")
+                        .addContent(Collections.class)
+                        .addContent(".unmodifiableMap(new ")
+                        .addContent(LinkedHashMap.class)
+                        .addContentLine("<>(it)));");
+            } else if (declaredType.isOptional() || declaredType.equals(OPTIONAL_COMMON_CONFIG)) {
                 constructor.addContent("builder." + getterName + "().map(")
                         .addContent(Function.class)
                         .addContentLine(".identity());");

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -58,7 +58,7 @@ import io.helidon.common.types.TypedElementInfo;
 import static io.helidon.codegen.CodegenUtil.capitalize;
 
 abstract class TypeHandlerCollection extends TypeHandlerContainer {
-    private static final Set<TypeName> BUILT_IN_MAPPERS = Set.of(
+    static final Set<TypeName> BUILT_IN_MAPPERS = Set.of(
             TypeNames.STRING,
             TypeNames.BOXED_BOOLEAN,
             TypeNames.BOXED_BYTE,

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerOptional.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerOptional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,23 @@
 
 package io.helidon.builder.codegen;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import io.helidon.builder.codegen.spi.BuilderCodegenExtension;
 import io.helidon.codegen.classmodel.ClassBase;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.codegen.classmodel.Field;
 import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.codegen.classmodel.Method;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
@@ -35,6 +41,9 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.codegen.CodegenUtil.capitalize;
+import static io.helidon.common.types.TypeNames.LIST;
+import static io.helidon.common.types.TypeNames.MAP;
+import static io.helidon.common.types.TypeNames.SET;
 
 class TypeHandlerOptional extends TypeHandlerBasic {
     TypeHandlerOptional(List<BuilderCodegenExtension> extensions, PrototypeInfo prototypeInfo, OptionInfo option) {
@@ -64,7 +73,74 @@ class TypeHandlerOptional extends TypeHandlerBasic {
     }
 
     @Override
+    public void generateFromConfig(Method.Builder method, OptionConfigured optionConfigured) {
+        if (optionalMap()) {
+            generateOptionalMapFromConfig(method, optionConfigured);
+            return;
+        }
+        if (optionalCollection()) {
+            generateOptionalCollectionFromConfig(method, optionConfigured);
+            return;
+        }
+        super.generateFromConfig(method, optionConfigured);
+    }
+
+    @Override
+    GeneratedMethod prepareBuilderSetter(Javadoc getterJavadoc) {
+        if (!optionalContainer()) {
+            return super.prepareBuilderSetter(getterJavadoc);
+        }
+
+        TypeName returnType = Utils.builderReturnType();
+        String name = option().name();
+
+        var method = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(option().accessModifier())
+                .typeName(returnType)
+                .elementName(option().setterName())
+                .update(this::deprecation)
+                .update(it -> option().annotations().forEach(it::addAnnotation));
+
+        method.addParameterArgument(param -> param
+                .kind(ElementKind.PARAMETER)
+                .typeName(containerParameterType())
+                .elementName(name)
+        );
+
+        Consumer<ContentBuilder<?>> contentConsumer = it -> {
+            it.addContent(Objects.class)
+                    .addContentLine(".requireNonNull(" + name + ");");
+            option().decorator()
+                    .ifPresent(decorator -> {
+                        it.addContent("new ")
+                                .addContent(decorator)
+                                .addContent("().decorate(this, ");
+                        optionalDecoratorValue(it);
+                        it.addContentLine(");");
+                    });
+
+            it.addContent("this.")
+                    .addContent(name)
+                    .addContent(" = ");
+            mutableContainer(it, name);
+            it.addContentLine(";")
+                    .addContentLine("return self();");
+        };
+
+        return GeneratedMethod.builder()
+                .method(method.build())
+                .javadoc(setterJavadoc(getterJavadoc, name, ""))
+                .contentBuilder(contentConsumer)
+                .build();
+    }
+
+    @Override
     Optional<GeneratedMethod> prepareBuilderSetterDeclared(Javadoc getterJavadoc) {
+        if (optionalContainer()) {
+            return prepareOptionalContainerSetterDeclared(getterJavadoc);
+        }
+
         TypeName typeName = asTypeArgument(TypeNames.OPTIONAL);
         TypeName returnType = Utils.builderReturnType();
 
@@ -116,6 +192,64 @@ class TypeHandlerOptional extends TypeHandlerBasic {
     }
 
     @Override
+    Optional<GeneratedMethod> prepareBuilderAddCollection(Javadoc getterJavadoc) {
+        if (!optionalContainer()) {
+            return Optional.empty();
+        }
+
+        TypeName returnType = Utils.builderReturnType();
+        String name = option().name();
+
+        var method = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(option().accessModifier())
+                .typeName(returnType)
+                .elementName("add" + capitalize(option().name()))
+                .update(this::deprecation)
+                .update(it -> option().annotations().forEach(it::addAnnotation));
+
+        method.addParameterArgument(param -> param
+                .kind(ElementKind.PARAMETER)
+                .typeName(containerParameterType())
+                .elementName(name)
+        );
+
+        Consumer<ContentBuilder<?>> contentConsumer = it -> {
+            it.addContent(Objects.class)
+                    .addContentLine(".requireNonNull(" + name + ");");
+            option().decorator()
+                    .ifPresent(decorator -> {
+                        it.addContent("new ")
+                                .addContent(decorator)
+                                .addContent("().decorate(this, ");
+                        optionalDecoratorValue(it);
+                        it.addContentLine(");");
+                    });
+
+            it.addContentLine("if (this." + name + " == null) {")
+                    .addContent("this.")
+                    .addContent(name)
+                    .addContent(" = ");
+            emptyMutableContainer(it);
+            it.addContentLine(";")
+                    .addContentLine("}");
+
+            if (optionalMap()) {
+                it.addContentLine("this." + name + ".putAll(" + name + ");");
+            } else {
+                it.addContentLine("this." + name + ".addAll(" + name + ");");
+            }
+            it.addContentLine("return self();");
+        };
+
+        return Optional.of(GeneratedMethod.builder()
+                                   .method(method.build())
+                                   .javadoc(setterJavadoc(getterJavadoc, name, "add values to "))
+                                   .contentBuilder(contentConsumer)
+                                   .build());
+    }
+
+    @Override
     Optional<GeneratedMethod> prepareBuilderClear(Javadoc getterJavadoc) {
         TypeName returnType = Utils.builderReturnType();
 
@@ -159,5 +293,301 @@ class TypeHandlerOptional extends TypeHandlerBasic {
                 .addContent(".of(")
                 .addContent(optionName)
                 .addContent(")");
+    }
+
+    private Optional<GeneratedMethod> prepareOptionalContainerSetterDeclared(Javadoc getterJavadoc) {
+        TypeName typeName = asTypeArgument(TypeNames.OPTIONAL);
+        TypeName returnType = Utils.builderReturnType();
+
+        String name = option().name();
+
+        var method = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .accessModifier(AccessModifier.PACKAGE_PRIVATE)
+                .typeName(returnType)
+                .elementName(option().setterName())
+                .update(this::deprecation)
+                .update(it -> option().annotations().forEach(it::addAnnotation));
+
+        method.addParameterArgument(param -> param
+                .kind(ElementKind.PARAMETER)
+                .typeName(typeName)
+                .elementName(name)
+        );
+
+        Consumer<ContentBuilder<?>> contentConsumer = it -> {
+            it.addContent(Objects.class)
+                    .addContentLine(".requireNonNull(" + name + ");")
+                    .addContent(name)
+                    .addContent(".ifPresent(it -> this.")
+                    .addContent(name)
+                    .addContent(" = ");
+            mutableContainer(it, "it");
+            it.addContentLine(");")
+                    .addContentLine("return self();");
+        };
+
+        return Optional.of(GeneratedMethod.builder()
+                                   .method(method.build())
+                                   .javadoc(setterJavadoc(getterJavadoc, name, ""))
+                                   .contentBuilder(contentConsumer)
+                                   .build());
+    }
+
+    private void generateOptionalCollectionFromConfig(Method.Builder method, OptionConfigured optionConfigured) {
+        TypeName actualType = type().typeArguments().getFirst().genericTypeName();
+        String setterName = option().setterName();
+
+        Optional<FactoryMethod> factoryMethod = optionConfigured.factoryMethod();
+        if (factoryMethod.isPresent()) {
+            var fm = factoryMethod.get();
+            TypeName returnType = fm.returnType();
+
+            boolean mapList;
+            if (returnType.isList() || returnType.isSet()) {
+                mapList = false;
+            } else {
+                mapList = Utils.typesEqual(actualType, returnType);
+            }
+            if (mapList) {
+                method.addContent(configGet(optionConfigured))
+                        .addContent(".asList(")
+                        .update(it -> generateMapListFromConfig(it, fm))
+                        .addContent(")");
+                collectionConfigMapper(method);
+                method.addContentLine(".ifPresent(this::" + setterName + ");");
+            } else {
+                method.addContent(configGet(optionConfigured));
+                generateFromConfig(method, fm.returnType(), Optional.of(fm));
+                collectionConfigMapper(method);
+                method.addContentLine(".ifPresent(this::" + setterName + ");");
+            }
+        } else if (TypeHandlerCollection.BUILT_IN_MAPPERS.contains(actualType)) {
+            method.addContent(configGet(optionConfigured))
+                    .addContent(".asList(")
+                    .addContent(actualType.genericTypeName())
+                    .addContent(".class)");
+            collectionConfigMapper(method);
+            method.addContentLine(".ifPresent(this::" + setterName + ");");
+        } else {
+            method.addContent(configGet(optionConfigured)
+                                      + ".asNodeList()"
+                                      + ".map(nodeList -> nodeList.stream()"
+                                      + ".map(cfg -> cfg");
+            generateFromConfig(method, actualType, Optional.empty());
+            method.addContent(".get()).");
+            collectionCollector(method);
+            method.addContentLine(").ifPresent(this::" + setterName + ");");
+        }
+    }
+
+    private void generateOptionalMapFromConfig(Method.Builder method, OptionConfigured optionConfigured) {
+        TypeName keyType = type().typeArguments().get(0);
+        TypeName valueType = type().typeArguments().get(1);
+        String optionName = option().name();
+
+        if (TypeNames.STRING.equals(keyType) && TypeNames.STRING.equals(valueType)) {
+            method.addContentLine(configGet(optionConfigured) + ".detach().asMap().ifPresent(this::" + optionName + ");");
+        } else {
+            method.addContentLine("if (" + configGet(optionConfigured) + ".exists()) {")
+                    .addContent("this.")
+                    .addContent(optionName)
+                    .addContent(" = ");
+            emptyMutableContainer(method);
+            method.addContentLine(";");
+
+            if (optionConfigured.traverse()) {
+                method.addContent(configGet(optionConfigured) + ".detach().traverse().filter(")
+                        .addContent(Types.COMMON_CONFIG)
+                        .addContent("::hasValue).forEach(node -> "
+                                            + optionName)
+                        .addContent(".put(node.get(\"name\").asString().orElse(node.key().toString()), node");
+                generateFromConfig(method, valueType, optionConfigured.factoryMethod());
+                method.addContentLine(".get()));");
+            } else {
+                method.addContent(configGet(optionConfigured)
+                                          + ".asNodeList().orElseGet("
+                                          + List.class.getCanonicalName()
+                                          + "::of).forEach(node -> "
+                                          + optionName + ".put(node.get(\"name\").asString().orElse(node.name()), node");
+                generateFromConfig(method, valueType, optionConfigured.factoryMethod());
+                method.addContentLine(".get()));");
+            }
+            method.addContentLine("}");
+        }
+    }
+
+    private void generateFromConfig(ContentBuilder<?> content,
+                                    TypeName usedType,
+                                    Optional<FactoryMethod> factoryMethod) {
+        if (factoryMethod.isPresent()) {
+            FactoryMethod fm = factoryMethod.get();
+            content.addContent(".as(")
+                    .addContent(fm.declaringType().genericTypeName())
+                    .addContent("::");
+            if (!usedType.typeArguments().isEmpty()) {
+                content.addContent("<");
+                var iterator = usedType.typeArguments().iterator();
+                while (iterator.hasNext()) {
+                    content.addContent(iterator.next());
+                    if (iterator.hasNext()) {
+                        content.addContent(", ");
+                    }
+                }
+                content.addContent(">");
+            }
+            content.addContent(fm.methodName())
+                    .addContent(")");
+            return;
+        }
+
+        if (usedType.fqName().equals("char[]")) {
+            content.addContent(".asString().as(")
+                    .addContent(String.class)
+                    .addContent("::toCharArray)");
+            return;
+        }
+
+        if (usedType.equals(TypeNames.STRING)) {
+            content.addContent(".asString()");
+            return;
+        }
+
+        if (usedType.boxed().equals(TypeNames.BOXED_INT)) {
+            content.addContent(".asInt()");
+            return;
+        }
+
+        if (usedType.boxed().equals(TypeNames.BOXED_DOUBLE)) {
+            content.addContent(".asDouble()");
+            return;
+        }
+
+        if (usedType.boxed().equals(TypeNames.BOXED_BOOLEAN)) {
+            content.addContent(".asBoolean()");
+            return;
+        }
+
+        if (usedType.boxed().equals(TypeNames.BOXED_LONG)) {
+            content.addContent(".asLong()");
+            return;
+        }
+
+        content.addContent(".as(")
+                .addContent(usedType.boxed().genericTypeName())
+                .addContent(".class)");
+    }
+
+    private void generateMapListFromConfig(ContentBuilder<?> content, FactoryMethod factoryMethod) {
+        var declaringType = factoryMethod.declaringType();
+        var methodName = factoryMethod.methodName();
+
+        content.addContent(declaringType.genericTypeName())
+                .addContent("::")
+                .addContent(methodName);
+    }
+
+    private boolean optionalContainer() {
+        return optionalCollection() || optionalMap();
+    }
+
+    private boolean optionalCollection() {
+        return type().isList() || type().isSet();
+    }
+
+    private boolean optionalMap() {
+        return type().isMap();
+    }
+
+    private TypeName containerParameterType() {
+        if (optionalMap()) {
+            return TypeName.builder(MAP)
+                    .addTypeArgument(Utils.toWildcard(type().typeArguments().get(0)))
+                    .addTypeArgument(Utils.toWildcard(type().typeArguments().get(1)))
+                    .build();
+        }
+        return TypeName.builder(collectionType())
+                .addTypeArgument(Utils.toWildcard(type().typeArguments().getFirst()))
+                .build();
+    }
+
+    private TypeName collectionType() {
+        return type().isList() ? LIST : SET;
+    }
+
+    private void collectionConfigMapper(ContentBuilder<?> content) {
+        if (type().isSet()) {
+            content.addContent(".map(")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("::new)");
+        }
+    }
+
+    private void collectionCollector(ContentBuilder<?> content) {
+        if (type().isList()) {
+            content.addContent("toList()");
+        } else {
+            content.addContent("collect(")
+                    .addContent(Collectors.class)
+                    .addContent(".toCollection(")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("::new))");
+        }
+    }
+
+    private void optionalDecoratorValue(ContentBuilder<?> content) {
+        content.addContent(Optional.class)
+                .addContent(".of(");
+        immutableContainer(content, option().name());
+        content.addContent(")");
+    }
+
+    private void mutableContainer(ContentBuilder<?> content, String source) {
+        content.addContent("new ");
+        if (type().isList()) {
+            content.addContent(ArrayList.class);
+        } else if (type().isSet()) {
+            content.addContent(LinkedHashSet.class);
+        } else {
+            content.addContent(LinkedHashMap.class);
+        }
+        content.addContent("<>(")
+                .addContent(source)
+                .addContent(")");
+    }
+
+    private void emptyMutableContainer(ContentBuilder<?> content) {
+        content.addContent("new ");
+        if (type().isList()) {
+            content.addContent(ArrayList.class);
+        } else if (type().isSet()) {
+            content.addContent(LinkedHashSet.class);
+        } else {
+            content.addContent(LinkedHashMap.class);
+        }
+        content.addContent("<>()");
+    }
+
+    private void immutableContainer(ContentBuilder<?> content, String source) {
+        if (type().isList()) {
+            content.addContent(List.class)
+                    .addContent(".copyOf(")
+                    .addContent(source)
+                    .addContent(")");
+        } else if (type().isSet()) {
+            content.addContent(Collections.class)
+                    .addContent(".unmodifiableSet(new ")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("<>(")
+                    .addContent(source)
+                    .addContent("))");
+        } else {
+            content.addContent(Collections.class)
+                    .addContent(".unmodifiableMap(new ")
+                    .addContent(LinkedHashMap.class)
+                    .addContent("<>(")
+                    .addContent(source)
+                    .addContent("))");
+        }
     }
 }

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ConfigMapBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ConfigMapBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package io.helidon.builder.test.testsubjects;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
@@ -27,4 +30,16 @@ interface ConfigMapBlueprint {
     @Option.Configured
     @Option.Singular
     Map<String, String> properties();
+
+    @Option.Configured
+    Optional<Map<String, String>> optionalProperties();
+
+    @Option.Configured
+    Optional<Map<String, Integer>> optionalNumbers();
+
+    @Option.Configured
+    Optional<List<String>> optionalList();
+
+    @Option.Configured
+    Optional<Set<String>> optionalSet();
 }

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.builder.test.testsubjects;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
@@ -46,8 +47,24 @@ interface WithProviderBlueprint {
     List<SomeProvider.SomeService> listDiscover();
 
     @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<List<SomeProvider.SomeService>> optionalListDiscover();
+
+    @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<Set<SomeProvider.SomeService>> optionalSetDiscover();
+
+    @Option.Configured
     @Option.Provider(value = SomeProvider.class, discoverServices = false)
     List<SomeProvider.SomeService> listNotDiscover();
+
+    @Option.Configured
+    @Option.Provider(value = SomeProvider.class, discoverServices = false)
+    Optional<List<SomeProvider.SomeService>> optionalListNotDiscover();
+
+    @Option.Configured
+    @Option.Provider(value = SomeProvider.class, discoverServices = false)
+    Optional<Set<SomeProvider.SomeService>> optionalSetNotDiscover();
 
     /*
     The following should always be empty, as there are no implementations
@@ -62,6 +79,12 @@ interface WithProviderBlueprint {
 
     @Option.Provider(ProviderNoImpls.SomeService.class)
     Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<List<ProviderNoImpls.SomeService>> optionalListNoImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<Set<ProviderNoImpls.SomeService>> optionalSetNoImplDiscoverNoConfig();
 
     @Option.Configured
     @Option.Provider(value = ProviderNoImpls.class, discoverServices = false)

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderRegistryBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderRegistryBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,24 @@ interface WithProviderRegistryBlueprint {
     List<SomeProvider.SomeService> listDiscover();
 
     @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<List<SomeProvider.SomeService>> optionalListDiscover();
+
+    @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<Set<SomeProvider.SomeService>> optionalSetDiscover();
+
+    @Option.Configured
     @Option.Provider(value = SomeProvider.class, discoverServices = false)
     List<SomeProvider.SomeService> listNotDiscover();
+
+    @Option.Configured
+    @Option.Provider(value = SomeProvider.class, discoverServices = false)
+    Optional<List<SomeProvider.SomeService>> optionalListNotDiscover();
+
+    @Option.Configured
+    @Option.Provider(value = SomeProvider.class, discoverServices = false)
+    Optional<Set<SomeProvider.SomeService>> optionalSetNotDiscover();
 
     /*
     The following should always be empty, as there are no implementations
@@ -73,6 +89,12 @@ interface WithProviderRegistryBlueprint {
 
     @Option.Provider(ProviderNoImpls.SomeService.class)
     Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<List<ProviderNoImpls.SomeService>> optionalListNoImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<Set<ProviderNoImpls.SomeService>> optionalSetNoImplDiscoverNoConfig();
 
     @Option.Configured
     @Option.Provider(value = ProviderNoImpls.class, discoverServices = false)

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ConfigMapTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ConfigMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,12 @@
 
 package io.helidon.builder.test;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.helidon.builder.test.testsubjects.ConfigMap;
 import io.helidon.config.Config;
@@ -26,7 +31,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConfigMapTest {
     private static Config config;
@@ -43,5 +51,100 @@ public class ConfigMapTest {
 
         assertThat(properties, hasEntry("my.first.key", "firstValue"));
         assertThat(properties, hasEntry("my.second.key", "secondValue"));
+    }
+
+    @Test
+    void testOptionalContainersFromConfig() {
+        ConfigMap configMap = ConfigMap.create(config.get("optional-containers"));
+
+        Map<String, String> optionalProperties = configMap.optionalProperties().orElseThrow();
+        assertThat(optionalProperties, is(Map.of("my.first.key", "firstValue",
+                                                 "my.second.key", "secondValue")));
+        Map<String, Integer> optionalNumbers = configMap.optionalNumbers().orElseThrow();
+        assertThat(optionalNumbers, is(Map.of("one", 1, "two", 2)));
+        assertThat(configMap.optionalList().orElseThrow(), is(List.of("first", "second")));
+        assertThat(configMap.optionalSet().orElseThrow(), is(Set.of("first", "second")));
+    }
+
+    @Test
+    void testOptionalContainersEmptyFromConfig() {
+        ConfigMap configMap = ConfigMap.create(config.get("optional-empty-containers"));
+
+        assertThat(configMap.optionalProperties().orElseThrow().entrySet(), empty());
+        assertThat(configMap.optionalNumbers().orElseThrow().entrySet(), empty());
+        assertThat(configMap.optionalList().orElseThrow(), empty());
+        assertThat(configMap.optionalSet().orElseThrow(), empty());
+    }
+
+    @Test
+    void testOptionalContainersAbsentFromConfig() {
+        ConfigMap configMap = ConfigMap.create(config.get("absent"));
+
+        assertThat(configMap.optionalProperties().isEmpty(), is(true));
+        assertThat(configMap.optionalNumbers().isEmpty(), is(true));
+        assertThat(configMap.optionalList().isEmpty(), is(true));
+        assertThat(configMap.optionalSet().isEmpty(), is(true));
+    }
+
+    @Test
+    void testOptionalMapAdders() {
+        Map<String, String> first = new LinkedHashMap<>();
+        first.put("first", "one");
+        Map<String, String> second = new LinkedHashMap<>();
+        second.put("second", "two");
+
+        ConfigMap configMap = ConfigMap.builder()
+                .addOptionalProperties(first)
+                .addOptionalProperties(second)
+                .build();
+
+        first.clear();
+        second.clear();
+
+        Map<String, String> builtMap = configMap.optionalProperties().orElseThrow();
+        assertThat(builtMap, is(Map.of("first", "one", "second", "two")));
+        assertThrows(UnsupportedOperationException.class, () -> builtMap.put("third", "three"));
+
+        configMap = ConfigMap.builder()
+                .addOptionalProperties(Map.of())
+                .build();
+        assertThat(configMap.optionalProperties().orElseThrow().entrySet(), empty());
+
+        configMap = ConfigMap.builder()
+                .addOptionalProperties(Map.of("first", "one"))
+                .optionalProperties(Map.of("replacement", "value"))
+                .build();
+        assertThat(configMap.optionalProperties().orElseThrow(), is(Map.of("replacement", "value")));
+    }
+
+    @Test
+    void testOptionalContainerDefensiveCopies() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("key", "value");
+        List<String> list = new ArrayList<>();
+        list.add("value");
+        Set<String> set = new LinkedHashSet<>();
+        set.add("value");
+
+        ConfigMap configMap = ConfigMap.builder()
+                .optionalProperties(map)
+                .optionalList(list)
+                .optionalSet(set)
+                .build();
+
+        map.clear();
+        list.clear();
+        set.clear();
+
+        Map<String, String> builtMap = configMap.optionalProperties().orElseThrow();
+        List<String> builtList = configMap.optionalList().orElseThrow();
+        Set<String> builtSet = configMap.optionalSet().orElseThrow();
+
+        assertThat(builtMap, is(Map.of("key", "value")));
+        assertThat(builtList, is(List.of("value")));
+        assertThat(builtSet, is(Set.of("value")));
+        assertThrows(UnsupportedOperationException.class, () -> builtMap.put("another", "value"));
+        assertThrows(UnsupportedOperationException.class, () -> builtList.add("another"));
+        assertThrows(UnsupportedOperationException.class, () -> builtSet.add("another"));
     }
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ConfigMapTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ConfigMapTest.java
@@ -118,6 +118,48 @@ public class ConfigMapTest {
     }
 
     @Test
+    void testOptionalCollectionAdders() {
+        ConfigMap configMap = ConfigMap.builder()
+                .addOptionalList(List.of())
+                .addOptionalSet(Set.of())
+                .build();
+
+        assertThat(configMap.optionalList().orElseThrow(), empty());
+        assertThat(configMap.optionalSet().orElseThrow(), empty());
+
+        List<String> firstList = new ArrayList<>();
+        firstList.add("first");
+        List<String> secondList = new ArrayList<>();
+        secondList.add("second");
+        Set<String> firstSet = new LinkedHashSet<>();
+        firstSet.add("first");
+        firstSet.add("duplicate");
+        Set<String> secondSet = new LinkedHashSet<>();
+        secondSet.add("second");
+        secondSet.add("duplicate");
+
+        ConfigMap.Builder builder = ConfigMap.builder()
+                .addOptionalList(firstList)
+                .addOptionalList(secondList)
+                .addOptionalSet(firstSet)
+                .addOptionalSet(secondSet);
+        firstList.clear();
+        secondList.clear();
+        firstSet.clear();
+        secondSet.clear();
+
+        configMap = builder.build();
+
+        List<String> builtList = configMap.optionalList().orElseThrow();
+        Set<String> builtSet = configMap.optionalSet().orElseThrow();
+
+        assertThat(builtList, is(List.of("first", "second")));
+        assertThat(builtSet, is(Set.of("first", "second", "duplicate")));
+        assertThrows(UnsupportedOperationException.class, () -> builtList.add("third"));
+        assertThrows(UnsupportedOperationException.class, () -> builtSet.add("third"));
+    }
+
+    @Test
     void testOptionalContainerDefensiveCopies() {
         Map<String, String> map = new LinkedHashMap<>();
         map.put("key", "value");

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
@@ -241,6 +241,72 @@ class ProviderRegistryTest {
         assertThat(copy.listDiscover(), is(List.of()));
     }
 
+    @Test
+    void testDisabledOptionalContainerDiscoveryOnTheCopy() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of())
+                .optionalSetDiscover(Set.of())
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .build();
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        WithProviderRegistry copy = WithProviderRegistry.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProviderRegistry.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of(someService))
+                .optionalSetDiscover(Set.of(someService))
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .build();
+        copy = WithProviderRegistry.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
+    }
+
+    @Test
+    void testDisabledOptionalContainerDiscoveryOnTheCopiedBuilder() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithProviderRegistry.Builder value = WithProviderRegistry.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of())
+                .optionalSetDiscover(Set.of())
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create());
+
+        WithProviderRegistry copy = WithProviderRegistry.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProviderRegistry.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of(someService))
+                .optionalSetDiscover(Set.of(someService))
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create());
+        copy = WithProviderRegistry.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
+    }
+
     private static class DummyService implements SomeProvider.SomeService {
         @Override
         public String prop() {

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package io.helidon.builder.test;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import io.helidon.builder.test.testsubjects.SomeProvider;
 import io.helidon.builder.test.testsubjects.WithProviderRegistry;
@@ -33,6 +35,7 @@ import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -61,7 +64,15 @@ class ProviderRegistryTest {
         assertThat(value.optionalNotDiscover().map(SomeProvider.SomeService::prop), optionalEmpty());
 
         assertThat(value.listDiscover(), hasSize(2));
+        List<SomeProvider.SomeService> optionalListDiscover = value.optionalListDiscover().orElseThrow();
+        Collection<SomeProvider.SomeService> optionalSetDiscover = value.optionalSetDiscover().orElseThrow();
+        assertServicePropsInOrder(optionalListDiscover, "some-1", "some-2");
+        assertServiceProps(optionalSetDiscover, "some-1", "some-2");
+        assertUnmodifiable(optionalListDiscover);
+        assertUnmodifiable(optionalSetDiscover);
         assertThat(value.listNotDiscover(), hasSize(0));
+        assertThat(value.optionalListNotDiscover(), optionalEmpty());
+        assertThat(value.optionalSetNotDiscover(), optionalEmpty());
 
         /*
         Test all the methods for a provider with no implementations
@@ -69,6 +80,8 @@ class ProviderRegistryTest {
         assertThat(value.optionalNoImplDiscover(), optionalEmpty());
         assertThat(value.optionalNoImplNotDiscover(), optionalEmpty());
         assertThat(value.listNoImplDiscover(), hasSize(0));
+        assertThat(value.optionalListNoImplDiscoverNoConfig(), optionalEmpty());
+        assertThat(value.optionalSetNoImplDiscoverNoConfig(), optionalEmpty());
         assertThat(value.listNoImplNotDiscover(), hasSize(0));
     }
 
@@ -97,6 +110,11 @@ class ProviderRegistryTest {
         assertThat(value.listNotDiscover(), hasSize(2));
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("config2"));
+
+        assertServicePropsInOrder(value.optionalListDiscover().orElseThrow(), "config", "config2");
+        assertServiceProps(value.optionalSetDiscover().orElseThrow(), "config", "config2");
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "config", "config2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "config", "config2");
     }
 
     @Test
@@ -135,6 +153,61 @@ class ProviderRegistryTest {
         services = value.listNotDiscover();
         assertThat(value.listNotDiscover(), hasSize(1));
         assertThat(services.get(0).prop(), is("config2"));
+
+        assertServicePropsInOrder(value.optionalListDiscover().orElseThrow(), "config", "some-2");
+        assertServiceProps(value.optionalSetDiscover().orElseThrow(), "config", "some-2");
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "config2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "config2");
+    }
+
+    @Test
+    void testEmptyOptionalProviderContainers() {
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .config(config.get("empty-optional-containers-object"))
+                .mappersExplicit(Mappers.create())
+                .build();
+
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProviderRegistry.builder()
+                .config(config.get("empty-optional-containers-array"))
+                .mappersExplicit(Mappers.create())
+                .build();
+
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
+    }
+
+    @Test
+    void testOptionalProviderContainerDiscoveryEnabled() {
+        SomeProvider.SomeService someService = new DummyService();
+
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .config(config.get("min-defined"))
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .optionalListNotDiscoverDiscoverServices(true)
+                .optionalSetNotDiscoverDiscoverServices(true)
+                .build();
+
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "some-1", "some-2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "some-1", "some-2");
+    }
+
+    @Test
+    void testOptionalProviderContainerDiscoveryEnabledFromConfig() {
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .config(config.get("discover-optional-containers-from-config"))
+                .mappersExplicit(Mappers.create())
+                .build();
+
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "some-1", "some-2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "some-1", "some-2");
     }
 
     @Test
@@ -183,6 +256,18 @@ class ProviderRegistryTest {
         public String type() {
             return null;
         }
+    }
+
+    private static void assertServiceProps(Collection<SomeProvider.SomeService> services, String... props) {
+        assertThat(services.stream().map(SomeProvider.SomeService::prop).toList(), containsInAnyOrder(props));
+    }
+
+    private static void assertServicePropsInOrder(List<SomeProvider.SomeService> services, String... props) {
+        assertThat(services.stream().map(SomeProvider.SomeService::prop).toList(), is(List.of(props)));
+    }
+
+    private static void assertUnmodifiable(Collection<SomeProvider.SomeService> services) {
+        assertThrows(UnsupportedOperationException.class, () -> services.add(new DummyService()));
     }
 
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
@@ -250,6 +250,68 @@ class ProviderTest {
     }
 
     @Test
+    void testDisabledOptionalContainerDiscoveryOnTheCopy() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithProvider value = WithProvider.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of())
+                .optionalSetDiscover(Set.of())
+                .oneNotDiscover(someService)
+                .build();
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        WithProvider copy = WithProvider.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProvider.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of(someService))
+                .optionalSetDiscover(Set.of(someService))
+                .oneNotDiscover(someService)
+                .build();
+        copy = WithProvider.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
+    }
+
+    @Test
+    void testDisabledOptionalContainerDiscoveryOnTheCopiedBuilder() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithProvider.Builder value = WithProvider.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of())
+                .optionalSetDiscover(Set.of())
+                .oneNotDiscover(someService);
+
+        WithProvider copy = WithProvider.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProvider.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of(someService))
+                .optionalSetDiscover(Set.of(someService))
+                .oneNotDiscover(someService);
+        copy = WithProvider.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
+    }
+
+    @Test
     void testDisabledDiscoveryOnInheritedBuilder() {
         SomeProvider.SomeService someService = new DummyService();
         WithInheritedProvider value = WithInheritedProvider.builder()

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
@@ -16,7 +16,9 @@
 
 package io.helidon.builder.test;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import io.helidon.builder.test.testsubjects.SomeProvider;
 import io.helidon.builder.test.testsubjects.WithInheritedProvider;
@@ -35,6 +37,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -60,7 +63,15 @@ class ProviderTest {
         assertThat(value.optionalNotDiscover().map(SomeProvider.SomeService::prop), optionalEmpty());
 
         assertThat(value.listDiscover(), hasSize(2));
+        List<SomeProvider.SomeService> optionalListDiscover = value.optionalListDiscover().orElseThrow();
+        Collection<SomeProvider.SomeService> optionalSetDiscover = value.optionalSetDiscover().orElseThrow();
+        assertServicePropsInOrder(optionalListDiscover, "some-1", "some-2");
+        assertServiceProps(optionalSetDiscover, "some-1", "some-2");
+        assertUnmodifiable(optionalListDiscover);
+        assertUnmodifiable(optionalSetDiscover);
         assertThat(value.listNotDiscover(), hasSize(0));
+        assertThat(value.optionalListNotDiscover(), optionalEmpty());
+        assertThat(value.optionalSetNotDiscover(), optionalEmpty());
 
         /*
         Test all the methods for a provider with no implementations
@@ -68,6 +79,8 @@ class ProviderTest {
         assertThat(value.optionalNoImplDiscover(), optionalEmpty());
         assertThat(value.optionalNoImplNotDiscover(), optionalEmpty());
         assertThat(value.listNoImplDiscover(), hasSize(0));
+        assertThat(value.optionalListNoImplDiscoverNoConfig(), optionalEmpty());
+        assertThat(value.optionalSetNoImplDiscoverNoConfig(), optionalEmpty());
         assertThat(value.listNoImplNotDiscover(), hasSize(0));
     }
 
@@ -93,6 +106,11 @@ class ProviderTest {
         assertThat(value.listNotDiscover(), hasSize(2));
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("config2"));
+
+        assertServicePropsInOrder(value.optionalListDiscover().orElseThrow(), "config", "config2");
+        assertServiceProps(value.optionalSetDiscover().orElseThrow(), "config", "config2");
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "config", "config2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "config", "config2");
     }
 
     @Test
@@ -125,6 +143,82 @@ class ProviderTest {
         services = value.listNotDiscover();
         assertThat(value.listNotDiscover(), hasSize(1));
         assertThat(services.get(0).prop(), is("config2"));
+
+        assertServicePropsInOrder(value.optionalListDiscover().orElseThrow(), "config", "some-2");
+        assertServiceProps(value.optionalSetDiscover().orElseThrow(), "config", "some-2");
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "config2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "config2");
+    }
+
+    @Test
+    void testEmptyOptionalProviderContainers() {
+        WithProvider value = WithProvider.create(config.get("empty-optional-containers-object"));
+
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProvider.create(config.get("empty-optional-containers-array"));
+
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
+    }
+
+    @Test
+    void testOptionalProviderContainerBuilderMethods() {
+        SomeProvider.SomeService someService = new DummyService();
+
+        WithProvider value = WithProvider.builder()
+                .oneNotDiscover(someService)
+                .optionalListNotDiscover(List.of())
+                .optionalSetNotDiscover(Set.of())
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProvider.builder()
+                .oneNotDiscover(someService)
+                .addOptionalListNotDiscover(List.of(someService))
+                .addOptionalSetNotDiscover(Set.of(someService))
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of(someService))));
+
+        value = WithProvider.builder()
+                .oneNotDiscover(someService)
+                .optionalListNotDiscover(List.of(someService))
+                .optionalSetNotDiscover(Set.of(someService))
+                .clearOptionalListNotDiscover()
+                .clearOptionalSetNotDiscover()
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalEmpty());
+        assertThat(value.optionalSetNotDiscover(), optionalEmpty());
+    }
+
+    @Test
+    void testOptionalProviderContainerDiscoveryEnabled() {
+        SomeProvider.SomeService someService = new DummyService();
+
+        WithProvider value = WithProvider.builder()
+                .config(config.get("min-defined"))
+                .oneNotDiscover(someService)
+                .optionalListNotDiscoverDiscoverServices(true)
+                .optionalSetNotDiscoverDiscoverServices(true)
+                .build();
+
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "some-1", "some-2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "some-1", "some-2");
+    }
+
+    @Test
+    void testOptionalProviderContainerDiscoveryEnabledFromConfig() {
+        WithProvider value = WithProvider.create(config.get("discover-optional-containers-from-config"));
+
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "some-1", "some-2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "some-1", "some-2");
     }
 
     @Test
@@ -210,6 +304,18 @@ class ProviderTest {
         public String type() {
             return null;
         }
+    }
+
+    private static void assertServiceProps(Collection<SomeProvider.SomeService> services, String... props) {
+        assertThat(services.stream().map(SomeProvider.SomeService::prop).toList(), containsInAnyOrder(props));
+    }
+
+    private static void assertServicePropsInOrder(List<SomeProvider.SomeService> services, String... props) {
+        assertThat(services.stream().map(SomeProvider.SomeService::prop).toList(), is(List.of(props)));
+    }
+
+    private static void assertUnmodifiable(Collection<SomeProvider.SomeService> services) {
+        assertThrows(UnsupportedOperationException.class, () -> services.add(new DummyService()));
     }
 
 }

--- a/builder/tests/builder/src/test/resources/config-map-test.yaml
+++ b/builder/tests/builder/src/test/resources/config-map-test.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,3 +19,22 @@ properties:
   my.first.key: "firstValue"
   my.second.key: "secondValue"
 
+optional-containers:
+  optional-properties:
+    my.first.key: "firstValue"
+    my.second.key: "secondValue"
+  optional-numbers:
+    one: 1
+    two: 2
+  optional-list:
+    - "first"
+    - "second"
+  optional-set:
+    - "first"
+    - "second"
+
+optional-empty-containers:
+  optional-properties: {}
+  optional-numbers: {}
+  optional-list: []
+  optional-set: []

--- a/builder/tests/builder/src/test/resources/provider-test.yaml
+++ b/builder/tests/builder/src/test/resources/provider-test.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,7 +37,27 @@ all-defined:
       prop: "config"
     some-2:
       prop: "config2"
+  optional-list-discover:
+    some-1:
+      prop: "config"
+    some-2:
+      prop: "config2"
+  optional-set-discover:
+    some-1:
+      prop: "config"
+    some-2:
+      prop: "config2"
   list-not-discover:
+    some-1:
+      prop: "config"
+    some-2:
+      prop: "config2"
+  optional-list-not-discover:
+    some-1:
+      prop: "config"
+    some-2:
+      prop: "config2"
+  optional-set-not-discover:
     some-1:
       prop: "config"
     some-2:
@@ -50,6 +70,40 @@ single-list:
   list-discover:
     some-1:
       prop: "config"
+  optional-list-discover:
+    some-1:
+      prop: "config"
+  optional-set-discover:
+    some-1:
+      prop: "config"
   list-not-discover:
     some-2:
       prop: "config2"
+  optional-list-not-discover:
+    some-2:
+      prop: "config2"
+  optional-set-not-discover:
+    some-2:
+      prop: "config2"
+empty-optional-containers-object:
+  one-not-discover:
+    some-1:
+      prop: "config"
+  optional-list-discover: {}
+  optional-set-discover: {}
+  optional-list-not-discover: {}
+  optional-set-not-discover: {}
+empty-optional-containers-array:
+  one-not-discover:
+    some-1:
+      prop: "config"
+  optional-list-discover: []
+  optional-set-discover: []
+  optional-list-not-discover: []
+  optional-set-not-discover: []
+discover-optional-containers-from-config:
+  one-not-discover:
+    some-1:
+      prop: "config"
+  optional-list-not-discover-discover-services: true
+  optional-set-not-discover-discover-services: true


### PR DESCRIPTION
Resolves #11967

Adds optional container handling to builder codegen so `Optional<Map>`, `Optional<List>`, and `Optional<Set>` use the same config, setter/add, defensive-copy, and immutable built-value behavior as their non-optional container counterparts.

Also extends provider-backed optional collection discovery for service-loader and registry-backed providers, preserving absent versus explicit-empty container semantics.
