### PR TITLE
Use custom uncaught exception handlers in WebServer

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -919,6 +919,9 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             } catch (SocketWriterException e) {
                 handlerThread.interrupt();
                 LOGGER.log(DEBUG, "Socket writer error on writer thread", e);
+            } catch (ServerConnectionException e) {
+                handlerThread.interrupt();
+                LOGGER.log(TRACE, "server I/O issue on HTTP/2 stream thread", e);
             } catch (UncheckedIOException e) {
                 // Broken connection
                 if (e.getCause() instanceof SocketException) {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -71,6 +71,7 @@ import static io.helidon.http.HeaderNames.X_FORWARDED_PORT;
 import static io.helidon.http.HeaderNames.X_HELIDON_CN;
 import static io.helidon.http.http2.Http2Util.PREFACE_LENGTH;
 import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.TRACE;
 
 /**
@@ -925,8 +926,10 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                     handlerThread.interrupt();
                     LOGGER.log(DEBUG, "Socket error on writer thread", e);
                 } else {
-                    throw e;
+                    LOGGER.log(ERROR, "Unhandled exception on HTTP/2 stream thread", e);
                 }
+            } catch (Throwable e) {
+                LOGGER.log(ERROR, "Unhandled exception on HTTP/2 stream thread", e);
             } finally {
                 // 5.1 - In HALF-CLOSED state we need to wait for either RST-STREAM or DATA with endStream flag
                 if (stream.streamState() == Http2StreamState.CLOSED) {

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -147,7 +148,7 @@ class Http2ConnectionTest {
         streams.put(new Http2Connection.StreamContext(1, 8192, stream));
 
         try (TestLogHandler handler = TestLogHandler.install()) {
-            new Http2Connection.StreamRunnable(streams, stream, Thread.currentThread()).run();
+            assertDoesNotThrow(() -> new Http2Connection.StreamRunnable(streams, stream, Thread.currentThread()).run());
             streams.doMaintenance(0);
             LogRecord record = handler.await();
 
@@ -170,7 +171,7 @@ class Http2ConnectionTest {
         streams.put(new Http2Connection.StreamContext(1, 8192, stream));
 
         try (TestLogHandler handler = TestLogHandler.install()) {
-            new Http2Connection.StreamRunnable(streams, stream, Thread.currentThread()).run();
+            assertDoesNotThrow(() -> new Http2Connection.StreamRunnable(streams, stream, Thread.currentThread()).run());
             streams.doMaintenance(0);
             LogRecord record = handler.await();
 
@@ -179,6 +180,39 @@ class Http2ConnectionTest {
                     () -> assertThat(record.getThrown(), sameInstance(failure)),
                     () -> assertThat(streams.get(1), is(nullValue()))
             );
+        }
+    }
+
+    @Test
+    void streamRunnableLogsServerConnectionExceptionAsServerIoIssue() throws Exception {
+        ServerConnectionException failure = new ServerConnectionException("stream failure", new IOException("closed"));
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        doThrow(failure).when(stream).run();
+        when(stream.streamId()).thenReturn(1);
+        when(stream.streamState()).thenReturn(Http2StreamState.CLOSED);
+        streams.put(new Http2Connection.StreamContext(1, 8192, stream));
+
+        boolean previouslyInterrupted = Thread.interrupted();
+        try (TestLogHandler handler = TestLogHandler.install()) {
+            assertDoesNotThrow(() -> new Http2Connection.StreamRunnable(streams, stream, Thread.currentThread()).run());
+            boolean interrupted = Thread.currentThread().isInterrupted();
+            Thread.interrupted();
+            streams.doMaintenance(0);
+            LogRecord record = handler.await();
+
+            assertAll(
+                    () -> assertThat(interrupted, is(true)),
+                    () -> assertThat(record.getMessage(), containsString("server I/O issue on HTTP/2 stream thread")),
+                    () -> assertThat(record.getLevel(), is(Level.FINER)),
+                    () -> assertThat(record.getThrown(), sameInstance(failure)),
+                    () -> assertThat(streams.get(1), is(nullValue()))
+            );
+        } finally {
+            Thread.interrupted();
+            if (previouslyInterrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -16,11 +16,19 @@
 
 package io.helidon.webserver.http2;
 
+import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.SocketException;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -39,8 +47,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -127,6 +137,52 @@ class Http2ConnectionTest {
     }
 
     @Test
+    void streamRunnableLogsUnhandledThrowable() throws Exception {
+        IllegalStateException failure = new IllegalStateException("stream failure");
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        doThrow(failure).when(stream).run();
+        when(stream.streamId()).thenReturn(1);
+        when(stream.streamState()).thenReturn(Http2StreamState.CLOSED);
+        streams.put(new Http2Connection.StreamContext(1, 8192, stream));
+
+        try (TestLogHandler handler = TestLogHandler.install()) {
+            new Http2Connection.StreamRunnable(streams, stream, Thread.currentThread()).run();
+            streams.doMaintenance(0);
+            LogRecord record = handler.await();
+
+            assertAll(
+                    () -> assertThat(record.getMessage(), containsString("Unhandled exception on HTTP/2 stream thread")),
+                    () -> assertThat(record.getThrown(), sameInstance(failure)),
+                    () -> assertThat(streams.get(1), is(nullValue()))
+            );
+        }
+    }
+
+    @Test
+    void streamRunnableLogsUnhandledUncheckedIOException() throws Exception {
+        UncheckedIOException failure = new UncheckedIOException(new IOException("stream failure"));
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        doThrow(failure).when(stream).run();
+        when(stream.streamId()).thenReturn(1);
+        when(stream.streamState()).thenReturn(Http2StreamState.CLOSED);
+        streams.put(new Http2Connection.StreamContext(1, 8192, stream));
+
+        try (TestLogHandler handler = TestLogHandler.install()) {
+            new Http2Connection.StreamRunnable(streams, stream, Thread.currentThread()).run();
+            streams.doMaintenance(0);
+            LogRecord record = handler.await();
+
+            assertAll(
+                    () -> assertThat(record.getMessage(), containsString("Unhandled exception on HTTP/2 stream thread")),
+                    () -> assertThat(record.getThrown(), sameInstance(failure)),
+                    () -> assertThat(streams.get(1), is(nullValue()))
+            );
+        }
+    }
+
+    @Test
     void closeConnectionWrapsUncheckedIOException() {
         DataWriter writer = mock(DataWriter.class);
         doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
@@ -178,5 +234,48 @@ class Http2ConnectionTest {
         when(ctx.dataWriter()).thenReturn(writer);
         when(ctx.dataReader()).thenReturn(mock(DataReader.class));
         return ctx;
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final Logger logger;
+        private final Level previousLevel;
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private final AtomicReference<LogRecord> record = new AtomicReference<>();
+
+        private TestLogHandler(Logger logger) {
+            this.logger = logger;
+            this.previousLevel = logger.getLevel();
+            setLevel(Level.ALL);
+        }
+
+        static TestLogHandler install() {
+            Logger logger = Logger.getLogger(Http2Connection.class.getName());
+            TestLogHandler handler = new TestLogHandler(logger);
+            logger.setLevel(Level.ALL);
+            logger.addHandler(handler);
+            return handler;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (this.record.compareAndSet(null, record)) {
+                latch.countDown();
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setLevel(previousLevel);
+        }
+
+        private LogRecord await() throws InterruptedException {
+            assertThat(latch.await(5, TimeUnit.SECONDS), is(true));
+            return record.get();
+        }
     }
 }

--- a/webserver/observe/telemetry/metrics/pom.xml
+++ b/webserver/observe/telemetry/metrics/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
+++ b/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
@@ -42,6 +42,8 @@ import io.opentelemetry.semconv.HttpAttributes;
 import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.UrlAttributes;
 
+import static java.lang.System.Logger.Level.DEBUG;
+
 /**
  * Provider of automatic metrics for HTTP requests which implements the OpenTelemetry server HTTP semantic conventions.
  * <p>
@@ -108,6 +110,7 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
     }
 
     static class MetricsRecordingFilter implements Filter {
+        private static final System.Logger LOGGER = System.getLogger(MetricsRecordingFilter.class.getName());
 
         private final DoubleHistogram httpRequestDuration;
         private final AutoHttpMetricsConfig config;
@@ -126,11 +129,21 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
              */
             try {
                 chain.proceed();
-                Thread.ofVirtual().start(() -> updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), null));
+                runAsyncMetricsUpdate(() -> updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), null));
             } catch (Exception e) {
-                Thread.ofVirtual().start(() -> updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), e));
+                runAsyncMetricsUpdate(() -> updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), e));
                 throw e;
             }
