### PR TITLE
Enable single-module Javadoc warning checks

### DIFF
--- a/graphql/server/pom.xml
+++ b/graphql/server/pom.xml
@@ -31,6 +31,10 @@
     <artifactId>helidon-graphql-server</artifactId>
     <name>Helidon GraphQL Server</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.graphql-java</groupId>

--- a/helidon/pom.xml
+++ b/helidon/pom.xml
@@ -30,6 +30,10 @@
 
     <description>Helidon main entry point</description>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/http/media/jackson/pom.xml
+++ b/http/media/jackson/pom.xml
@@ -28,9 +28,7 @@
     <name>Helidon HTTP Media Jackson</name>
 
     <properties>
-        <!-- this must be disabled, as jars contain module-info.java, but Javadoc is generated without modules,
-         so generated links were invalid -->
-        <javadoc.fail-on-warnings>false</javadoc.fail-on-warnings>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
     </properties>
 
     <dependencies>
@@ -170,6 +168,17 @@
                             <version>${helidon.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <!-- Jackson Javadocs are published for unnamed modules. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>
+                        <option>--link-modularity-mismatch</option>
+                        <option>info</option>
+                    </additionalOptions>
                 </configuration>
             </plugin>
         </plugins>

--- a/openapi/openapi/pom.xml
+++ b/openapi/openapi/pom.xml
@@ -31,6 +31,7 @@
     </description>
 
     <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
     </properties>
 

--- a/telemetry/opentelemetry-config/pom.xml
+++ b/telemetry/opentelemetry-config/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>helidon-telemetry-opentelemetry-config</artifactId>
     <name>Helidon OpenTelemetry Configuration Support</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/websocket/pom.xml
+++ b/websocket/pom.xml
@@ -28,6 +28,10 @@
     <artifactId>helidon-websocket</artifactId>
     <name>Helidon WebSocket</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
@@ -76,4 +80,3 @@
         </plugins>
     </build>
 </project>
-

--- a/websocket/src/main/java/io/helidon/websocket/AbstractWsFrame.java
+++ b/websocket/src/main/java/io/helidon/websocket/AbstractWsFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,13 @@ abstract sealed class AbstractWsFrame implements WsFrame permits ServerWsFrame, 
         return opCode + (fin ? " (last): \n" : ": \n") + unmaskedData.get().debugDataHex();
     }
 
+    /**
+     * Read a WebSocket frame header.
+     *
+     * @param reader data reader
+     * @param maxFrameLength maximal allowed frame length
+     * @return frame header
+     */
     protected static FrameHeader readFrameHeader(DataReader reader, int maxFrameLength) {
         int opCodeByte = reader.read();
         boolean fin = (opCodeByte & 0b10000000) != 0;
@@ -112,11 +119,24 @@ abstract sealed class AbstractWsFrame implements WsFrame permits ServerWsFrame, 
         return new FrameHeader(opCode, fin, masked, (int) frameLength);
     }
 
+    /**
+     * Read frame payload.
+     *
+     * @param reader data reader
+     * @param header frame header
+     * @return payload data
+     */
     protected static BufferData readPayload(DataReader reader, FrameHeader header) {
         int length = header.length();
         return length == 0 ? BufferData.empty() : reader.readBuffer(length);
     }
 
