### PR TITLE
27.x: upgrade jackson, typesafe-config, snakeyaml

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -59,7 +59,7 @@
         <version.lib.hibernate>${version.lib.hibernate.family}.1.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
-        <version.lib.jackson>2.21.1</version.lib.jackson>
+        <version.lib.jackson>2.21.3</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.1.3</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.1.1</version.lib.jakarta.annotation-api>
         <!-- Needed for transaction/jta -->
@@ -103,9 +103,9 @@
         <version.lib.prometheus>0.16.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <version.lib.slf4j>2.0.17</version.lib.slf4j>
-        <version.lib.snakeyaml>2.5</version.lib.snakeyaml>
+        <version.lib.snakeyaml>2.6</version.lib.snakeyaml>
         <version.lib.testcontainers>1.21.4</version.lib.testcontainers>
-        <version.lib.typesafe-config>1.4.4</version.lib.typesafe-config>
+        <version.lib.typesafe-config>1.4.8</version.lib.typesafe-config>
         <version.lib.yasson>3.0.4</version.lib.yasson>
         <version.lib.zookeeper>3.5.7</version.lib.zookeeper>
     </properties>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -105,13 +105,27 @@
 </suppress>
 
 <!-- False Positive.
-     Another FP against prometheus server (not prometheus simple client)
+     This CVE is against prometheus server (not client libraries).
  -->
 <suppress>
     <notes><![CDATA[
     file name: simpleclient-0.16.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient.*@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: prometheus-metrics-core-1.3.10.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/prometheus-metrics-.*@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: micrometer-registry-prometheus-1.15.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-registry-prometheus.*@.*$</packageUrl>
     <cve>CVE-2026-42154</cve>
 </suppress>
 
@@ -277,6 +291,26 @@
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus-utils@.*$</packageUrl>
     <cve>CVE-2025-67030</cve>
 </suppress>
+
+<!-- False Positive
+     These CVEs are against GraphQL, not dataloader.
+     https://github.com/dependency-check/DependencyCheck/issues/8387
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: java-dataloader-3.3.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.graphql-java/java-dataloader@.*$</packageUrl>
+    <cve>CVE-2022-37734</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: java-dataloader-3.3.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.graphql-java/java-dataloader@.*$</packageUrl>
+    <cve>CVE-2023-28867</cve>
+</suppress>
+
 
 
 </suppressions>


### PR DESCRIPTION
### Description

- Upgrade Jackson to 2.21.3
- Upgrade typesafe-config to 1.4.8
- Upgrade snakeyaml to 2.6

Add suppression for graphql and more prometheus false positives.