+        }
+
+        static void runAsyncMetricsUpdate(Runnable update) {
+            Thread.ofVirtual().start(() -> {
+                try {
+                    update.run();
+                } catch (Throwable e) {
+                    LOGGER.log(DEBUG, "Failed to record HTTP request metrics", e);
+                }
+            });
         }
 
         private static MetricsRecordingFilter create(DoubleHistogram httpRequestDuration, AutoHttpMetricsConfig config) {

--- a/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
+++ b/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
@@ -42,7 +42,7 @@ import io.opentelemetry.semconv.HttpAttributes;
 import io.opentelemetry.semconv.ServerAttributes;
 import io.opentelemetry.semconv.UrlAttributes;
 
-import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.WARNING;
 
 /**
  * Provider of automatic metrics for HTTP requests which implements the OpenTelemetry server HTTP semantic conventions.
@@ -126,24 +126,26 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
             /*
             Duplicating the synch/async handling in the normal and exception case avoids the overhead of using an Optional to hold
             the exception (if any) for use in a lambda.
-             */
+            */
             try {
                 chain.proceed();
-                runAsyncMetricsUpdate(() -> updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), null));
+                Thread.ofVirtual().start(() -> {
+                    try {
+                        updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), null);
+                    } catch (Throwable e) {
+                        LOGGER.log(WARNING, "Failed to record HTTP request metrics", e);
+                    }
+                });
             } catch (Exception e) {
-                runAsyncMetricsUpdate(() -> updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), e));
+                Thread.ofVirtual().start(() -> {
+                    try {
+                        updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), e);
+                    } catch (Throwable metricsUpdateFailure) {
+                        LOGGER.log(WARNING, "Failed to record HTTP request metrics", metricsUpdateFailure);
+                    }
+                });
                 throw e;
             }