+    /**
+     * Check whether the frame is a text or binary data frame.
+     *
+     * @param header frame header
+     * @return whether the frame is a text or binary data frame
+     */
     protected static boolean isPayload(FrameHeader header) {
         WsOpCode opCode = header.opCode;
         return opCode == WsOpCode.BINARY || opCode == WsOpCode.TEXT;

--- a/websocket/src/main/java/io/helidon/websocket/WebSocket.java
+++ b/websocket/src/main/java/io/helidon/websocket/WebSocket.java
@@ -33,7 +33,10 @@ import io.helidon.service.registry.Service;
 public class WebSocket {
     /**
      * Create a new WebSocket annotation container.
+     *
+     * @deprecated This type only groups nested annotations and should not be instantiated.
      */
+    @Deprecated(forRemoval = true, since = "27.0.0")
     public WebSocket() {
     }
 

--- a/websocket/src/main/java/io/helidon/websocket/WebSocket.java
+++ b/websocket/src/main/java/io/helidon/websocket/WebSocket.java
@@ -31,13 +31,7 @@ import io.helidon.service.registry.Service;
  * Each annotated method can have an unqualified parameter {@link io.helidon.websocket.WsSession}.
  */
 public class WebSocket {
-    /**
-     * Create a new WebSocket annotation container.
-     *
-     * @deprecated This type only groups nested annotations and should not be instantiated.
-     */
-    @Deprecated(forRemoval = true, since = "27.0.0")
-    public WebSocket() {
+    private WebSocket() {
     }
 
     /**

--- a/websocket/src/main/java/io/helidon/websocket/WebSocket.java
+++ b/websocket/src/main/java/io/helidon/websocket/WebSocket.java
@@ -32,6 +32,12 @@ import io.helidon.service.registry.Service;
  */
 public class WebSocket {
     /**
+     * Create a new WebSocket annotation container.
+     */
+    public WebSocket() {
+    }
+
+    /**
      * A message listener method. There can be maximally two methods on a service with this annotation, and they must
      * use different message type (i.e. one method max for binary, and one method max for string messages).
      * <p>

--- a/websocket/src/main/java/io/helidon/websocket/WsCloseException.java
+++ b/websocket/src/main/java/io/helidon/websocket/WsCloseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@ package io.helidon.websocket;
  * Exception requesting a close of the WebSocket communication.
  */
 public class WsCloseException extends RuntimeException {
+    /**
+     * WebSocket close code.
+     */
     private final int code;
 
     /**

--- a/websocket/src/main/java/io/helidon/websocket/WsListenerBase.java
+++ b/websocket/src/main/java/io/helidon/websocket/WsListenerBase.java
@@ -68,6 +68,20 @@ public abstract class WsListenerBase implements WsListener {
 
     private List<BufferData> buffers;
 
+    /**
+     * Create a new listener base.
+     */
+    public WsListenerBase() {
+    }
+
+    /**
+     * Process a text message chunk as a string.
+     *
+     * @param session WebSocket session
+     * @param text text chunk
+     * @param last whether this is the last chunk
+     * @param stringConsumer consumer of the complete text message
+     */
     protected void textString(WsSession session,
                               String text,
                               boolean last,
@@ -85,6 +99,14 @@ public abstract class WsListenerBase implements WsListener {
     }
 
     // runs on current connection thread
+    /**
+     * Process a text message chunk as a reader.
+     *
+     * @param session WebSocket session
+     * @param text text chunk
+     * @param last whether this is the last chunk
+     * @param readerConsumer consumer of the text reader
+     */
     protected void textReader(WsSession session,
                               String text,
                               boolean last,
@@ -141,6 +163,14 @@ public abstract class WsListenerBase implements WsListener {
         }
     }
 
+    /**
+     * Process a binary message chunk as buffer data.
+     *
+     * @param session WebSocket session
+     * @param buffer binary chunk
+     * @param last whether this is the last chunk
+     * @param bufferDataConsumer consumer of the complete binary message
+     */
     protected void binaryBufferData(WsSession session,
                                     BufferData buffer,
                                     boolean last,
@@ -160,6 +190,14 @@ public abstract class WsListenerBase implements WsListener {
         }
     }
 
+    /**
+     * Process a binary message chunk as a byte buffer.
+     *
+     * @param session WebSocket session
+     * @param buffer binary chunk
+     * @param last whether this is the last chunk
+     * @param streamConsumer consumer of the complete binary message
+     */
     protected void binaryByteBuffer(WsSession session,
                                     BufferData buffer,
                                     boolean last,
@@ -183,6 +221,14 @@ public abstract class WsListenerBase implements WsListener {
         }
     }
 
+    /**
+     * Process a binary message chunk as a byte array.
+     *
+     * @param session WebSocket session
+     * @param buffer binary chunk
+     * @param last whether this is the last chunk
+     * @param byteArrayConsumer consumer of the complete binary message
+     */
     protected void binaryByteArray(WsSession session,
                                    BufferData buffer,
                                    boolean last,
@@ -205,6 +251,14 @@ public abstract class WsListenerBase implements WsListener {
         }
     }
 
+    /**
+     * Process a binary message chunk as an input stream.
+     *
+     * @param session WebSocket session
+     * @param buffer binary chunk
+     * @param last whether this is the last chunk
+     * @param streamConsumer consumer of the binary input stream
+     */
     protected void binaryInputStream(WsSession session,
                                      BufferData buffer,
                                      boolean last,

--- a/websocket/src/main/java/io/helidon/websocket/WsListenerBase.java
+++ b/websocket/src/main/java/io/helidon/websocket/WsListenerBase.java
@@ -70,7 +70,10 @@ public abstract class WsListenerBase implements WsListener {
 
     /**
      * Create a new listener base.
+     *
+     * @deprecated This type is intended only as a base class for inheriting listeners.
      */
+    @Deprecated(forRemoval = true, since = "27.0.0")
     public WsListenerBase() {
     }
 

--- a/websocket/src/main/java/io/helidon/websocket/WsListenerBase.java
+++ b/websocket/src/main/java/io/helidon/websocket/WsListenerBase.java
@@ -69,12 +69,9 @@ public abstract class WsListenerBase implements WsListener {
     private List<BufferData> buffers;
 
     /**
-     * Create a new listener base.
-     *
-     * @deprecated This type is intended only as a base class for inheriting listeners.
+     * Create a new listener base for subclasses.
      */
-    @Deprecated(forRemoval = true, since = "27.0.0")
-    public WsListenerBase() {
+    protected WsListenerBase() {
     }
 
     /**


### PR DESCRIPTION
Part of #9356

Enables Javadoc fail-on-warning for the remaining single-module groups in the epic: GraphQL server, Helidon entry point, HTTP media Jackson, OpenAPI, OpenTelemetry config, and WebSocket.

Also documents the WebSocket members that Javadoc reports and configures the Jackson external-link modularity mismatch as informational so the module can fail on real Javadoc warnings.
