### PR TITLE
27.x: Support disabling OIDC redirect attempt param

### DIFF
--- a/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
@@ -67,6 +67,12 @@ for a JWT
 5. The JWT is stored in a cookie (if cookie support is enabled, which it is by default)
 6. Helidon service redirects to original endpoint (on itself)
 
+Redirect attempts are counted to prevent infinite login redirects. By default, Helidon stores the count in the
+`redirect-attempt-param` query parameter. Set `redirect-attempt-counter-strategy` to `COOKIE` to store the counter in
+a small cookie instead. Set it to `NONE` to disable redirect attempt counting and `max-redirects` loop protection. The
+`redirect-attempt-param` value is used as the cookie name prefix when the `COOKIE` strategy is used; the full cookie
+name also includes a tenant and original URI hash.
+
 Helidon obtains a token from request (from cookie, header, or query parameter):
 
 1. Token is parsed as a singed JWT

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -235,8 +235,12 @@ import io.helidon.webclient.tracing.WebClientTracing;
  * <tr>
  *     <td>redirect-attempt-param</td>
  *     <td>{@value DEFAULT_ATTEMPT_PARAM}</td>
- *     <td>Query parameter holding the number of times we redirected to an identity server. Customizable to prevent
- *     conflicts with application parameters</td>
+ *     <td>Redirect attempt query parameter name, or cookie name prefix for cookie-based counters.</td>
+ * </tr>
+ * <tr>
+ *     <td>redirect-attempt-counter-strategy</td>
+ *     <td>{@link RedirectAttemptCounterStrategy#PARAM}</td>
+ *     <td>Strategy used to count redirects to an identity server.</td>
  * </tr>
  * <tr>
  *     <td>max-redirects</td>
@@ -360,6 +364,7 @@ public final class OidcConfig extends TenantConfigImpl {
     private final String frontendUri;
     private final boolean redirect;
     private final String redirectAttemptParam;
+    private final RedirectAttemptCounterStrategy redirectAttemptCounterStrategy;
     private final int maxRedirects;
     private final URI postLogoutUri;
     private final boolean forceHttpsRedirects;
@@ -396,6 +401,7 @@ public final class OidcConfig extends TenantConfigImpl {
         this.postLogoutUri = builder.postLogoutUri;
         this.redirect = builder.redirect;
         this.redirectAttemptParam = builder.redirectAttemptParam;
+        this.redirectAttemptCounterStrategy = builder.redirectAttemptCounterStrategy;
         this.maxRedirects = builder.maxRedirects;
         this.forceHttpsRedirects = builder.forceHttpsRedirects;
         this.tokenRefreshSkew = builder.tokenRefreshSkew;
@@ -648,14 +654,17 @@ public final class OidcConfig extends TenantConfigImpl {
         return redirect;
     }
 
-    /**
-     * Name of the parameter used in state passed to OIDC to store the number of attempted redirects.
-     * This is to prevent infinite redirects.
-     *
-     * @return name of the query parameter
+    /** Name used by the redirect attempt query parameter, or as the cookie name prefix for cookie-based counters.
+     * @return name of the query parameter or cookie name prefix
      */
     public String redirectAttemptParam() {
         return redirectAttemptParam;
+    }
+    /** Strategy used to count redirects to an identity server.
+     * @return redirect attempt counter strategy
+     */
+    public RedirectAttemptCounterStrategy redirectAttemptCounterStrategy() {
+        return redirectAttemptCounterStrategy;
     }
 
     /**
@@ -930,6 +939,7 @@ public final class OidcConfig extends TenantConfigImpl {
         private String frontendUri;
         private boolean redirect = DEFAULT_REDIRECT;
         private String redirectAttemptParam = DEFAULT_ATTEMPT_PARAM;
+        private RedirectAttemptCounterStrategy redirectAttemptCounterStrategy = RedirectAttemptCounterStrategy.PARAM;
         private int maxRedirects = DEFAULT_MAX_REDIRECTS;
         private URI postLogoutUri;
         private boolean forceHttpsRedirects = DEFAULT_FORCE_HTTPS_REDIRECTS;
@@ -1001,6 +1011,7 @@ public final class OidcConfig extends TenantConfigImpl {
                                             + "is set as an outbound type and \"idcs\" is the server type");
                 }
             }
+            redirectAttemptCounterStrategy.validateRedirectAttemptParam(redirectAttemptParam, collector);
 
             // second set of validations
             collector.collect().checkValid();
@@ -1099,6 +1110,8 @@ public final class OidcConfig extends TenantConfigImpl {
 
             config.get("redirect").asBoolean().ifPresent(this::redirect);
             config.get("redirect-attempt-param").asString().ifPresent(this::redirectAttemptParam);
+            config.get("redirect-attempt-counter-strategy").as(RedirectAttemptCounterStrategy.class)
+                    .ifPresent(this::redirectAttemptCounterStrategy);
             config.get("max-redirects").asInt().ifPresent(this::maxRedirects);
             config.get("force-https-redirects").asBoolean().ifPresent(this::forceHttpsRedirects);
 
@@ -1243,17 +1256,23 @@ public final class OidcConfig extends TenantConfigImpl {
             return this;
         }
 
-        /**
-         * Configure the parameter used to store the number of attempts in redirect.
-         * <p>
-         * Defaults to {@value #DEFAULT_ATTEMPT_PARAM}
-         *
-         * @param paramName name of the parameter used in the state parameter
+        /** Configure the redirect attempt query parameter and cookie name prefix.
+         * @param paramName name of the parameter or cookie name prefix
          * @return updated builder instance
          */
         @ConfiguredOption(value = DEFAULT_ATTEMPT_PARAM)
         public Builder redirectAttemptParam(String paramName) {
             this.redirectAttemptParam = paramName;
+            return this;
+        }
+
+        /** Configure the strategy used to count redirects to an identity server.
+         * @param strategy redirect attempt counter strategy
+         * @return updated builder instance
+         */
+        @ConfiguredOption(value = "PARAM")
+        public Builder redirectAttemptCounterStrategy(RedirectAttemptCounterStrategy strategy) {
+            this.redirectAttemptCounterStrategy = Objects.requireNonNull(strategy);
             return this;
         }
 

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/RedirectAttemptCounterStrategy.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/RedirectAttemptCounterStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.oidc.common;
+
+import io.helidon.common.Errors;
+import io.helidon.http.HttpToken;
+
+/**
+ * Strategy used to count redirects to an identity server.
+ */
+public enum RedirectAttemptCounterStrategy {
+    /**
+     * Do not count redirect attempts.
+     */
+    NONE,
+
+    /**
+     * Count redirect attempts using a query parameter on the original URI.
+     */
+    PARAM,
+
+    /**
+     * Count redirect attempts using a small cookie.
+     */
+    COOKIE;
+
+    void validateRedirectAttemptParam(String redirectAttemptParam, Errors.Collector collector) {
+        if (this != COOKIE) {
+            return;
+        }
+        if (redirectAttemptParam == null) {
+            collector.fatal("redirect-attempt-param must be configured when redirect-attempt-counter-strategy "
+                                    + "is COOKIE");
+            return;
+        }
+        try {
+            HttpToken.validate(redirectAttemptParam + "_");
+        } catch (IllegalArgumentException ignored) {
+            collector.fatal("redirect-attempt-param must be a valid cookie name prefix when "
+                                    + "redirect-attempt-counter-strategy is COOKIE");
+        }
+    }
+}

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 
+import io.helidon.common.Errors;
 import io.helidon.common.configurable.Resource;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
@@ -46,11 +47,14 @@ import static io.helidon.security.providers.oidc.common.OidcConfig.DEFAULT_PARAM
 import static io.helidon.security.providers.oidc.common.OidcConfig.DEFAULT_REDIRECT;
 import static io.helidon.security.providers.oidc.common.OidcConfig.DEFAULT_REDIRECT_URI;
 import static io.helidon.security.providers.oidc.common.OidcConfig.DEFAULT_TOKEN_REFRESH_SKEW;
+import static io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy.COOKIE;
+import static io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy.PARAM;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit test for {@link OidcConfig}.
@@ -104,6 +108,8 @@ class OidcConfigFromBuilderTest extends OidcConfigAbstractTest {
                 () -> assertThat("Cookie name", tokenCookieHandler.cookieName(), is(DEFAULT_COOKIE_NAME)),
                 () -> assertThat("Realm", config.realm(), is(OidcConfig.Builder.DEFAULT_REALM)),
                 () -> assertThat("Redirect Attempt Parameter", config.redirectAttemptParam(), is(DEFAULT_ATTEMPT_PARAM)),
+                () -> assertThat("Redirect Attempt Counter Strategy",
+                                 config.redirectAttemptCounterStrategy(), is(PARAM)),
                 () -> assertThat("Max Redirects", config.maxRedirects(), is(DEFAULT_MAX_REDIRECTS)),
                 () -> assertThat("Client Timeout", config.clientTimeout(), is(Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS))),
                 () -> assertThat("Force HTTPS Redirects", config.forceHttpsRedirects(), is(DEFAULT_FORCE_HTTPS_REDIRECTS)),
@@ -116,6 +122,46 @@ class OidcConfigFromBuilderTest extends OidcConfigAbstractTest {
                 () -> assertThat("Client without authentication", config.generalWebClient(), notNullValue()),
                 () -> assertThat("Client with authentication", config.appWebClient(), notNullValue()),
                 () -> assertThat("JWK Keys", config.signJwk(), notNullValue()));
+    }
+
+    @Test
+    void testRedirectAttemptCounterStrategyFromBuilder() {
+        OidcConfig config = OidcConfig.builder()
+                .identityUri(URI.create("https://identity.oracle.com"))
+                .clientId("client-id-value")
+                .clientSecret("client-secret-value")
+                .oidcMetadataWellKnown(false)
+                .redirectAttemptCounterStrategy(COOKIE)
+                .build();
+
+        assertThat(config.redirectAttemptCounterStrategy(), is(COOKIE));
+    }
+
+    @Test
+    void testCookieStrategyRejectsInvalidRedirectAttemptCookiePrefix() {
+        assertThrows(Errors.ErrorMessagesException.class,
+                     () -> OidcConfig.builder()
+                             .identityUri(URI.create("https://identity.oracle.com"))
+                             .clientId("client-id-value")
+                             .clientSecret("client-secret-value")
+                             .oidcMetadataWellKnown(false)
+                             .redirectAttemptParam("foo[]")
+                             .redirectAttemptCounterStrategy(COOKIE)
+                             .build());
+    }
+
+    @Test
+    void testParamStrategyAllowsQueryStyleRedirectAttemptParam() {
+        OidcConfig config = OidcConfig.builder()
+                .identityUri(URI.create("https://identity.oracle.com"))
+                .clientId("client-id-value")
+                .clientSecret("client-secret-value")
+                .oidcMetadataWellKnown(false)
+                .redirectAttemptParam("foo[]")
+                .redirectAttemptCounterStrategy(PARAM)
+                .build();
+
+        assertThat(config.redirectAttemptParam(), is("foo[]"));
     }
 
     @Test

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromConfigTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import io.helidon.config.Config;
 
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy.COOKIE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -56,6 +57,12 @@ class OidcConfigFromConfigTest extends OidcConfigAbstractTest {
     void testDisabledAudience() {
         OidcConfig oidcConfig = OidcConfig.create(config.get("security.oidc-disabled-aud"));
         assertThat(oidcConfig.checkAudience(), is(false));
+    }
+
+    @Test
+    void testRedirectAttemptCounterStrategy() {
+        OidcConfig oidcConfig = OidcConfig.create(config.get("security.oidc-redirect-attempt-cookie"));
+        assertThat(oidcConfig.redirectAttemptCounterStrategy(), is(COOKIE));
     }
 
 }

--- a/security/providers/oidc-common/src/test/resources/application.yaml
+++ b/security/providers/oidc-common/src/test/resources/application.yaml
@@ -43,3 +43,10 @@ security:
     client-id: "my-id"
     client-secret: "my-well-known-secret"
     check-audience: false
+
+  oidc-redirect-attempt-cookie:
+    identity-uri: "https://my.identity"
+    client-id: "my-id"
+    client-secret: "my-well-known-secret"
+    oidc-metadata-well-known: false
+    redirect-attempt-counter-strategy: COOKIE

--- a/security/providers/oidc/pom.xml
+++ b/security/providers/oidc/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>helidon-common-crypto</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-uri</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.security</groupId>
             <artifactId>helidon-security</artifactId>
         </dependency>

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcFeature.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcFeature.java
@@ -55,6 +55,7 @@ import io.helidon.security.jwt.SignedJwt;
 import io.helidon.security.jwt.jwk.JwkKeys;
 import io.helidon.security.providers.oidc.common.OidcConfig;
 import io.helidon.security.providers.oidc.common.OidcCookieHandler;
+import io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy;
 import io.helidon.security.providers.oidc.common.Tenant;
 import io.helidon.security.providers.oidc.common.TenantConfig;
 import io.helidon.security.providers.oidc.common.spi.TenantConfigFinder;
@@ -395,6 +396,8 @@ public final class OidcFeature implements HttpFeature {
         String queryState = req.query().get("state");
         if (!state.equals(queryState)) {
             processError(res,
+                         tenantName,
+                         stateCookie,
                          Status.UNAUTHORIZED_401,
                          "State of the original request and obtained from identity server does not match");
             return;
@@ -427,24 +430,24 @@ public final class OidcFeature implements HttpFeature {
                     JsonObject jsonObject = response.as(JsonObject.class);
                     processJsonResponse(req, res, jsonObject, tenantName, stateCookie, tenant);
                 } catch (Exception e) {
-                    processError(res, e, "Failed to read JSON from response");
+                    processError(res, tenantName, stateCookie, e, "Failed to read JSON from response");
                 }
             } else {
                 String message;
                 try {
                     message = response.as(String.class);
                 } catch (Exception e) {
-                    processError(res, e, "Failed to process error entity");
+                    processError(res, tenantName, stateCookie, e, "Failed to process error entity");
                     return;
                 }
                 try {
-                    processError(res, response.status(), message);
+                    processError(res, tenantName, stateCookie, response.status(), message);
                 } catch (Exception e) {
                     throw new SecurityException("Failed to process request: " + message);
                 }
             }
         } catch (Exception e) {
-            processError(res, e, "Failed to invoke request");
+            processError(res, tenantName, stateCookie, e, "Failed to invoke request");
         }
     }
 
@@ -515,6 +518,7 @@ public final class OidcFeature implements HttpFeature {
 
         //redirect to "originalUri"
         String originalUri = stateCookie.stringValue("originalUri", DEFAULT_REDIRECT);
+        ServerResponseHeaders headers = res.headers();
         res.status(Status.TEMPORARY_REDIRECT_307);
         if (oidcConfig.useParam()) {
             originalUri += (originalUri.contains("?") ? "&" : "?") + encode(oidcConfig.paramName()) + "=" + accessToken;
@@ -526,8 +530,8 @@ public final class OidcFeature implements HttpFeature {
             }
         }
 
-        originalUri = increaseRedirectCounter(originalUri);
-        res.headers().add(HeaderNames.LOCATION, originalUri);
+        originalUri = updateRedirectCounter(req, headers, tenantName, originalUri);
+        headers.add(HeaderNames.LOCATION, originalUri);
 
         if (oidcConfig.useCookie()) {
             try {
@@ -537,8 +541,6 @@ public final class OidcFeature implements HttpFeature {
                         .build();
                 String encodedAccessToken = Base64.getEncoder()
                         .encodeToString(accessTokenJson.toString().getBytes(StandardCharsets.UTF_8));
-
-                ServerResponseHeaders headers = res.headers();
 
                 OidcCookieHandler tenantCookieHandler = oidcConfig.tenantCookieHandler();
 
@@ -590,6 +592,24 @@ public final class OidcFeature implements HttpFeature {
         return Optional.empty();
     }
 
+    private Optional<String> processError(ServerResponse res,
+                                          String tenantName,
+                                          JsonObject stateCookie,
+                                          Status status,
+                                          String entity) {
+        clearRedirectAttemptCookie(res.headers(), tenantName, stateCookie);
+        return processError(res, status, entity);
+    }
+
+    private Optional<String> processError(ServerResponse res,
+                                          String tenantName,
+                                          JsonObject stateCookie,
+                                          Throwable t,
+                                          String message) {
+        clearRedirectAttemptCookie(res.headers(), tenantName, stateCookie);
+        return processError(res, t, message);
+    }
+
     // this must always be the same, so clients cannot guess what kind of problem they are facing
     // if they try to provide wrong data
     private void sendErrorResponse(ServerResponse serverResponse) {
@@ -618,7 +638,30 @@ public final class OidcFeature implements HttpFeature {
         }
     }
 
-    private void processError(ServerRequest req, ServerResponse res) {
+    String updateRedirectCounter(ServerRequest req, ServerResponseHeaders headers, String state) {
+        return updateRedirectCounter(req, headers, DEFAULT_TENANT_ID, state);
+    }
+
+    String updateRedirectCounter(ServerRequest req, ServerResponseHeaders headers, String tenantName, String state) {
+        switch (oidcConfig.redirectAttemptCounterStrategy()) {
+        case NONE:
+            return state;
+        case PARAM:
+            return increaseRedirectCounter(state);
+        case COOKIE:
+            return state;
+        default:
+            throw new IllegalStateException("Unsupported redirect attempt counter strategy: "
+                                                    + oidcConfig.redirectAttemptCounterStrategy());
+        }
+    }
+
+    void processError(ServerRequest req, ServerResponse res) {
+        String tenantName = req.query().first(oidcConfig.tenantParamName()).orElse(DEFAULT_TENANT_ID);
+        stateCookie(req).ifPresent(stateCookie -> {
+            res.headers().addCookie(stateCookieHandler.removeCookie().build());
+            clearRedirectAttemptCookie(res.headers(), tenantName, stateCookie);
+        });
         String error = req.query().first("error").orElse("invalid_request");
         String errorDescription = req.query().first("error_description")
                 .orElseGet(() -> "Failed to process authorization request. Expected redirect from OIDC server with code"
@@ -631,6 +674,31 @@ public final class OidcFeature implements HttpFeature {
 
         res.status(Status.BAD_REQUEST_400);
         res.send("{\"error\": \"" + error + "\", \"error_description\": \"" + errorDescription + "\"}");
+    }
+
+    private Optional<JsonObject> stateCookie(ServerRequest req) {
+        return stateCookieHandler.findCookie(req.headers().toMap())
+                .flatMap(this::decodeStateCookie);
+    }
+
+    private Optional<JsonObject> decodeStateCookie(String encodedStateCookie) {
+        try {
+            String stateCookieJson = new String(Base64.getDecoder().decode(encodedStateCookie), StandardCharsets.UTF_8);
+            return Optional.of(JsonParser.create(stateCookieJson).readJsonObject());
+        } catch (Exception e) {
+            LOGGER.log(Level.DEBUG, "Failed to process OIDC state cookie", e);
+            return Optional.empty();
+        }
+    }
+
+    private void clearRedirectAttemptCookie(ServerResponseHeaders headers, String tenantName, JsonObject stateCookie) {
+        if (oidcConfig.redirectAttemptCounterStrategy() != RedirectAttemptCounterStrategy.COOKIE) {
+            return;
+        }
+        stateCookie.stringValue("originalUri")
+                .ifPresent(originalUri -> headers.addCookie(RedirectAttemptCookie.remove(oidcConfig,
+                                                                                         tenantName,
+                                                                                         originalUri)));
     }
 
     /**

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/RedirectAttemptCookie.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/RedirectAttemptCookie.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.oidc;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.common.uri.UriEncoding;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.SetCookie;
+import io.helidon.security.providers.oidc.common.OidcConfig;
+import io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy;
+
+final class RedirectAttemptCookie {
+    private RedirectAttemptCookie() {
+    }
+
+    static SetCookie create(OidcConfig oidcConfig, String tenantId, String state, int attempt) {
+        String value = String.valueOf(attempt);
+        return builder(oidcConfig, name(oidcConfig, tenantId, state), value, true)
+                .build();
+    }
+
+    static SetCookie remove(OidcConfig oidcConfig, String tenantId, String state) {
+        return builder(oidcConfig, name(oidcConfig, tenantId, state), "", false)
+                .build();
+    }
+
+    static Optional<String> find(OidcConfig oidcConfig,
+                                 Map<String, List<String>> headers,
+                                 String tenantId,
+                                 String state) {
+        List<String> cookies = headers.get(HeaderNames.COOKIE_NAME);
+        if ((cookies == null) || cookies.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String valuePrefix = name(oidcConfig, tenantId, state) + "=";
+        for (String cookie : cookies) {
+            for (String cookieValue : cookie.split(";\\s?")) {
+                String trimmed = cookieValue.trim();
+                if (trimmed.startsWith(valuePrefix)) {
+                    return Optional.of(trimmed.substring(valuePrefix.length()));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    static String name(OidcConfig oidcConfig, String tenantId, String state) {
+        return oidcConfig.redirectAttemptParam() + "_" + hash(tenantId + "\n" + counterState(oidcConfig, state));
+    }
+
+    static String counterState(OidcConfig oidcConfig, String state) {
+        int queryStart = state.indexOf('?');
+        if (queryStart < 0) {
+            return state;
+        }
+
+        int fragmentStart = state.indexOf('#', queryStart);
+        String path = state.substring(0, queryStart);
+        String query = fragmentStart < 0
+                ? state.substring(queryStart + 1)
+                : state.substring(queryStart + 1, fragmentStart);
+        String fragment = fragmentStart < 0 ? "" : state.substring(fragmentStart);
+
+        Set<String> paramsToRemove = new HashSet<>();
+        if (oidcConfig.redirectAttemptCounterStrategy() == RedirectAttemptCounterStrategy.PARAM) {
+            paramsToRemove.add(oidcConfig.redirectAttemptParam());
+        }
+        if (oidcConfig.useParam()) {
+            paramsToRemove.add(oidcConfig.paramName());
+            paramsToRemove.add(oidcConfig.idTokenParamName());
+            paramsToRemove.add(oidcConfig.tenantParamName());
+        }
+
+        String counterQuery = filterQuery(query, paramsToRemove);
+        if (counterQuery.isEmpty()) {
+            return path + fragment;
+        }
+        return path + "?" + counterQuery + fragment;
+    }
+
+    private static String filterQuery(String query, Set<String> namesToRemove) {
+        if (namesToRemove.isEmpty()) {
+            return query;
+        }
+
+        StringBuilder result = new StringBuilder(query.length());
+        int start = 0;
+        while (start <= query.length()) {
+            int end = query.indexOf('&', start);
+            if (end < 0) {
+                end = query.length();
+            }
+
+            String queryParam = query.substring(start, end);
+            if (!removeQueryParam(queryParam, namesToRemove)) {
+                if (!result.isEmpty()) {
+                    result.append('&');
+                }
+                result.append(queryParam);
+            }
+
+            if (end == query.length()) {
+                break;
+            }
+            start = end + 1;
+        }
+        return result.toString();
+    }
+
+    private static boolean removeQueryParam(String queryParam, Set<String> namesToRemove) {
+        int equals = queryParam.indexOf('=');
+        String rawName = equals < 0 ? queryParam : queryParam.substring(0, equals);
+        return namesToRemove.contains(rawName) || namesToRemove.contains(UriEncoding.decodeUri(rawName));
+    }
+
+    private static SetCookie.Builder builder(OidcConfig oidcConfig, String name, String value, boolean create) {
+        SetCookie configuredCookie = create
+                ? oidcConfig.tokenCookieHandler().createCookie(value).build()
+                : oidcConfig.tokenCookieHandler().removeCookie().build();
+        SetCookie.Builder builder = SetCookie.builder(name, value);
+        configuredCookie.expires().ifPresent(builder::expires);
+        configuredCookie.maxAge().ifPresent(builder::maxAge);
+        configuredCookie.domain().ifPresent(builder::domain);
+        configuredCookie.path().ifPresent(builder::path);
+        builder.secure(configuredCookie.secure());
+        builder.httpOnly(configuredCookie.httpOnly());
+        configuredCookie.sameSite().ifPresent(builder::sameSite);
+        return builder;
+    }
+
+    private static String hash(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(Arrays.copyOf(digest, 12));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 message digest is not available", e);
+        }
+    }
+}

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -73,6 +73,7 @@ import io.helidon.security.jwt.jwk.JwkKeys;
 import io.helidon.security.providers.common.TokenCredential;
 import io.helidon.security.providers.oidc.common.OidcConfig;
 import io.helidon.security.providers.oidc.common.PkceChallengeMethod;
+import io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy;
 import io.helidon.security.providers.oidc.common.Tenant;
 import io.helidon.security.providers.oidc.common.TenantConfig;
 import io.helidon.security.util.TokenHandler;
@@ -378,9 +379,13 @@ class TenantAuthenticationHandler {
         if (oidcConfig.shouldRedirect()) {
             // make sure we do not exceed redirect limit
             String origUri = origUri(providerRequest);
-            int redirectAttempt = redirectAttempt(origUri);
-            if (redirectAttempt >= oidcConfig.maxRedirects()) {
-                return errorResponseNoRedirect(code, description, status);
+            RedirectAttemptCounterStrategy counterStrategy = oidcConfig.redirectAttemptCounterStrategy();
+            int redirectAttempt = 0;
+            if (counterStrategy != RedirectAttemptCounterStrategy.NONE) {
+                redirectAttempt = redirectAttempt(providerRequest, tenantId, origUri);
+                if (redirectAttempt >= oidcConfig.maxRedirects()) {
+                    return errorResponseNoRedirect(code, description, status, tenantId, origUri);
+                }
             }
             String state = generateRandomString();
             String pkceVerifier = oidcConfig.pkceEnabled() ? generateCodeVerifier() : "";
@@ -438,13 +443,19 @@ class TenantAuthenticationHandler {
 
             String stateBase64 = Base64.getEncoder().encodeToString(stateJson.toString().getBytes(StandardCharsets.UTF_8));
             SetCookie cookie = oidcConfig.stateCookieHandler().createCookie(stateBase64).build();
+            List<String> responseCookies = new ArrayList<>();
+            responseCookies.add(cookie.toString());
+            if (counterStrategy == RedirectAttemptCounterStrategy.COOKIE) {
+                responseCookies.add(RedirectAttemptCookie.create(oidcConfig, tenantId, origUri, redirectAttempt + 1)
+                                            .toString());
+            }
 
             // must redirect
             return AuthenticationResponse
                     .builder()
                     .status(SecurityResponse.SecurityStatus.FAILURE_FINISH)
                     .statusCode(Status.TEMPORARY_REDIRECT_307.code())
-                    .responseHeader(HeaderNames.SET_COOKIE.defaultCase(), cookie.toString())
+                    .responseHeader(HeaderNames.SET_COOKIE.defaultCase(), responseCookies)
                     .description("Redirecting to identity server: " + description)
                     .responseHeader("Location", authorizationEndpoint + queryString)
                     .build();
@@ -480,31 +491,60 @@ class TenantAuthenticationHandler {
     }
 
     private AuthenticationResponse errorResponseNoRedirect(String code, String description, Status status) {
+        return errorResponseNoRedirect(code, description, status, null, null);
+    }
+
+    private AuthenticationResponse errorResponseNoRedirect(String code,
+                                                           String description,
+                                                           Status status,
+                                                           String tenantId,
+                                                           String state) {
         if (optional) {
-            return AuthenticationResponse.builder()
+            return noRedirectResponse(AuthenticationResponse.builder()
                     .status(SecurityResponse.SecurityStatus.ABSTAIN)
-                    .description(description)
-                    .build();
+                    .description(description), tenantId, state);
         }
         if (null == code) {
-            return AuthenticationResponse.builder()
+            return noRedirectResponse(AuthenticationResponse.builder()
                     .status(SecurityResponse.SecurityStatus.FAILURE)
                     .statusCode(Status.UNAUTHORIZED_401.code())
                     .responseHeader(HeaderNames.WWW_AUTHENTICATE.defaultCase(),
                                     "Bearer realm=\"" + tenantConfig.realm() + "\"")
-                    .description(description)
-                    .build();
+                    .description(description), tenantId, state);
         } else {
-            return AuthenticationResponse.builder()
+            return noRedirectResponse(AuthenticationResponse.builder()
                     .status(SecurityResponse.SecurityStatus.FAILURE)
                     .statusCode(status.code())
                     .responseHeader(HeaderNames.WWW_AUTHENTICATE.defaultCase(), errorHeader(code, description))
-                    .description(description)
-                    .build();
+                    .description(description), tenantId, state);
         }
     }
 
-    private int redirectAttempt(String state) {
+    private AuthenticationResponse noRedirectResponse(AuthenticationResponse.Builder builder,
+                                                      String tenantId,
+                                                      String state) {
+        if (oidcConfig.redirectAttemptCounterStrategy() == RedirectAttemptCounterStrategy.COOKIE && state != null) {
+            builder.responseHeader(HeaderNames.SET_COOKIE.defaultCase(),
+                                   RedirectAttemptCookie.remove(oidcConfig, tenantId, state).toString());
+        }
+        return builder.build();
+    }
+
+    int redirectAttempt(ProviderRequest providerRequest, String tenantId, String state) {
+        RedirectAttemptCounterStrategy strategy = oidcConfig.redirectAttemptCounterStrategy();
+        switch (strategy) {
+        case NONE:
+            return 0;
+        case PARAM:
+            return redirectAttemptParam(state);
+        case COOKIE:
+            return redirectAttemptCookie(providerRequest, tenantId, state);
+        default:
+            throw new IllegalStateException("Unsupported redirect attempt counter strategy: " + strategy);
+        }
+    }
+
+    private int redirectAttemptParam(String state) {
         if (state.contains("?")) {
             // there are parameters
             Matcher matcher = attemptPattern.matcher(state);
@@ -514,6 +554,26 @@ class TenantAuthenticationHandler {
         }
 
         return 1;
+    }
+
+    private int redirectAttemptCookie(ProviderRequest providerRequest, String tenantId, String state) {
+        return RedirectAttemptCookie.find(oidcConfig, providerRequest.env().headers(), tenantId, state)
+                .map(this::parseRedirectAttemptCookie)
+                .orElse(0);
+    }
+
+    private int parseRedirectAttemptCookie(String value) {
+        try {
+            int attempt = Integer.parseInt(value);
+            if (attempt > 0) {
+                return attempt;
+            }
+            LOGGER.log(System.Logger.Level.DEBUG, "Invalid OIDC redirect attempt cookie value");
+            return oidcConfig.maxRedirects();
+        } catch (NumberFormatException e) {
+            LOGGER.log(System.Logger.Level.DEBUG, "Invalid OIDC redirect attempt cookie value", e);
+            return oidcConfig.maxRedirects();
+        }
     }
 
     private String errorHeader(String code, String description) {
@@ -831,11 +891,12 @@ class TenantAuthenticationHandler {
                         .status(SecurityResponse.SecurityStatus.SUCCESS)
                         .user(subject);
 
-                if (cookies.isEmpty()) {
+                List<String> responseCookies = successCookies(cookies, providerRequest, tenantId);
+                if (responseCookies.isEmpty()) {
                     return response.build();
                 } else {
                     return response
-                            .responseHeader(HeaderNames.SET_COOKIE.defaultCase(), cookies)
+                            .responseHeader(HeaderNames.SET_COOKIE.defaultCase(), responseCookies)
                             .build();
                 }
             } else {
@@ -857,6 +918,19 @@ class TenantAuthenticationHandler {
                                  "Token not valid",
                                  tenantId);
         }
+    }
+
+    List<String> successCookies(List<String> cookies, ProviderRequest providerRequest, String tenantId) {
+        if (oidcConfig.redirectAttemptCounterStrategy() != RedirectAttemptCounterStrategy.COOKIE) {
+            return cookies;
+        }
+        String originalUri = origUri(providerRequest);
+        if (RedirectAttemptCookie.find(oidcConfig, providerRequest.env().headers(), tenantId, originalUri).isEmpty()) {
+            return cookies;
+        }
+        List<String> responseCookies = new ArrayList<>(cookies);
+        responseCookies.add(RedirectAttemptCookie.remove(oidcConfig, tenantId, originalUri).toString());
+        return responseCookies;
     }
 
     // Package-private to allow focused tests to exercise subject construction without invoking remote OIDC flows.

--- a/security/providers/oidc/src/main/java/module-info.java
+++ b/security/providers/oidc/src/main/java/module-info.java
@@ -27,6 +27,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 module io.helidon.security.providers.oidc {
 
     requires io.helidon.common.crypto;
+    requires io.helidon.common.uri;
     requires io.helidon.common;
     requires io.helidon.json;
     requires io.helidon.webclient;

--- a/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/OidcFeatureTest.java
+++ b/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/OidcFeatureTest.java
@@ -17,12 +17,21 @@
 package io.helidon.security.providers.oidc;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.helidon.common.uri.UriQuery;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.json.JsonObject;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.OutboundSecurityResponse;
 import io.helidon.security.ProviderRequest;
@@ -36,14 +45,20 @@ import io.helidon.security.providers.common.TokenCredential;
 import io.helidon.security.providers.oidc.common.OidcConfig;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy.COOKIE;
+import static io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy.NONE;
+import static io.helidon.security.providers.oidc.common.spi.TenantConfigFinder.DEFAULT_TENANT_ID;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.mockito.Mockito.when;
@@ -73,9 +88,31 @@ class OidcFeatureTest {
             .oidcMetadataWellKnown(false)
             .redirectAttemptParam(PARAM_NAME)
             .build();
+    private final OidcConfig oidcConfigDisabledParam = OidcConfig.builder()
+            .clientId("id")
+            .clientSecret("secret")
+            .identityUri(URI.create("http://localhost:7774/identity"))
+            .tokenEndpointUri(URI.create("http://localhost:7774/token"))
+            .authorizationEndpointUri(URI.create("http://localhost:7774/authorize"))
+            .signJwk(JwkKeys.builder().build())
+            .oidcMetadataWellKnown(false)
+            .redirectAttemptCounterStrategy(NONE)
+            .build();
+    private final OidcConfig oidcConfigCookieCounter = OidcConfig.builder()
+            .clientId("id")
+            .clientSecret("secret")
+            .identityUri(URI.create("http://localhost:7774/identity"))
+            .tokenEndpointUri(URI.create("http://localhost:7774/token"))
+            .authorizationEndpointUri(URI.create("http://localhost:7774/authorize"))
+            .signJwk(JwkKeys.builder().build())
+            .oidcMetadataWellKnown(false)
+            .redirectAttemptCounterStrategy(COOKIE)
+            .build();
 
     private final OidcFeature oidcFeature = OidcFeature.create(oidcConfig);
     private final OidcFeature oidcFeatureCustomParam = OidcFeature.create(oidcConfigCustomParam);
+    private final OidcFeature oidcFeatureDisabledParam = OidcFeature.create(oidcConfigDisabledParam);
+    private final OidcFeature oidcFeatureCookieCounter = OidcFeature.create(oidcConfigCookieCounter);
     private final OidcProvider provider = OidcProvider.builder()
             .oidcConfig(oidcConfig)
             .outboundConfig(OutboundConfig.builder()
@@ -161,6 +198,49 @@ class OidcFeatureTest {
     }
 
     @Test
+    void testRedirectAttemptCounterDisabled() {
+        String state = "http://localhost:7145/test?a=first&b=second";
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        String newState = oidcFeatureDisabledParam.updateRedirectCounter(request(), responseHeaders, state);
+
+        assertThat(newState, is(state));
+        assertThat(responseHeaders.values(HeaderNames.SET_COOKIE).isEmpty(), is(true));
+    }
+
+    @Test
+    void testRedirectAttemptCookieCounter() {
+        String state = "http://localhost:7145/test?a=first&b=second";
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+
+        String newState = oidcFeatureCookieCounter.updateRedirectCounter(request(), responseHeaders, state);
+
+        assertThat(newState, is(state));
+        assertThat(responseHeaders.values(HeaderNames.SET_COOKIE).isEmpty(), is(true));
+    }
+
+    @Test
+    void testMissingCodeErrorClearsCookieCounter() {
+        String state = "state-123";
+        String originalUri = "/test?resource=a";
+        ServerRequest request = requestWithQuery("error=access_denied&state=" + state,
+                                                 stateCookie(oidcConfigCookieCounter, originalUri, state));
+        ServerResponse response = Mockito.mock(ServerResponse.class);
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        when(response.headers()).thenReturn(responseHeaders);
+        when(response.status(Status.BAD_REQUEST_400)).thenReturn(response);
+
+        oidcFeatureCookieCounter.processError(request, response);
+
+        List<String> cookies = responseHeaders.values(HeaderNames.SET_COOKIE);
+        assertThat(cookies,
+                   hasItem(startsWith(oidcConfigCookieCounter.stateCookieHandler().cookieName() + "=;")));
+        assertThat(cookies,
+                   hasItem(startsWith(RedirectAttemptCookie.name(oidcConfigCookieCounter,
+                                                                 DEFAULT_TENANT_ID,
+                                                                 originalUri) + "=;")));
+    }
+
+    @Test
     void testOutbound() {
         String tokenContent = "huhahihohyhe";
         TokenCredential tokenCredential = TokenCredential.builder()
@@ -236,5 +316,34 @@ class OidcFeatureTest {
         assertThat(feature.socketRequired(), is(false));
         assertThat(feature.hashCode(), not(0));
         assertThat(feature.toString(), notNullValue());
+    }
+
+    private ServerRequest request(String... cookies) {
+        ServerRequest request = Mockito.mock(ServerRequest.class);
+        WritableHeaders<?> writableHeaders = WritableHeaders.create();
+        for (String cookie : cookies) {
+            writableHeaders.add(HeaderNames.COOKIE, cookie);
+        }
+        when(request.headers()).thenReturn(ServerRequestHeaders.create(writableHeaders));
+        return request;
+    }
+
+    private ServerRequest requestWithQuery(String query, String... cookies) {
+        ServerRequest request = request(cookies);
+        when(request.query()).thenReturn(UriQuery.create(query));
+        return request;
+    }
+
+    private static String stateCookie(OidcConfig oidcConfig, String originalUri, String state) {
+        JsonObject stateJson = JsonObject.builder()
+                .set("originalUri", originalUri)
+                .set("state", state)
+                .build();
+        String encoded = Base64.getEncoder()
+                .encodeToString(stateJson.toString().getBytes(StandardCharsets.UTF_8));
+        return oidcConfig.stateCookieHandler()
+                .createCookie(encoded)
+                .build()
+                .toString();
     }
 }

--- a/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/TenantAuthenticationHandlerTest.java
+++ b/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/TenantAuthenticationHandlerTest.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 
 import io.helidon.config.Config;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.SetCookie;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonString;
@@ -38,12 +40,19 @@ import io.helidon.security.jwt.Jwt;
 import io.helidon.security.jwt.SignedJwt;
 import io.helidon.security.jwt.jwk.Jwk;
 import io.helidon.security.providers.oidc.common.OidcConfig;
+import io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy;
 import io.helidon.security.providers.oidc.common.Tenant;
 
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy.COOKIE;
+import static io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy.NONE;
+import static io.helidon.security.providers.oidc.common.RedirectAttemptCounterStrategy.PARAM;
+import static io.helidon.security.providers.oidc.common.spi.TenantConfigFinder.DEFAULT_TENANT_ID;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -52,6 +61,7 @@ import static org.mockito.Mockito.when;
  * Unit test for {@link TenantAuthenticationHandler}.
  */
 class TenantAuthenticationHandlerTest {
+    private static final String ATTEMPT_PARAM = "h_ra";
 
     @Test
     public void testCustomJwtGroupsPath() {
@@ -105,7 +115,7 @@ class TenantAuthenticationHandlerTest {
                 .build();
         SignedJwt signedJwt = SignedJwt.sign(jwt, Jwk.NONE_JWK);
 
-        AuthenticationResponse authenticationResponse = provider.authenticate(request(signedJwt.tokenContent()));
+        AuthenticationResponse authenticationResponse = provider.authenticate(bearerRequest(signedJwt.tokenContent()));
 
         assertThat(authenticationResponse.description().orElse("Unexpected authentication response"),
                    authenticationResponse.status(),
@@ -172,7 +182,272 @@ class TenantAuthenticationHandlerTest {
         assertThat(authenticationHandler.origUri(providerRequest), is("/noQuery"));
     }
 
-    private ProviderRequest request(String token) {
+    @Test
+    public void testRedirectAttemptParamStrategy() {
+        OidcConfig oidcConfig = oidcConfig(PARAM);
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(),
+                                                         DEFAULT_TENANT_ID,
+                                                         "/test?someUri=value"),
+                   is(1));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(), DEFAULT_TENANT_ID, "/test?someUri=value&"
+                + ATTEMPT_PARAM + "=4"), is(4));
+    }
+
+    @Test
+    public void testRedirectAttemptCookieStrategy() {
+        OidcConfig oidcConfig = oidcConfig(COOKIE);
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+        String state = "/test?someUri=value";
+        String otherState = "/other?someUri=value";
+
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(), DEFAULT_TENANT_ID, state), is(0));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         state,
+                                                                                         4)),
+                                                        DEFAULT_TENANT_ID,
+                                                        state),
+                   is(4));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         otherState,
+                                                                                         4)),
+                                                        DEFAULT_TENANT_ID,
+                                                        state),
+                   is(0));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         "tenant-a",
+                                                                                         state,
+                                                                                         4)),
+                                                        DEFAULT_TENANT_ID,
+                                                        state),
+                   is(0));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         state,
+                                                                                         4)),
+                                                        DEFAULT_TENANT_ID,
+                                                        state + "&accessToken=token&id_token=id-token&h_tenant=tenant"),
+                   is(0));
+    }
+
+    @Test
+    public void testRedirectAttemptCookieStrategyWithQueryParamTokenPropagation() {
+        OidcConfig oidcConfig = oidcConfig(COOKIE, true);
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+        String state = "/test?someUri=value";
+        String stateWithTokens = state + "&accessToken=token&id_token=id-token&h_tenant=tenant";
+        String stateWithMoreTokens = stateWithTokens + "&accessToken=next-token&id_token=next-id-token";
+        String stateWithManyParams = "/test?k548985=1&k764588=1&k641847=1&k970313=1&k64254=1&k814904=1"
+                + "&k504434=1&k906606=1&k239978=1&k301748=1&k136569=1&k998473=1";
+        String stateWithManyParamsAndTokens = stateWithManyParams
+                + "&accessToken=token&id_token=id-token&h_tenant=tenant";
+
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         state,
+                                                                                         4)),
+                                                        DEFAULT_TENANT_ID,
+                                                        stateWithTokens),
+                   is(4));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         stateWithManyParams,
+                                                                                         4)),
+                                                        DEFAULT_TENANT_ID,
+                                                        stateWithManyParamsAndTokens),
+                   is(4));
+        assertThat(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, stateWithMoreTokens),
+                   is(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, state)));
+        assertThat(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, stateWithManyParamsAndTokens),
+                   is(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, stateWithManyParams)));
+        assertThat(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, state + "&other=value")
+                           .equals(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, state)),
+                   is(false));
+        assertThat(RedirectAttemptCookie.name(oidcConfig, "tenant-a", state)
+                           .equals(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, state)),
+                   is(false));
+    }
+
+    @Test
+    public void testRedirectAttemptCookieStrategyWithInvalidCookieValue() {
+        OidcConfig oidcConfig = oidcConfig(COOKIE);
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+        String state = "/test?someUri=value";
+
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         state,
+                                                                                         "invalid")),
+                                                        DEFAULT_TENANT_ID,
+                                                        state),
+                   is(oidcConfig.maxRedirects()));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         state,
+                                                                                         "999999999999999999999")),
+                                                        DEFAULT_TENANT_ID,
+                                                        state),
+                   is(oidcConfig.maxRedirects()));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         state,
+                                                                                         "-1")),
+                                                        DEFAULT_TENANT_ID,
+                                                        state),
+                   is(oidcConfig.maxRedirects()));
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(attemptCookie(oidcConfig,
+                                                                                         DEFAULT_TENANT_ID,
+                                                                                         state,
+                                                                                         "0")),
+                                                        DEFAULT_TENANT_ID,
+                                                        state),
+                   is(oidcConfig.maxRedirects()));
+    }
+
+    @Test
+    public void testRedirectAttemptCookieStrategyWithEncodedQueryParamNames() {
+        OidcConfig oidcConfig = OidcConfig.builder()
+                .clientId("test")
+                .clientSecret("123")
+                .identityUri(URI.create("http://localhost:1234"))
+                .oidcMetadataWellKnown(false)
+                .redirectAttemptCounterStrategy(COOKIE)
+                .useParam(true)
+                .paramName("access token")
+                .idTokenParamName("id token")
+                .paramTenantName("h tenant")
+                .build();
+        String state = "/test?someUri=value&h_ra=4";
+        String stateWithTokens = state + "&access+token=token"
+                + "&id+token=id-token"
+                + "&h+tenant=tenant";
+        String stateWithPercentEncodedName = state + "&%61ccess+token=token"
+                + "&id+token=id-token"
+                + "&h+tenant=tenant";
+
+        assertThat(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, stateWithTokens),
+                   is(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, state)));
+        assertThat(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, stateWithPercentEncodedName),
+                   is(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, state)));
+        assertThat(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, "/test?someUri=value&h_ra=5")
+                           .equals(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, state)),
+                   is(false));
+    }
+
+    @Test
+    public void testRedirectAttemptNoneStrategy() {
+        OidcConfig oidcConfig = oidcConfig(NONE);
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+
+        assertThat(authenticationHandler.redirectAttempt(requestWithCookies(ATTEMPT_PARAM + "=4"),
+                                                         DEFAULT_TENANT_ID,
+                                                         "/test?someUri=value&" + ATTEMPT_PARAM + "=4"),
+                   is(0));
+    }
+
+    @Test
+    public void testRedirectAttemptNoneStrategyIgnoresMaxRedirects() {
+        OidcConfig oidcConfig = OidcConfig.builder()
+                .clientId("test")
+                .clientSecret("123")
+                .identityUri(URI.create("http://localhost:1234"))
+                .oidcMetadataWellKnown(false)
+                .redirectAttemptCounterStrategy(NONE)
+                .maxRedirects(0)
+                .build();
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+
+        AuthenticationResponse response = authenticationHandler.authenticate(DEFAULT_TENANT_ID, requestWithCookies());
+
+        assertThat(response.status(), is(SecurityResponse.SecurityStatus.FAILURE_FINISH));
+    }
+
+    @Test
+    public void testSuccessfulAuthenticationClearsCookieCounter() {
+        OidcConfig oidcConfig = oidcConfig(COOKIE);
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+        ProviderRequest providerRequest = requestWithUri(URI.create("http://localhost:1234/test"),
+                                                         attemptCookie(oidcConfig, DEFAULT_TENANT_ID, "/test", 1));
+
+        assertThat(authenticationHandler.successCookies(List.of("other=value"), providerRequest, DEFAULT_TENANT_ID),
+                   hasItem(startsWith(RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, "/test") + "=;")));
+    }
+
+    @Test
+    public void testSuccessfulAuthenticationDoesNotClearMissingCookieCounter() {
+        OidcConfig oidcConfig = oidcConfig(COOKIE);
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+        ProviderRequest providerRequest = requestWithUri(URI.create("http://localhost:1234/test"),
+                                                         attemptCookie(oidcConfig, DEFAULT_TENANT_ID, "/other", 1));
+        List<String> cookies = List.of("other=value");
+
+        assertThat(authenticationHandler.successCookies(cookies, providerRequest, DEFAULT_TENANT_ID), is(cookies));
+    }
+
+    @Test
+    public void testRedirectSetsCookieCounter() {
+        OidcConfig oidcConfig = OidcConfig.builder()
+                .clientId("test")
+                .clientSecret("123")
+                .identityUri(URI.create("http://localhost:1234"))
+                .oidcMetadataWellKnown(false)
+                .redirectAttemptCounterStrategy(COOKIE)
+                .cookieSecure(true)
+                .cookieDomain("example.com")
+                .cookiePath("/app")
+                .cookieSameSite(SetCookie.SameSite.STRICT)
+                .cookieHttpOnly(false)
+                .build();
+        TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig);
+        String state = "/app/test?resource=a";
+        ProviderRequest providerRequest = requestWithUri(URI.create("http://localhost:1234" + state),
+                                                         attemptCookie(oidcConfig, DEFAULT_TENANT_ID, state, 2));
+
+        AuthenticationResponse response = authenticationHandler.authenticate(DEFAULT_TENANT_ID, providerRequest);
+        List<String> cookies = response.responseHeaders().get(HeaderNames.SET_COOKIE.defaultCase());
+        String cookieName = RedirectAttemptCookie.name(oidcConfig, DEFAULT_TENANT_ID, state);
+        String cookieValue = cookies.stream()
+                .filter(it -> it.startsWith(cookieName + "="))
+                .findFirst()
+                .orElseThrow();
+        SetCookie cookie = SetCookie.parse(cookieValue);
+
+        assertThat(response.status(), is(SecurityResponse.SecurityStatus.FAILURE_FINISH));
+        assertThat(cookie.name(), is(cookieName));
+        assertThat(cookie.value(), is("3"));
+        assertThat(cookie.secure(), is(true));
+        assertThat(cookie.httpOnly(), is(false));
+        assertThat(cookie.domain().orElseThrow(), is("example.com"));
+        assertThat(cookie.path().orElseThrow(), is("/app"));
+        assertThat(cookie.sameSite().orElseThrow(), is(SetCookie.SameSite.STRICT));
+    }
+
+    private static OidcConfig oidcConfig(RedirectAttemptCounterStrategy strategy) {
+        return oidcConfig(strategy, false);
+    }
+
+    private static OidcConfig oidcConfig(RedirectAttemptCounterStrategy strategy, boolean useParam) {
+        return OidcConfig.builder()
+                .clientId("test")
+                .clientSecret("123")
+                .identityUri(URI.create("http://localhost:1234"))
+                .oidcMetadataWellKnown(false)
+                .redirectAttemptCounterStrategy(strategy)
+                .useParam(useParam)
+                .build();
+    }
+
+    private static TenantAuthenticationHandler authenticationHandler(OidcConfig oidcConfig) {
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.tenantConfig()).thenReturn(oidcConfig);
+        when(tenant.authorizationEndpointUri()).thenReturn("http://localhost:1234/authorize");
+        return new TenantAuthenticationHandler(oidcConfig, tenant, false, true);
+    }
+
+    private static ProviderRequest bearerRequest(String token) {
         ProviderRequest providerRequest = mock(ProviderRequest.class);
         SecurityEnvironment securityEnvironment = SecurityEnvironment.builder()
                 .header("Authorization", "bearer " + token)
@@ -184,6 +459,33 @@ class TenantAuthenticationHandlerTest {
         when(endpointConfig.securityLevels()).thenReturn(List.of());
         when(providerRequest.endpointConfig()).thenReturn(endpointConfig);
 
+        return providerRequest;
+    }
+
+    private static String attemptCookie(OidcConfig oidcConfig, String tenantId, String state, int attempt) {
+        return attemptCookie(oidcConfig, tenantId, state, String.valueOf(attempt));
+    }
+
+    private static String attemptCookie(OidcConfig oidcConfig, String tenantId, String state, String attempt) {
+        return RedirectAttemptCookie.name(oidcConfig, tenantId, state) + "=" + attempt;
+    }
+
+    private static ProviderRequest requestWithCookies(String... cookies) {
+        return requestWithUri(URI.create("http://localhost:1234/test"), cookies);
+    }
+
+    private static ProviderRequest requestWithUri(URI targetUri, String... cookies) {
+        ProviderRequest providerRequest = mock(ProviderRequest.class);
+        SecurityEnvironment.Builder securityEnvironmentBuilder = SecurityEnvironment.builder()
+                .targetUri(targetUri)
+                .header("Host", "localhost:1234");
+        for (String cookie : cookies) {
+            securityEnvironmentBuilder.header("Cookie", cookie);
+        }
+        when(providerRequest.env()).thenReturn(securityEnvironmentBuilder.build());
+        EndpointConfig endpointConfig = mock(EndpointConfig.class);
+        when(endpointConfig.securityLevels()).thenReturn(List.of());
+        when(providerRequest.endpointConfig()).thenReturn(endpointConfig);
         return providerRequest;
     }
 


### PR DESCRIPTION
### Description

Fixes #12008

Forward port of #7754 / #11992.

This ports the OIDC redirect attempt counter strategy support from `helidon-4.x`.

The new `redirect-attempt-counter-strategy` setting supports:

- `PARAM`, the default, preserving the existing `redirect-attempt-param` query parameter behavior
- `COOKIE`, storing the redirect attempt counter in a scoped cookie without modifying the original redirect URI
- `NONE`, disabling redirect attempt counting

It also adds the cookie counter helper, config parsing and validation, docs, and focused tests for config and runtime behavior.

### Documentation

Updated OIDC provider configuration docs.
