### PR TITLE
4.x: Deprecate LockingStreamIdSequence constructor

### DIFF
--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -82,7 +82,7 @@ public class Http2ClientConnection {
 
     private final Http2FrameListener sendListener = new Http2LoggingFrameListener("cl-send");
     private final Http2FrameListener recvListener = new Http2LoggingFrameListener("cl-recv");
-    private final LockingStreamIdSequence streamIdSeq = new LockingStreamIdSequence();
+    private final LockingStreamIdSequence streamIdSeq = LockingStreamIdSequence.create();
     private final ReadWriteLock streamsLock = new ReentrantReadWriteLock();
     // streams may be accessed from connection thread, or stream thread, must be guarded by the above lock
     private final Map<Integer, Http2ClientStream> streams = new HashMap<>();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,24 @@ public class LockingStreamIdSequence {
 
     private final AtomicInteger streamIdSeq = new AtomicInteger(0);
     private final Lock lock = new ReentrantLock();
+
+    /**
+     * Create a new locking stream ID sequence.
+     *
+     * @deprecated use {@link #create()} instead
+     */
+    @Deprecated(forRemoval = true, since = "4.5.0")
+    public LockingStreamIdSequence() {
+    }
+
+    /**
+     * Create a new locking stream ID sequence.
+     *
+     * @return a new locking stream ID sequence
+     */
+    public static LockingStreamIdSequence create() {
+        return new LockingStreamIdSequence();
+    }
 
     int lockAndNext() {
         lock.lock();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
@@ -174,7 +174,7 @@ class Http2ClientConnectionPingTest {
                                          socket,
                                          STREAM_CONFIG,
                                          clientConfig,
-                                         new LockingStreamIdSequence());
+                                         LockingStreamIdSequence.create());
         }
     }
 


### PR DESCRIPTION
Fixes #12012

Backport of #12003.

### Description

Adds `LockingStreamIdSequence.create()` and updates HTTP/2 client usage to use the factory method.

The public constructor remains for compatibility and is explicitly deprecated for removal since `4.5.0`.

### Documentation

None

### Testing

- `mvn -ntp -pl :helidon-webclient-http2 -am -Dtest=io.helidon.webclient.http2.Http2ClientConnectionPingTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`
- `bash ./etc/scripts/copyright.sh`
- `bash ./etc/scripts/checkstyle.sh`
