### PR TITLE
Enable WebServer Javadoc fail on warning

### DIFF
--- a/webserver/grpc-tracing/src/main/java/io/helidon/webserver/grpc/tracing/GrpcTracingConfigBlueprint.java
+++ b/webserver/grpc-tracing/src/main/java/io/helidon/webserver/grpc/tracing/GrpcTracingConfigBlueprint.java
@@ -35,6 +35,8 @@ interface GrpcTracingConfigBlueprint {
 
     /**
      * A flag indicating if tracing is enabled.
+     *
+     * @return whether tracing is enabled
      */
     @Option.Configured
     @Option.DefaultBoolean(true)
@@ -42,6 +44,8 @@ interface GrpcTracingConfigBlueprint {
 
     /**
      * A flag indicating verbose logging.
+     *
+     * @return whether verbose logging is enabled
      */
     @Option.Configured
     @Option.DefaultBoolean(false)
@@ -49,6 +53,8 @@ interface GrpcTracingConfigBlueprint {
 
     /**
      * A flag indicating streaming logging.
+     *
+     * @return whether streaming logging is enabled
      */
     @Option.Configured
     @Option.DefaultBoolean(false)

--- a/webserver/grpc-tracing/src/main/java/io/helidon/webserver/grpc/tracing/GrpcTracingServiceProvider.java
+++ b/webserver/grpc-tracing/src/main/java/io/helidon/webserver/grpc/tracing/GrpcTracingServiceProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.webserver.grpc.tracing;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.grpc.spi.GrpcServerService;
 import io.helidon.webserver.grpc.spi.GrpcServerServiceProvider;
@@ -23,6 +24,12 @@ import io.helidon.webserver.grpc.spi.GrpcServerServiceProvider;
  * Provider for {@link io.helidon.webserver.grpc.tracing.GrpcTracingService}.
  */
 public class GrpcTracingServiceProvider implements GrpcServerServiceProvider {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    @Api.Internal
+    public GrpcTracingServiceProvider() {
+    }
 
     @Override
     public String configKey() {

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@ import io.helidon.webserver.grpc.spi.GrpcServerServiceProvider;
 import io.helidon.webserver.spi.ProtocolConfig;
 import io.helidon.webserver.spi.ProtocolConfigProvider;
 
+/**
+ * gRPC protocol configuration.
+ */
 @Prototype.Blueprint
 @Prototype.Configured(root = false, value = GrpcProtocolProvider.CONFIG_NAME)
 @Prototype.Provides(ProtocolConfigProvider.class)
@@ -83,6 +86,8 @@ interface GrpcConfigBlueprint extends ProtocolConfig {
      * Max size of gRPC reading buffer. If receiving an entity larger than this,
      * processing will be aborted. This can help prevent DoS attacks. Default
      * set to 2 MB.
+     *
+     * @return max read buffer size
      */
     @Option.Configured
     @Option.DefaultInt(2 * 1024 * 1024)

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolConfigProvider.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolConfigProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.grpc;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ProtocolConfigProvider;
 
@@ -23,6 +24,13 @@ import io.helidon.webserver.spi.ProtocolConfigProvider;
  * Implementation of a service provider interface to create grpc protocol configuration.
  */
 public class GrpcProtocolConfigProvider implements ProtocolConfigProvider<GrpcConfig> {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    @Api.Internal
+    public GrpcProtocolConfigProvider() {
+    }
+
     @Override
     public String configKey() {
         return GrpcProtocolProvider.CONFIG_NAME;

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ProtocolConfigProvider.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ProtocolConfigProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http2;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ProtocolConfigProvider;
 
@@ -24,6 +25,13 @@ import io.helidon.webserver.spi.ProtocolConfigProvider;
  * This configuration is used both when upgrading from HTTP/1 and when using selector.
  */
 public class Http2ProtocolConfigProvider implements ProtocolConfigProvider<Http2Config> {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    @Api.Internal
+    public Http2ProtocolConfigProvider() {
+    }
+
     @Override
     public String configKey() {
         return Http2ConnectionProvider.CONFIG_NAME;

--- a/webserver/jsonrpc/src/main/java/module-info.java
+++ b/webserver/jsonrpc/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module io.helidon.webserver.jsonrpc {
     requires io.helidon.builder.api;
     requires io.helidon.webserver;
     requires io.helidon.jsonrpc.core;
+    requires io.helidon.http.media.jsonp;
     requires jakarta.json;
     requires jakarta.json.bind;
     requires io.helidon.common.features.api;

--- a/webserver/pom.xml
+++ b/webserver/pom.xml
@@ -31,6 +31,10 @@
     <name>Helidon WebServer Project</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>access-log</module>
         <module>context</module>

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityConfigSupport.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityConfigSupport.java
@@ -110,6 +110,7 @@ class SecurityConfigSupport {
          * This creates a hard dependency on a specific security provider, so use with care.
          *
          * @param builder builder instance
+         * @param objectType type to register the object under
          * @param object  An object expected by security provider
          */
         @Prototype.BuilderMethod

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityFeatureProvider.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityFeatureProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.security;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -26,6 +27,13 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
  */
 @Weight(SecurityFeature.WEIGHT)
 public class SecurityFeatureProvider implements ServerFeatureProvider<SecurityFeature> {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    @Api.Internal
+    public SecurityFeatureProvider() {
+    }
+
     @Override
     public String configKey() {
         return SecurityFeature.SECURITY_ID;

--- a/webserver/security/src/main/java/module-info.java
+++ b/webserver/security/src/main/java/module-info.java
@@ -22,6 +22,7 @@ module io.helidon.webserver.security {
 
     requires io.helidon.common.context;
     requires io.helidon.webserver;
+    requires io.helidon.webserver.context;
     requires io.helidon.service.registry;
     requires io.helidon.security.integration.common;
     requires io.helidon.security.providers.common;

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/SseSinkProvider.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/SseSinkProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.sse;
 
+import io.helidon.common.Api;
 import io.helidon.common.GenericType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.sse.SseEvent;
@@ -30,6 +31,12 @@ import io.helidon.webserver.http.spi.SinkProviderContext;
  * @see io.helidon.webserver.http.spi.SinkProvider
  */
 public class SseSinkProvider implements SinkProvider<SseEvent> {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    @Api.Internal
+    public SseSinkProvider() {
+    }
 
     @Override
     public boolean supports(GenericType<? extends Sink<?>> type, ServerRequest request) {

--- a/webserver/testing/junit5/grpc/pom.xml
+++ b/webserver/testing/junit5/grpc/pom.xml
@@ -32,6 +32,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
         </dependency>

--- a/webserver/testing/junit5/grpc/src/main/java/io/helidon/webserver/testing/junit5/grpc/GrpcServerExtension.java
+++ b/webserver/testing/junit5/grpc/src/main/java/io/helidon/webserver/testing/junit5/grpc/GrpcServerExtension.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.testing.junit5.grpc;
 
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.grpc.GrpcClient;
 import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.Router;
@@ -39,6 +40,7 @@ public class GrpcServerExtension implements ServerJunitExtension {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public GrpcServerExtension() {
     }
 

--- a/webserver/testing/junit5/grpc/src/main/java/io/helidon/webserver/testing/junit5/grpc/GrpcServerExtension.java
+++ b/webserver/testing/junit5/grpc/src/main/java/io/helidon/webserver/testing/junit5/grpc/GrpcServerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,11 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  * artifacts, such as {@link io.helidon.webclient.grpc.GrpcClient} in Helidon integration tests.
  */
 public class GrpcServerExtension implements ServerJunitExtension {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    public GrpcServerExtension() {
+    }
 
     @Override
     public Optional<ParamHandler<?>> setUpRouteParamHandler(Class<?> type) {

--- a/webserver/testing/junit5/grpc/src/main/java/module-info.java
+++ b/webserver/testing/junit5/grpc/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
  */
 module io.helidon.webserver.testing.junit5.grpc {
 
+    requires static io.helidon.common;
     requires io.helidon.webclient.grpc;
     requires io.helidon.webserver.grpc;
 

--- a/webserver/testing/junit5/http2/src/main/java/module-info.java
+++ b/webserver/testing/junit5/http2/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ module io.helidon.webserver.testing.junit5.http2 {
 
     requires io.helidon.webclient.http2;
     requires io.helidon.webserver.http2;
+    requires static io.helidon.webserver.security;
 
     requires transitive io.helidon.webserver.testing.junit5;
     requires transitive org.junit.jupiter.api;

--- a/webserver/testing/junit5/jsonrpc/pom.xml
+++ b/webserver/testing/junit5/jsonrpc/pom.xml
@@ -32,6 +32,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
         </dependency>

--- a/webserver/testing/junit5/jsonrpc/src/main/java/io/helidon/webserver/testing/junit5/jsonrpc/JsonRpcServerExtension.java
+++ b/webserver/testing/junit5/jsonrpc/src/main/java/io/helidon/webserver/testing/junit5/jsonrpc/JsonRpcServerExtension.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.testing.junit5.jsonrpc;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.testing.junit5.Junit5Util;
@@ -34,6 +35,7 @@ public class JsonRpcServerExtension implements ServerJunitExtension {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public JsonRpcServerExtension() {
     }
 

--- a/webserver/testing/junit5/jsonrpc/src/main/java/io/helidon/webserver/testing/junit5/jsonrpc/JsonRpcServerExtension.java
+++ b/webserver/testing/junit5/jsonrpc/src/main/java/io/helidon/webserver/testing/junit5/jsonrpc/JsonRpcServerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,11 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  * {@link io.helidon.webclient.jsonrpc.JsonRpcClient} in Helidon integration tests.
  */
 public class JsonRpcServerExtension implements ServerJunitExtension {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    public JsonRpcServerExtension() {
+    }
 
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)

--- a/webserver/testing/junit5/jsonrpc/src/main/java/module-info.java
+++ b/webserver/testing/junit5/jsonrpc/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
  */
 module io.helidon.webserver.testing.junit5.jsonrpc {
 
+    requires static io.helidon.common;
     requires io.helidon.webclient.jsonrpc;
     requires io.helidon.webserver.jsonrpc;
     requires transitive io.helidon.webserver.testing.junit5;

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/Http1DirectJunitExtension.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/Http1DirectJunitExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,12 @@ import static io.helidon.webserver.WebServer.DEFAULT_SOCKET_NAME;
 public class Http1DirectJunitExtension implements DirectJunitExtension {
     private final Map<String, DirectClient> clients = new HashMap<>();
     private final Map<String, DirectWebClient> webClients = new HashMap<>();
+
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    public Http1DirectJunitExtension() {
+    }
 
     @Override
     public void afterAll(ExtensionContext context) {

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/Http1DirectJunitExtension.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/Http1DirectJunitExtension.java
@@ -24,6 +24,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Builder;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
@@ -51,6 +52,7 @@ public class Http1DirectJunitExtension implements DirectJunitExtension {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public Http1DirectJunitExtension() {
     }
 

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/spi/DirectJunitExtension.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/spi/DirectJunitExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public interface DirectJunitExtension extends HelidonJunitExtension {
     /**
      * Check if the type is supported and return a handler for it.
      *
-     * @param features
+     * @param features server features
      * @param type     type of the parameter to {@link io.helidon.webserver.testing.junit5.SetUpRoute} method
      * @return parameter handler if the type is supported, empty otherwise
      */

--- a/webserver/testing/junit5/junit5/src/main/java/module-info.java
+++ b/webserver/testing/junit5/junit5/src/main/java/module-info.java
@@ -26,6 +26,7 @@ module io.helidon.webserver.testing.junit5 {
     requires io.helidon.common;
     requires io.helidon.logging.common;
     requires io.helidon.common.testing.virtualthreads;
+    requires io.helidon.config.yaml;
 
     requires transitive hamcrest.all;
     requires transitive io.helidon.common.testing.http.junit5;

--- a/webserver/testing/junit5/junit5/src/main/java/module-info.java
+++ b/webserver/testing/junit5/junit5/src/main/java/module-info.java
@@ -23,6 +23,7 @@
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module io.helidon.webserver.testing.junit5 {
 
+    requires io.helidon.common;
     requires io.helidon.logging.common;
     requires io.helidon.common.testing.virtualthreads;
 

--- a/webserver/testing/junit5/websocket/pom.xml
+++ b/webserver/testing/junit5/websocket/pom.xml
@@ -32,6 +32,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
         </dependency>

--- a/webserver/testing/junit5/websocket/src/main/java/io/helidon/webserver/testing/junit5/websocket/WsDirectExtension.java
+++ b/webserver/testing/junit5/websocket/src/main/java/io/helidon/webserver/testing/junit5/websocket/WsDirectExtension.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.websocket.WsClient;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.spi.ServerFeature;
@@ -43,6 +44,7 @@ public class WsDirectExtension implements DirectJunitExtension {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public WsDirectExtension() {
     }
 

--- a/webserver/testing/junit5/websocket/src/main/java/io/helidon/webserver/testing/junit5/websocket/WsDirectExtension.java
+++ b/webserver/testing/junit5/websocket/src/main/java/io/helidon/webserver/testing/junit5/websocket/WsDirectExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,12 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  */
 public class WsDirectExtension implements DirectJunitExtension {
     private final Map<String, DirectWsClient> clients = new HashMap<>();
+
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    public WsDirectExtension() {
+    }
 
     @Override
     public void afterAll(ExtensionContext context) {

--- a/webserver/testing/junit5/websocket/src/main/java/io/helidon/webserver/testing/junit5/websocket/WsServerExtension.java
+++ b/webserver/testing/junit5/websocket/src/main/java/io/helidon/webserver/testing/junit5/websocket/WsServerExtension.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.testing.junit5.websocket;
 
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.webclient.websocket.WsClient;
 import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.Router;
@@ -39,6 +40,7 @@ public class WsServerExtension implements ServerJunitExtension {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public WsServerExtension() {
     }
 

--- a/webserver/testing/junit5/websocket/src/main/java/io/helidon/webserver/testing/junit5/websocket/WsServerExtension.java
+++ b/webserver/testing/junit5/websocket/src/main/java/io/helidon/webserver/testing/junit5/websocket/WsServerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,12 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  * artifacts, such as {@link io.helidon.webclient.websocket.WsClient} in Helidon WebServer integration tests.
  */
 public class WsServerExtension implements ServerJunitExtension {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    public WsServerExtension() {
+    }
+
     @Override
     public Optional<ParamHandler<?>> setUpRouteParamHandler(Class<?> type) {
         if (WsRouting.Builder.class.equals(type)) {

--- a/webserver/testing/junit5/websocket/src/main/java/module-info.java
+++ b/webserver/testing/junit5/websocket/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
  */
 module io.helidon.webserver.testing.junit5.websocket {
 
+    requires static io.helidon.common;
     requires io.helidon.webclient.websocket;
     requires io.helidon.webserver.websocket;
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ErrorHandlingBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ErrorHandlingBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package io.helidon.webserver;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
+/**
+ * Error handling configuration.
+ */
 @Prototype.Configured
 @Prototype.Blueprint
 interface ErrorHandlingBlueprint {
@@ -37,6 +40,8 @@ interface ErrorHandlingBlueprint {
      * Whether to log all messages in a {@link io.helidon.http.RequestException} or not.
      * If set to {@code false}, only those that return {@code true} for
      * {@link io.helidon.http.RequestException#safeMessage()} are logged.
+     *
+     * @return whether to log all messages
      */
     @Option.Configured
     @Option.DefaultBoolean(false)

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpEntryPoint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpEntryPoint.java
@@ -36,6 +36,12 @@ import io.helidon.service.registry.ServiceDescriptor;
 @Api.Incubating
 public class HttpEntryPoint {
     /**
+     * Create an instance.
+     */
+    public HttpEntryPoint() {
+    }
+
+    /**
      * Interceptor of an HTTP entry point.
      * This interceptor has direct access to {@link io.helidon.webserver.http.ServerRequest} and
      * {@link io.helidon.webserver.http.ServerResponse}, as well as metadata of the invoked endpoint.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpEntryPoint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpEntryPoint.java
@@ -35,10 +35,7 @@ import io.helidon.service.registry.ServiceDescriptor;
  */
 @Api.Incubating
 public class HttpEntryPoint {
-    /**
-     * Create an instance.
-     */
-    public HttpEntryPoint() {
+    private HttpEntryPoint() {
     }
 
     /**

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsProtocolConfigProvider.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsProtocolConfigProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.websocket;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ProtocolConfigProvider;
 
@@ -23,6 +24,13 @@ import io.helidon.webserver.spi.ProtocolConfigProvider;
  * Service provider implementation for WebSocket protocol configuration.
  */
 public class WsProtocolConfigProvider implements ProtocolConfigProvider<WsConfig> {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    @Api.Internal
+    public WsProtocolConfigProvider() {
+    }
+
     @Override
     public String configKey() {
         return WsUpgradeProvider.CONFIG_NAME;

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgrader.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgrader.java
@@ -105,6 +105,11 @@ public class WsUpgrader implements Http1Upgrader {
     private final Set<String> origins;
     private final boolean anyOrigin;
 
+    /**
+     * Create an upgrader.
+     *
+     * @param wsConfig WebSocket configuration
+     */
     protected WsUpgrader(WsConfig wsConfig) {
         this.origins = wsConfig.origins();
         this.anyOrigin = this.origins.isEmpty();
@@ -197,10 +202,20 @@ public class WsUpgrader implements Http1Upgrader {
         }
     }
 
+    /**
+     * Whether no explicit origin allowlist is configured.
+     *
+     * @return whether origin validation falls back to host authority matching
+     */
     protected boolean anyOrigin() {
         return anyOrigin;
     }
 
+    /**
+     * Configured allowed origins.
+     *
+     * @return configured allowed origins
+     */
     protected Set<String> origins() {
         return origins;
     }
@@ -318,6 +333,13 @@ public class WsUpgrader implements Http1Upgrader {
         return "https".equalsIgnoreCase(scheme) ? 443 : 80;
     }
 
+    /**
+     * Create the WebSocket accept hash.
+     *
+     * @param ctx connection context
+     * @param wsKey WebSocket key
+     * @return WebSocket accept hash
+     */
     protected String hash(ConnectionContext ctx, String wsKey) {
         byte[] decodedBytes = B64_DECODER.decode(wsKey);
         if (decodedBytes.length != 16) {


### PR DESCRIPTION
Part of #9356

Enables Javadoc fail-on-warning for the WebServer group and fixes WebServer Javadoc warnings found by a clean generated Javadoc build.
