### PR TITLE
27.x: dependency check updates

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -116,6 +116,52 @@
 </suppress>
 
 <!-- False Positives.
+     These are confusing prometheus simple client tracer for otel with OTel dotnet, Go, python
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient_tracer_otel-0.16.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
+    <cve>CVE-2026-40894</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient_tracer_otel-0.16.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
+    <cve>CVE-2026-39882</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient_tracer_otel-0.16.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
+    <cve>CVE-2026-41078</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient_tracer_otel-0.16.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
+    <cve>CVE-2023-47108</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient_tracer_otel-0.16.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
+    <cve>CVE-2023-45142</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: simpleclient_tracer_otel-0.16.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
+    <cve>CVE-2023-43810</cve>
+</suppress>
+
+<!-- False Positives.
      This CVE is against the XML Database component of Oracle Database Server.
      The below are client libraries for XML and XML JDBC support.
 -->

--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,9 +56,9 @@ fi
 # Set OSS_INDEX_USERNAME and OSS_INDEX_PASSWORD to authenticate.
 # Otherwise OSS Index analyzer will be disabled
 # And yes, this option uses a lower case i while Username and Password has an upper case I
-OSS_INDEX_OPTIONS="-DossindexAnalyzerEnabled=false"
+OSS_INDEX_OPTIONS="-DossIndexAnalyzerEnabled=false"
 if [ -n "${OSS_INDEX_PASSWORD}" ] && [ -n "${OSS_INDEX_USERNAME}" ]; then
-    OSS_INDEX_OPTIONS="-DossindexAnalyzerEnabled=true -DossIndexUsername=${OSS_INDEX_USERNAME} -DossIndexPassword=${OSS_INDEX_PASSWORD}"
+    OSS_INDEX_OPTIONS="-DossIndexAnalyzerEnabled=true -DossIndexUsername=${OSS_INDEX_USERNAME} -DossIndexPassword=${OSS_INDEX_PASSWORD}"
 fi
 
 # Setting NVD_API_KEY is not required but improves behavior of NVD API throttling

--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,8 @@
                         <skipTestScope>true</skipTestScope>
                         <failBuildOnCVSS>0</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <!-- Bump up from 24 to 72 to reduce token use -->
+                        <ossIndexAnalyzerCacheValidForHours>72</ossIndexAnalyzerCacheValidForHours>
                         <excludes>
                             <!-- Exclude stuff we do not deploy -->
                             <exclude>io.helidon.tracing:helidon-tracing-tests</exclude>
@@ -543,7 +545,6 @@
                         </excludes>
                         <formats>
                             <format>HTML</format>
-                            <format>CSV</format>
                         </formats>
                         <suppressionFiles>
                             <!--suppress UnresolvedMavenProperty -->


### PR DESCRIPTION
### Description

- Suppress some false positives around otel
- Update owasp dependency check plugin config:
   - Increase OSSIndex cache validation period to 72 hours to reduce API usage
   - Change some deprecated flags to use new version of flags
   - Don't generate CSV file since we don't use it

See https://dependency-check.github.io/DependencyCheck/analyzers/oss-index-analyzer.html for background info on changes to Sonatype's OSS Index and migration to Sonatype Guide.

