### PR TITLE
4.x: Upgrade typesafe to 1.4.8

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -166,7 +166,7 @@
         <version.lib.smallrye-openapi>3.3.4</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>2.5</version.lib.snakeyaml>
         <version.lib.testcontainers>1.21.4</version.lib.testcontainers>
-        <version.lib.typesafe-config>1.4.4</version.lib.typesafe-config>
+        <version.lib.typesafe-config>1.4.8</version.lib.typesafe-config>
         <version.lib.tyrus>2.1.5</version.lib.tyrus>
         <version.lib.weld-api>5.0.SP3</version.lib.weld-api>
         <version.lib.weld>5.1.6.Final</version.lib.weld>


### PR DESCRIPTION
### Description

Upgrade typesafe to 1.4.8


