### PR TITLE
Backward compatible SamplerType configuration

### DIFF
--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestOtelTracingConfig.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestOtelTracingConfig.java
@@ -19,25 +19,18 @@ package io.helidon.tracing.providers.opentelemetry;
 import java.util.List;
 import java.util.Map;
 
-import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
-import io.helidon.tracing.Span;
-import io.helidon.tracing.SpanProcessorType;
+import io.helidon.tracing.SamplerType;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
-import org.hamcrest.TypeSafeMatcher;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -181,6 +174,27 @@ class TestOtelTracingConfig {
         assertThat("OpenTelemetry",
                    tracer.prototype().openTelemetry().toString(),
                    containsString("spanExporter=OtlpHttpSpanExporter"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"constant", "const", "CONSTANT", "CONST"})
+    void testConstantSamplerTypeCompatibility(String samplerType) {
+        var configSettings = """
+                tracing:
+                  service: tracing-test
+                  global: false
+                  sampler-type: %s
+                """.formatted(samplerType);
+        Config config = Config.just(ConfigSources.create(configSettings, MediaTypes.APPLICATION_YAML));
+
+        OpenTelemetryTracer tracer = OpenTelemetryTracer.builder()
+                .config(config.get("tracing"))
+                .build();
+
+        assertThat("Sampler type", tracer.prototype().samplerType(), equalTo(SamplerType.CONSTANT));
+        assertThat("OpenTelemetry",
+                   tracer.prototype().openTelemetry().toString(),
+                   containsString("sampler=AlwaysOnSampler"));
     }
 
 

--- a/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprint.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprint.java
@@ -29,6 +29,7 @@ import io.helidon.common.configurable.Resource;
  */
 @Prototype.Blueprint
 @Prototype.Configured
+@Prototype.CustomMethods(ExtendedTracerConfigBlueprintSupport.class)
 interface ExtendedTracerConfigBlueprint {
 
     /**

--- a/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprintSupport.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprintSupport.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tracing;
+
+import java.util.Locale;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.config.Config;
+
+class ExtendedTracerConfigBlueprintSupport {
+
+    private ExtendedTracerConfigBlueprintSupport() {
+    }
+
+    @Prototype.ConfigFactoryMethod("samplerType")
+    static SamplerType createSamplerType(Config config) {
+        String samplerType = config.asString().get().toUpperCase(Locale.ROOT);
+        samplerType = "CONST".equals(samplerType) ? SamplerType.CONSTANT.name() : samplerType;
+        return SamplerType.valueOf(samplerType);
+    }
+}


### PR DESCRIPTION
Adds a custom config factory so sampler-type accepts the legacy const spelling while the public SamplerType value remains CONSTANT. Also covers lowercase and uppercase constant/const configuration values in OpenTelemetry tracing config tests.