### PR TITLE
Fix intercepted field injection descriptor generation (27.x)

### DIFF
--- a/service/tests/interception/src/main/java/io/helidon/service/tests/interception/FieldInjectedDependency.java
+++ b/service/tests/interception/src/main/java/io/helidon/service/tests/interception/FieldInjectedDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,11 @@
 
 package io.helidon.service.tests.interception;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import io.helidon.service.registry.Service;
 
-import io.helidon.service.registry.Interception;
-
-/**
- * Modify call.
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Documented
-@Interception.Intercepted
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
-@Inherited
-@interface Modify {
+@Service.Singleton
+class FieldInjectedDependency {
+    String message() {
+        return "field injected";
+    }
 }

--- a/service/tests/interception/src/main/java/io/helidon/service/tests/interception/FieldInjectionService.java
+++ b/service/tests/interception/src/main/java/io/helidon/service/tests/interception/FieldInjectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,15 @@
 
 package io.helidon.service.tests.interception;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import io.helidon.service.registry.Service;
 
-import io.helidon.service.registry.Interception;
+@Service.Singleton
+class FieldInjectionService {
+    @Service.Inject
+    @Modify
+    FieldInjectedDependency dependency;
 
-/**
- * Modify call.
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Documented
-@Interception.Intercepted
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
-@Inherited
-@interface Modify {
+    String dependencyMessage() {
+        return dependency.message();
+    }
 }

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/FieldInjectionInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/FieldInjectionInterceptionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.interception;
+
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class FieldInjectionInterceptionTest {
+    private static final ServiceRegistryManager REGISTRY_MANAGER = ServiceRegistryManager.create();
+    private static final ServiceRegistry REGISTRY = REGISTRY_MANAGER.registry();
+
+    @AfterAll
+    static void shutdown() {
+        REGISTRY_MANAGER.shutdown();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        ModifyingInterceptor.lastCall();
+    }
+
+    @Test
+    void fieldInjectionCanBeIntercepted() {
+        FieldInjectionService service = REGISTRY.get(FieldInjectionService.class);
+        Invocation invocation = ModifyingInterceptor.lastCall();
+
+        assertAll(
+                () -> assertThat(service.dependencyMessage(), is("field injected")),
+                () -> assertThat(invocation, notNullValue()),
+                () -> assertThat(invocation.methodName(), equalTo("dependency")),
+                () -> assertThat(invocation.args().length, is(1)),
+                () -> assertThat(invocation.args()[0], instanceOf(FieldInjectedDependency.class))
+        );
+    }
+}


### PR DESCRIPTION
Resolves #12031

Fix service descriptor generation for intercepted field injection so the generated assignment invokes the field-specific interception invoker. Add interception test coverage for a non-`config` field injection to prove the generated descriptor compiles and the field injection interceptor runs.
