### PR TITLE
Make LockingStreamIdSequence constructor private

### DIFF
--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/LockingStreamIdSequence.java
@@ -27,13 +27,7 @@ public class LockingStreamIdSequence {
     private final AtomicInteger streamIdSeq = new AtomicInteger(0);
     private final Lock lock = new ReentrantLock();
 
-    /**
-     * Create a new locking stream ID sequence.
-     *
-     * @deprecated use {@link #create()} instead
-     */
-    @Deprecated(forRemoval = true, since = "27.0.0")
-    public LockingStreamIdSequence() {
+    private LockingStreamIdSequence() {
     }
 
     /**


### PR DESCRIPTION
### Description

Fixes #12017

Makes `LockingStreamIdSequence` use `create()` as the only public construction path on `main` by making the constructor private.

This is a follow-up to #12003; the compatibility deprecation used there is not needed on `main`, and the existing call sites already use `LockingStreamIdSequence.create()`.

### Documentation

None

### Testing

- `mvn -ntp -pl :helidon-webclient-http2 -am -Dtest=io.helidon.webclient.http2.Http2ClientConnectionPingTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`
- `bash ./etc/scripts/copyright.sh`
- `bash ./etc/scripts/checkstyle.sh`
