### PR TITLE
Enable scheduling Javadoc fail on warning

### DIFF
--- a/scheduling/pom.xml
+++ b/scheduling/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>helidon-scheduling</artifactId>
     <name>Helidon Scheduling</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.cronutils</groupId>


### PR DESCRIPTION
Part of #9356

Enable Javadoc fail-on-warning for the scheduling module.
