### PR TITLE
4.x: Fix HTTP/2 client h2c stalls under load

### DIFF
--- a/tests/integration/h2spec-client/Dockerfile
+++ b/tests/integration/h2spec-client/Dockerfile
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM container-registry.oracle.com/os/oraclelinux:9-slim AS build
+ENV GO111MODULE=on
+ENV GOPROXY=https://proxy.golang.org
+ENV CGO_ENABLED=0
+ENV VERSION=2.6.1-SNAPSHOT
+ENV COMMIT=af83a65f0b6273ef38bf778d400d98892e7653d8
+
+RUN microdnf install go-toolset git -y
+
+WORKDIR /workspace
+RUN git clone https://github.com/summerwind/h2spec.git
+
+WORKDIR /workspace/h2spec
+RUN git checkout ${COMMIT}
+#
+# h2specd hardcodes a 3-second launcher timeout in spec/specd.go. That is too short for a
+# JVM client started repeatedly inside a container, so honor the existing --timeout flag instead.
+RUN sed -i 's/time.Duration(3) \* time.Second/c.Timeout/' spec/specd.go
+RUN grep -nF 'time.After(c.Timeout)' spec/specd.go
+RUN go build -ldflags "-X main.VERSION=${VERSION} -X main.COMMIT=${COMMIT}" ./cmd/h2specd
+
+FROM container-registry.oracle.com/os/oraclelinux:9-slim
+RUN microdnf install java-21-openjdk-headless -y \
+    && microdnf clean all
+
+WORKDIR /opt/helidon/app
+RUN mkdir -p /opt/helidon/app
+COPY --from=build /workspace/h2spec/h2specd /usr/local/bin/h2specd
+
+CMD ["/usr/local/bin/h2specd"]

--- a/tests/integration/h2spec-client/pom.xml
+++ b/tests/integration/h2spec-client/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration-project</artifactId>
+        <version>4.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-h2spec-client</artifactId>
+    <name>Helidon Tests Integration Http/2 h2spec Client</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-http2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--suppress VulnerableLibrariesLocal -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>
+                            ${project.build.testOutputDirectory}/logging-test.properties
+                        </java.util.logging.config.file>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/h2spec-client/src/main/java/io/helidon/tests/integration/h2spec/client/H2SpecClientMain.java
+++ b/tests/integration/h2spec-client/src/main/java/io/helidon/tests/integration/h2spec/client/H2SpecClientMain.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.h2spec.client;
+
+import java.net.URI;
+import java.time.Duration;
+
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webclient.http2.Http2ClientProtocolConfig;
+
+/**
+ * Minimal Helidon HTTP/2 client launcher for upstream {@code h2specd}.
+ * <p>
+ * {@code h2specd} appends the target URL as the final command argument and expects the
+ * launched client to perform one complete request/response exchange.
+ */
+public final class H2SpecClientMain {
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(2);
+
+    private H2SpecClientMain() {
+    }
+
+    /**
+     * Run a single HTTP/2 request against the URL provided by {@code h2specd}.
+     *
+     * @param args command-line arguments, expecting the target URL as the final element
+     */
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            System.err.println("Usage: H2SpecClientMain <url>");
+            System.exit(2);
+        }
+
+        URI uri = URI.create(args[args.length - 1]);
+        boolean priorKnowledge = "http".equalsIgnoreCase(uri.getScheme());
+
+        Http2ClientProtocolConfig protocolConfig = Http2ClientProtocolConfig.builder()
+                .priorKnowledge(priorKnowledge)
+                .build();
+
+        Http2Client client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .baseUri(uri.toString())
+                .connectTimeout(REQUEST_TIMEOUT)
+                .readTimeout(REQUEST_TIMEOUT)
+                .protocolConfig(protocolConfig)
+                .build();
+
+        try (var response = client.get().request()) {
+            // Consume the full body so the client observes the complete frame sequence under test.
+            response.entity().as(byte[].class);
+        } catch (Throwable t) {
+            t.printStackTrace(System.err);
+            System.exit(1);
+        } finally {
+            client.closeResource();
+        }
+    }
+}

