### PR TITLE
4.x: HTTP/2 WebClient flow control fix

### DIFF
--- a/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,9 +102,14 @@ public class ConnectionFlowControl {
      * Increment outbound connection flow control window, called when WINDOW_UPDATE is received.
      *
      * @param increment number of bytes other side has requested on top of actual demand
-     * @return outbound window size after increment
+     * @return outbound window size after applying the increment; if this value is greater than
+     *         {@link WindowSize#MAX_WIN_SIZE}, the increment was rejected and the outbound window was not updated
      */
     public long incrementOutboundConnectionWindowSize(int increment) {
+        long updatedWindowSize = (long) outboundConnectionWindowSize.getRemainingWindowSize() + increment;
+        if (updatedWindowSize > WindowSize.MAX_WIN_SIZE) {
+            return updatedWindowSize;
+        }
         return outboundConnectionWindowSize.incrementWindowSize(increment);
     }
 

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
@@ -68,8 +68,8 @@ public interface FlowControl {
          * Increment stream window size.
          *
          * @param increment increment in bytes
-         * @return outbound stream window size after applying the increment, before overflow clamping; a value greater
-         *         than {@link WindowSize#MAX_WIN_SIZE} means the peer exceeded the maximum allowed flow-control window
+         * @return outbound stream window size after applying the increment; if this value is greater than
+         *         {@link WindowSize#MAX_WIN_SIZE}, the increment was rejected and the outbound stream window was not updated
          */
         long incrementStreamWindowSize(int increment);
 

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
@@ -68,7 +68,8 @@ public interface FlowControl {
          * Increment stream window size.
          *
          * @param increment increment in bytes
-         * @return {@code true} if succeeded, {@code false} if timed out
+         * @return outbound stream window size after applying the increment, before overflow clamping; a value greater
+         *         than {@link WindowSize#MAX_WIN_SIZE} means the peer exceeded the maximum allowed flow-control window
          */
         long incrementStreamWindowSize(int increment);
 

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControlImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControlImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,10 @@ abstract class FlowControlImpl implements FlowControl {
 
         @Override
         public long incrementStreamWindowSize(int increment) {
+            long updatedWindowSize = (long) streamWindowSize.getRemainingWindowSize() + increment;
+            if (updatedWindowSize > WindowSize.MAX_WIN_SIZE) {
+                return updatedWindowSize;
+            }
             long remaining = streamWindowSize.incrementWindowSize(increment);
             if (LOGGER_OUTBOUND.isLoggable(DEBUG)) {
                 LOGGER_OUTBOUND.log(DEBUG, String.format("%s OFC STR %d: +%d(%d)", type, streamId(), increment, remaining));

--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSize.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSize.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSize.java
@@ -93,8 +93,9 @@ public interface WindowSize {
     /**
      * Increment window size.
      *
-     * @param increment increment
-     * @return whether the increment succeeded
+     * @param increment increment in bytes
+     * @return window size after applying the increment, before overflow clamping; a value greater than
+     *         {@link #MAX_WIN_SIZE} means the peer exceeded the maximum allowed flow-control window
      */
     long incrementWindowSize(int increment);
 

--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ abstract class WindowSizeImpl implements WindowSize {
                         ? increment + r
                         : MAX_WIN_SIZE);
 
-        return remaining + increment;
+        return (long) remaining + increment;
     }
 
     @Override

--- a/http/http2/src/test/java/io/helidon/http/http2/WindowSizeImplTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/WindowSizeImplTest.java
@@ -35,7 +35,7 @@ class WindowSizeImplTest {
         long remaining = flowControl.incrementOutboundConnectionWindowSize(WindowSize.MAX_WIN_SIZE);
 
         assertThat(remaining, is((long) WindowSize.DEFAULT_WIN_SIZE + WindowSize.MAX_WIN_SIZE));
-        assertThat(flowControl.outbound().getRemainingWindowSize(), is(WindowSize.MAX_WIN_SIZE));
+        assertThat(flowControl.outbound().getRemainingWindowSize(), is(WindowSize.DEFAULT_WIN_SIZE));
     }
 
     @Test
@@ -49,5 +49,6 @@ class WindowSizeImplTest {
         long remaining = streamFlowControl.outbound().incrementStreamWindowSize(WindowSize.MAX_WIN_SIZE);
 
         assertThat(remaining, is((long) WindowSize.DEFAULT_WIN_SIZE + WindowSize.MAX_WIN_SIZE));
+        assertThat(streamFlowControl.outbound().getRemainingWindowSize(), is(WindowSize.DEFAULT_WIN_SIZE));
     }
 }

--- a/http/http2/src/test/java/io/helidon/http/http2/WindowSizeImplTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/WindowSizeImplTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.http.http2;
+
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class WindowSizeImplTest {
+
+    private static final BiConsumer<Integer, Http2WindowUpdate> NOOP_WINDOW_UPDATE_WRITER = (streamId, windowUpdate) -> {
+    };
+
+    @Test
+    void connectionWindowIncrementReturnsOverflowValueAsLong() {
+        ConnectionFlowControl flowControl = ConnectionFlowControl.clientBuilder(NOOP_WINDOW_UPDATE_WRITER)
+                .build();
+
+        long remaining = flowControl.incrementOutboundConnectionWindowSize(WindowSize.MAX_WIN_SIZE);
+
+        assertThat(remaining, is((long) WindowSize.DEFAULT_WIN_SIZE + WindowSize.MAX_WIN_SIZE));
+        assertThat(flowControl.outbound().getRemainingWindowSize(), is(WindowSize.MAX_WIN_SIZE));
+    }
+
+    @Test
+    void streamWindowIncrementReturnsOverflowValueAsLong() {
+        ConnectionFlowControl flowControl = ConnectionFlowControl.clientBuilder(NOOP_WINDOW_UPDATE_WRITER)
+                .build();
+        StreamFlowControl streamFlowControl = flowControl.createStreamFlowControl(1,
+                                                                                 WindowSize.DEFAULT_WIN_SIZE,
+                                                                                 WindowSize.DEFAULT_MAX_FRAME_SIZE);
+
+        long remaining = streamFlowControl.outbound().incrementStreamWindowSize(WindowSize.MAX_WIN_SIZE);
+
+        assertThat(remaining, is((long) WindowSize.DEFAULT_WIN_SIZE + WindowSize.MAX_WIN_SIZE));
+    }
+}

--- a/tests/integration/h2spec-client/src/test/java/io/helidon/tests/integration/h2spec/client/H2SpecClientIT.java
+++ b/tests/integration/h2spec-client/src/test/java/io/helidon/tests/integration/h2spec/client/H2SpecClientIT.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -33,7 +32,6 @@ import java.util.stream.Stream;
 import io.helidon.logging.common.LogConfig;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -81,13 +79,6 @@ class H2SpecClientIT {
     private static final Pattern CASE_PATTERN =
             Pattern.compile("^\\s*(?:([\\u2714\\u00D7])\\s+)?(\\d+):\\s+(.*)$");
 
-    private static final Set<KnownFailure> KNOWN_FAILURES = Set.of(
-            new KnownFailure("client/6.9.1/1",
-                             "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1"),
-            new KnownFailure("client/6.9.1/2",
-                             "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream")
-    );
-
     static {
         LogConfig.configureRuntime();
     }
@@ -101,10 +92,6 @@ class H2SpecClientIT {
 
         if (skipped != null) {
             Assertions.fail("Unexpected h2specd skip for " + id + " (" + desc + "): " + skipped);
-        }
-
-        if (err != null && isKnownFailure(id, desc)) {
-            Assumptions.abort("Known failure tracked by #11771:\n" + err);
         }
 
         if (err != null) {
@@ -390,13 +377,6 @@ class H2SpecClientIT {
         } catch (IOException e) {
             throw new IllegalStateException("Failed to persist h2specd client output to " + outputPath, e);
         }
-    }
-
-    private static boolean isKnownFailure(String id, String desc) {
-        return KNOWN_FAILURES.contains(new KnownFailure(id, desc));
-    }
-
-    private record KnownFailure(String id, String description) {
     }
 
     private record H2SpecCaseResult(String caseName,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -719,7 +719,7 @@ public class Http2ClientConnection {
         recvListener.frameHeader(ctx, streamId, frameHeader);
         recvListener.frame(ctx, streamId, windowUpdate);
         if (streamId == 0) {
-            updateConnectionWindow(windowUpdate);
+            return updateConnectionWindow(windowUpdate);
         } else {
             Http2ClientStream stream = stream(streamId);
             if (stream == null) {
@@ -732,17 +732,18 @@ public class Http2ClientConnection {
         return true;
     }
 
-    private void updateConnectionWindow(Http2WindowUpdate windowUpdate) {
+    private boolean updateConnectionWindow(Http2WindowUpdate windowUpdate) {
         int increment = windowUpdate.windowSizeIncrement();
         if (increment == 0) {
-            Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.PROTOCOL, "Window size 0");
-            writer.write(frame.toFrameData(serverSettings, 0, Http2Flag.NoFlags.create()));
+            goAway(0, Http2ErrorCode.PROTOCOL, "Window size 0");
+            return false;
         }
         boolean overflow = connectionFlowControl.incrementOutboundConnectionWindowSize(increment) > WindowSize.MAX_WIN_SIZE;
         if (overflow) {
-            Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.FLOW_CONTROL, "Window size too big. Max: ");
-            writer.write(frame.toFrameData(serverSettings, 0, Http2Flag.NoFlags.create()));
+            goAway(0, Http2ErrorCode.FLOW_CONTROL, "Window size too big. Max: ");
+            return false;
         }
+        return true;
     }
 
     private boolean handlePingFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -153,14 +153,12 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
         //6.9/2
         if (increment == 0) {
-            Http2RstStream frame = new Http2RstStream(Http2ErrorCode.PROTOCOL);
-            connection.writer().write(frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            resetStream(Http2ErrorCode.PROTOCOL);
             return;
         }
         //6.9.1/3
         if (flowControl.outbound().incrementStreamWindowSize(increment) > WindowSize.MAX_WIN_SIZE) {
-            Http2RstStream frame = new Http2RstStream(Http2ErrorCode.FLOW_CONTROL);
-            connection.writer().write(frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            resetStream(Http2ErrorCode.FLOW_CONTROL);
         }
     }
 
@@ -693,6 +691,22 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         this.state = newState;
         if (newState == Http2StreamState.CLOSED) {
             releaseReservation();
+        }
+    }
+
+    private void resetStream(Http2ErrorCode errorCode) {
+        Http2RstStream frame = new Http2RstStream(errorCode);
+        Http2FrameData frameData = frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create());
+        Http2StreamState nextState = Http2StreamState.checkAndGetState(this.state,
+                                                                       Http2FrameType.RST_STREAM,
+                                                                       true,
+                                                                       false,
+                                                                       false);
+        try {
+            connection.writer().write(frameData);
+        } finally {
+            updateState(nextState);
+            close();
         }
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -155,16 +155,13 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         if (increment == 0) {
             Http2RstStream frame = new Http2RstStream(Http2ErrorCode.PROTOCOL);
             connection.writer().write(frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            return;
         }
         //6.9.1/3
         if (flowControl.outbound().incrementStreamWindowSize(increment) > WindowSize.MAX_WIN_SIZE) {
             Http2RstStream frame = new Http2RstStream(Http2ErrorCode.FLOW_CONTROL);
             connection.writer().write(frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
         }
-
-        flowControl()
-                .outbound()
-                .incrementStreamWindowSize(increment);
     }
 
     @Override

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
@@ -16,8 +16,11 @@
 
 package io.helidon.webclient.http2;
 
+import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -27,8 +30,18 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2GoAway;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2WindowUpdate;
+import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
 
 import org.junit.jupiter.api.Test;
@@ -42,6 +55,7 @@ import static org.mockito.Mockito.when;
 
 class Http2ClientConnectionPingTest {
     private static final Duration TEST_WAIT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Method HANDLE_METHOD = handleMethod();
     private static final Http2StreamConfig STREAM_CONFIG = new Http2StreamConfig() {
         @Override
         public boolean priorKnowledge() {
@@ -100,6 +114,54 @@ class Http2ClientConnectionPingTest {
         assertThat(pingFuture.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(false));
     }
 
+    @Test
+    void connectionWindowOverflowWritesFlowControlGoAway() throws Exception {
+        Http2FrameData frameData = new Http2WindowUpdate(WindowSize.MAX_WIN_SIZE)
+                .toFrameData(Http2Settings.create(), 0, Http2Flag.NoFlags.create());
+        MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100), frameBytes(frameData));
+
+        assertThat(invokeHandle(test.connection()), is(true));
+
+        assertThat(test.writes(), hasSize(1));
+        BufferData write = test.writes().get(0);
+        Http2FrameHeader header = readFrameHeader(write);
+        assertThat(header.type(), is(Http2FrameType.GO_AWAY));
+        assertThat(header.streamId(), is(0));
+        assertThat(Http2GoAway.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
+    }
+
+    @Test
+    void streamWindowUpdateIncrementsOutboundWindowOnce() {
+        MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100));
+        Http2ClientStream stream = test.newStream();
+        stream.writeHeaders(Http2Headers.create(WritableHeaders.create()), false);
+        test.clearWrites();
+        test.connection().flowControl().incrementOutboundConnectionWindowSize(2);
+
+        int remainingBeforeUpdate = stream.flowControl().outbound().getRemainingWindowSize();
+        stream.windowUpdate(new Http2WindowUpdate(1));
+
+        assertThat(stream.flowControl().outbound().getRemainingWindowSize(), is(remainingBeforeUpdate + 1));
+        assertThat(test.writes(), hasSize(0));
+    }
+
+    @Test
+    void streamWindowOverflowWritesFlowControlRstStream() {
+        MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100));
+        Http2ClientStream stream = test.newStream();
+        stream.writeHeaders(Http2Headers.create(WritableHeaders.create()), false);
+        test.clearWrites();
+
+        stream.windowUpdate(new Http2WindowUpdate(WindowSize.MAX_WIN_SIZE));
+
+        assertThat(test.writes(), hasSize(1));
+        BufferData write = test.writes().get(0);
+        Http2FrameHeader header = readFrameHeader(write);
+        assertThat(header.type(), is(Http2FrameType.RST_STREAM));
+        assertThat(header.streamId(), is(1));
+        assertThat(Http2RstStream.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
+    }
+
     private static CompletableFuture<Boolean> startPing(MockedConnectionTestContext test) {
         CompletableFuture<Boolean> pingFuture = new CompletableFuture<>();
         Thread.ofPlatform().start(() -> {
@@ -110,6 +172,29 @@ class Http2ClientConnectionPingTest {
             }
         });
         return pingFuture;
+    }
+
+    private static boolean invokeHandle(Http2ClientConnection connection) throws Exception {
+        return (boolean) HANDLE_METHOD.invoke(connection);
+    }
+
+    private static Method handleMethod() {
+        try {
+            Method method = Http2ClientConnection.class.getDeclaredMethod("handle");
+            method.setAccessible(true);
+            return method;
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static byte[] frameBytes(Http2FrameData frame) {
+        return BufferData.create(frame.header().write(), frame.data().copy()).readBytes();
+    }
+
+    private static Http2FrameHeader readFrameHeader(BufferData frame) {
+        frame.rewind();
+        return Http2FrameHeader.create(frame);
     }
 
     private static long readPingPayloadId(BufferData frame) {
@@ -127,7 +212,7 @@ class Http2ClientConnectionPingTest {
         private final Http2ClientConnection connection;
         private final CaptureWriter dataWriter = new CaptureWriter();
 
-        private MockedConnectionTestContext(Duration pingTimeout) {
+        private MockedConnectionTestContext(Duration pingTimeout, byte[]... reads) {
             Http2ClientProtocolConfig protocolConfig = Http2ClientProtocolConfig.builder()
                     .ping(true)
                     .pingTimeout(pingTimeout)
@@ -140,10 +225,11 @@ class Http2ClientConnectionPingTest {
             Http2ClientImpl client = mock(Http2ClientImpl.class);
             ClientConnection clientConnection = mock(ClientConnection.class);
             this.socket = mock(HelidonSocket.class);
+            Queue<byte[]> readQueue = new ArrayDeque<>(List.of(reads));
 
             when(client.protocolConfig()).thenReturn(protocolConfig);
             when(client.clientConfig()).thenReturn(clientConfig);
-            when(clientConnection.reader()).thenReturn(DataReader.create(() -> null));
+            when(clientConnection.reader()).thenReturn(DataReader.create(readQueue::poll));
             when(clientConnection.writer()).thenReturn(dataWriter);
             when(clientConnection.helidonSocket()).thenReturn(socket);
             when(socket.socketId()).thenReturn("test-socket");
@@ -158,6 +244,10 @@ class Http2ClientConnectionPingTest {
 
         private List<BufferData> writes() {
             return dataWriter.writes;
+        }
+
+        private void clearWrites() {
+            dataWriter.clear();
         }
 
         private BufferData awaitWrite() throws InterruptedException {
@@ -181,6 +271,11 @@ class Http2ClientConnectionPingTest {
     private static final class CaptureWriter implements DataWriter {
         private final List<BufferData> writes = new CopyOnWriteArrayList<>();
         private final LinkedBlockingQueue<BufferData> asyncWrites = new LinkedBlockingQueue<>();
+
+        private void clear() {
+            writes.clear();
+            asyncWrites.clear();
+        }
 
         @Override
         public void write(BufferData... buffers) {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
@@ -16,11 +16,8 @@
 
 package io.helidon.webclient.http2;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
-import java.util.ArrayDeque;
 import java.util.List;
-import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -32,11 +29,8 @@ import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2ErrorCode;
-import io.helidon.http.http2.Http2Flag;
-import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameType;
-import io.helidon.http.http2.Http2GoAway;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Settings;
@@ -55,7 +49,6 @@ import static org.mockito.Mockito.when;
 
 class Http2ClientConnectionPingTest {
     private static final Duration TEST_WAIT_TIMEOUT = Duration.ofSeconds(10);
-    private static final Method HANDLE_METHOD = handleMethod();
     private static final Http2StreamConfig STREAM_CONFIG = new Http2StreamConfig() {
         @Override
         public boolean priorKnowledge() {
@@ -115,22 +108,6 @@ class Http2ClientConnectionPingTest {
     }
 
     @Test
-    void connectionWindowOverflowWritesFlowControlGoAway() throws Exception {
-        Http2FrameData frameData = new Http2WindowUpdate(WindowSize.MAX_WIN_SIZE)
-                .toFrameData(Http2Settings.create(), 0, Http2Flag.NoFlags.create());
-        MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100), frameBytes(frameData));
-
-        assertThat(invokeHandle(test.connection()), is(true));
-
-        assertThat(test.writes(), hasSize(1));
-        BufferData write = test.writes().get(0);
-        Http2FrameHeader header = readFrameHeader(write);
-        assertThat(header.type(), is(Http2FrameType.GO_AWAY));
-        assertThat(header.streamId(), is(0));
-        assertThat(Http2GoAway.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
-    }
-
-    @Test
     void streamWindowUpdateIncrementsOutboundWindowOnce() {
         MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100));
         Http2ClientStream stream = test.newStream();
@@ -174,24 +151,6 @@ class Http2ClientConnectionPingTest {
         return pingFuture;
     }
 
-    private static boolean invokeHandle(Http2ClientConnection connection) throws Exception {
-        return (boolean) HANDLE_METHOD.invoke(connection);
-    }
-
-    private static Method handleMethod() {
-        try {
-            Method method = Http2ClientConnection.class.getDeclaredMethod("handle");
-            method.setAccessible(true);
-            return method;
-        } catch (NoSuchMethodException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    private static byte[] frameBytes(Http2FrameData frame) {
-        return BufferData.create(frame.header().write(), frame.data().copy()).readBytes();
-    }
-
     private static Http2FrameHeader readFrameHeader(BufferData frame) {
         frame.rewind();
         return Http2FrameHeader.create(frame);
@@ -212,7 +171,7 @@ class Http2ClientConnectionPingTest {
         private final Http2ClientConnection connection;
         private final CaptureWriter dataWriter = new CaptureWriter();
 
-        private MockedConnectionTestContext(Duration pingTimeout, byte[]... reads) {
+        private MockedConnectionTestContext(Duration pingTimeout) {
             Http2ClientProtocolConfig protocolConfig = Http2ClientProtocolConfig.builder()
                     .ping(true)
                     .pingTimeout(pingTimeout)
@@ -225,11 +184,10 @@ class Http2ClientConnectionPingTest {
             Http2ClientImpl client = mock(Http2ClientImpl.class);
             ClientConnection clientConnection = mock(ClientConnection.class);
             this.socket = mock(HelidonSocket.class);
-            Queue<byte[]> readQueue = new ArrayDeque<>(List.of(reads));
 
             when(client.protocolConfig()).thenReturn(protocolConfig);
             when(client.clientConfig()).thenReturn(clientConfig);
-            when(clientConnection.reader()).thenReturn(DataReader.create(readQueue::poll));
+            when(clientConnection.reader()).thenReturn(DataReader.create(() -> null));
             when(clientConnection.writer()).thenReturn(dataWriter);
             when(clientConnection.helidonSocket()).thenReturn(socket);
             when(socket.socketId()).thenReturn("test-socket");

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -39,6 +39,7 @@ import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
@@ -50,6 +51,7 @@ import io.helidon.http.http2.Http2HuffmanEncoder;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2StreamState;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
@@ -454,6 +456,36 @@ class Http2ClientConnectionTest {
             assertThat(Http2GoAway.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
             assertThat(connection.closed(), is(true));
             test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void streamWindowOverflowWritesFlowControlRstStreamAndClosesStream() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+            stream.writeHeaders(requestHeaders(), false);
+            assertNull(connection.tryStream(STREAM_CONFIG));
+            test.clearWrites();
+
+            test.offerInbound(windowUpdateFrame(stream.streamId(), WindowSize.MAX_WIN_SIZE));
+
+            BufferData write = test.awaitWrite(Http2FrameType.RST_STREAM);
+            Http2FrameHeader header = readFrameHeader(write);
+            assertThat(header.type(), is(Http2FrameType.RST_STREAM));
+            assertThat(header.streamId(), is(stream.streamId()));
+            assertThat(Http2RstStream.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
+
+            test.awaitStreamClosed(stream);
+            assertThrows(Http2Exception.class,
+                         () -> stream.writeData(BufferData.create("late".getBytes(StandardCharsets.UTF_8)), false));
+
+            Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
+            assertNotNull(recoveredStream);
+            recoveredStream.close();
+            connection.close();
         }
     }
 
@@ -906,6 +938,14 @@ class Http2ClientConnectionTest {
                 }
                 assertThat("Unexpected outbound frame before " + expectedType, header.type(), is(Http2FrameType.SETTINGS));
             }
+        }
+
+        private void awaitStreamClosed(Http2ClientStream stream) throws InterruptedException {
+            long deadline = System.nanoTime() + TEST_WAIT_TIMEOUT.toNanos();
+            while (stream.streamState() != Http2StreamState.CLOSED && System.nanoTime() < deadline) {
+                Thread.sleep(10);
+            }
+            assertThat(stream.streamState(), is(Http2StreamState.CLOSED));
         }
 
         private void assertConnectionClosed() {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -42,13 +42,16 @@ import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
+import io.helidon.http.http2.Http2GoAway;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanEncoder;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
 import io.helidon.http.http2.Http2WindowUpdate;
+import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.WebClient;
 
@@ -436,6 +439,25 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void connectionWindowOverflowWritesFlowControlGoAwayAndClosesConnection() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            test.clearWrites();
+
+            test.offerInbound(windowUpdateFrame(0, WindowSize.MAX_WIN_SIZE));
+
+            BufferData write = test.awaitWrite(Http2FrameType.GO_AWAY);
+            Http2FrameHeader header = readFrameHeader(write);
+            assertThat(header.type(), is(Http2FrameType.GO_AWAY));
+            assertThat(header.streamId(), is(0));
+            assertThat(Http2GoAway.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
+            assertThat(connection.closed(), is(true));
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
     void rstStreamForNeverOpenedStreamClosesConnection() {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.offerInbound(settingsFrame(10));
@@ -670,7 +692,11 @@ class Http2ClientConnectionTest {
     }
 
     private static Http2FrameData windowUpdateFrame(int streamId) {
-        return new Http2WindowUpdate(1)
+        return windowUpdateFrame(streamId, 1);
+    }
+
+    private static Http2FrameData windowUpdateFrame(int streamId, int increment) {
+        return new Http2WindowUpdate(increment)
                 .toFrameData(null, streamId, Http2Flag.NoFlags.create());
     }
 
@@ -777,11 +803,17 @@ class Http2ClientConnectionTest {
         return bytes;
     }
 
+    private static Http2FrameHeader readFrameHeader(BufferData frame) {
+        frame.rewind();
+        return Http2FrameHeader.create(frame);
+    }
+
     private static final class MockedConnectionTestContext implements AutoCloseable {
         private static final byte[] END_INBOUND = new byte[0];
 
         private final ExecutorService connectionExecutor = Executors.newSingleThreadExecutor();
         private final LinkedBlockingQueue<byte[]> inboundFrames = new LinkedBlockingQueue<>();
+        private final LinkedBlockingQueue<BufferData> outboundWrites = new LinkedBlockingQueue<>();
         private final AtomicBoolean failWrites = new AtomicBoolean();
         private final AtomicReference<BlockedWrite> blockedWrite = new AtomicReference<>();
         private final DataWriter dataWriter = mock(DataWriter.class);
@@ -814,11 +846,13 @@ class Http2ClientConnectionTest {
             }).when(dataWriter).write(any(BufferData[].class));
             doAnswer(invocation -> {
                 maybeFailWrites();
+                captureWriteNow(invocation.<BufferData>getArgument(0));
                 maybeBlockWriteNow();
                 return null;
             }).when(dataWriter).writeNow(any(BufferData.class));
             doAnswer(invocation -> {
                 maybeFailWrites();
+                captureWriteNow(invocation.<BufferData[]>getArgument(0));
                 maybeBlockWriteNow();
                 return null;
             }).when(dataWriter).writeNow(any(BufferData[].class));
@@ -853,6 +887,27 @@ class Http2ClientConnectionTest {
             inboundFrames.add(END_INBOUND);
         }
 
+        private void clearWrites() {
+            outboundWrites.clear();
+        }
+
+        private BufferData awaitWrite(Http2FrameType expectedType) throws InterruptedException {
+            long deadline = System.nanoTime() + TEST_WAIT_TIMEOUT.toNanos();
+            while (true) {
+                long remainingNanos = deadline - System.nanoTime();
+                assertTrue(remainingNanos > 0, "Timed out waiting for outbound " + expectedType + " frame");
+
+                BufferData write = outboundWrites.poll(remainingNanos, TimeUnit.NANOSECONDS);
+                assertNotNull(write, "Timed out waiting for outbound " + expectedType + " frame");
+                Http2FrameHeader header = readFrameHeader(write);
+                if (header.type() == expectedType) {
+                    write.rewind();
+                    return write;
+                }
+                assertThat("Unexpected outbound frame before " + expectedType, header.type(), is(Http2FrameType.SETTINGS));
+            }
+        }
+
         private void assertConnectionClosed() {
             verify(clientConnection, timeout(TEST_WAIT_TIMEOUT.toMillis())).closeResource();
         }
@@ -884,6 +939,10 @@ class Http2ClientConnectionTest {
             if (block != null) {
                 block.block();
             }
+        }
+
+        private void captureWriteNow(BufferData... buffers) {
+            outboundWrites.add(BufferData.create(buffers).copy());
         }
 
         private byte[] nextInboundFrame() {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -454,6 +454,7 @@ class Http2ClientConnectionTest {
             assertThat(header.type(), is(Http2FrameType.GO_AWAY));
             assertThat(header.streamId(), is(0));
             assertThat(Http2GoAway.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
+            assertThat(connection.flowControl().outbound().getRemainingWindowSize(), is(WindowSize.DEFAULT_WIN_SIZE));
             assertThat(connection.closed(), is(true));
             test.assertConnectionClosed();
         }
@@ -477,6 +478,7 @@ class Http2ClientConnectionTest {
             assertThat(header.type(), is(Http2FrameType.RST_STREAM));
             assertThat(header.streamId(), is(stream.streamId()));
             assertThat(Http2RstStream.create(write).errorCode(), is(Http2ErrorCode.FLOW_CONTROL));
+            assertThat(stream.flowControl().outbound().getRemainingWindowSize(), is(WindowSize.DEFAULT_WIN_SIZE));
 
             test.awaitStreamClosed(stream);
             assertThrows(Http2Exception.class,


### PR DESCRIPTION
Fixes #11771

Backport of #12005.

### Description

Fixes HTTP/2 outbound window overflow detection for received `WINDOW_UPDATE` frames by returning the post-increment window size using `long` arithmetic.

Also avoids applying stream `WINDOW_UPDATE` frames twice and adds focused regression coverage for connection-level `GOAWAY` and stream-level `RST_STREAM` `FLOW_CONTROL_ERROR` handling.

### Documentation

None

### Testing

- `mvn -ntp -pl :helidon-http-http2,:helidon-webclient-http2 -am -Dtest=io.helidon.http.http2.WindowSizeImplTest,io.helidon.webclient.http2.Http2ClientConnectionPingTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -ntp -Ptests -pl :helidon-tests-integration-h2spec-client -am -DskipTests test-compile`
- `git diff --cached --check`
- `git diff --check upstream/helidon-4.x...HEAD`
- `bash ./etc/scripts/copyright.sh`
- `bash ./etc/scripts/checkstyle.sh`