-        }
-
-        static void runAsyncMetricsUpdate(Runnable update) {
-            Thread.ofVirtual().start(() -> {
-                try {
-                    update.run();
-                } catch (Throwable e) {
-                    LOGGER.log(DEBUG, "Failed to record HTTP request metrics", e);
-                }
-            });
         }
 
         private static MetricsRecordingFilter create(DoubleHistogram httpRequestDuration, AutoHttpMetricsConfig config) {

--- a/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
+++ b/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
@@ -62,25 +62,8 @@ import static org.mockito.Mockito.when;
 class OpenTelemetryMetricsHttpSemanticConventionsTest {
 
     @Test
-    void asyncMetricsUpdateLogsUnhandledFailure() throws Exception {
-        IllegalStateException failure = new IllegalStateException("metrics failure");
-
-        try (TestLogHandler handler = TestLogHandler.install()) {
-            OpenTelemetryMetricsHttpSemanticConventions.MetricsRecordingFilter.runAsyncMetricsUpdate(() -> {
-                throw failure;
-            });
-
-            LogRecord record = handler.await();
-
-            assertThat(record.getMessage(), containsString("Failed to record HTTP request metrics"));
-            assertThat(record.getLevel(), is(Level.FINE));
-            assertThat(record.getThrown(), sameInstance(failure));
-        }
-    }
-
-    @Test
     void filterLogsMetricsFailureAfterSuccessfulChain() throws Exception {
-        IllegalStateException failure = new IllegalStateException("metrics failure");
+        AssertionError failure = new AssertionError("metrics failure");
         Filter filter = filter(failure);
 
         try (TestLogHandler handler = TestLogHandler.install()) {
@@ -88,14 +71,14 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
 
             LogRecord record = handler.await();
             assertThat(record.getMessage(), containsString("Failed to record HTTP request metrics"));
-            assertThat(record.getLevel(), is(Level.FINE));
+            assertThat(record.getLevel(), is(Level.WARNING));
             assertThat(record.getThrown(), sameInstance(failure));
         }
     }
 
     @Test
     void filterLogsMetricsFailureAfterExceptionalChain() throws Exception {
-        IllegalStateException metricsFailure = new IllegalStateException("metrics failure");
+        AssertionError metricsFailure = new AssertionError("metrics failure");
         IllegalArgumentException chainFailure = new IllegalArgumentException("chain failure");
         Filter filter = filter(metricsFailure);
         FilterChain chain = mock(FilterChain.class);
@@ -108,12 +91,12 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
 
             assertThat(exception, sameInstance(chainFailure));
             assertThat(record.getMessage(), containsString("Failed to record HTTP request metrics"));
-            assertThat(record.getLevel(), is(Level.FINE));
+            assertThat(record.getLevel(), is(Level.WARNING));
             assertThat(record.getThrown(), sameInstance(metricsFailure));
         }
     }
 
-    private static Filter filter(RuntimeException failure) {
+    private static Filter filter(Throwable failure) {
         OpenTelemetry openTelemetry = mock(OpenTelemetry.class);
         MeterBuilder meterBuilder = mock(MeterBuilder.class);
         Meter meter = mock(Meter.class);

--- a/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
+++ b/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe.telemetry.metrics;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.http.Filter;
+import io.helidon.webserver.http.FilterChain;
+import io.helidon.webserver.http.RoutingRequest;
+import io.helidon.webserver.http.RoutingResponse;
+import io.helidon.webserver.observe.metrics.MetricsObserverConfig;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OpenTelemetryMetricsHttpSemanticConventionsTest {
+
+    @Test
+    void asyncMetricsUpdateLogsUnhandledFailure() throws Exception {
+        IllegalStateException failure = new IllegalStateException("metrics failure");
+
+        try (TestLogHandler handler = TestLogHandler.install()) {
+            OpenTelemetryMetricsHttpSemanticConventions.MetricsRecordingFilter.runAsyncMetricsUpdate(() -> {
+                throw failure;
+            });
+
+            LogRecord record = handler.await();
+
+            assertThat(record.getMessage(), containsString("Failed to record HTTP request metrics"));
+            assertThat(record.getLevel(), is(Level.FINE));
+            assertThat(record.getThrown(), sameInstance(failure));
+        }
+    }
+
+    @Test
+    void filterLogsMetricsFailureAfterSuccessfulChain() throws Exception {
+        IllegalStateException failure = new IllegalStateException("metrics failure");
+        Filter filter = filter(failure);
+
+        try (TestLogHandler handler = TestLogHandler.install()) {
+            filter.filter(mock(FilterChain.class), request(), response());
+
+            LogRecord record = handler.await();
+            assertThat(record.getMessage(), containsString("Failed to record HTTP request metrics"));
+            assertThat(record.getLevel(), is(Level.FINE));
+            assertThat(record.getThrown(), sameInstance(failure));
+        }
+    }
+
+    @Test
+    void filterLogsMetricsFailureAfterExceptionalChain() throws Exception {
+        IllegalStateException metricsFailure = new IllegalStateException("metrics failure");
+        IllegalArgumentException chainFailure = new IllegalArgumentException("chain failure");
+        Filter filter = filter(metricsFailure);
+        FilterChain chain = mock(FilterChain.class);
+        doThrow(chainFailure).when(chain).proceed();
+
+        try (TestLogHandler handler = TestLogHandler.install()) {
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                             () -> filter.filter(chain, request(), response()));
+            LogRecord record = handler.await();
+
+            assertThat(exception, sameInstance(chainFailure));
+            assertThat(record.getMessage(), containsString("Failed to record HTTP request metrics"));
+            assertThat(record.getLevel(), is(Level.FINE));
+            assertThat(record.getThrown(), sameInstance(metricsFailure));
+        }
+    }
+
+    private static Filter filter(RuntimeException failure) {
+        OpenTelemetry openTelemetry = mock(OpenTelemetry.class);
+        MeterBuilder meterBuilder = mock(MeterBuilder.class);
+        Meter meter = mock(Meter.class);
+        DoubleHistogramBuilder histogramBuilder = mock(DoubleHistogramBuilder.class);
+        DoubleHistogram histogram = mock(DoubleHistogram.class);
+
+        when(openTelemetry.meterBuilder(anyString())).thenReturn(meterBuilder);
+        when(meterBuilder.build()).thenReturn(meter);
+        when(meter.histogramBuilder(OpenTelemetryMetricsHttpSemanticConventions.TIMER_NAME)).thenReturn(histogramBuilder);
+        when(histogramBuilder.setDescription(anyString())).thenReturn(histogramBuilder);
+        when(histogramBuilder.setUnit(anyString())).thenReturn(histogramBuilder);
+        doReturn(histogramBuilder).when(histogramBuilder).setExplicitBucketBoundariesAdvice(any());
+        when(histogramBuilder.build()).thenReturn(histogram);
+        doThrow(failure).when(histogram).record(anyDouble(), any(Attributes.class));
+
+        OpenTelemetryMetricsHttpSemanticConventions provider =
+                new OpenTelemetryMetricsHttpSemanticConventions(openTelemetry,
+                                                                Config.just("telemetry.service: test",
+                                                                            MediaTypes.APPLICATION_YAML));
+
+        return provider.filter(MetricsObserverConfig.create()).orElseThrow();
+    }
+
+    private static RoutingRequest request() {
+        RoutingRequest request = mock(RoutingRequest.class);
+        ListenerConfig listenerConfig = mock(ListenerConfig.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+
+        when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
+                                                                "HTTP",
+                                                                "1.1",
+                                                                Method.GET,
+                                                                "/test",
+                                                                false));
+        when(request.matchingPattern()).thenReturn(Optional.empty());
+        when(request.listenerContext()).thenReturn(listenerContext);
+        when(listenerContext.config()).thenReturn(listenerConfig);
+        when(listenerConfig.name()).thenReturn("@default");
+
+        return request;
+    }
+
+    private static RoutingResponse response() {
+        RoutingResponse response = mock(RoutingResponse.class);
+        when(response.status()).thenReturn(Status.OK_200);
+        return response;
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final Logger logger;
+        private final Level previousLevel;
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private final AtomicReference<LogRecord> record = new AtomicReference<>();
+
+        private TestLogHandler(Logger logger) {
+            this.logger = logger;
+            this.previousLevel = logger.getLevel();
+            setLevel(Level.ALL);
+        }
+
+        static TestLogHandler install() {
+            Logger logger = Logger.getLogger(OpenTelemetryMetricsHttpSemanticConventions.MetricsRecordingFilter.class.getName());
+            TestLogHandler handler = new TestLogHandler(logger);
+            logger.setLevel(Level.ALL);
+            logger.addHandler(handler);
+            return handler;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (this.record.compareAndSet(null, record)) {
+                latch.countDown();
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setLevel(previousLevel);
+        }
+
+        private LogRecord await() throws InterruptedException {
+            assertThat(latch.await(5, TimeUnit.SECONDS), is(true));
+            return record.get();
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -56,6 +56,7 @@ import io.helidon.webserver.spi.ServerConnection;
 import io.helidon.webserver.spi.ServerConnectionSelector;
 
 import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
@@ -126,7 +127,11 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     @Override
     public final void run() {
         try {
-            run(channelId);
+            try {
+                run(channelId);
+            } catch (Throwable e) {
+                LOGGER.log(ERROR, "Unexpected throwable while handling connection", e);
+            }
         } finally {
             releaseConnectionLimit(handlingStarted);
             if (writer != null) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,11 @@ import io.helidon.common.task.HelidonTaskExecutor;
  * <a href="https://github.com/enso-org/enso/pull/10783#discussion_r1768000821">available in PR-10783</a>.
  */
 final class ExecutorsFactory {
+    private static final System.Logger LOGGER = System.getLogger(ExecutorsFactory.class.getName());
+    private static final Thread.UncaughtExceptionHandler UNCAUGHT_EXCEPTION_HANDLER =
+            (thread, throwable) -> LOGGER.log(System.Logger.Level.ERROR,
+                                              "Uncaught exception in WebServer executor thread " + thread.getName(),
+                                              throwable);
 
     private ExecutorsFactory() {
     }
@@ -42,10 +47,10 @@ final class ExecutorsFactory {
     /**
      * Used by {@link LoomServer} to allocate its executor service.
      *
-     * @return {@link Executors#newVirtualThreadPerTaskExecutor()}
+     * @return {@link Executors#newThreadPerTaskExecutor(java.util.concurrent.ThreadFactory)}
      */
     static ExecutorService newLoomServerVirtualThreadPerTaskExecutor() {
-        return Executors.newVirtualThreadPerTaskExecutor();
+        return Executors.newThreadPerTaskExecutor(virtualThreadFactory());
     }
 
     /**
@@ -67,6 +72,8 @@ final class ExecutorsFactory {
     }
 
     private static ThreadFactory virtualThreadFactory() {
-        return Thread.ofVirtual().factory();
+        return Thread.ofVirtual()
+                .uncaughtExceptionHandler(UNCAUGHT_EXCEPTION_HANDLER)
+                .factory();
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
@@ -59,7 +59,7 @@ final class ExecutorsFactory {
      * @return {@link ThreadPerTaskExecutor#create(java.util.concurrent.ThreadFactory)}
      */
     static HelidonTaskExecutor newServerListenerReaderExecutor() {
-        return ThreadPerTaskExecutor.create(virtualThreadFactory());
+        return ThreadPerTaskExecutor.create(Thread.ofVirtual().factory());
     }
 
     /**

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,30 @@
 package io.helidon.webserver;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.channels.SocketChannel;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.LimitAlgorithm;
+import io.helidon.common.tls.Tls;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ConnectionHandlerTest {
 
@@ -30,5 +47,76 @@ class ConnectionHandlerTest {
     void testHttp10Prologue() {
         DataReader reader = DataReader.create(() -> "GET / HTTP/1.0\r\n".getBytes(StandardCharsets.US_ASCII));
         assertThat(ConnectionHandler.isHttp10Connection(reader), is(true));
+    }
+
+    @Test
+    void logsUnexpectedThrowableFromConnectionHandling() throws Exception {
+        AssertionError failure = new AssertionError("unexpected failure");
+        ListenerConfig listenerConfig = mock(ListenerConfig.class);
+        when(listenerConfig.enableProxyProtocol()).thenThrow(failure);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.config()).thenReturn(listenerConfig);
+        LimitAlgorithm.Token token = mock(LimitAlgorithm.Token.class);
+        ConnectionHandler handler = new ConnectionHandler(listenerContext,
+                                                          token,
+                                                          mock(Limit.class),
+                                                          ConnectionProviders.create(List.of()),
+                                                          mock(SocketChannel.class),
+                                                          "server",
+                                                          Router.empty(),
+                                                          mock(Tls.class),
+                                                          it -> { });
+
+        try (TestLogHandler logHandler = TestLogHandler.install()) {
+            handler.run();
+
+            LogRecord record = logHandler.await();
+            assertThat(record.getMessage(), containsString("Unexpected throwable while handling connection"));
+            assertThat(record.getThrown(), sameInstance(failure));
+            verify(token).ignore();
+        }
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final Logger logger;
+        private final Level previousLevel;
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private final AtomicReference<LogRecord> record = new AtomicReference<>();
+
+        private TestLogHandler(Logger logger) {
+            this.logger = logger;
+            this.previousLevel = logger.getLevel();
+            setLevel(Level.ALL);
+        }
+
+        static TestLogHandler install() {
+            Logger logger = Logger.getLogger(ConnectionHandler.class.getName());
+            TestLogHandler handler = new TestLogHandler(logger);
+            logger.setLevel(Level.ALL);
+            logger.addHandler(handler);
+            return handler;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (this.record.compareAndSet(null, record)) {
+                latch.countDown();
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setLevel(previousLevel);
+        }
+
+        private LogRecord await() throws InterruptedException {
+            assertThat(latch.await(5, TimeUnit.SECONDS), is(true));
+            return record.get();
+        }
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ExecutorsFactoryTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ExecutorsFactoryTest.java
@@ -35,11 +35,20 @@ import static org.hamcrest.Matchers.sameInstance;
 class ExecutorsFactoryTest {
 
     @Test
+    void loomServerExecutorLogsUncaughtException() throws Exception {
+        assertExecutorLogsUncaughtException(ExecutorsFactory.newLoomServerVirtualThreadPerTaskExecutor());
+    }
+
+    @Test
     void sharedExecutorLogsUncaughtException() throws Exception {
+        assertExecutorLogsUncaughtException(ExecutorsFactory.newServerListenerSharedExecutor());
+    }
+
+    private static void assertExecutorLogsUncaughtException(ExecutorService executor) throws Exception {
         IllegalStateException failure = new IllegalStateException("test failure");
 
-        try (TestLogHandler handler = TestLogHandler.install();
-                ExecutorService executor = ExecutorsFactory.newServerListenerSharedExecutor()) {
+        try (TestLogHandler handler = TestLogHandler.install(ExecutorsFactory.class);
+                executor) {
             executor.execute(() -> {
                 throw failure;
             });
@@ -63,8 +72,8 @@ class ExecutorsFactoryTest {
             setLevel(Level.ALL);
         }
 
-        static TestLogHandler install() {
-            Logger logger = Logger.getLogger(ExecutorsFactory.class.getName());
+        static TestLogHandler install(Class<?> clazz) {
+            Logger logger = Logger.getLogger(clazz.getName());
             TestLogHandler handler = new TestLogHandler(logger);
             logger.setLevel(Level.ALL);
             logger.addHandler(handler);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ExecutorsFactoryTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ExecutorsFactoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+class ExecutorsFactoryTest {
+
+    @Test
+    void sharedExecutorLogsUncaughtException() throws Exception {
+        IllegalStateException failure = new IllegalStateException("test failure");
+
+        try (TestLogHandler handler = TestLogHandler.install();
+                ExecutorService executor = ExecutorsFactory.newServerListenerSharedExecutor()) {
+            executor.execute(() -> {
+                throw failure;
+            });
+
+            LogRecord record = handler.await();
+
+            assertThat(record.getMessage(), containsString("Uncaught exception in WebServer executor thread"));
+            assertThat(record.getThrown(), sameInstance(failure));
+        }
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final Logger logger;
+        private final Level previousLevel;
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private final AtomicReference<LogRecord> record = new AtomicReference<>();
+
+        private TestLogHandler(Logger logger) {
+            this.logger = logger;
+            this.previousLevel = logger.getLevel();
+            setLevel(Level.ALL);
+        }
+
+        static TestLogHandler install() {
+            Logger logger = Logger.getLogger(ExecutorsFactory.class.getName());
+            TestLogHandler handler = new TestLogHandler(logger);
+            logger.setLevel(Level.ALL);
+            logger.addHandler(handler);
+            return handler;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (this.record.compareAndSet(null, record)) {
+                latch.countDown();
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setLevel(previousLevel);
+        }
+
+        private LogRecord await() throws InterruptedException {
+            assertThat(latch.await(5, TimeUnit.SECONDS), is(true));
+            return record.get();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #6180

Adds WebServer virtual-thread uncaught exception handlers for executor-service paths and logs unexpected failures from fire-and-forget WebServer work.
