### PR TITLE
Enable WebClient Javadoc fail on warning

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -97,6 +97,16 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private ClientConnection connection;
     private Boolean sendExpectContinue;
 
+    /**
+     * Create a new request.
+     *
+     * @param clientConfig client configuration
+     * @param cookieManager cookie manager
+     * @param protocolId protocol identifier
+     * @param method HTTP method
+     * @param clientUri request URI
+     * @param properties request properties
+     */
     protected ClientRequestBase(HttpClientConfig clientConfig,
                                 WebClientCookieManager cookieManager,
                                 String protocolId,
@@ -106,6 +116,17 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         this(clientConfig, cookieManager, protocolId, method, clientUri, null, properties);
     }
 
+    /**
+     * Create a new request.
+     *
+     * @param clientConfig client configuration
+     * @param cookieManager cookie manager
+     * @param protocolId protocol identifier
+     * @param method HTTP method
+     * @param clientUri request URI
+     * @param sendExpectContinue whether to send the {@code Expect: 100-Continue} header
+     * @param properties request properties
+     */
     protected ClientRequestBase(HttpClientConfig clientConfig,
                                 WebClientCookieManager cookieManager,
                                 String protocolId,
@@ -116,6 +137,18 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         this(clientConfig, cookieManager, protocolId, method, clientUri, sendExpectContinue, properties, null);
     }
 
+    /**
+     * Create a new request.
+     *
+     * @param clientConfig client configuration
+     * @param cookieManager cookie manager
+     * @param protocolId protocol identifier
+     * @param method HTTP method
+     * @param clientUri request URI
+     * @param sendExpectContinue whether to send the {@code Expect: 100-Continue} header
+     * @param properties request properties
+     * @param redirectSourceUri original request URI for redirect handling
+     */
     protected ClientRequestBase(HttpClientConfig clientConfig,
                                 WebClientCookieManager cookieManager,
                                 String protocolId,
@@ -434,8 +467,20 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         return Optional.ofNullable(socketAddress);
     }
 
+    /**
+     * Submit a request entity.
+     *
+     * @param entity request entity
+     * @return HTTP client response
+     */
     protected abstract R doSubmit(Object entity);
 
+    /**
+     * Submit a request entity provided through an output stream.
+     *
+     * @param outputStreamHandler output stream handler
+     * @return HTTP client response
+     */
     protected abstract R doOutputStream(OutputStreamHandler outputStreamHandler);
 
     /**

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionListener.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionListener.java
@@ -47,6 +47,7 @@ public interface ConnectionListener {
      * Called when the given {@link Socket} connection has been established and {@link io.helidon.common.socket.SocketOptions}
      * applied, but before any TLS or HTTP application traffic has been sent.
      * @param socketInfo The newly connected socket.
+     * @throws IOException if an I/O error occurs
      */
     void socketConnected(ConnectedSocketInfo socketInfo) throws IOException;
 
