### PR TITLE
4.x: Upgrade OCI SDK to 3.86.2

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/oci/files/server/src/test/java/__pkg__/server/GreetResourceMockedTest.java.mustache
+++ b/archetypes/archetypes/src/main/archetype/mp/oci/files/server/src/test/java/__pkg__/server/GreetResourceMockedTest.java.mustache
@@ -82,6 +82,9 @@ class GreetResourceMockedTest {
         public void close() {}
 
         @Override
+        public void enableDualStackEndpoints(boolean dualStackEndpointTemplateEnabled) {}
+
+        @Override
         public String getEndpoint() {
             return this.endpoint;
         }

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -141,7 +141,7 @@
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
         <version.lib.netty>4.1.133.Final</version.lib.netty>
-        <version.lib.oci>3.78.1</version.lib.oci>
+        <version.lib.oci>3.86.2</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>


### PR DESCRIPTION
### Description

Upgrade OCI SDK to 3.86.2

