### PR TITLE
Enable security Javadoc fail on warning

### DIFF
--- a/security/abac/policy/src/main/java/io/helidon/security/abac/policy/PolicyValidatorService.java
+++ b/security/abac/policy/src/main/java/io/helidon/security/abac/policy/PolicyValidatorService.java
@@ -25,6 +25,12 @@ import io.helidon.security.providers.abac.spi.AbacValidatorService;
  * A validator of policy statements java service to plug into Abac security provider.
  */
 public class PolicyValidatorService implements AbacValidatorService {
+    /**
+     * Create a policy validator service.
+     */
+    public PolicyValidatorService() {
+    }
+
     @Override
     public String configKey() {
         return "policy-validator";

--- a/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleAnnotationAnalyzer.java
+++ b/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleAnnotationAnalyzer.java
@@ -36,6 +36,12 @@ import jakarta.annotation.security.PermitAll;
 @Weight(Weighted.DEFAULT_WEIGHT) // Helidon service loader loaded and ordered
 public class RoleAnnotationAnalyzer implements AnnotationAnalyzer {
 
+    /**
+     * Create a role annotation analyzer.
+     */
+    public RoleAnnotationAnalyzer() {
+    }
+
     @Override
     public AnalyzerResponse analyze(Class<?> maybeAnnotated) {
         return analyze(TypeName.create(maybeAnnotated), AnnotationFactory.create(maybeAnnotated));

--- a/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleValidator.java
+++ b/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleValidator.java
@@ -391,6 +391,15 @@ public final class RoleValidator implements AbacValidator<RoleValidator.RoleConf
             private boolean permitAll = false;
             private boolean denyAll = false;
 
+            /**
+             * Create a new builder instance.
+             *
+             * @deprecated Use {@link RoleConfig#builder()} instead.
+             */
+            @Deprecated(forRemoval = true, since = "27.0.0")
+            public Builder() {
+            }
+
             @Override
             public RoleConfig build() {
                 return new RoleConfig(this);

--- a/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleValidatorService.java
+++ b/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleValidatorService.java
@@ -25,6 +25,12 @@ import io.helidon.security.providers.abac.spi.AbacValidatorService;
  * Java service for {@link RoleValidator} ABAC security provider.
  */
 public class RoleValidatorService implements AbacValidatorService {
+    /**
+     * Create a role validator service.
+     */
+    public RoleValidatorService() {
+    }
+
     @Override
     public String configKey() {
         return "role-validator";

--- a/security/abac/scope/src/main/java/io/helidon/security/abac/scope/ScopeValidatorService.java
+++ b/security/abac/scope/src/main/java/io/helidon/security/abac/scope/ScopeValidatorService.java
@@ -26,6 +26,12 @@ import io.helidon.security.providers.abac.spi.AbacValidatorService;
  * A service to provide {@link ScopeValidator} to {@link AbacProvider}.
  */
 public class ScopeValidatorService implements AbacValidatorService {
+    /**
+     * Create a scope validator service.
+     */
+    public ScopeValidatorService() {
+    }
+
     @Override
     public String configKey() {
         return "scope-validator";

--- a/security/abac/time/src/main/java/io/helidon/security/abac/time/TimeValidatorService.java
+++ b/security/abac/time/src/main/java/io/helidon/security/abac/time/TimeValidatorService.java
@@ -26,6 +26,12 @@ import io.helidon.security.providers.abac.spi.AbacValidatorService;
  * Time validator java service for {@link AbacProvider}.
  */
 public class TimeValidatorService implements AbacValidatorService {
+    /**
+     * Create a time validator service.
+     */
+    public TimeValidatorService() {
+    }
+
     @Override
     public String configKey() {
         return "time-validator";

--- a/security/integration/common/src/main/java/io/helidon/security/integration/common/CommonTracing.java
+++ b/security/integration/common/src/main/java/io/helidon/security/integration/common/CommonTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +134,11 @@ abstract class CommonTracing {
         });
     }
 
+    /**
+     * Tracing configuration for this span.
+     *
+     * @return tracing configuration
+     */
     protected SpanTracingConfig spanConfig() {
         return spanConfig;
     }

--- a/security/jwt/src/main/java/io/helidon/security/jwt/CommonValidator.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/CommonValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,11 @@ abstract class CommonValidator implements ClaimValidator {
             return scope;
         }
 
+        /**
+         * Typed builder instance.
+         *
+         * @return this builder instance
+         */
         @SuppressWarnings("unchecked")
         protected B me() {
             return (B) this;

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtClaims.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtClaims.java
@@ -30,6 +30,14 @@ class JwtClaims {
     protected JwtClaims() {
     }
 
+    /**
+     * Decode a Base64 URL encoded JWT segment.
+     *
+     * @param base64 base64 URL encoded value
+     * @param collector error collector
+     * @param description description of the decoded value
+     * @return decoded value, or {@code null} when decoding fails
+     */
     protected static String decode(String base64, Errors.Collector collector, String description) {
         try {
             return new String(URL_DECODER.decode(base64), StandardCharsets.UTF_8);
@@ -39,6 +47,15 @@ class JwtClaims {
         }
     }
 
+    /**
+     * Parse a decoded JWT segment as JSON object.
+     *
+     * @param jsonString decoded JSON string
+     * @param collector error collector
+     * @param base64 original Base64 URL encoded value
+     * @param description description of the decoded value
+     * @return parsed JSON object, or {@code null} when parsing fails
+     */
     protected static JsonObject parseJson(String jsonString, Errors.Collector collector, String base64, String description) {
         try {
             return JsonParser.create(new StringReader(jsonString)).readJsonObject();

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
@@ -569,26 +569,56 @@ public final class JwtUtil {
             this.country = getString(jsonObject, "country");
         }
 
+        /**
+         * Full formatted mailing address.
+         *
+         * @return formatted address
+         */
         public Optional<String> getFormatted() {
             return formatted;
         }
 
+        /**
+         * Street address.
+         *
+         * @return street address
+         */
         public Optional<String> getStreetAddress() {
             return streetAddress;
         }
 
+        /**
+         * Locality or city.
+         *
+         * @return locality
+         */
         public Optional<String> getLocality() {
             return locality;
         }
 
+        /**
+         * State, province, prefecture, or region.
+         *
+         * @return region
+         */
         public Optional<String> getRegion() {
             return region;
         }
 
+        /**
+         * Postal code.
+         *
+         * @return postal code
+         */
         public Optional<String> getPostalCode() {
             return postalCode;
         }
 
+        /**
+         * Country.
+         *
+         * @return country
+         */
         public Optional<String> getCountry() {
             return country;
         }

--- a/security/jwt/src/main/java/io/helidon/security/jwt/jwk/Jwk.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/jwk/Jwk.java
@@ -383,7 +383,7 @@ public abstract class Jwk {
 
         /**
          * Intended usage of this JWK.
-         * You may configure usage, {@link #operations} or neither (never both).
+         * You may configure usage, {@link #operations(List) operations} or neither (never both).
          *
          * @param usage usage of this JWK
          * @return updated builder instance
@@ -397,7 +397,7 @@ public abstract class Jwk {
 
         /**
          * Intended operations of this JWK.
-         * You may configure operations, {@link #usage} or neither (never both).
+         * You may configure operations, {@link #usage(String) usage} or neither (never both).
          *
          * @param operations operations to use, replaces existing operations
          * @return updated builder instance
@@ -415,7 +415,7 @@ public abstract class Jwk {
 
         /**
          * Add intended operation of this JWK.
-         * You may configure operations, {@link #usage} or neither (never both).
+         * You may configure operations, {@link #usage(String) usage} or neither (never both).
          *
          * @param operation operation to add to list of operations
          * @return updated builder instance

--- a/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkPki.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkPki.java
@@ -80,22 +80,47 @@ abstract class JwkPki extends Jwk {
         this.sha256Thumbprint = Optional.ofNullable(builder.sha256Thumbprint);
     }
 
+    /**
+     * Private key if available.
+     *
+     * @return private key
+     */
     public Optional<PrivateKey> privateKey() {
         return privateKey;
     }
 
+    /**
+     * Public key.
+     *
+     * @return public key
+     */
     public PublicKey publicKey() {
         return publicKey;
     }
 
+    /**
+     * X.509 certificate chain.
+     *
+     * @return certificate chain
+     */
     public Optional<List<X509Certificate>> certificateChain() {
         return certificateChain;
     }
 
+    /**
+     * X.509 certificate SHA-1 thumbprint.
+     *
+     * @return SHA-1 thumbprint bytes
+     */
     public Optional<byte[]> sha1Thumbprint() {
         return sha1Thumbprint;
     }
 
+    /**
+     * X.509 certificate SHA-256 thumbprint.
+     *
+     * @return SHA-256 thumbprint bytes
+     */
     public Optional<byte[]> sha256Thumbprint() {
         return sha256Thumbprint;
     }

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -31,6 +31,10 @@
     <artifactId>helidon-security-project</artifactId>
     <name>Helidon Security Project</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>annotations</module>
         <module>util</module>

--- a/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProviderService.java
+++ b/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProviderService.java
@@ -27,6 +27,12 @@ public class AbacProviderService implements SecurityProviderService {
 
     static final String PROVIDER_CONFIG_KEY = "abac";
 
+    /**
+     * Create an ABAC provider service.
+     */
+    public AbacProviderService() {
+    }
+
     @Override
     public String providerConfigKey() {
         return PROVIDER_CONFIG_KEY;

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/EvictableCache.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/EvictableCache.java
@@ -203,6 +203,15 @@ public interface EvictableCache<K, V> {
         private BiFunction<K, V, Boolean> evictor = (key, value) -> false;
 
         /**
+         * Create a new builder instance.
+         *
+         * @deprecated Use {@link EvictableCache#builder()} instead.
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public Builder() {
+        }
+
+        /**
          * Build a new instance of the cache based on configuration of this builder.
          *
          * @return a new instance of the cache

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/OutboundConfig.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/OutboundConfig.java
@@ -61,6 +61,12 @@ public final class OutboundConfig {
     private final LinkedList<OutboundTarget> targets = new LinkedList<>();
 
     /**
+     * Create a new empty outbound configuration.
+     */
+    public OutboundConfig() {
+    }
+
+    /**
      * Parse targets from provider configuration.
      *
      * @param providerConfig configuration object of current provider

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/OutboundConfig.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/OutboundConfig.java
@@ -62,7 +62,10 @@ public final class OutboundConfig {
 
     /**
      * Create a new empty outbound configuration.
+     *
+     * @deprecated Use {@link #builder()}, {@link #create(Config)}, or {@link #create(Config, OutboundTarget...)} instead.
      */
+    @Deprecated(forRemoval = true, since = "27.0.0")
     public OutboundConfig() {
     }
 

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/OutboundTarget.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/OutboundTarget.java
@@ -70,7 +70,7 @@ public final class OutboundTarget {
     private final List<Pattern> pathPatterns = new LinkedList<>();
     private final Set<String> methods = new HashSet<>();
     private final Config config;
-    private final ClassToInstanceStore<Object> customObjects = new ClassToInstanceStore<>();
+    private final ClassToInstanceStore<Object> customObjects = ClassToInstanceStore.create();
     private final boolean matchAllTransports;
     private final boolean matchAllHosts;
     private final boolean matchAllPaths;
@@ -285,7 +285,7 @@ public final class OutboundTarget {
         private final Set<String> hosts = new HashSet<>();
         private final Set<String> paths = new HashSet<>();
         private final Set<String> methods = new HashSet<>();
-        private final ClassToInstanceStore<Object> customObjects = new ClassToInstanceStore<>();
+        private final ClassToInstanceStore<Object> customObjects = ClassToInstanceStore.create();
         private String name;
         private Config config;
 

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/TokenCredential.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/TokenCredential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public class TokenCredential {
     private final Optional<Instant> issueTime;
     private final Optional<Instant> expTime;
     private final String token;
-    private final ClassToInstanceStore<Object> tokens = new ClassToInstanceStore<>();
+    private final ClassToInstanceStore<Object> tokens = ClassToInstanceStore.create();
 
     private TokenCredential(Builder builder) {
         this.token = builder.token;
@@ -124,7 +124,7 @@ public class TokenCredential {
      * Fluent API builder for {@link TokenCredential}.
      */
     public static final class Builder implements io.helidon.common.Builder<Builder, TokenCredential> {
-        private final ClassToInstanceStore<Object> tokens = new ClassToInstanceStore<>();
+        private final ClassToInstanceStore<Object> tokens = ClassToInstanceStore.create();
         private Instant issueTime;
         private Instant expTime;
         private String issuer;

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/spi/AnnotationAnalyzer.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/spi/AnnotationAnalyzer.java
@@ -269,6 +269,15 @@ public interface AnnotationAnalyzer {
             private String authenticator;
             private String authorizer;
 
+            /**
+             * Create a new builder instance.
+             *
+             * @deprecated Use {@link AnalyzerResponse#builder()} instead.
+             */
+            @Deprecated(forRemoval = true, since = "27.0.0")
+            public Builder() {
+            }
+
             @Override
             public AnalyzerResponse build() {
                 return new AnalyzerResponse(this);

--- a/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnService.java
+++ b/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnService.java
@@ -28,6 +28,12 @@ public class HeaderAtnService implements SecurityProviderService {
 
     static final String PROVIDER_CONFIG_KEY = "header-atn";
 
+    /**
+     * Create a header authentication provider service.
+     */
+    public HeaderAtnService() {
+    }
+
     @Override
     public String providerConfigKey() {
         return PROVIDER_CONFIG_KEY;

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
@@ -35,6 +35,12 @@ public class ConfigUserStore implements SecureUserStore {
     private final Map<String, ConfigUser> users = new HashMap<>();
 
     /**
+     * Create an empty user store.
+     */
+    public ConfigUserStore() {
+    }
+
+    /**
      * Create an instance from config. Expects key "users" to be the current key.
      * Example:
      * <pre>
@@ -80,6 +86,12 @@ public class ConfigUserStore implements SecureUserStore {
         private final Set<String> roles = new LinkedHashSet<>();
         private String login;
         private char[] password;
+
+        /**
+         * Create an empty config user.
+         */
+        public ConfigUser() {
+        }
 
         /**
          * Create a new user from configuration.

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
@@ -36,7 +36,10 @@ public class ConfigUserStore implements SecureUserStore {
 
     /**
      * Create an empty user store.
+     *
+     * @deprecated Use {@link #create(Config)} instead.
      */
+    @Deprecated(forRemoval = true, since = "27.0.0")
     public ConfigUserStore() {
     }
 
@@ -89,7 +92,10 @@ public class ConfigUserStore implements SecureUserStore {
 
         /**
          * Create an empty config user.
+         *
+         * @deprecated Use {@link #create(Config)} instead.
          */
+        @Deprecated(forRemoval = true, since = "27.0.0")
         public ConfigUser() {
         }
 

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthService.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthService.java
@@ -25,6 +25,13 @@ import io.helidon.security.spi.SecurityProviderService;
  */
 public class HttpBasicAuthService implements SecurityProviderService {
     static final String PROVIDER_CONFIG_KEY =  "http-basic-auth";
+
+    /**
+     * Create a basic authentication service.
+     */
+    public HttpBasicAuthService() {
+    }
+
     @Override
     public String providerConfigKey() {
         return PROVIDER_CONFIG_KEY;

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignService.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignService.java
@@ -28,6 +28,12 @@ public class HttpSignService implements SecurityProviderService {
 
     static final String PROVIDER_CONFIG_KEY = "http-signatures";
 
+    /**
+     * Create an HTTP signature provider service.
+     */
+    public HttpSignService() {
+    }
+
     @Override
     public String providerConfigKey() {
         return PROVIDER_CONFIG_KEY;

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
@@ -172,6 +172,14 @@ public abstract class IdcsRoleMapperProviderBase implements SubjectMappingProvid
         return builder.build();
     }
 
+    /**
+     * Request roles from IDCS and process the response.
+     *
+     * @param request HTTP request to submit
+     * @param entity request entity
+     * @param subjectName subject name for diagnostics
+     * @return grants returned from IDCS, or an empty list on failure
+     */
     protected List<? extends Grant> processRoleRequest(HttpClientRequest request, Object entity, String subjectName) {
         try (HttpClientResponse response = request.submit(entity)) {
             if (response.status().family() == Status.Family.SUCCESSFUL) {
@@ -390,12 +398,25 @@ public abstract class IdcsRoleMapperProviderBase implements SubjectMappingProvid
         private final URI tokenEndpointUri;
         private final Duration tokenRefreshSkew;
 
+        /**
+         * Create an application token cache.
+         *
+         * @param webClient web client to request tokens
+         * @param tokenEndpointUri token endpoint URI
+         * @param tokenRefreshSkew token refresh skew
+         */
         protected AppToken(WebClient webClient, URI tokenEndpointUri, Duration tokenRefreshSkew) {
             this.webClient = webClient;
             this.tokenEndpointUri = tokenEndpointUri;
             this.tokenRefreshSkew = tokenRefreshSkew;
         }
 
+        /**
+         * Return a cached application token, requesting a new token when needed.
+         *
+         * @param tracing role mapper tracing
+         * @return token content
+         */
         protected Optional<String> getToken(RoleMapTracing tracing) {
             LazyValue<AppTokenData> currentTokenData = token.get();
             if (currentTokenData == null) {

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderService.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderService.java
@@ -26,6 +26,12 @@ public class IdcsRoleMapperProviderService implements SecurityProviderService {
 
     static final String PROVIDER_CONFIG_KEY = "idcs-role-mapper";
 
+    /**
+     * Create an IDCS role mapper provider service.
+     */
+    public IdcsRoleMapperProviderService() {
+    }
+
     @Override
     public String providerConfigKey() {
         return PROVIDER_CONFIG_KEY;

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProviderService.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProviderService.java
@@ -28,6 +28,12 @@ public class JwtProviderService implements SecurityProviderService {
 
     static final String PROVIDER_CONFIG_KEY = "jwt";
 
+    /**
+     * Create a JWT provider service.
+     */
+    public JwtProviderService() {
+    }
+
     @Override
     public String providerConfigKey() {
         return PROVIDER_CONFIG_KEY;

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -978,6 +978,9 @@ public final class OidcConfig extends TenantConfigImpl {
                                       .addMediaSupport(JsonSupport.create())
                                       .build());
 
+        /**
+         * Create an OIDC configuration builder.
+         */
         protected Builder() {
         }
 

--- a/security/providers/oidc/pom.xml
+++ b/security/providers/oidc/pom.xml
@@ -107,11 +107,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.logging</groupId>
             <artifactId>helidon-logging-jul</artifactId>
             <scope>test</scope>

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
@@ -319,6 +319,15 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
                 .tokenPrefix("Bearer ")
                 .build();
 
+        /**
+         * Create a new builder instance.
+         *
+         * @deprecated Use {@link OidcProvider#builder()} instead.
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public Builder() {
+        }
+
         @Override
         public OidcProvider build() {
             if (null == oidcConfig) {

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProviderService.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProviderService.java
@@ -30,6 +30,12 @@ public class OidcProviderService implements SecurityProviderService {
      */
     public static final String PROVIDER_CONFIG_KEY = "oidc";
 
+    /**
+     * Create an OIDC provider service.
+     */
+    public OidcProviderService() {
+    }
+
     @Override
     public String providerConfigKey() {
         return PROVIDER_CONFIG_KEY;

--- a/security/security/src/main/java/io/helidon/security/AuthorizationResponse.java
+++ b/security/security/src/main/java/io/helidon/security/AuthorizationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,15 @@ public final class AuthorizationResponse extends SecurityResponse {
      * Builder for custom Authorization responses.
      */
     public static class Builder extends SecurityResponse.SecurityResponseBuilder<Builder, AuthorizationResponse> {
+        /**
+         * Create a new builder instance.
+         *
+         * @deprecated Use {@link AuthorizationResponse#builder()} instead.
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public Builder() {
+        }
+
         /**
          * Create a new authorization response based on this builder.
          *

--- a/security/security/src/main/java/io/helidon/security/ClassToInstanceStore.java
+++ b/security/security/src/main/java/io/helidon/security/ClassToInstanceStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,15 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public final class ClassToInstanceStore<T> {
     private final Map<Class<? extends T>, T> backingMap = new IdentityHashMap<>();
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    /**
+     * Create an empty mutable class-to-instance store.
+     *
+     * @deprecated Use {@link #create(Object...)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "27.0.0")
+    public ClassToInstanceStore() {
+    }
 
     /**
      * Create a new instance based on explicit instances.

--- a/security/security/src/main/java/io/helidon/security/EndpointConfig.java
+++ b/security/security/src/main/java/io/helidon/security/EndpointConfig.java
@@ -66,7 +66,7 @@ public class EndpointConfig implements AbacSupport {
     private EndpointConfig(Builder builder) {
         this.securityLevels = Collections.unmodifiableList(builder.securityLevels);
         this.attributes = BasicAttributes.create(builder.attributes);
-        this.customObjects = new ClassToInstanceStore<>();
+        this.customObjects = ClassToInstanceStore.create();
         this.customObjects.putAll(builder.customObjects);
         this.configMap = new HashMap<>(builder.configMap);
     }
@@ -186,7 +186,7 @@ public class EndpointConfig implements AbacSupport {
      * A fluent API builder for {@link EndpointConfig}.
      */
     public static final class Builder implements io.helidon.common.Builder<Builder, EndpointConfig> {
-        private final ClassToInstanceStore<Object> customObjects = new ClassToInstanceStore<>();
+        private final ClassToInstanceStore<Object> customObjects = ClassToInstanceStore.create();
         private final Map<String, Config> configMap = new HashMap<>();
         private final List<SecurityLevel> securityLevels = new ArrayList<>();
         private BasicAttributes attributes = BasicAttributes.create();

--- a/security/security/src/main/java/io/helidon/security/OutboundSecurityResponse.java
+++ b/security/security/src/main/java/io/helidon/security/OutboundSecurityResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,15 @@ public final class OutboundSecurityResponse extends SecurityResponse {
      * Builder class to build custom identity propagation responses.
      */
     public static class Builder extends SecurityResponse.SecurityResponseBuilder<Builder, OutboundSecurityResponse> {
+        /**
+         * Create a new builder instance.
+         *
+         * @deprecated Use {@link OutboundSecurityResponse#builder()} instead.
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public Builder() {
+        }
+
         /**
          * Build identity propagation response based on this builder.
          *

--- a/security/security/src/main/java/io/helidon/security/SecurityResponse.java
+++ b/security/security/src/main/java/io/helidon/security/SecurityResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,6 +156,11 @@ public abstract class SecurityResponse {
             this.success = success;
         }
 
+        /**
+         * Whether this status represents a successful security operation.
+         *
+         * @return whether this status is successful
+         */
         public boolean isSuccess() {
             return success;
         }

--- a/security/security/src/main/java/io/helidon/security/Subject.java
+++ b/security/security/src/main/java/io/helidon/security/Subject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ public final class Subject implements AbacSupport {
     private final AbacSupport attributes;
     private final Principal principal;
 
-    private final ClassToInstanceStore<Object> privateCredentials = new ClassToInstanceStore<>();
-    private final ClassToInstanceStore<Object> publicCredentials = new ClassToInstanceStore<>();
+    private final ClassToInstanceStore<Object> privateCredentials = ClassToInstanceStore.create();
+    private final ClassToInstanceStore<Object> publicCredentials = ClassToInstanceStore.create();
 
     private Subject(Builder builder) {
         BasicAttributes properties = BasicAttributes.create(builder.properties);
@@ -230,8 +230,8 @@ public final class Subject implements AbacSupport {
     public static final class Builder implements io.helidon.common.Builder<Builder, Subject> {
         private final List<Grant> grants = new LinkedList<>();
         private final List<Principal> principals = new LinkedList<>();
-        private final ClassToInstanceStore<Object> privateCredentials = new ClassToInstanceStore<>();
-        private final ClassToInstanceStore<Object> publicCredentials = new ClassToInstanceStore<>();
+        private final ClassToInstanceStore<Object> privateCredentials = ClassToInstanceStore.create();
+        private final ClassToInstanceStore<Object> publicCredentials = ClassToInstanceStore.create();
         private BasicAttributes properties = BasicAttributes.create();
         private Principal principal;
 

--- a/security/security/src/test/java/io/helidon/security/ClassToInstanceStoreTest.java
+++ b/security/security/src/test/java/io/helidon/security/ClassToInstanceStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class ClassToInstanceStoreTest {
 
     @Test
     public void simpleInstance() {
-        ClassToInstanceStore<Object> ctim = new ClassToInstanceStore<>();
+        ClassToInstanceStore<Object> ctim = ClassToInstanceStore.create();
 
         String first = "a String";
         String second = "a second String";
@@ -66,7 +66,7 @@ public class ClassToInstanceStoreTest {
 
     @Test
     public void ifaceAndImpl() {
-        ClassToInstanceStore<Object> ctim = new ClassToInstanceStore<>();
+        ClassToInstanceStore<Object> ctim = ClassToInstanceStore.create();
 
         CharSequence first = "a String";
         CharSequence second = "a second String";
@@ -90,7 +90,7 @@ public class ClassToInstanceStoreTest {
 
     @Test
     public void putAll() {
-        ClassToInstanceStore<Object> ctim = new ClassToInstanceStore<>();
+        ClassToInstanceStore<Object> ctim = ClassToInstanceStore.create();
 
         String first = "a String";
         String second = "a second String";
@@ -98,7 +98,7 @@ public class ClassToInstanceStoreTest {
         ctim.putInstance(CharSequence.class, first);
         ctim.putInstance(String.class, second);
 
-        ClassToInstanceStore<Object> copy = new ClassToInstanceStore<>();
+        ClassToInstanceStore<Object> copy = ClassToInstanceStore.create();
 
         copy.putAll(ctim);
 
@@ -108,7 +108,7 @@ public class ClassToInstanceStoreTest {
 
     @Test
     public void containsKey() {
-        ClassToInstanceStore<Object> ctim = new ClassToInstanceStore<>();
+        ClassToInstanceStore<Object> ctim = ClassToInstanceStore.create();
 
         String first = "a String";
         String second = "a second String";
@@ -123,7 +123,7 @@ public class ClassToInstanceStoreTest {
 
     @Test
     public void testIsEmpty() {
-        ClassToInstanceStore<CharSequence> ctis = new ClassToInstanceStore<>();
+        ClassToInstanceStore<CharSequence> ctis = ClassToInstanceStore.create();
 
         assertThat(ctis.isEmpty(), is(true));
 
@@ -134,7 +134,7 @@ public class ClassToInstanceStoreTest {
 
     @Test
     public void testPutInstanceNoClass() {
-        ClassToInstanceStore<CharSequence> ctis = new ClassToInstanceStore<>();
+        ClassToInstanceStore<CharSequence> ctis = ClassToInstanceStore.create();
         Optional<String> optional = ctis.putInstance("test");
 
         if (optional.isPresent()) {
@@ -164,7 +164,7 @@ public class ClassToInstanceStoreTest {
 
     @Test
     public void testKeysAndValues() {
-        ClassToInstanceStore<CharSequence> ctis = new ClassToInstanceStore<>();
+        ClassToInstanceStore<CharSequence> ctis = ClassToInstanceStore.create();
         String value1 = "aValue";
         StringBuffer value2 = new StringBuffer("anotherValue");
         StringBuilder value3 = new StringBuilder("someValue");
@@ -185,7 +185,7 @@ public class ClassToInstanceStoreTest {
 
     @Test
     public void testToString() {
-        ClassToInstanceStore<CharSequence> ctis = new ClassToInstanceStore<>();
+        ClassToInstanceStore<CharSequence> ctis = ClassToInstanceStore.create();
         ctis.putInstance("MyValue");
         ctis.putInstance(new StringBuilder("Some value"));
 

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityHandler.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityHandler.java
@@ -106,7 +106,7 @@ public final class SecurityHandler implements Handler, RuntimeType.Api<SecurityH
         // must copy values to be safely immutable
         this.customObjects = config.customObjects()
                 .map(it -> {
-                    ClassToInstanceStore<Object> ctis = new ClassToInstanceStore<>();
+                    ClassToInstanceStore<Object> ctis = ClassToInstanceStore.create();
                     ctis.putAll(it);
                     return ctis;
                 });
@@ -470,7 +470,7 @@ public final class SecurityHandler implements Handler, RuntimeType.Api<SecurityH
         securityContext.endpointConfig(securityContext.endpointConfig()
                                                .derive()
                                                .configMap(configMap)
-                                               .customObjects(customObjects.orElse(new ClassToInstanceStore<>()))
+                                               .customObjects(customObjects.orElseGet(ClassToInstanceStore::create))
                                                .build());
 
         try {


### PR DESCRIPTION
Part of #9356

Enable Javadoc fail-on-warning for security modules and fix the warnings it surfaced.
