### PR TITLE
Fix ListContext unregister identity handling (main)

### DIFF
--- a/common/context/context/src/main/java/io/helidon/common/context/Context.java
+++ b/common/context/context/src/main/java/io/helidon/common/context/Context.java
@@ -16,6 +16,7 @@
 
 package io.helidon.common.context;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -92,10 +93,17 @@ public interface Context {
     /**
      * Remove an instance registration from the context.
      *
+     * <p>The default implementation does nothing. Context instances created by this API remove registrations whose
+     * stored instance is the same object as the parameter. Object equality is not used. If the same object was
+     * registered more than once, all matching registrations are removed. A supplied registration can be matched by
+     * instance only after its supplier has been resolved.
+     *
      * @param instance an instance to remove from context
      * @param <T> type of the instance
+     * @throws NullPointerException if the instance is {@code null}
      */
     default <T> void unregister(T instance) {
+        Objects.requireNonNull(instance, "Parameter 'instance' is null!");
         // do nothing by default for backward compatibility
     }
 
@@ -138,11 +146,19 @@ public interface Context {
     /**
      * Remove an instance registration from the context.
      *
+     * <p>The default implementation does nothing. Context instances created by this API remove registrations whose
+     * stored instance is the same object as the parameter. Object equality is not used. If the same object was
+     * registered more than once for the classifier, all matching registrations are removed. A supplied registration
+     * can be matched by instance only after its supplier has been resolved.
+     *
      * @param classifier an additional registered instance classifier
      * @param instance an instance to remove from context
      * @param <T> type of the instance
+     * @throws NullPointerException if the classifier or instance is {@code null}
      */
     default <T> void unregister(Object classifier, T instance) {
+        Objects.requireNonNull(classifier, "Parameter 'classifier' is null!");
+        Objects.requireNonNull(instance, "Parameter 'instance' is null!");
         // do nothing by default for backward compatibility
     }
 

--- a/common/context/context/src/main/java/io/helidon/common/context/ListContext.java
+++ b/common/context/context/src/main/java/io/helidon/common/context/ListContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,15 +128,17 @@ class ListContext implements Context {
         T get();
 
         Class<T> getType();
+
+        default boolean isRegisteredInstance(Object instance) {
+            return false;
+        }
     }
 
     private static class ClassifiedRegistry {
         private final ReadWriteLock lock = new ReentrantReadWriteLock();
         private final List<RegisteredItem<?>> content = new ArrayList<>();
 
-        // we actually want to do an instance equality
-        @SuppressWarnings("ObjectEquality")
-        private void registerItem(RegisteredItem<?> item, boolean register) {
+        private void registerItem(RegisteredItem<?> item) {
             Lock l = lock.writeLock();
             try {
                 Class<?> c = item.getType();
@@ -148,8 +150,21 @@ class ListContext implements Context {
                         break;
                     }
                 }
-                if (register) {
-                    content.add(item);
+                content.add(item);
+            } finally {
+                l.unlock();
+            }
+        }
+
+        private void unregisterInstance(Object instance) {
+            Lock l = lock.writeLock();
+            try {
+                l.lock();
+                for (int i = content.size() - 1; i >= 0; i--) {
+                    RegisteredItem<?> reg = content.get(i);
+                    if (reg.isRegisteredInstance(instance)) {
+                        content.remove(i);
+                    }
                 }
             } finally {
                 l.unlock();
@@ -158,18 +173,18 @@ class ListContext implements Context {
 
         <T> void register(T instance) {
             Objects.requireNonNull(instance, "Parameter 'instance' is null!");
-            registerItem(new RegisteredInstance<>(instance), true);
+            registerItem(new RegisteredInstance<>(instance));
         }
 
         void unregister(Object instance) {
             Objects.requireNonNull(instance, "Parameter 'instance' is null!");
-            registerItem(new RegisteredInstance<>(instance), false);
+            unregisterInstance(instance);
         }
 
         <T> void supply(Class<T> type, Supplier<T> supplier) {
             Objects.requireNonNull(type, "Parameter 'type' is null!");
             Objects.requireNonNull(supplier, "Parameter 'supplier' is null!");
-            registerItem(new RegisteredSupplier<>(type, supplier), true);
+            registerItem(new RegisteredSupplier<>(type, supplier));
         }
 
         <T> T get(Class<T> type) {
@@ -208,6 +223,12 @@ class ListContext implements Context {
         public Class<T> getType() {
             return type;
         }
+
+        @Override
+        @SuppressWarnings("ObjectEquality")
+        public boolean isRegisteredInstance(Object instance) {
+            return value.isLoaded() && value.get() == instance;
+        }
     }
 
     private static class RegisteredInstance<T> implements RegisteredItem<T> {
@@ -226,6 +247,12 @@ class ListContext implements Context {
         @SuppressWarnings("unchecked")
         public Class<T> getType() {
             return (Class<T>) instance.getClass();
+        }
+
+        @Override
+        @SuppressWarnings("ObjectEquality")
+        public boolean isRegisteredInstance(Object instance) {
+            return this.instance == instance;
         }
 
         @Override

--- a/common/context/context/src/test/java/io/helidon/common/context/ListContextTest.java
+++ b/common/context/context/src/test/java/io/helidon/common/context/ListContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,15 @@ package io.helidon.common.context;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 
@@ -77,6 +81,154 @@ public class ListContextTest {
         context.register("bbb");
         assertThat(context.get(String.class), is(Optional.of("bbb")));
         assertThat(context.get(Object.class), is(Optional.of("bbb")));
+    }
+
+    @Test
+    public void unregisterOldInstanceKeepsReplacement() {
+        Context context = Context.create();
+        TestValue first = new TestValue();
+        TestValue second = new TestValue();
+
+        context.register(first);
+        context.register(second);
+
+        assertThat(first, is(second));
+        assertThat(first, not(sameInstance(second)));
+        assertThat(context.get(TestValue.class).get(), sameInstance(second));
+
+        context.unregister(first);
+
+        assertThat(context.get(TestValue.class).get(), sameInstance(second));
+
+        context.unregister(second);
+
+        assertThat(context.get(TestValue.class), is(Optional.empty()));
+    }
+
+    @Test
+    public void unregisterOldClassifiedInstanceKeepsReplacement() {
+        Context context = Context.create();
+        String classifier = "classifier";
+        TestValue first = new TestValue();
+        TestValue second = new TestValue();
+
+        context.register(classifier, first);
+        context.register(classifier, second);
+
+        assertThat(first, is(second));
+        assertThat(first, not(sameInstance(second)));
+        assertThat(context.get(classifier, TestValue.class).get(), sameInstance(second));
+
+        context.unregister(classifier, first);
+
+        assertThat(context.get(classifier, TestValue.class).get(), sameInstance(second));
+
+        context.unregister(classifier, second);
+
+        assertThat(context.get(classifier, TestValue.class), is(Optional.empty()));
+    }
+
+    @Test
+    public void unregisterSuppliedInstanceUsesLoadedIdentity() {
+        Context context = Context.create();
+        AtomicInteger counter = new AtomicInteger();
+        TestValue supplied = new TestValue();
+        TestValue equal = new TestValue();
+
+        context.supply(TestValue.class, () -> {
+            counter.incrementAndGet();
+            return supplied;
+        });
+
+        context.unregister(supplied);
+
+        assertThat(counter.get(), is(0));
+        assertThat(context.get(TestValue.class).get(), sameInstance(supplied));
+        assertThat(counter.get(), is(1));
+
+        context.unregister(equal);
+
+        assertThat(context.get(TestValue.class).get(), sameInstance(supplied));
+        assertThat(counter.get(), is(1));
+
+        context.unregister(supplied);
+
+        assertThat(context.get(TestValue.class), is(Optional.empty()));
+        assertThat(counter.get(), is(1));
+    }
+
+    @Test
+    public void unregisterClassifiedSuppliedInstanceUsesLoadedIdentity() {
+        Context context = Context.create();
+        String classifier = "classifier";
+        AtomicInteger counter = new AtomicInteger();
+        TestValue supplied = new TestValue();
+        TestValue equal = new TestValue();
+
+        context.supply(classifier, TestValue.class, () -> {
+            counter.incrementAndGet();
+            return supplied;
+        });
+
+        context.unregister(classifier, supplied);
+
+        assertThat(counter.get(), is(0));
+        assertThat(context.get(classifier, TestValue.class).get(), sameInstance(supplied));
+        assertThat(counter.get(), is(1));
+
+        context.unregister(classifier, equal);
+
+        assertThat(context.get(classifier, TestValue.class).get(), sameInstance(supplied));
+        assertThat(counter.get(), is(1));
+
+        context.unregister(classifier, supplied);
+
+        assertThat(context.get(classifier, TestValue.class), is(Optional.empty()));
+        assertThat(counter.get(), is(1));
+    }
+
+    @Test
+    public void unregisterRemovesAllRegistrationsForTheSameInstance() {
+        Context context = Context.create();
+        TestValue supplied = new TestValue();
+
+        context.supply(TestValueInterface.class, () -> supplied);
+        assertThat(context.get(TestValueInterface.class).get(), sameInstance(supplied));
+
+        context.register(supplied);
+        assertThat(context.get(TestValueInterface.class).get(), sameInstance(supplied));
+
+        context.unregister(supplied);
+
+        assertThat(context.get(TestValueInterface.class), is(Optional.empty()));
+        assertThat(context.get(TestValue.class), is(Optional.empty()));
+    }
+
+    @Test
+    public void unregisterRemovesAllClassifiedRegistrationsForTheSameInstance() {
+        Context context = Context.create();
+        String classifier = "classifier";
+        TestValue supplied = new TestValue();
+
+        context.supply(classifier, TestValueInterface.class, () -> supplied);
+        assertThat(context.get(classifier, TestValueInterface.class).get(), sameInstance(supplied));
+
+        context.register(classifier, supplied);
+        assertThat(context.get(classifier, TestValueInterface.class).get(), sameInstance(supplied));
+
+        context.unregister(classifier, supplied);
+
+        assertThat(context.get(classifier, TestValueInterface.class), is(Optional.empty()));
+        assertThat(context.get(classifier, TestValue.class), is(Optional.empty()));
+    }
+
+    @Test
+    public void defaultUnregisterRejectsNulls() {
+        Context context = new DefaultUnregisterContext();
+
+        assertThrows(NullPointerException.class, () -> context.unregister((Object) null));
+        assertThrows(NullPointerException.class, () -> context.unregister(null, new TestValue()));
+        assertThrows(NullPointerException.class, () -> context.unregister("classifier", (TestValue) null));
     }
 
     @Test
@@ -184,5 +336,53 @@ public class ListContextTest {
         assertThat(context.get(classifier, Date.class), is(Optional.of(date)));
         assertThat(context.get(classifier, String.class), is(Optional.of("bbb")));
         assertThat(counter.get(), is(1));
+    }
+
+    private static class TestValue implements TestValueInterface {
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof TestValue;
+        }
+
+        @Override
+        public int hashCode() {
+            return TestValue.class.hashCode();
+        }
+    }
+
+    private interface TestValueInterface {
+    }
+
+    private static class DefaultUnregisterContext implements Context {
+        @Override
+        public <T> void register(T instance) {
+        }
+
+        @Override
+        public <T> void supply(Class<T> type, Supplier<T> supplier) {
+        }
+
+        @Override
+        public <T> Optional<T> get(Class<T> type) {
+            return Optional.empty();
+        }
+
+        @Override
+        public <T> void register(Object classifier, T instance) {
+        }
+
+        @Override
+        public <T> void supply(Object classifier, Class<T> type, Supplier<T> supplier) {
+        }
+
+        @Override
+        public <T> Optional<T> get(Object classifier, Class<T> type) {
+            return Optional.empty();
+        }
+
+        @Override
+        public String id() {
+            return "default-unregister";
+        }
     }
 }


### PR DESCRIPTION
Resolves #11906

Carries the `ListContext.unregister(instance)` identity handling fix from #11907 forward to `main`.

The change keeps registration replacement by type, but makes unregister remove only stored registrations whose instance is identical to the argument, including already resolved suppliers.
