### PR TITLE
Enable dbclient Javadoc fail on warning

### DIFF
--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientContext.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientContext.java
@@ -96,6 +96,15 @@ public class DbClientContext implements DbContext {
      */
     public static final class Builder extends BuilderBase<Builder, DbClientContext> {
 
+        /**
+         * Creates a new builder.
+         *
+         * @deprecated use {@link DbClientContext#builder()} instead
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public Builder() {
+        }
+
         @Override
         public DbClientContext build() {
             return new DbClientContext(this);

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbExecuteContext.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbExecuteContext.java
@@ -130,6 +130,15 @@ public class DbExecuteContext implements DbContext {
      */
     public static final class Builder extends BuilderBase<Builder, DbExecuteContext> {
 
+        /**
+         * Creates a new builder.
+         *
+         * @deprecated use {@link DbExecuteContext#builder()} instead
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public Builder() {
+        }
+
         @Override
         public DbExecuteContext build() {
             return new DbExecuteContext(this);
@@ -149,6 +158,17 @@ public class DbExecuteContext implements DbContext {
         private String statementName;
         private String statement;
         private DbClientContext clientContext;
+
+        /**
+         * Creates an instance of base builder for {@link DbExecuteContext}.
+         * Child classes may call this constructor; only direct public use is not supported.
+         *
+         * @deprecated direct public use is not supported; use {@link DbExecuteContext#builder()}
+         *         for the built-in execution context builder
+         */
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        public BuilderBase() {
+        }
 
         /**
          * Set the execution statement.

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbIndexedStatementParameters.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbIndexedStatementParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,12 @@ import java.util.List;
 public class DbIndexedStatementParameters extends DbStatementParameters {
 
     private final List<Object> parameters = new LinkedList<>();
+
+    /**
+     * Creates indexed statement parameters.
+     */
+    public DbIndexedStatementParameters() {
+    }
 
     @Override
     public DbStatementParameters addParam(Object parameter) {

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbNamedStatementParameters.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbNamedStatementParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,12 @@ import java.util.Map;
 public class DbNamedStatementParameters extends DbStatementParameters {
 
     private final Map<String, Object> parameters = new HashMap<>();
+
+    /**
+     * Creates named statement parameters.
+     */
+    public DbNamedStatementParameters() {
+    }
 
     @Override
     public DbStatementParameters addParam(String name, Object parameter) {

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbRowBase.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbRowBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,12 @@ public abstract class DbRowBase implements DbRow {
     private final DbColumnBase[] columns;
     private final Map<String, DbColumnBase> namesIndex;
 
+    /**
+     * Creates a row base.
+     *
+     * @param columns row columns
+     * @param dbMapperManager mapper manager
+     */
     protected DbRowBase(DbColumnBase[] columns, DbMapperManager dbMapperManager) {
         this.columns = columns;
         this.dbMapperManager = dbMapperManager;

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbStatementException.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbStatementException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@ package io.helidon.dbclient;
  */
 public class DbStatementException extends DbClientException {
 
+    /**
+     * Database statement that caused an exception.
+     */
     private final String statement;
 
     /**

--- a/dbclient/health/src/main/java/io/helidon/dbclient/health/DbClientHealthCheck.java
+++ b/dbclient/health/src/main/java/io/helidon/dbclient/health/DbClientHealthCheck.java
@@ -90,6 +90,11 @@ public abstract class DbClientHealthCheck implements HealthCheck {
         return builder.build();
     }
 
+    /**
+     * Database client used by this health check.
+     *
+     * @return database client
+     */
     protected DbClient dbClient() {
         return dbClient;
     }

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcClientProvider.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcClientProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,12 @@ public class JdbcClientProvider implements DbClientProvider {
 
     // Name of this JDBC DB client provider and also JDBC database URL prefix.
     private static final String JDBC_DB_NAME = "jdbc";
+
+    /**
+     * Creates a JDBC database client provider.
+     */
+    public JdbcClientProvider() {
+    }
 
     @Override
     public String name() {

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcConnectionPool.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcConnectionPool.java
@@ -139,6 +139,9 @@ public interface JdbcConnectionPool extends NamedService {
         private String username;
         private String password;
 
+        /**
+         * Creates a JDBC connection pool builder base.
+         */
         protected BuilderBase() {
         }
 

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcExecuteContext.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcExecuteContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ class JdbcExecuteContext extends DbExecuteContext {
     /**
      * Builder for {@link DbExecuteContext}.
      */
+    @SuppressWarnings("removal")
     public static final class Builder extends BuilderBase<Builder, JdbcExecuteContext> {
 
         @Override

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcParametersConfigBlueprint.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcParametersConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ interface JdbcParametersConfigBlueprint {
     boolean useStringBinding();
 
     /**
-     * {@link String} values with length above this limit will be bound
+     * String values with length above this limit will be bound
      * using {@link java.sql.PreparedStatement#setCharacterStream(int, java.io.Reader, int)}
      * if {@link #useStringBinding()} is set to {@code true}.
      * Default value is {@code 1024}.

--- a/dbclient/json/src/main/java/io/helidon/dbclient/json/JsonMapperProvider.java
+++ b/dbclient/json/src/main/java/io/helidon/dbclient/json/JsonMapperProvider.java
@@ -28,6 +28,13 @@ import io.helidon.json.JsonObject;
  */
 @Weight(Weighted.DEFAULT_WEIGHT)
 public class JsonMapperProvider implements DbMapperProvider {
+
+    /**
+     * Creates a Helidon JSON mapper provider.
+     */
+    public JsonMapperProvider() {
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T> Optional<DbMapper<T>> mapper(Class<T> type) {

--- a/dbclient/jsonp/src/main/java/io/helidon/dbclient/jsonp/JsonProcessingMapperProvider.java
+++ b/dbclient/jsonp/src/main/java/io/helidon/dbclient/jsonp/JsonProcessingMapperProvider.java
@@ -29,6 +29,13 @@ import jakarta.json.JsonObject;
  */
 @Weight(Weighted.DEFAULT_WEIGHT)
 public class JsonProcessingMapperProvider implements DbMapperProvider {
+
+    /**
+     * Creates a JSON-P mapper provider.
+     */
+    public JsonProcessingMapperProvider() {
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T> Optional<DbMapper<T>> mapper(Class<T> type) {

--- a/dbclient/metrics-hikari/src/main/java/io/helidon/dbclient/metrics/hikari/HikariMetricsExtensionProvider.java
+++ b/dbclient/metrics-hikari/src/main/java/io/helidon/dbclient/metrics/hikari/HikariMetricsExtensionProvider.java
@@ -24,6 +24,12 @@ import io.helidon.dbclient.hikari.spi.HikariMetricsProvider;
  */
 public final class HikariMetricsExtensionProvider implements HikariMetricsProvider {
 
+    /**
+     * Creates a Hikari metrics extension provider.
+     */
+    public HikariMetricsExtensionProvider() {
+    }
+
     @Override
     public String configKey() {
         return "pool-metrics";

--- a/dbclient/metrics-hikari/src/main/java/module-info.java
+++ b/dbclient/metrics-hikari/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module helidon.dbclient.metrics.hikari {
     requires transitive io.helidon.common.features.api;
 
     requires transitive io.helidon.config;
+    requires transitive io.helidon.dbclient.metrics;
     requires transitive io.helidon.metrics.api;
     requires transitive io.helidon.dbclient.jdbc;
     requires transitive io.helidon.dbclient.hikari;

--- a/dbclient/metrics/src/main/java/io/helidon/dbclient/metrics/DbClientMetricBuilder.java
+++ b/dbclient/metrics/src/main/java/io/helidon/dbclient/metrics/DbClientMetricBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,4 +25,15 @@ import io.helidon.dbclient.DbClientServiceBase;
  */
 public abstract class DbClientMetricBuilder<B extends DbClientMetricBuilder<B, T>, T extends DbClientServiceBase>
         extends MetricBuilderBase<B, T> {
+
+    /**
+     * Creates a database client metric builder.
+     * Child classes may call this constructor; only direct public use is not supported.
+     *
+     * @deprecated direct public use is not supported; use {@link DbClientMetrics#counter()}
+     *         or {@link DbClientMetrics#timer()} for the built-in metric builders
+     */
+    @Deprecated(forRemoval = true, since = "27.0.0")
+    public DbClientMetricBuilder() {
+    }
 }

--- a/dbclient/metrics/src/main/java/io/helidon/dbclient/metrics/DbClientMetricsProvider.java
+++ b/dbclient/metrics/src/main/java/io/helidon/dbclient/metrics/DbClientMetricsProvider.java
@@ -30,6 +30,12 @@ import io.helidon.dbclient.spi.DbClientServiceProvider;
 public class DbClientMetricsProvider implements DbClientServiceProvider {
     private static final System.Logger LOGGER = System.getLogger(DbClientMetricsProvider.class.getName());
 
+    /**
+     * Creates a database client metrics provider.
+     */
+    public DbClientMetricsProvider() {
+    }
+
     @Override
     public String configKey() {
         return "metrics";

--- a/dbclient/metrics/src/main/java/io/helidon/dbclient/metrics/MetricCounter.java
+++ b/dbclient/metrics/src/main/java/io/helidon/dbclient/metrics/MetricCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ final class MetricCounter extends MetricService<Counter> {
     /**
      * Fluent API builder for {@link MetricCounter}.
      */
+    @SuppressWarnings("removal")
     static class Builder extends DbClientMetricBuilder<Builder, MetricCounter> {
 
         @Override

--- a/dbclient/metrics/src/main/java/io/helidon/dbclient/metrics/MetricTimer.java
+++ b/dbclient/metrics/src/main/java/io/helidon/dbclient/metrics/MetricTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ final class MetricTimer extends MetricService<Timer> {
     /**
      * Fluent API builder for {@link MetricTimer}.
      */
+    @SuppressWarnings("removal")
     static class Builder extends DbClientMetricBuilder<Builder, MetricTimer> {
 
         @Override

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbClientProvider.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbClientProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ import io.helidon.dbclient.spi.DbClientProvider;
 public class MongoDbClientProvider implements DbClientProvider {
 
     static final String DB_TYPE = "mongoDb";
+
+    /**
+     * Creates a MongoDB database client provider.
+     */
+    public MongoDbClientProvider() {
+    }
 
     @Override
     public String name() {

--- a/dbclient/pom.xml
+++ b/dbclient/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>helidon-dbclient-project</artifactId>
     <name>Helidon Database Client Project</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>dbclient</module>
         <module>jdbc</module>

--- a/dbclient/tracing/src/main/java/io/helidon/dbclient/tracing/DbClientTracingProvider.java
+++ b/dbclient/tracing/src/main/java/io/helidon/dbclient/tracing/DbClientTracingProvider.java
@@ -30,6 +30,12 @@ public class DbClientTracingProvider implements DbClientServiceProvider {
 
     private static final System.Logger LOGGER = System.getLogger(DbClientTracingProvider.class.getName());
 
+    /**
+     * Creates a database client tracing provider.
+     */
+    public DbClientTracingProvider() {
+    }
+
     @Override
     public String configKey() {
         return "tracing";


### PR DESCRIPTION
Part of #9356

Enable Javadoc fail-on-warning for dbclient modules and fix the warnings it surfaced.
