### PR TITLE
Fix WebServer idle timeout task lifecycle (27.x)

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/IdleTimeoutHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/IdleTimeoutHandler.java
@@ -64,8 +64,11 @@ class IdleTimeoutHandler extends TimerTask {
                 }
             }
         } finally {
-            Thread.currentThread().setName(name);
-            runLock.unlock();
+            try {
+                Thread.currentThread().setName(name);
+            } finally {
+                runLock.unlock();
+            }
         }
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/IdleTimeoutHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/IdleTimeoutHandler.java
@@ -20,6 +20,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 class IdleTimeoutHandler extends TimerTask {
@@ -28,6 +30,8 @@ class IdleTimeoutHandler extends TimerTask {
     private final Duration timeout;
     private final Duration period;
     private final String taskName;
+    private final Lock runLock = new ReentrantLock();
+    private volatile boolean cancelled;
 
     IdleTimeoutHandler(Timer timer,
                        ListenerConfig listenerConfig,
@@ -44,20 +48,39 @@ class IdleTimeoutHandler extends TimerTask {
     @Override
     public void run() {
         String name = Thread.currentThread().getName();
-        Thread.currentThread().setName(taskName);
-        List<ConnectionHandler> connectionHandlers = handlerSupplier.get();
-        for (ConnectionHandler connectionHandler : connectionHandlers) {
-            try {
-                connectionHandler.closeIfIdle(timeout);
-            } catch (Throwable t) {
-                System.getLogger(IdleTimeoutHandler.class.getName() + "." + taskName)
-                        .log(System.Logger.Level.TRACE, "Failed to close an idle connection", t);
+        runLock.lock();
+        try {
+            if (cancelled) {
+                return;
             }
+            Thread.currentThread().setName(taskName);
+            List<ConnectionHandler> connectionHandlers = handlerSupplier.get();
+            for (ConnectionHandler connectionHandler : connectionHandlers) {
+                try {
+                    connectionHandler.closeIfIdle(timeout);
+                } catch (Throwable t) {
+                    System.getLogger(IdleTimeoutHandler.class.getName() + "." + taskName)
+                            .log(System.Logger.Level.TRACE, "Failed to close an idle connection", t);
+                }
+            }
+        } finally {
+            Thread.currentThread().setName(name);
+            runLock.unlock();
         }
-        Thread.currentThread().setName(name);
     }
 
     void start() {
         timer.schedule(this, period.toMillis(), period.toMillis());
+    }
+
+    void cancelAndAwait() {
+        cancelled = true;
+        cancel();
+        runLock.lock();
+        try {
+            // Wait for an in-flight idle timeout pass to finish.
+        } finally {
+            runLock.unlock();
+        }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/IdleTimeoutHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/IdleTimeoutHandler.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
@@ -30,7 +29,7 @@ class IdleTimeoutHandler extends TimerTask {
     private final Duration timeout;
     private final Duration period;
     private final String taskName;
-    private final Lock runLock = new ReentrantLock();
+    private final ReentrantLock runLock = new ReentrantLock();
     private volatile boolean cancelled;
 
     IdleTimeoutHandler(Timer timer,
@@ -77,13 +76,27 @@ class IdleTimeoutHandler extends TimerTask {
     }
 
     void cancelAndAwait() {
+        cancelOnly();
+        awaitFinished();
+    }
+
+    void cancelOnly() {
         cancelled = true;
         cancel();
+    }
+
+    void awaitFinished() {
+        // Acquiring the lock acts as a barrier: if run() is scanning connections, this waits for that pass to finish.
         runLock.lock();
         try {
-            // Wait for an in-flight idle timeout pass to finish.
+            // Wait barrier only.
         } finally {
             runLock.unlock();
         }
+    }
+
+    // Intended for tests that need to observe cancellation waiting without stack walking.
+    boolean awaitingRunCompletion() {
+        return runLock.hasQueuedThreads();
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -318,9 +318,11 @@ class ServerListener implements ListenerContext {
         Throwable failure = null;
         // Stop listening for connections
         closeServerSocketForStop();
+        IdleTimeoutHandler cancelledIdleTimeoutHandler = null;
 
         try {
-            cancelIdleTimeoutHandler();
+            cancelledIdleTimeoutHandler = cancelIdleTimeoutHandler();
+            purgeCancelledIdleTimeoutHandler(cancelledIdleTimeoutHandler);
         } catch (RuntimeException | Error e) {
             failure = LifecycleFailures.add(failure, e);
         }
@@ -349,6 +351,12 @@ class ServerListener implements ListenerContext {
         try {
             // Interrupt and close any accepted and active connections
             failure = LifecycleFailures.add(failure, closeOpenConnections(true));
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+
+        try {
+            awaitIdleTimeoutHandler(cancelledIdleTimeoutHandler);
         } catch (RuntimeException | Error e) {
             failure = LifecycleFailures.add(failure, e);
         }
@@ -388,8 +396,10 @@ class ServerListener implements ListenerContext {
         } catch (IOException e) {
             LOGGER.log(INFO, "Exception thrown on socket close", e);
         }
+        IdleTimeoutHandler cancelledIdleTimeoutHandler = null;
         try {
-            cancelIdleTimeoutHandler();
+            cancelledIdleTimeoutHandler = cancelIdleTimeoutHandler();
+            purgeCancelledIdleTimeoutHandler(cancelledIdleTimeoutHandler);
         } catch (RuntimeException | Error e) {
             failure = LifecycleFailures.add(failure, e);
         }
@@ -397,6 +407,11 @@ class ServerListener implements ListenerContext {
         failure = LifecycleFailures.add(failure, closeOpenConnections(false));
         // Interrupt and close any accepted and active connections
         failure = LifecycleFailures.add(failure, closeOpenConnections(true));
+        try {
+            awaitIdleTimeoutHandler(cancelledIdleTimeoutHandler);
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
 
         Thread localServerThread = serverThread;
         if (localServerThread != null) {
@@ -510,7 +525,7 @@ class ServerListener implements ListenerContext {
     private void rollbackFailedStart(Throwable startupFailure, boolean lifecycleStarted) {
         running = false;
         suppressCleanupFailure(startupFailure, this::closeServerSocketOnFailure);
-        suppressCleanupFailure(startupFailure, this::cancelIdleTimeoutHandler);
+        suppressCleanupFailure(startupFailure, this::cancelAndAwaitIdleTimeoutHandler);
         suppressCleanupFailure(startupFailure, this::shutdownReaderExecutor);
         suppressCleanupFailure(startupFailure, this::shutdownSharedExecutor);
         if (lifecycleStarted) {
@@ -644,18 +659,46 @@ class ServerListener implements ListenerContext {
         }
     }
 
-    private void cancelIdleTimeoutHandler() {
+    private IdleTimeoutHandler cancelIdleTimeoutHandler() {
         idleTimeoutLock.lock();
         try {
             IdleTimeoutHandler handler = idleTimeoutHandler;
             if (handler == null) {
-                return;
+                return null;
             }
             idleTimeoutHandler = null;
-            handler.cancelAndAwait();
-            idleConnectionTimer.purge();
+            handler.cancelOnly();
+            return handler;
         } finally {
             idleTimeoutLock.unlock();
+        }
+    }
+
+    private void cancelAndAwaitIdleTimeoutHandler() {
+        IdleTimeoutHandler handler = cancelIdleTimeoutHandler();
+        Throwable failure = null;
+        try {
+            purgeCancelledIdleTimeoutHandler(handler);
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+        try {
+            awaitIdleTimeoutHandler(handler);
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
+        LifecycleFailures.throwIfFailed(failure, "Failed to cancel listener idle timeout task for " + socketName);
+    }
+
+    private void purgeCancelledIdleTimeoutHandler(IdleTimeoutHandler handler) {
+        if (handler != null) {
+            idleConnectionTimer.purge();
+        }
+    }
+
+    private static void awaitIdleTimeoutHandler(IdleTimeoutHandler handler) {
+        if (handler != null) {
+            handler.awaitFinished();
         }
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -40,6 +40,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 
 import javax.net.ssl.SSLParameters;
@@ -84,6 +86,8 @@ class ServerListener implements ListenerContext {
     private final SocketOptions connectionOptions;
     private final SocketAddress configuredAddress;
     private final Duration gracePeriod;
+    private final Timer idleConnectionTimer;
+    private final Lock idleTimeoutLock = new ReentrantLock();
 
     private final MediaContext mediaContext;
     private final ContentEncodingContext contentEncodingContext;
@@ -98,6 +102,7 @@ class ServerListener implements ListenerContext {
     private volatile ServerSocketChannel serverSocket;
     private volatile Thread serverThread;
     private volatile CompletableFuture<Void> closeFuture;
+    private volatile IdleTimeoutHandler idleTimeoutHandler;
 
     @SuppressWarnings("unchecked")
     ServerListener(String socketName,
@@ -179,12 +184,7 @@ class ServerListener implements ListenerContext {
                 });
 
         this.router = router;
-
-        // handle idle connection timeout
-        IdleTimeoutHandler ith = new IdleTimeoutHandler(idleConnectionTimer,
-                                                        listenerConfig,
-                                                        this::connectionHandlers);
-        ith.start();
+        this.idleConnectionTimer = idleConnectionTimer;
     }
 
     @Override
@@ -316,6 +316,11 @@ class ServerListener implements ListenerContext {
 
     private Throwable stopResources() {
         Throwable failure = null;
+        try {
+            cancelIdleTimeoutHandler();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
         // Stop listening for connections
         closeServerSocketForStop();
 
@@ -368,6 +373,11 @@ class ServerListener implements ListenerContext {
 
     private void suspendForCheckpoint() {
         Throwable failure = null;
+        try {
+            cancelIdleTimeoutHandler();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
+        }
         try {
             // Stop listening for connections
             serverSocket.close();
@@ -427,6 +437,7 @@ class ServerListener implements ListenerContext {
             String serverChannelId = "0x" + HexFormat.of().toHexDigits(System.identityHashCode(serverSocket));
 
             running = true;
+            startIdleTimeoutHandler();
 
             if (LOGGER.isLoggable(INFO)) {
                 if (configuredAddress instanceof InetSocketAddress inetAddress) {
@@ -497,6 +508,7 @@ class ServerListener implements ListenerContext {
 
     private void rollbackFailedStart(Throwable startupFailure, boolean lifecycleStarted) {
         running = false;
+        suppressCleanupFailure(startupFailure, this::cancelIdleTimeoutHandler);
         suppressCleanupFailure(startupFailure, this::closeServerSocketOnFailure);
         suppressCleanupFailure(startupFailure, this::shutdownReaderExecutor);
         suppressCleanupFailure(startupFailure, this::shutdownSharedExecutor);
@@ -615,6 +627,34 @@ class ServerListener implements ListenerContext {
         List<Runnable> running = sharedExecutor.shutdownNow();
         if (!running.isEmpty()) {
             LOGGER.log(DEBUG, running.size() + " tasks in shared executor did not terminate gracefully");
+        }
+    }
+
+    private void startIdleTimeoutHandler() {
+        idleTimeoutLock.lock();
+        try {
+            IdleTimeoutHandler handler = new IdleTimeoutHandler(idleConnectionTimer,
+                                                                listenerConfig,
+                                                                this::connectionHandlers);
+            handler.start();
+            idleTimeoutHandler = handler;
+        } finally {
+            idleTimeoutLock.unlock();
+        }
+    }
+
+    private void cancelIdleTimeoutHandler() {
+        idleTimeoutLock.lock();
+        try {
+            IdleTimeoutHandler handler = idleTimeoutHandler;
+            if (handler == null) {
+                return;
+            }
+            idleTimeoutHandler = null;
+            handler.cancelAndAwait();
+            idleConnectionTimer.purge();
+        } finally {
+            idleTimeoutLock.unlock();
         }
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -316,13 +316,14 @@ class ServerListener implements ListenerContext {
 
     private Throwable stopResources() {
         Throwable failure = null;
+        // Stop listening for connections
+        closeServerSocketForStop();
+
         try {
             cancelIdleTimeoutHandler();
         } catch (RuntimeException | Error e) {
             failure = LifecycleFailures.add(failure, e);
         }
-        // Stop listening for connections
-        closeServerSocketForStop();
 
         try {
             // Stop handling any new requests on all accepted and active connections
@@ -374,11 +375,6 @@ class ServerListener implements ListenerContext {
     private void suspendForCheckpoint() {
         Throwable failure = null;
         try {
-            cancelIdleTimeoutHandler();
-        } catch (RuntimeException | Error e) {
-            failure = LifecycleFailures.add(failure, e);
-        }
-        try {
             // Stop listening for connections
             serverSocket.close();
             if (configuredAddress instanceof UnixDomainSocketAddress udsa) {
@@ -391,6 +387,11 @@ class ServerListener implements ListenerContext {
             }
         } catch (IOException e) {
             LOGGER.log(INFO, "Exception thrown on socket close", e);
+        }
+        try {
+            cancelIdleTimeoutHandler();
+        } catch (RuntimeException | Error e) {
+            failure = LifecycleFailures.add(failure, e);
         }
         // Stop handling any new requests on all accepted and active connections
         failure = LifecycleFailures.add(failure, closeOpenConnections(false));
@@ -508,8 +509,8 @@ class ServerListener implements ListenerContext {
 
     private void rollbackFailedStart(Throwable startupFailure, boolean lifecycleStarted) {
         running = false;
-        suppressCleanupFailure(startupFailure, this::cancelIdleTimeoutHandler);
         suppressCleanupFailure(startupFailure, this::closeServerSocketOnFailure);
+        suppressCleanupFailure(startupFailure, this::cancelIdleTimeoutHandler);
         suppressCleanupFailure(startupFailure, this::shutdownReaderExecutor);
         suppressCleanupFailure(startupFailure, this::shutdownSharedExecutor);
         if (lifecycleStarted) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerIdleTimeoutTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerIdleTimeoutTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.context.Context;
+import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.http.media.MediaContext;
+import io.helidon.webserver.http.DirectHandlers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+class ServerListenerIdleTimeoutTest {
+    @Test
+    void idleTimeoutTaskStartsAndStopsWithListener() throws Exception {
+        RecordingTimer timer = new RecordingTimer();
+        ServerListener listener = newServerListener(timer);
+
+        assertThat(timer.scheduledTasks(), is(0));
+
+        try {
+            listener.start();
+            TimerTask task = timer.awaitTask(0);
+
+            listener.stop();
+
+            assertThat("idle timeout task should be cancelled by listener stop", wasAlreadyCancelled(task), is(true));
+            listener.stop();
+        } finally {
+            listener.stop();
+            timer.cancel();
+        }
+    }
+
+    @Test
+    void suspendCancelsIdleTimeoutTaskAndResumeStartsNewTask() throws Exception {
+        RecordingTimer timer = new RecordingTimer();
+        ServerListener listener = newServerListener(timer);
+
+        try {
+            listener.start();
+            TimerTask firstTask = timer.awaitTask(0);
+
+            listener.suspend();
+
+            assertThat("idle timeout task should be cancelled by listener suspend",
+                       wasAlreadyCancelled(firstTask),
+                       is(true));
+
+            listener.resume();
+            TimerTask secondTask = timer.awaitTask(1);
+
+            listener.stop();
+
+            assertThat("resumed idle timeout task should be cancelled by listener stop",
+                       wasAlreadyCancelled(secondTask),
+                       is(true));
+        } finally {
+            listener.stop();
+            timer.cancel();
+        }
+    }
+
+    @Test
+    void cancelWaitsForRunningIdleTimeoutTask() throws Exception {
+        RecordingTimer timer = new RecordingTimer();
+        CountDownLatch blockingCloseEntered = new CountDownLatch(1);
+        CountDownLatch releaseBlockingClose = new CountDownLatch(1);
+        IdleTimeoutHandler handler = new IdleTimeoutHandler(timer,
+                                                            listenerConfig(),
+                                                            () -> List.of(blockingConnectionHandler(blockingCloseEntered,
+                                                                                                    releaseBlockingClose)));
+        CountDownLatch cancelDone = new CountDownLatch(1);
+
+        Thread runThread = Thread.ofPlatform()
+                .name("test-idle-timeout-run")
+                .start(handler::run);
+        assertThat(blockingCloseEntered.await(5, TimeUnit.SECONDS), is(true));
+
+        Thread cancelThread = Thread.ofPlatform()
+                .name("test-idle-timeout-cancel")
+                .start(() -> {
+                    handler.cancelAndAwait();
+                    cancelDone.countDown();
+                });
+
+        try {
+            assertThat(cancelDone.await(100, TimeUnit.MILLISECONDS), is(false));
+
+            releaseBlockingClose.countDown();
+            runThread.join(TimeUnit.SECONDS.toMillis(5));
+            cancelThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(runThread.isAlive(), is(false));
+            assertThat(cancelThread.isAlive(), is(false));
+            assertThat(cancelDone.getCount(), is(0L));
+        } finally {
+            releaseBlockingClose.countDown();
+            timer.cancel();
+        }
+    }
+
+    private static ServerListener newServerListener(RecordingTimer timer) throws Exception {
+        WebServerConfig config = listenerConfig();
+
+        return new ServerListener(WebServer.DEFAULT_SOCKET_NAME,
+                                  config,
+                                  Router.empty(),
+                                  Context.builder()
+                                          .id("idle-timeout-lifecycle-test")
+                                          .build(),
+                                  timer,
+                                  MediaContext.create(),
+                                  ContentEncodingContext.create(),
+                                  DirectHandlers.create());
+    }
+
+    private static WebServerConfig listenerConfig() {
+        return WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .shutdownGracePeriod(Duration.ZERO)
+                .idleConnectionPeriod(Duration.ofDays(1))
+                .buildPrototype();
+    }
+
+    private static ConnectionHandler blockingConnectionHandler(CountDownLatch blockingCloseEntered,
+                                                              CountDownLatch releaseBlockingClose) {
+        ConnectionHandler handler = mock(ConnectionHandler.class);
+        doAnswer(_ -> {
+            blockingCloseEntered.countDown();
+            assertThat(releaseBlockingClose.await(5, TimeUnit.SECONDS), is(true));
+            return null;
+        }).when(handler).closeIfIdle(any(Duration.class));
+        return handler;
+    }
+
+    private static boolean wasAlreadyCancelled(TimerTask task) {
+        return !task.cancel();
+    }
+
+    private static final class RecordingTimer extends Timer {
+        private final List<TimerTask> tasks = new CopyOnWriteArrayList<>();
+
+        private RecordingTimer() {
+            super("idle-timeout-lifecycle-test", true);
+        }
+
+        @Override
+        public void schedule(TimerTask task, long delay, long period) {
+            tasks.add(task);
+            super.schedule(task, delay, period);
+        }
+
+        private int scheduledTasks() {
+            return tasks.size();
+        }
+
+        private TimerTask awaitTask(int index) throws InterruptedException {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (System.nanoTime() < deadline) {
+                if (tasks.size() > index) {
+                    return tasks.get(index);
+                }
+                TimeUnit.MILLISECONDS.sleep(10);
+            }
+            throw new AssertionError("Idle timeout task was not scheduled");
+        }
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerIdleTimeoutTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerIdleTimeoutTest.java
@@ -17,22 +17,33 @@
 package io.helidon.webserver;
 
 import java.net.InetAddress;
+import java.net.Socket;
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 
+import io.helidon.common.buffers.BufferData;
 import io.helidon.common.context.Context;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webserver.http.DirectHandlers;
+import io.helidon.webserver.spi.ServerConnection;
+import io.helidon.webserver.spi.ServerConnectionSelector;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -90,6 +101,26 @@ class ServerListenerIdleTimeoutTest {
     }
 
     @Test
+    void stopCancelsIdleTimeoutTaskBeforeClosingConnections() throws Exception {
+        lifecycleCancelsIdleTimeoutTaskBeforeClosingConnections(false);
+    }
+
+    @Test
+    void suspendCancelsIdleTimeoutTaskBeforeClosingConnections() throws Exception {
+        lifecycleCancelsIdleTimeoutTaskBeforeClosingConnections(true);
+    }
+
+    @Test
+    void stopWaitsForRunningIdleTimeoutTaskWhenTimerPurgeFails() throws Exception {
+        lifecycleWaitsForRunningIdleTimeoutTaskWhenTimerPurgeFails(false);
+    }
+
+    @Test
+    void suspendWaitsForRunningIdleTimeoutTaskWhenTimerPurgeFails() throws Exception {
+        lifecycleWaitsForRunningIdleTimeoutTaskWhenTimerPurgeFails(true);
+    }
+
+    @Test
     void cancelWaitsForRunningIdleTimeoutTask() throws Exception {
         RecordingTimer timer = new RecordingTimer();
         CountDownLatch blockingCloseEntered = new CountDownLatch(1);
@@ -113,7 +144,13 @@ class ServerListenerIdleTimeoutTest {
                 });
 
         try {
-            assertThat(cancelDone.await(100, TimeUnit.MILLISECONDS), is(false));
+            waitFor(Duration.ofSeconds(5),
+                    () -> handler.awaitingRunCompletion() || cancelDone.getCount() == 0,
+                    "idle timeout cancellation did not try to wait for the running task");
+            assertThat("idle timeout cancellation should wait for the running task",
+                       handler.awaitingRunCompletion(),
+                       is(true));
+            assertThat(cancelDone.getCount(), is(1L));
 
             releaseBlockingClose.countDown();
             runThread.join(TimeUnit.SECONDS.toMillis(5));
@@ -128,9 +165,144 @@ class ServerListenerIdleTimeoutTest {
         }
     }
 
-    private static ServerListener newServerListener(RecordingTimer timer) throws Exception {
-        WebServerConfig config = listenerConfig();
+    private static void lifecycleWaitsForRunningIdleTimeoutTaskWhenTimerPurgeFails(boolean suspend) throws Exception {
+        ThrowingPurgeTimer timer = new ThrowingPurgeTimer();
+        PurgeFailureConnection connection = new PurgeFailureConnection();
+        ServerListener listener = newServerListener(timer, new SingleConnectionSelector(connection));
+        AtomicReference<Throwable> lifecycleFailure = new AtomicReference<>();
+        CountDownLatch lifecycleDone = new CountDownLatch(1);
+        String lifecycle = suspend ? "suspend" : "stop";
+        Thread runThread = null;
+        Thread lifecycleThread = null;
 
+        try {
+            listener.start();
+            IdleTimeoutHandler handler = (IdleTimeoutHandler) timer.awaitTask(0);
+
+            try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), listener.port())) {
+                socket.getOutputStream().write('x');
+                assertThat(connection.awaitHandling(), is(true));
+
+                runThread = Thread.ofPlatform()
+                        .name("test-idle-timeout-purge-failure-run")
+                        .start(handler::run);
+                assertThat(connection.awaitIdleClose(), is(true));
+
+                lifecycleThread = Thread.ofPlatform()
+                        .name("test-idle-timeout-purge-failure-" + lifecycle)
+                        .start(() -> {
+                            try {
+                                if (suspend) {
+                                    listener.suspend();
+                                } else {
+                                    listener.stop();
+                                }
+                            } catch (RuntimeException | Error e) {
+                                lifecycleFailure.set(e);
+                            } finally {
+                                lifecycleDone.countDown();
+                            }
+                        });
+
+                assertThat(connection.awaitForcedClose(), is(true));
+                waitFor(Duration.ofSeconds(5),
+                        () -> handler.awaitingRunCompletion() || lifecycleDone.getCount() == 0,
+                        lifecycle + " did not try to wait for the running idle timeout task");
+                assertThat(lifecycle + " should wait for the running idle timeout task after purge failure",
+                           handler.awaitingRunCompletion(),
+                           is(true));
+                assertThat(lifecycleDone.getCount(), is(1L));
+
+                connection.releaseIdleClose();
+                runThread.join(TimeUnit.SECONDS.toMillis(5));
+                lifecycleThread.join(TimeUnit.SECONDS.toMillis(5));
+
+                assertThat(runThread.isAlive(), is(false));
+                assertThat(lifecycleThread.isAlive(), is(false));
+                assertThat(timer.purgeCalled(), is(true));
+                assertThat(lifecycleFailure.get(), notNullValue());
+            }
+        } finally {
+            connection.releaseIdleClose();
+            connection.releaseHandling();
+            if (runThread != null && runThread.isAlive()) {
+                runThread.interrupt();
+            }
+            if (lifecycleThread != null && lifecycleThread.isAlive()) {
+                lifecycleThread.interrupt();
+            }
+            listener.stop();
+            timer.cancel();
+        }
+    }
+
+    private static void lifecycleCancelsIdleTimeoutTaskBeforeClosingConnections(boolean suspend) throws Exception {
+        RecordingTimer timer = new RecordingTimer();
+        AtomicReference<TimerTask> idleTimeoutTask = new AtomicReference<>();
+        CancelObservedConnection connection =
+                new CancelObservedConnection(() -> wasAlreadyCancelled(idleTimeoutTask.get()));
+        ServerListener listener = newServerListener(timer, new SingleConnectionSelector(connection));
+        AtomicReference<Throwable> lifecycleFailure = new AtomicReference<>();
+        String lifecycle = suspend ? "suspend" : "stop";
+        Thread lifecycleThread = null;
+
+        try {
+            listener.start();
+            idleTimeoutTask.set(timer.awaitTask(0));
+
+            try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), listener.port())) {
+                socket.getOutputStream().write('x');
+                assertThat(connection.awaitHandling(), is(true));
+
+                lifecycleThread = Thread.ofPlatform()
+                        .name("test-idle-timeout-cancel-before-" + lifecycle + "-close")
+                        .start(() -> {
+                            try {
+                                if (suspend) {
+                                    listener.suspend();
+                                } else {
+                                    listener.stop();
+                                }
+                            } catch (RuntimeException | Error e) {
+                                lifecycleFailure.set(e);
+                            }
+                        });
+
+                assertThat(connection.awaitClose(), is(true));
+                assertThat("idle timeout task should be cancelled before listener closes connections",
+                           connection.closeSawCancelledIdleTimeoutTask(),
+                           is(true));
+
+                connection.releaseClose();
+                lifecycleThread.join(TimeUnit.SECONDS.toMillis(5));
+
+                assertThat(lifecycleThread.isAlive(), is(false));
+                assertThat(lifecycleFailure.get(), nullValue());
+            }
+        } finally {
+            connection.releaseClose();
+            connection.releaseHandling();
+            if (lifecycleThread != null && lifecycleThread.isAlive()) {
+                lifecycleThread.interrupt();
+            }
+            listener.stop();
+            timer.cancel();
+        }
+    }
+
+    private static ServerListener newServerListener(RecordingTimer timer) throws Exception {
+        WebServerConfig config = listenerConfig(null);
+
+        return newServerListener(timer, config);
+    }
+
+    private static ServerListener newServerListener(RecordingTimer timer, ServerConnectionSelector selector) throws Exception {
+        WebServerConfig config = listenerConfig(selector);
+
+        return newServerListener(timer, config);
+    }
+
+    private static ServerListener newServerListener(RecordingTimer timer, WebServerConfig config) throws Exception {
         return new ServerListener(WebServer.DEFAULT_SOCKET_NAME,
                                   config,
                                   Router.empty(),
@@ -144,13 +316,20 @@ class ServerListenerIdleTimeoutTest {
     }
 
     private static WebServerConfig listenerConfig() {
-        return WebServer.builder()
+        return listenerConfig(null);
+    }
+
+    private static WebServerConfig listenerConfig(ServerConnectionSelector selector) {
+        var builder = WebServer.builder()
                 .shutdownHook(false)
                 .address(InetAddress.getLoopbackAddress())
                 .port(0)
                 .shutdownGracePeriod(Duration.ZERO)
-                .idleConnectionPeriod(Duration.ofDays(1))
-                .buildPrototype();
+                .idleConnectionPeriod(Duration.ofDays(1));
+        if (selector != null) {
+            builder.addConnectionSelector(selector);
+        }
+        return builder.buildPrototype();
     }
 
     private static ConnectionHandler blockingConnectionHandler(CountDownLatch blockingCloseEntered,
@@ -168,7 +347,18 @@ class ServerListenerIdleTimeoutTest {
         return !task.cancel();
     }
 
-    private static final class RecordingTimer extends Timer {
+    private static void waitFor(Duration timeout, BooleanSupplier condition, String message) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(10);
+        }
+        throw new AssertionError(message);
+    }
+
+    private static class RecordingTimer extends Timer {
         private final List<TimerTask> tasks = new CopyOnWriteArrayList<>();
 
         private RecordingTimer() {
@@ -185,7 +375,7 @@ class ServerListenerIdleTimeoutTest {
             return tasks.size();
         }
 
-        private TimerTask awaitTask(int index) throws InterruptedException {
+        TimerTask awaitTask(int index) throws InterruptedException {
             long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
             while (System.nanoTime() < deadline) {
                 if (tasks.size() > index) {
@@ -194,6 +384,183 @@ class ServerListenerIdleTimeoutTest {
                 TimeUnit.MILLISECONDS.sleep(10);
             }
             throw new AssertionError("Idle timeout task was not scheduled");
+        }
+    }
+
+    private static final class ThrowingPurgeTimer extends RecordingTimer {
+        private final CountDownLatch purgeCalled = new CountDownLatch(1);
+
+        @Override
+        public int purge() {
+            purgeCalled.countDown();
+            throw new IllegalStateException("timer purge failure");
+        }
+
+        private boolean purgeCalled() {
+            return purgeCalled.getCount() == 0;
+        }
+    }
+
+    private static final class SingleConnectionSelector implements ServerConnectionSelector {
+        private final ServerConnection connection;
+
+        private SingleConnectionSelector(ServerConnection connection) {
+            this.connection = connection;
+        }
+
+        @Override
+        public int bytesToIdentifyConnection() {
+            return 0;
+        }
+
+        @Override
+        public Support supports(BufferData data) {
+            return Support.SUPPORTED;
+        }
+
+        @Override
+        public Set<String> supportedApplicationProtocols() {
+            return Set.of("test-idle-timeout-cancel-before-close");
+        }
+
+        @Override
+        public ServerConnection connection(ConnectionContext ctx) {
+            return connection;
+        }
+    }
+
+    private static final class PurgeFailureConnection implements ServerConnection {
+        private final CountDownLatch handling = new CountDownLatch(1);
+        private final CountDownLatch idleCloseEntered = new CountDownLatch(1);
+        private final CountDownLatch forcedCloseEntered = new CountDownLatch(1);
+        private final CountDownLatch releaseIdleClose = new CountDownLatch(1);
+        private final CountDownLatch releaseHandling = new CountDownLatch(1);
+        private final AtomicInteger gracefulCloses = new AtomicInteger();
+
+        @Override
+        public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+            handling.countDown();
+            while (releaseHandling.getCount() != 0) {
+                try {
+                    releaseHandling.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts so shutdown must close the connection.
+                }
+            }
+        }
+
+        @Override
+        public Duration idleTime() {
+            return Duration.ofDays(1);
+        }
+
+        @Override
+        public void close(boolean interrupt) {
+            if (interrupt) {
+                forcedCloseEntered.countDown();
+                releaseHandling.countDown();
+                return;
+            }
+            if (gracefulCloses.incrementAndGet() == 1) {
+                idleCloseEntered.countDown();
+                while (releaseIdleClose.getCount() != 0) {
+                    try {
+                        releaseIdleClose.await(1, TimeUnit.SECONDS);
+                    } catch (InterruptedException _) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            }
+        }
+
+        private boolean awaitHandling() throws InterruptedException {
+            return handling.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean awaitIdleClose() throws InterruptedException {
+            return idleCloseEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean awaitForcedClose() throws InterruptedException {
+            return forcedCloseEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        private void releaseIdleClose() {
+            releaseIdleClose.countDown();
+        }
+
+        private void releaseHandling() {
+            releaseHandling.countDown();
+        }
+    }
+
+    private static final class CancelObservedConnection implements ServerConnection {
+        private final BooleanSupplier idleTimeoutTaskCancelled;
+        private final CountDownLatch handling = new CountDownLatch(1);
+        private final CountDownLatch closeEntered = new CountDownLatch(1);
+        private final CountDownLatch releaseClose = new CountDownLatch(1);
+        private final CountDownLatch releaseHandling = new CountDownLatch(1);
+        private final AtomicBoolean closeSawCancelledIdleTimeoutTask = new AtomicBoolean();
+
+        private CancelObservedConnection(BooleanSupplier idleTimeoutTaskCancelled) {
+            this.idleTimeoutTaskCancelled = idleTimeoutTaskCancelled;
+        }
+
+        @Override
+        public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+            handling.countDown();
+            while (releaseHandling.getCount() != 0) {
+                try {
+                    releaseHandling.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts so shutdown must close the connection.
+                }
+            }
+        }
+
+        @Override
+        public Duration idleTime() {
+            return Duration.ZERO;
+        }
+
+        @Override
+        public void close(boolean interrupt) {
+            if (interrupt) {
+                releaseClose.countDown();
+                releaseHandling.countDown();
+                return;
+            }
+            closeSawCancelledIdleTimeoutTask.set(idleTimeoutTaskCancelled.getAsBoolean());
+            closeEntered.countDown();
+            while (releaseClose.getCount() != 0) {
+                try {
+                    releaseClose.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+
+        private boolean awaitHandling() throws InterruptedException {
+            return handling.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean awaitClose() throws InterruptedException {
+            return closeEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean closeSawCancelledIdleTimeoutTask() {
+            return closeSawCancelledIdleTimeoutTask.get();
+        }
+
+        private void releaseClose() {
+            releaseClose.countDown();
+        }
+
+        private void releaseHandling() {
+            releaseHandling.countDown();
         }
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -17,7 +17,9 @@
 package io.helidon.webserver;
 
 import java.io.UncheckedIOException;
+import java.net.ConnectException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
@@ -653,70 +655,12 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
-    void stopWaitsForRunningIdleTimeoutTask() throws Exception {
-        CountDownLatch handling = new CountDownLatch(1);
-        CountDownLatch idleCloseEntered = new CountDownLatch(1);
-        CountDownLatch releaseIdleClose = new CountDownLatch(1);
-        CountDownLatch releaseHandling = new CountDownLatch(1);
+    void stopClosesListenerSocketBeforeWaitingForRunningIdleTimeoutTask() throws Exception {
         CountDownLatch stopStarted = new CountDownLatch(1);
         CountDownLatch stopDone = new CountDownLatch(1);
-        AtomicInteger gracefulCloses = new AtomicInteger();
         AtomicReference<Throwable> stopFailure = new AtomicReference<>();
-        ServerConnection connection = new ServerConnection() {
-            @Override
-            public void handle(io.helidon.common.concurrency.limits.Limit limit) {
-                handling.countDown();
-                while (releaseHandling.getCount() != 0) {
-                    try {
-                        releaseHandling.await(1, TimeUnit.SECONDS);
-                    } catch (InterruptedException _) {
-                        // Deliberately ignore interrupts so shutdown must close the connection.
-                    }
-                }
-            }
-
-            @Override
-            public Duration idleTime() {
-                return Duration.ofMinutes(1);
-            }
-
-            @Override
-            public void close(boolean interrupt) {
-                if (interrupt) {
-                    releaseHandling.countDown();
-                    return;
-                }
-                if (gracefulCloses.incrementAndGet() == 1) {
-                    idleCloseEntered.countDown();
-                    try {
-                        releaseIdleClose.await(5, TimeUnit.SECONDS);
-                    } catch (InterruptedException _) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
-            }
-        };
-        ServerConnectionSelector selector = new ServerConnectionSelector() {
-            @Override
-            public int bytesToIdentifyConnection() {
-                return 0;
-            }
-
-            @Override
-            public Support supports(BufferData data) {
-                return Support.SUPPORTED;
-            }
-
-            @Override
-            public Set<String> supportedApplicationProtocols() {
-                return Set.of("test-stop-waits-for-idle-timeout");
-            }
-
-            @Override
-            public ServerConnection connection(ConnectionContext ctx) {
-                return connection;
-            }
-        };
+        BlockingIdleCloseConnection connection = new BlockingIdleCloseConnection();
+        QueueingConnectionSelector selector = new QueueingConnectionSelector(connection);
         LoomServer server = (LoomServer) WebServer.builder()
                 .shutdownHook(false)
                 .address(InetAddress.getLoopbackAddress())
@@ -727,11 +671,12 @@ class ServerListenerLifecycleTest {
                 .build()
                 .start();
         Thread stopThread = null;
+        int port = server.port();
 
-        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), port)) {
             socket.getOutputStream().write('x');
-            assertThat(handling.await(5, TimeUnit.SECONDS), is(true));
-            assertThat(idleCloseEntered.await(5, TimeUnit.SECONDS), is(true));
+            assertThat(connection.awaitHandling(), is(true));
+            assertThat(connection.awaitIdleClose(), is(true));
 
             stopThread = Thread.ofPlatform()
                     .name("test-stop-waits-for-idle-timeout")
@@ -751,18 +696,79 @@ class ServerListenerLifecycleTest {
             waitFor(Duration.ofSeconds(5),
                     () -> localStopThread.getState() == Thread.State.WAITING && stopDone.getCount() != 0,
                     "stop did not wait for the running idle timeout task");
-            assertThat(gracefulCloses.get(), is(1));
+            assertThat(connection.gracefulCloses(), is(1));
+            assertPortRefusesConnections(port);
 
-            releaseIdleClose.countDown();
+            connection.releaseIdleClose();
             stopThread.join(TimeUnit.SECONDS.toMillis(5));
 
             assertThat(stopThread.isAlive(), is(false));
             assertThat(stopFailure.get(), nullValue());
         } finally {
-            releaseIdleClose.countDown();
-            releaseHandling.countDown();
+            connection.releaseIdleClose();
+            connection.releaseHandling();
             if (stopThread != null && stopThread.isAlive()) {
                 stopThread.interrupt();
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
+    void suspendClosesListenerSocketBeforeWaitingForRunningIdleTimeoutTask() throws Exception {
+        CountDownLatch suspendStarted = new CountDownLatch(1);
+        CountDownLatch suspendDone = new CountDownLatch(1);
+        AtomicReference<Throwable> suspendFailure = new AtomicReference<>();
+        BlockingIdleCloseConnection connection = new BlockingIdleCloseConnection();
+        QueueingConnectionSelector selector = new QueueingConnectionSelector(connection);
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .idleConnectionTimeout(Duration.ofMillis(1))
+                .idleConnectionPeriod(Duration.ofMillis(10))
+                .addConnectionSelector(selector)
+                .build()
+                .start();
+        Thread suspendThread = null;
+        int port = server.port();
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), port)) {
+            socket.getOutputStream().write('x');
+            assertThat(connection.awaitHandling(), is(true));
+            assertThat(connection.awaitIdleClose(), is(true));
+
+            suspendThread = Thread.ofPlatform()
+                    .name("test-suspend-closes-listener-before-idle-timeout-wait")
+                    .start(() -> {
+                        suspendStarted.countDown();
+                        try {
+                            server.suspend();
+                        } catch (RuntimeException | Error e) {
+                            suspendFailure.set(e);
+                        } finally {
+                            suspendDone.countDown();
+                        }
+                    });
+
+            assertThat(suspendStarted.await(5, TimeUnit.SECONDS), is(true));
+            Thread localSuspendThread = suspendThread;
+            waitFor(Duration.ofSeconds(5),
+                    () -> localSuspendThread.getState() == Thread.State.WAITING && suspendDone.getCount() != 0,
+                    "suspend did not wait for the running idle timeout task");
+            assertThat(connection.gracefulCloses(), is(1));
+            assertPortRefusesConnections(port);
+
+            connection.releaseIdleClose();
+            suspendThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(suspendThread.isAlive(), is(false));
+            assertThat(suspendFailure.get(), nullValue());
+        } finally {
+            connection.releaseIdleClose();
+            connection.releaseHandling();
+            if (suspendThread != null && suspendThread.isAlive()) {
+                suspendThread.interrupt();
             }
             stopUntilStopped(server);
         }
@@ -927,6 +933,16 @@ class ServerListenerLifecycleTest {
         assertThat(port > 0, is(true));
         try (ServerSocket _ = new ServerSocket(port, 50, InetAddress.getLoopbackAddress())) {
             // validates that failed startup cleanup released the socket
+        }
+    }
+
+    private static void assertPortRefusesConnections(int port) throws Exception {
+        assertThat(port > 0, is(true));
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), port), 250);
+            throw new AssertionError("Listener socket still accepted connections on port " + port);
+        } catch (ConnectException | SocketTimeoutException _) {
+            // validates that the listener socket is closed while shutdown waits for idle-timeout cleanup
         }
     }
 
@@ -1336,6 +1352,67 @@ class ServerListenerLifecycleTest {
 
         private void release() {
             release.countDown();
+        }
+    }
+
+    private static final class BlockingIdleCloseConnection implements ServerConnection {
+        private final CountDownLatch handling = new CountDownLatch(1);
+        private final CountDownLatch idleCloseEntered = new CountDownLatch(1);
+        private final CountDownLatch releaseIdleClose = new CountDownLatch(1);
+        private final CountDownLatch releaseHandling = new CountDownLatch(1);
+        private final AtomicInteger gracefulCloses = new AtomicInteger();
+
+        @Override
+        public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+            handling.countDown();
+            while (releaseHandling.getCount() != 0) {
+                try {
+                    releaseHandling.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    // Deliberately ignore interrupts so shutdown must close the connection.
+                }
+            }
+        }
+
+        @Override
+        public Duration idleTime() {
+            return Duration.ofMinutes(1);
+        }
+
+        @Override
+        public void close(boolean interrupt) {
+            if (interrupt) {
+                releaseHandling.countDown();
+                return;
+            }
+            if (gracefulCloses.incrementAndGet() == 1) {
+                idleCloseEntered.countDown();
+                try {
+                    releaseIdleClose.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException _) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        private boolean awaitHandling() throws InterruptedException {
+            return handling.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean awaitIdleClose() throws InterruptedException {
+            return idleCloseEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        private int gracefulCloses() {
+            return gracefulCloses.get();
+        }
+
+        private void releaseIdleClose() {
+            releaseIdleClose.countDown();
+        }
+
+        private void releaseHandling() {
+            releaseHandling.countDown();
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -655,7 +655,7 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
-    void stopClosesListenerSocketBeforeWaitingForRunningIdleTimeoutTask() throws Exception {
+    void stopForcesConnectionsBeforeWaitingForRunningIdleTimeoutTask() throws Exception {
         CountDownLatch stopStarted = new CountDownLatch(1);
         CountDownLatch stopDone = new CountDownLatch(1);
         AtomicReference<Throwable> stopFailure = new AtomicReference<>();
@@ -679,7 +679,7 @@ class ServerListenerLifecycleTest {
             assertThat(connection.awaitIdleClose(), is(true));
 
             stopThread = Thread.ofPlatform()
-                    .name("test-stop-waits-for-idle-timeout")
+                    .name("test-stop-forces-before-idle-timeout-wait")
                     .start(() -> {
                         stopStarted.countDown();
                         try {
@@ -692,11 +692,10 @@ class ServerListenerLifecycleTest {
                     });
 
             assertThat(stopStarted.await(5, TimeUnit.SECONDS), is(true));
-            Thread localStopThread = stopThread;
-            waitFor(Duration.ofSeconds(5),
-                    () -> localStopThread.getState() == Thread.State.WAITING && stopDone.getCount() != 0,
-                    "stop did not wait for the running idle timeout task");
-            assertThat(connection.gracefulCloses(), is(1));
+            assertThat(connection.awaitForcedClose(), is(true));
+            assertThat("stop should wait for the running idle timeout task",
+                       stopDone.getCount(),
+                       is(1L));
             assertPortRefusesConnections(port);
 
             connection.releaseIdleClose();
@@ -715,7 +714,7 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
-    void suspendClosesListenerSocketBeforeWaitingForRunningIdleTimeoutTask() throws Exception {
+    void suspendForcesConnectionsBeforeWaitingForRunningIdleTimeoutTask() throws Exception {
         CountDownLatch suspendStarted = new CountDownLatch(1);
         CountDownLatch suspendDone = new CountDownLatch(1);
         AtomicReference<Throwable> suspendFailure = new AtomicReference<>();
@@ -739,7 +738,7 @@ class ServerListenerLifecycleTest {
             assertThat(connection.awaitIdleClose(), is(true));
 
             suspendThread = Thread.ofPlatform()
-                    .name("test-suspend-closes-listener-before-idle-timeout-wait")
+                    .name("test-suspend-forces-before-idle-timeout-wait")
                     .start(() -> {
                         suspendStarted.countDown();
                         try {
@@ -752,11 +751,10 @@ class ServerListenerLifecycleTest {
                     });
 
             assertThat(suspendStarted.await(5, TimeUnit.SECONDS), is(true));
-            Thread localSuspendThread = suspendThread;
-            waitFor(Duration.ofSeconds(5),
-                    () -> localSuspendThread.getState() == Thread.State.WAITING && suspendDone.getCount() != 0,
-                    "suspend did not wait for the running idle timeout task");
-            assertThat(connection.gracefulCloses(), is(1));
+            assertThat(connection.awaitForcedClose(), is(true));
+            assertThat("suspend should wait for the running idle timeout task",
+                       suspendDone.getCount(),
+                       is(1L));
             assertPortRefusesConnections(port);
 
             connection.releaseIdleClose();
@@ -1358,6 +1356,7 @@ class ServerListenerLifecycleTest {
     private static final class BlockingIdleCloseConnection implements ServerConnection {
         private final CountDownLatch handling = new CountDownLatch(1);
         private final CountDownLatch idleCloseEntered = new CountDownLatch(1);
+        private final CountDownLatch forcedCloseEntered = new CountDownLatch(1);
         private final CountDownLatch releaseIdleClose = new CountDownLatch(1);
         private final CountDownLatch releaseHandling = new CountDownLatch(1);
         private final AtomicInteger gracefulCloses = new AtomicInteger();
@@ -1382,15 +1381,19 @@ class ServerListenerLifecycleTest {
         @Override
         public void close(boolean interrupt) {
             if (interrupt) {
+                forcedCloseEntered.countDown();
                 releaseHandling.countDown();
                 return;
             }
             if (gracefulCloses.incrementAndGet() == 1) {
                 idleCloseEntered.countDown();
-                try {
-                    releaseIdleClose.await(5, TimeUnit.SECONDS);
-                } catch (InterruptedException _) {
-                    Thread.currentThread().interrupt();
+                while (releaseIdleClose.getCount() != 0) {
+                    try {
+                        releaseIdleClose.await(1, TimeUnit.SECONDS);
+                    } catch (InterruptedException _) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
                 }
             }
         }
@@ -1403,8 +1406,8 @@ class ServerListenerLifecycleTest {
             return idleCloseEntered.await(5, TimeUnit.SECONDS);
         }
 
-        private int gracefulCloses() {
-            return gracefulCloses.get();
+        private boolean awaitForcedClose() throws InterruptedException {
+            return forcedCloseEntered.await(5, TimeUnit.SECONDS);
         }
 
         private void releaseIdleClose() {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -653,6 +653,122 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
+    void stopWaitsForRunningIdleTimeoutTask() throws Exception {
+        CountDownLatch handling = new CountDownLatch(1);
+        CountDownLatch idleCloseEntered = new CountDownLatch(1);
+        CountDownLatch releaseIdleClose = new CountDownLatch(1);
+        CountDownLatch releaseHandling = new CountDownLatch(1);
+        CountDownLatch stopStarted = new CountDownLatch(1);
+        CountDownLatch stopDone = new CountDownLatch(1);
+        AtomicInteger gracefulCloses = new AtomicInteger();
+        AtomicReference<Throwable> stopFailure = new AtomicReference<>();
+        ServerConnection connection = new ServerConnection() {
+            @Override
+            public void handle(io.helidon.common.concurrency.limits.Limit limit) {
+                handling.countDown();
+                while (releaseHandling.getCount() != 0) {
+                    try {
+                        releaseHandling.await(1, TimeUnit.SECONDS);
+                    } catch (InterruptedException _) {
+                        // Deliberately ignore interrupts so shutdown must close the connection.
+                    }
+                }
+            }
+
+            @Override
+            public Duration idleTime() {
+                return Duration.ofMinutes(1);
+            }
+
+            @Override
+            public void close(boolean interrupt) {
+                if (interrupt) {
+                    releaseHandling.countDown();
+                    return;
+                }
+                if (gracefulCloses.incrementAndGet() == 1) {
+                    idleCloseEntered.countDown();
+                    try {
+                        releaseIdleClose.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException _) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+        };
+        ServerConnectionSelector selector = new ServerConnectionSelector() {
+            @Override
+            public int bytesToIdentifyConnection() {
+                return 0;
+            }
+
+            @Override
+            public Support supports(BufferData data) {
+                return Support.SUPPORTED;
+            }
+
+            @Override
+            public Set<String> supportedApplicationProtocols() {
+                return Set.of("test-stop-waits-for-idle-timeout");
+            }
+
+            @Override
+            public ServerConnection connection(ConnectionContext ctx) {
+                return connection;
+            }
+        };
+        LoomServer server = (LoomServer) WebServer.builder()
+                .shutdownHook(false)
+                .address(InetAddress.getLoopbackAddress())
+                .port(0)
+                .idleConnectionTimeout(Duration.ofMillis(1))
+                .idleConnectionPeriod(Duration.ofMillis(10))
+                .addConnectionSelector(selector)
+                .build()
+                .start();
+        Thread stopThread = null;
+
+        try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), server.port())) {
+            socket.getOutputStream().write('x');
+            assertThat(handling.await(5, TimeUnit.SECONDS), is(true));
+            assertThat(idleCloseEntered.await(5, TimeUnit.SECONDS), is(true));
+
+            stopThread = Thread.ofPlatform()
+                    .name("test-stop-waits-for-idle-timeout")
+                    .start(() -> {
+                        stopStarted.countDown();
+                        try {
+                            server.stop();
+                        } catch (RuntimeException | Error e) {
+                            stopFailure.set(e);
+                        } finally {
+                            stopDone.countDown();
+                        }
+                    });
+
+            assertThat(stopStarted.await(5, TimeUnit.SECONDS), is(true));
+            Thread localStopThread = stopThread;
+            waitFor(Duration.ofSeconds(5),
+                    () -> localStopThread.getState() == Thread.State.WAITING && stopDone.getCount() != 0,
+                    "stop did not wait for the running idle timeout task");
+            assertThat(gracefulCloses.get(), is(1));
+
+            releaseIdleClose.countDown();
+            stopThread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(stopThread.isAlive(), is(false));
+            assertThat(stopFailure.get(), nullValue());
+        } finally {
+            releaseIdleClose.countDown();
+            releaseHandling.countDown();
+            if (stopThread != null && stopThread.isAlive()) {
+                stopThread.interrupt();
+            }
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
     void webServerStopFailureThrowsAfterStoppingAllListeners() {
         LifecycleService defaultService = new LifecycleService("default", true);
         LifecycleService adminService = new LifecycleService("admin", true);


### PR DESCRIPTION
Resolves #11939

Moves the WebServer idle timeout task into the listener lifecycle so it starts with listener startup, is recreated after checkpoint resume, and is cancelled during stop, suspend, and failed-start cleanup. Adds focused coverage for stop, suspend, repeated cleanup, and resume scheduling without relying on real-time idle waits.
