### PR TITLE
Close typed client response when eager entity decoding fails (27.x)

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
@@ -41,7 +41,7 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
             entity = response.as(entityType);
             thrown = null;
         } catch (RuntimeException e) {
-            thrown = e;
+            thrown = closeOnDecodeFailure(response, e);
             entity = null;
         }
         this.thrown = thrown;
@@ -58,7 +58,7 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
             entity = entity(response, entityType);
             thrown = null;
         } catch (RuntimeException e) {
-            thrown = e;
+            thrown = closeOnDecodeFailure(response, e);
             entity = null;
         }
         this.thrown = thrown;
@@ -156,5 +156,14 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
             return null;
         }
         return GenericType.create(actualTypeArguments[0]);
+    }
+
+    private static RuntimeException closeOnDecodeFailure(HttpClientResponse response, RuntimeException cause) {
+        try {
+            response.close();
+        } catch (RuntimeException e) {
+            cause.addSuppressed(e);
+        }
+        return cause;
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientResponseTypedImplTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientResponseTypedImplTest.java
@@ -24,6 +24,7 @@ import io.helidon.common.GenericType;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.ClientResponseTrailers;
+import io.helidon.http.HttpException;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.media.ReadableEntity;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class ClientResponseTypedImplTest {
@@ -59,17 +61,34 @@ class ClientResponseTypedImplTest {
         assertDoesNotThrow(() -> handling.handle("/missing", requestHeaders, response, OPTIONAL_STRING));
     }
 
+    @Test
+    void eagerDecodeFailureClosesResponseBeforeErrorHandlingThrows() {
+        DefaultErrorHandling handling = new DefaultErrorHandling(List.of());
+        var response = new TestHttpClientResponse(Status.INTERNAL_SERVER_ERROR_500, new FailingReadableEntity());
+        ClientRequestHeaders requestHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+
+        var typedResponse = new ClientResponseTypedImpl<>(response, String.class);
+
+        assertThrows(HttpException.class, () -> handling.handle("/failure", requestHeaders, typedResponse, String.class));
+        assertThat(response.closed(), is(true));
+    }
+
     private static class TestHttpClientResponse implements HttpClientResponse {
         private static final ClientResponseHeaders EMPTY_HEADERS =
                 ClientResponseHeaders.create(WritableHeaders.create());
 
         private final Status status;
-        private final TestReadableEntity entity = new TestReadableEntity();
+        private final ReadableEntity entity;
         private boolean entityRequested;
         private boolean closed;
 
         TestHttpClientResponse(Status status) {
+            this(status, new TestReadableEntity());
+        }
+
+        TestHttpClientResponse(Status status, ReadableEntity entity) {
             this.status = status;
+            this.entity = entity;
         }
 
         @Override
@@ -189,6 +208,13 @@ class ClientResponseTypedImplTest {
         @Override
         public void consume() {
             consumed = true;
+        }
+    }
+
+    private static class FailingReadableEntity extends TestReadableEntity {
+        @Override
+        public <T> T as(GenericType<T> type) {
+            throw new IllegalStateException("Cannot decode entity");
         }
     }
 }


### PR DESCRIPTION
Resolves #12022

Closes the underlying WebClient response when eager typed entity decoding fails. This prevents declarative client error handling from leaving the response open if it throws before the stored decode exception is consumed, and adds focused regression coverage for that path.