@@ -54,6 +55,7 @@ public interface ConnectionListener {
      * Called when the given {@link SocketChannel} connection has been established and
      * {@link io.helidon.common.socket.SocketOptions} applied, but before any TLS or HTTP application traffic has been sent.
      * @param socketInfo The newly connected socket channel.
+     * @throws IOException if an I/O error occurs
      */
     void socketChannelConnected(ConnectedSocketChannelInfo socketInfo) throws IOException;
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -252,6 +252,8 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      * For most HTTP protocols, we may cache connections to various endpoints for keep alive (or stream reuse in case of HTTP/2).
      * This option limits the size. Setting this number lower than the "usual" number of target services will cause connections
      * to be closed and reopened frequently.
+     *
+     * @return maximal size of the connection cache
      */
     @Option.Configured
     @Option.DefaultInt(256)

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/ClientConnectionCache.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/ClientConnectionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,11 @@ public abstract class ClientConnectionCache implements ReleasableResource, Resum
 
     private static final System.Logger LOGGER = System.getLogger(ClientConnectionCache.class.getName());
 
+    /**
+     * Create a client connection cache.
+     *
+     * @param shared whether the cache is shared and should be closed on JVM shutdown
+     */
     protected ClientConnectionCache(boolean shared) {
         if (shared) {
             Runtime.getRuntime().addShutdownHook(new Thread(this::onShutdown));
@@ -44,6 +49,9 @@ public abstract class ClientConnectionCache implements ReleasableResource, Resum
 
     }
 
+    /**
+     * Evict all cached connections.
+     */
     protected abstract void evict();
 
     private void onShutdown() {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientProtocolConfigBlueprint.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientProtocolConfigBlueprint.java
@@ -28,11 +28,21 @@ import io.helidon.webclient.spi.ProtocolConfig;
 @Prototype.Configured
 @Prototype.IncludeDefaultMethods("maxBufferedEntitySize")
 interface Http1ClientProtocolConfigBlueprint extends ProtocolConfig {
+    /**
+     * Type of this protocol.
+     *
+     * @return protocol type
+     */
     @Override
     default String type() {
         return Http1ProtocolProvider.CONFIG_KEY;
     }
 
+    /**
+     * Name of this protocol.
+     *
+     * @return protocol name
+     */
     @Option.Configured
     @Option.Default(Http1ProtocolProvider.CONFIG_KEY)
     @Override

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientProtocolConfigBlueprint.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientProtocolConfigBlueprint.java
@@ -23,15 +23,28 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.common.Size;
 import io.helidon.webclient.spi.ProtocolConfig;
 
+/**
+ * HTTP/2 client protocol configuration.
+ */
 @Prototype.Blueprint(decorator = Http2ClientConfigSupport.ProtocolConfigDecorator.class)
 @Prototype.Configured
 @Prototype.IncludeDefaultMethods("maxBufferedEntitySize")
 interface Http2ClientProtocolConfigBlueprint extends ProtocolConfig {
+    /**
+     * Type of this protocol.
+     *
+     * @return protocol type
+     */
     @Override
     default String type() {
         return Http2ProtocolProvider.CONFIG_KEY;
     }
 
+    /**
+     * Name of this protocol.
+     *
+     * @return protocol name
+     */
     @Option.Configured
     @Option.Default(Http2ProtocolProvider.CONFIG_KEY)
     @Override

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -84,6 +84,16 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private int streamId;
     private StreamBuffer buffer;
 
+    /**
+     * Create a new HTTP/2 client stream.
+     *
+     * @param connection client connection
+     * @param serverSettings server settings
+     * @param ctx socket context
+     * @param http2StreamConfig stream configuration
+     * @param http2ClientConfig client configuration
+     * @param streamIdSeq stream ID sequence
+     */
     protected Http2ClientStream(Http2ClientConnection connection,
                                 Http2Settings serverSettings,
                                 SocketContext ctx,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,12 @@ public class LockingStreamIdSequence {
 
     private final AtomicInteger streamIdSeq = new AtomicInteger(0);
     private final Lock lock = new ReentrantLock();
+
+    /**
+     * Create a new locking stream ID sequence.
+     */
+    public LockingStreamIdSequence() {
+    }
 
     int lockAndNext() {
         lock.lock();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamTimeoutException.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import java.time.Duration;
  * Thrown when no data are received over the stream within configured request timeout.
  */
 public class StreamTimeoutException extends RuntimeException {
+    /**
+     * Stream that timed out.
+     */
     private final Http2ClientStream stream;
 
     StreamTimeoutException(Http2ClientStream stream, int streamId, Duration timeout) {

--- a/webclient/pom.xml
+++ b/webclient/pom.xml
@@ -30,6 +30,10 @@
 
     <packaging>pom</packaging>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>api</module>
         <module>discovery</module>

--- a/webclient/sse/src/main/java/io/helidon/webclient/sse/SseSourceHandlerProvider.java
+++ b/webclient/sse/src/main/java/io/helidon/webclient/sse/SseSourceHandlerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,12 @@ public class SseSourceHandlerProvider implements SourceHandlerProvider<SseEvent>
     private static final String DATA = "data:";
     private static final String RETRY = "retry:";
     private static final String EVENT = "event:";
+
+    /**
+     * Create an SSE source handler provider.
+     */
+    public SseSourceHandlerProvider() {
+    }
 
     @Override
     public boolean supports(GenericType<? extends Source<?>> type, HttpClientResponse response) {


### PR DESCRIPTION
Part of #9356

Enables Javadoc fail-on-warning for the WebClient group and fixes the WebClient Javadoc warnings found by a clean generated Javadoc build.
