### PR TITLE
27.x: HTTP/2 WebClient flow control fix

### DIFF
--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
@@ -62,7 +62,7 @@ abstract class WindowSizeImpl implements WindowSize {
                         ? increment + r
                         : MAX_WIN_SIZE);
 
-        return remaining + increment;
+        return (long) remaining + increment;
     }
 
     @Override

--- a/http/http2/src/test/java/io/helidon/http/http2/WindowSizeImplTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/WindowSizeImplTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.http.http2;
+
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class WindowSizeImplTest {
+
+    private static final BiConsumer<Integer, Http2WindowUpdate> NOOP_WINDOW_UPDATE_WRITER = (streamId, windowUpdate) -> {
+    };
+
+    @Test
+    void connectionWindowIncrementReturnsOverflowValueAsLong() {
+        ConnectionFlowControl flowControl = ConnectionFlowControl.clientBuilder(NOOP_WINDOW_UPDATE_WRITER)
+                .build();
+
+        long remaining = flowControl.incrementOutboundConnectionWindowSize(WindowSize.MAX_WIN_SIZE);
+
+        assertThat(remaining, is((long) WindowSize.DEFAULT_WIN_SIZE + WindowSize.MAX_WIN_SIZE));
+        assertThat(flowControl.outbound().getRemainingWindowSize(), is(WindowSize.MAX_WIN_SIZE));
+    }
+
+    @Test
+    void streamWindowIncrementReturnsOverflowValueAsLong() {
+        ConnectionFlowControl flowControl = ConnectionFlowControl.clientBuilder(NOOP_WINDOW_UPDATE_WRITER)
+                .build();
+        StreamFlowControl streamFlowControl = flowControl.createStreamFlowControl(1,
+                                                                                 WindowSize.DEFAULT_WIN_SIZE,
+                                                                                 WindowSize.DEFAULT_MAX_FRAME_SIZE);
+
+        long remaining = streamFlowControl.outbound().incrementStreamWindowSize(WindowSize.MAX_WIN_SIZE);
+
+        assertThat(remaining, is((long) WindowSize.DEFAULT_WIN_SIZE + WindowSize.MAX_WIN_SIZE));
+    }
+}