--- a/tests/integration/h2spec-client/src/main/java/io/helidon/tests/integration/h2spec/client/H2SpecClientMain.java
+++ b/tests/integration/h2spec-client/src/main/java/io/helidon/tests/integration/h2spec/client/H2SpecClientMain.java
@@ -63,7 +63,7 @@ public final class H2SpecClientMain {
         try (var response = client.get().request()) {
             // Consume the full body so the client observes the complete frame sequence under test.
             response.entity().as(byte[].class);
-        } catch (Throwable t) {
+        } catch (RuntimeException t) {
             t.printStackTrace(System.err);
             System.exit(1);
         } finally {

--- a/tests/integration/h2spec-client/src/test/java/io/helidon/tests/integration/h2spec/client/H2SpecClientIT.java
+++ b/tests/integration/h2spec-client/src/test/java/io/helidon/tests/integration/h2spec/client/H2SpecClientIT.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.h2spec.client;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import io.helidon.logging.common.LogConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+@Testcontainers(disabledWithoutDocker = true)
+class H2SpecClientIT {
+    private static final Path OUTPUT_PATH = Path.of("./target/h2spec-client-output.txt");
+    private static final Path OUTPUT_DIR = Path.of("./target/h2spec-client-sections");
+    private static final String CONTAINER_APP_DIR = "/opt/helidon/app";
+    private static final String CONTAINER_APPLICATION_JAR = CONTAINER_APP_DIR + "/application.jar";
+    private static final String CONTAINER_APPLICATION_LIBS = CONTAINER_APP_DIR + "/libs";
+    private static final int H2SPEC_TIMEOUT_SECONDS = 30;
+    private static final int EXPECTED_TOTAL_CASES = 57;
+    private static final int MAX_PARALLEL_SECTION_RUNS = 2;
+    private static final Path APPLICATION_JAR = Path.of("./target/helidon-tests-integration-h2spec-client.jar");
+    private static final Path APPLICATION_LIBS = Path.of("./target/libs");
+    private static final ImageFromDockerfile IMAGE = new ImageFromDockerfile("helidon-h2spec-client", false)
+            .withDockerfile(Path.of("./Dockerfile"));
+    private static final List<H2SpecSection> SECTIONS = List.of(
+            new H2SpecSection("client/1", 34_000),
+            new H2SpecSection("client/4", 34_100),
+            new H2SpecSection("client/5", 34_200),
+            new H2SpecSection("client/6.1", 34_300),
+            new H2SpecSection("client/6.2", 34_400),
+            new H2SpecSection("client/6.3", 34_500),
+            new H2SpecSection("client/6.4", 34_600),
+            new H2SpecSection("client/6.5", 34_700),
+            new H2SpecSection("client/6.7", 34_800),
+            new H2SpecSection("client/6.8", 34_900),
+            new H2SpecSection("client/6.9", 35_000),
+            new H2SpecSection("client/6.10", 35_100)
+    );
+    private static final Pattern ANSI_PATTERN = Pattern.compile("\\u001B\\[[;\\d]*m");
+    private static final Pattern SUMMARY_PATTERN =
+            Pattern.compile("(?m)^(\\d+) tests, (\\d+) passed, (\\d+) skipped, (\\d+) failed$");
+    private static final Pattern GROUP_PATTERN =
+            Pattern.compile("^\\s*(\\d+(?:\\.\\d+)*)\\.\\s+(.*)$");
+    private static final Pattern CASE_PATTERN =
+            Pattern.compile("^\\s*(?:([\\u2714\\u00D7])\\s+)?(\\d+):\\s+(.*)$");
+
+    // These are the two known upstream client conformance failures tracked by issue #11771.
+    private static final Set<String> KNOWN_FAILING_IDS = Set.of(
+            "client/6.9.1/1",
+            "client/6.9.1/2"
+    );
+    private static final Set<String> KNOWN_FAILING_DESCRIPTIONS = Set.of(
+            "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1",
+            "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream"
+    );
+
+    static {
+        LogConfig.configureRuntime();
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(H2SpecClientIT.class);
+
+    @ParameterizedTest(name = "{0}: {1}")
+    @MethodSource("runH2Spec")
+    void h2spec(String caseName, String desc, String id, String err, String skipped) {
+        LOGGER.info("{}: \n - {} \nID: {}", caseName, desc, id);
+
+        if (skipped != null) {
+            Assumptions.abort(skipped);
+        }
+
+        if (err != null && isKnownFailure(id, desc)) {
+            Assumptions.abort("Known failure tracked by #11771:\n" + err);
+        }
+
+        if (err != null) {
+            Assertions.fail(err);
+        }
+    }
+
+    private static Stream<Arguments> runH2Spec() {
+        Assertions.assertTrue(APPLICATION_JAR.toFile().isFile(),
+                              "Expected packaged client launcher jar: " + APPLICATION_JAR);
+        Assertions.assertTrue(APPLICATION_LIBS.toFile().isDirectory(),
+                              "Expected packaged runtime libs directory: " + APPLICATION_LIBS);
+
+        try {
+            prepareOutputFiles();
+            String imageName = resolveImageName();
+            List<H2SpecSectionResult> sectionResults = runSections(imageName);
+            persistOutput(sectionResults);
+
+            List<H2SpecCaseResult> caseResults = sectionResults.stream()
+                    .flatMap(sectionResult -> sectionResult.caseResults().stream())
+                    .toList();
+
+            Assertions.assertEquals(EXPECTED_TOTAL_CASES,
+                                    caseResults.size(),
+                                    "Parallel section execution did not cover the expected full client suite.");
+
+            return caseResults.stream()
+                    .map(caseResult -> Arguments.of(caseResult.caseName(),
+                                                    caseResult.description(),
+                                                    caseResult.id(),
+                                                    caseResult.error(),
+                                                    caseResult.skipped()));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to execute h2specd client suite.", e);
+        }
+    }
+
+    private static String resolveImageName() {
+        return IMAGE.get();
+    }
+
+    private static List<H2SpecSectionResult> runSections(String imageName) {
+        // Starting too many one-shot containers at once makes the shortest jobs flaky under Testcontainers.
+        try (var executor = Executors.newFixedThreadPool(Math.min(SECTIONS.size(), MAX_PARALLEL_SECTION_RUNS))) {
+            List<SectionFuture> futures = new ArrayList<>(SECTIONS.size());
+            for (H2SpecSection section : SECTIONS) {
+                futures.add(new SectionFuture(section, executor.submit(() -> runSection(imageName, section))));
+            }
+
+            List<H2SpecSectionResult> results = new ArrayList<>(SECTIONS.size());
+            for (SectionFuture sectionFuture : futures) {
+                try {
+                    results.add(sectionFuture.future().get());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while waiting for " + sectionFuture.section().id(), e);
+                } catch (ExecutionException e) {
+                    throw new IllegalStateException("Failed to execute " + sectionFuture.section().id(), e.getCause());
+                }
+            }
+            return results;
+        }
+    }
+
+    private static H2SpecSectionResult runSection(String imageName, H2SpecSection section) {
+        LOGGER.info("Running h2specd section {}", section.id());
+
+        try (var cont = new GenericContainer<>(imageName)
+                .withCopyFileToContainer(MountableFile.forHostPath(APPLICATION_JAR), CONTAINER_APPLICATION_JAR)
+                .withCopyFileToContainer(MountableFile.forHostPath(APPLICATION_LIBS), CONTAINER_APPLICATION_LIBS)
+                .withImagePullPolicy(PullPolicy.ageBased(Duration.ofDays(365)))
+                .withCommand("sh", "-c", "while true; do sleep 3600; done")
+                .withStartupAttempts(1)) {
+
+            cont.start();
+
+            var execResult = execSection(cont, section);
+
+            String output = combineExecOutput(execResult.getStdout(), execResult.getStderr());
+            persistSectionOutput(section, output);
+
+            if (execResult.getExitCode() != 0) {
+                throw new IllegalStateException("h2specd failed for " + section.id()
+                                                        + " with exit code " + execResult.getExitCode()
+                                                        + ".\nOutput:\n" + output);
+            }
+
+            return new H2SpecSectionResult(section, output, parseOutput(output));
+        }
+    }
+
+    private static org.testcontainers.containers.Container.ExecResult execSection(GenericContainer<?> cont,
+                                                                                  H2SpecSection section) {
+        try {
+            return cont.execInContainer(
+                    "sh",
+                    "-c",
+                    "/usr/local/bin/h2specd " + section.id() + " "
+                            + "--host 127.0.0.1 "
+                            + "--from-port " + section.fromPort() + " "
+                            // Containerized JVM startup is slower than the host-side ad hoc run.
+                            + "--timeout " + H2SPEC_TIMEOUT_SECONDS + " "
+                            + "-e 'java -cp " + CONTAINER_APPLICATION_JAR + ":" + CONTAINER_APPLICATION_LIBS + "/* "
+                            + "io.helidon.tests.integration.h2spec.client.H2SpecClientMain'");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while executing h2specd inside container for " + section.id(), e);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to execute h2specd inside container for " + section.id(), e);
+        }
+    }
+
+    // h2specd client mode does not implement --junit-report, so the IT derives per-case
+    // results from the plain-text output and keeps the raw log under target/ for debugging.
+    private static List<H2SpecCaseResult> parseOutput(String output) {
+        String normalized = normalizeOutput(output);
+        var summaryMatcher = SUMMARY_PATTERN.matcher(normalized);
+        Assertions.assertTrue(summaryMatcher.find(), "Missing h2specd client summary.\nOutput:\n" + normalized);
+
+        int expectedTotal = Integer.parseInt(summaryMatcher.group(1));
+        int expectedPassed = Integer.parseInt(summaryMatcher.group(2));
+        int expectedSkipped = Integer.parseInt(summaryMatcher.group(3));
+        int expectedFailed = Integer.parseInt(summaryMatcher.group(4));
+
+        String executionOutput = normalized;
+        int failuresStart = normalized.indexOf("\nFailures:");
+        if (failuresStart >= 0) {
+            executionOutput = normalized.substring(0, failuresStart);
+        }
+
+        List<H2SpecCaseResult> result = new ArrayList<>();
+        String currentCaseName = null;
+        String currentSection = null;
+        String currentDescription = null;
+        String currentId = null;
+        String currentSkipped = null;
+        StringBuilder currentError = null;
+
+        for (String line : executionOutput.split("\n")) {
+            if (line.isBlank()) {
+                continue;
+            }
+
+            var groupMatcher = GROUP_PATTERN.matcher(line);
+            if (groupMatcher.matches()) {
+                if (currentId != null) {
+                    addCase(result, currentCaseName, currentDescription, currentId, currentError, currentSkipped);
+                    currentDescription = null;
+                    currentId = null;
+                    currentSkipped = null;
+                    currentError = null;
+                }
+                currentSection = groupMatcher.group(1);
+                currentCaseName = currentSection + ". " + groupMatcher.group(2);
+                continue;
+            }
+
+            var caseMatcher = CASE_PATTERN.matcher(line);
+            if (caseMatcher.matches() && currentSection != null) {
+                if (currentId != null) {
+                    addCase(result, currentCaseName, currentDescription, currentId, currentError, currentSkipped);
+                }
+
+                String status = caseMatcher.group(1);
+                String sequence = caseMatcher.group(2);
+                currentDescription = caseMatcher.group(3);
+                currentId = "client/" + currentSection + "/" + sequence;
+                currentSkipped = status == null ? "Skipped by h2specd" : null;
+                currentError = "\u00D7".equals(status) ? new StringBuilder() : null;
+                continue;
+            }
+
+            if (currentError != null) {
+                String trimmed = line.stripLeading();
+                if (!trimmed.isEmpty()) {
+                    if (!currentError.isEmpty()) {
+                        currentError.append('\n');
+                    }
+                    currentError.append(trimmed);
+                }
+            }
+        }
+
+        if (currentId != null) {
+            addCase(result, currentCaseName, currentDescription, currentId, currentError, currentSkipped);
+        }
+
+        long actualFailed = result.stream()
+                .filter(caseResult -> caseResult.error() != null)
+                .count();
+        long actualSkipped = result.stream()
+                .filter(caseResult -> caseResult.skipped() != null)
+                .count();
+        long actualPassed = result.size() - actualFailed - actualSkipped;
+
+        Assertions.assertEquals(expectedTotal,
+                                result.size(),
+                                "Parsed h2specd client case count does not match the reported total.");
+        Assertions.assertEquals(expectedPassed,
+                                actualPassed,
+                                "Parsed h2specd client passed count does not match the reported summary.");
+        Assertions.assertEquals(expectedSkipped,
+                                actualSkipped,
+                                "Parsed h2specd client skipped count does not match the reported summary.");
+        Assertions.assertEquals(expectedFailed,
+                                actualFailed,
+                                "Parsed h2specd client failed count does not match the reported summary.");
+
+        return result;
+    }
+
+    private static void addCase(List<H2SpecCaseResult> result,
+                                String caseName,
+                                String description,
+                                String id,
+                                StringBuilder error,
+                                String skipped) {
+        result.add(new H2SpecCaseResult(caseName,
+                                        description,
+                                        id,
+                                        error == null ? null : error.toString(),
+                                        skipped));
+    }
+
+    private static String normalizeOutput(String output) {
+        return ANSI_PATTERN.matcher(output)
+                .replaceAll("")
+                .replace("\r", "\n");
+    }
+
+    private static String combineExecOutput(String stdout, String stderr) {
+        if (stderr == null || stderr.isBlank()) {
+            return stdout;
+        }
+        if (stdout == null || stdout.isBlank()) {
+            return stderr;
+        }
+        return stdout + System.lineSeparator() + stderr;
+    }
+
+    private static void prepareOutputFiles() {
+        try {
+            Files.createDirectories(OUTPUT_DIR);
+            Files.deleteIfExists(OUTPUT_PATH);
+
+            // Remove stale per-section logs so an older shard layout does not leave misleading files behind.
+            try (Stream<Path> paths = Files.list(OUTPUT_DIR)) {
+                for (Path path : paths.filter(Files::isRegularFile).toList()) {
+                    Files.deleteIfExists(path);
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to prepare h2specd client output files.", e);
+        }
+    }
+
+    private static void persistOutput(List<H2SpecSectionResult> sectionResults) {
+        try {
+            Files.createDirectories(OUTPUT_PATH.getParent());
+            StringBuilder combined = new StringBuilder();
+            for (H2SpecSectionResult sectionResult : sectionResults) {
+                if (!combined.isEmpty()) {
+                    combined.append('\n');
+                }
+                combined.append("=== ").append(sectionResult.section().id()).append(" ===").append('\n')
+                        .append(sectionResult.output());
+            }
+            Files.writeString(OUTPUT_PATH, combined.toString(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to persist h2specd client output to " + OUTPUT_PATH, e);
+        }
+    }
+
+    private static void persistSectionOutput(H2SpecSection section, String output) {
+        Path outputPath = OUTPUT_DIR.resolve(section.fileName());
+        try {
+            Files.createDirectories(OUTPUT_DIR);
+            Files.writeString(outputPath, output, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to persist h2specd client output to " + outputPath, e);
+        }
+    }
+
+    private static boolean isKnownFailure(String id, String desc) {
+        return KNOWN_FAILING_IDS.contains(id) || KNOWN_FAILING_DESCRIPTIONS.contains(desc);
+    }
+
+    private record H2SpecCaseResult(String caseName,
+                                    String description,
+                                    String id,
+                                    String error,
+                                    String skipped) {
+    }
+
+    private record H2SpecSection(String id, int fromPort) {
+        String fileName() {
+            return id.replace('/', '-') + ".txt";
+        }
+
+        String logName() {
+            return id.replace('/', '.');
+        }
+    }
+
+    private record H2SpecSectionResult(H2SpecSection section,
+                                       String output,
+                                       List<H2SpecCaseResult> caseResults) {
+    }
+
+    private record SectionFuture(H2SpecSection section,
+                                 Future<H2SpecSectionResult> future) {
+    }
+}

--- a/tests/integration/h2spec-client/src/test/java/io/helidon/tests/integration/h2spec/client/H2SpecClientIT.java
+++ b/tests/integration/h2spec-client/src/test/java/io/helidon/tests/integration/h2spec/client/H2SpecClientIT.java
@@ -81,14 +81,11 @@ class H2SpecClientIT {
     private static final Pattern CASE_PATTERN =
             Pattern.compile("^\\s*(?:([\\u2714\\u00D7])\\s+)?(\\d+):\\s+(.*)$");
 
-    // These are the two known upstream client conformance failures tracked by issue #11771.
-    private static final Set<String> KNOWN_FAILING_IDS = Set.of(
-            "client/6.9.1/1",
-            "client/6.9.1/2"
-    );
-    private static final Set<String> KNOWN_FAILING_DESCRIPTIONS = Set.of(
-            "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1",
-            "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream"
+    private static final Set<KnownFailure> KNOWN_FAILURES = Set.of(
+            new KnownFailure("client/6.9.1/1",
+                             "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1"),
+            new KnownFailure("client/6.9.1/2",
+                             "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream")
     );
 
     static {
@@ -103,7 +100,7 @@ class H2SpecClientIT {
         LOGGER.info("{}: \n - {} \nID: {}", caseName, desc, id);
 
         if (skipped != null) {
-            Assumptions.abort(skipped);
+            Assertions.fail("Unexpected h2specd skip for " + id + " (" + desc + "): " + skipped);
         }
 
         if (err != null && isKnownFailure(id, desc)) {
@@ -232,6 +229,9 @@ class H2SpecClientIT {
         int expectedPassed = Integer.parseInt(summaryMatcher.group(2));
         int expectedSkipped = Integer.parseInt(summaryMatcher.group(3));
         int expectedFailed = Integer.parseInt(summaryMatcher.group(4));
+        Assertions.assertEquals(0,
+                                expectedSkipped,
+                                "h2specd reported skipped client cases; update the allowlist if this is expected.");
 
         String executionOutput = normalized;
         int failuresStart = normalized.indexOf("\nFailures:");
@@ -393,7 +393,10 @@ class H2SpecClientIT {
     }
 
     private static boolean isKnownFailure(String id, String desc) {
-        return KNOWN_FAILING_IDS.contains(id) || KNOWN_FAILING_DESCRIPTIONS.contains(desc);
+        return KNOWN_FAILURES.contains(new KnownFailure(id, desc));
+    }
+
+    private record KnownFailure(String id, String description) {
     }
 
     private record H2SpecCaseResult(String caseName,

--- a/tests/integration/h2spec-client/src/test/resources/logging-test.properties
+++ b/tests/integration/h2spec-client/src/test/resources/logging-test.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = INFO

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -66,6 +66,7 @@
         <module>zipkin-mp-2.2</module>
         <module>tls-revocation-config</module>
         <module>h2spec</module>
+        <module>h2spec-client</module>
         <module>mp-telemetry</module>
         <module>mp-jaxrs-preserve-headers</module>
         <module>mp-metrics-gh-9995</module>

--- a/webclient/http2/pom.xml
+++ b/webclient/http2/pom.xml
@@ -29,7 +29,6 @@
 
     <properties>
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
-        <jetty.h2c.peer.version>11.0.18</jetty.h2c.peer.version>
     </properties>
 
     <dependencies>
@@ -92,24 +91,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${jetty.h2c.peer.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.h2c.peer.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.http2</groupId>
-            <artifactId>http2-server</artifactId>
-            <version>${jetty.h2c.peer.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -179,31 +160,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>issue-11529-it</id>
-            <activation>
-                <property>
-                    <name>issue11529.run</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/webclient/http2/pom.xml
+++ b/webclient/http2/pom.xml
@@ -29,6 +29,7 @@
 
     <properties>
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+        <jetty.h2c.peer.version>11.0.18</jetty.h2c.peer.version>
     </properties>
 
     <dependencies>
@@ -91,6 +92,24 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.h2c.peer.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.h2c.peer.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
+            <version>${jetty.h2c.peer.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -159,4 +178,32 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>issue-11529-it</id>
+            <activation>
+                <property>
+                    <name>issue11529.run</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -132,7 +132,24 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
             if (!clientRequest().outputStreamRedirect()) {
                 http2Client.connectionCache().remove(connectionKey);
             }
+            closeFailedStream(result);
             throw e;
+        } catch (RuntimeException | Error e) {
+            closeFailedStream(result);
+            throw e;
+        }
+    }
+
+    private void closeFailedStream(Http2ConnectionAttemptResult result) {
+        if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
+            Http2ClientStream failedStream = result.stream();
+            try {
+                failedStream.cancel();
+            } catch (RuntimeException | Error ignored) {
+                // Preserve the original request failure; close still releases the reserved stream slot.
+            } finally {
+                failedStream.close();
+            }
         }
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -126,15 +126,15 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
                 this.response = result.response();
                 return doProceed(serviceRequest, result.response());
             }
-        } catch (StreamTimeoutException e){
+        } catch (StreamTimeoutException e) {
             //This request was waiting for 100 Continue, but it was very likely not supported by the server.
             //Do not remove connection from the cache in that case.
             if (!clientRequest().outputStreamRedirect()) {
                 http2Client.connectionCache().remove(connectionKey);
+                closeFailedStream(result);
             }
-            closeFailedStream(result);
             throw e;
-        } catch (RuntimeException | Error e) {
+        } catch (RuntimeException e) {
             closeFailedStream(result);
             throw e;
         }
@@ -145,7 +145,7 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
             Http2ClientStream failedStream = result.stream();
             try {
                 failedStream.cancel();
-            } catch (RuntimeException | Error ignored) {
+            } catch (RuntimeException ignored) {
                 // Preserve the original request failure; close still releases the reserved stream slot.
             } finally {
                 failedStream.close();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -308,7 +308,13 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                     redirectUri.port(lastUri.port());
                 }
                 lastUri = redirectUri;
-                stream.close();
+                // Queue RST_STREAM before releasing this stream's reservation, so redirected HEADERS
+                // are serialized after the abandoned upload is reset for max-concurrent-streams peers.
+                try {
+                    stream.cancel();
+                } finally {
+                    stream.close();
+                }
                 Http2ClientRequestImpl clientRequest = new Http2ClientRequestImpl(lastRequest,
                                                                                   method,
                                                                                   redirectUri,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.http2;
 
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -46,6 +46,7 @@ import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameListener;
+import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2GoAway;
 import io.helidon.http.http2.Http2Headers;
@@ -81,9 +82,7 @@ public class Http2ClientConnection {
     private final ConnectionFlowControl connectionFlowControl;
     private final Http2Headers.DynamicTable inboundDynamicTable =
             Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
-    private final AtomicLong inboundHeaderBlockSequence = new AtomicLong();
-    private final ReentrantLock inboundHeaderDecodeLock = new ReentrantLock();
-    private final Condition inboundHeaderDecodeTurn = inboundHeaderDecodeLock.newCondition();
+    private final PendingInboundHeaders pendingInboundHeaders;
     private final Http2ClientProtocolConfig protocolConfig;
     private final ClientConnection connection;
     private final SocketContext ctx;
@@ -105,12 +104,10 @@ public class Http2ClientConnection {
             .build();
     private Future<?> handleTask;
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
-    // Guarded by inboundHeaderDecodeLock.
-    private long nextInboundHeaderBlockToDecode = 1;
-
     Http2ClientConnection(Http2ClientImpl http2Client, ClientConnection connection) {
         this.protocolConfig = http2Client.protocolConfig();
         this.clientConfig = http2Client.clientConfig();
+        this.pendingInboundHeaders = new PendingInboundHeaders(protocolConfig.maxHeaderListSize());
         this.connectionFlowControl = ConnectionFlowControl.clientBuilder(this::writeWindowsUpdate)
                 .maxFrameSize(protocolConfig.maxFrameSize())
                 .initialWindowSize(protocolConfig.initialWindowSize())
@@ -144,10 +141,6 @@ public class Http2ClientConnection {
 
     Http2ConnectionWriter writer() {
         return writer;
-    }
-
-    Http2Headers.DynamicTable getInboundDynamicTable() {
-        return this.inboundDynamicTable;
     }
 
     ConnectionFlowControl flowControl() {
@@ -309,7 +302,6 @@ public class Http2ClientConnection {
         initialSettingsLatch.countDown();
         this.goAway(0, Http2ErrorCode.NO_ERROR, "Closing connection");
         if (state.getAndSet(State.CLOSED) != State.CLOSED) {
-            signalInboundHeaderDecodeWaiters();
             try {
                 handleTask.cancel(true);
                 ctx.log(LOGGER, TRACE, "Closing connection");
@@ -317,23 +309,7 @@ public class Http2ClientConnection {
             } catch (Throwable e) {
                 ctx.log(LOGGER, TRACE, "Failed to close HTTP/2 connection.", e);
             }
-        } else {
-            signalInboundHeaderDecodeWaiters();
         }
-    }
-
-    /**
-     * Closes the connection after a stream is abandoned with queued or in-progress
-     * inbound header decoding.
-     * This is intentional: later streams decode HPACK state in connection wire order,
-     * so abandoning an earlier block would otherwise deadlock the remaining decoders.
-     *
-     * @param streamId stream that was closed while still owning undecoded headers
-     */
-    void closeUndecodedHeaders(int streamId) {
-        ctx.log(LOGGER, DEBUG, "%d: closing connection because stream %d was abandoned with undecoded headers",
-                0, streamId);
-        close();
     }
 
     static Http2Settings settings(Http2ClientProtocolConfig config) {
@@ -345,63 +321,6 @@ public class Http2ClientConnection {
                 .add(Http2Setting.MAX_FRAME_SIZE, (long) config.maxFrameSize())
                 .add(Http2Setting.ENABLE_PUSH, false)
                 .build();
-    }
-
-    /**
-     * Reads the HTTP/2 headers for the specified client stream from this connection.
-     * Thread-safe: Uses a connection-level decode lock to preserve inbound HPACK state.
-     *
-     * @param stream the HTTP/2 client stream for which headers are being read
-     * @param decoder the Huffman decoder to decode the headers
-     * @param headers the existing headers object to populate or use as a basis
-     * @param headerBlockOrder the order in which the complete inbound header block arrived on the wire
-     * @param array the array of HTTP/2 frame data to process
-     * @return the processed HTTP/2 headers
-     */
-    Http2Headers readHeaders(Http2ClientStream stream,
-                             Http2HuffmanDecoder decoder,
-                             Http2Headers headers,
-                             long headerBlockOrder,
-                             Http2FrameData[] array) {
-        inboundHeaderDecodeLock.lock();
-        try {
-            // HPACK dynamic-table updates are connection-scoped, so blocks must decode in wire order.
-            while (headerBlockOrder != nextInboundHeaderBlockToDecode) {
-                if (state.get().closed()) {
-                    throw new IllegalStateException("Connection closed while waiting to decode HTTP/2 headers");
-                }
-                inboundHeaderDecodeTurn.await();
-            }
-            try {
-                return Http2Headers.create(stream,
-                                           inboundDynamicTable,
-                                           decoder,
-                                           headers,
-                                           array);
-            } finally {
-                nextInboundHeaderBlockToDecode++;
-                inboundHeaderDecodeTurn.signalAll();
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while waiting to decode HTTP/2 headers", e);
-        } finally {
-            inboundHeaderDecodeLock.unlock();
-        }
-    }
-
-    /**
-     * Wakes threads waiting for their inbound HPACK decode turn during shutdown.
-     * Without this signal, a blocked decoder could wait forever for an earlier
-     * header block that will never finish once the connection is closing.
-     */
-    private void signalInboundHeaderDecodeWaiters() {
-        inboundHeaderDecodeLock.lock();
-        try {
-            inboundHeaderDecodeTurn.signalAll();
-        } finally {
-            inboundHeaderDecodeLock.unlock();
-        }
     }
 
     private void sendPreface(Http2ClientProtocolConfig config, boolean sendSettings) {
@@ -544,6 +463,7 @@ public class Http2ClientConnection {
         frameHeader.type().checkLength(frameHeader.length());
         BufferData data = readFrameData(frameHeader);
         int streamId = frameHeader.streamId();
+        validateHeaderContinuation(frameHeader, streamId);
 
         return switch (frameHeader.type()) {
         case GO_AWAY -> handleGoAwayFrame(streamId, frameHeader, data);
@@ -571,6 +491,42 @@ public class Http2ClientConnection {
             return BufferData.empty();
         }
         return reader.readBuffer(frameHeader.length());
+    }
+
+    private void validateHeaderContinuation(Http2FrameHeader frameHeader, int streamId) {
+        int expectedStreamId = pendingInboundHeaders.streamId();
+        if (expectedStreamId == 0) {
+            return;
+        }
+        if (frameHeader.type() != Http2FrameType.CONTINUATION) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                     "Expecting CONTINUATION for stream " + expectedStreamId
+                                             + ", received " + frameHeader.type() + " for " + streamId);
+        }
+        if (expectedStreamId != streamId) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                     "Received CONTINUATION for stream " + streamId
+                                             + ", expected for " + expectedStreamId);
+        }
+    }
+
+    /**
+     * Decodes one complete inbound header block on the connection thread.
+     * The HPACK dynamic table is shared by all streams on this connection, so
+     * decoding must happen in wire order here instead of in whichever caller
+     * thread reaches {@code Http2ClientStream.readHeaders()} first.
+     *
+     * @param stream stream receiving the decoded headers
+     * @param headerFrames full {@code HEADERS}/{@code CONTINUATION} block in wire order
+     * @return decoded headers
+     */
+    private Http2Headers decodeInboundHeaders(Http2ClientStream stream, Http2FrameData... headerFrames) {
+        // Keep HPACK decode on the connection thread so the shared dynamic table advances in wire order.
+        return Http2Headers.create(stream,
+                                   inboundDynamicTable,
+                                   Http2HuffmanDecoder.create(),
+                                   stream.inboundHeaderDecodeBasis(),
+                                   headerFrames);
     }
 
     private boolean handleGoAwayFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
@@ -722,26 +678,63 @@ public class Http2ClientConnection {
     private void handleDataFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
         Http2ClientStream stream = stream(streamId);
         if (stream == null) {
-            ctx.log(LOGGER, DEBUG, "%d: received data for stream %d, which does not exist", 0, streamId);
+            if (LOGGER.isLoggable(DEBUG)) {
+                ctx.log(LOGGER, DEBUG, "%d: received data for stream %d, which does not exist", 0, streamId);
+            }
             return;
         }
         stream.flowControl().inbound().decrementWindowSize(frameHeader.length());
-        ctx.log(LOGGER, DEBUG, "%d: received data for stream %d", 0, streamId);
+        if (LOGGER.isLoggable(DEBUG)) {
+            ctx.log(LOGGER, DEBUG, "%d: received data for stream %d", 0, streamId);
+        }
         stream.push(new Http2FrameData(frameHeader, data));
     }
 
     private boolean handleHeadersFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
+        recvListener.frameHeader(ctx, streamId, frameHeader);
+        // Http2LoggingFrameListener inspects BufferData without advancing it; copying here would drain the live payload.
+        recvListener.frame(ctx, streamId, data);
+
+        Http2FrameData[] headerFrames;
+        boolean endOfStream;
+        if (frameHeader.type() == Http2FrameType.HEADERS) {
+            if (!endOfHeaders(frameHeader)) {
+                pendingInboundHeaders.begin(frameHeader, data);
+                return true;
+            }
+            endOfStream = frameHeader.flags(Http2FrameTypes.HEADERS).endOfStream();
+            headerFrames = new Http2FrameData[] {new Http2FrameData(frameHeader, data)};
+        } else {
+            pendingInboundHeaders.add(frameHeader, data);
+            if (!endOfHeaders(frameHeader)) {
+                return true;
+            }
+            endOfStream = pendingInboundHeaders.endOfStream();
+            headerFrames = pendingInboundHeaders.frames();
+            pendingInboundHeaders.clear();
+        }
+
         Http2ClientStream headerStream = stream(streamId);
         if (headerStream == null) {
-            ctx.log(LOGGER, DEBUG, "%d: received %s for stream %d, which does not exist", 0, frameHeader.type(), streamId);
+            if (LOGGER.isLoggable(DEBUG)) {
+                ctx.log(LOGGER, DEBUG, "%d: received %s for stream %d, which does not exist",
+                        0, frameHeader.type(), streamId);
+            }
             return true;
         }
-        if ((frameHeader.flags() & Http2Flag.END_OF_HEADERS) == Http2Flag.END_OF_HEADERS) {
-            // Capture the arrival order of each complete header block before stream threads decode it.
-            headerStream.inboundHeaderBlock(inboundHeaderBlockSequence.incrementAndGet());
-        }
-        headerStream.push(new Http2FrameData(frameHeader, data));
+
+        Http2Headers headers = decodeInboundHeaders(headerStream, headerFrames);
+        recvListener.headers(ctx, streamId, headers);
+        headerStream.inboundHeaders(headers, endOfStream);
         return true;
+    }
+
+    private static boolean endOfHeaders(Http2FrameHeader frameHeader) {
+        return switch (frameHeader.type()) {
+        case HEADERS -> frameHeader.flags(Http2FrameTypes.HEADERS).endOfHeaders();
+        case CONTINUATION -> frameHeader.flags(Http2FrameTypes.CONTINUATION).endOfHeaders();
+        default -> false;
+        };
     }
 
     private void ackSettings() {
@@ -779,6 +772,113 @@ public class Http2ClientConnection {
 
         boolean closed() {
             return closed;
+        }
+    }
+
+    /**
+     * Collects one split inbound {@code HEADERS}/{@code CONTINUATION} block until
+     * the terminating {@code END_HEADERS} frame arrives.
+     * The client keeps a single HPACK dynamic table per connection, so the raw
+     * frames must stay on the connection thread and be decoded only once the
+     * full block is available in wire order. This also enforces the negotiated
+     * header-list cap while the block is still in flight, mirroring the server path.
+     */
+    static final class PendingInboundHeaders {
+        private final List<Http2FrameData> headerFrames = new ArrayList<>();
+        private final long maxHeaderListSize;
+        private Http2FrameHeader firstHeader;
+        private long headerListSize;
+
+        PendingInboundHeaders(long maxHeaderListSize) {
+            this.maxHeaderListSize = maxHeaderListSize;
+        }
+
+        /**
+         * Starts tracking a split inbound header block.
+         *
+         * @param frameHeader initial {@code HEADERS} frame header
+         * @param data initial payload bytes
+         */
+        void begin(Http2FrameHeader frameHeader, BufferData data) {
+            clear();
+            firstHeader = frameHeader;
+            headerFrames.add(new Http2FrameData(frameHeader, data));
+            addAndValidateHeaderListSize(frameHeader.length());
+        }
+
+        /**
+         * Appends one inbound {@code CONTINUATION} frame to the current block.
+         *
+         * @param frameHeader continuation frame header
+         * @param data continuation payload bytes
+         */
+        void add(Http2FrameHeader frameHeader, BufferData data) {
+            if (headerFrames.isEmpty()) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received continuation without headers.");
+            }
+            headerFrames.add(new Http2FrameData(frameHeader, data));
+            addAndValidateHeaderListSize(frameHeader.length());
+        }
+
+        /**
+         * Returns the stream id of the block currently being assembled, or {@code 0}
+         * when no split header block is in progress.
+         *
+         * @return stream id that still expects {@code CONTINUATION}
+         */
+        int streamId() {
+            if (firstHeader == null) {
+                return 0;
+            }
+            return firstHeader.streamId();
+        }
+
+        /**
+         * Returns the collected header frames in wire order.
+         *
+         * @return current pending frames
+         */
+        Http2FrameData[] frames() {
+            return headerFrames.toArray(new Http2FrameData[0]);
+        }
+
+        /**
+         * Returns whether the initial {@code HEADERS} frame carried the
+         * {@code END_STREAM} flag.
+         *
+         * @return {@code true} if the completed block also ends the stream
+         */
+        boolean endOfStream() {
+            if (firstHeader == null) {
+                throw new IllegalStateException("No inbound headers are pending.");
+            }
+            return firstHeader.flags(Http2FrameTypes.HEADERS).endOfStream();
+        }
+
+        /**
+         * Clears the currently tracked split header block after decode or error.
+         */
+        void clear() {
+            headerFrames.clear();
+            firstHeader = null;
+            headerListSize = 0;
+        }
+
+        /**
+         * Tracks the encoded header bytes accumulated for the current block and
+         * rejects peers that exceed the configured header-list budget before decode.
+         *
+         * @param headerSizeIncrement bytes contributed by the next frame
+         */
+        private void addAndValidateHeaderListSize(int headerSizeIncrement) {
+            if (maxHeaderListSize <= 0) {
+                return;
+            }
+            headerListSize += headerSizeIncrement;
+            if (headerListSize > maxHeaderListSize) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                         "Response Header Fields Too Large");
+            }
         }
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -80,43 +80,6 @@ public class Http2ClientConnection {
     private static final Http2Headers EMPTY_INBOUND_HEADERS = Http2Headers.create(WritableHeaders.create());
     private static final Http2Stream DROPPED_INBOUND_HEADERS_STREAM = new DroppedInboundHeadersStream();
 
-    private static final class DroppedInboundHeadersStream implements Http2Stream {
-        @Override
-        public boolean rstStream(Http2RstStream rstStream) {
-            return false;
-        }
-
-        @Override
-        public void windowUpdate(Http2WindowUpdate windowUpdate) {
-        }
-
-        @Override
-        public void headers(Http2Headers headers, boolean endOfStream) {
-        }
-
-        @Override
-        public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
-        }
-
-        @Override
-        public void priority(Http2Priority http2Priority) {
-        }
-
-        @Override
-        public int streamId() {
-            return 0;
-        }
-
-        @Override
-        public Http2StreamState streamState() {
-            return Http2StreamState.CLOSED;
-        }
-
-        @Override
-        public StreamFlowControl flowControl() {
-            return null;
-        }
-    }
     private final Http2FrameListener sendListener = new Http2LoggingFrameListener("cl-send");
     private final Http2FrameListener recvListener = new Http2LoggingFrameListener("cl-recv");
     private final LockingStreamIdSequence streamIdSeq = new LockingStreamIdSequence();
@@ -1052,6 +1015,44 @@ public class Http2ClientConnection {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL,
                                          "Response Header Fields Too Large");
             }
+        }
+    }
+
+    private static final class DroppedInboundHeadersStream implements Http2Stream {
+        @Override
+        public boolean rstStream(Http2RstStream rstStream) {
+            return false;
+        }
+
+        @Override
+        public void windowUpdate(Http2WindowUpdate windowUpdate) {
+        }
+
+        @Override
+        public void headers(Http2Headers headers, boolean endOfStream) {
+        }
+
+        @Override
+        public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
+        }
+
+        @Override
+        public void priority(Http2Priority http2Priority) {
+        }
+
+        @Override
+        public int streamId() {
+            return 0;
+        }
+
+        @Override
+        public Http2StreamState streamState() {
+            return Http2StreamState.CLOSED;
+        }
+
+        @Override
+        public StreamFlowControl flowControl() {
+            return null;
         }
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -124,6 +124,8 @@ public class Http2ClientConnection {
     private final ConnectionFlowControl connectionFlowControl;
     private final Http2Headers.DynamicTable inboundDynamicTable =
             Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+    // Inbound header decode is serialized on the connection thread, so one decoder instance is enough.
+    private final Http2HuffmanDecoder inboundHuffman = Http2HuffmanDecoder.create();
     private final PendingInboundHeaders pendingInboundHeaders;
     private final Http2ClientProtocolConfig protocolConfig;
     private final ClientConnection connection;
@@ -587,7 +589,7 @@ public class Http2ClientConnection {
         // Keep HPACK decode on the connection thread so the shared dynamic table advances in wire order.
         return Http2Headers.create(stream,
                                    inboundDynamicTable,
-                                   Http2HuffmanDecoder.create(),
+                                   inboundHuffman,
                                    headerDecodeBasis,
                                    headerFrames);
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -37,6 +37,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketContext;
+import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.ConnectionFlowControl;
 import io.helidon.http.http2.FlowControl;
 import io.helidon.http.http2.Http2ConnectionWriter;
@@ -53,12 +54,15 @@ import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanDecoder;
 import io.helidon.http.http2.Http2LoggingFrameListener;
 import io.helidon.http.http2.Http2Ping;
+import io.helidon.http.http2.Http2Priority;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2Stream;
 import io.helidon.http.http2.Http2StreamState;
 import io.helidon.http.http2.Http2Util;
 import io.helidon.http.http2.Http2WindowUpdate;
+import io.helidon.http.http2.StreamFlowControl;
 import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
 
@@ -73,6 +77,44 @@ public class Http2ClientConnection {
     private static final System.Logger LOGGER = System.getLogger(Http2ClientConnection.class.getName());
     private static final int FRAME_HEADER_LENGTH = 9;
     private static final long NO_PING_ACK = Long.MIN_VALUE;
+    private static final Http2Headers EMPTY_INBOUND_HEADERS = Http2Headers.create(WritableHeaders.create());
+    private static final Http2Stream DROPPED_INBOUND_HEADERS_STREAM = new Http2Stream() {
+        @Override
+        public boolean rstStream(Http2RstStream rstStream) {
+            return false;
+        }
+
+        @Override
+        public void windowUpdate(Http2WindowUpdate windowUpdate) {
+        }
+
+        @Override
+        public void headers(Http2Headers headers, boolean endOfStream) {
+        }
+
+        @Override
+        public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
+        }
+
+        @Override
+        public void priority(Http2Priority http2Priority) {
+        }
+
+        @Override
+        public int streamId() {
+            return 0;
+        }
+
+        @Override
+        public Http2StreamState streamState() {
+            return Http2StreamState.CLOSED;
+        }
+
+        @Override
+        public StreamFlowControl flowControl() {
+            return null;
+        }
+    };
     private final Http2FrameListener sendListener = new Http2LoggingFrameListener("cl-send");
     private final Http2FrameListener recvListener = new Http2LoggingFrameListener("cl-recv");
     private final LockingStreamIdSequence streamIdSeq = new LockingStreamIdSequence();
@@ -100,7 +142,8 @@ public class Http2ClientConnection {
     private volatile boolean initialSettingsReceived;
     private int reservedStreams;
 
-    private Http2Settings serverSettings = Http2Settings.builder()
+    // SETTINGS arrive on the connection thread and are read from stream threads when encoding outbound frames.
+    private volatile Http2Settings serverSettings = Http2Settings.builder()
             .build();
     private Future<?> handleTask;
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
@@ -133,10 +176,28 @@ public class Http2ClientConnection {
                                         boolean sendSettings) {
 
         Http2ClientConnection h2conn = new Http2ClientConnection(http2Client, connection);
-        h2conn.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
-        h2conn.awaitInitialSettings();
+        return create(h2conn, http2Client, sendSettings);
+    }
 
-        return h2conn;
+    /**
+     * Starts a pre-created client connection instance and waits for the peer's
+     * initial {@code SETTINGS}. This is primarily used by package-local tests
+     * that need a specialized connection subtype while keeping the production
+     * startup path identical.
+     *
+     * @param connection started connection instance
+     * @param http2Client owning client
+     * @param sendSettings whether to send the client preface settings
+     * @param <T> concrete connection type
+     * @return started connection instance
+     */
+    static <T extends Http2ClientConnection> T create(T connection,
+                                                      Http2ClientImpl http2Client,
+                                                      boolean sendSettings) {
+        Http2ClientConnection rawConnection = connection;
+        rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
+        rawConnection.awaitInitialSettings();
+        return connection;
     }
 
     Http2ConnectionWriter writer() {
@@ -520,13 +581,46 @@ public class Http2ClientConnection {
      * @param headerFrames full {@code HEADERS}/{@code CONTINUATION} block in wire order
      * @return decoded headers
      */
-    private Http2Headers decodeInboundHeaders(Http2ClientStream stream, Http2FrameData... headerFrames) {
+    private Http2Headers decodeInboundHeaders(Http2Stream stream,
+                                              Http2Headers headerDecodeBasis,
+                                              Http2FrameData... headerFrames) {
         // Keep HPACK decode on the connection thread so the shared dynamic table advances in wire order.
         return Http2Headers.create(stream,
                                    inboundDynamicTable,
                                    Http2HuffmanDecoder.create(),
-                                   stream.inboundHeaderDecodeBasis(),
+                                   headerDecodeBasis,
                                    headerFrames);
+    }
+
+    private Http2Headers decodeInboundHeaders(Http2ClientStream stream, Http2FrameData... headerFrames) {
+        return decodeInboundHeaders(stream, stream.inboundHeaderDecodeBasis(), headerFrames);
+    }
+
+    /**
+     * Hook invoked on the connection thread once an inbound header block has
+     * been decoded and survived the post-decode stream-membership check, but
+     * before it is logged and delivered to the stream. Production code leaves
+     * this empty; tests can override it to force close timing in the narrow
+     * post-decode/pre-delivery window.
+     *
+     * @param stream live stream about to receive the decoded headers
+     * @param headers decoded headers
+     * @param endOfStream whether the block also closes the remote side
+     */
+    void beforeDeliverInboundHeaders(Http2ClientStream stream, Http2Headers headers, boolean endOfStream) {
+    }
+
+    /**
+     * Decodes and discards an inbound header block that no longer has a live stream consumer.
+     * Even abandoned streams can carry HPACK dynamic-table mutations, so the connection must
+     * still consume the block to keep later stream decodes aligned with the wire state.
+     * An empty semantic basis is intentional here because the decoded headers are discarded;
+     * only the connection-scoped HPACK side effects must be preserved.
+     *
+     * @param headerFrames full inbound header block in wire order
+     */
+    private void decodeDroppedInboundHeaders(Http2FrameData... headerFrames) {
+        decodeInboundHeaders(DROPPED_INBOUND_HEADERS_STREAM, EMPTY_INBOUND_HEADERS, headerFrames);
     }
 
     private boolean handleGoAwayFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
@@ -716,6 +810,8 @@ public class Http2ClientConnection {
 
         Http2ClientStream headerStream = stream(streamId);
         if (headerStream == null) {
+            // Keep the shared inbound HPACK table in sync even if the application already closed the stream.
+            decodeDroppedInboundHeaders(headerFrames);
             if (LOGGER.isLoggable(DEBUG)) {
                 ctx.log(LOGGER, DEBUG, "%d: received %s for stream %d, which does not exist",
                         0, frameHeader.type(), streamId);
@@ -724,6 +820,7 @@ public class Http2ClientConnection {
         }
 
         Http2Headers headers = decodeInboundHeaders(headerStream, headerFrames);
+        beforeDeliverInboundHeaders(headerStream, headers, endOfStream);
         recvListener.headers(ctx, streamId, headers);
         headerStream.inboundHeaders(headers, endOfStream);
         return true;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -80,7 +81,9 @@ public class Http2ClientConnection {
     private final ConnectionFlowControl connectionFlowControl;
     private final Http2Headers.DynamicTable inboundDynamicTable =
             Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
-    private final ReentrantLock inboundDynamicTableLock = new ReentrantLock();
+    private final AtomicLong inboundHeaderBlockSequence = new AtomicLong();
+    private final ReentrantLock inboundHeaderDecodeLock = new ReentrantLock();
+    private final Condition inboundHeaderDecodeTurn = inboundHeaderDecodeLock.newCondition();
     private final Http2ClientProtocolConfig protocolConfig;
     private final ClientConnection connection;
     private final SocketContext ctx;
@@ -90,13 +93,20 @@ public class Http2ClientConnection {
     private final Semaphore pingPongSemaphore = new Semaphore(0);
     private final AtomicLong pingIdSequence = new AtomicLong();
     private final Http2ClientConfig clientConfig;
+    private final ReentrantLock reservedStreamsLock = new ReentrantLock();
+    private final CountDownLatch initialSettingsLatch = new CountDownLatch(1);
     private volatile int lastStreamId;
     private volatile long expectedPingAck = NO_PING_ACK;
+    private volatile long peerMaxConcurrentStreams = Http2Setting.MAX_CONCURRENT_STREAMS.defaultValue();
+    private volatile boolean initialSettingsReceived;
+    private int reservedStreams;
 
     private Http2Settings serverSettings = Http2Settings.builder()
             .build();
     private Future<?> handleTask;
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
+    // Guarded by inboundHeaderDecodeLock.
+    private long nextInboundHeaderBlockToDecode = 1;
 
     Http2ClientConnection(Http2ClientImpl http2Client, ClientConnection connection) {
         this.protocolConfig = http2Client.protocolConfig();
@@ -127,6 +137,7 @@ public class Http2ClientConnection {
 
         Http2ClientConnection h2conn = new Http2ClientConnection(http2Client, connection);
         h2conn.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
+        h2conn.awaitInitialSettings();
 
         return h2conn;
     }
@@ -163,7 +174,20 @@ public class Http2ClientConnection {
         return streamIdSeq;
     }
 
+    /**
+     * Creates a new client stream after the peer's initial {@code SETTINGS} are known.
+     * Waiting here ensures we honor peer-provided limits such as
+     * {@code SETTINGS_MAX_CONCURRENT_STREAMS} before reserving capacity.
+     *
+     * @param config stream configuration
+     * @return a new client stream with one reserved peer-concurrency slot
+     */
     Http2ClientStream createStream(Http2StreamConfig config) {
+        // The peer can tighten MAX_CONCURRENT_STREAMS in its first SETTINGS frame.
+        awaitInitialSettings();
+        if (!reserveStream()) {
+            throw new IllegalStateException("Peer max concurrent streams reached: " + peerMaxConcurrentStreams);
+        }
         Http2ClientStream stream = new Http2ClientStream(this,
                 serverSettings,
                 ctx,
@@ -171,6 +195,22 @@ public class Http2ClientConnection {
                 clientConfig,
                 streamIdSeq);
         return stream;
+    }
+
+    /**
+     * Releases one previously reserved peer-concurrency slot.
+     * This is invoked from stream close paths so capacity is returned both after
+     * successful exchanges and after failures during stream startup.
+     */
+    void releaseReservedStream() {
+        reservedStreamsLock.lock();
+        try {
+            if (reservedStreams > 0) {
+                reservedStreams--;
+            }
+        } finally {
+            reservedStreamsLock.unlock();
+        }
     }
 
     /**
@@ -266,8 +306,10 @@ public class Http2ClientConnection {
      * Closes this connection.
      */
     public void close() {
+        initialSettingsLatch.countDown();
         this.goAway(0, Http2ErrorCode.NO_ERROR, "Closing connection");
         if (state.getAndSet(State.CLOSED) != State.CLOSED) {
+            signalInboundHeaderDecodeWaiters();
             try {
                 handleTask.cancel(true);
                 ctx.log(LOGGER, TRACE, "Closing connection");
@@ -275,7 +317,23 @@ public class Http2ClientConnection {
             } catch (Throwable e) {
                 ctx.log(LOGGER, TRACE, "Failed to close HTTP/2 connection.", e);
             }
+        } else {
+            signalInboundHeaderDecodeWaiters();
         }
+    }
+
+    /**
+     * Closes the connection after a stream is abandoned with queued or in-progress
+     * inbound header decoding.
+     * This is intentional: later streams decode HPACK state in connection wire order,
+     * so abandoning an earlier block would otherwise deadlock the remaining decoders.
+     *
+     * @param streamId stream that was closed while still owning undecoded headers
+     */
+    void closeUndecodedHeaders(int streamId) {
+        ctx.log(LOGGER, DEBUG, "%d: closing connection because stream %d was abandoned with undecoded headers",
+                0, streamId);
+        close();
     }
 
     static Http2Settings settings(Http2ClientProtocolConfig config) {
@@ -291,27 +349,58 @@ public class Http2ClientConnection {
 
     /**
      * Reads the HTTP/2 headers for the specified client stream from this connection.
-     * Thread-safe: Uses connection inbound dynamic table synchronized per connection.
+     * Thread-safe: Uses a connection-level decode lock to preserve inbound HPACK state.
      *
      * @param stream the HTTP/2 client stream for which headers are being read
      * @param decoder the Huffman decoder to decode the headers
      * @param headers the existing headers object to populate or use as a basis
+     * @param headerBlockOrder the order in which the complete inbound header block arrived on the wire
      * @param array the array of HTTP/2 frame data to process
      * @return the processed HTTP/2 headers
      */
     Http2Headers readHeaders(Http2ClientStream stream,
                              Http2HuffmanDecoder decoder,
                              Http2Headers headers,
+                             long headerBlockOrder,
                              Http2FrameData[] array) {
-        inboundDynamicTableLock.lock();
+        inboundHeaderDecodeLock.lock();
         try {
-            return Http2Headers.create(stream,
-                                       inboundDynamicTable,
-                                       decoder,
-                                       headers,
-                                       array);
+            // HPACK dynamic-table updates are connection-scoped, so blocks must decode in wire order.
+            while (headerBlockOrder != nextInboundHeaderBlockToDecode) {
+                if (state.get().closed()) {
+                    throw new IllegalStateException("Connection closed while waiting to decode HTTP/2 headers");
+                }
+                inboundHeaderDecodeTurn.await();
+            }
+            try {
+                return Http2Headers.create(stream,
+                                           inboundDynamicTable,
+                                           decoder,
+                                           headers,
+                                           array);
+            } finally {
+                nextInboundHeaderBlockToDecode++;
+                inboundHeaderDecodeTurn.signalAll();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting to decode HTTP/2 headers", e);
         } finally {
-            inboundDynamicTableLock.unlock();
+            inboundHeaderDecodeLock.unlock();
+        }
+    }
+
+    /**
+     * Wakes threads waiting for their inbound HPACK decode turn during shutdown.
+     * Without this signal, a blocked decoder could wait forever for an earlier
+     * header block that will never finish once the connection is closing.
+     */
+    private void signalInboundHeaderDecodeWaiters() {
+        inboundHeaderDecodeLock.lock();
+        try {
+            inboundHeaderDecodeTurn.signalAll();
+        } finally {
+            inboundHeaderDecodeLock.unlock();
         }
     }
 
@@ -380,6 +469,48 @@ public class Http2ClientConnection {
         }
     }
 
+    /**
+     * Waits for the peer's initial {@code SETTINGS} frame to be processed.
+     * Stream creation depends on these values, especially the peer's concurrent
+     * stream limit, so callers must not proceed until they are known.
+     */
+    private void awaitInitialSettings() {
+        if (initialSettingsReceived) {
+            return;
+        }
+        try {
+            if (!initialSettingsLatch.await(20, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Failed to receive initial HTTP/2 settings within 20 seconds");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for initial HTTP/2 settings", e);
+        }
+        if (!initialSettingsReceived) {
+            throw new IllegalStateException("Connection closed before initial HTTP/2 settings were received");
+        }
+    }
+
+    /**
+     * Reserves one peer-concurrency slot before a stream is opened on the wire.
+     * Reserving early prevents concurrent callers from overshooting the peer's
+     * advertised {@code SETTINGS_MAX_CONCURRENT_STREAMS} while stream startup is in progress.
+     *
+     * @return {@code true} if a slot was reserved, {@code false} if the peer limit was already reached
+     */
+    private boolean reserveStream() {
+        reservedStreamsLock.lock();
+        try {
+            if (reservedStreams >= peerMaxConcurrentStreams) {
+                return false;
+            }
+            reservedStreams++;
+            return true;
+        } finally {
+            reservedStreamsLock.unlock();
+        }
+    }
+
     private void writeWindowsUpdate(int streamId, Http2WindowUpdate windowUpdateFrame) {
         if (streamId == 0) {
             writer.write(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
@@ -411,141 +542,205 @@ public class Http2ClientConnection {
         BufferData frameHeaderBuffer = this.reader.readBuffer(FRAME_HEADER_LENGTH);
         Http2FrameHeader frameHeader = Http2FrameHeader.create(frameHeaderBuffer);
         frameHeader.type().checkLength(frameHeader.length());
-        BufferData data;
-        if (frameHeader.length() != 0) {
-            data = this.reader.readBuffer(frameHeader.length());
-        } else {
-            data = BufferData.empty();
-        }
-
+        BufferData data = readFrameData(frameHeader);
         int streamId = frameHeader.streamId();
 
-        switch (frameHeader.type()) {
-        case GO_AWAY:
-            Http2GoAway http2GoAway = Http2GoAway.create(data);
-            recvListener.frameHeader(ctx, streamId, frameHeader);
-            recvListener.frame(ctx, streamId, http2GoAway);
-            this.close();
-            ctx.log(LOGGER, TRACE, "Connection closed by remote peer, error code: %s, last stream: %d",
-                    http2GoAway.errorCode(),
-                    http2GoAway.lastStreamId());
-            return false;
-        case SETTINGS:
-            Http2Flag.SettingsFlags flags = frameHeader.flags(Http2FrameTypes.SETTINGS);
-
-            // if ack flag set, empty frame and no processing
-            if (flags.ack()) {
-                if (frameHeader.length() > 0) {
-                    throw new Http2Exception(Http2ErrorCode.FRAME_SIZE,
-                                             "Settings with ACK should not have payload.");
-                }
-                return true;
-            }
-
-            serverSettings = Http2Settings.create(data);
-            recvListener.frameHeader(ctx, streamId, frameHeader);
-            recvListener.frame(ctx, streamId, serverSettings);
-            // §4.3.1 Endpoint communicates the size chosen by its HPACK decoder context
-            inboundDynamicTable.protocolMaxTableSize(serverSettings.value(Http2Setting.HEADER_TABLE_SIZE));
-            if (serverSettings.hasValue(Http2Setting.MAX_FRAME_SIZE)) {
-                connectionFlowControl.resetMaxFrameSize(serverSettings.value(Http2Setting.MAX_FRAME_SIZE).intValue());
-            }
-            // §6.5.2 Update initial window size for new streams and window sizes of all already existing streams
-            if (serverSettings.hasValue(Http2Setting.INITIAL_WINDOW_SIZE)) {
-                Long initWinSizeLong = serverSettings.value(Http2Setting.INITIAL_WINDOW_SIZE);
-                if (initWinSizeLong > WindowSize.MAX_WIN_SIZE) {
-                    goAway(streamId, Http2ErrorCode.FLOW_CONTROL, "Window size too big. Max: ");
-                    throw new Http2Exception(Http2ErrorCode.PROTOCOL,
-                                             "Received too big INITIAL_WINDOW_SIZE " + initWinSizeLong);
-                }
-                int initWinSize = initWinSizeLong.intValue();
-                connectionFlowControl.resetInitialWindowSize(initWinSize);
-                Lock lock = streamsLock.readLock();
-                lock.lock();
-                try {
-                    streams.values().forEach(stream -> stream.flowControl().outbound().resetStreamWindowSize(initWinSize));
-                } finally {
-                    lock.unlock();
-                }
-
-            }
-            // §6.5.3 Settings Synchronization
-            ackSettings();
-
-            return true;
-
-        case WINDOW_UPDATE:
-            Http2WindowUpdate windowUpdate = Http2WindowUpdate.create(data);
-            recvListener.frameHeader(ctx, streamId, frameHeader);
-            recvListener.frame(ctx, streamId, windowUpdate);
-            // Outbound flow-control window update
-            if (streamId == 0) {
-                int increment = windowUpdate.windowSizeIncrement();
-                boolean overflow;
-                // overall connection
-                if (increment == 0) {
-                    Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.PROTOCOL, "Window size 0");
-                    writer.write(frame.toFrameData(serverSettings, 0, Http2Flag.NoFlags.create()));
-                }
-                overflow = connectionFlowControl.incrementOutboundConnectionWindowSize(increment) > WindowSize.MAX_WIN_SIZE;
-                if (overflow) {
-                    Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.FLOW_CONTROL, "Window size too big. Max: ");
-                    writer.write(frame.toFrameData(serverSettings, 0, Http2Flag.NoFlags.create()));
-                }
-
-            } else {
-                stream(streamId)
-                        .windowUpdate(windowUpdate);
-            }
-            return true;
-        case PING:
-            if (streamId != 0) {
-                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
-                                         "Received ping for a stream " + streamId);
-            }
-            if (frameHeader.length() != 8) {
-                throw new Http2Exception(Http2ErrorCode.FRAME_SIZE,
-                                         "Received ping with wrong size. Should be 8 bytes, is " + frameHeader.length());
-            }
-            if (!frameHeader.flags(Http2FrameTypes.PING).ack()) {
-                Http2Ping ping = Http2Ping.create(data);
-                recvListener.frame(ctx, streamId, ping);
-                BufferData frame = ping.data();
-                Http2FrameHeader header = Http2FrameHeader.create(frame.available(),
-                                                                  Http2FrameTypes.PING,
-                                                                  Http2Flag.PingFlags.create(Http2Flag.ACK),
-                                                                  0);
-                writer.write(new Http2FrameData(header, frame));
-            } else {
-                pong(data.readLong());
-            }
-            break;
-
-        case RST_STREAM:
-            Http2RstStream rstStream = Http2RstStream.create(data);
-            recvListener.frame(ctx, streamId, rstStream);
-            stream(streamId).rstStream(rstStream);
-            break;
-
-        case DATA:
-            Http2ClientStream stream = stream(streamId);
-            if (stream == null) {
-                // most likely a closed stream
-                ctx.log(LOGGER, DEBUG, "%d: received data for stream %d, which does not exist", 0, streamId);
-            } else {
-                stream.flowControl().inbound().decrementWindowSize(frameHeader.length());
-                ctx.log(LOGGER, DEBUG, "%d: received data for stream %d", 0, streamId);
-                stream.push(new Http2FrameData(frameHeader, data));
-            }
-            break;
-        case HEADERS, CONTINUATION:
-            stream(streamId).push(new Http2FrameData(frameHeader, data));
-            return true;
-
-        default:
+        return switch (frameHeader.type()) {
+        case GO_AWAY -> handleGoAwayFrame(streamId, frameHeader, data);
+        case SETTINGS -> handleSettingsFrame(streamId, frameHeader, data);
+        case WINDOW_UPDATE -> handleWindowUpdateFrame(streamId, frameHeader, data);
+        case PING -> handlePingFrame(streamId, frameHeader, data);
+        case RST_STREAM -> {
+            handleRstStreamFrame(streamId, data);
+            yield true;
+        }
+        case DATA -> {
+            handleDataFrame(streamId, frameHeader, data);
+            yield true;
+        }
+        case HEADERS, CONTINUATION -> handleHeadersFrame(streamId, frameHeader, data);
+        default -> {
             LOGGER.log(WARNING, "Unsupported frame type!! " + frameHeader.type());
+            yield true;
+        }
+        };
+    }
+
+    private BufferData readFrameData(Http2FrameHeader frameHeader) {
+        if (frameHeader.length() == 0) {
+            return BufferData.empty();
+        }
+        return reader.readBuffer(frameHeader.length());
+    }
+
+    private boolean handleGoAwayFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
+        Http2GoAway http2GoAway = Http2GoAway.create(data);
+        recvListener.frameHeader(ctx, streamId, frameHeader);
+        recvListener.frame(ctx, streamId, http2GoAway);
+        this.close();
+        ctx.log(LOGGER, TRACE, "Connection closed by remote peer, error code: %s, last stream: %d",
+                http2GoAway.errorCode(),
+                http2GoAway.lastStreamId());
+        return false;
+    }
+
+    private boolean handleSettingsFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
+        Http2Flag.SettingsFlags flags = frameHeader.flags(Http2FrameTypes.SETTINGS);
+        if (flags.ack()) {
+            if (frameHeader.length() > 0) {
+                throw new Http2Exception(Http2ErrorCode.FRAME_SIZE,
+                                         "Settings with ACK should not have payload.");
+            }
+            return true;
         }
 
+        Http2Settings receivedSettings = Http2Settings.create(data);
+        recvListener.frameHeader(ctx, streamId, frameHeader);
+        recvListener.frame(ctx, streamId, receivedSettings);
+        serverSettings = mergeSettings(serverSettings, receivedSettings);
+        updatePeerSettings(receivedSettings);
+        initialSettingsReceived = true;
+        initialSettingsLatch.countDown();
+        ackSettings();
+        return true;
+    }
+
+    private void updatePeerSettings(Http2Settings receivedSettings) {
+        if (receivedSettings.hasValue(Http2Setting.MAX_CONCURRENT_STREAMS) || !initialSettingsReceived) {
+            reservedStreamsLock.lock();
+            try {
+                peerMaxConcurrentStreams = serverSettings.value(Http2Setting.MAX_CONCURRENT_STREAMS);
+            } finally {
+                reservedStreamsLock.unlock();
+            }
+        }
+        if (receivedSettings.hasValue(Http2Setting.HEADER_TABLE_SIZE)) {
+            inboundDynamicTable.protocolMaxTableSize(serverSettings.value(Http2Setting.HEADER_TABLE_SIZE));
+        }
+        if (receivedSettings.hasValue(Http2Setting.MAX_FRAME_SIZE)) {
+            connectionFlowControl.resetMaxFrameSize(serverSettings.value(Http2Setting.MAX_FRAME_SIZE).intValue());
+        }
+        if (receivedSettings.hasValue(Http2Setting.INITIAL_WINDOW_SIZE)) {
+            updateInitialWindowSize(receivedSettings.value(Http2Setting.INITIAL_WINDOW_SIZE));
+        }
+    }
+
+    private void updateInitialWindowSize(long initWinSizeLong) {
+        if (initWinSizeLong > WindowSize.MAX_WIN_SIZE) {
+            goAway(0, Http2ErrorCode.FLOW_CONTROL, "Window size too big. Max: ");
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                     "Received too big INITIAL_WINDOW_SIZE " + initWinSizeLong);
+        }
+        int initWinSize = (int) initWinSizeLong;
+        connectionFlowControl.resetInitialWindowSize(initWinSize);
+        Lock lock = streamsLock.readLock();
+        lock.lock();
+        try {
+            streams.values().forEach(stream -> stream.flowControl().outbound().resetStreamWindowSize(initWinSize));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private static Http2Settings mergeSettings(Http2Settings currentSettings, Http2Settings receivedSettings) {
+        Http2Settings.Builder builder = Http2Settings.builder();
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.HEADER_TABLE_SIZE);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.ENABLE_PUSH);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_CONCURRENT_STREAMS);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.INITIAL_WINDOW_SIZE);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_FRAME_SIZE);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_HEADER_LIST_SIZE);
+        return builder.build();
+    }
+
+    private static <T> void mergeSetting(Http2Settings.Builder builder,
+                                         Http2Settings currentSettings,
+                                         Http2Settings receivedSettings,
+                                         Http2Setting<T> setting) {
+        if (receivedSettings.hasValue(setting)) {
+            builder.add(setting, receivedSettings.value(setting));
+        } else if (currentSettings.hasValue(setting)) {
+            builder.add(setting, currentSettings.value(setting));
+        }
+    }
+
+    private boolean handleWindowUpdateFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
+        Http2WindowUpdate windowUpdate = Http2WindowUpdate.create(data);
+        recvListener.frameHeader(ctx, streamId, frameHeader);
+        recvListener.frame(ctx, streamId, windowUpdate);
+        if (streamId == 0) {
+            updateConnectionWindow(windowUpdate);
+        } else {
+            stream(streamId).windowUpdate(windowUpdate);
+        }
+        return true;
+    }
+
+    private void updateConnectionWindow(Http2WindowUpdate windowUpdate) {
+        int increment = windowUpdate.windowSizeIncrement();
+        if (increment == 0) {
+            Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.PROTOCOL, "Window size 0");
+            writer.write(frame.toFrameData(serverSettings, 0, Http2Flag.NoFlags.create()));
+        }
+        boolean overflow = connectionFlowControl.incrementOutboundConnectionWindowSize(increment) > WindowSize.MAX_WIN_SIZE;
+        if (overflow) {
+            Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.FLOW_CONTROL, "Window size too big. Max: ");
+            writer.write(frame.toFrameData(serverSettings, 0, Http2Flag.NoFlags.create()));
+        }
+    }
+
+    private boolean handlePingFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
+        if (streamId != 0) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                     "Received ping for a stream " + streamId);
+        }
+        if (frameHeader.length() != 8) {
+            throw new Http2Exception(Http2ErrorCode.FRAME_SIZE,
+                                     "Received ping with wrong size. Should be 8 bytes, is " + frameHeader.length());
+        }
+        if (!frameHeader.flags(Http2FrameTypes.PING).ack()) {
+            Http2Ping ping = Http2Ping.create(data);
+            recvListener.frame(ctx, streamId, ping);
+            BufferData frame = ping.data();
+            Http2FrameHeader header = Http2FrameHeader.create(frame.available(),
+                                                              Http2FrameTypes.PING,
+                                                              Http2Flag.PingFlags.create(Http2Flag.ACK),
+                                                              0);
+            writer.write(new Http2FrameData(header, frame));
+        } else {
+            pong(data.readLong());
+        }
+        return true;
+    }
+
+    private void handleRstStreamFrame(int streamId, BufferData data) {
+        Http2RstStream rstStream = Http2RstStream.create(data);
+        recvListener.frame(ctx, streamId, rstStream);
+        stream(streamId).rstStream(rstStream);
+    }
+
+    private void handleDataFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
+        Http2ClientStream stream = stream(streamId);
+        if (stream == null) {
+            ctx.log(LOGGER, DEBUG, "%d: received data for stream %d, which does not exist", 0, streamId);
+            return;
+        }
+        stream.flowControl().inbound().decrementWindowSize(frameHeader.length());
+        ctx.log(LOGGER, DEBUG, "%d: received data for stream %d", 0, streamId);
+        stream.push(new Http2FrameData(frameHeader, data));
+    }
+
+    private boolean handleHeadersFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
+        Http2ClientStream headerStream = stream(streamId);
+        if (headerStream == null) {
+            ctx.log(LOGGER, DEBUG, "%d: received %s for stream %d, which does not exist", 0, frameHeader.type(), streamId);
+            return true;
+        }
+        if ((frameHeader.flags() & Http2Flag.END_OF_HEADERS) == Http2Flag.END_OF_HEADERS) {
+            // Capture the arrival order of each complete header block before stream threads decode it.
+            headerStream.inboundHeaderBlock(inboundHeaderBlockSequence.incrementAndGet());
+        }
+        headerStream.push(new Http2FrameData(frameHeader, data));
         return true;
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -19,8 +19,10 @@ package io.helidon.webclient.http2;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -78,7 +80,9 @@ public class Http2ClientConnection {
     private static final int FRAME_HEADER_LENGTH = 9;
     private static final long NO_PING_ACK = Long.MIN_VALUE;
     private static final Http2Headers EMPTY_INBOUND_HEADERS = Http2Headers.create(WritableHeaders.create());
-    private static final Http2Stream DROPPED_INBOUND_HEADERS_STREAM = new Http2Stream() {
+    private static final Http2Stream DROPPED_INBOUND_HEADERS_STREAM = new DroppedInboundHeadersStream();
+
+    private static final class DroppedInboundHeadersStream implements Http2Stream {
         @Override
         public boolean rstStream(Http2RstStream rstStream) {
             return false;
@@ -114,13 +118,14 @@ public class Http2ClientConnection {
         public StreamFlowControl flowControl() {
             return null;
         }
-    };
+    }
     private final Http2FrameListener sendListener = new Http2LoggingFrameListener("cl-send");
     private final Http2FrameListener recvListener = new Http2LoggingFrameListener("cl-recv");
     private final LockingStreamIdSequence streamIdSeq = new LockingStreamIdSequence();
     private final ReadWriteLock streamsLock = new ReentrantReadWriteLock();
     // streams may be accessed from connection thread, or stream thread, must be guarded by the above lock
     private final Map<Integer, Http2ClientStream> streams = new HashMap<>();
+    private final Set<Integer> abandonedClientStreams = new HashSet<>();
     private final ConnectionFlowControl connectionFlowControl;
     private final Http2Headers.DynamicTable inboundDynamicTable =
             Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
@@ -197,12 +202,15 @@ public class Http2ClientConnection {
                                                       Http2ClientImpl http2Client,
                                                       boolean sendSettings) {
         Http2ClientConnection rawConnection = connection;
+        boolean success = false;
         try {
             rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
             rawConnection.awaitInitialSettings();
-        } catch (RuntimeException | Error e) {
-            rawConnection.close();
-            throw e;
+            success = true;
+        } finally {
+            if (!success) {
+                rawConnection.close();
+            }
         }
         return connection;
     }
@@ -247,6 +255,9 @@ public class Http2ClientConnection {
         // The peer can tighten MAX_CONCURRENT_STREAMS in its first SETTINGS frame.
         awaitInitialSettings();
         if (!reserveStream()) {
+            if (peerMaxConcurrentStreams == 0) {
+                close();
+            }
             throw new IllegalStateException("Peer max concurrent streams reached: " + peerMaxConcurrentStreams);
         }
         Http2ClientStream stream = new Http2ClientStream(this,
@@ -285,6 +296,7 @@ public class Http2ClientConnection {
         lock.lock();
         try {
             this.streams.put(streamId, stream);
+            this.abandonedClientStreams.remove(streamId);
         } finally {
             lock.unlock();
         }
@@ -299,7 +311,9 @@ public class Http2ClientConnection {
         Lock lock = streamsLock.writeLock();
         lock.lock();
         try {
-            this.streams.remove(streamId);
+            if (this.streams.remove(streamId) != null && clientStreamId(streamId)) {
+                this.abandonedClientStreams.add(streamId);
+            }
         } finally {
             lock.unlock();
         }
@@ -843,6 +857,11 @@ public class Http2ClientConnection {
 
         Http2ClientStream headerStream = stream(streamId);
         if (headerStream == null) {
+            if (!knownAbandonedClientStream(streamId)) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                         "Received " + frameHeader.type()
+                                                 + " frame for invalid stream " + streamId);
+            }
             // Keep the shared inbound HPACK table in sync even if the application already closed the stream.
             decodeDroppedInboundHeaders(headerFrames);
             if (LOGGER.isLoggable(DEBUG)) {
@@ -857,6 +876,20 @@ public class Http2ClientConnection {
         recvListener.headers(ctx, streamId, headers);
         headerStream.inboundHeaders(headers, endOfStream);
         return true;
+    }
+
+    private boolean knownAbandonedClientStream(int streamId) {
+        Lock lock = streamsLock.readLock();
+        lock.lock();
+        try {
+            return abandonedClientStreams.contains(streamId);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private static boolean clientStreamId(int streamId) {
+        return streamId > 0 && streamId % 2 == 1;
     }
 
     private static boolean endOfHeaders(Http2FrameHeader frameHeader) {
@@ -877,7 +910,7 @@ public class Http2ClientConnection {
     }
 
     private void goAway(int streamId, Http2ErrorCode errorCode, String msg) {
-        if (State.OPEN == state.getAndSet(State.GO_AWAY)) {
+        if (state.compareAndSet(State.OPEN, State.GO_AWAY)) {
             Http2Settings http2Settings = Http2Settings.create();
             Http2GoAway frame = new Http2GoAway(streamId, errorCode, msg);
             writer.write(frame.toFrameData(http2Settings, 0, Http2Flag.NoFlags.create()));

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -19,10 +19,8 @@ package io.helidon.webclient.http2;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -125,7 +123,6 @@ public class Http2ClientConnection {
     private final ReadWriteLock streamsLock = new ReentrantReadWriteLock();
     // streams may be accessed from connection thread, or stream thread, must be guarded by the above lock
     private final Map<Integer, Http2ClientStream> streams = new HashMap<>();
-    private final Set<Integer> abandonedClientStreams = new HashSet<>();
     private final ConnectionFlowControl connectionFlowControl;
     private final Http2Headers.DynamicTable inboundDynamicTable =
             Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
@@ -296,7 +293,6 @@ public class Http2ClientConnection {
         lock.lock();
         try {
             this.streams.put(streamId, stream);
-            this.abandonedClientStreams.remove(streamId);
         } finally {
             lock.unlock();
         }
@@ -311,9 +307,7 @@ public class Http2ClientConnection {
         Lock lock = streamsLock.writeLock();
         lock.lock();
         try {
-            if (this.streams.remove(streamId) != null && clientStreamId(streamId)) {
-                this.abandonedClientStreams.add(streamId);
-            }
+            this.streams.remove(streamId);
         } finally {
             lock.unlock();
         }
@@ -764,7 +758,13 @@ public class Http2ClientConnection {
         if (streamId == 0) {
             updateConnectionWindow(windowUpdate);
         } else {
-            stream(streamId).windowUpdate(windowUpdate);
+            Http2ClientStream stream = stream(streamId);
+            if (stream == null) {
+                validateKnownAbandonedClientStream(streamId, frameHeader.type());
+                logDroppedFrame(frameHeader.type(), streamId);
+            } else {
+                stream.windowUpdate(windowUpdate);
+            }
         }
         return true;
     }
@@ -809,7 +809,13 @@ public class Http2ClientConnection {
     private void handleRstStreamFrame(int streamId, BufferData data) {
         Http2RstStream rstStream = Http2RstStream.create(data);
         recvListener.frame(ctx, streamId, rstStream);
-        stream(streamId).rstStream(rstStream);
+        Http2ClientStream stream = stream(streamId);
+        if (stream == null) {
+            validateKnownAbandonedClientStream(streamId, Http2FrameType.RST_STREAM);
+            logDroppedFrame(Http2FrameType.RST_STREAM, streamId);
+        } else {
+            stream.rstStream(rstStream);
+        }
     }
 
     private void handleDataFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
@@ -857,17 +863,10 @@ public class Http2ClientConnection {
 
         Http2ClientStream headerStream = stream(streamId);
         if (headerStream == null) {
-            if (!knownAbandonedClientStream(streamId)) {
-                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
-                                         "Received " + frameHeader.type()
-                                                 + " frame for invalid stream " + streamId);
-            }
+            validateKnownAbandonedClientStream(streamId, frameHeader.type());
             // Keep the shared inbound HPACK table in sync even if the application already closed the stream.
             decodeDroppedInboundHeaders(headerFrames);
-            if (LOGGER.isLoggable(DEBUG)) {
-                ctx.log(LOGGER, DEBUG, "%d: received %s for stream %d, which does not exist",
-                        0, frameHeader.type(), streamId);
-            }
+            logDroppedFrame(frameHeader.type(), streamId);
             return true;
         }
 
@@ -879,12 +878,23 @@ public class Http2ClientConnection {
     }
 
     private boolean knownAbandonedClientStream(int streamId) {
-        Lock lock = streamsLock.readLock();
-        lock.lock();
-        try {
-            return abandonedClientStreams.contains(streamId);
-        } finally {
-            lock.unlock();
+        // Client stream IDs are monotonic odd numbers, so an opened ID at or below lastStreamId is locally abandoned
+        // when it no longer has an active stream entry.
+        return clientStreamId(streamId) && streamId <= lastStreamId;
+    }
+
+    private void validateKnownAbandonedClientStream(int streamId, Http2FrameType frameType) {
+        if (!knownAbandonedClientStream(streamId)) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                     "Received " + frameType
+                                             + " frame for invalid stream " + streamId);
+        }
+    }
+
+    private void logDroppedFrame(Http2FrameType frameType, int streamId) {
+        if (LOGGER.isLoggable(DEBUG)) {
+            ctx.log(LOGGER, DEBUG, "%d: received %s for stream %d, which does not exist",
+                    0, frameType, streamId);
         }
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -197,8 +197,13 @@ public class Http2ClientConnection {
                                                       Http2ClientImpl http2Client,
                                                       boolean sendSettings) {
         Http2ClientConnection rawConnection = connection;
-        rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
-        rawConnection.awaitInitialSettings();
+        try {
+            rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
+            rawConnection.awaitInitialSettings();
+        } catch (RuntimeException | Error e) {
+            rawConnection.close();
+            throw e;
+        }
         return connection;
     }
 
@@ -366,7 +371,9 @@ public class Http2ClientConnection {
         this.goAway(0, Http2ErrorCode.NO_ERROR, "Closing connection");
         if (state.getAndSet(State.CLOSED) != State.CLOSED) {
             try {
-                handleTask.cancel(true);
+                if (handleTask != null) {
+                    handleTask.cancel(true);
+                }
                 ctx.log(LOGGER, TRACE, "Closing connection");
                 connection.closeResource();
             } catch (Throwable e) {
@@ -526,6 +533,7 @@ public class Http2ClientConnection {
         frameHeader.type().checkLength(frameHeader.length());
         BufferData data = readFrameData(frameHeader);
         int streamId = frameHeader.streamId();
+        validateFrameStreamId(frameHeader, streamId);
         validateHeaderContinuation(frameHeader, streamId);
 
         return switch (frameHeader.type()) {
@@ -570,6 +578,25 @@ public class Http2ClientConnection {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL,
                                      "Received CONTINUATION for stream " + streamId
                                              + ", expected for " + expectedStreamId);
+        }
+    }
+
+    private void validateFrameStreamId(Http2FrameHeader frameHeader, int streamId) {
+        switch (frameHeader.type()) {
+        case DATA, HEADERS, CONTINUATION, RST_STREAM -> {
+            if (streamId == 0) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                         "Received " + frameHeader.type() + " frame with stream id 0");
+            }
+        }
+        case SETTINGS, PING, GO_AWAY -> {
+            if (streamId != 0) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                         "Received " + frameHeader.type() + " frame for stream " + streamId);
+            }
+        }
+        default -> {
+        }
         }
     }
 
@@ -779,11 +806,15 @@ public class Http2ClientConnection {
             }
             return;
         }
+        Http2FrameData frameData = new Http2FrameData(frameHeader, data);
+        if (!stream.prepareInboundData(frameData)) {
+            return;
+        }
         stream.flowControl().inbound().decrementWindowSize(frameHeader.length());
         if (LOGGER.isLoggable(DEBUG)) {
             ctx.log(LOGGER, DEBUG, "%d: received data for stream %d", 0, streamId);
         }
-        stream.push(new Http2FrameData(frameHeader, data));
+        stream.push(frameData);
     }
 
     private boolean handleHeadersFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,13 +111,13 @@ class Http2ClientConnectionHandler {
             if (conn == null) {
                 conn = createConnection(http2Client, request, initialUri);
                 // we must assume that a new connection can handle a new stream
-                stream = conn.createStream(request);
+                stream = createStreamOnNewConnection(conn, request);
             } else {
                 stream = conn.tryStream(request);
                 if (stream == null) {
                     // either the connection is closed, or it ran out of streams
                     conn = createConnection(http2Client, request, initialUri);
-                    stream = conn.createStream(request);
+                    stream = createStreamOnNewConnection(conn, request);
                 }
             }
 
@@ -292,6 +292,23 @@ class Http2ClientConnectionHandler {
         }
 
         return usedConnection;
+    }
+
+    private Http2ClientStream createStreamOnNewConnection(Http2ClientConnection connection,
+                                                          Http2ClientRequestImpl request) {
+        try {
+            return connection.createStream(request);
+        } catch (RuntimeException e) {
+            discardConnection(connection);
+            throw e;
+        }
+    }
+
+    private void discardConnection(Http2ClientConnection connection) {
+        activeConnection.compareAndSet(connection, null);
+        allConnections.remove(connection);
+        h2ConnByConn.values().remove(connection);
+        connection.close();
     }
 
     private ClientConnection connectClient(WebClient webClient, List<String> alpn) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -231,13 +231,20 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         }
         Http2RstStream rstStream = new Http2RstStream(Http2ErrorCode.CANCEL);
         Http2FrameData frameData = rstStream.toFrameData(settings, streamId, Http2Flag.NoFlags.create());
+        Http2StreamState nextState = Http2StreamState.checkAndGetState(this.state,
+                                                                       Http2FrameType.RST_STREAM,
+                                                                       true,
+                                                                       false,
+                                                                       false);
         sendListener.frameHeader(ctx, streamId, frameData.header());
         sendListener.frame(ctx, streamId, rstStream);
         try {
-            write(frameData, false);
+            connection.writer().write(frameData);
         } catch (UncheckedIOException e) {
             // we consider this to be a marker that the connection is already close
             ctx.log(LOGGER, DEBUG, "Exception during stream cancel", e);
+        } finally {
+            updateState(nextState);
         }
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -82,6 +82,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     // accessed from stream thread an connection thread
     private volatile StreamFlowControl flowControl;
     private boolean hasEntity;
+    private boolean inboundEndQueued;
 
     // streamId and buffer can only be created when we are locked in the stream id sequence
     private int streamId;
@@ -275,6 +276,29 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         buffer.push(frameData);
     }
 
+    boolean prepareInboundData(Http2FrameData frameData) {
+        int flags = frameData.header().flags();
+        boolean endOfStream = (flags & Http2Flag.END_OF_STREAM) == Http2Flag.END_OF_STREAM;
+
+        inboundStateLock.lock();
+        try {
+            if (closed) {
+                return false;
+            }
+            if (inboundEndQueued || readState != ReadState.DATA) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                         "Received DATA frame in invalid response read state " + readState);
+            }
+            Http2StreamState.checkAndGetState(state, frameData.header().type(), false, endOfStream, false);
+            if (endOfStream) {
+                inboundEndQueued = true;
+            }
+            return true;
+        } finally {
+            inboundStateLock.unlock();
+        }
+    }
+
     /**
      * Push decoded trailers into the stream buffer behind any earlier DATA frames.
      *
@@ -282,6 +306,15 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @param endOfStream whether the trailer block ended the stream
      */
     void pushTrailers(Http2Headers headers, boolean endOfStream) {
+        if (inboundEndQueued) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                     "Received trailers after inbound stream end was queued");
+        }
+        if (!endOfStream) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                     "Received trailers without END_STREAM");
+        }
+        inboundEndQueued = true;
         buffer.pushTrailers(headers, endOfStream);
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -512,10 +512,27 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @return the data frame
      */
     public Http2FrameData readOne(Duration pollTimeout) {
-        Object inboundItem = buffer.poll(pollTimeout);
+        StreamBuffer.InboundItem inboundItem = buffer.poll(pollTimeout);
 
         if (inboundItem != null) {
-            if (inboundItem instanceof StreamBuffer.InboundTrailers inboundTrailers) {
+            return switch (inboundItem) {
+            case StreamBuffer.InboundData inboundData -> {
+                Http2FrameData frameData = inboundData.frameData();
+                recvListener.frameHeader(ctx, streamId, frameData.header());
+                recvListener.frame(ctx, streamId, frameData.data());
+
+                switch (frameData.header().type()) {
+                case DATA:
+                    int flags = frameData.header().flags();
+                    boolean endOfStream = (flags & Http2Flag.END_OF_STREAM) == Http2Flag.END_OF_STREAM;
+                    data(frameData.header(), frameData.data(), endOfStream);
+                    yield frameData;
+                default:
+                    LOGGER.log(DEBUG, "Dropping frame " + frameData.header() + " expected header or data.");
+                    yield null;
+                }
+            }
+            case StreamBuffer.InboundTrailers inboundTrailers -> {
                 inboundStateLock.lock();
                 try {
                     trailersLocked(inboundTrailers.trailers(), inboundTrailers.endOfStream());
@@ -523,22 +540,9 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 } finally {
                     inboundStateLock.unlock();
                 }
-                return null;
+                yield null;
             }
-
-            Http2FrameData frameData = (Http2FrameData) inboundItem;
-            recvListener.frameHeader(ctx, streamId, frameData.header());
-            recvListener.frame(ctx, streamId, frameData.data());
-
-            switch (frameData.header().type()) {
-            case DATA:
-                int flags = frameData.header().flags();
-                boolean endOfStream = (flags & Http2Flag.END_OF_STREAM) == Http2Flag.END_OF_STREAM;
-                data(frameData.header(), frameData.data(), endOfStream);
-                return frameData;
-            default:
-                LOGGER.log(DEBUG, "Dropping frame " + frameData.header() + " expected header or data.");
-            }
+            };
         }
         return null;
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -20,7 +20,6 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -73,7 +72,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private final ReentrantLock inboundStateLock = new ReentrantLock();
     private final Condition inboundStateChanged = inboundStateLock.newCondition();
     private final CompletableFuture<Headers> trailers = new CompletableFuture<>();
-    private final AtomicBoolean closed = new AtomicBoolean();
+    private boolean closed;
 
     private Http2StreamState state = Http2StreamState.IDLE;
     private ReadState readState = ReadState.INIT;
@@ -243,19 +242,22 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * after local cancellation or connection shutdown.
      */
     public void close() {
-        if (closed.compareAndSet(false, true)) {
-            if (streamId != 0) {
-                connection.removeStream(streamId);
+        inboundStateLock.lock();
+        try {
+            if (closed) {
+                return;
             }
-            // A slot is reserved before request HEADERS are written, so every close must release it.
-            connection.releaseReservedStream();
-            inboundStateLock.lock();
-            try {
-                inboundStateChanged.signalAll();
-            } finally {
-                inboundStateLock.unlock();
-            }
+            closed = true;
+            inboundStateChanged.signalAll();
+        } finally {
+            inboundStateLock.unlock();
         }
+
+        if (streamId != 0) {
+            connection.removeStream(streamId);
+        }
+        // A slot is reserved before request HEADERS are written, so every close must release it.
+        connection.releaseReservedStream();
     }
 
     /**
@@ -296,7 +298,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         try {
             boolean expected100Continue = readState == ReadState.CONTINUE_100_HEADERS;
             long remainingNanos = readContinueTimeout.toNanos();
-            while (readState == ReadState.CONTINUE_100_HEADERS && !closed.get()) {
+            while (readState == ReadState.CONTINUE_100_HEADERS && !closed) {
                 if (remainingNanos <= 0) {
                     // Timeout, continue as if it was received.
                     readState = readState.check(ReadState.HEADERS);
@@ -403,13 +405,13 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         inboundStateLock.lock();
         try {
             long remainingNanos = timeout.toNanos();
-            while (readState == ReadState.HEADERS && !closed.get()) {
+            while (readState == ReadState.HEADERS && !closed) {
                 if (remainingNanos <= 0) {
                     throw new StreamTimeoutException(this, streamId, timeout);
                 }
                 remainingNanos = inboundStateChanged.awaitNanos(remainingNanos);
             }
-            if (currentHeaders == null && closed.get()) {
+            if (currentHeaders == null && closed) {
                 throw new IllegalStateException("Stream closed while waiting for response headers");
             }
             return currentHeaders;
@@ -487,6 +489,11 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     void inboundHeaders(Http2Headers headers, boolean endOfStream) {
         inboundStateLock.lock();
         try {
+            // A locally closed stream must not publish late headers, but the connection
+            // thread still decodes them to keep HPACK state aligned for other streams.
+            if (closed) {
+                return;
+            }
             switch (readState) {
             case CONTINUE_100_HEADERS -> continue100Locked(headers, endOfStream);
             case HEADERS -> headersLocked(headers, endOfStream);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -20,6 +20,7 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -71,6 +72,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private final Http2FrameListener sendListener = new Http2LoggingFrameListener("cl-send");
     private final Http2FrameListener recvListener = new Http2LoggingFrameListener("cl-recv");
     private final Http2Settings settings = Http2Settings.create();
+    private final AtomicBoolean reservationReleased = new AtomicBoolean();
     private final ReentrantLock inboundStateLock = new ReentrantLock();
     private final Condition inboundStateChanged = inboundStateLock.newCondition();
     private final CompletableFuture<Headers> trailers = new CompletableFuture<>();
@@ -130,11 +132,11 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                                      "Received RST_STREAM for stream "
                                              + streamId + " in IDLE state");
         }
-        this.state = Http2StreamState.checkAndGetState(this.state,
-                                                       Http2FrameType.RST_STREAM,
-                                                       false,
-                                                       false,
-                                                       false);
+        updateState(Http2StreamState.checkAndGetState(this.state,
+                                                      Http2FrameType.RST_STREAM,
+                                                      false,
+                                                      false,
+                                                      false));
 
         throw new RuntimeException("Reset of " + streamId + " stream received!");
     }
@@ -167,7 +169,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
     @Override
     public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
-        this.state = Http2StreamState.checkAndGetState(this.state, header.type(), false, endOfStream, false);
+        updateState(Http2StreamState.checkAndGetState(this.state, header.type(), false, endOfStream, false));
         readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
         flowControl.inbound().incrementWindowSize(header.length());
     }
@@ -260,7 +262,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             connection.removeStream(streamId);
         }
         // A slot is reserved before request HEADERS are written, so every close must release it.
-        connection.releaseReservedStream();
+        releaseReservation();
     }
 
     /**
@@ -289,9 +291,16 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL,
                                          "Received DATA frame in invalid response read state " + readState);
             }
-            Http2StreamState.checkAndGetState(state, frameData.header().type(), false, endOfStream, false);
+            Http2StreamState nextState = Http2StreamState.checkAndGetState(state,
+                                                                           frameData.header().type(),
+                                                                           false,
+                                                                           endOfStream,
+                                                                           false);
             if (endOfStream) {
                 inboundEndQueued = true;
+                if (nextState == Http2StreamState.CLOSED || state == Http2StreamState.HALF_CLOSED_LOCAL) {
+                    releaseReservation();
+                }
             }
             return true;
         } finally {
@@ -314,7 +323,15 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL,
                                      "Received trailers without END_STREAM");
         }
+        Http2StreamState nextState = Http2StreamState.checkAndGetState(state,
+                                                                       Http2FrameType.HEADERS,
+                                                                       false,
+                                                                       true,
+                                                                       true);
         inboundEndQueued = true;
+        if (nextState == Http2StreamState.CLOSED || state == Http2StreamState.HALF_CLOSED_LOCAL) {
+            releaseReservation();
+        }
         buffer.pushTrailers(headers, endOfStream);
     }
 
@@ -375,7 +392,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     public void writeHeaders(Http2Headers http2Headers, boolean endOfStream) {
         inboundStateLock.lock();
         try {
-            this.state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, true, endOfStream, true);
+            updateState(Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, true, endOfStream, true));
             this.readState = readState.check(http2Headers.httpHeaders().containsToken(HeaderValues.EXPECT_100)
                                                      ? ReadState.CONTINUE_100_HEADERS
                                                      : ReadState.HEADERS);
@@ -390,6 +407,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             flags = Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS);
         }
 
+        boolean success = false;
         try {
             // Keep ascending streamId order among concurrent streams
             // §5.1.1 - The identifier of a newly established stream MUST be numerically
@@ -408,11 +426,12 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             sendListener.headers(ctx, streamId, http2Headers);
             // First call to the server-starting stream, needs to be increasing sequence of odd numbers
             connection.writer().writeHeaders(http2Headers, streamId, flags, flowControl.outbound());
-        } catch (RuntimeException | Error e) {
-            // Undo stream registration and the reserved concurrency slot if the open/write path fails.
-            close();
-            throw e;
+            success = true;
         } finally {
+            if (!success) {
+                // Undo stream registration and the reserved concurrency slot if the open/write path fails.
+                close();
+            }
             streamIdSeq.unlock();
         }
     }
@@ -484,13 +503,13 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @return the data frame
      */
     public Http2FrameData readOne(Duration pollTimeout) {
-        StreamBuffer.InboundItem inboundItem = buffer.poll(pollTimeout);
+        Object inboundItem = buffer.poll(pollTimeout);
 
         if (inboundItem != null) {
-            if (inboundItem.isTrailers()) {
+            if (inboundItem instanceof StreamBuffer.InboundTrailers inboundTrailers) {
                 inboundStateLock.lock();
                 try {
-                    trailersLocked(inboundItem.trailers(), inboundItem.endOfStream());
+                    trailersLocked(inboundTrailers.trailers(), inboundTrailers.endOfStream());
                     inboundStateChanged.signalAll();
                 } finally {
                     inboundStateLock.unlock();
@@ -498,7 +517,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 return null;
             }
 
-            Http2FrameData frameData = inboundItem.frameData();
+            Http2FrameData frameData = (Http2FrameData) inboundItem;
             recvListener.frameHeader(ctx, streamId, frameData.header());
             recvListener.frame(ctx, streamId, frameData.data());
 
@@ -587,7 +606,12 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @param endOfStream whether the headers also closed the remote side
      */
     private void headersLocked(Http2Headers headers, boolean endOfStream) {
-        this.state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
+        Http2StreamState nextState =
+                Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
+        if (endOfStream && (nextState == Http2StreamState.CLOSED || state == Http2StreamState.HALF_CLOSED_LOCAL)) {
+            releaseReservation();
+        }
+        updateState(nextState);
         readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
         this.currentHeaders = headers;
         this.hasEntity = !endOfStream;
@@ -605,6 +629,9 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         // No stream state check as 100 continues are an exception.
         this.currentHeaders = headers;
         if (endOfStream) {
+            if (state == Http2StreamState.HALF_CLOSED_LOCAL) {
+                releaseReservation();
+            }
             readState = readState.check(ReadState.END);
         } else if (headers.status() == Status.CONTINUE_100) {
             // After 100 continue normal headers are expected.
@@ -624,20 +651,38 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @param endOfStream trailers must always close the remote side
      */
     private void trailersLocked(Http2Headers headers, boolean endOfStream) {
-        state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
+        Http2StreamState nextState =
+                Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
+        if (endOfStream && (nextState == Http2StreamState.CLOSED || state == Http2StreamState.HALF_CLOSED_LOCAL)) {
+            releaseReservation();
+        }
+        updateState(nextState);
         readState = readState.check(ReadState.END);
         hasEntity = false;
         trailers.complete(headers.httpHeaders());
     }
 
     private void write(Http2FrameData frameData, boolean endOfStream) {
-        this.state = Http2StreamState.checkAndGetState(this.state,
-                                                       frameData.header().type(),
-                                                       true,
-                                                       endOfStream,
-                                                       false);
+        updateState(Http2StreamState.checkAndGetState(this.state,
+                                                      frameData.header().type(),
+                                                      true,
+                                                      endOfStream,
+                                                      false));
         connection.writer().writeData(frameData,
                                       flowControl().outbound());
+    }
+
+    private void updateState(Http2StreamState newState) {
+        this.state = newState;
+        if (newState == Http2StreamState.CLOSED) {
+            releaseReservation();
+        }
+    }
+
+    private void releaseReservation() {
+        if (reservationReleased.compareAndSet(false, true)) {
+            connection.releaseReservedStream();
+        }
     }
 
     enum ReadState {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -18,10 +18,15 @@ package io.helidon.webclient.http2;
 
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.socket.SocketContext;
@@ -71,13 +76,17 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private final Http2FrameListener recvListener = new Http2LoggingFrameListener("cl-recv");
     private final Http2Settings settings = Http2Settings.create();
     private final List<Http2FrameData> continuationData = new ArrayList<>();
+    private final Lock pendingInboundHeadersLock = new ReentrantLock();
+    private final Deque<PendingInboundHeaders> pendingInboundHeaders = new ArrayDeque<>();
     private final CompletableFuture<Headers> trailers = new CompletableFuture<>();
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     private Http2StreamState state = Http2StreamState.IDLE;
     private ReadState readState = ReadState.INIT;
     private Http2Headers currentHeaders;
     // accessed from stream thread an connection thread
     private volatile StreamFlowControl flowControl;
+    private PendingInboundHeaders activeInboundHeaders;
     private boolean hasEntity;
 
     // streamId and buffer can only be created when we are locked in the stream id sequence
@@ -224,10 +233,25 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     }
 
     /**
-     * Removes the stream from underlying connection.
+     * Closes the stream, releases its reserved peer-concurrency slot, and
+     * escalates to a connection close if this stream still owns undecoded
+     * inbound header blocks.
+     * The connection close is deliberate because later streams cannot skip over
+     * an abandoned HPACK decode turn without corrupting connection-wide decoder state.
      */
     public void close() {
-        connection.removeStream(streamId);
+        if (closed.compareAndSet(false, true)) {
+            boolean hasUndecodedInboundHeaders = hasUndecodedInboundHeaders();
+            if (streamId != 0) {
+                connection.removeStream(streamId);
+            }
+            // A slot is reserved before request HEADERS are written, so every close must release it.
+            connection.releaseReservedStream();
+            if (hasUndecodedInboundHeaders) {
+                // Leaving queued header blocks behind would stall later HPACK decodes on the connection.
+                connection.closeUndecodedHeaders(streamId);
+            }
+        }
     }
 
     /**
@@ -241,6 +265,22 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         }
 
         buffer.push(frameData);
+    }
+
+    /**
+     * Queues one completed inbound header block for later decoding by the stream thread.
+     * The connection assigns the decode order when {@code END_OF_HEADERS} arrives so
+     * HPACK dynamic-table mutations are replayed in wire order even across streams.
+     *
+     * @param headerBlockOrder wire-order position of the completed header block
+     */
+    void inboundHeaderBlock(long headerBlockOrder) {
+        pendingInboundHeadersLock.lock();
+        try {
+            pendingInboundHeaders.addLast(PendingInboundHeaders.create(headerBlockOrder));
+        } finally {
+            pendingInboundHeadersLock.unlock();
+        }
     }
 
     BufferData read(int i) {
@@ -319,6 +359,10 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             sendListener.headers(ctx, streamId, http2Headers);
             // First call to the server-starting stream, needs to be increasing sequence of odd numbers
             connection.writer().writeHeaders(http2Headers, streamId, flags, flowControl.outbound());
+        } catch (RuntimeException | Error e) {
+            // Undo stream registration and the reserved concurrency slot if the open/write path fails.
+            close();
+            throw e;
         } finally {
             streamIdSeq.unlock();
         }
@@ -408,6 +452,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 // ^------- endOfHeaders
                 if (endOfHeaders) {
                     var requestHuffman = Http2HuffmanDecoder.create();
+                    PendingInboundHeaders pendingInboundHeaders = beginInboundHeaderBlock();
 
                     //  HTTP/1.1 100 Continue            HEADERS
                     //  Extension-Field: bar       ==>     - END_STREAM
@@ -430,25 +475,29 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                     //                                     + END_STREAM
                     //                                     + END_HEADERS
                     //                                       foo = bar
-                    switch (readState) {
-                    case CONTINUE_100_HEADERS -> {
-                        Http2Headers http2Headers = readHeaders(requestHuffman, false);
-                        // Clear out for headers
-                        continuationData.clear();
-                        this.continue100(http2Headers, endOfStream);
-                    }
-                    case HEADERS -> {
-                        // Add extension headers from 100 Continue
-                        Http2Headers http2Headers = readHeaders(requestHuffman, true);
-                        // Clear out for trailers
-                        continuationData.clear();
-                        this.headers(http2Headers, endOfStream);
-                    }
-                    case DATA, TRAILERS -> {
-                        Http2Headers http2Headers = readHeaders(requestHuffman, false);
-                        this.trailers(http2Headers, endOfStream);
-                    }
-                    default -> throw new IllegalStateException("Client is in wrong read state " + readState.name());
+                    try {
+                        switch (readState) {
+                        case CONTINUE_100_HEADERS -> {
+                            Http2Headers http2Headers = readHeaders(requestHuffman, false, pendingInboundHeaders);
+                            // Clear out for headers
+                            continuationData.clear();
+                            this.continue100(http2Headers, endOfStream);
+                        }
+                        case HEADERS -> {
+                            // Add extension headers from 100 Continue
+                            Http2Headers http2Headers = readHeaders(requestHuffman, true, pendingInboundHeaders);
+                            // Clear out for trailers
+                            continuationData.clear();
+                            this.headers(http2Headers, endOfStream);
+                        }
+                        case DATA, TRAILERS -> {
+                            Http2Headers http2Headers = readHeaders(requestHuffman, false, pendingInboundHeaders);
+                            this.trailers(http2Headers, endOfStream);
+                        }
+                        default -> throw new IllegalStateException("Client is in wrong read state " + readState.name());
+                        }
+                    } finally {
+                        finishInboundHeaderBlock();
                     }
                 }
                 break;
@@ -474,16 +523,82 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         this.hasEntity = !endOfStream;
     }
 
-    private Http2Headers readHeaders(Http2HuffmanDecoder decoder, boolean mergeWithPrevious) {
+    /**
+     * Decodes one completed inbound header block using the connection-assigned decode order
+     * stored in {@code pendingInboundHeaders}.
+     * That order preserves HPACK dynamic-table consistency when multiple streams are
+     * receiving headers concurrently.
+     *
+     * @param decoder Huffman decoder used for literal decoding
+     * @param mergeWithPrevious whether to merge into previously received headers
+     * @param pendingInboundHeaders captured frames and decode order for the current block
+     * @return decoded HTTP/2 headers
+     */
+    private Http2Headers readHeaders(Http2HuffmanDecoder decoder,
+                                     boolean mergeWithPrevious,
+                                     PendingInboundHeaders pendingInboundHeaders) {
         Http2Headers http2Headers =
                 connection.readHeaders(this,
                                        decoder,
                                        mergeWithPrevious && currentHeaders != null
                                                ? currentHeaders
                                                : Http2Headers.create(WritableHeaders.create()),
-                                       continuationData.toArray(new Http2FrameData[0]));
+                                       pendingInboundHeaders.decodeOrder(),
+                                       pendingInboundHeaders.frameData());
         recvListener.headers(ctx, streamId, http2Headers);
         return http2Headers;
+    }
+
+    /**
+     * Marks the oldest queued inbound header block as actively decoding and snapshots
+     * the accumulated {@code HEADERS}/{@code CONTINUATION} frames for it.
+     * Tracking the active block lets {@link #close()} detect whether abandoning this
+     * stream would strand the connection-level decode sequence.
+     *
+     * @return metadata for the header block currently being decoded
+     */
+    private PendingInboundHeaders beginInboundHeaderBlock() {
+        pendingInboundHeadersLock.lock();
+        try {
+            PendingInboundHeaders pendingInboundHeaders = this.pendingInboundHeaders.pollFirst();
+            if (pendingInboundHeaders == null) {
+                throw new IllegalStateException("Missing inbound header block order for stream " + streamId);
+            }
+            pendingInboundHeaders.captureFrames(continuationData);
+            activeInboundHeaders = pendingInboundHeaders;
+            return pendingInboundHeaders;
+        } finally {
+            pendingInboundHeadersLock.unlock();
+        }
+    }
+
+    /**
+     * Clears the active inbound header block after decode completes or fails.
+     * This distinguishes finished work from stranded work when the stream is closed.
+     */
+    private void finishInboundHeaderBlock() {
+        pendingInboundHeadersLock.lock();
+        try {
+            activeInboundHeaders = null;
+        } finally {
+            pendingInboundHeadersLock.unlock();
+        }
+    }
+
+    /**
+     * Returns whether this stream still owns queued or in-progress inbound header blocks.
+     * This is used during close to decide whether the connection must also be closed to
+     * unblock later HPACK decoders waiting for this stream's turn.
+     *
+     * @return {@code true} if there are queued or active undecoded header blocks
+     */
+    private boolean hasUndecodedInboundHeaders() {
+        pendingInboundHeadersLock.lock();
+        try {
+            return activeInboundHeaders != null || !pendingInboundHeaders.isEmpty();
+        } finally {
+            pendingInboundHeadersLock.unlock();
+        }
     }
 
     private void write(Http2FrameData frameData, boolean endOfStream) {
@@ -515,6 +630,58 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 return newState;
             }
             throw new IllegalStateException("Transition from " + this + " to " + newState + " is not allowed!");
+        }
+    }
+
+    /**
+     * Captures one completed inbound header block until the stream thread is ready to decode it.
+     * The connection assigns {@link #decodeOrder()} when {@code END_OF_HEADERS} arrives because
+     * HPACK dynamic-table updates are connection-scoped and later blocks must not overtake earlier ones.
+     */
+    private static final class PendingInboundHeaders {
+        private final long decodeOrder;
+        private Http2FrameData[] frameData = new Http2FrameData[0];
+
+        private PendingInboundHeaders(long decodeOrder) {
+            this.decodeOrder = decodeOrder;
+        }
+
+        /**
+         * Creates a holder for one completed inbound header block.
+         *
+         * @param decodeOrder wire-order position assigned by the connection
+         * @return pending inbound header metadata
+         */
+        static PendingInboundHeaders create(long decodeOrder) {
+            return new PendingInboundHeaders(decodeOrder);
+        }
+
+        /**
+         * Returns the wire-order position this block must use during HPACK decode.
+         *
+         * @return decode order assigned by the connection
+         */
+        long decodeOrder() {
+            return decodeOrder;
+        }
+
+        /**
+         * Returns the captured {@code HEADERS}/{@code CONTINUATION} frames for this block.
+         *
+         * @return frame data for the completed header block
+         */
+        Http2FrameData[] frameData() {
+            return frameData;
+        }
+
+        /**
+         * Copies the accumulated header frames into this holder so the stream can reuse
+         * its working buffer for subsequent header blocks.
+         *
+         * @param continuationData frames collected for the completed header block
+         */
+        void captureFrames(List<Http2FrameData> continuationData) {
+            frameData = continuationData.toArray(new Http2FrameData[0]);
         }
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -59,6 +59,8 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
     private static final System.Logger LOGGER = System.getLogger(Http2ClientStream.class.getName());
     private static final Set<Http2StreamState> NON_CANCELABLE = Set.of(Http2StreamState.CLOSED, Http2StreamState.IDLE);
+    // Http2Headers.create(...) clones the supplied basis headers, so one shared empty basis is sufficient.
+    private static final Http2Headers EMPTY_INBOUND_HEADER_DECODE_BASIS = Http2Headers.create(WritableHeaders.create());
 
     private final Http2ClientConnection connection;
     private final Http2Settings serverSettings;
@@ -273,6 +275,16 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         buffer.push(frameData);
     }
 
+    /**
+     * Push decoded trailers into the stream buffer behind any earlier DATA frames.
+     *
+     * @param headers decoded trailer headers
+     * @param endOfStream whether the trailer block ended the stream
+     */
+    void pushTrailers(Http2Headers headers, boolean endOfStream) {
+        buffer.pushTrailers(headers, endOfStream);
+    }
+
     BufferData read(int i) {
         return read();
     }
@@ -439,9 +451,21 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @return the data frame
      */
     public Http2FrameData readOne(Duration pollTimeout) {
-        Http2FrameData frameData = buffer.poll(pollTimeout);
+        StreamBuffer.InboundItem inboundItem = buffer.poll(pollTimeout);
 
-        if (frameData != null) {
+        if (inboundItem != null) {
+            if (inboundItem.isTrailers()) {
+                inboundStateLock.lock();
+                try {
+                    trailersLocked(inboundItem.trailers(), inboundItem.endOfStream());
+                    inboundStateChanged.signalAll();
+                } finally {
+                    inboundStateLock.unlock();
+                }
+                return null;
+            }
+
+            Http2FrameData frameData = inboundItem.frameData();
             recvListener.frameHeader(ctx, streamId, frameData.header());
             recvListener.frame(ctx, streamId, frameData.data());
 
@@ -472,7 +496,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             if (readState == ReadState.HEADERS && currentHeaders != null) {
                 return currentHeaders;
             }
-            return Http2Headers.create(WritableHeaders.create());
+            return EMPTY_INBOUND_HEADER_DECODE_BASIS;
         } finally {
             inboundStateLock.unlock();
         }
@@ -497,7 +521,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             switch (readState) {
             case CONTINUE_100_HEADERS -> continue100Locked(headers, endOfStream);
             case HEADERS -> headersLocked(headers, endOfStream);
-            case DATA, TRAILERS -> trailersLocked(headers, endOfStream);
+            case DATA, TRAILERS -> pushTrailers(headers, endOfStream);
             default -> throw new IllegalStateException("Client is in wrong read state " + readState.name());
             }
             inboundStateChanged.signalAll();
@@ -569,6 +593,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private void trailersLocked(Http2Headers headers, boolean endOfStream) {
         state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
         readState = readState.check(ReadState.END);
+        hasEntity = false;
         trailers.complete(headers.httpHeaders());
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -18,14 +18,10 @@ package io.helidon.webclient.http2;
 
 import java.io.UncheckedIOException;
 import java.time.Duration;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
@@ -43,7 +39,6 @@ import io.helidon.http.http2.Http2FrameListener;
 import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
-import io.helidon.http.http2.Http2HuffmanDecoder;
 import io.helidon.http.http2.Http2LoggingFrameListener;
 import io.helidon.http.http2.Http2Ping;
 import io.helidon.http.http2.Http2Priority;
@@ -75,9 +70,8 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private final Http2FrameListener sendListener = new Http2LoggingFrameListener("cl-send");
     private final Http2FrameListener recvListener = new Http2LoggingFrameListener("cl-recv");
     private final Http2Settings settings = Http2Settings.create();
-    private final List<Http2FrameData> continuationData = new ArrayList<>();
-    private final Lock pendingInboundHeadersLock = new ReentrantLock();
-    private final Deque<PendingInboundHeaders> pendingInboundHeaders = new ArrayDeque<>();
+    private final ReentrantLock inboundStateLock = new ReentrantLock();
+    private final Condition inboundStateChanged = inboundStateLock.newCondition();
     private final CompletableFuture<Headers> trailers = new CompletableFuture<>();
     private final AtomicBoolean closed = new AtomicBoolean();
 
@@ -86,7 +80,6 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private Http2Headers currentHeaders;
     // accessed from stream thread an connection thread
     private volatile StreamFlowControl flowControl;
-    private PendingInboundHeaders activeInboundHeaders;
     private boolean hasEntity;
 
     // streamId and buffer can only be created when we are locked in the stream id sequence
@@ -119,10 +112,13 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
     @Override
     public void headers(Http2Headers headers, boolean endOfStream) {
-        this.state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
-        readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
-        this.currentHeaders = headers;
-        this.hasEntity = !endOfStream;
+        inboundStateLock.lock();
+        try {
+            headersLocked(headers, endOfStream);
+            inboundStateChanged.signalAll();
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     @Override
@@ -189,9 +185,13 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     }
 
     void trailers(Http2Headers headers, boolean endOfStream) {
-        state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
-        readState = readState.check(ReadState.END);
-        trailers.complete(headers.httpHeaders());
+        inboundStateLock.lock();
+        try {
+            trailersLocked(headers, endOfStream);
+            inboundStateChanged.signalAll();
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     /**
@@ -210,7 +210,12 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @return {@code true} if entity expected, {@code false} otherwise.
      */
     public boolean hasEntity() {
-        return hasEntity;
+        inboundStateLock.lock();
+        try {
+            return hasEntity;
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     /**
@@ -233,23 +238,22 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     }
 
     /**
-     * Closes the stream, releases its reserved peer-concurrency slot, and
-     * escalates to a connection close if this stream still owns undecoded
-     * inbound header blocks.
-     * The connection close is deliberate because later streams cannot skip over
-     * an abandoned HPACK decode turn without corrupting connection-wide decoder state.
+     * Closes the stream and releases its reserved peer-concurrency slot.
+     * Waiting callers are signaled so response-header waits do not block forever
+     * after local cancellation or connection shutdown.
      */
     public void close() {
         if (closed.compareAndSet(false, true)) {
-            boolean hasUndecodedInboundHeaders = hasUndecodedInboundHeaders();
             if (streamId != 0) {
                 connection.removeStream(streamId);
             }
             // A slot is reserved before request HEADERS are written, so every close must release it.
             connection.releaseReservedStream();
-            if (hasUndecodedInboundHeaders) {
-                // Leaving queued header blocks behind would stall later HPACK decodes on the connection.
-                connection.closeUndecodedHeaders(streamId);
+            inboundStateLock.lock();
+            try {
+                inboundStateChanged.signalAll();
+            } finally {
+                inboundStateLock.unlock();
             }
         }
     }
@@ -267,22 +271,6 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         buffer.push(frameData);
     }
 
-    /**
-     * Queues one completed inbound header block for later decoding by the stream thread.
-     * The connection assigns the decode order when {@code END_OF_HEADERS} arrives so
-     * HPACK dynamic-table mutations are replayed in wire order even across streams.
-     *
-     * @param headerBlockOrder wire-order position of the completed header block
-     */
-    void inboundHeaderBlock(long headerBlockOrder) {
-        pendingInboundHeadersLock.lock();
-        try {
-            pendingInboundHeaders.addLast(PendingInboundHeaders.create(headerBlockOrder));
-        } finally {
-            pendingInboundHeadersLock.unlock();
-        }
-    }
-
     BufferData read(int i) {
         return read();
     }
@@ -293,7 +281,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @return the buffer data
      */
     public BufferData read() {
-        while (state == Http2StreamState.HALF_CLOSED_LOCAL && readState != ReadState.END && hasEntity) {
+        while (expectsEntityData()) {
             Http2FrameData frameData = readOne(timeout);
             if (frameData != null) {
                 return frameData.data();
@@ -304,23 +292,31 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
     Status waitFor100Continue() {
         Duration readContinueTimeout = http2ClientConfig.readContinueTimeout();
-        boolean expected100Continue = readState == ReadState.CONTINUE_100_HEADERS;
+        inboundStateLock.lock();
         try {
-            while (readState == ReadState.CONTINUE_100_HEADERS) {
-                readOne(readContinueTimeout);
+            boolean expected100Continue = readState == ReadState.CONTINUE_100_HEADERS;
+            long remainingNanos = readContinueTimeout.toNanos();
+            while (readState == ReadState.CONTINUE_100_HEADERS && !closed.get()) {
+                if (remainingNanos <= 0) {
+                    // Timeout, continue as if it was received.
+                    readState = readState.check(ReadState.HEADERS);
+                    LOGGER.log(DEBUG, "Server didn't respond within 100 Continue timeout in "
+                            + readContinueTimeout
+                            + ", sending data.");
+                    return Status.CONTINUE_100;
+                }
+                remainingNanos = inboundStateChanged.awaitNanos(remainingNanos);
             }
-        } catch (StreamTimeoutException ignored) {
-            // Timeout, continue as if it was received
-            readState = readState.check(ReadState.HEADERS);
-            LOGGER.log(DEBUG, "Server didn't respond within 100 Continue timeout in "
-                    + readContinueTimeout
-                    + ", sending data.");
-            return Status.CONTINUE_100;
+            if (expected100Continue && currentHeaders != null) {
+                return currentHeaders.status();
+            }
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for 100 Continue response", e);
+        } finally {
+            inboundStateLock.unlock();
         }
-        if (expected100Continue && currentHeaders != null) {
-            return currentHeaders.status();
-        }
-        return null;
     }
 
     /**
@@ -330,10 +326,16 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @param endOfStream  end of stream marker
      */
     public void writeHeaders(Http2Headers http2Headers, boolean endOfStream) {
-        this.state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, true, endOfStream, true);
-        this.readState = readState.check(http2Headers.httpHeaders().containsToken(HeaderValues.EXPECT_100)
-                                                 ? ReadState.CONTINUE_100_HEADERS
-                                                 : ReadState.HEADERS);
+        inboundStateLock.lock();
+        try {
+            this.state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, true, endOfStream, true);
+            this.readState = readState.check(http2Headers.httpHeaders().containsToken(HeaderValues.EXPECT_100)
+                                                     ? ReadState.CONTINUE_100_HEADERS
+                                                     : ReadState.HEADERS);
+            inboundStateChanged.signalAll();
+        } finally {
+            inboundStateLock.unlock();
+        }
         Http2Flag.HeaderFlags flags;
         if (endOfStream) {
             flags = Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM);
@@ -398,13 +400,25 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @return the headers
      */
     public Http2Headers readHeaders() {
-        while (readState == ReadState.HEADERS) {
-            Http2FrameData frameData = readOne(timeout);
-            if (frameData != null) {
-                throw new IllegalStateException("Unexpected frame type " + frameData.header() + ", HEADERS are expected.");
+        inboundStateLock.lock();
+        try {
+            long remainingNanos = timeout.toNanos();
+            while (readState == ReadState.HEADERS && !closed.get()) {
+                if (remainingNanos <= 0) {
+                    throw new StreamTimeoutException(this, streamId, timeout);
+                }
+                remainingNanos = inboundStateChanged.awaitNanos(remainingNanos);
             }
+            if (currentHeaders == null && closed.get()) {
+                throw new IllegalStateException("Stream closed while waiting for response headers");
+            }
+            return currentHeaders;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for response headers", e);
+        } finally {
+            inboundStateLock.unlock();
         }
-        return currentHeaders;
     }
 
     /**
@@ -426,81 +440,15 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         Http2FrameData frameData = buffer.poll(pollTimeout);
 
         if (frameData != null) {
-
             recvListener.frameHeader(ctx, streamId, frameData.header());
             recvListener.frame(ctx, streamId, frameData.data());
 
-            int flags = frameData.header().flags();
-            boolean endOfStream = (flags & Http2Flag.END_OF_STREAM) == Http2Flag.END_OF_STREAM;
-            boolean endOfHeaders = (flags & Http2Flag.END_OF_HEADERS) == Http2Flag.END_OF_HEADERS;
-
             switch (frameData.header().type()) {
             case DATA:
+                int flags = frameData.header().flags();
+                boolean endOfStream = (flags & Http2Flag.END_OF_STREAM) == Http2Flag.END_OF_STREAM;
                 data(frameData.header(), frameData.data(), endOfStream);
                 return frameData;
-
-            case HEADERS, CONTINUATION:
-                continuationData.add(frameData);
-
-                // (HEADERS[100-continue] CONTINUATION*)*
-                // ^------- endOfHeaders
-                // HEADERS+
-                // CONTINUATION*
-                // ^------- endOfHeaders
-                // DATA*
-                // (HEADERS[trailers] CONTINUATION*)+
-                // ^------- endOfHeaders
-                if (endOfHeaders) {
-                    var requestHuffman = Http2HuffmanDecoder.create();
-                    PendingInboundHeaders pendingInboundHeaders = beginInboundHeaderBlock();
-
-                    //  HTTP/1.1 100 Continue            HEADERS
-                    //  Extension-Field: bar       ==>     - END_STREAM
-                    //                                     + END_HEADERS
-                    //                                       :status = 100
-                    //                                       extension-field = bar
-                    //
-                    //  HTTP/1.1 200 OK                  HEADERS
-                    //  Content-Type: image/jpeg   ==>     - END_STREAM
-                    //  Transfer-Encoding: chunked         + END_HEADERS
-                    //  Trailer: Foo                         :status = 200
-                    //                                       content-type = image/jpeg
-                    //  123                                  trailer = Foo
-                    //  {binary data}
-                    //  0                                DATA
-                    //  Foo: bar                           - END_STREAM
-                    //                                   {binary data}
-                    //
-                    //                                   HEADERS
-                    //                                     + END_STREAM
-                    //                                     + END_HEADERS
-                    //                                       foo = bar
-                    try {
-                        switch (readState) {
-                        case CONTINUE_100_HEADERS -> {
-                            Http2Headers http2Headers = readHeaders(requestHuffman, false, pendingInboundHeaders);
-                            // Clear out for headers
-                            continuationData.clear();
-                            this.continue100(http2Headers, endOfStream);
-                        }
-                        case HEADERS -> {
-                            // Add extension headers from 100 Continue
-                            Http2Headers http2Headers = readHeaders(requestHuffman, true, pendingInboundHeaders);
-                            // Clear out for trailers
-                            continuationData.clear();
-                            this.headers(http2Headers, endOfStream);
-                        }
-                        case DATA, TRAILERS -> {
-                            Http2Headers http2Headers = readHeaders(requestHuffman, false, pendingInboundHeaders);
-                            this.trailers(http2Headers, endOfStream);
-                        }
-                        default -> throw new IllegalStateException("Client is in wrong read state " + readState.name());
-                        }
-                    } finally {
-                        finishInboundHeaderBlock();
-                    }
-                }
-                break;
             default:
                 LOGGER.log(DEBUG, "Dropping frame " + frameData.header() + " expected header or data.");
             }
@@ -508,97 +456,113 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         return null;
     }
 
-    private void continue100(Http2Headers headers, boolean endOfStream) {
-        // no stream state check as 100 continues are an exception
+    /**
+     * Returns the base headers to use when decoding the next inbound header block.
+     * Final response headers after a {@code 100 Continue} must merge the previously
+     * received informational headers, while the first informational block and trailers
+     * always start from a fresh header set.
+     *
+     * @return base headers for the next inbound decode
+     */
+    Http2Headers inboundHeaderDecodeBasis() {
+        inboundStateLock.lock();
+        try {
+            if (readState == ReadState.HEADERS && currentHeaders != null) {
+                return currentHeaders;
+            }
+            return Http2Headers.create(WritableHeaders.create());
+        } finally {
+            inboundStateLock.unlock();
+        }
+    }
+
+    /**
+     * Applies a fully decoded inbound header block received on the connection thread.
+     * The block is routed according to the current inbound read state:
+     * informational headers, final response headers, or trailers.
+     *
+     * @param headers decoded headers
+     * @param endOfStream whether the decoded block also ended the stream
+     */
+    void inboundHeaders(Http2Headers headers, boolean endOfStream) {
+        inboundStateLock.lock();
+        try {
+            switch (readState) {
+            case CONTINUE_100_HEADERS -> continue100Locked(headers, endOfStream);
+            case HEADERS -> headersLocked(headers, endOfStream);
+            case DATA, TRAILERS -> trailersLocked(headers, endOfStream);
+            default -> throw new IllegalStateException("Client is in wrong read state " + readState.name());
+            }
+            inboundStateChanged.signalAll();
+        } finally {
+            inboundStateLock.unlock();
+        }
+    }
+
+    /**
+     * Determines whether the caller should keep polling for inbound {@code DATA}
+     * frames. Once final headers or trailers mark the response complete, reads
+     * stop even if no explicit empty data frame is received.
+     *
+     * @return {@code true} when entity data is still expected
+     */
+    private boolean expectsEntityData() {
+        inboundStateLock.lock();
+        try {
+            return state == Http2StreamState.HALF_CLOSED_LOCAL && readState != ReadState.END && hasEntity;
+        } finally {
+            inboundStateLock.unlock();
+        }
+    }
+
+    /**
+     * Applies the final non-trailer response headers and advances the inbound
+     * stream state to either body reads or end-of-stream.
+     *
+     * @param headers decoded response headers
+     * @param endOfStream whether the headers also closed the remote side
+     */
+    private void headersLocked(Http2Headers headers, boolean endOfStream) {
+        this.state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
+        readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
+        this.currentHeaders = headers;
+        this.hasEntity = !endOfStream;
+    }
+
+    /**
+     * Applies informational headers received while the caller is still waiting
+     * on {@code Expect: 100-continue}. A final non-100 response can also arrive
+     * in this state, so this method must handle both cases.
+     *
+     * @param headers decoded informational or final headers
+     * @param endOfStream whether the headers also closed the remote side
+     */
+    private void continue100Locked(Http2Headers headers, boolean endOfStream) {
+        // No stream state check as 100 continues are an exception.
         this.currentHeaders = headers;
         if (endOfStream) {
             readState = readState.check(ReadState.END);
         } else if (headers.status() == Status.CONTINUE_100) {
-            // After 100 continue normal headers are expected
+            // After 100 continue normal headers are expected.
             readState = readState.check(ReadState.HEADERS);
         } else {
-            // Some headers already came, but not 100 continue
+            // Some headers already came, but not 100 continue.
             readState = readState.check(ReadState.DATA);
         }
         this.hasEntity = !endOfStream;
     }
 
     /**
-     * Decodes one completed inbound header block using the connection-assigned decode order
-     * stored in {@code pendingInboundHeaders}.
-     * That order preserves HPACK dynamic-table consistency when multiple streams are
-     * receiving headers concurrently.
+     * Publishes inbound trailers and completes the trailers future once the
+     * remote side finishes the response.
      *
-     * @param decoder Huffman decoder used for literal decoding
-     * @param mergeWithPrevious whether to merge into previously received headers
-     * @param pendingInboundHeaders captured frames and decode order for the current block
-     * @return decoded HTTP/2 headers
+     * @param headers decoded trailer headers
+     * @param endOfStream trailers must always close the remote side
      */
-    private Http2Headers readHeaders(Http2HuffmanDecoder decoder,
-                                     boolean mergeWithPrevious,
-                                     PendingInboundHeaders pendingInboundHeaders) {
-        Http2Headers http2Headers =
-                connection.readHeaders(this,
-                                       decoder,
-                                       mergeWithPrevious && currentHeaders != null
-                                               ? currentHeaders
-                                               : Http2Headers.create(WritableHeaders.create()),
-                                       pendingInboundHeaders.decodeOrder(),
-                                       pendingInboundHeaders.frameData());
-        recvListener.headers(ctx, streamId, http2Headers);
-        return http2Headers;
-    }
-
-    /**
-     * Marks the oldest queued inbound header block as actively decoding and snapshots
-     * the accumulated {@code HEADERS}/{@code CONTINUATION} frames for it.
-     * Tracking the active block lets {@link #close()} detect whether abandoning this
-     * stream would strand the connection-level decode sequence.
-     *
-     * @return metadata for the header block currently being decoded
-     */
-    private PendingInboundHeaders beginInboundHeaderBlock() {
-        pendingInboundHeadersLock.lock();
-        try {
-            PendingInboundHeaders pendingInboundHeaders = this.pendingInboundHeaders.pollFirst();
-            if (pendingInboundHeaders == null) {
-                throw new IllegalStateException("Missing inbound header block order for stream " + streamId);
-            }
-            pendingInboundHeaders.captureFrames(continuationData);
-            activeInboundHeaders = pendingInboundHeaders;
-            return pendingInboundHeaders;
-        } finally {
-            pendingInboundHeadersLock.unlock();
-        }
-    }
-
-    /**
-     * Clears the active inbound header block after decode completes or fails.
-     * This distinguishes finished work from stranded work when the stream is closed.
-     */
-    private void finishInboundHeaderBlock() {
-        pendingInboundHeadersLock.lock();
-        try {
-            activeInboundHeaders = null;
-        } finally {
-            pendingInboundHeadersLock.unlock();
-        }
-    }
-
-    /**
-     * Returns whether this stream still owns queued or in-progress inbound header blocks.
-     * This is used during close to decide whether the connection must also be closed to
-     * unblock later HPACK decoders waiting for this stream's turn.
-     *
-     * @return {@code true} if there are queued or active undecoded header blocks
-     */
-    private boolean hasUndecodedInboundHeaders() {
-        pendingInboundHeadersLock.lock();
-        try {
-            return activeInboundHeaders != null || !pendingInboundHeaders.isEmpty();
-        } finally {
-            pendingInboundHeadersLock.unlock();
-        }
+    private void trailersLocked(Http2Headers headers, boolean endOfStream) {
+        state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
+        readState = readState.check(ReadState.END);
+        trailers.complete(headers.httpHeaders());
     }
 
     private void write(Http2FrameData frameData, boolean endOfStream) {
@@ -630,58 +594,6 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 return newState;
             }
             throw new IllegalStateException("Transition from " + this + " to " + newState + " is not allowed!");
-        }
-    }
-
-    /**
-     * Captures one completed inbound header block until the stream thread is ready to decode it.
-     * The connection assigns {@link #decodeOrder()} when {@code END_OF_HEADERS} arrives because
-     * HPACK dynamic-table updates are connection-scoped and later blocks must not overtake earlier ones.
-     */
-    private static final class PendingInboundHeaders {
-        private final long decodeOrder;
-        private Http2FrameData[] frameData = new Http2FrameData[0];
-
-        private PendingInboundHeaders(long decodeOrder) {
-            this.decodeOrder = decodeOrder;
-        }
-
-        /**
-         * Creates a holder for one completed inbound header block.
-         *
-         * @param decodeOrder wire-order position assigned by the connection
-         * @return pending inbound header metadata
-         */
-        static PendingInboundHeaders create(long decodeOrder) {
-            return new PendingInboundHeaders(decodeOrder);
-        }
-
-        /**
-         * Returns the wire-order position this block must use during HPACK decode.
-         *
-         * @return decode order assigned by the connection
-         */
-        long decodeOrder() {
-            return decodeOrder;
-        }
-
-        /**
-         * Returns the captured {@code HEADERS}/{@code CONTINUATION} frames for this block.
-         *
-         * @return frame data for the completed header block
-         */
-        Http2FrameData[] frameData() {
-            return frameData;
-        }
-
-        /**
-         * Copies the accumulated header frames into this holder so the stream can reuse
-         * its working buffer for subsequent header blocks.
-         *
-         * @param continuationData frames collected for the completed header block
-         */
-        void captureFrames(List<Http2FrameData> continuationData) {
-            frameData = continuationData.toArray(new Http2FrameData[0]);
         }
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -76,15 +76,15 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private final ReentrantLock inboundStateLock = new ReentrantLock();
     private final Condition inboundStateChanged = inboundStateLock.newCondition();
     private final CompletableFuture<Headers> trailers = new CompletableFuture<>();
-    private boolean closed;
+    private volatile boolean closed;
 
-    private Http2StreamState state = Http2StreamState.IDLE;
-    private ReadState readState = ReadState.INIT;
+    private volatile Http2StreamState state = Http2StreamState.IDLE;
+    private volatile ReadState readState = ReadState.INIT;
     private Http2Headers currentHeaders;
     // accessed from stream thread an connection thread
     private volatile StreamFlowControl flowControl;
     private boolean hasEntity;
-    private boolean inboundEndQueued;
+    private volatile boolean inboundEndQueued;
 
     // streamId and buffer can only be created when we are locked in the stream id sequence
     private int streamId;
@@ -281,26 +281,35 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     boolean prepareInboundData(Http2FrameData frameData) {
         int flags = frameData.header().flags();
         boolean endOfStream = (flags & Http2Flag.END_OF_STREAM) == Http2Flag.END_OF_STREAM;
+        ReadState currentReadState = readState;
+
+        if (closed) {
+            return false;
+        }
+        if (inboundEndQueued || currentReadState != ReadState.DATA) {
+            throw invalidInboundDataState(currentReadState);
+        }
+        if (!endOfStream) {
+            return true;
+        }
 
         inboundStateLock.lock();
         try {
             if (closed) {
                 return false;
             }
-            if (inboundEndQueued || readState != ReadState.DATA) {
-                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
-                                         "Received DATA frame in invalid response read state " + readState);
+            currentReadState = readState;
+            if (inboundEndQueued || currentReadState != ReadState.DATA) {
+                throw invalidInboundDataState(currentReadState);
             }
             Http2StreamState nextState = Http2StreamState.checkAndGetState(state,
                                                                            frameData.header().type(),
                                                                            false,
                                                                            endOfStream,
                                                                            false);
-            if (endOfStream) {
-                inboundEndQueued = true;
-                if (nextState == Http2StreamState.CLOSED || state == Http2StreamState.HALF_CLOSED_LOCAL) {
-                    releaseReservation();
-                }
+            inboundEndQueued = true;
+            if (nextState == Http2StreamState.CLOSED || state == Http2StreamState.HALF_CLOSED_LOCAL) {
+                releaseReservation();
             }
             return true;
         } finally {
@@ -683,6 +692,11 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         if (reservationReleased.compareAndSet(false, true)) {
             connection.releaseReservedStream();
         }
+    }
+
+    private Http2Exception invalidInboundDataState(ReadState currentReadState) {
+        return new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                  "Received DATA frame in invalid response read state " + currentReadState);
     }
 
     enum ReadState {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
@@ -31,7 +31,7 @@ class StreamBuffer {
 
     private final Lock streamLock = new ReentrantLock();
     private final Semaphore dequeSemaphore = new Semaphore(1);
-    private final Queue<Object> buffer = new ArrayDeque<>();
+    private final Queue<InboundItem> buffer = new ArrayDeque<>();
     private final Http2ClientStream stream;
     private final int streamId;
 
@@ -40,7 +40,7 @@ class StreamBuffer {
         this.streamId = streamId;
     }
 
-    Object poll(Duration timeout) {
+    InboundItem poll(Duration timeout) {
         try {
             // Block deque thread when queue is empty
             // avoid CPU burning
@@ -59,14 +59,14 @@ class StreamBuffer {
     }
 
     void push(Http2FrameData frameData) {
-        push((Object) frameData);
+        push(new InboundData(frameData));
     }
 
     void pushTrailers(Http2Headers headers, boolean endOfStream) {
         push(new InboundTrailers(headers, endOfStream));
     }
 
-    private void push(Object item) {
+    private void push(InboundItem item) {
         try {
             streamLock.lock();
             buffer.add(item);
@@ -77,6 +77,12 @@ class StreamBuffer {
         }
     }
 
-    record InboundTrailers(Http2Headers trailers, boolean endOfStream) {
+    sealed interface InboundItem permits InboundData, InboundTrailers {
+    }
+
+    record InboundData(Http2FrameData frameData) implements InboundItem {
+    }
+
+    record InboundTrailers(Http2Headers trailers, boolean endOfStream) implements InboundItem {
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,13 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2Headers;
 
 class StreamBuffer {
 
     private final Lock streamLock = new ReentrantLock();
     private final Semaphore dequeSemaphore = new Semaphore(1);
-    private final Queue<Http2FrameData> buffer = new ArrayDeque<>();
+    private final Queue<InboundItem> buffer = new ArrayDeque<>();
     private final Http2ClientStream stream;
     private final int streamId;
 
@@ -39,7 +40,7 @@ class StreamBuffer {
         this.streamId = streamId;
     }
 
-    Http2FrameData poll(Duration timeout) {
+    InboundItem poll(Duration timeout) {
         try {
             // Block deque thread when queue is empty
             // avoid CPU burning
@@ -58,13 +59,57 @@ class StreamBuffer {
     }
 
     void push(Http2FrameData frameData) {
+        push(InboundItem.data(frameData));
+    }
+
+    void pushTrailers(Http2Headers headers, boolean endOfStream) {
+        push(InboundItem.trailers(headers, endOfStream));
+    }
+
+    private void push(InboundItem item) {
         try {
             streamLock.lock();
-            buffer.add(frameData);
+            buffer.add(item);
         } finally {
             streamLock.unlock();
             // Release deque threads
             dequeSemaphore.release();
+        }
+    }
+
+    static final class InboundItem {
+        private final Http2FrameData frameData;
+        private final Http2Headers trailers;
+        private final boolean endOfStream;
+
+        private InboundItem(Http2FrameData frameData, Http2Headers trailers, boolean endOfStream) {
+            this.frameData = frameData;
+            this.trailers = trailers;
+            this.endOfStream = endOfStream;
+        }
+
+        private static InboundItem data(Http2FrameData frameData) {
+            return new InboundItem(frameData, null, false);
+        }
+
+        private static InboundItem trailers(Http2Headers trailers, boolean endOfStream) {
+            return new InboundItem(null, trailers, endOfStream);
+        }
+
+        boolean isTrailers() {
+            return trailers != null;
+        }
+
+        Http2FrameData frameData() {
+            return frameData;
+        }
+
+        Http2Headers trailers() {
+            return trailers;
+        }
+
+        boolean endOfStream() {
+            return endOfStream;
         }
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
@@ -31,7 +31,7 @@ class StreamBuffer {
 
     private final Lock streamLock = new ReentrantLock();
     private final Semaphore dequeSemaphore = new Semaphore(1);
-    private final Queue<InboundItem> buffer = new ArrayDeque<>();
+    private final Queue<Object> buffer = new ArrayDeque<>();
     private final Http2ClientStream stream;
     private final int streamId;
 
@@ -40,7 +40,7 @@ class StreamBuffer {
         this.streamId = streamId;
     }
 
-    InboundItem poll(Duration timeout) {
+    Object poll(Duration timeout) {
         try {
             // Block deque thread when queue is empty
             // avoid CPU burning
@@ -59,14 +59,14 @@ class StreamBuffer {
     }
 
     void push(Http2FrameData frameData) {
-        push(InboundItem.data(frameData));
+        push((Object) frameData);
     }
 
     void pushTrailers(Http2Headers headers, boolean endOfStream) {
-        push(InboundItem.trailers(headers, endOfStream));
+        push(new InboundTrailers(headers, endOfStream));
     }
 
-    private void push(InboundItem item) {
+    private void push(Object item) {
         try {
             streamLock.lock();
             buffer.add(item);
@@ -77,39 +77,6 @@ class StreamBuffer {
         }
     }
 
-    static final class InboundItem {
-        private final Http2FrameData frameData;
-        private final Http2Headers trailers;
-        private final boolean endOfStream;
-
-        private InboundItem(Http2FrameData frameData, Http2Headers trailers, boolean endOfStream) {
-            this.frameData = frameData;
-            this.trailers = trailers;
-            this.endOfStream = endOfStream;
-        }
-
-        private static InboundItem data(Http2FrameData frameData) {
-            return new InboundItem(frameData, null, false);
-        }
-
-        private static InboundItem trailers(Http2Headers trailers, boolean endOfStream) {
-            return new InboundItem(null, trailers, endOfStream);
-        }
-
-        boolean isTrailers() {
-            return trailers != null;
-        }
-
-        Http2FrameData frameData() {
-            return frameData;
-        }
-
-        Http2Headers trailers() {
-            return trailers;
-        }
-
-        boolean endOfStream() {
-            return endOfStream;
-        }
+    record InboundTrailers(Http2Headers trailers, boolean endOfStream) {
     }
 }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -60,6 +60,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Http2ClientConnectionTest {
@@ -145,6 +147,83 @@ class Http2ClientConnectionTest {
                                                                       huffman));
             firstStream.close();
             secondStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void headersOnStreamZeroCloseConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            test.createConnection(false);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedSplitHeaderFrames(0, encodedResponseHeaders(false), inboundTable, huffman)[0]);
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void initialSettingsFailureClosesConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.closeInbound();
+
+            assertThrows(IllegalStateException.class, () -> test.createConnection(false));
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void dataBeforeResponseHeadersClosesConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+            stream.writeHeaders(requestHeaders(), true);
+            test.offerInbound(dataFrame(stream.streamId(), "hello".getBytes(StandardCharsets.UTF_8), false));
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void dataAfterTrailersClosesConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+                              encodedHeaderFrame(stream.streamId(), encodedTrailers(), inboundTable, huffman, true),
+                              dataFrame(stream.streamId(), "late".getBytes(StandardCharsets.UTF_8), false));
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void closeBeforeWriteHeadersReleasesReservedStream() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream reservedStream = connection.createStream(STREAM_CONFIG);
+
+            assertNull(connection.tryStream(STREAM_CONFIG));
+
+            reservedStream.close();
+
+            Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
+            assertNotNull(recoveredStream);
+            recoveredStream.close();
             connection.close();
         }
     }
@@ -465,6 +544,8 @@ class Http2ClientConnectionTest {
     }
 
     private static final class MockedConnectionTestContext implements AutoCloseable {
+        private static final byte[] END_INBOUND = new byte[0];
+
         private final ExecutorService connectionExecutor = Executors.newSingleThreadExecutor();
         private final LinkedBlockingQueue<byte[]> inboundFrames = new LinkedBlockingQueue<>();
         private final AtomicBoolean failWrites = new AtomicBoolean();
@@ -531,6 +612,14 @@ class Http2ClientConnectionTest {
             }
         }
 
+        private void closeInbound() {
+            inboundFrames.add(END_INBOUND);
+        }
+
+        private void assertConnectionClosed() {
+            verify(clientConnection, timeout(TEST_WAIT_TIMEOUT.toMillis())).closeResource();
+        }
+
         private void failWrites() {
             failWrites.set(true);
         }
@@ -547,7 +636,11 @@ class Http2ClientConnectionTest {
 
         private byte[] nextInboundFrame() {
             try {
-                return inboundFrames.take();
+                byte[] frame = inboundFrames.take();
+                if (frame == END_INBOUND) {
+                    return null;
+                }
+                return frame;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return null;

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -167,6 +167,21 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void missingStreamHeadersForNeverOpenedStreamCloseConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            test.createConnection(false);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(1, encodedResponseHeaders(false), inboundTable, huffman));
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
     void initialSettingsFailureClosesConnection() {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.closeInbound();
@@ -225,6 +240,82 @@ class Http2ClientConnectionTest {
             assertNotNull(recoveredStream);
             recoveredStream.close();
             connection.close();
+        }
+    }
+
+    @Test
+    void inboundHeadersEndStreamReleasesReservedStreamBeforeApplicationClose() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+
+            firstStream.writeHeaders(requestHeaders(), true);
+            assertNull(connection.tryStream(STREAM_CONFIG));
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(firstStream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman,
+                                                 true));
+
+            assertThat(firstStream.readHeaders().status(), is(Status.OK_200));
+
+            Http2ClientStream secondStream = connection.tryStream(STREAM_CONFIG);
+            assertNotNull(secondStream);
+
+            secondStream.close();
+            firstStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void inboundDataEndStreamReleasesReservedStreamBeforeApplicationClose() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+
+            firstStream.writeHeaders(requestHeaders(), true);
+            assertNull(connection.tryStream(STREAM_CONFIG));
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(firstStream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman),
+                              dataFrame(firstStream.streamId(), "done".getBytes(StandardCharsets.UTF_8), true));
+
+            assertThat(firstStream.readHeaders().status(), is(Status.OK_200));
+            BufferData data = firstStream.read();
+            byte[] entity = new byte[data.available()];
+            data.read(entity);
+            assertThat(new String(entity, StandardCharsets.UTF_8), is("done"));
+
+            Http2ClientStream secondStream = connection.tryStream(STREAM_CONFIG);
+            assertNotNull(secondStream);
+
+            secondStream.close();
+            firstStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void initialZeroMaxConcurrentStreamsClosesUnusableConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(0));
+            Http2ClientConnection connection = test.createConnection(false);
+
+            assertThrows(IllegalStateException.class, () -> connection.createStream(STREAM_CONFIG));
+
+            test.assertConnectionClosed();
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameTypes;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2HuffmanDecoder;
+import io.helidon.http.http2.Http2Setting;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.WebClient;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Http2ClientConnectionTest {
+    private static final Duration TEST_WAIT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Http2StreamConfig STREAM_CONFIG = new Http2StreamConfig() {
+        @Override
+        public boolean priorKnowledge() {
+            return true;
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+
+        @Override
+        public Duration readTimeout() {
+            return Duration.ofSeconds(1);
+        }
+    };
+
+    @Test
+    void readHeadersWaitsForExpectedDecodeOrder() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            Http2ClientConnection connection = test.newConnection();
+            Http2ClientStream firstStream = mock(Http2ClientStream.class);
+            Http2ClientStream secondStream = mock(Http2ClientStream.class);
+
+            // RFC 7541 C.4 fixtures: the second block references a dynamic-table entry introduced by the first block.
+            Http2FrameData firstHeaderBlock =
+                    headerFrame(1, "828684418cf1e3c2e5f23a6ba0ab90f4ff");
+            Http2FrameData secondHeaderBlock =
+                    headerFrame(3, "828684be5886a8eb10649cbf");
+
+            ExecutorService decodeExecutor = Executors.newFixedThreadPool(2);
+            try {
+                CountDownLatch secondDecodeStarted = new CountDownLatch(1);
+                CompletableFuture<Http2Headers> secondDecode = CompletableFuture.supplyAsync(() -> {
+                    secondDecodeStarted.countDown();
+                    return connection.readHeaders(secondStream,
+                                                  Http2HuffmanDecoder.create(),
+                                                  Http2Headers.create(WritableHeaders.create()),
+                                                  2,
+                                                  new Http2FrameData[] {secondHeaderBlock});
+                }, decodeExecutor);
+
+                assertTrue(secondDecodeStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+                assertThrows(TimeoutException.class, () -> secondDecode.get(200, TimeUnit.MILLISECONDS));
+
+                Http2Headers firstHeaders = connection.readHeaders(firstStream,
+                                                                   Http2HuffmanDecoder.create(),
+                                                                   Http2Headers.create(WritableHeaders.create()),
+                                                                   1,
+                                                                   new Http2FrameData[] {firstHeaderBlock});
+
+                assertThat(firstHeaders.authority(), is("www.example.com"));
+
+                Http2Headers secondHeaders = secondDecode.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                assertThat(secondHeaders.authority(), is("www.example.com"));
+                assertThat(secondHeaders.httpHeaders().get(HeaderNames.CACHE_CONTROL).get(), is("no-cache"));
+            } finally {
+                decodeExecutor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    void createWaitsForInitialSettingsAndHonorsPeerMaxConcurrentStreams() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            CompletableFuture<Http2ClientConnection> connectionFuture = new CompletableFuture<>();
+            Thread.ofPlatform().start(() -> {
+                try {
+                    connectionFuture.complete(test.createConnection(false));
+                } catch (Throwable t) {
+                    connectionFuture.completeExceptionally(t);
+                }
+            });
+
+            assertThrows(TimeoutException.class, () -> connectionFuture.get(200, TimeUnit.MILLISECONDS));
+
+            test.offerInbound(settingsFrame(1));
+
+            Http2ClientConnection connection = connectionFuture.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            assertNotNull(firstStream);
+            assertNull(connection.tryStream(STREAM_CONFIG));
+
+            firstStream.close();
+
+            Http2ClientStream secondStream = connection.tryStream(STREAM_CONFIG);
+            assertNotNull(secondStream);
+            secondStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void writeHeadersFailureReleasesReservedStream() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            CompletableFuture<Http2ClientConnection> connectionFuture = new CompletableFuture<>();
+            Thread.ofPlatform().start(() -> {
+                try {
+                    connectionFuture.complete(test.createConnection(false));
+                } catch (Throwable t) {
+                    connectionFuture.completeExceptionally(t);
+                }
+            });
+
+            test.offerInbound(settingsFrame(1));
+
+            Http2ClientConnection connection = connectionFuture.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            Http2ClientStream failingStream = connection.createStream(STREAM_CONFIG);
+
+            test.failWrites();
+            assertThrows(UncheckedIOException.class, () -> failingStream.writeHeaders(requestHeaders(), false));
+            test.allowWrites();
+
+            Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
+            assertNotNull(recoveredStream);
+            recoveredStream.close();
+            connection.close();
+        }
+    }
+
+    private static Http2FrameData headerFrame(int streamId, String hexEncoded) {
+        BufferData data = data(hexEncoded);
+        Http2FrameHeader header = Http2FrameHeader.create(data.available(),
+                                                          Http2FrameTypes.HEADERS,
+                                                          Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                                          streamId);
+        return new Http2FrameData(header, data);
+    }
+
+    private static Http2FrameData settingsFrame(long maxConcurrentStreams) {
+        Http2Settings settings = Http2Settings.builder()
+                .add(Http2Setting.MAX_CONCURRENT_STREAMS, maxConcurrentStreams)
+                .build();
+        return settings.toFrameData(null, 0, Http2Flag.SettingsFlags.create(0));
+    }
+
+    private static BufferData data(String hexEncoded) {
+        byte[] bytes = HexFormat.of().parseHex(hexEncoded.replace(" ", ""));
+        return BufferData.create(bytes);
+    }
+
+    private static Http2Headers requestHeaders() {
+        return Http2Headers.create(WritableHeaders.create())
+                .method(Method.GET)
+                .path("/")
+                .authority("www.example.com");
+    }
+
+    private static byte[] serializeFrame(Http2FrameData frameData) {
+        BufferData serialized = BufferData.create(frameData.header().write(), frameData.data().copy());
+        byte[] bytes = new byte[serialized.available()];
+        serialized.read(bytes);
+        return bytes;
+    }
+
+    private static final class MockedConnectionTestContext implements AutoCloseable {
+        private final ExecutorService connectionExecutor = Executors.newSingleThreadExecutor();
+        private final LinkedBlockingQueue<byte[]> inboundFrames = new LinkedBlockingQueue<>();
+        private final AtomicBoolean failWrites = new AtomicBoolean();
+        private final DataWriter dataWriter = mock(DataWriter.class);
+        private final HelidonSocket socket;
+        private final Http2ClientConfig clientConfig;
+        private final Http2ClientImpl client;
+        private final ClientConnection clientConnection;
+
+        private MockedConnectionTestContext() {
+            Http2ClientProtocolConfig protocolConfig = Http2ClientProtocolConfig.builder()
+                    .ping(true)
+                    .pingTimeout(Duration.ofMillis(100))
+                    .build();
+
+            this.clientConfig = Http2ClientConfig.builder()
+                    .protocolConfig(protocolConfig)
+                    .buildPrototype();
+
+            this.client = mock(Http2ClientImpl.class);
+            this.clientConnection = mock(ClientConnection.class);
+            this.socket = mock(HelidonSocket.class);
+            WebClient webClient = mock(WebClient.class);
+
+            doAnswer(invocation -> {
+                maybeFailWrites();
+                return null;
+            }).when(dataWriter).write(any(BufferData.class));
+            doAnswer(invocation -> {
+                maybeFailWrites();
+                return null;
+            }).when(dataWriter).write(any(BufferData[].class));
+            doAnswer(invocation -> {
+                maybeFailWrites();
+                return null;
+            }).when(dataWriter).writeNow(any(BufferData.class));
+            doAnswer(invocation -> {
+                maybeFailWrites();
+                return null;
+            }).when(dataWriter).writeNow(any(BufferData[].class));
+
+            when(client.protocolConfig()).thenReturn(protocolConfig);
+            when(client.clientConfig()).thenReturn(clientConfig);
+            when(client.webClient()).thenReturn(webClient);
+            when(webClient.executor()).thenReturn(connectionExecutor);
+            when(clientConnection.reader()).thenReturn(DataReader.create(this::nextInboundFrame));
+            when(clientConnection.writer()).thenReturn(dataWriter);
+            when(clientConnection.helidonSocket()).thenReturn(socket);
+            when(socket.socketId()).thenReturn("test-socket");
+            when(socket.childSocketId()).thenReturn("0");
+        }
+
+        private Http2ClientConnection newConnection() {
+            return new Http2ClientConnection(client, clientConnection);
+        }
+
+        private Http2ClientConnection createConnection(boolean sendSettings) {
+            return Http2ClientConnection.create(client, clientConnection, sendSettings);
+        }
+
+        private void offerInbound(Http2FrameData frameData) {
+            inboundFrames.add(serializeFrame(frameData));
+        }
+
+        private void failWrites() {
+            failWrites.set(true);
+        }
+
+        private void allowWrites() {
+            failWrites.set(false);
+        }
+
+        private void maybeFailWrites() {
+            if (failWrites.get()) {
+                throw new UncheckedIOException(new IOException("expected test write failure"));
+            }
+        }
+
+        private byte[] nextInboundFrame() {
+            try {
+                return inboundFrames.take();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+
+        @Override
+        public void close() {
+            connectionExecutor.shutdownNow();
+        }
+    }
+}

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -247,6 +247,42 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void cancelReleasesReservedStreamAfterRstWrite() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+            stream.writeHeaders(requestHeaders(), false);
+            assertNull(connection.tryStream(STREAM_CONFIG));
+
+            MockedConnectionTestContext.BlockedWrite blockedWrite = test.blockNextWriteNow();
+            CompletableFuture<Void> cancel = CompletableFuture.runAsync(stream::cancel);
+
+            assertTrue(blockedWrite.awaitEntered());
+            try {
+                Http2ClientStream unexpectedStream = connection.tryStream(STREAM_CONFIG);
+                try {
+                    assertNull(unexpectedStream);
+                } finally {
+                    if (unexpectedStream != null) {
+                        unexpectedStream.close();
+                    }
+                }
+            } finally {
+                blockedWrite.release();
+            }
+            cancel.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            stream.close();
+
+            Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
+            assertNotNull(recoveredStream);
+            recoveredStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
     void inboundHeadersEndStreamReleasesReservedStreamBeforeApplicationClose() {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.offerInbound(settingsFrame(1));
@@ -747,6 +783,7 @@ class Http2ClientConnectionTest {
         private final ExecutorService connectionExecutor = Executors.newSingleThreadExecutor();
         private final LinkedBlockingQueue<byte[]> inboundFrames = new LinkedBlockingQueue<>();
         private final AtomicBoolean failWrites = new AtomicBoolean();
+        private final AtomicReference<BlockedWrite> blockedWrite = new AtomicReference<>();
         private final DataWriter dataWriter = mock(DataWriter.class);
         private final io.helidon.common.socket.HelidonSocket socket = mock(io.helidon.common.socket.HelidonSocket.class);
         private final Http2ClientConfig clientConfig;
@@ -777,10 +814,12 @@ class Http2ClientConnectionTest {
             }).when(dataWriter).write(any(BufferData[].class));
             doAnswer(invocation -> {
                 maybeFailWrites();
+                maybeBlockWriteNow();
                 return null;
             }).when(dataWriter).writeNow(any(BufferData.class));
             doAnswer(invocation -> {
                 maybeFailWrites();
+                maybeBlockWriteNow();
                 return null;
             }).when(dataWriter).writeNow(any(BufferData[].class));
 
@@ -826,9 +865,24 @@ class Http2ClientConnectionTest {
             failWrites.set(false);
         }
 
+        private BlockedWrite blockNextWriteNow() {
+            BlockedWrite result = new BlockedWrite();
+            if (!blockedWrite.compareAndSet(null, result)) {
+                throw new IllegalStateException("A write is already blocked");
+            }
+            return result;
+        }
+
         private void maybeFailWrites() {
             if (failWrites.get()) {
                 throw new UncheckedIOException(new IOException("expected test write failure"));
+            }
+        }
+
+        private void maybeBlockWriteNow() {
+            BlockedWrite block = blockedWrite.getAndSet(null);
+            if (block != null) {
+                block.block();
             }
         }
 
@@ -848,6 +902,31 @@ class Http2ClientConnectionTest {
         @Override
         public void close() {
             connectionExecutor.shutdownNow();
+        }
+
+        private static final class BlockedWrite {
+            private final CountDownLatch entered = new CountDownLatch(1);
+            private final CountDownLatch released = new CountDownLatch(1);
+
+            private boolean awaitEntered() throws InterruptedException {
+                return entered.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            }
+
+            private void release() {
+                released.countDown();
+            }
+
+            private void block() {
+                entered.countDown();
+                try {
+                    if (!released.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                        throw new IllegalStateException("Timed out waiting for test to release blocked write");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while blocking test write", e);
+                }
+            }
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -18,6 +18,7 @@ package io.helidon.webclient.http2;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -33,6 +34,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.Headers;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
@@ -63,6 +65,7 @@ import static org.mockito.Mockito.when;
 class Http2ClientConnectionTest {
     private static final Duration TEST_WAIT_TIMEOUT = Duration.ofSeconds(10);
     private static final io.helidon.http.HeaderName SHARED_HEADER = HeaderNames.create("x-shared");
+    private static final io.helidon.http.HeaderName GRPC_STATUS_HEADER = HeaderNames.create("grpc-status");
     private static final Http2StreamConfig STREAM_CONFIG = new Http2StreamConfig() {
         @Override
         public boolean priorKnowledge() {
@@ -230,6 +233,49 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void decodedTrailersWaitBehindBufferedData() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            AtomicReference<Http2ClientStream> streamToTrack = new AtomicReference<>();
+            CountDownLatch decodedHeaderBlocks = new CountDownLatch(2);
+            Http2ClientConnection connection = test.createConnection((client, clientConnection) ->
+                                                                             new HookedHttp2ClientConnection(client,
+                                                                                                             clientConnection,
+                                                                                                             streamToTrack,
+                                                                                                             decodedHeaderBlocks::countDown),
+                                                                     false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+            stream.writeHeaders(requestHeaders(), true);
+            streamToTrack.set(stream);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+                              dataFrame(stream.streamId(), "hello".getBytes(StandardCharsets.UTF_8), false),
+                              encodedHeaderFrame(stream.streamId(), encodedTrailers(), inboundTable, huffman, true));
+
+            assertTrue(decodedHeaderBlocks.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+
+            Http2Headers headers = stream.readHeaders();
+            assertThat(headers.status(), is(Status.OK_200));
+
+            BufferData data = stream.read();
+            byte[] entity = new byte[data.available()];
+            data.read(entity);
+            assertThat(new String(entity, StandardCharsets.UTF_8), is("hello"));
+
+            assertThat(stream.read().available(), is(0));
+            Headers trailers = stream.trailers().get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            assertThat(trailers.get(GRPC_STATUS_HEADER).get(), is("0"));
+
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
     void createWaitsForInitialSettingsAndHonorsPeerMaxConcurrentStreams() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             CompletableFuture<Http2ClientConnection> connectionFuture = new CompletableFuture<>();
@@ -291,14 +337,33 @@ class Http2ClientConnectionTest {
                                                      Http2Headers headers,
                                                      Http2Headers.DynamicTable dynamicTable,
                                                      Http2HuffmanEncoder huffman) {
+        return encodedHeaderFrame(streamId, headers, dynamicTable, huffman, false);
+    }
+
+    private static Http2FrameData encodedHeaderFrame(int streamId,
+                                                     Http2Headers headers,
+                                                     Http2Headers.DynamicTable dynamicTable,
+                                                     Http2HuffmanEncoder huffman,
+                                                     boolean endOfStream) {
         BufferData data = BufferData.create(256);
         headers.write(dynamicTable, huffman, data);
         data.rewind();
+        int flags = endOfStream ? Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM : Http2Flag.END_OF_HEADERS;
         Http2FrameHeader header = Http2FrameHeader.create(data.available(),
                                                           Http2FrameTypes.HEADERS,
-                                                          Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                                          Http2Flag.HeaderFlags.create(flags),
                                                           streamId);
         return new Http2FrameData(header, data);
+    }
+
+    private static Http2FrameData dataFrame(int streamId, byte[] bytes, boolean endOfStream) {
+        Http2FrameHeader header = Http2FrameHeader.create(bytes.length,
+                                                          Http2FrameTypes.DATA,
+                                                          Http2Flag.DataFlags.create(endOfStream
+                                                                                             ? Http2Flag.END_OF_STREAM
+                                                                                             : 0),
+                                                          streamId);
+        return new Http2FrameData(header, BufferData.create(bytes));
     }
 
     private static Http2FrameData[] encodedSplitHeaderFrames(int streamId,
@@ -344,6 +409,12 @@ class Http2ClientConnectionTest {
         }
         return Http2Headers.create(headers)
                 .status(Status.OK_200);
+    }
+
+    private static Http2Headers encodedTrailers() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.set(GRPC_STATUS_HEADER, "0");
+        return Http2Headers.create(headers);
     }
 
     private static Http2Headers requestHeaders() {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -38,14 +38,17 @@ import io.helidon.http.Headers;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanEncoder;
+import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.WebClient;
 
@@ -354,6 +357,100 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void lateControlFramesForAbandonedStreamDoNotCloseConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream abandonedStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream secondStream = connection.createStream(STREAM_CONFIG);
+
+            abandonedStream.writeHeaders(requestHeaders(), false);
+            secondStream.writeHeaders(requestHeaders(), false);
+            abandonedStream.close();
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(windowUpdateFrame(abandonedStream.streamId()),
+                              rstStreamFrame(abandonedStream.streamId()),
+                              encodedHeaderFrame(secondStream.streamId(),
+                                                 encodedResponseHeaders(true),
+                                                 inboundTable,
+                                                 huffman));
+
+            Http2Headers secondHeaders = secondStream.readHeaders();
+            assertThat(secondHeaders.status(), is(Status.OK_200));
+            assertThat(secondHeaders.httpHeaders().get(HeaderNames.CACHE_CONTROL).get(), is("no-cache"));
+
+            secondStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void controlFrameForNeverOpenedStreamClosesConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            test.createConnection(false);
+
+            test.offerInbound(windowUpdateFrame(1));
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void rstStreamForNeverOpenedStreamClosesConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            test.createConnection(false);
+
+            test.offerInbound(rstStreamFrame(1));
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void missingServerInitiatedHeadersCloseConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            stream.writeHeaders(requestHeaders(), false);
+
+            test.offerInbound(encodedHeaderFrame(2, encodedResponseHeaders(false), inboundTable, huffman));
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void missingFutureClientStreamHeadersCloseConnection() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            stream.writeHeaders(requestHeaders(), false);
+
+            test.offerInbound(encodedHeaderFrame(stream.streamId() + 4,
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
     void closedStreamDoesNotReceiveHeadersWhenClosedAfterDecode() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.offerInbound(settingsFrame(10));
@@ -534,6 +631,16 @@ class Http2ClientConnectionTest {
                                                                                              : 0),
                                                           streamId);
         return new Http2FrameData(header, BufferData.create(bytes));
+    }
+
+    private static Http2FrameData windowUpdateFrame(int streamId) {
+        return new Http2WindowUpdate(1)
+                .toFrameData(null, streamId, Http2Flag.NoFlags.create());
+    }
+
+    private static Http2FrameData rstStreamFrame(int streamId) {
+        return new Http2RstStream(Http2ErrorCode.CANCEL)
+                .toFrameData(null, streamId, Http2Flag.NoFlags.create());
     }
 
     private static Http2FrameData[] encodedSplitHeaderFrames(int streamId,

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -19,7 +19,6 @@ package io.helidon.webclient.http2;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
-import java.util.HexFormat;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -35,13 +34,14 @@ import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
+import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
-import io.helidon.http.http2.Http2HuffmanDecoder;
+import io.helidon.http.http2.Http2HuffmanEncoder;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
 import io.helidon.webclient.api.ClientConnection;
@@ -62,6 +62,7 @@ import static org.mockito.Mockito.when;
 
 class Http2ClientConnectionTest {
     private static final Duration TEST_WAIT_TIMEOUT = Duration.ofSeconds(10);
+    private static final io.helidon.http.HeaderName SHARED_HEADER = HeaderNames.create("x-shared");
     private static final Http2StreamConfig STREAM_CONFIG = new Http2StreamConfig() {
         @Override
         public boolean priorKnowledge() {
@@ -80,47 +81,52 @@ class Http2ClientConnectionTest {
     };
 
     @Test
-    void readHeadersWaitsForExpectedDecodeOrder() throws Exception {
+    void readHeadersDoNotDependOnCallerDecodeOrder() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
-            Http2ClientConnection connection = test.newConnection();
-            Http2ClientStream firstStream = mock(Http2ClientStream.class);
-            Http2ClientStream secondStream = mock(Http2ClientStream.class);
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream secondStream = connection.createStream(STREAM_CONFIG);
 
-            // RFC 7541 C.4 fixtures: the second block references a dynamic-table entry introduced by the first block.
+            firstStream.writeHeaders(requestHeaders(), false);
+            secondStream.writeHeaders(requestHeaders(), false);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
             Http2FrameData firstHeaderBlock =
-                    headerFrame(1, "828684418cf1e3c2e5f23a6ba0ab90f4ff");
+                    encodedHeaderFrame(firstStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman);
             Http2FrameData secondHeaderBlock =
-                    headerFrame(3, "828684be5886a8eb10649cbf");
+                    encodedHeaderFrame(secondStream.streamId(), encodedResponseHeaders(true), inboundTable, huffman);
 
-            ExecutorService decodeExecutor = Executors.newFixedThreadPool(2);
+            ExecutorService readExecutor = Executors.newSingleThreadExecutor();
             try {
-                CountDownLatch secondDecodeStarted = new CountDownLatch(1);
-                CompletableFuture<Http2Headers> secondDecode = CompletableFuture.supplyAsync(() -> {
-                    secondDecodeStarted.countDown();
-                    return connection.readHeaders(secondStream,
-                                                  Http2HuffmanDecoder.create(),
-                                                  Http2Headers.create(WritableHeaders.create()),
-                                                  2,
-                                                  new Http2FrameData[] {secondHeaderBlock});
-                }, decodeExecutor);
+                CountDownLatch secondReadStarted = new CountDownLatch(1);
+                CompletableFuture<Http2Headers> secondRead = CompletableFuture.supplyAsync(() -> {
+                    secondReadStarted.countDown();
+                    return secondStream.readHeaders();
+                }, readExecutor);
 
-                assertTrue(secondDecodeStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
-                assertThrows(TimeoutException.class, () -> secondDecode.get(200, TimeUnit.MILLISECONDS));
+                assertTrue(secondReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
 
-                Http2Headers firstHeaders = connection.readHeaders(firstStream,
-                                                                   Http2HuffmanDecoder.create(),
-                                                                   Http2Headers.create(WritableHeaders.create()),
-                                                                   1,
-                                                                   new Http2FrameData[] {firstHeaderBlock});
+                // Stream 3 must become readable as soon as its frames arrive; stream 1's caller is still idle here.
+                test.offerInbound(firstHeaderBlock);
+                test.offerInbound(secondHeaderBlock);
 
-                assertThat(firstHeaders.authority(), is("www.example.com"));
-
-                Http2Headers secondHeaders = secondDecode.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-                assertThat(secondHeaders.authority(), is("www.example.com"));
+                Http2Headers secondHeaders = secondRead.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                assertThat(secondHeaders.status(), is(Status.OK_200));
+                assertThat(secondHeaders.httpHeaders().get(SHARED_HEADER).get(), is("shared-value"));
                 assertThat(secondHeaders.httpHeaders().get(HeaderNames.CACHE_CONTROL).get(), is("no-cache"));
+
+                Http2Headers firstHeaders = firstStream.readHeaders();
+                assertThat(firstHeaders.status(), is(Status.OK_200));
+                assertThat(firstHeaders.httpHeaders().get(SHARED_HEADER).get(), is("shared-value"));
             } finally {
-                decodeExecutor.shutdownNow();
+                readExecutor.shutdownNow();
             }
+            firstStream.close();
+            secondStream.close();
+            connection.close();
         }
     }
 
@@ -182,8 +188,13 @@ class Http2ClientConnectionTest {
         }
     }
 
-    private static Http2FrameData headerFrame(int streamId, String hexEncoded) {
-        BufferData data = data(hexEncoded);
+    private static Http2FrameData encodedHeaderFrame(int streamId,
+                                                     Http2Headers headers,
+                                                     Http2Headers.DynamicTable dynamicTable,
+                                                     Http2HuffmanEncoder huffman) {
+        BufferData data = BufferData.create(256);
+        headers.write(dynamicTable, huffman, data);
+        data.rewind();
         Http2FrameHeader header = Http2FrameHeader.create(data.available(),
                                                           Http2FrameTypes.HEADERS,
                                                           Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
@@ -198,14 +209,20 @@ class Http2ClientConnectionTest {
         return settings.toFrameData(null, 0, Http2Flag.SettingsFlags.create(0));
     }
 
-    private static BufferData data(String hexEncoded) {
-        byte[] bytes = HexFormat.of().parseHex(hexEncoded.replace(" ", ""));
-        return BufferData.create(bytes);
+    private static Http2Headers encodedResponseHeaders(boolean includeCacheControl) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.set(SHARED_HEADER, "shared-value");
+        if (includeCacheControl) {
+            headers.set(HeaderNames.CACHE_CONTROL, "no-cache");
+        }
+        return Http2Headers.create(headers)
+                .status(Status.OK_200);
     }
 
     private static Http2Headers requestHeaders() {
         return Http2Headers.create(WritableHeaders.create())
                 .method(Method.GET)
+                .scheme("http")
                 .path("/")
                 .authority("www.example.com");
     }
@@ -268,10 +285,6 @@ class Http2ClientConnectionTest {
             when(clientConnection.helidonSocket()).thenReturn(socket);
             when(socket.socketId()).thenReturn("test-socket");
             when(socket.childSocketId()).thenReturn("0");
-        }
-
-        private Http2ClientConnection newConnection() {
-            return new Http2ClientConnection(client, clientConnection);
         }
 
         private Http2ClientConnection createConnection(boolean sendSettings) {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -19,7 +19,6 @@ package io.helidon.webclient.http2;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -27,11 +26,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
-import io.helidon.common.socket.HelidonSocket;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
@@ -94,39 +94,138 @@ class Http2ClientConnectionTest {
             Http2Headers.DynamicTable inboundTable =
                     Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
             Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            assertHeadersDecodeInArrivalOrder(test,
+                                              firstStream,
+                                              secondStream,
+                                              new Http2FrameData[] {
+                                                      encodedHeaderFrame(firstStream.streamId(),
+                                                                         encodedResponseHeaders(false),
+                                                                         inboundTable,
+                                                                         huffman)
+                                              },
+                                              new Http2FrameData[] {
+                                                      encodedHeaderFrame(secondStream.streamId(),
+                                                                         encodedResponseHeaders(true),
+                                                                         inboundTable,
+                                                                         huffman)
+                                              });
+            firstStream.close();
+            secondStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void splitHeadersDoNotDependOnCallerDecodeOrder() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream secondStream = connection.createStream(STREAM_CONFIG);
+
+            firstStream.writeHeaders(requestHeaders(), false);
+            secondStream.writeHeaders(requestHeaders(), false);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            assertHeadersDecodeInArrivalOrder(test,
+                                              firstStream,
+                                              secondStream,
+                                              encodedSplitHeaderFrames(firstStream.streamId(),
+                                                                      encodedResponseHeaders(false),
+                                                                      inboundTable,
+                                                                      huffman),
+                                              encodedSplitHeaderFrames(secondStream.streamId(),
+                                                                      encodedResponseHeaders(true),
+                                                                      inboundTable,
+                                                                      huffman));
+            firstStream.close();
+            secondStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void missingStreamHeadersStillAdvanceConnectionHpackState() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream abandonedStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream secondStream = connection.createStream(STREAM_CONFIG);
+
+            abandonedStream.writeHeaders(requestHeaders(), false);
+            secondStream.writeHeaders(requestHeaders(), false);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            Http2FrameData[] abandonedHeaderBlock =
+                    encodedSplitHeaderFrames(abandonedStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman);
+            Http2FrameData secondHeaderBlock =
+                    encodedHeaderFrame(secondStream.streamId(), encodedResponseHeaders(true), inboundTable, huffman);
+
+            abandonedStream.close();
+
+            test.offerInbound(abandonedHeaderBlock);
+            test.offerInbound(secondHeaderBlock);
+
+            Http2Headers secondHeaders = secondStream.readHeaders();
+            assertThat(secondHeaders.status(), is(Status.OK_200));
+            assertThat(secondHeaders.httpHeaders().get(SHARED_HEADER).get(), is("shared-value"));
+            assertThat(secondHeaders.httpHeaders().get(HeaderNames.CACHE_CONTROL).get(), is("no-cache"));
+
+            secondStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void closedStreamDoesNotReceiveHeadersWhenClosedAfterDecode() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            AtomicReference<Http2ClientStream> streamToClose = new AtomicReference<>();
+            CountDownLatch firstHeadersDecoded = new CountDownLatch(1);
+            Http2ClientConnection connection = test.createConnection((client, clientConnection) ->
+                                                                             new HookedHttp2ClientConnection(client,
+                                                                                                             clientConnection,
+                                                                                                             streamToClose,
+                                                                                                             () -> {
+                                                                                                                 streamToClose.get().close();
+                                                                                                                 firstHeadersDecoded.countDown();
+                                                                                                             }),
+                                                                     false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream secondStream = connection.createStream(STREAM_CONFIG);
+
+            firstStream.writeHeaders(requestHeaders(), false);
+            secondStream.writeHeaders(requestHeaders(), false);
+            streamToClose.set(firstStream);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
             Http2FrameData firstHeaderBlock =
                     encodedHeaderFrame(firstStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman);
             Http2FrameData secondHeaderBlock =
                     encodedHeaderFrame(secondStream.streamId(), encodedResponseHeaders(true), inboundTable, huffman);
 
-            ExecutorService readExecutor = Executors.newSingleThreadExecutor();
             try {
-                CountDownLatch secondReadStarted = new CountDownLatch(1);
-                CompletableFuture<Http2Headers> secondRead = CompletableFuture.supplyAsync(() -> {
-                    secondReadStarted.countDown();
-                    return secondStream.readHeaders();
-                }, readExecutor);
-
-                assertTrue(secondReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
-
-                // Stream 3 must become readable as soon as its frames arrive; stream 1's caller is still idle here.
                 test.offerInbound(firstHeaderBlock);
+                assertTrue(firstHeadersDecoded.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+
                 test.offerInbound(secondHeaderBlock);
 
-                Http2Headers secondHeaders = secondRead.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                Http2Headers secondHeaders = secondStream.readHeaders();
                 assertThat(secondHeaders.status(), is(Status.OK_200));
                 assertThat(secondHeaders.httpHeaders().get(SHARED_HEADER).get(), is("shared-value"));
                 assertThat(secondHeaders.httpHeaders().get(HeaderNames.CACHE_CONTROL).get(), is("no-cache"));
 
-                Http2Headers firstHeaders = firstStream.readHeaders();
-                assertThat(firstHeaders.status(), is(Status.OK_200));
-                assertThat(firstHeaders.httpHeaders().get(SHARED_HEADER).get(), is("shared-value"));
+                assertThrows(IllegalStateException.class, firstStream::readHeaders);
             } finally {
-                readExecutor.shutdownNow();
+                secondStream.close();
+                connection.close();
             }
-            firstStream.close();
-            secondStream.close();
-            connection.close();
         }
     }
 
@@ -202,6 +301,34 @@ class Http2ClientConnectionTest {
         return new Http2FrameData(header, data);
     }
 
+    private static Http2FrameData[] encodedSplitHeaderFrames(int streamId,
+                                                             Http2Headers headers,
+                                                             Http2Headers.DynamicTable dynamicTable,
+                                                             Http2HuffmanEncoder huffman) {
+        BufferData data = BufferData.create(256);
+        headers.write(dynamicTable, huffman, data);
+        data.rewind();
+
+        int splitIndex = Math.min(data.available() - 1, Math.max(1, data.available() / 2));
+        byte[] firstPart = new byte[splitIndex];
+        data.read(firstPart);
+        byte[] secondPart = new byte[data.available()];
+        data.read(secondPart);
+
+        Http2FrameData firstFrame = new Http2FrameData(Http2FrameHeader.create(firstPart.length,
+                                                                               Http2FrameTypes.HEADERS,
+                                                                               Http2Flag.HeaderFlags.create(0),
+                                                                               streamId),
+                                                       BufferData.create(firstPart));
+        Http2FrameData secondFrame = new Http2FrameData(Http2FrameHeader.create(secondPart.length,
+                                                                                Http2FrameTypes.CONTINUATION,
+                                                                                Http2Flag.ContinuationFlags.create(
+                                                                                        Http2Flag.END_OF_HEADERS),
+                                                                                streamId),
+                                                        BufferData.create(secondPart));
+        return new Http2FrameData[] {firstFrame, secondFrame};
+    }
+
     private static Http2FrameData settingsFrame(long maxConcurrentStreams) {
         Http2Settings settings = Http2Settings.builder()
                 .add(Http2Setting.MAX_CONCURRENT_STREAMS, maxConcurrentStreams)
@@ -227,6 +354,38 @@ class Http2ClientConnectionTest {
                 .authority("www.example.com");
     }
 
+    private static void assertHeadersDecodeInArrivalOrder(MockedConnectionTestContext test,
+                                                          Http2ClientStream firstStream,
+                                                          Http2ClientStream secondStream,
+                                                          Http2FrameData[] firstHeaderBlock,
+                                                          Http2FrameData[] secondHeaderBlock) throws Exception {
+        ExecutorService readExecutor = Executors.newSingleThreadExecutor();
+        try {
+            CountDownLatch secondReadStarted = new CountDownLatch(1);
+            CompletableFuture<Http2Headers> secondRead = CompletableFuture.supplyAsync(() -> {
+                secondReadStarted.countDown();
+                return secondStream.readHeaders();
+            }, readExecutor);
+
+            assertTrue(secondReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+
+            // The later stream must become readable as soon as its frames arrive, even if an earlier stream caller is idle.
+            test.offerInbound(firstHeaderBlock);
+            test.offerInbound(secondHeaderBlock);
+
+            Http2Headers secondHeaders = secondRead.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            assertThat(secondHeaders.status(), is(Status.OK_200));
+            assertThat(secondHeaders.httpHeaders().get(SHARED_HEADER).get(), is("shared-value"));
+            assertThat(secondHeaders.httpHeaders().get(HeaderNames.CACHE_CONTROL).get(), is("no-cache"));
+
+            Http2Headers firstHeaders = firstStream.readHeaders();
+            assertThat(firstHeaders.status(), is(Status.OK_200));
+            assertThat(firstHeaders.httpHeaders().get(SHARED_HEADER).get(), is("shared-value"));
+        } finally {
+            readExecutor.shutdownNow();
+        }
+    }
+
     private static byte[] serializeFrame(Http2FrameData frameData) {
         BufferData serialized = BufferData.create(frameData.header().write(), frameData.data().copy());
         byte[] bytes = new byte[serialized.available()];
@@ -239,7 +398,7 @@ class Http2ClientConnectionTest {
         private final LinkedBlockingQueue<byte[]> inboundFrames = new LinkedBlockingQueue<>();
         private final AtomicBoolean failWrites = new AtomicBoolean();
         private final DataWriter dataWriter = mock(DataWriter.class);
-        private final HelidonSocket socket;
+        private final io.helidon.common.socket.HelidonSocket socket = mock(io.helidon.common.socket.HelidonSocket.class);
         private final Http2ClientConfig clientConfig;
         private final Http2ClientImpl client;
         private final ClientConnection clientConnection;
@@ -256,7 +415,6 @@ class Http2ClientConnectionTest {
 
             this.client = mock(Http2ClientImpl.class);
             this.clientConnection = mock(ClientConnection.class);
-            this.socket = mock(HelidonSocket.class);
             WebClient webClient = mock(WebClient.class);
 
             doAnswer(invocation -> {
@@ -291,8 +449,15 @@ class Http2ClientConnectionTest {
             return Http2ClientConnection.create(client, clientConnection, sendSettings);
         }
 
-        private void offerInbound(Http2FrameData frameData) {
-            inboundFrames.add(serializeFrame(frameData));
+        private <T extends Http2ClientConnection> T createConnection(ConnectionFactory<T> connectionFactory,
+                                                                     boolean sendSettings) {
+            return Http2ClientConnection.create(connectionFactory.create(client, clientConnection), client, sendSettings);
+        }
+
+        private void offerInbound(Http2FrameData... frameData) {
+            for (Http2FrameData oneFrame : frameData) {
+                inboundFrames.add(serializeFrame(oneFrame));
+            }
         }
 
         private void failWrites() {
@@ -321,6 +486,32 @@ class Http2ClientConnectionTest {
         @Override
         public void close() {
             connectionExecutor.shutdownNow();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ConnectionFactory<T extends Http2ClientConnection> {
+        T create(Http2ClientImpl client, ClientConnection clientConnection);
+    }
+
+    private static final class HookedHttp2ClientConnection extends Http2ClientConnection {
+        private final AtomicReference<Http2ClientStream> streamToClose;
+        private final Runnable beforeDeliverHeaders;
+
+        private HookedHttp2ClientConnection(Http2ClientImpl client,
+                                            ClientConnection clientConnection,
+                                            AtomicReference<Http2ClientStream> streamToClose,
+                                            Runnable beforeDeliverHeaders) {
+            super(client, clientConnection);
+            this.streamToClose = streamToClose;
+            this.beforeDeliverHeaders = beforeDeliverHeaders;
+        }
+
+        @Override
+        void beforeDeliverInboundHeaders(Http2ClientStream stream, Http2Headers headers, boolean endOfStream) {
+            if (stream == streamToClose.get()) {
+                beforeDeliverHeaders.run();
+            }
         }
     }
 }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2JettyH2cReproducerIT.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2JettyH2cReproducerIT.java
@@ -1,0 +1,516 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HttpMediaTypes;
+import io.helidon.webclient.api.HttpClientResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Manual integration-test reproducer for issue 11529.
+ *
+ * <p>Run explicitly with:
+ * {@code mvn -pl webclient/http2 -am verify -Dissue11529.run=true -Dit.test=Http2JettyH2cReproducerIT}
+ */
+@EnabledIfSystemProperty(named = "issue11529.run", matches = "true")
+public class Http2JettyH2cReproducerIT {
+    private static final StringBuilder PEER_LOG = new StringBuilder();
+    private static final Lock PEER_LOG_LOCK = new ReentrantLock();
+    private static final String APP_PATH = "/api/field-service/appcache/v1/rpc/get_properties";
+    private static final int THREAD_COUNT = Integer.getInteger("issue11529.threads", 500);
+    private static final int REQUEST_COUNT = Integer.getInteger("issue11529.requests", 10_000);
+    private static final int RETRY_COUNT = Integer.getInteger("issue11529.retryCount", 1);
+    private static final int PROGRESS_EVERY = Integer.getInteger("issue11529.progressEvery",
+                                                                 Math.max(1, REQUEST_COUNT / 10));
+    private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(THREAD_COUNT);
+    private static final String REQUEST_BODY = """
+            {"data":{"entity":2,"context":"all_fields_api_inventory","options":1,"entity_id":26030351,"provider_id":0,"page_id":1,"user_id":"1"}}
+            """.trim();
+    private static Process peerProcess;
+    private static int peerPort;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        peerPort = nextFreePort();
+        peerProcess = startPeerProcess(peerPort);
+        waitForPeer(peerPort, Duration.ofSeconds(20));
+    }
+
+    @AfterAll
+    static void afterAll() throws InterruptedException {
+        if (peerProcess != null) {
+            peerProcess.destroy();
+            if (!peerProcess.waitFor(10, TimeUnit.SECONDS)) {
+                peerProcess.destroyForcibly();
+                peerProcess.waitFor(10, TimeUnit.SECONDS);
+            }
+        }
+
+        EXECUTOR.shutdown();
+        if (!EXECUTOR.awaitTermination(30, TimeUnit.SECONDS)) {
+            EXECUTOR.shutdownNow();
+        }
+    }
+
+    @Test
+    void priorKnowledgePostAgainstJettyH2cWireMockLikeLoad()
+            throws Exception {
+
+        Http2Client client = Http2Client.builder()
+                .protocolConfig(Http2ClientProtocolConfig.builder()
+                                        .priorKnowledge(true)
+                                        .build())
+                .connectTimeout(Duration.ofSeconds(5))
+                .readTimeout(Duration.ofSeconds(10))
+                .readContinueTimeout(Duration.ofSeconds(5))
+                .build();
+
+        try {
+            AtomicInteger ok = new AtomicInteger();
+            AtomicInteger fail = new AtomicInteger();
+            AtomicInteger completed = new AtomicInteger();
+            Map<String, AtomicInteger> errorTypes = new ConcurrentHashMap<>();
+            Map<Integer, AtomicInteger> non200Statuses = new ConcurrentHashMap<>();
+            Lock latenciesLock = new ReentrantLock();
+            List<Long> latenciesMs = new ArrayList<>(REQUEST_COUNT);
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<?>> futures = new ArrayList<>(REQUEST_COUNT);
+
+            System.out.printf("Starting WireMock-like h2c load: url=http://127.0.0.1:%d%s threads=%d requests=%d clients=%d%n",
+                              peerPort,
+                              APP_PATH,
+                              THREAD_COUNT,
+                              REQUEST_COUNT,
+                              1);
+            System.out.flush();
+
+            long startedAt = System.nanoTime();
+            for (int requestIndex = 0; requestIndex < REQUEST_COUNT; requestIndex++) {
+                futures.add(EXECUTOR.submit(() -> {
+                    await(start);
+                    invoke(client, ok, fail, completed, non200Statuses, errorTypes, latenciesLock, latenciesMs);
+                }));
+            }
+
+            start.countDown();
+            for (Future<?> future : futures) {
+                future.get();
+            }
+
+            long totalMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+            String report = loadReport(ok.get(), fail.get(), totalMs, non200Statuses, errorTypes, latenciesLock, latenciesMs);
+            System.out.println(report);
+            System.out.flush();
+
+            if (fail.get() > 0 || !non200Statuses.isEmpty()) {
+                fail(report + "\nPeer log:\n" + peerLog());
+            }
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    private static void invoke(Http2Client client,
+                               AtomicInteger ok,
+                               AtomicInteger fail,
+                               AtomicInteger completed,
+                               Map<Integer, AtomicInteger> non200Statuses,
+                               Map<String, AtomicInteger> errorTypes,
+                               Lock latenciesLock,
+                               List<Long> latenciesMs) {
+        ensurePeerAlive();
+
+        try {
+            URI uri = URI.create("http://127.0.0.1:" + peerPort + APP_PATH);
+            for (int attempt = 0; attempt <= RETRY_COUNT; attempt++) {
+                long requestStarted = System.nanoTime();
+                try (HttpClientResponse response = client.post()
+                        .uri(uri)
+                        .contentType(HttpMediaTypes.JSON_UTF_8)
+                        .header(HeaderNames.ACCEPT, "application/json")
+                        .submit(REQUEST_BODY)) {
+
+                    int status = response.status().code();
+                    addLatency(latenciesLock, latenciesMs, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestStarted));
+                    if (status == 200) {
+                        ok.incrementAndGet();
+                    } else {
+                        fail.incrementAndGet();
+                        non200Statuses.computeIfAbsent(status, ignored -> new AtomicInteger()).incrementAndGet();
+                    }
+
+                    response.inputStream().readAllBytes();
+                    return;
+                } catch (Exception e) {
+                    if (retryable(e) && attempt < RETRY_COUNT) {
+                        continue;
+                    }
+                    fail.incrementAndGet();
+                    String error = e.getClass().getSimpleName() + ": " + String.valueOf(e.getMessage());
+                    errorTypes.computeIfAbsent(error, ignored -> new AtomicInteger()).incrementAndGet();
+                    return;
+                }
+            }
+        } finally {
+            int done = completed.incrementAndGet();
+            if (done % PROGRESS_EVERY == 0 || done == REQUEST_COUNT) {
+                System.out.println("PROGRESS completed " + done + " / " + REQUEST_COUNT);
+                System.out.flush();
+            }
+        }
+    }
+
+    private static Process startPeerProcess(int port) throws IOException {
+        String classPath = System.getProperty("surefire.test.class.path");
+        if (classPath == null || classPath.isBlank()) {
+            classPath = System.getProperty("java.class.path");
+        }
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                javaBinary(),
+                "-Dissue11529.jetty.sharedHeaders=" + Integer.getInteger("issue11529.jetty.sharedHeaders", 0),
+                "-Dissue11529.jetty.varyingHeaders=" + Integer.getInteger("issue11529.jetty.varyingHeaders", 0),
+                "-Dissue11529.maxConcurrentStreams=" + Integer.getInteger("issue11529.maxConcurrentStreams", -1),
+                "-Dissue11529.chunkCount=" + Integer.getInteger("issue11529.chunkCount", 1),
+                "-Dissue11529.chunkDelayMillis=" + Integer.getInteger("issue11529.chunkDelayMillis", 0),
+                "-cp",
+                classPath,
+                JettyH2cPeerMain.class.getName(),
+                Integer.toString(port));
+        processBuilder.redirectErrorStream(true);
+
+        Process process = processBuilder.start();
+        EXECUTOR.submit(() -> consumePeerLog(process));
+        return process;
+    }
+
+    private static void waitForPeer(int port, Duration timeout) throws Exception {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            ensurePeerAlive();
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress("127.0.0.1", port), 200);
+                return;
+            } catch (IOException ignored) {
+                Thread.sleep(100);
+            }
+        }
+        fail("Jetty h2c peer did not start within " + timeout + "\nPeer log:\n" + peerLog());
+    }
+
+    private static void consumePeerLog(Process process) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(),
+                                                                              StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                appendPeerLog(line);
+            }
+        } catch (IOException e) {
+            appendPeerLog("Failed to read peer log: " + e);
+        }
+    }
+
+    private static void ensurePeerAlive() {
+        if (peerProcess != null && !peerProcess.isAlive()) {
+            fail("Jetty h2c peer exited unexpectedly with code " + peerProcess.exitValue()
+                         + "\nPeer log:\n" + peerLog());
+        }
+    }
+
+    private static String peerLog() {
+        PEER_LOG_LOCK.lock();
+        try {
+            return PEER_LOG.toString();
+        } finally {
+            PEER_LOG_LOCK.unlock();
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting to start test wave", e);
+        }
+    }
+
+    private static int nextFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private static String javaBinary() {
+        return System.getProperty("java.home") + "/bin/java";
+    }
+
+    private static boolean retryable(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof UncheckedIOException) {
+                return true;
+            }
+            if (current.getClass().getSimpleName().contains("StreamTimeoutException")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static String loadReport(int ok,
+                                     int fail,
+                                     long totalMs,
+                                     Map<Integer, AtomicInteger> non200Statuses,
+                                     Map<String, AtomicInteger> errorTypes,
+                                     Lock latenciesLock,
+                                     List<Long> latenciesMs) {
+        StringBuilder report = new StringBuilder();
+        report.append("\n=== WireMock-like h2c Load Report ===\n");
+        report.append("Requests total: ").append(REQUEST_COUNT).append('\n');
+        report.append("Success (200):  ").append(ok).append('\n');
+        report.append("Failed:         ").append(fail).append('\n');
+        report.append("Duration ms:    ").append(totalMs).append('\n');
+        if (totalMs > 0) {
+            report.append(String.format("RPS:            %.2f%n", REQUEST_COUNT * 1000.0 / totalMs));
+        } else {
+            report.append("RPS:            0.00\n");
+        }
+
+        List<Long> sorted = snapshotLatencies(latenciesLock, latenciesMs);
+        if (!sorted.isEmpty()) {
+            sorted.sort(Comparator.naturalOrder());
+            report.append("Latency ms p50: ").append(percentile(sorted, 50)).append('\n');
+            report.append("Latency ms p95: ").append(percentile(sorted, 95)).append('\n');
+            report.append("Latency ms max: ").append(sorted.get(sorted.size() - 1)).append('\n');
+        }
+
+        if (!non200Statuses.isEmpty()) {
+            report.append("Non-200 statuses:\n");
+            non200Statuses.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> report.append("  ")
+                            .append(entry.getKey())
+                            .append(" -> ")
+                            .append(entry.getValue().get())
+                            .append('\n'));
+        }
+
+        if (!errorTypes.isEmpty()) {
+            report.append("Exceptions:\n");
+            errorTypes.entrySet().stream()
+                    .sorted((left, right) -> Integer.compare(right.getValue().get(), left.getValue().get()))
+                    .forEach(entry -> report.append("  ")
+                            .append(entry.getKey())
+                            .append(" -> ")
+                            .append(entry.getValue().get())
+                            .append('\n'));
+        }
+
+        return report.toString();
+    }
+
+    private static void appendPeerLog(String line) {
+        PEER_LOG_LOCK.lock();
+        try {
+            PEER_LOG.append(line).append(System.lineSeparator());
+        } finally {
+            PEER_LOG_LOCK.unlock();
+        }
+    }
+
+    private static void addLatency(Lock latenciesLock, List<Long> latenciesMs, long latencyMs) {
+        latenciesLock.lock();
+        try {
+            latenciesMs.add(latencyMs);
+        } finally {
+            latenciesLock.unlock();
+        }
+    }
+
+    private static List<Long> snapshotLatencies(Lock latenciesLock, List<Long> latenciesMs) {
+        latenciesLock.lock();
+        try {
+            return new ArrayList<>(latenciesMs);
+        } finally {
+            latenciesLock.unlock();
+        }
+    }
+
+    private static long percentile(List<Long> sorted, int percentile) {
+        int index = (int) Math.ceil((percentile / 100.0) * sorted.size()) - 1;
+        index = Math.max(0, Math.min(index, sorted.size() - 1));
+        return sorted.get(index);
+    }
+
+    /**
+     * Out-of-process non-Helidon h2c peer used by the issue 11529 reproducer.
+     */
+    public static final class JettyH2cPeerMain {
+        private static final int SHARED_HEADER_COUNT = Integer.getInteger("issue11529.jetty.sharedHeaders", 0);
+        private static final int VARYING_HEADER_COUNT = Integer.getInteger("issue11529.jetty.varyingHeaders", 0);
+        private static final int MAX_CONCURRENT_STREAMS = Integer.getInteger("issue11529.maxConcurrentStreams", -1);
+        private static final int LARGE_HEADER_REPEAT = Integer.getInteger("issue11529.jetty.headerRepeat", 16);
+        private static final int CHUNK_COUNT = Integer.getInteger("issue11529.chunkCount", 1);
+        private static final int CHUNK_DELAY_MILLIS = Integer.getInteger("issue11529.chunkDelayMillis", 0);
+
+        private JettyH2cPeerMain() {
+        }
+
+        public static void main(String[] args) throws Exception {
+            int port = Integer.parseInt(args[0]);
+
+            Server server = new Server();
+
+            HttpConfiguration httpConfiguration = new HttpConfiguration();
+            httpConfiguration.setRequestHeaderSize(256 * 1024);
+            httpConfiguration.setResponseHeaderSize(256 * 1024);
+            HTTP2CServerConnectionFactory h2c = new HTTP2CServerConnectionFactory(httpConfiguration);
+            h2c.setMaxHeaderBlockFragment(256 * 1024);
+            if (MAX_CONCURRENT_STREAMS > 0) {
+                h2c.setMaxConcurrentStreams(MAX_CONCURRENT_STREAMS);
+            }
+
+            ServerConnector connector = new ServerConnector(server, h2c);
+            connector.setPort(port);
+            connector.setIdleTimeout(300_000);
+            server.addConnector(connector);
+
+            ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+            context.setContextPath("/");
+            ServletHolder servlet = new ServletHolder(new StressServlet());
+            context.addServlet(servlet, APP_PATH);
+            context.addServlet(servlet, "/rpc");
+            server.setHandler(context);
+
+            server.start();
+            System.out.println("READY " + connector.getLocalPort()
+                                       + " maxConcurrentStreams="
+                                       + h2c.getMaxConcurrentStreams());
+            System.out.flush();
+            server.join();
+        }
+
+        private static final class StressServlet extends HttpServlet {
+            @Override
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+                try {
+                    String execId = valueOrDefault(req.getParameter("execId"), "00");
+                    String waveId = valueOrDefault(req.getParameter("wave"), "00");
+                    byte[] requestBody = req.getInputStream().readAllBytes();
+
+                    resp.setStatus(HttpServletResponse.SC_OK);
+                    resp.setContentType("application/json");
+                    for (int i = 0; i < SHARED_HEADER_COUNT; i++) {
+                        resp.addHeader("issue-11529-jetty-shared-" + i, largeHeaderValue("shared", i));
+                    }
+                    for (int i = 0; i < VARYING_HEADER_COUNT; i++) {
+                        resp.addHeader("issue-11529-jetty-vary-" + i, largeHeaderValue(execId + "-" + waveId, i));
+                    }
+
+                    if (CHUNK_COUNT <= 1) {
+                        resp.getOutputStream()
+                                .write(responseBody(execId, waveId, requestBody.length).getBytes(StandardCharsets.UTF_8));
+                    } else {
+                        for (int i = 0; i < CHUNK_COUNT; i++) {
+                            resp.getOutputStream()
+                                    .write((responseChunk(execId, waveId, requestBody.length, i) + "\n")
+                                                   .getBytes(StandardCharsets.UTF_8));
+                            resp.flushBuffer();
+                            if (CHUNK_DELAY_MILLIS > 0) {
+                                Thread.sleep(CHUNK_DELAY_MILLIS);
+                            }
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while streaming response", e);
+                } catch (Throwable t) {
+                    t.printStackTrace(System.out);
+                    System.out.flush();
+                    throw t;
+                }
+            }
+        }
+
+        private static String valueOrDefault(String value, String defaultValue) {
+            return value == null ? defaultValue : value;
+        }
+
+        private static String largeHeaderValue(String execId, int i) {
+            String seed = "issue-11529-jetty-" + execId + "-" + i + "-";
+            return seed.repeat(LARGE_HEADER_REPEAT);
+        }
+
+        private static String responseBody(String execId, String waveId, int bodySize) {
+            return "{\"status\":\"ok\""
+                    + ",\"execId\":\"" + execId + "\""
+                    + ",\"wave\":\"" + waveId + "\""
+                    + ",\"bodySize\":" + bodySize
+                    + "}";
+        }
+
+        static String responseChunk(String execId, String waveId, int bodySize, int chunk) {
+            return "{\"execId\":\"" + execId
+                    + "\",\"wave\":\"" + waveId
+                    + "\",\"bodySize\":" + bodySize
+                    + ",\"chunk\":\"" + String.format("%03d", chunk)
+                    + "\"}";
+        }
+    }
+}

--- a/webclient/tests/http2/pom.xml
+++ b/webclient/tests/http2/pom.xml
@@ -28,6 +28,10 @@
     <name>Helidon WebClient Tests HTTP/2</name>
     <description>WebClient HTTP/2 tests</description>
 
+    <properties>
+        <jetty.h2c.peer.version>11.0.18</jetty.h2c.peer.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
@@ -62,5 +66,40 @@
             <artifactId>vertx-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.h2c.peer.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.h2c.peer.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
+            <version>${jetty.h2c.peer.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2JettyH2cReproducerIT.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2JettyH2cReproducerIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.helidon.webclient.http2;
+package io.helidon.webclient.tests.http2;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -43,6 +43,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpMediaTypes;
 import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webclient.http2.Http2ClientProtocolConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -56,7 +58,6 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -64,19 +65,19 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Manual integration-test reproducer for issue 11529.
  *
  * <p>Run explicitly with:
- * {@code mvn -pl webclient/http2 -am verify -Dissue11529.run=true -Dit.test=Http2JettyH2cReproducerIT}
+ * {@code mvn -Ptests -pl :helidon-webclient-tests-http2 -am verify -Dit.test=Http2JettyH2cReproducerIT}
  */
-@EnabledIfSystemProperty(named = "issue11529.run", matches = "true")
 public class Http2JettyH2cReproducerIT {
     private static final StringBuilder PEER_LOG = new StringBuilder();
     private static final Lock PEER_LOG_LOCK = new ReentrantLock();
     private static final String APP_PATH = "/api/field-service/appcache/v1/rpc/get_properties";
-    private static final int THREAD_COUNT = Integer.getInteger("issue11529.threads", 500);
-    private static final int REQUEST_COUNT = Integer.getInteger("issue11529.requests", 10_000);
+    private static final int THREAD_COUNT = Integer.getInteger("issue11529.threads", 64);
+    private static final int REQUEST_COUNT = Integer.getInteger("issue11529.requests", 512);
     private static final int RETRY_COUNT = Integer.getInteger("issue11529.retryCount", 1);
     private static final int PROGRESS_EVERY = Integer.getInteger("issue11529.progressEvery",
                                                                  Math.max(1, REQUEST_COUNT / 10));
     private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(THREAD_COUNT);
+    private static final ExecutorService PEER_LOG_EXECUTOR = Executors.newSingleThreadExecutor();
     private static final String REQUEST_BODY = """
             {"data":{"entity":2,"context":"all_fields_api_inventory","options":1,"entity_id":26030351,"provider_id":0,"page_id":1,"user_id":"1"}}
             """.trim();
@@ -103,6 +104,10 @@ public class Http2JettyH2cReproducerIT {
         EXECUTOR.shutdown();
         if (!EXECUTOR.awaitTermination(30, TimeUnit.SECONDS)) {
             EXECUTOR.shutdownNow();
+        }
+        PEER_LOG_EXECUTOR.shutdown();
+        if (!PEER_LOG_EXECUTOR.awaitTermination(30, TimeUnit.SECONDS)) {
+            PEER_LOG_EXECUTOR.shutdownNow();
         }
     }
 
@@ -185,6 +190,7 @@ public class Http2JettyH2cReproducerIT {
                         .submit(REQUEST_BODY)) {
 
                     int status = response.status().code();
+                    response.inputStream().readAllBytes();
                     addLatency(latenciesLock, latenciesMs, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestStarted));
                     if (status == 200) {
                         ok.incrementAndGet();
@@ -192,8 +198,6 @@ public class Http2JettyH2cReproducerIT {
                         fail.incrementAndGet();
                         non200Statuses.computeIfAbsent(status, ignored -> new AtomicInteger()).incrementAndGet();
                     }
-
-                    response.inputStream().readAllBytes();
                     return;
                 } catch (Exception e) {
                     if (retryable(e) && attempt < RETRY_COUNT) {
@@ -234,7 +238,7 @@ public class Http2JettyH2cReproducerIT {
         processBuilder.redirectErrorStream(true);
 
         Process process = processBuilder.start();
-        EXECUTOR.submit(() -> consumePeerLog(process));
+        PEER_LOG_EXECUTOR.submit(() -> consumePeerLog(process));
         return process;
     }
 
@@ -480,7 +484,7 @@ public class Http2JettyH2cReproducerIT {
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new IOException("Interrupted while streaming response", e);
-                } catch (Throwable t) {
+                } catch (IOException | RuntimeException t) {
                     t.printStackTrace(System.out);
                     System.out.flush();
                     throw t;

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/MaxFrameSizeTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/MaxFrameSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ class MaxFrameSizeTest {
     }
 
     @Test
-    void maxFrameChangeMidConnection() throws InterruptedException {
+    void maxFrameChangeMidConnection() throws InterruptedException, ExecutionException, TimeoutException {
         Http2Client
                 client = Http2Client.builder()
                 .shareConnectionCache(false)
@@ -164,6 +164,7 @@ class MaxFrameSizeTest {
         }
 
         // Trigger server to change MAX_FRAME_SIZE=18_000
+        SETTINGS_ACKED = new CompletableFuture<>();
         try (Http2ClientResponse res = client
                 .method(Method.GET)
                 .path("/trigger-settings")
@@ -172,7 +173,10 @@ class MaxFrameSizeTest {
                 .request()) {
 
             assertThat(res.status(), is(Status.OK_200));
+            assertThat(res.as(String.class), is("Settings size change triggered: 18000"));
         }
+        // Wait for the client SETTINGS ACK before the next request observes the updated frame size.
+        SETTINGS_ACKED.get(TIMEOUT.getSeconds(), TimeUnit.SECONDS);
 
         // Test that the client honors MAX_FRAME_SIZE=18_000
         try (Http2ClientResponse res = client


### PR DESCRIPTION
Fixes #11529

### Summary

- Decode inbound HTTP/2 client header blocks on the connection thread so the shared HPACK dynamic table advances in wire order.
- Preserve HPACK state only for known abandoned client streams; reject invalid missing-stream HEADERS with PROTOCOL_ERROR.
- Release peer `MAX_CONCURRENT_STREAMS` reservations on inbound completion and discard unusable newly published connections.
- Keep the DATA receive hot path allocation-light and avoid the extra inbound-state lock for ordinary DATA frames.
- Add Jetty h2c regression coverage under `webclient/tests/http2` and the h2specd client conformance integration module.

### Testing

- `mvn -ntp -pl webclient/http2 -DskipITs -DskipTests=false -Dtest=Http2ClientConnectionTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -ntp -Ptests -pl :helidon-webclient-tests-http2 -am -Dtest=FollowRedirectTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test`
- `mvn -ntp -f tests/integration/h2spec-client/pom.xml -DskipTests test-compile`
- `mvn -ntp -Ptests -pl :helidon-webclient-tests-http2 -am -Dtest=NoSuchTest -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=Http2JettyH2cReproducerIT verify`
- `bash ./etc/scripts/copyright.sh`
- `bash ./etc/scripts/checkstyle.sh`
- `git diff --check`
