### PR TITLE
Enable gRPC Javadoc fail on warning

### DIFF
--- a/grpc/api/src/main/java/module-info.java
+++ b/grpc/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+/**
+ * Helidon gRPC API module.
  */
 module io.helidon.grpc.api {
 

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -32,6 +32,10 @@
 
     <description>gRPC support for Helidon</description>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>api</module>
         <module>core</module>


### PR DESCRIPTION
Part of #9356

Enables Javadoc fail-on-warning for the gRPC group and adds the missing API module descriptor Javadoc needed for a clean generated Javadoc build.
