### PR TITLE
Fix SSE comment-only events

### DIFF
--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -121,7 +121,7 @@ class DataWriterSseSink implements SseSink {
                 outputStream.write(SSE_NL);
             }
             Object data = sseEvent.data();
-            if (data != null) {
+            if (data != SseEvent.NO_DATA) {
                 MediaType mediaType = sseEvent.mediaType().orElse(MediaTypes.TEXT_PLAIN);
 
                 // is it multi-line string data?

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBaseTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBaseTest.java
@@ -137,6 +137,15 @@ class SseBaseTest {
         }
     }
 
+    static void sseCommentOnly(ServerRequest req, ServerResponse res) {
+        try (SseSink sseSink = res.sink(SseSink.TYPE)) {
+            SseEvent event = SseEvent.builder()
+                    .comment("This is a comment")
+                    .build();
+            sseSink.emit(event);
+        }
+    }
+
     protected void testSse(String path, String... events) throws Exception {
         testSse(path, List.of(), events);
     }

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
@@ -45,6 +45,7 @@ class SseServerTest extends SseBaseTest {
         rules.get("/sseJson2", SseServerTest::sseJson2);
         rules.get("/sseMixed", SseServerTest::sseMixed);
         rules.get("/sseIdComment", SseServerTest::sseIdComment);
+        rules.get("/sseCommentOnly", SseServerTest::sseCommentOnly);
     }
 
     @Test
@@ -76,6 +77,11 @@ class SseServerTest extends SseBaseTest {
     @Test
     void testIdComment() throws Exception {
         testSse("/sseIdComment", ":This is a comment\nid:1\ndata:hello");
+    }
+
+    @Test
+    void testCommentOnly() throws Exception {
+        testSse("/sseCommentOnly", ":This is a comment");
     }
 
     @Test


### PR DESCRIPTION
### Description

Fixes #11834.

SSE events without data were treated as having data because `DataWriterSseSink` checked only for `null`, while `SseEvent` uses the `SseEvent.NO_DATA` sentinel to represent absent data.

This caused comment-only SSE events, such as keep-alive events, to attempt serialization of the sentinel object instead of emitting only the comment.

The fix updates `DataWriterSseSink` to skip data serialization when `sseEvent.data()` returns `SseEvent.NO_DATA`.
A regression test was added for comment-only SSE events.

### Documentation
None