--- a/tests/integration/h2spec-client/src/test/java/io/helidon/tests/integration/h2spec/client/H2SpecClientIT.java
+++ b/tests/integration/h2spec-client/src/test/java/io/helidon/tests/integration/h2spec/client/H2SpecClientIT.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -33,7 +32,6 @@ import java.util.stream.Stream;
 import io.helidon.logging.common.LogConfig;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -81,12 +79,6 @@ class H2SpecClientIT {
     private static final Pattern CASE_PATTERN =
             Pattern.compile("^\\s*(?:([\\u2714\\u00D7])\\s+)?(\\d+):\\s+(.*)$");
 
-    private static final Set<KnownFailure> KNOWN_FAILURES = Set.of(
-            new KnownFailure("client/6.9.1/1",
-                             "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1"),
-            new KnownFailure("client/6.9.1/2",
-                             "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream")
-    );
     private static final Logger LOGGER = LoggerFactory.getLogger(H2SpecClientIT.class);
 
     static {
@@ -373,10 +365,6 @@ class H2SpecClientIT {
         }
     }
 
-    private static boolean isKnownFailure(String id, String desc) {
-        return KNOWN_FAILURES.contains(new KnownFailure(id, desc));
-    }
-
     @ParameterizedTest(name = "{0}: {1}")
     @MethodSource("runH2Spec")
     void h2spec(String caseName, String desc, String id, String err, String skipped) {
@@ -386,16 +374,9 @@ class H2SpecClientIT {
             Assertions.fail("Unexpected h2specd skip for " + id + " (" + desc + "): " + skipped);
         }
 
-        if (err != null && isKnownFailure(id, desc)) {
-            Assumptions.abort("Known failure tracked by #11771:\n" + err);
-        }
-
         if (err != null) {
             Assertions.fail(err);
         }
-    }
-
-    private record KnownFailure(String id, String description) {
     }
 
     private record H2SpecCaseResult(String caseName,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -165,16 +165,13 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         if (increment == 0) {
             Http2RstStream frame = new Http2RstStream(Http2ErrorCode.PROTOCOL);
             connection.writer().write(frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            return;
         }
         //6.9.1/3
         if (flowControl.outbound().incrementStreamWindowSize(increment) > WindowSize.MAX_WIN_SIZE) {
             Http2RstStream frame = new Http2RstStream(Http2ErrorCode.FLOW_CONTROL);
             connection.writer().write(frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
         }
-
-        flowControl()
-                .outbound()
-                .incrementStreamWindowSize(increment);
     }
 
     @Override

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
@@ -16,8 +16,11 @@
 
 package io.helidon.webclient.http2;
 
+import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -27,8 +30,18 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2GoAway;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2WindowUpdate;
+import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
 
 import org.junit.jupiter.api.Test;
@@ -42,6 +55,7 @@ import static org.mockito.Mockito.when;
 
 class Http2ClientConnectionPingTest {
     private static final Duration TEST_WAIT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Method HANDLE_METHOD = handleMethod();
     private static final Http2StreamConfig STREAM_CONFIG = new Http2StreamConfig() {
         @Override
         public boolean priorKnowledge() {
@@ -100,6 +114,54 @@ class Http2ClientConnectionPingTest {
         assertThat(pingFuture.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(false));
     }
 
+    @Test
+    void connectionWindowOverflowWritesFlowControlGoAway() throws Exception {
+        Http2FrameData frameData = new Http2WindowUpdate(WindowSize.MAX_WIN_SIZE)
+                .toFrameData(Http2Settings.create(), 0, Http2Flag.NoFlags.create());
+        MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100), frameBytes(frameData));
+
+        assertThat(invokeHandle(test.connection()), is(true));
+
+        assertThat(test.writes(), hasSize(1));
+        BufferData write = test.writes().get(0);
+        Http2FrameHeader header = readFrameHeader(write);
+        assertThat(header.type(), is(Http2FrameType.GO_AWAY));
+        assertThat(header.streamId(), is(0));
+        assertThat(Http2GoAway.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
+    }
+
+    @Test
+    void streamWindowUpdateIncrementsOutboundWindowOnce() {
+        MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100));
+        Http2ClientStream stream = test.newStream();
+        stream.writeHeaders(Http2Headers.create(WritableHeaders.create()), false);
+        test.clearWrites();
+        test.connection().flowControl().incrementOutboundConnectionWindowSize(2);
+
+        int remainingBeforeUpdate = stream.flowControl().outbound().getRemainingWindowSize();
+        stream.windowUpdate(new Http2WindowUpdate(1));
+
+        assertThat(stream.flowControl().outbound().getRemainingWindowSize(), is(remainingBeforeUpdate + 1));
+        assertThat(test.writes(), hasSize(0));
+    }
+
+    @Test
+    void streamWindowOverflowWritesFlowControlRstStream() {
+        MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100));
+        Http2ClientStream stream = test.newStream();
+        stream.writeHeaders(Http2Headers.create(WritableHeaders.create()), false);
+        test.clearWrites();
+
+        stream.windowUpdate(new Http2WindowUpdate(WindowSize.MAX_WIN_SIZE));
+
+        assertThat(test.writes(), hasSize(1));
+        BufferData write = test.writes().get(0);
+        Http2FrameHeader header = readFrameHeader(write);
+        assertThat(header.type(), is(Http2FrameType.RST_STREAM));
+        assertThat(header.streamId(), is(1));
+        assertThat(Http2RstStream.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
+    }
+
     private static CompletableFuture<Boolean> startPing(MockedConnectionTestContext test) {
         CompletableFuture<Boolean> pingFuture = new CompletableFuture<>();
         Thread.ofPlatform().start(() -> {
@@ -110,6 +172,29 @@ class Http2ClientConnectionPingTest {
             }
         });
         return pingFuture;
+    }
+
+    private static boolean invokeHandle(Http2ClientConnection connection) throws Exception {
+        return (boolean) HANDLE_METHOD.invoke(connection);
+    }
+
+    private static Method handleMethod() {
+        try {
+            Method method = Http2ClientConnection.class.getDeclaredMethod("handle");
+            method.setAccessible(true);
+            return method;
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static byte[] frameBytes(Http2FrameData frame) {
+        return BufferData.create(frame.header().write(), frame.data().copy()).readBytes();
+    }
+
+    private static Http2FrameHeader readFrameHeader(BufferData frame) {
+        frame.rewind();
+        return Http2FrameHeader.create(frame);
     }
 
     private static long readPingPayloadId(BufferData frame) {
@@ -127,7 +212,7 @@ class Http2ClientConnectionPingTest {
         private final Http2ClientConnection connection;
         private final CaptureWriter dataWriter = new CaptureWriter();
 
-        private MockedConnectionTestContext(Duration pingTimeout) {
+        private MockedConnectionTestContext(Duration pingTimeout, byte[]... reads) {
             Http2ClientProtocolConfig protocolConfig = Http2ClientProtocolConfig.builder()
                     .ping(true)
                     .pingTimeout(pingTimeout)
@@ -140,10 +225,11 @@ class Http2ClientConnectionPingTest {
             Http2ClientImpl client = mock(Http2ClientImpl.class);
             ClientConnection clientConnection = mock(ClientConnection.class);
             this.socket = mock(HelidonSocket.class);
+            Queue<byte[]> readQueue = new ArrayDeque<>(List.of(reads));
 
             when(client.protocolConfig()).thenReturn(protocolConfig);
             when(client.clientConfig()).thenReturn(clientConfig);
-            when(clientConnection.reader()).thenReturn(DataReader.create(() -> null));
+            when(clientConnection.reader()).thenReturn(DataReader.create(readQueue::poll));
             when(clientConnection.writer()).thenReturn(dataWriter);
             when(clientConnection.helidonSocket()).thenReturn(socket);
             when(socket.socketId()).thenReturn("test-socket");
@@ -158,6 +244,10 @@ class Http2ClientConnectionPingTest {
 
         private List<BufferData> writes() {
             return dataWriter.writes;
+        }
+
+        private void clearWrites() {
+            dataWriter.clear();
         }
 
         private BufferData awaitWrite() throws InterruptedException {
@@ -181,6 +271,11 @@ class Http2ClientConnectionPingTest {
     private static final class CaptureWriter implements DataWriter {
         private final List<BufferData> writes = new CopyOnWriteArrayList<>();
         private final LinkedBlockingQueue<BufferData> asyncWrites = new LinkedBlockingQueue<>();
+
+        private void clear() {
+            writes.clear();
+            asyncWrites.clear();
+        }
 
         @Override
         public void write(BufferData... buffers) {


### PR DESCRIPTION
### Description

Fixes #12004

Forward port of #11771.

This fixes HTTP/2 outbound window overflow detection for received `WINDOW_UPDATE` frames by returning the post-increment window size with `long` arithmetic. It also avoids applying stream `WINDOW_UPDATE` frames twice and adds focused regression coverage for connection-level `GOAWAY` and stream-level `RST_STREAM` `FLOW_CONTROL_ERROR` handling.

### Documentation

None
