### PR TITLE
27.x: Deprecate LockingStreamIdSequence constructor

### DIFF
--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -74,7 +74,7 @@ public class Http2ClientConnection {
     private static final long NO_PING_ACK = Long.MIN_VALUE;
     private final Http2FrameListener sendListener = new Http2LoggingFrameListener("cl-send");
     private final Http2FrameListener recvListener = new Http2LoggingFrameListener("cl-recv");
-    private final LockingStreamIdSequence streamIdSeq = new LockingStreamIdSequence();
+    private final LockingStreamIdSequence streamIdSeq = LockingStreamIdSequence.create();
     private final ReadWriteLock streamsLock = new ReentrantReadWriteLock();
     // streams may be accessed from connection thread, or stream thread, must be guarded by the above lock
     private final Map<Integer, Http2ClientStream> streams = new HashMap<>();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
@@ -29,7 +29,19 @@ public class LockingStreamIdSequence {
 
     /**
      * Create a new locking stream ID sequence.
+     *
+     * @return a new locking stream ID sequence
      */
+    public static LockingStreamIdSequence create() {
+        return new LockingStreamIdSequence();
+    }
+
+    /**
+     * Create a new locking stream ID sequence.
+     *
+     * @deprecated use {@link #create()} instead
+     */
+    @Deprecated(forRemoval = true, since = "27.0.0")
     public LockingStreamIdSequence() {
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
@@ -30,19 +30,19 @@ public class LockingStreamIdSequence {
     /**
      * Create a new locking stream ID sequence.
      *
-     * @return a new locking stream ID sequence
+     * @deprecated use {@link #create()} instead
      */
-    public static LockingStreamIdSequence create() {
-        return new LockingStreamIdSequence();
+    @Deprecated(forRemoval = true, since = "27.0.0")
+    public LockingStreamIdSequence() {
     }
 
     /**
      * Create a new locking stream ID sequence.
      *
-     * @deprecated use {@link #create()} instead
+     * @return a new locking stream ID sequence
      */
-    @Deprecated(forRemoval = true, since = "27.0.0")
-    public LockingStreamIdSequence() {
+    public static LockingStreamIdSequence create() {
+        return new LockingStreamIdSequence();
     }
 
     int lockAndNext() {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
@@ -174,7 +174,7 @@ class Http2ClientConnectionPingTest {
                                          socket,
                                          STREAM_CONFIG,
                                          clientConfig,
-                                         new LockingStreamIdSequence());
+                                         LockingStreamIdSequence.create());
         }
     }
 


### PR DESCRIPTION
### Description

Fixes #11986

Adds `LockingStreamIdSequence.create()` and updates HTTP/2 client usage to use the factory method. Deprecates the public constructor for removal while preserving compatibility in 27.x.

### Documentation

None
