### PR TITLE
Fix FT bulkhead waiting metrics cleanup (4.x)

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -767,7 +767,7 @@ class MethodInvoker implements FtSupplier<Object> {
                 startNanos[0] = state.starts.removeFirst();
                 found[0] = true;
                 if (!state.completionObserved) {
-                    state.listenerOwnsCompletionRecord = true;
+                    state.recordedBeforeCompletion = true;
                 }
                 return state.starts.isEmpty() && state.completionObserved ? null : state;
             });
@@ -785,9 +785,11 @@ class MethodInvoker implements FtSupplier<Object> {
                     return state;
                 }
                 startNanos[0] = state.starts.removeFirst();
-                record[0] = state.completionObserved;
-                return state.starts.isEmpty() && (state.completionObserved || !state.listenerOwnsCompletionRecord)
-                        ? null : state;
+                record[0] = true;
+                if (!state.completionObserved) {
+                    state.recordedBeforeCompletion = true;
+                }
+                return state.starts.isEmpty() && state.completionObserved ? null : state;
             });
             if (record[0]) {
                 recordWaitingDuration(startNanos[0]);
@@ -805,11 +807,11 @@ class MethodInvoker implements FtSupplier<Object> {
                 }
                 if (!state.starts.isEmpty()) {
                     state.completionObserved = true;
-                    state.listenerOwnsCompletionRecord = false;
+                    state.recordedBeforeCompletion = false;
                     result[0] = true;
                     return state;
                 }
-                if (state.listenerOwnsCompletionRecord) {
+                if (state.recordedBeforeCompletion) {
                     result[0] = true;
                     return null;
                 }
@@ -833,7 +835,7 @@ class MethodInvoker implements FtSupplier<Object> {
 
         private static class WaitingState {
             private final Deque<Long> starts = new ArrayDeque<>();
-            private boolean listenerOwnsCompletionRecord;
+            private boolean recordedBeforeCompletion;
             private boolean completionObserved;
         }
     }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -588,43 +588,7 @@ class MethodInvoker implements FtSupplier<Object> {
 
         methodState.lock.lock();
         try {
-            // Retries
-            if (introspector.hasRetry()) {
-                long retryCounter = methodState.retry.retryCounter();
-                boolean wasRetried = retryCounter > 0;
-                Counter retryRetriesTotal = RetryRetriesTotal.get(introspector.getMethodNameTag());
-
-                // Update retry counter
-                if (wasRetried) {
-                    retryRetriesTotal.inc(retryCounter);
-                }
-
-                // Update retry metrics based on outcome
-                if (cause == null) {
-                    RetryCallsTotal.get(introspector.getMethodNameTag(),
-                                        wasRetried ? RetryRetried.TRUE.get() : RetryRetried.FALSE.get(),
-                                        RetryResult.VALUE_RETURNED.get()).inc();
-                } else if (cause instanceof RetryTimeoutException) {
-                    RetryCallsTotal.get(introspector.getMethodNameTag(),
-                                        wasRetried ? RetryRetried.TRUE.get() : RetryRetried.FALSE.get(),
-                                        RetryResult.MAX_DURATION_REACHED.get()).inc();
-                } else {
-                    // Exception thrown but not RetryTimeoutException
-                    int maxRetries = introspector.getRetry().maxRetries();
-                    if (maxRetries == -1) {
-                        maxRetries = Integer.MAX_VALUE;
-                    }
-                    if (retryCounter == maxRetries) {
-                        RetryCallsTotal.get(introspector.getMethodNameTag(),
-                                            wasRetried ? RetryRetried.TRUE.get() : RetryRetried.FALSE.get(),
-                                            RetryResult.MAX_RETRIES_REACHED.get()).inc();
-                    } else if (retryCounter < maxRetries) {
-                        RetryCallsTotal.get(introspector.getMethodNameTag(),
-                                            wasRetried ? RetryRetried.TRUE.get() : RetryRetried.FALSE.get(),
-                                            RetryResult.EXCEPTION_NOT_RETRYABLE.get()).inc();
-                    }
-                }
-            }
+            updateRetryMetrics(cause);
 
             // CircuitBreaker
             if (introspector.hasCircuitBreaker()) {
@@ -735,6 +699,47 @@ class MethodInvoker implements FtSupplier<Object> {
             InvocationsTotal.get(introspector.getMethodNameTag(),
                                  EXCEPTION_THROWN.get(),
                                  introspector.getFallbackTag(fallbackCalled.get())).inc();
+        }
+    }
+
+    private void updateRetryMetrics(Throwable cause) {
+        if (!introspector.hasRetry()) {
+            return;
+        }
+
+        long retryCounter = methodState.retry.retryCounter();
+        boolean wasRetried = retryCounter > 0;
+        Counter retryRetriesTotal = RetryRetriesTotal.get(introspector.getMethodNameTag());
+
+        // Update retry counter
+        if (wasRetried) {
+            retryRetriesTotal.inc(retryCounter);
+        }
+
+        // Update retry metrics based on outcome
+        if (cause == null) {
+            RetryCallsTotal.get(introspector.getMethodNameTag(),
+                                wasRetried ? RetryRetried.TRUE.get() : RetryRetried.FALSE.get(),
+                                RetryResult.VALUE_RETURNED.get()).inc();
+        } else if (cause instanceof RetryTimeoutException) {
+            RetryCallsTotal.get(introspector.getMethodNameTag(),
+                                wasRetried ? RetryRetried.TRUE.get() : RetryRetried.FALSE.get(),
+                                RetryResult.MAX_DURATION_REACHED.get()).inc();
+        } else {
+            // Exception thrown but not RetryTimeoutException
+            int maxRetries = introspector.getRetry().maxRetries();
+            if (maxRetries == -1) {
+                maxRetries = Integer.MAX_VALUE;
+            }
+            if (retryCounter == maxRetries) {
+                RetryCallsTotal.get(introspector.getMethodNameTag(),
+                                    wasRetried ? RetryRetried.TRUE.get() : RetryRetried.FALSE.get(),
+                                    RetryResult.MAX_RETRIES_REACHED.get()).inc();
+            } else if (retryCounter < maxRetries) {
+                RetryCallsTotal.get(introspector.getMethodNameTag(),
+                                    wasRetried ? RetryRetried.TRUE.get() : RetryRetried.FALSE.get(),
+                                    RetryResult.EXCEPTION_NOT_RETRYABLE.get()).inc();
+            }
         }
     }
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -378,10 +378,11 @@ class MethodInvoker implements FtSupplier<Object> {
                 cancellableSupplier.cancel();
                 // Cancel supplier in bulkhead in case it is queued
                 if (introspector.hasBulkhead()) {
-                    if (methodState.bulkheadWaitingStarts != null) {
+                    boolean removedFromQueue = methodState.bulkhead.cancelSupplier(handlerSupplier);
+                    // If the supplier was already dequeued, the queue listener owns recording waiting time.
+                    if (removedFromQueue && methodState.bulkheadWaitingStarts != null) {
                         methodState.bulkheadWaitingStarts.remove(handlerSupplier);
                     }
-                    methodState.bulkhead.cancelSupplier(handlerSupplier);
                 }
                 asyncFuture.cancel(mayInterrupt.get());
             }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -15,13 +15,15 @@
  */
 package io.helidon.microprofile.faulttolerance;
 
+import java.lang.System.Logger.Level;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -93,6 +95,11 @@ class MethodInvoker implements FtSupplier<Object> {
      * be shared by all instances of this class.
      */
     private static final MethodStateCache METHOD_STATES = new MethodStateCache();
+
+    /**
+     * System logger.
+     */
+    private static final System.Logger LOGGER = System.getLogger(MethodInvoker.class.getName());
 
     /**
      * The method being intercepted.
@@ -379,9 +386,9 @@ class MethodInvoker implements FtSupplier<Object> {
                 // Cancel supplier in bulkhead in case it is queued
                 if (introspector.hasBulkhead()) {
                     boolean removedFromQueue = methodState.bulkhead.cancelSupplier(handlerSupplier);
-                    // If the supplier was already dequeued, the queue listener owns recording waiting time.
-                    if (removedFromQueue && methodState.bulkheadWaitingStarts != null) {
-                        methodState.bulkheadWaitingStarts.remove(handlerSupplier);
+                    BulkheadWaitingTracker waitingTracker = methodState.bulkheadWaitingTracker;
+                    if (removedFromQueue && waitingTracker != null) {
+                        waitingTracker.cancelled(handlerSupplier);
                     }
                 }
                 asyncFuture.cancel(mayInterrupt.get());
@@ -404,28 +411,18 @@ class MethodInvoker implements FtSupplier<Object> {
             methodState.bulkhead = Bulkhead.create(builder -> {
                 builder.limit(introspector.getBulkhead().value())
                         .queueLength(introspector.isAsynchronous() ? introspector.getBulkhead().waitingTaskQueue() : 0);
-                if (introspector.isAsynchronous()) {
-                    ConcurrentMap<Supplier<?>, Long> waitingStarts = new ConcurrentHashMap<>();
-                    Set<Supplier<?>> waitingRecorded = ConcurrentHashMap.newKeySet();
-                    Tag methodNameTag = introspector.getMethodNameTag();
-
-                    methodState.bulkheadWaitingStarts = waitingStarts;
-                    methodState.bulkheadWaitingRecorded = waitingRecorded;
+                if (introspector.isAsynchronous() && isFaultToleranceMetricsEnabled()) {
+                    BulkheadWaitingTracker waitingTracker = new BulkheadWaitingTracker(introspector.getMethodNameTag());
+                    methodState.bulkheadWaitingTracker = waitingTracker;
                     builder.addQueueListener(new Bulkhead.QueueListener() {
                         @Override
                         public <T> void enqueueing(Supplier<? extends T> supplier) {
-                            if (isFaultToleranceMetricsEnabled()) {
-                                waitingStarts.put(supplier, System.nanoTime());
-                            }
+                            waitingTracker.enqueueing(supplier);
                         }
 
                         @Override
                         public <T> void dequeued(Supplier<? extends T> supplier) {
-                            Long startNanos = waitingStarts.remove(supplier);
-                            if (startNanos != null && isFaultToleranceMetricsEnabled()) {
-                                BulkheadWaitingDuration.get(methodNameTag).update(System.nanoTime() - startNanos);
-                                waitingRecorded.add(supplier);
-                            }
+                            waitingTracker.dequeued(supplier);
                         }
                     });
                 }
@@ -564,20 +561,16 @@ class MethodInvoker implements FtSupplier<Object> {
      */
     private void updateMetricsAfter(Throwable cause) {
         boolean metricsEnabled = isFaultToleranceMetricsEnabled();
+        if (!metricsEnabled) {
+            return;
+        }
+
         boolean asyncBulkhead = introspector.hasBulkhead() && introspector.isAsynchronous();
         boolean waitingRecordedBeforeCompletion = false;
         if (asyncBulkhead) {
-            ConcurrentMap<Supplier<?>, Long> waitingStarts = methodState.bulkheadWaitingStarts;
-            if (waitingStarts != null) {
-                waitingStarts.remove(handlerSupplier);
-            }
-            Set<Supplier<?>> waitingRecorded = methodState.bulkheadWaitingRecorded;
-            waitingRecordedBeforeCompletion = waitingRecorded != null
-                    && waitingRecorded.remove(handlerSupplier);
-        }
-
-        if (!metricsEnabled) {
-            return;
+            BulkheadWaitingTracker waitingTracker = methodState.bulkheadWaitingTracker;
+            waitingRecordedBeforeCompletion = waitingTracker != null
+                    && waitingTracker.recordedOrPending(handlerSupplier);
         }
 
         // Calculate execution time
@@ -656,7 +649,7 @@ class MethodInvoker implements FtSupplier<Object> {
                 }
 
                 // Update histograms if task accepted
-                if (!(cause instanceof BulkheadException)) {
+                if (invocationStartNanos != 0 && !(cause instanceof BulkheadException)) {
                     long waitingTime = invocationStartNanos - handlerStartNanos;
                     bulkheadRunningDuration = executionTime - waitingTime;
                     updateBulkheadDuration = true;
@@ -744,6 +737,107 @@ class MethodInvoker implements FtSupplier<Object> {
         }
     }
 
+    private static class BulkheadWaitingTracker {
+        private final Tag methodNameTag;
+        private final ConcurrentMap<Supplier<?>, WaitingState> states = new ConcurrentHashMap<>();
+
+        BulkheadWaitingTracker(Tag methodNameTag) {
+            this.methodNameTag = methodNameTag;
+        }
+
+        void enqueueing(Supplier<?> supplier) {
+            if (!isFaultToleranceMetricsEnabled()) {
+                return;
+            }
+            long startNanos = System.nanoTime();
+            states.compute(supplier, (ignored, state) -> {
+                WaitingState newState = state == null ? new WaitingState() : state;
+                newState.starts.addLast(startNanos);
+                return newState;
+            });
+        }
+
+        void dequeued(Supplier<?> supplier) {
+            long[] startNanos = new long[1];
+            boolean[] found = new boolean[1];
+            states.compute(supplier, (ignored, state) -> {
+                if (state == null || state.starts.isEmpty()) {
+                    return state;
+                }
+                startNanos[0] = state.starts.removeFirst();
+                found[0] = true;
+                if (!state.completionObserved) {
+                    state.listenerOwnsCompletionRecord = true;
+                }
+                return state.starts.isEmpty() && state.completionObserved ? null : state;
+            });
+
+            if (found[0]) {
+                recordWaitingDuration(startNanos[0]);
+            }
+        }
+
+        void cancelled(Supplier<?> supplier) {
+            long[] startNanos = new long[1];
+            boolean[] record = new boolean[1];
+            states.compute(supplier, (ignored, state) -> {
+                if (state == null || state.starts.isEmpty()) {
+                    return state;
+                }
+                startNanos[0] = state.starts.removeFirst();
+                record[0] = state.completionObserved;
+                return state.starts.isEmpty() && (state.completionObserved || !state.listenerOwnsCompletionRecord)
+                        ? null : state;
+            });
+            if (record[0]) {
+                recordWaitingDuration(startNanos[0]);
+            }
+        }
+
+        boolean recordedOrPending(Supplier<?> supplier) {
+            if (states.get(supplier) == null) {
+                return false;
+            }
+            boolean[] result = new boolean[1];
+            states.compute(supplier, (ignored, state) -> {
+                if (state == null) {
+                    return null;
+                }
+                if (!state.starts.isEmpty()) {
+                    state.completionObserved = true;
+                    state.listenerOwnsCompletionRecord = false;
+                    result[0] = true;
+                    return state;
+                }
+                if (state.listenerOwnsCompletionRecord) {
+                    result[0] = true;
+                    return null;
+                }
+                return null;
+            });
+            return result[0];
+        }
+
+        private void recordWaitingDuration(long startNanos) {
+            if (!isFaultToleranceMetricsEnabled()) {
+                return;
+            }
+
+            try {
+                // Keep metric failures from escaping permit handoff or queued-cancel cleanup.
+                BulkheadWaitingDuration.get(methodNameTag).update(System.nanoTime() - startNanos);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.DEBUG, "Failed to update bulkhead waiting duration metric", e);
+            }
+        }
+
+        private static class WaitingState {
+            private final Deque<Long> starts = new ArrayDeque<>();
+            private boolean listenerOwnsCompletionRecord;
+            private boolean completionObserved;
+        }
+    }
+
     /**
      * State associated with a method in {@code METHOD_STATES}.
      */
@@ -751,8 +845,7 @@ class MethodInvoker implements FtSupplier<Object> {
         private final ReentrantLock lock = new ReentrantLock();
         private Retry retry;
         private Bulkhead bulkhead;
-        private ConcurrentMap<Supplier<?>, Long> bulkheadWaitingStarts;
-        private Set<Supplier<?>> bulkheadWaitingRecorded;
+        private BulkheadWaitingTracker bulkheadWaitingTracker;
         private CircuitBreaker breaker;
         private Timeout timeout;
         private State lastBreakerState;

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,6 +51,7 @@ import jakarta.interceptor.InvocationContext;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Tag;
 
 import static io.helidon.faulttolerance.SupplierHelper.toRuntimeException;
 import static io.helidon.faulttolerance.SupplierHelper.unwrapThrowable;
@@ -374,6 +378,9 @@ class MethodInvoker implements FtSupplier<Object> {
                 cancellableSupplier.cancel();
                 // Cancel supplier in bulkhead in case it is queued
                 if (introspector.hasBulkhead()) {
+                    if (methodState.bulkheadWaitingStarts != null) {
+                        methodState.bulkheadWaitingStarts.remove(handlerSupplier);
+                    }
                     methodState.bulkhead.cancelSupplier(handlerSupplier);
                 }
                 asyncFuture.cancel(mayInterrupt.get());
@@ -393,8 +400,35 @@ class MethodInvoker implements FtSupplier<Object> {
      */
     private void initMethodHandler(MethodState methodState) {
         if (introspector.hasBulkhead()) {
-            methodState.bulkhead = Bulkhead.create(builder -> builder.limit(introspector.getBulkhead().value())
-                    .queueLength(introspector.isAsynchronous() ? introspector.getBulkhead().waitingTaskQueue() : 0));
+            methodState.bulkhead = Bulkhead.create(builder -> {
+                builder.limit(introspector.getBulkhead().value())
+                        .queueLength(introspector.isAsynchronous() ? introspector.getBulkhead().waitingTaskQueue() : 0);
+                if (introspector.isAsynchronous()) {
+                    ConcurrentMap<Supplier<?>, Long> waitingStarts = new ConcurrentHashMap<>();
+                    Set<Supplier<?>> waitingRecorded = ConcurrentHashMap.newKeySet();
+                    Tag methodNameTag = introspector.getMethodNameTag();
+
+                    methodState.bulkheadWaitingStarts = waitingStarts;
+                    methodState.bulkheadWaitingRecorded = waitingRecorded;
+                    builder.addQueueListener(new Bulkhead.QueueListener() {
+                        @Override
+                        public <T> void enqueueing(Supplier<? extends T> supplier) {
+                            if (isFaultToleranceMetricsEnabled()) {
+                                waitingStarts.put(supplier, System.nanoTime());
+                            }
+                        }
+
+                        @Override
+                        public <T> void dequeued(Supplier<? extends T> supplier) {
+                            Long startNanos = waitingStarts.remove(supplier);
+                            if (startNanos != null && isFaultToleranceMetricsEnabled()) {
+                                BulkheadWaitingDuration.get(methodNameTag).update(System.nanoTime() - startNanos);
+                                waitingRecorded.add(supplier);
+                            }
+                        }
+                    });
+                }
+            });
         }
 
         if (introspector.hasTimeout()) {
@@ -528,15 +562,32 @@ class MethodInvoker implements FtSupplier<Object> {
      * @param cause Mapped cause or {@code null} if successful.
      */
     private void updateMetricsAfter(Throwable cause) {
-        if (!isFaultToleranceMetricsEnabled()) {
+        boolean metricsEnabled = isFaultToleranceMetricsEnabled();
+        boolean asyncBulkhead = introspector.hasBulkhead() && introspector.isAsynchronous();
+        boolean waitingRecordedBeforeCompletion = false;
+        if (asyncBulkhead) {
+            ConcurrentMap<Supplier<?>, Long> waitingStarts = methodState.bulkheadWaitingStarts;
+            if (waitingStarts != null) {
+                waitingStarts.remove(handlerSupplier);
+            }
+            Set<Supplier<?>> waitingRecorded = methodState.bulkheadWaitingRecorded;
+            waitingRecordedBeforeCompletion = waitingRecorded != null
+                    && waitingRecorded.remove(handlerSupplier);
+        }
+
+        if (!metricsEnabled) {
             return;
         }
 
+        // Calculate execution time
+        long executionTime = System.nanoTime() - handlerStartNanos;
+        boolean updateBulkheadDuration = false;
+        long bulkheadRunningDuration = 0L;
+        boolean updateBulkheadWaitingDuration = false;
+        long bulkheadWaitingDuration = 0L;
+
         methodState.lock.lock();
         try {
-            // Calculate execution time
-            long executionTime = System.nanoTime() - handlerStartNanos;
-
             // Retries
             if (introspector.hasRetry()) {
                 long retryCounter = methodState.retry.retryCounter();
@@ -573,18 +624,6 @@ class MethodInvoker implements FtSupplier<Object> {
                                             RetryResult.EXCEPTION_NOT_RETRYABLE.get()).inc();
                     }
                 }
-            }
-
-            // Timeout
-            if (introspector.hasTimeout()) {
-                if (cause instanceof org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException) {
-                    TimeoutCallsTotal.get(introspector.getMethodNameTag(),
-                                          TimeoutTimedOut.TRUE.get()).inc();
-                } else {
-                    TimeoutCallsTotal.get(introspector.getMethodNameTag(),
-                                          TimeoutTimedOut.FALSE.get()).inc();
-                }
-                TimeoutExecutionDuration.get(introspector.getMethodNameTag()).update(executionTime);
             }
 
             // CircuitBreaker
@@ -654,26 +693,48 @@ class MethodInvoker implements FtSupplier<Object> {
                 // Update histograms if task accepted
                 if (!(cause instanceof BulkheadException)) {
                     long waitingTime = invocationStartNanos - handlerStartNanos;
-                    BulkheadRunningDuration.get(introspector.getMethodNameTag())
-                            .update(executionTime - waitingTime);
+                    bulkheadRunningDuration = executionTime - waitingTime;
+                    updateBulkheadDuration = true;
                     if (introspector.isAsynchronous()) {
-                        BulkheadWaitingDuration.get(introspector.getMethodNameTag()).update(waitingTime);
+                        if (!waitingRecordedBeforeCompletion) {
+                            bulkheadWaitingDuration = waitingTime;
+                            updateBulkheadWaitingDuration = true;
+                        }
                     }
                 }
             }
-
-            // Global method counters
-            if (cause == null) {
-                InvocationsTotal.get(introspector.getMethodNameTag(),
-                                     VALUE_RETURNED.get(),
-                                     introspector.getFallbackTag(fallbackCalled.get())).inc();
-            } else {
-                InvocationsTotal.get(introspector.getMethodNameTag(),
-                                     EXCEPTION_THROWN.get(),
-                                     introspector.getFallbackTag(fallbackCalled.get())).inc();
-            }
         } finally {
             methodState.lock.unlock();
+        }
+
+        // Timeout
+        if (introspector.hasTimeout()) {
+            if (cause instanceof org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException) {
+                TimeoutCallsTotal.get(introspector.getMethodNameTag(),
+                                      TimeoutTimedOut.TRUE.get()).inc();
+            } else {
+                TimeoutCallsTotal.get(introspector.getMethodNameTag(),
+                                      TimeoutTimedOut.FALSE.get()).inc();
+            }
+            TimeoutExecutionDuration.get(introspector.getMethodNameTag()).update(executionTime);
+        }
+
+        if (updateBulkheadDuration) {
+            BulkheadRunningDuration.get(introspector.getMethodNameTag()).update(bulkheadRunningDuration);
+            if (updateBulkheadWaitingDuration) {
+                BulkheadWaitingDuration.get(introspector.getMethodNameTag()).update(bulkheadWaitingDuration);
+            }
+        }
+
+        // Global method counters
+        if (cause == null) {
+            InvocationsTotal.get(introspector.getMethodNameTag(),
+                                 VALUE_RETURNED.get(),
+                                 introspector.getFallbackTag(fallbackCalled.get())).inc();
+        } else {
+            InvocationsTotal.get(introspector.getMethodNameTag(),
+                                 EXCEPTION_THROWN.get(),
+                                 introspector.getFallbackTag(fallbackCalled.get())).inc();
         }
     }
 
@@ -684,6 +745,8 @@ class MethodInvoker implements FtSupplier<Object> {
         private final ReentrantLock lock = new ReentrantLock();
         private Retry retry;
         private Bulkhead bulkhead;
+        private ConcurrentMap<Supplier<?>, Long> bulkheadWaitingStarts;
+        private Set<Supplier<?>> bulkheadWaitingRecorded;
         private CircuitBreaker breaker;
         private Timeout timeout;
         private State lastBreakerState;

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsBean.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsBean.java
@@ -49,6 +49,8 @@ class MetricsBean {
     private final CountDownLatch retryingBulkheadRelease = new CountDownLatch(1);
     private final CountDownLatch timedBulkheadEntered = new CountDownLatch(1);
     private final CountDownLatch timedBulkheadRelease = new CountDownLatch(1);
+    private final CountDownLatch cancellableBulkheadEntered = new CountDownLatch(1);
+    private final CountDownLatch cancellableBulkheadRelease = new CountDownLatch(1);
     private final AtomicInteger retryingBulkheadAttempts = new AtomicInteger();
 
     Counter getCounter() {
@@ -232,6 +234,26 @@ class MetricsBean {
 
     void releaseTimedBulkhead() {
         timedBulkheadRelease.countDown();
+    }
+
+    @Asynchronous
+    @Bulkhead(value = 1, waitingTaskQueue = 1)
+    CompletableFuture<String> cancellableBulkhead(boolean block) {
+        FaultToleranceTest.printStatus("MetricsBean::cancellableBulkhead()", block ? "block" : "success");
+        if (block) {
+            cancellableBulkheadEntered.countDown();
+            await(cancellableBulkheadRelease);
+            return CompletableFuture.completedFuture("blocker");
+        }
+        return CompletableFuture.completedFuture("queued");
+    }
+
+    boolean awaitCancellableBulkheadEntered() throws InterruptedException {
+        return cancellableBulkheadEntered.await(5, TimeUnit.SECONDS);
+    }
+
+    void releaseCancellableBulkhead() {
+        cancellableBulkheadRelease.countDown();
     }
 
     private static void await(CountDownLatch latch) {

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsBean.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.helidon.microprofile.faulttolerance;
 
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.enterprise.context.Dependent;
@@ -28,6 +30,7 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
@@ -42,6 +45,11 @@ class MetricsBean {
     @Inject
     @Metric(name = "counter")
     private Counter counter;
+    private final CountDownLatch retryingBulkheadEntered = new CountDownLatch(1);
+    private final CountDownLatch retryingBulkheadRelease = new CountDownLatch(1);
+    private final CountDownLatch timedBulkheadEntered = new CountDownLatch(1);
+    private final CountDownLatch timedBulkheadRelease = new CountDownLatch(1);
+    private final AtomicInteger retryingBulkheadAttempts = new AtomicInteger();
 
     Counter getCounter() {
         return counter;
@@ -180,5 +188,60 @@ class MetricsBean {
             // falls through
         }
         return CompletableFuture.completedFuture("success");
+    }
+
+    @Asynchronous
+    @Retry(maxRetries = 1, delay = 10L, retryOn = TimeoutException.class)
+    @Timeout(value = 300, unit = ChronoUnit.MILLIS)
+    @Bulkhead(value = 1, waitingTaskQueue = 4)
+    CompletableFuture<String> retryingBulkhead(boolean block) {
+        int attempt = retryingBulkheadAttempts.incrementAndGet();
+        FaultToleranceTest.printStatus("MetricsBean::retryingBulkhead()", "attempt " + attempt);
+        if (block) {
+            retryingBulkheadEntered.countDown();
+            await(retryingBulkheadRelease);
+            return CompletableFuture.completedFuture("blocker");
+        }
+        return CompletableFuture.completedFuture("retry-" + attempt);
+    }
+
+    boolean awaitRetryingBulkheadEntered() throws InterruptedException {
+        return retryingBulkheadEntered.await(5, TimeUnit.SECONDS);
+    }
+
+    void releaseRetryingBulkhead() {
+        retryingBulkheadRelease.countDown();
+    }
+
+    @Asynchronous
+    @Timeout(value = 300, unit = ChronoUnit.MILLIS)
+    @Bulkhead(value = 1, waitingTaskQueue = 1)
+    CompletableFuture<String> timedBulkhead(boolean block) {
+        FaultToleranceTest.printStatus("MetricsBean::timedBulkhead()", block ? "block" : "success");
+        if (block) {
+            timedBulkheadEntered.countDown();
+            await(timedBulkheadRelease);
+            return CompletableFuture.completedFuture("blocker");
+        }
+        return CompletableFuture.completedFuture("queued");
+    }
+
+    boolean awaitTimedBulkheadEntered() throws InterruptedException {
+        return timedBulkheadEntered.await(5, TimeUnit.SECONDS);
+    }
+
+    void releaseTimedBulkhead() {
+        timedBulkheadRelease.countDown();
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out waiting for controlled bulkhead release");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -479,10 +480,6 @@ class MetricsTest extends FaultToleranceTest {
 
         try {
             CompletableFuture<String> retried = bean.retryingBulkhead(false);
-            Gauge<Long> executionsWaiting = BulkheadExecutionsWaiting.get(
-                    getMethodTag(bean, "retryingBulkhead"));
-            awaitGaugeValue(executionsWaiting, 3L);
-
             assertCompleteExceptionally(retried, TimeoutException.class);
             bean.releaseRetryingBulkhead();
             awaitHistogramCount(waitingDuration, startCount + 3);
@@ -504,10 +501,6 @@ class MetricsTest extends FaultToleranceTest {
 
         try {
             CompletableFuture<String> queued = bean.timedBulkhead(false);
-            Gauge<Long> executionsWaiting = BulkheadExecutionsWaiting.get(
-                    getMethodTag(bean, "timedBulkhead"));
-            awaitGaugeValue(executionsWaiting, 1L);
-
             assertCompleteExceptionally(queued, TimeoutException.class);
             awaitHistogramCount(waitingDuration, startCount + 1);
         } finally {
@@ -516,12 +509,36 @@ class MetricsTest extends FaultToleranceTest {
         }
     }
 
-    private static void awaitGaugeValue(Gauge<Long> gauge, long expected) throws InterruptedException {
+    @Test
+    void testBulkheadWaitingDurationRecordsExplicitCancel() throws Exception {
+        MetricsBean bean = newBean(MetricsBean.class);
+        Histogram waitingDuration = BulkheadWaitingDuration.get(
+                getMethodTag(bean, "cancellableBulkhead"));
+        long startCount = waitingDuration.getCount();
+
+        CompletableFuture<String> blocker = bean.cancellableBulkhead(true);
+        assertThat(bean.awaitCancellableBulkheadEntered(), is(true));
+
+        try {
+            CompletableFuture<String> queued = bean.cancellableBulkhead(false);
+            Gauge<Long> executionsWaiting = BulkheadExecutionsWaiting.get(
+                    getMethodTag(bean, "cancellableBulkhead"));
+            awaitGaugeAtLeast(executionsWaiting, 1L);
+
+            assertThat(queued.cancel(true), is(true));
+            awaitHistogramCount(waitingDuration, startCount + 1);
+        } finally {
+            bean.releaseCancellableBulkhead();
+            blocker.handle((result, throwable) -> null).get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private static void awaitGaugeAtLeast(Gauge<Long> gauge, long expected) throws InterruptedException {
         long timeoutNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        while (System.nanoTime() < timeoutNanos && gauge.getValue() != expected) {
+        while (System.nanoTime() < timeoutNanos && gauge.getValue() < expected) {
             Thread.sleep(10);
         }
-        assertThat(gauge.getValue(), is(expected));
+        assertThat(gauge.getValue(), greaterThanOrEqualTo(expected));
     }
 
     private static void awaitHistogramCount(Histogram histogram, long expected) throws InterruptedException {

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,17 @@
 package io.helidon.microprofile.faulttolerance;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricUnits;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -464,5 +465,70 @@ class MetricsTest extends FaultToleranceTest {
         Histogram awaitingDuration = BulkheadWaitingDuration.get(
                 getMethodTag(bean, "concurrentAsync"));
         assertThat(awaitingDuration.getCount(), is(greaterThan(0L)));
+    }
+
+    @Test
+    void testBulkheadWaitingDurationRecordsRetriedQueueAttempts() throws Exception {
+        MetricsBean bean = newBean(MetricsBean.class);
+        Histogram waitingDuration = BulkheadWaitingDuration.get(
+                getMethodTag(bean, "retryingBulkhead"));
+        long startCount = waitingDuration.getCount();
+
+        CompletableFuture<String> blocker = bean.retryingBulkhead(true);
+        assertThat(bean.awaitRetryingBulkheadEntered(), is(true));
+
+        try {
+            CompletableFuture<String> retried = bean.retryingBulkhead(false);
+            Gauge<Long> executionsWaiting = BulkheadExecutionsWaiting.get(
+                    getMethodTag(bean, "retryingBulkhead"));
+            awaitGaugeValue(executionsWaiting, 3L);
+
+            assertCompleteExceptionally(retried, TimeoutException.class);
+            bean.releaseRetryingBulkhead();
+            awaitHistogramCount(waitingDuration, startCount + 3);
+        } finally {
+            bean.releaseRetryingBulkhead();
+            blocker.handle((result, throwable) -> null).get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testBulkheadWaitingDurationRecordsQueuedTimeout() throws Exception {
+        MetricsBean bean = newBean(MetricsBean.class);
+        Histogram waitingDuration = BulkheadWaitingDuration.get(
+                getMethodTag(bean, "timedBulkhead"));
+        long startCount = waitingDuration.getCount();
+
+        CompletableFuture<String> blocker = bean.timedBulkhead(true);
+        assertThat(bean.awaitTimedBulkheadEntered(), is(true));
+
+        try {
+            CompletableFuture<String> queued = bean.timedBulkhead(false);
+            Gauge<Long> executionsWaiting = BulkheadExecutionsWaiting.get(
+                    getMethodTag(bean, "timedBulkhead"));
+            awaitGaugeValue(executionsWaiting, 1L);
+
+            assertCompleteExceptionally(queued, TimeoutException.class);
+            awaitHistogramCount(waitingDuration, startCount + 1);
+        } finally {
+            bean.releaseTimedBulkhead();
+            blocker.handle((result, throwable) -> null).get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private static void awaitGaugeValue(Gauge<Long> gauge, long expected) throws InterruptedException {
+        long timeoutNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < timeoutNanos && gauge.getValue() != expected) {
+            Thread.sleep(10);
+        }
+        assertThat(gauge.getValue(), is(expected));
+    }
+
+    private static void awaitHistogramCount(Histogram histogram, long expected) throws InterruptedException {
+        long timeoutNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < timeoutNanos && histogram.getCount() != expected) {
+            Thread.sleep(10);
+        }
+        assertThat(histogram.getCount(), is(expected));
     }
 }


### PR DESCRIPTION
Fixes async bulkhead waiting-duration metric bookkeeping so per-invocation suppliers are cleaned up from method-scoped tracking when invocations are rejected, cancelled, or complete after queue timing is recorded.

This is a required fix to consistently pass FaultTolerance TCK on MacOS ARM machines.

Validation:
- `env JAVA_HOME=/Users/tomas/.sdkman/candidates/java/21.0.7-oracle mvn -Ptests,tck -pl microprofile/tests/tck/tck-fault-tolerance -am -DskipTests install`
- `env JAVA_HOME=/Users/tomas/.sdkman/candidates/java/21.0.7-oracle mvn -Ptests,tck -pl microprofile/tests/tck/tck-fault-tolerance test`
- `./etc/scripts/copyright.sh`
