### PR TITLE
Apply container semantics to TypeHandlerOptional (27.x)

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -560,10 +560,16 @@ final class GenerateAbstractBuilder {
                 .anyMatch(it -> it.provider().isPresent());
     }
 
-    private static boolean optionalProviderList(TypeName typeName) {
+    private static boolean optionalProviderContainer(TypeName typeName) {
         return typeName.isOptional()
                 && !typeName.typeArguments().isEmpty()
-                && typeName.typeArguments().getFirst().isList();
+                && (typeName.typeArguments().getFirst().isList() || typeName.typeArguments().getFirst().isSet());
+    }
+
+    private static boolean optionalProviderSet(TypeName typeName) {
+        return typeName.isOptional()
+                && !typeName.typeArguments().isEmpty()
+                && typeName.typeArguments().getFirst().isSet();
     }
 
     private static TypeName providerContainerType(TypeName typeName) {
@@ -581,19 +587,40 @@ final class GenerateAbstractBuilder {
         return optionHandler.typeHandler().type();
     }
 
-    private static void optionalProviderListExisting(ContentBuilder<?> content, OptionInfo option) {
+    private static void optionalProviderExisting(ContentBuilder<?> content, OptionInfo option, boolean optionalSet) {
         content.addContent(option.name())
                 .addContent(" == null ? ")
                 .addContent(List.class)
-                .addContent(".of() : ")
-                .addContent(option.name());
+                .addContent(".of() : ");
+        if (optionalSet) {
+            content.addContent(List.class)
+                    .addContent(".copyOf(")
+                    .addContent(option.name())
+                    .addContent(")");
+        } else {
+            content.addContent(option.name());
+        }
     }
 
-    private static void optionalProviderListEmpty(ContentBuilder<?> content, TypeName providerValueType) {
+    private static void optionalProviderEmpty(ContentBuilder<?> content, TypeName providerValueType) {
         content.addContent(List.class)
                 .addContent(".<")
                 .addContent(providerValueType.genericTypeName())
                 .addContent(">of()");
+    }
+
+    private static void addOptionalProviderDiscovered(Method.Builder preBuildBuilder, OptionInfo option, boolean optionalSet) {
+        preBuildBuilder.addContent("this.add")
+                .addContent(capitalize(option.name()))
+                .addContent("(");
+        if (optionalSet) {
+            preBuildBuilder.addContent("new ")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("<>(discovered)");
+        } else {
+            preBuildBuilder.addContent("discovered");
+        }
+        preBuildBuilder.addContentLine(");");
     }
 
     private static void serviceLoaderPropertyDiscovery(Method.Builder preBuildBuilder,
@@ -609,7 +636,8 @@ final class GenerateAbstractBuilder {
         if (propertyConfigured) {
             OptionConfigured configured = option.configured().get();
 
-            if (optionalProviderList(typeName)) {
+            if (optionalProviderContainer(typeName)) {
+                boolean optionalSet = optionalProviderSet(typeName);
                 preBuildBuilder.addContentLine("{")
                         .addContent("var optionConfig = config.get(\"")
                         .addContent(configured.configKey())
@@ -620,7 +648,7 @@ final class GenerateAbstractBuilder {
                         .increaseContentPadding()
                         .increaseContentPadding()
                         .addContent("? ")
-                        .update(it -> optionalProviderListEmpty(it, providerValueType))
+                        .update(it -> optionalProviderEmpty(it, providerValueType))
                         .addContentLine("")
                         .addContent(": ")
                         .addContent(CONFIG_BUILDER_SUPPORT)
@@ -633,17 +661,15 @@ final class GenerateAbstractBuilder {
                         .addContent(".class, ")
                         .addContent(option.name())
                         .addContent("DiscoverServices, ")
-                        .update(it -> optionalProviderListExisting(it, option))
+                        .update(it -> optionalProviderExisting(it, option, optionalSet))
                         .addContentLine(");")
                         .decreaseContentPadding()
                         .decreaseContentPadding()
                         .addContent("if (optionConfig.exists() || ")
                         .addContent(option.name())
-                        .addContentLine(" != null || !discovered.isEmpty()) {")
-                        .addContent("this.add")
-                        .addContent(capitalize(option.name()))
-                        .addContentLine("(discovered);")
-                        .addContentLine("}")
+                        .addContentLine(" != null || !discovered.isEmpty()) {");
+                addOptionalProviderDiscovered(preBuildBuilder, option, optionalSet);
+                preBuildBuilder.addContentLine("}")
                         .addContentLine("}");
             } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
@@ -681,7 +707,8 @@ final class GenerateAbstractBuilder {
                         .addContentLine(");");
             }
         } else {
-            if (optionalProviderList(typeName)) {
+            if (optionalProviderContainer(typeName)) {
+                boolean optionalSet = optionalProviderSet(typeName);
                 preBuildBuilder.addContentLine("{")
                         .addContent("var discovered = ")
                         .addContent(BUILDER_SUPPORT)
@@ -690,15 +717,13 @@ final class GenerateAbstractBuilder {
                         .addContent(".class, ")
                         .addContent(option.name())
                         .addContent("DiscoverServices, ")
-                        .update(it -> optionalProviderListExisting(it, option))
+                        .update(it -> optionalProviderExisting(it, option, optionalSet))
                         .addContentLine(");")
                         .addContent("if (")
                         .addContent(option.name())
-                        .addContentLine(" != null || !discovered.isEmpty()) {")
-                        .addContent("this.add")
-                        .addContent(capitalize(option.name()))
-                        .addContentLine("(discovered);")
-                        .addContentLine("}")
+                        .addContentLine(" != null || !discovered.isEmpty()) {");
+                addOptionalProviderDiscovered(preBuildBuilder, option, optionalSet);
+                preBuildBuilder.addContentLine("}")
                         .addContentLine("}");
             } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
@@ -865,12 +890,13 @@ final class GenerateAbstractBuilder {
         if (propertyConfigured) {
             OptionConfigured configured = option.configured().get();
 
-            if (optionalProviderList(typeName)) {
-                serviceRegistryConfiguredOptionalProviderList(preBuildBuilder,
-                                                              option,
-                                                              configured,
-                                                              providerType,
-                                                              providerValueType);
+            if (optionalProviderContainer(typeName)) {
+                serviceRegistryConfiguredOptionalProviderContainer(preBuildBuilder,
+                                                                   option,
+                                                                   configured,
+                                                                   providerType,
+                                                                   providerValueType,
+                                                                   optionalProviderSet(typeName));
             } else if (typeName.isList() || typeName.isSet()) {
                 preBuildBuilder.addContent("this.add")
                         .addContent(capitalize(option.name()))
@@ -924,24 +950,31 @@ final class GenerateAbstractBuilder {
                         .decreaseContentPadding();
             }
         } else {
-            if (optionalProviderList(typeName)) {
+            if (optionalProviderContainer(typeName)) {
+                boolean optionalSet = optionalProviderSet(typeName);
                 preBuildBuilder.addContentLine("{")
                         .addContent("var discovered = ")
-                        .addContent(REGISTRY_BUILDER_SUPPORT)
-                        .addContent(".<")
-                        .addContent(providerValueType.genericTypeName())
-                        .addContent(">serviceList(registry, ")
-                        .addContentCreate(providerValueType)
-                        .addContent(", ")
-                        .addContent(option.name())
+                        .addContent(REGISTRY_BUILDER_SUPPORT);
+                if (optionalSet) {
+                    preBuildBuilder.addContent(".<")
+                            .addContent(providerValueType.genericTypeName())
+                            .addContent(">serviceSet(registry, ")
+                            .addContentCreate(providerValueType)
+                            .addContent(", ");
+                } else {
+                    preBuildBuilder.addContent(".<")
+                            .addContent(providerValueType.genericTypeName())
+                            .addContent(">serviceList(registry, ")
+                            .addContentCreate(providerValueType)
+                            .addContent(", ");
+                }
+                preBuildBuilder.addContent(option.name())
                         .addContentLine("DiscoverServices);")
                         .addContent("if (")
                         .addContent(option.name())
-                        .addContentLine(" != null || !discovered.isEmpty()) {")
-                        .addContent("this.add")
-                        .addContent(capitalize(option.name()))
-                        .addContentLine("(discovered);")
-                        .addContentLine("}")
+                        .addContentLine(" != null || !discovered.isEmpty()) {");
+                addOptionalProviderDiscovered(preBuildBuilder, option, false);
+                preBuildBuilder.addContentLine("}")
                         .addContentLine("}");
             } else if (typeName.isList()) {
                 preBuildBuilder
@@ -983,11 +1016,12 @@ final class GenerateAbstractBuilder {
         }
     }
 
-    private static void serviceRegistryConfiguredOptionalProviderList(Method.Builder preBuildBuilder,
-                                                                     OptionInfo option,
-                                                                     OptionConfigured configured,
-                                                                     TypeName providerType,
-                                                                     TypeName providerValueType) {
+    private static void serviceRegistryConfiguredOptionalProviderContainer(Method.Builder preBuildBuilder,
+                                                                          OptionInfo option,
+                                                                          OptionConfigured configured,
+                                                                          TypeName providerType,
+                                                                          TypeName providerValueType,
+                                                                          boolean optionalSet) {
         preBuildBuilder.addContentLine("{")
                 .addContent("var optionConfig = config.get(\"")
                 .addContent(configured.configKey())
@@ -998,7 +1032,7 @@ final class GenerateAbstractBuilder {
                 .increaseContentPadding()
                 .increaseContentPadding()
                 .addContent("? ")
-                .update(it -> optionalProviderListEmpty(it, providerValueType))
+                .update(it -> optionalProviderEmpty(it, providerValueType))
                 .addContentLine("")
                 .addContent(": ")
                 .addContent(CONFIG_BUILDER_SUPPORT)
@@ -1016,7 +1050,7 @@ final class GenerateAbstractBuilder {
                 .addContentLine(".class,")
                 .addContent(option.name())
                 .addContentLine("DiscoverServices,")
-                .update(it -> optionalProviderListExisting(it, option))
+                .update(it -> optionalProviderExisting(it, option, optionalSet))
                 .addContentLine(");")
                 .decreaseContentPadding()
                 .decreaseContentPadding()
@@ -1025,11 +1059,9 @@ final class GenerateAbstractBuilder {
                 .decreaseContentPadding()
                 .addContent("if (optionConfig.exists() || ")
                 .addContent(option.name())
-                .addContentLine(" != null || !discovered.isEmpty()) {")
-                .addContent("this.add")
-                .addContent(capitalize(option.name()))
-                .addContentLine("(discovered);")
-                .addContentLine("}")
+                .addContentLine(" != null || !discovered.isEmpty()) {");
+        addOptionalProviderDiscovered(preBuildBuilder, option, optionalSet);
+        preBuildBuilder.addContentLine("}")
                 .addContentLine("}");
     }
 
@@ -1450,6 +1482,12 @@ final class GenerateAbstractBuilder {
                         .addContent(Collections.class)
                         .addContent(".unmodifiableSet(new ")
                         .addContent(LinkedHashSet.class)
+                        .addContentLine("<>(it)));");
+            } else if (declaredType.isOptional() && optionHandler.typeHandler().type().isMap()) {
+                constructor.addContent("builder." + getterName + "().map(it -> ")
+                        .addContent(Collections.class)
+                        .addContent(".unmodifiableMap(new ")
+                        .addContent(LinkedHashMap.class)
                         .addContentLine("<>(it)));");
             } else if (declaredType.isOptional()) {
                 constructor.addContent("builder." + getterName + "().map(")

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -58,7 +58,7 @@ import io.helidon.common.types.TypedElementInfo;
 import static io.helidon.codegen.CodegenUtil.capitalize;
 
 abstract class TypeHandlerCollection extends TypeHandlerContainer {
-    private static final Set<TypeName> BUILT_IN_MAPPERS = Set.of(
+    static final Set<TypeName> BUILT_IN_MAPPERS = Set.of(
             TypeNames.STRING,
             TypeNames.BOXED_BOOLEAN,
             TypeNames.BOXED_BYTE,

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerOptional.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerOptional.java
@@ -17,18 +17,22 @@
 package io.helidon.builder.codegen;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import io.helidon.builder.codegen.spi.BuilderCodegenExtension;
 import io.helidon.codegen.classmodel.ClassBase;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.codegen.classmodel.Field;
 import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.codegen.classmodel.Method;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
@@ -37,6 +41,9 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.codegen.CodegenUtil.capitalize;
+import static io.helidon.common.types.TypeNames.LIST;
+import static io.helidon.common.types.TypeNames.MAP;
+import static io.helidon.common.types.TypeNames.SET;
 
 class TypeHandlerOptional extends TypeHandlerBasic {
     TypeHandlerOptional(List<BuilderCodegenExtension> extensions, PrototypeInfo prototypeInfo, OptionInfo option) {
@@ -66,8 +73,21 @@ class TypeHandlerOptional extends TypeHandlerBasic {
     }
 
     @Override
+    public void generateFromConfig(Method.Builder method, OptionConfigured optionConfigured) {
+        if (optionalMap()) {
+            generateOptionalMapFromConfig(method, optionConfigured);
+            return;
+        }
+        if (optionalCollection()) {
+            generateOptionalCollectionFromConfig(method, optionConfigured);
+            return;
+        }
+        super.generateFromConfig(method, optionConfigured);
+    }
+
+    @Override
     GeneratedMethod prepareBuilderSetter(Javadoc getterJavadoc) {
-        if (!optionalCollection()) {
+        if (!optionalContainer()) {
             return super.prepareBuilderSetter(getterJavadoc);
         }
 
@@ -84,7 +104,7 @@ class TypeHandlerOptional extends TypeHandlerBasic {
 
         method.addParameterArgument(param -> param
                 .kind(ElementKind.PARAMETER)
-                .typeName(collectionParameterType())
+                .typeName(containerParameterType())
                 .elementName(name)
         );
 
@@ -103,7 +123,7 @@ class TypeHandlerOptional extends TypeHandlerBasic {
             it.addContent("this.")
                     .addContent(name)
                     .addContent(" = ");
-            mutableCollection(it, name);
+            mutableContainer(it, name);
             it.addContentLine(";")
                     .addContentLine("return self();");
         };
@@ -117,8 +137,8 @@ class TypeHandlerOptional extends TypeHandlerBasic {
 
     @Override
     Optional<GeneratedMethod> prepareBuilderSetterDeclared(Javadoc getterJavadoc) {
-        if (optionalCollection()) {
-            return prepareOptionalCollectionSetterDeclared(getterJavadoc);
+        if (optionalContainer()) {
+            return prepareOptionalContainerSetterDeclared(getterJavadoc);
         }
 
         TypeName typeName = asTypeArgument(TypeNames.OPTIONAL);
@@ -173,7 +193,7 @@ class TypeHandlerOptional extends TypeHandlerBasic {
 
     @Override
     Optional<GeneratedMethod> prepareBuilderAddCollection(Javadoc getterJavadoc) {
-        if (!optionalCollection()) {
+        if (!optionalContainer()) {
             return Optional.empty();
         }
 
@@ -190,7 +210,7 @@ class TypeHandlerOptional extends TypeHandlerBasic {
 
         method.addParameterArgument(param -> param
                 .kind(ElementKind.PARAMETER)
-                .typeName(collectionParameterType())
+                .typeName(containerParameterType())
                 .elementName(name)
         );
 
@@ -210,11 +230,16 @@ class TypeHandlerOptional extends TypeHandlerBasic {
                     .addContent("this.")
                     .addContent(name)
                     .addContent(" = ");
-            emptyMutableCollection(it);
+            emptyMutableContainer(it);
             it.addContentLine(";")
-                    .addContentLine("}")
-                    .addContentLine("this." + name + ".addAll(" + name + ");")
-                    .addContentLine("return self();");
+                    .addContentLine("}");
+
+            if (optionalMap()) {
+                it.addContentLine("this." + name + ".putAll(" + name + ");");
+            } else {
+                it.addContentLine("this." + name + ".addAll(" + name + ");");
+            }
+            it.addContentLine("return self();");
         };
 
         return Optional.of(GeneratedMethod.builder()
@@ -270,7 +295,7 @@ class TypeHandlerOptional extends TypeHandlerBasic {
                 .addContent(")");
     }
 
-    private Optional<GeneratedMethod> prepareOptionalCollectionSetterDeclared(Javadoc getterJavadoc) {
+    private Optional<GeneratedMethod> prepareOptionalContainerSetterDeclared(Javadoc getterJavadoc) {
         TypeName typeName = asTypeArgument(TypeNames.OPTIONAL);
         TypeName returnType = Utils.builderReturnType();
 
@@ -297,7 +322,7 @@ class TypeHandlerOptional extends TypeHandlerBasic {
                     .addContent(".ifPresent(it -> this.")
                     .addContent(name)
                     .addContent(" = ");
-            mutableCollection(it, "it");
+            mutableContainer(it, "it");
             it.addContentLine(");")
                     .addContentLine("return self();");
         };
@@ -309,54 +334,260 @@ class TypeHandlerOptional extends TypeHandlerBasic {
                                    .build());
     }
 
+    private void generateOptionalCollectionFromConfig(Method.Builder method, OptionConfigured optionConfigured) {
+        TypeName actualType = type().typeArguments().getFirst().genericTypeName();
+        String setterName = option().setterName();
+
+        Optional<FactoryMethod> factoryMethod = optionConfigured.factoryMethod();
+        if (factoryMethod.isPresent()) {
+            var fm = factoryMethod.get();
+            TypeName returnType = fm.returnType();
+
+            boolean mapList;
+            if (returnType.isList() || returnType.isSet()) {
+                mapList = false;
+            } else {
+                mapList = Utils.typesEqual(actualType, returnType);
+            }
+            if (mapList) {
+                method.addContent(configGet(optionConfigured))
+                        .addContent(".asList(")
+                        .update(it -> generateMapListFromConfig(it, fm))
+                        .addContent(")");
+                collectionConfigMapper(method);
+                method.addContentLine(".ifPresent(this::" + setterName + ");");
+            } else {
+                method.addContent(configGet(optionConfigured));
+                generateFromConfig(method, fm.returnType(), Optional.of(fm));
+                collectionConfigMapper(method);
+                method.addContentLine(".ifPresent(this::" + setterName + ");");
+            }
+        } else if (TypeHandlerCollection.BUILT_IN_MAPPERS.contains(actualType)) {
+            method.addContent(configGet(optionConfigured))
+                    .addContent(".asList(")
+                    .addContent(actualType.genericTypeName())
+                    .addContent(".class)");
+            collectionConfigMapper(method);
+            method.addContentLine(".ifPresent(this::" + setterName + ");");
+        } else {
+            method.addContent(configGet(optionConfigured)
+                                      + ".asNodeList()"
+                                      + ".map(nodeList -> nodeList.stream()"
+                                      + ".map(cfg -> cfg");
+            generateFromConfig(method, actualType, Optional.empty());
+            method.addContent(".get()).");
+            collectionCollector(method);
+            method.addContentLine(").ifPresent(this::" + setterName + ");");
+        }
+    }
+
+    private void generateOptionalMapFromConfig(Method.Builder method, OptionConfigured optionConfigured) {
+        TypeName keyType = type().typeArguments().get(0);
+        TypeName valueType = type().typeArguments().get(1);
+        String optionName = option().name();
+
+        if (TypeNames.STRING.equals(keyType) && TypeNames.STRING.equals(valueType)) {
+            method.addContentLine(configGet(optionConfigured) + ".detach().asMap().ifPresent(this::" + optionName + ");");
+        } else {
+            method.addContentLine("if (" + configGet(optionConfigured) + ".exists()) {")
+                    .addContent("this.")
+                    .addContent(optionName)
+                    .addContent(" = ");
+            emptyMutableContainer(method);
+            method.addContentLine(";");
+
+            if (optionConfigured.traverse()) {
+                method.addContent(configGet(optionConfigured) + ".detach().traverse().filter(")
+                        .addContent(Types.CONFIG)
+                        .addContent("::hasValue).forEach(node -> "
+                                            + optionName)
+                        .addContent(".put(node.get(\"name\").asString().orElse(node.key().toString()), node");
+                generateFromConfig(method, valueType, optionConfigured.factoryMethod());
+                method.addContentLine(".get()));");
+            } else {
+                method.addContent(configGet(optionConfigured)
+                                          + ".asNodeList().orElseGet("
+                                          + List.class.getCanonicalName()
+                                          + "::of).forEach(node -> "
+                                          + optionName + ".put(node.get(\"name\").asString().orElse(node.name()), node");
+                generateFromConfig(method, valueType, optionConfigured.factoryMethod());
+                method.addContentLine(".get()));");
+            }
+            method.addContentLine("}");
+        }
+    }
+
+    private void generateFromConfig(ContentBuilder<?> content,
+                                    TypeName usedType,
+                                    Optional<FactoryMethod> factoryMethod) {
+        if (factoryMethod.isPresent()) {
+            FactoryMethod fm = factoryMethod.get();
+            content.addContent(".as(")
+                    .addContent(fm.declaringType().genericTypeName())
+                    .addContent("::");
+            if (!usedType.typeArguments().isEmpty()) {
+                content.addContent("<");
+                var iterator = usedType.typeArguments().iterator();
+                while (iterator.hasNext()) {
+                    content.addContent(iterator.next());
+                    if (iterator.hasNext()) {
+                        content.addContent(", ");
+                    }
+                }
+                content.addContent(">");
+            }
+            content.addContent(fm.methodName())
+                    .addContent(")");
+            return;
+        }
+
+        if (usedType.fqName().equals("char[]")) {
+            content.addContent(".asString().as(")
+                    .addContent(String.class)
+                    .addContent("::toCharArray)");
+            return;
+        }
+
+        if (usedType.equals(TypeNames.STRING)) {
+            content.addContent(".asString()");
+            return;
+        }
+
+        if (usedType.boxed().equals(TypeNames.BOXED_INT)) {
+            content.addContent(".asInt()");
+            return;
+        }
+
+        if (usedType.boxed().equals(TypeNames.BOXED_DOUBLE)) {
+            content.addContent(".asDouble()");
+            return;
+        }
+
+        if (usedType.boxed().equals(TypeNames.BOXED_BOOLEAN)) {
+            content.addContent(".asBoolean()");
+            return;
+        }
+
+        if (usedType.boxed().equals(TypeNames.BOXED_LONG)) {
+            content.addContent(".asLong()");
+            return;
+        }
+
+        content.addContent(".as(")
+                .addContent(usedType.boxed().genericTypeName())
+                .addContent(".class)");
+    }
+
+    private void generateMapListFromConfig(ContentBuilder<?> content, FactoryMethod factoryMethod) {
+        var declaringType = factoryMethod.declaringType();
+        var methodName = factoryMethod.methodName();
+
+        content.addContent(declaringType.genericTypeName())
+                .addContent("::")
+                .addContent(methodName);
+    }
+
+    private boolean optionalContainer() {
+        return optionalCollection() || optionalMap();
+    }
+
     private boolean optionalCollection() {
         return type().isList() || type().isSet();
     }
 
-    private TypeName collectionParameterType() {
+    private boolean optionalMap() {
+        return type().isMap();
+    }
+
+    private TypeName containerParameterType() {
+        if (optionalMap()) {
+            return TypeName.builder(MAP)
+                    .addTypeArgument(Utils.toWildcard(type().typeArguments().get(0)))
+                    .addTypeArgument(Utils.toWildcard(type().typeArguments().get(1)))
+                    .build();
+        }
         return TypeName.builder(collectionType())
                 .addTypeArgument(Utils.toWildcard(type().typeArguments().getFirst()))
                 .build();
     }
 
     private TypeName collectionType() {
-        return type().isList() ? TypeNames.LIST : TypeNames.SET;
+        return type().isList() ? LIST : SET;
+    }
+
+    private void collectionConfigMapper(ContentBuilder<?> content) {
+        if (type().isSet()) {
+            content.addContent(".map(")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("::new)");
+        }
+    }
+
+    private void collectionCollector(ContentBuilder<?> content) {
+        if (type().isList()) {
+            content.addContent("toList()");
+        } else {
+            content.addContent("collect(")
+                    .addContent(Collectors.class)
+                    .addContent(".toCollection(")
+                    .addContent(LinkedHashSet.class)
+                    .addContent("::new))");
+        }
     }
 
     private void optionalDecoratorValue(ContentBuilder<?> content) {
         content.addContent(Optional.class)
-                .addContent(".of(")
-                .addContent(collectionType())
-                .addContent(".copyOf(")
-                .addContent(option().name())
-                .addContent("))");
+                .addContent(".of(");
+        immutableContainer(content, option().name());
+        content.addContent(")");
     }
 
-    private void mutableCollection(ContentBuilder<?> content, String source) {
+    private void mutableContainer(ContentBuilder<?> content, String source) {
+        content.addContent("new ");
         if (type().isList()) {
-            content.addContent("new ")
-                    .addContent(ArrayList.class)
-                    .addContent("<>(")
-                    .addContent(source)
-                    .addContent(")");
+            content.addContent(ArrayList.class);
+        } else if (type().isSet()) {
+            content.addContent(LinkedHashSet.class);
         } else {
-            content.addContent("new ")
-                    .addContent(LinkedHashSet.class)
-                    .addContent("<>(")
-                    .addContent(source)
-                    .addContent(")");
+            content.addContent(LinkedHashMap.class);
         }
+        content.addContent("<>(")
+                .addContent(source)
+                .addContent(")");
     }
 
-    private void emptyMutableCollection(ContentBuilder<?> content) {
+    private void emptyMutableContainer(ContentBuilder<?> content) {
+        content.addContent("new ");
         if (type().isList()) {
-            content.addContent("new ")
-                    .addContent(ArrayList.class)
-                    .addContent("<>()");
+            content.addContent(ArrayList.class);
+        } else if (type().isSet()) {
+            content.addContent(LinkedHashSet.class);
         } else {
-            content.addContent("new ")
+            content.addContent(LinkedHashMap.class);
+        }
+        content.addContent("<>()");
+    }
+
+    private void immutableContainer(ContentBuilder<?> content, String source) {
+        if (type().isList()) {
+            content.addContent(List.class)
+                    .addContent(".copyOf(")
+                    .addContent(source)
+                    .addContent(")");
+        } else if (type().isSet()) {
+            content.addContent(Collections.class)
+                    .addContent(".unmodifiableSet(new ")
                     .addContent(LinkedHashSet.class)
-                    .addContent("<>()");
+                    .addContent("<>(")
+                    .addContent(source)
+                    .addContent("))");
+        } else {
+            content.addContent(Collections.class)
+                    .addContent(".unmodifiableMap(new ")
+                    .addContent(LinkedHashMap.class)
+                    .addContent("<>(")
+                    .addContent(source)
+                    .addContent("))");
         }
     }
 }

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ConfigMapBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ConfigMapBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package io.helidon.builder.test.testsubjects;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
@@ -27,4 +30,16 @@ interface ConfigMapBlueprint {
     @Option.Configured
     @Option.Singular
     Map<String, String> properties();
+
+    @Option.Configured
+    Optional<Map<String, String>> optionalProperties();
+
+    @Option.Configured
+    Optional<Map<String, Integer>> optionalNumbers();
+
+    @Option.Configured
+    Optional<List<String>> optionalList();
+
+    @Option.Configured
+    Optional<Set<String>> optionalSet();
 }

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderBlueprint.java
@@ -18,6 +18,7 @@ package io.helidon.builder.test.testsubjects;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
@@ -50,12 +51,20 @@ interface WithProviderBlueprint {
     Optional<List<SomeProvider.SomeService>> optionalListDiscover();
 
     @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<Set<SomeProvider.SomeService>> optionalSetDiscover();
+
+    @Option.Configured
     @Option.Provider(value = SomeProvider.class, discoverServices = false)
     List<SomeProvider.SomeService> listNotDiscover();
 
     @Option.Configured
     @Option.Provider(value = SomeProvider.class, discoverServices = false)
     Optional<List<SomeProvider.SomeService>> optionalListNotDiscover();
+
+    @Option.Configured
+    @Option.Provider(value = SomeProvider.class, discoverServices = false)
+    Optional<Set<SomeProvider.SomeService>> optionalSetNotDiscover();
 
     /*
     The following should always be empty, as there are no implementations
@@ -69,10 +78,13 @@ interface WithProviderBlueprint {
     List<ProviderNoImpls.SomeService> listNoImplDiscoverNoConfig();
 
     @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
     Optional<List<ProviderNoImpls.SomeService>> optionalListNoImplDiscoverNoConfig();
 
     @Option.Provider(ProviderNoImpls.SomeService.class)
-    Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();
+    Optional<Set<ProviderNoImpls.SomeService>> optionalSetNoImplDiscoverNoConfig();
 
     @Option.Configured
     @Option.Provider(value = ProviderNoImpls.class, discoverServices = false)

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderRegistryBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderRegistryBlueprint.java
@@ -53,12 +53,20 @@ interface WithProviderRegistryBlueprint {
     Optional<List<SomeProvider.SomeService>> optionalListDiscover();
 
     @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<Set<SomeProvider.SomeService>> optionalSetDiscover();
+
+    @Option.Configured
     @Option.Provider(value = SomeProvider.class, discoverServices = false)
     List<SomeProvider.SomeService> listNotDiscover();
 
     @Option.Configured
     @Option.Provider(value = SomeProvider.class, discoverServices = false)
     Optional<List<SomeProvider.SomeService>> optionalListNotDiscover();
+
+    @Option.Configured
+    @Option.Provider(value = SomeProvider.class, discoverServices = false)
+    Optional<Set<SomeProvider.SomeService>> optionalSetNotDiscover();
 
     /*
     The following should always be empty, as there are no implementations
@@ -80,10 +88,13 @@ interface WithProviderRegistryBlueprint {
     List<ProviderNoImpls.SomeService> listNoImplDiscoverNoConfig();
 
     @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
     Optional<List<ProviderNoImpls.SomeService>> optionalListNoImplDiscoverNoConfig();
 
     @Option.Provider(ProviderNoImpls.SomeService.class)
-    Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();
+    Optional<Set<ProviderNoImpls.SomeService>> optionalSetNoImplDiscoverNoConfig();
 
     @Option.Configured
     @Option.Provider(value = ProviderNoImpls.class, discoverServices = false)

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ConfigMapTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ConfigMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,12 @@
 
 package io.helidon.builder.test;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.helidon.builder.test.testsubjects.ConfigMap;
 import io.helidon.config.Config;
@@ -26,7 +31,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConfigMapTest {
     private static Config config;
@@ -43,5 +51,142 @@ public class ConfigMapTest {
 
         assertThat(properties, hasEntry("my.first.key", "firstValue"));
         assertThat(properties, hasEntry("my.second.key", "secondValue"));
+    }
+
+    @Test
+    void testOptionalContainersFromConfig() {
+        ConfigMap configMap = ConfigMap.create(config.get("optional-containers"));
+
+        Map<String, String> optionalProperties = configMap.optionalProperties().orElseThrow();
+        assertThat(optionalProperties, is(Map.of("my.first.key", "firstValue",
+                                                 "my.second.key", "secondValue")));
+        Map<String, Integer> optionalNumbers = configMap.optionalNumbers().orElseThrow();
+        assertThat(optionalNumbers, is(Map.of("one", 1, "two", 2)));
+        assertThat(configMap.optionalList().orElseThrow(), is(List.of("first", "second")));
+        assertThat(configMap.optionalSet().orElseThrow(), is(Set.of("first", "second")));
+    }
+
+    @Test
+    void testOptionalContainersEmptyFromConfig() {
+        ConfigMap configMap = ConfigMap.create(config.get("optional-empty-containers"));
+
+        assertThat(configMap.optionalProperties().orElseThrow().entrySet(), empty());
+        assertThat(configMap.optionalNumbers().orElseThrow().entrySet(), empty());
+        assertThat(configMap.optionalList().orElseThrow(), empty());
+        assertThat(configMap.optionalSet().orElseThrow(), empty());
+    }
+
+    @Test
+    void testOptionalContainersAbsentFromConfig() {
+        ConfigMap configMap = ConfigMap.create(config.get("absent"));
+
+        assertThat(configMap.optionalProperties().isEmpty(), is(true));
+        assertThat(configMap.optionalNumbers().isEmpty(), is(true));
+        assertThat(configMap.optionalList().isEmpty(), is(true));
+        assertThat(configMap.optionalSet().isEmpty(), is(true));
+    }
+
+    @Test
+    void testOptionalMapAdders() {
+        Map<String, String> first = new LinkedHashMap<>();
+        first.put("first", "one");
+        Map<String, String> second = new LinkedHashMap<>();
+        second.put("second", "two");
+
+        ConfigMap configMap = ConfigMap.builder()
+                .addOptionalProperties(first)
+                .addOptionalProperties(second)
+                .build();
+
+        first.clear();
+        second.clear();
+
+        Map<String, String> builtMap = configMap.optionalProperties().orElseThrow();
+        assertThat(builtMap, is(Map.of("first", "one", "second", "two")));
+        assertThrows(UnsupportedOperationException.class, () -> builtMap.put("third", "three"));
+
+        configMap = ConfigMap.builder()
+                .addOptionalProperties(Map.of())
+                .build();
+        assertThat(configMap.optionalProperties().orElseThrow().entrySet(), empty());
+
+        configMap = ConfigMap.builder()
+                .addOptionalProperties(Map.of("first", "one"))
+                .optionalProperties(Map.of("replacement", "value"))
+                .build();
+        assertThat(configMap.optionalProperties().orElseThrow(), is(Map.of("replacement", "value")));
+    }
+
+    @Test
+    void testOptionalCollectionAdders() {
+        ConfigMap configMap = ConfigMap.builder()
+                .addOptionalList(List.of())
+                .addOptionalSet(Set.of())
+                .build();
+
+        assertThat(configMap.optionalList().orElseThrow(), empty());
+        assertThat(configMap.optionalSet().orElseThrow(), empty());
+
+        List<String> firstList = new ArrayList<>();
+        firstList.add("first");
+        List<String> secondList = new ArrayList<>();
+        secondList.add("second");
+        Set<String> firstSet = new LinkedHashSet<>();
+        firstSet.add("first");
+        firstSet.add("duplicate");
+        Set<String> secondSet = new LinkedHashSet<>();
+        secondSet.add("second");
+        secondSet.add("duplicate");
+
+        ConfigMap.Builder builder = ConfigMap.builder()
+                .addOptionalList(firstList)
+                .addOptionalList(secondList)
+                .addOptionalSet(firstSet)
+                .addOptionalSet(secondSet);
+        firstList.clear();
+        secondList.clear();
+        firstSet.clear();
+        secondSet.clear();
+
+        configMap = builder.build();
+
+        List<String> builtList = configMap.optionalList().orElseThrow();
+        Set<String> builtSet = configMap.optionalSet().orElseThrow();
+
+        assertThat(builtList, is(List.of("first", "second")));
+        assertThat(builtSet, is(Set.of("first", "second", "duplicate")));
+        assertThrows(UnsupportedOperationException.class, () -> builtList.add("third"));
+        assertThrows(UnsupportedOperationException.class, () -> builtSet.add("third"));
+    }
+
+    @Test
+    void testOptionalContainerDefensiveCopies() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("key", "value");
+        List<String> list = new ArrayList<>();
+        list.add("value");
+        Set<String> set = new LinkedHashSet<>();
+        set.add("value");
+
+        ConfigMap configMap = ConfigMap.builder()
+                .optionalProperties(map)
+                .optionalList(list)
+                .optionalSet(set)
+                .build();
+
+        map.clear();
+        list.clear();
+        set.clear();
+
+        Map<String, String> builtMap = configMap.optionalProperties().orElseThrow();
+        List<String> builtList = configMap.optionalList().orElseThrow();
+        Set<String> builtSet = configMap.optionalSet().orElseThrow();
+
+        assertThat(builtMap, is(Map.of("key", "value")));
+        assertThat(builtList, is(List.of("value")));
+        assertThat(builtSet, is(Set.of("value")));
+        assertThrows(UnsupportedOperationException.class, () -> builtMap.put("another", "value"));
+        assertThrows(UnsupportedOperationException.class, () -> builtList.add("another"));
+        assertThrows(UnsupportedOperationException.class, () -> builtSet.add("another"));
     }
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
@@ -17,7 +17,9 @@
 package io.helidon.builder.test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import io.helidon.builder.test.testsubjects.SomeProvider;
 import io.helidon.builder.test.testsubjects.WithProviderRegistry;
@@ -34,6 +36,7 @@ import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -62,12 +65,15 @@ class ProviderRegistryTest {
         assertThat(value.optionalNotDiscover().map(SomeProvider.SomeService::prop), optionalEmpty());
 
         assertThat(value.listDiscover(), hasSize(2));
-        List<SomeProvider.SomeService> services = value.optionalListDiscover().orElseThrow();
-        assertThat(services, hasSize(2));
-        assertThat(services.get(0).prop(), is("some-1"));
-        assertThat(services.get(1).prop(), is("some-2"));
+        List<SomeProvider.SomeService> optionalListDiscover = value.optionalListDiscover().orElseThrow();
+        Collection<SomeProvider.SomeService> optionalSetDiscover = value.optionalSetDiscover().orElseThrow();
+        assertServicePropsInOrder(optionalListDiscover, "some-1", "some-2");
+        assertServiceProps(optionalSetDiscover, "some-1", "some-2");
+        assertUnmodifiable(optionalListDiscover);
+        assertUnmodifiable(optionalSetDiscover);
         assertThat(value.listNotDiscover(), hasSize(0));
         assertThat(value.optionalListNotDiscover(), optionalEmpty());
+        assertThat(value.optionalSetNotDiscover(), optionalEmpty());
 
         /*
         Test all the methods for a provider with no implementations
@@ -76,6 +82,7 @@ class ProviderRegistryTest {
         assertThat(value.optionalNoImplNotDiscover(), optionalEmpty());
         assertThat(value.listNoImplDiscover(), hasSize(0));
         assertThat(value.optionalListNoImplDiscoverNoConfig(), optionalEmpty());
+        assertThat(value.optionalSetNoImplDiscoverNoConfig(), optionalEmpty());
         assertThat(value.listNoImplNotDiscover(), hasSize(0));
     }
 
@@ -110,10 +117,10 @@ class ProviderRegistryTest {
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("config2"));
 
-        services = value.optionalListNotDiscover().orElseThrow();
-        assertThat(services, hasSize(2));
-        assertThat(services.get(0).prop(), is("config"));
-        assertThat(services.get(1).prop(), is("config2"));
+        assertServicePropsInOrder(value.optionalListDiscover().orElseThrow(), "config", "config2");
+        assertServiceProps(value.optionalSetDiscover().orElseThrow(), "config", "config2");
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "config", "config2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "config", "config2");
     }
 
     @Test
@@ -158,55 +165,33 @@ class ProviderRegistryTest {
         assertThat(value.listNotDiscover(), hasSize(1));
         assertThat(services.get(0).prop(), is("config2"));
 
-        services = value.optionalListNotDiscover().orElseThrow();
-        assertThat(services, hasSize(1));
-        assertThat(services.get(0).prop(), is("config2"));
+        assertServicePropsInOrder(value.optionalListDiscover().orElseThrow(), "config", "some-2");
+        assertServiceProps(value.optionalSetDiscover().orElseThrow(), "config", "some-2");
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "config2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "config2");
     }
 
     @Test
-    void testEmptyOptionalList() {
+    void testEmptyOptionalProviderContainers() {
         WithProviderRegistry value = WithProviderRegistry.builder()
-                .config(config.get("empty-optional-list-object"))
+                .config(config.get("empty-optional-containers-object"))
                 .mappersExplicit(Mappers.create())
                 .build();
 
         assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
         assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
 
         value = WithProviderRegistry.builder()
-                .config(config.get("empty-optional-list-array"))
+                .config(config.get("empty-optional-containers-array"))
                 .mappersExplicit(Mappers.create())
                 .build();
 
         assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
         assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
-    }
-
-    @Test
-    void testOptionalListBuilderMethods() {
-        SomeProvider.SomeService someService = new DummyService();
-
-        WithProviderRegistry value = WithProviderRegistry.builder()
-                .oneNotDiscover(someService)
-                .mappersExplicit(Mappers.create())
-                .optionalListNotDiscover(List.of())
-                .build();
-        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
-
-        value = WithProviderRegistry.builder()
-                .oneNotDiscover(someService)
-                .mappersExplicit(Mappers.create())
-                .addOptionalListNotDiscover(List.of(someService))
-                .build();
-        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of(someService))));
-
-        value = WithProviderRegistry.builder()
-                .oneNotDiscover(someService)
-                .mappersExplicit(Mappers.create())
-                .optionalListNotDiscover(List.of(someService))
-                .clearOptionalListNotDiscover()
-                .build();
-        assertThat(value.optionalListNotDiscover(), optionalEmpty());
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
     }
 
     @Test
@@ -228,7 +213,41 @@ class ProviderRegistryTest {
     }
 
     @Test
-    void testOptionalListDiscoveryEnabled() {
+    void testOptionalProviderContainerBuilderMethods() {
+        SomeProvider.SomeService someService = new DummyService();
+
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .optionalListNotDiscover(List.of())
+                .optionalSetNotDiscover(Set.of())
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProviderRegistry.builder()
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .addOptionalListNotDiscover(List.of(someService))
+                .addOptionalSetNotDiscover(Set.of(someService))
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of(someService))));
+
+        value = WithProviderRegistry.builder()
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .optionalListNotDiscover(List.of(someService))
+                .optionalSetNotDiscover(Set.of(someService))
+                .clearOptionalListNotDiscover()
+                .clearOptionalSetNotDiscover()
+                .build();
+        assertThat(value.optionalListNotDiscover(), optionalEmpty());
+        assertThat(value.optionalSetNotDiscover(), optionalEmpty());
+    }
+
+    @Test
+    void testOptionalProviderContainerDiscoveryEnabled() {
         SomeProvider.SomeService someService = new DummyService();
 
         WithProviderRegistry value = WithProviderRegistry.builder()
@@ -236,25 +255,22 @@ class ProviderRegistryTest {
                 .oneNotDiscover(someService)
                 .mappersExplicit(Mappers.create())
                 .optionalListNotDiscoverDiscoverServices(true)
+                .optionalSetNotDiscoverDiscoverServices(true)
                 .build();
 
-        List<SomeProvider.SomeService> services = value.optionalListNotDiscover().orElseThrow();
-        assertThat(services, hasSize(2));
-        assertThat(services.get(0).prop(), is("some-1"));
-        assertThat(services.get(1).prop(), is("some-2"));
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "some-1", "some-2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "some-1", "some-2");
     }
 
     @Test
-    void testOptionalListDiscoveryEnabledFromConfig() {
+    void testOptionalProviderContainerDiscoveryEnabledFromConfig() {
         WithProviderRegistry value = WithProviderRegistry.builder()
-                .config(config.get("discover-optional-list-from-config"))
+                .config(config.get("discover-optional-containers-from-config"))
                 .mappersExplicit(Mappers.create())
                 .build();
 
-        List<SomeProvider.SomeService> services = value.optionalListNotDiscover().orElseThrow();
-        assertThat(services, hasSize(2));
-        assertThat(services.get(0).prop(), is("some-1"));
-        assertThat(services.get(1).prop(), is("some-2"));
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "some-1", "some-2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "some-1", "some-2");
     }
 
     @Test
@@ -288,6 +304,72 @@ class ProviderRegistryTest {
         assertThat(copy.listDiscover(), is(List.of()));
     }
 
+    @Test
+    void testDisabledOptionalContainerDiscoveryOnTheCopy() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithProviderRegistry value = WithProviderRegistry.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of())
+                .optionalSetDiscover(Set.of())
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .build();
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        WithProviderRegistry copy = WithProviderRegistry.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProviderRegistry.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of(someService))
+                .optionalSetDiscover(Set.of(someService))
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create())
+                .build();
+        copy = WithProviderRegistry.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
+    }
+
+    @Test
+    void testDisabledOptionalContainerDiscoveryOnTheCopiedBuilder() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithProviderRegistry.Builder value = WithProviderRegistry.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of())
+                .optionalSetDiscover(Set.of())
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create());
+
+        WithProviderRegistry copy = WithProviderRegistry.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProviderRegistry.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of(someService))
+                .optionalSetDiscover(Set.of(someService))
+                .oneNotDiscover(someService)
+                .mappersExplicit(Mappers.create());
+        copy = WithProviderRegistry.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
+    }
+
     private static class DummyService implements SomeProvider.SomeService {
         @Override
         public String prop() {
@@ -303,6 +385,18 @@ class ProviderRegistryTest {
         public String type() {
             return null;
         }
+    }
+
+    private static void assertServiceProps(Collection<SomeProvider.SomeService> services, String... props) {
+        assertThat(services.stream().map(SomeProvider.SomeService::prop).toList(), containsInAnyOrder(props));
+    }
+
+    private static void assertServicePropsInOrder(List<SomeProvider.SomeService> services, String... props) {
+        assertThat(services.stream().map(SomeProvider.SomeService::prop).toList(), is(List.of(props)));
+    }
+
+    private static void assertUnmodifiable(Collection<SomeProvider.SomeService> services) {
+        assertThrows(UnsupportedOperationException.class, () -> services.add(new DummyService()));
     }
 
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
@@ -17,7 +17,9 @@
 package io.helidon.builder.test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import io.helidon.builder.test.testsubjects.SomeProvider;
 import io.helidon.builder.test.testsubjects.WithInheritedProvider;
@@ -36,6 +38,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -61,12 +64,15 @@ class ProviderTest {
         assertThat(value.optionalNotDiscover().map(SomeProvider.SomeService::prop), optionalEmpty());
 
         assertThat(value.listDiscover(), hasSize(2));
-        List<SomeProvider.SomeService> services = value.optionalListDiscover().orElseThrow();
-        assertThat(services, hasSize(2));
-        assertThat(services.get(0).prop(), is("some-1"));
-        assertThat(services.get(1).prop(), is("some-2"));
+        List<SomeProvider.SomeService> optionalListDiscover = value.optionalListDiscover().orElseThrow();
+        Collection<SomeProvider.SomeService> optionalSetDiscover = value.optionalSetDiscover().orElseThrow();
+        assertServicePropsInOrder(optionalListDiscover, "some-1", "some-2");
+        assertServiceProps(optionalSetDiscover, "some-1", "some-2");
+        assertUnmodifiable(optionalListDiscover);
+        assertUnmodifiable(optionalSetDiscover);
         assertThat(value.listNotDiscover(), hasSize(0));
         assertThat(value.optionalListNotDiscover(), optionalEmpty());
+        assertThat(value.optionalSetNotDiscover(), optionalEmpty());
 
         /*
         Test all the methods for a provider with no implementations
@@ -75,6 +81,7 @@ class ProviderTest {
         assertThat(value.optionalNoImplNotDiscover(), optionalEmpty());
         assertThat(value.listNoImplDiscover(), hasSize(0));
         assertThat(value.optionalListNoImplDiscoverNoConfig(), optionalEmpty());
+        assertThat(value.optionalSetNoImplDiscoverNoConfig(), optionalEmpty());
         assertThat(value.listNoImplNotDiscover(), hasSize(0));
     }
 
@@ -106,10 +113,10 @@ class ProviderTest {
         assertThat(services.get(0).prop(), is("config"));
         assertThat(services.get(1).prop(), is("config2"));
 
-        services = value.optionalListNotDiscover().orElseThrow();
-        assertThat(services, hasSize(2));
-        assertThat(services.get(0).prop(), is("config"));
-        assertThat(services.get(1).prop(), is("config2"));
+        assertServicePropsInOrder(value.optionalListDiscover().orElseThrow(), "config", "config2");
+        assertServiceProps(value.optionalSetDiscover().orElseThrow(), "config", "config2");
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "config", "config2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "config", "config2");
     }
 
     @Test
@@ -148,46 +155,58 @@ class ProviderTest {
         assertThat(value.listNotDiscover(), hasSize(1));
         assertThat(services.get(0).prop(), is("config2"));
 
-        services = value.optionalListNotDiscover().orElseThrow();
-        assertThat(services, hasSize(1));
-        assertThat(services.get(0).prop(), is("config2"));
+        assertServicePropsInOrder(value.optionalListDiscover().orElseThrow(), "config", "some-2");
+        assertServiceProps(value.optionalSetDiscover().orElseThrow(), "config", "some-2");
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "config2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "config2");
     }
 
     @Test
-    void testEmptyOptionalList() {
-        WithProvider value = WithProvider.create(config.get("empty-optional-list-object"));
+    void testEmptyOptionalProviderContainers() {
+        WithProvider value = WithProvider.create(config.get("empty-optional-containers-object"));
 
         assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
         assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
 
-        value = WithProvider.create(config.get("empty-optional-list-array"));
+        value = WithProvider.create(config.get("empty-optional-containers-array"));
 
         assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
         assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
     }
 
     @Test
-    void testOptionalListBuilderMethods() {
+    void testOptionalProviderContainerBuilderMethods() {
         SomeProvider.SomeService someService = new DummyService();
 
         WithProvider value = WithProvider.builder()
                 .oneNotDiscover(someService)
                 .optionalListNotDiscover(List.of())
+                .optionalSetNotDiscover(Set.of())
                 .build();
         assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of())));
 
         value = WithProvider.builder()
                 .oneNotDiscover(someService)
                 .addOptionalListNotDiscover(List.of(someService))
+                .addOptionalSetNotDiscover(Set.of(someService))
                 .build();
         assertThat(value.optionalListNotDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(value.optionalSetNotDiscover(), optionalValue(is(Set.of(someService))));
 
         value = WithProvider.builder()
                 .oneNotDiscover(someService)
                 .optionalListNotDiscover(List.of(someService))
+                .optionalSetNotDiscover(Set.of(someService))
                 .clearOptionalListNotDiscover()
+                .clearOptionalSetNotDiscover()
                 .build();
         assertThat(value.optionalListNotDiscover(), optionalEmpty());
+        assertThat(value.optionalSetNotDiscover(), optionalEmpty());
     }
 
     @Test
@@ -208,29 +227,26 @@ class ProviderTest {
     }
 
     @Test
-    void testOptionalListDiscoveryEnabled() {
+    void testOptionalProviderContainerDiscoveryEnabled() {
         SomeProvider.SomeService someService = new DummyService();
 
         WithProvider value = WithProvider.builder()
                 .config(config.get("min-defined"))
                 .oneNotDiscover(someService)
                 .optionalListNotDiscoverDiscoverServices(true)
+                .optionalSetNotDiscoverDiscoverServices(true)
                 .build();
 
-        List<SomeProvider.SomeService> services = value.optionalListNotDiscover().orElseThrow();
-        assertThat(services, hasSize(2));
-        assertThat(services.get(0).prop(), is("some-1"));
-        assertThat(services.get(1).prop(), is("some-2"));
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "some-1", "some-2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "some-1", "some-2");
     }
 
     @Test
-    void testOptionalListDiscoveryEnabledFromConfig() {
-        WithProvider value = WithProvider.create(config.get("discover-optional-list-from-config"));
+    void testOptionalProviderContainerDiscoveryEnabledFromConfig() {
+        WithProvider value = WithProvider.create(config.get("discover-optional-containers-from-config"));
 
-        List<SomeProvider.SomeService> services = value.optionalListNotDiscover().orElseThrow();
-        assertThat(services, hasSize(2));
-        assertThat(services.get(0).prop(), is("some-1"));
-        assertThat(services.get(1).prop(), is("some-2"));
+        assertServicePropsInOrder(value.optionalListNotDiscover().orElseThrow(), "some-1", "some-2");
+        assertServiceProps(value.optionalSetNotDiscover().orElseThrow(), "some-1", "some-2");
     }
 
     @Test
@@ -259,6 +275,68 @@ class ProviderTest {
                 .from(value)
                 .build();
         assertThat(copy.listDiscover(), is(List.of()));
+    }
+
+    @Test
+    void testDisabledOptionalContainerDiscoveryOnTheCopy() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithProvider value = WithProvider.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of())
+                .optionalSetDiscover(Set.of())
+                .oneNotDiscover(someService)
+                .build();
+        assertThat(value.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(value.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        WithProvider copy = WithProvider.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProvider.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of(someService))
+                .optionalSetDiscover(Set.of(someService))
+                .oneNotDiscover(someService)
+                .build();
+        copy = WithProvider.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
+    }
+
+    @Test
+    void testDisabledOptionalContainerDiscoveryOnTheCopiedBuilder() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithProvider.Builder value = WithProvider.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of())
+                .optionalSetDiscover(Set.of())
+                .oneNotDiscover(someService);
+
+        WithProvider copy = WithProvider.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of())));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of())));
+
+        value = WithProvider.builder()
+                .optionalListDiscoverDiscoverServices(false)
+                .optionalSetDiscoverDiscoverServices(false)
+                .optionalListDiscover(List.of(someService))
+                .optionalSetDiscover(Set.of(someService))
+                .oneNotDiscover(someService);
+        copy = WithProvider.builder()
+                .from(value)
+                .build();
+        assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
+        assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
     }
 
     @Test
@@ -316,6 +394,18 @@ class ProviderTest {
         public String type() {
             return null;
         }
+    }
+
+    private static void assertServiceProps(Collection<SomeProvider.SomeService> services, String... props) {
+        assertThat(services.stream().map(SomeProvider.SomeService::prop).toList(), containsInAnyOrder(props));
+    }
+
+    private static void assertServicePropsInOrder(List<SomeProvider.SomeService> services, String... props) {
+        assertThat(services.stream().map(SomeProvider.SomeService::prop).toList(), is(List.of(props)));
+    }
+
+    private static void assertUnmodifiable(Collection<SomeProvider.SomeService> services) {
+        assertThrows(UnsupportedOperationException.class, () -> services.add(new DummyService()));
     }
 
 }

--- a/builder/tests/builder/src/test/resources/config-map-test.yaml
+++ b/builder/tests/builder/src/test/resources/config-map-test.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,3 +19,22 @@ properties:
   my.first.key: "firstValue"
   my.second.key: "secondValue"
 
+optional-containers:
+  optional-properties:
+    my.first.key: "firstValue"
+    my.second.key: "secondValue"
+  optional-numbers:
+    one: 1
+    two: 2
+  optional-list:
+    - "first"
+    - "second"
+  optional-set:
+    - "first"
+    - "second"
+
+optional-empty-containers:
+  optional-properties: {}
+  optional-numbers: {}
+  optional-list: []
+  optional-set: []

--- a/builder/tests/builder/src/test/resources/provider-test.yaml
+++ b/builder/tests/builder/src/test/resources/provider-test.yaml
@@ -42,12 +42,22 @@ all-defined:
       prop: "config"
     some-2:
       prop: "config2"
+  optional-set-discover:
+    some-1:
+      prop: "config"
+    some-2:
+      prop: "config2"
   list-not-discover:
     some-1:
       prop: "config"
     some-2:
       prop: "config2"
   optional-list-not-discover:
+    some-1:
+      prop: "config"
+    some-2:
+      prop: "config2"
+  optional-set-not-discover:
     some-1:
       prop: "config"
     some-2:
@@ -63,26 +73,37 @@ single-list:
   optional-list-discover:
     some-1:
       prop: "config"
+  optional-set-discover:
+    some-1:
+      prop: "config"
   list-not-discover:
     some-2:
       prop: "config2"
   optional-list-not-discover:
     some-2:
       prop: "config2"
-empty-optional-list-object:
+  optional-set-not-discover:
+    some-2:
+      prop: "config2"
+empty-optional-containers-object:
   one-not-discover:
     some-1:
       prop: "config"
   optional-list-discover: {}
+  optional-set-discover: {}
   optional-list-not-discover: {}
-empty-optional-list-array:
+  optional-set-not-discover: {}
+empty-optional-containers-array:
   one-not-discover:
     some-1:
       prop: "config"
   optional-list-discover: []
+  optional-set-discover: []
   optional-list-not-discover: []
-discover-optional-list-from-config:
+  optional-set-not-discover: []
+discover-optional-containers-from-config:
   one-not-discover:
     some-1:
       prop: "config"
   optional-list-not-discover-discover-services: true
+  optional-set-not-discover-discover-services: true


### PR DESCRIPTION
Resolves #11972

Carries forward #11970 to main.

The builder code generator now applies container semantics when an option is declared as `Optional<Map<...>>`, `Optional<List<...>>`, or `Optional<Set<...>>`. This keeps config loading, setter/add/clear builder methods, defensive copies, immutable built values, and absent versus explicitly empty values aligned with the non-optional container behavior.

The carry-forward also extends provider-backed optional collection discovery for service-loader and registry-backed providers. The main-line adaptation keeps using the `io.helidon.config.Config` codegen path instead of the 4.x common-config compatibility path.
