### PR TITLE
Enable tracing Javadoc fail-on-warning 

### DIFF
--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>helidon-tracing-project</artifactId>
     <name>Helidon Tracing Project</name>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>tracing</module>
         <module>config</module>

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
@@ -95,7 +95,7 @@ public final class HelidonOpenTelemetry {
      *
      * @param span open telemetry span
      * @param baggage open telemetry baggage
-     * @return Helidon (@link io.helidon.tracing.Span}
+     * @return Helidon {@link io.helidon.tracing.Span}
      */
     public static io.helidon.tracing.Span create(Span span, Baggage baggage) {
         return new OpenTelemetrySpan(span, baggage, SPAN_LISTENERS.get());

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,7 +147,7 @@ public interface Span {
      * @param key String Key
      * @param value String Value
      * @return current Span instance
-     * @deprecated Use {@link #baggage()} and then {@link io.helidon.tracing.WritableBaggage#set(String, String)}}.
+     * @deprecated Use {@link #baggage()} and then {@link io.helidon.tracing.WritableBaggage#set(String, String)}.
      */
     @Deprecated(since = "4.0.5", forRemoval = true)
     Span baggage(String key, String value);


### PR DESCRIPTION
Resolves #9356

Enables Javadoc fail-on-warning for the tracing module group and fixes malformed inline links in tracing Javadocs.
