### PR TITLE
Enable metrics Javadoc fail on warning

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
@@ -64,7 +64,7 @@ public interface MetricsFactory {
     /**
      * Returns a new metrics factory instance from a highest-weight provider using the provided
      * config node to set up the metrics factory and saving the resulting metrics factory
-     * as the current one, returned by {@link #getInstance()}}.
+     * as the current one, returned by {@link #getInstance()}.
      *
      * @param metricsConfigNode metrics config node
      * @return new instance configured as directed

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SeMetricsProgrammaticConfig.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SeMetricsProgrammaticConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.metrics.api;
 
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.metrics.spi.MetricsProgrammaticConfig;
 
 /**
@@ -25,8 +26,9 @@ import io.helidon.metrics.spi.MetricsProgrammaticConfig;
 public class SeMetricsProgrammaticConfig implements MetricsProgrammaticConfig {
 
     /**
-     * For service loading.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public SeMetricsProgrammaticConfig() {
     }
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>helidon-metrics-project</artifactId>
     <name>Helidon Metrics Project</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>metrics</module>
         <module>providers</module>

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MDistributionStatisticsConfig.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MDistributionStatisticsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,11 +96,11 @@ class MDistributionStatisticsConfig implements io.helidon.metrics.api.Distributi
     }
 
     /**
-     * Builder for the {@link }{@link io.helidon.metrics.api.DistributionStatisticsConfig}} in the Micrometer provider.
+     * Builder for the {@link io.helidon.metrics.api.DistributionStatisticsConfig} in the Micrometer provider.
      * <p>
      *     Although Micrometer uses its own stats config builder internally it is not accessible to us. Instead, for example to
      *     set the percentiles in the Micrometer stats config builder, we invoke a method on the Micrometer
-     *     {}@link {@link io.micrometer.core.instrument.DistributionSummary.Builder}, and it delegates to its internal stats
+     *     {@link io.micrometer.core.instrument.DistributionSummary.Builder}, and it delegates to its internal stats
      *     builder.
      * <p>
      *     Therefore, the "delegate" for this builder is the builder for the Micrometer DistributionSummary. Further, because

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactoryProvider.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactoryProvider.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.MetricsConfig;
 import io.helidon.metrics.api.MetricsFactory;
@@ -37,8 +38,9 @@ public class MicrometerMetricsFactoryProvider implements MetricsFactoryProvider 
     private final List<MicrometerMetricsFactory> metricsFactories = new ArrayList<>();
 
     /**
-     * Creates a new {@link io.helidon.metrics.api.MetricsFactory} based on Micrometer. Public for service loading.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public MicrometerMetricsFactoryProvider() {
         observeGlobalRegistry();
         addSystemTagsFilter();

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/OtlpPublisherProvider.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/OtlpPublisherProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.metrics.providers.micrometer;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.MetricsPublisher;
 import io.helidon.metrics.spi.MetricsPublisherProvider;
@@ -29,8 +30,9 @@ public class OtlpPublisherProvider implements MetricsPublisherProvider {
     static final String TYPE = "otlp";
 
     /**
-     * Creates a new provider for service loading.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public OtlpPublisherProvider() {
     }
 

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisherProvider.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisherProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.metrics.providers.micrometer;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.MetricsPublisher;
 import io.helidon.metrics.spi.MetricsPublisherProvider;
@@ -29,8 +30,9 @@ public class PrometheusPublisherProvider implements MetricsPublisherProvider {
     static final String TYPE = "prometheus";
 
     /**
-     * Creates a new provider for service loading.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public PrometheusPublisherProvider() {
     }
 

--- a/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/VThreadSystemMetersProvider.java
+++ b/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/VThreadSystemMetersProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import io.helidon.Main;
+import io.helidon.common.Api;
 import io.helidon.common.LazyValue;
 import io.helidon.common.resumable.Resumable;
 import io.helidon.common.resumable.ResumableSupport;
@@ -77,8 +78,9 @@ public class VThreadSystemMetersProvider implements MetersProvider, HelidonShutd
     private MetricsConfig metricsConfig;
 
     /**
-     * For service loading.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public VThreadSystemMetersProvider() {
     }
 

--- a/metrics/trace-exemplar/pom.xml
+++ b/metrics/trace-exemplar/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.metrics.providers</groupId>
             <artifactId>helidon-metrics-providers-micrometer</artifactId>
         </dependency>

--- a/metrics/trace-exemplar/src/main/java/io/helidon/metrics/exemplartrace/MicrometerSpanContextSupplierProvider.java
+++ b/metrics/trace-exemplar/src/main/java/io/helidon/metrics/exemplartrace/MicrometerSpanContextSupplierProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.metrics.exemplartrace;
 
+import io.helidon.common.Api;
 import io.helidon.common.context.Contexts;
 import io.helidon.tracing.SpanContext;
 
@@ -25,6 +26,14 @@ import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
  */
 public class MicrometerSpanContextSupplierProvider
         implements io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider {
+
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    @Api.Internal
+    public MicrometerSpanContextSupplierProvider() {
+    }
+
     @Override
     public SpanContextSupplier get() {
         return new SpanContextSupplierImpl();

--- a/metrics/trace-exemplar/src/main/java/module-info.java
+++ b/metrics/trace-exemplar/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
  */
 module io.helidon.metrics.traceexemplar {
 
+    requires io.helidon.common;
     requires io.helidon.common.context;
     requires io.helidon.tracing;
     requires io.helidon.metrics.api;


### PR DESCRIPTION
Part of #9356

Enables Javadoc fail-on-warning for the metrics group and fixes metrics Javadoc warnings found by a clean generated Javadoc build.
