### PR TITLE
Add declarative CookieParam, FormParam, and RequestParams support (27.x)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/HttpCodegenValidation.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/HttpCodegenValidation.java
@@ -73,6 +73,18 @@ public final class HttpCodegenValidation {
     }
 
     /**
+     * Whether annotations contain a supported endpoint method parameter annotation.
+     *
+     * @param annotations annotations to inspect
+     * @return whether any supported endpoint method parameter annotation is present
+     */
+    public static boolean hasMethodParameterAnnotation(Collection<Annotation> annotations) {
+        return annotations.stream()
+                .map(Annotation::typeName)
+                .anyMatch(METHOD_PARAMETER_ANNOTATIONS::contains);
+    }
+
+    /**
      * Validate that a request parameter record component contains at most one supported request parameter annotation.
      *
      * @param annotations annotations to inspect

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/HttpCodegenValidation.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/HttpCodegenValidation.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.helidon.codegen.CodegenException;
+import io.helidon.common.Api;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypedElementInfo;
+
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_COOKIE_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_ENTITY_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PATH_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_QUERY_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_REQUEST_PARAMS_ANNOTATION;
+
+/**
+ * HTTP validation utilities used by code generation.
+ */
+@Api.Internal
+public final class HttpCodegenValidation {
+    private static final List<TypeName> METHOD_PARAMETER_ANNOTATIONS = List.of(HTTP_HEADER_PARAM_ANNOTATION,
+                                                                               HTTP_COOKIE_PARAM_ANNOTATION,
+                                                                               HTTP_QUERY_PARAM_ANNOTATION,
+                                                                               HTTP_FORM_PARAM_ANNOTATION,
+                                                                               HTTP_PATH_PARAM_ANNOTATION,
+                                                                               HTTP_ENTITY_ANNOTATION,
+                                                                               HTTP_REQUEST_PARAMS_ANNOTATION);
+    private static final List<TypeName> REQUEST_PARAMS_COMPONENT_ANNOTATIONS = List.of(HTTP_HEADER_PARAM_ANNOTATION,
+                                                                                      HTTP_COOKIE_PARAM_ANNOTATION,
+                                                                                      HTTP_QUERY_PARAM_ANNOTATION,
+                                                                                      HTTP_FORM_PARAM_ANNOTATION,
+                                                                                      HTTP_PATH_PARAM_ANNOTATION,
+                                                                                      HTTP_ENTITY_ANNOTATION);
+
+    private HttpCodegenValidation() {
+    }
+
+    /**
+     * Validate that endpoint method parameter annotations contain at most one supported request parameter annotation.
+     *
+     * @param annotations annotations to inspect
+     * @param message validation failure message
+     * @param originatingElement originating element
+     */
+    public static void validateMethodParameterAnnotationCount(Collection<Annotation> annotations,
+                                                              String message,
+                                                              Object originatingElement) {
+        validateSupportedAnnotationCount(annotations, METHOD_PARAMETER_ANNOTATIONS, message, originatingElement);
+    }
+
+    /**
+     * Validate that a request parameter record component contains at most one supported request parameter annotation.
+     *
+     * @param annotations annotations to inspect
+     * @param message validation failure message
+     * @param originatingElement originating element
+     */
+    public static void validateRequestParamsComponentAnnotationCount(Collection<Annotation> annotations,
+                                                                     String message,
+                                                                     Object originatingElement) {
+        validateSupportedAnnotationCount(annotations, REQUEST_PARAMS_COMPONENT_ANNOTATIONS, message, originatingElement);
+    }
+
+    /**
+     * Find the first supported request parameter record component annotation.
+     *
+     * @param annotations annotations to inspect
+     * @return first supported request parameter record component annotation
+     */
+    public static Optional<Annotation> firstRequestParamsComponentAnnotation(Collection<Annotation> annotations) {
+        return annotations.stream()
+                .filter(it -> REQUEST_PARAMS_COMPONENT_ANNOTATIONS.contains(it.typeName()))
+                .findFirst();
+    }
+
+    /**
+     * Whether the annotation collection contains the annotation type.
+     *
+     * @param annotations annotations to inspect
+     * @param annotation annotation type
+     * @return whether the annotation collection contains the annotation type
+     */
+    public static boolean hasAnnotation(Collection<Annotation> annotations, TypeName annotation) {
+        return annotations.stream()
+                .anyMatch(it -> it.typeName().equals(annotation));
+    }
+
+    /**
+     * Resolve and validate a request parameter record type.
+     *
+     * @param typeInfoResolver type info resolver
+     * @param requestParamsType request parameter type
+     * @param originatingElement originating element
+     * @return resolved request parameter record type
+     */
+    public static TypeInfo requestParamsRecordType(Function<TypeName, Optional<TypeInfo>> typeInfoResolver,
+                                                   TypeName requestParamsType,
+                                                   Object originatingElement) {
+        TypeInfo typeInfo = typeInfoResolver.apply(requestParamsType)
+                .orElseThrow(() -> new CodegenException("Cannot find type information for @Http.RequestParams type "
+                                                                + requestParamsType.fqName() + ".",
+                                                        originatingElement));
+        if (typeInfo.kind() != ElementKind.RECORD) {
+            throw new CodegenException("@Http.RequestParams type must be a record. Type "
+                                               + requestParamsType.fqName() + " is " + typeInfo.kind() + ".",
+                                       typeInfo.originatingElementValue());
+        }
+        return typeInfo;
+    }
+
+    /**
+     * Validate body parameter rules for a request parameter record.
+     *
+     * @param requestParamsType request parameter record type
+     */
+    public static void validateRequestParamsBodyComponents(TypeInfo requestParamsType) {
+        int entityCount = 0;
+        int formCount = 0;
+        TypedElementInfo firstBodyComponent = null;
+
+        for (TypedElementInfo component : requestParamsComponents(requestParamsType)) {
+            validateRequestParamsComponentAnnotationCount(component.annotations(),
+                                                         "Record component '" + component.elementName()
+                                                                 + "' of @Http.RequestParams type "
+                                                                 + requestParamsType.typeName().fqName()
+                                                                 + " must have at most one supported request "
+                                                                 + "parameter annotation.",
+                                                         component.originatingElementValue());
+            if (hasAnnotation(component.annotations(), HTTP_ENTITY_ANNOTATION)) {
+                entityCount++;
+                if (firstBodyComponent == null) {
+                    firstBodyComponent = component;
+                }
+            }
+            if (hasAnnotation(component.annotations(), HTTP_FORM_PARAM_ANNOTATION)) {
+                formCount++;
+                if (firstBodyComponent == null) {
+                    firstBodyComponent = component;
+                }
+            }
+        }
+
+        if (entityCount > 1) {
+            throw new CodegenException("Only one @Http.Entity record component is supported in @Http.RequestParams type "
+                                               + requestParamsType.typeName().fqName() + ".",
+                                       firstBodyComponent.originatingElementValue());
+        }
+        if (entityCount > 0 && formCount > 0) {
+            throw new CodegenException("@Http.Entity and @Http.FormParam record components cannot be combined in "
+                                               + "@Http.RequestParams type " + requestParamsType.typeName().fqName() + ".",
+                                       firstBodyComponent.originatingElementValue());
+        }
+    }
+
+    /**
+     * Components of a request parameter record.
+     *
+     * @param requestParamsType request parameter record type
+     * @return record components
+     */
+    public static List<TypedElementInfo> requestParamsComponents(TypeInfo requestParamsType) {
+        return requestParamsType.elementInfo()
+                .stream()
+                .filter(it -> it.kind() == ElementKind.RECORD_COMPONENT)
+                .toList();
+    }
+
+    /**
+     * Validate a cookie parameter name.
+     *
+     * @param name cookie parameter name
+     * @param annotationName annotation name for diagnostics
+     * @param originatingElement originating element
+     */
+    public static void validateCookieName(String name, String annotationName, Object originatingElement) {
+        if (!isToken(name)) {
+            throw invalidCookieName(annotationName, originatingElement);
+        }
+    }
+
+    private static void validateSupportedAnnotationCount(Collection<Annotation> annotations,
+                                                         List<TypeName> supportedAnnotationTypes,
+                                                         String message,
+                                                         Object originatingElement) {
+        long supportedAnnotations = annotations.stream()
+                .map(Annotation::typeName)
+                .filter(supportedAnnotationTypes::contains)
+                .count();
+        if (supportedAnnotations > 1) {
+            throw new CodegenException(message, originatingElement);
+        }
+    }
+
+    private static boolean isToken(String token) {
+        if (token.isEmpty()) {
+            return false;
+        }
+
+        for (int i = 0; i < token.length(); i++) {
+            char c = token.charAt(i);
+            if (c > 254 || Character.isISOControl(c) || Character.isWhitespace(c)) {
+                return false;
+            }
+            switch (c) {
+            case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}' -> {
+                return false;
+            }
+            default -> {
+                // valid token character
+            }
+            }
+        }
+
+        return true;
+    }
+
+    private static CodegenException invalidCookieName(String annotationName, Object originatingElement) {
+        String message = annotationName + " value must be a valid cookie name.";
+        if (originatingElement == null) {
+            return new CodegenException(message);
+        }
+        return new CodegenException(message, originatingElement);
+    }
+}

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/HttpTypes.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/HttpTypes.java
@@ -55,6 +55,10 @@ public final class HttpTypes {
      */
     public static final TypeName HTTP_HEADER_VALUES = TypeName.create("io.helidon.http.HeaderValues");
     /**
+     * HTTP support methods used from generated code.
+     */
+    public static final TypeName HTTP_SUPPORT = TypeName.create("io.helidon.http.HttpSupport");
+    /**
      * Http.Path annotation.
      */
     public static final TypeName HTTP_PATH_ANNOTATION = TypeName.create("io.helidon.http.Http.Path");
@@ -75,9 +79,17 @@ public final class HttpTypes {
      */
     public static final TypeName HTTP_PATH_PARAM_ANNOTATION = TypeName.create("io.helidon.http.Http.PathParam");
     /**
+     * Http.CookieParam annotation.
+     */
+    public static final TypeName HTTP_COOKIE_PARAM_ANNOTATION = TypeName.create("io.helidon.http.Http.CookieParam");
+    /**
      * Http.QueryParam annotation.
      */
     public static final TypeName HTTP_QUERY_PARAM_ANNOTATION = TypeName.create("io.helidon.http.Http.QueryParam");
+    /**
+     * Http.FormParam annotation.
+     */
+    public static final TypeName HTTP_FORM_PARAM_ANNOTATION = TypeName.create("io.helidon.http.Http.FormParam");
     /**
      * Http.HeaderParam annotation.
      */
@@ -86,6 +98,10 @@ public final class HttpTypes {
      * Http.Entity annotation.
      */
     public static final TypeName HTTP_ENTITY_ANNOTATION = TypeName.create("io.helidon.http.Http.Entity");
+    /**
+     * Http.RequestParams annotation.
+     */
+    public static final TypeName HTTP_REQUEST_PARAMS_ANNOTATION = TypeName.create("io.helidon.http.Http.RequestParams");
     /**
      * HTTP Header function.
      */

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
@@ -348,6 +348,8 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
                                              Method.Builder it,
                                              RestMethod method,
                                              Map<String, String> headerProducers) {
+        validateMethodParameters(method);
+
         method.parameters()
                 .forEach(param -> it.addParameter(newParam -> newParam
                         .name(param.name())
@@ -606,6 +608,17 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
             it.addContentLine("return declarative__response.entity();");
         } else {
             it.addContentLine("}");
+        }
+    }
+
+    private void validateMethodParameters(RestMethod method) {
+        for (RestMethodParameter parameter : method.parameters()) {
+            if (!HttpCodegenValidation.hasMethodParameterAnnotation(parameter.annotations())) {
+                throw new CodegenException("Parameter '" + parameter.name() + "' of declarative client method "
+                                                   + method.type().typeName().fqName() + "." + method.name()
+                                                   + "() must be annotated with a supported request parameter annotation.",
+                                           parameter.parameter().originatingElementValue());
+            }
         }
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -47,6 +48,7 @@ import io.helidon.common.types.TypedElementInfo;
 import io.helidon.declarative.codegen.DeclarativeTypes;
 import io.helidon.declarative.codegen.DeclarativeUtils;
 import io.helidon.declarative.codegen.DelcarativeConfigSupport;
+import io.helidon.declarative.codegen.http.HttpCodegenValidation;
 import io.helidon.declarative.codegen.http.HttpFields;
 import io.helidon.declarative.codegen.http.RestExtensionBase;
 import io.helidon.declarative.codegen.model.http.ClientEndpoint;
@@ -61,12 +63,16 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 
 import static io.helidon.declarative.codegen.DeclarativeTypes.CONFIG;
 import static io.helidon.declarative.codegen.DeclarativeTypes.SINGLETON_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_COOKIE_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_ENTITY_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_NAMES;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_PARAM_ANNOTATION;
-import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_VALUES;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PATH_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_QUERY_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_REQUEST_PARAMS_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_SUPPORT;
 import static io.helidon.declarative.codegen.http.restclient.RestClientTypes.REST_CLIENT_COMPUTED_HEADER;
 import static io.helidon.declarative.codegen.http.restclient.RestClientTypes.REST_CLIENT_COMPUTED_HEADERS;
 import static io.helidon.declarative.codegen.http.restclient.RestClientTypes.REST_CLIENT_ENDPOINT;
@@ -210,6 +216,12 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
                                                                                        methodInfo,
                                                                                        parameterInfo,
                                                                                        index));
+        HttpCodegenValidation.validateMethodParameterAnnotationCount(
+                annotations,
+                "Parameter '" + parameterInfo.elementName() + "' of declarative client method "
+                        + typeInfo.typeName().fqName() + "." + methodInfo.elementName()
+                        + "() must have at most one supported request parameter annotation.",
+                parameterInfo.originatingElementValue());
         var parameter = RestMethodParameter.builder()
                 .annotations(annotations)
                 .name(parameterInfo.elementName())
@@ -297,6 +309,10 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
 
         Map<String, String> headerProducerFields = headerProducers(fieldHandler, endpoint);
 
+        if (hasParameterValueHelper(endpoint)) {
+            addParameterValueHelper(classModel);
+        }
+
         for (RestMethod method : endpoint.methods()) {
             generateMethod(fieldHandler,
                            classModel,
@@ -336,8 +352,24 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
                 .forEach(param -> it.addParameter(newParam -> newParam
                         .name(param.name())
                         .type(param.typeName())));
+        addRequestParamsNullChecks(it, method);
 
-        if (method.pathParameters().isEmpty()) {
+        List<ClientParameter> clientParameters = clientParameters(method);
+        List<ClientParameter> pathParameters = annotatedParameters(clientParameters, HTTP_PATH_PARAM_ANNOTATION);
+        List<ClientParameter> formParameters = annotatedParameters(clientParameters, HTTP_FORM_PARAM_ANNOTATION);
+        List<ClientParameter> entityParameters = annotatedParameters(clientParameters, HTTP_ENTITY_ANNOTATION);
+        if (entityParameters.size() > 1) {
+            throw new CodegenException("Only one @Http.Entity parameter is supported on declarative client method "
+                                               + method.type().typeName().fqName() + "." + method.name() + "().",
+                                       entityParameters.getFirst().originatingElement().originatingElementValue());
+        }
+        if (!entityParameters.isEmpty() && !formParameters.isEmpty()) {
+            throw new CodegenException("@Http.Entity and @Http.FormParam cannot be combined on declarative client method "
+                                               + method.type().typeName().fqName() + "." + method.name() + "().",
+                                       entityParameters.getFirst().originatingElement().originatingElementValue());
+        }
+
+        if (pathParameters.isEmpty()) {
             String path = method.path().orElse(null);
             it.addContent("var declarative__uri = baseUri");
             if (path == null) {
@@ -382,10 +414,9 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
 
             var pathParamNameToParameterName = new HashMap<String, String>();
 
-            for (RestMethodParameter pathParameter : method.pathParameters()) {
-                String paramName = pathParameter.name();
+            for (ClientParameter pathParameter : pathParameters) {
                 String pathParam = pathParamNameFromPathParam(pathParameter);
-                pathParamNameToParameterName.put(pathParam, paramName);
+                pathParamNameToParameterName.put(pathParam, valueExpression(pathParameter));
             }
 
             it.addContent("var declarative__uri = baseUri")
@@ -404,46 +435,73 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
                     .addContent(HttpFields.ensureHttpMethodConstant(fieldHandler, method.httpMethod().name()))
                     .addContentLine(").path(declarative__uri);");
         }
+
+        List<ClientParameter> headerParameters = annotatedParameters(clientParameters, HTTP_HEADER_PARAM_ANNOTATION);
+        List<ClientParameter> cookieParameters = annotatedParameters(clientParameters, HTTP_COOKIE_PARAM_ANNOTATION);
+        boolean hasCookieHeaders = hasCookieHeaders(method, headerParameters, cookieParameters);
+        if (hasCookieHeaders) {
+            it.addContentLine("var declarative__cookies = new java.util.ArrayList<String>();");
+        }
+
         // now each header value, header producer, and header parameter
         for (HeaderValue header : method.headers()) {
-            it.addContent("declarative__builder.header(")
-                    .addContent(HttpFields.ensureHeaderValueConstant(fieldHandler, header))
-                    .addContentLine(");");
+            if (isCookieHeader(header.name())) {
+                it.addContent("declarative__cookies.add(")
+                        .addContentLiteral(header.value())
+                        .addContentLine(");");
+            } else {
+                it.addContent("declarative__builder.header(")
+                        .addContent(HttpFields.ensureHeaderValueConstant(fieldHandler, header))
+                        .addContentLine(");");
+            }
         }
         for (ComputedHeader computedHeader : method.computedHeaders()) {
             String headerNameConstant = HttpFields.ensureHeaderNameConstant(fieldHandler, computedHeader.headerName());
 
-            it.addContent(headerProducers.get(computedHeader.serviceName()))
-                    .addContent(".apply(")
-                    .addContent(headerNameConstant)
-                    .addContent(").ifPresent(declarative__it -> declarative__builder.header(declarative__it));");
+            if (isCookieHeader(computedHeader.headerName())) {
+                it.addContent(headerProducers.get(computedHeader.serviceName()))
+                        .addContent(".apply(")
+                        .addContent(headerNameConstant)
+                        .addContentLine(")")
+                        .increaseContentPadding()
+                        .increaseContentPadding()
+                        .addContentLine(".ifPresent(declarative__it -> "
+                                                + "declarative__cookies.addAll(declarative__it.allValues()));")
+                        .decreaseContentPadding()
+                        .decreaseContentPadding();
+            } else {
+                it.addContent(headerProducers.get(computedHeader.serviceName()))
+                        .addContent(".apply(")
+                        .addContent(headerNameConstant)
+                        .addContent(").ifPresent(declarative__it -> declarative__builder.header(declarative__it));");
+            }
         }
-        for (RestMethodParameter headerParameter : method.headerParameters()) {
-            it.addContent("declarative__builder.header(")
-                    .addContent(HTTP_HEADER_VALUES)
-                    .addContent(".create(")
-                    .addContent(HttpFields.ensureHeaderNameConstant(fieldHandler, headerNameFromHeaderParam(headerParameter)))
-                    .addContent(", ")
-                    .addContent(headerParameter.name())
-                    .addContentLine("));");
+        for (ClientParameter headerParameter : headerParameters) {
+            if (isCookieHeader(headerNameFromHeaderParam(headerParameter))) {
+                addCookieHeaderParameter(it, headerParameter);
+            } else {
+                addHeaderParameter(it, fieldHandler, headerParameter);
+            }
+        }
+        if (!cookieParameters.isEmpty()) {
+            for (ClientParameter cookieParameter : cookieParameters) {
+                addCookieParameter(it, cookieParameter);
+            }
+        }
+        if (hasCookieHeaders) {
+            it.addContentLine("if (!declarative__cookies.isEmpty()) {")
+                    .increaseContentPadding()
+                    .addContent("declarative__builder.header(")
+                    .addContent(HTTP_HEADER_NAMES)
+                    .addContent(".COOKIE, ")
+                    .addContent(HTTP_SUPPORT)
+                    .addContentLine(".cookieHeader(declarative__cookies));")
+                    .decreaseContentPadding()
+                    .addContentLine("}");
         }
         // query parameter
-        for (RestMethodParameter parameter : method.queryParameters()) {
-            boolean optional = parameter.typeName().isOptional();
-            String queryParamName = queryParameterName(parameter);
-            if (optional) {
-                it.addContent(parameter.name())
-                        .addContent(".ifPresent(declarative__it -> declarative__builder.queryParam(\"")
-                        .addContent(queryParamName)
-                        .addContent("\", String.valueOf(declarative__it)));");
-            } else {
-                it.addContent("declarative__builder.queryParam(\"")
-                        .addContent(queryParamName)
-                        .addContent("\", String.valueOf(")
-                        .addContent(parameter.name())
-                        .addContentLine(")));");
-            }
-
+        for (ClientParameter parameter : annotatedParameters(clientParameters, HTTP_QUERY_PARAM_ANNOTATION)) {
+            addQueryParameter(it, parameter);
         }
 
         List<String> produces = method.produces();
@@ -462,7 +520,14 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
                     .addContentLine(");");
         }
 
-        boolean hasEntity = method.entityParameter().isPresent();
+        if (!formParameters.isEmpty()) {
+            it.addContentLine("var declarative__formParams = io.helidon.common.parameters.Parameters.builder(\"form-params\");");
+            for (ClientParameter formParameter : formParameters) {
+                addFormParameter(it, formParameter);
+            }
+        }
+
+        boolean hasEntity = !entityParameters.isEmpty() || !formParameters.isEmpty();
         boolean hasResponse = !(
                 method.returnType().equals(TypeNames.BOXED_VOID)
                         || method.returnType().equals(TypeNames.PRIMITIVE_VOID));
@@ -495,7 +560,7 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
          */
         if (hasEntity && hasResponse) {
             it.addContent("var declarative__response = declarative__builder.submit(")
-                    .addContent(method.entityParameter().get().name())
+                    .addContent(entityExpression(entityParameters, formParameters))
                     .addContent(", ");
             if (useGenericType) {
                 it.addContent(genericTypeField);
@@ -506,7 +571,7 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
             it.addContentLine(");");
         } else if (hasEntity) {
             it.addContent("try (var declarative__response = declarative__builder.submit(")
-                    .addContent(method.entityParameter().get().name())
+                    .addContent(entityExpression(entityParameters, formParameters))
                     .addContentLine(")) {");
         } else if (hasResponse) {
             it.addContent("var declarative__response = declarative__builder.request(");
@@ -544,33 +609,434 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         }
     }
 
-    private String queryParameterName(RestMethodParameter parameter) {
-        return Annotations.findFirst(HTTP_QUERY_PARAM_ANNOTATION,
-                                     parameter.annotations())
-                .flatMap(Annotation::value)
-                .orElseThrow(() -> new CodegenException("Parameter is recognized as @Http.QueryParam yet it is not annotated: "
-                                                                + parameter.name(), parameter.parameter()
-                                                                .originatingElementValue()));
-    }
-
-    private String pathParamNameFromPathParam(RestMethodParameter parameter) {
-        return Annotations.findFirst(HTTP_PATH_PARAM_ANNOTATION,
-                                     parameter.annotations())
-                .flatMap(Annotation::value)
-                .orElseThrow(() -> new CodegenException("Parameter is recognized as @Http.HeaderParam yet it is not annotated: "
-                                                                + parameter.name(), parameter.parameter()
-                                                                .originatingElementValue()));
-    }
-
-    private String headerNameFromHeaderParam(RestMethodParameter parameter) {
-        for (Annotation annotation : parameter.annotations()) {
-            if (annotation.typeName().equals(HTTP_HEADER_PARAM_ANNOTATION)) {
-                return annotation.value().orElseThrow();
+    private List<ClientParameter> clientParameters(RestMethod method) {
+        List<ClientParameter> result = new ArrayList<>();
+        for (RestMethodParameter parameter : method.parameters()) {
+            if (Annotations.findFirst(HTTP_REQUEST_PARAMS_ANNOTATION, parameter.annotations()).isPresent()) {
+                addRequestParamsComponents(result, parameter);
+            } else {
+                result.add(ClientParameter.create(parameter));
             }
         }
-        throw new CodegenException("Parameter is recognized as @Http.HeaderParam yet it is not annotated: "
-                                           + parameter.name(), parameter.parameter()
-                                           .originatingElementValue());
+        return result;
+    }
+
+    private void addRequestParamsComponents(List<ClientParameter> result, RestMethodParameter parameter) {
+        TypeInfo requestParamsType = HttpCodegenValidation.requestParamsRecordType(
+                ctx::typeInfo,
+                parameter.typeName(),
+                parameter.parameter().originatingElementValue());
+
+        HttpCodegenValidation.validateRequestParamsBodyComponents(requestParamsType);
+
+        for (TypedElementInfo component : HttpCodegenValidation.requestParamsComponents(requestParamsType)) {
+            Set<Annotation> annotations = new HashSet<>(component.annotations());
+            if (HttpCodegenValidation.firstRequestParamsComponentAnnotation(annotations).isEmpty()) {
+                throw new CodegenException("Record component '" + component.elementName()
+                                                   + "' of @Http.RequestParams type " + parameter.typeName().fqName()
+                                                   + " is not annotated with a supported request parameter annotation.",
+                                           component.originatingElementValue());
+            }
+            result.add(ClientParameter.create(component,
+                                              parameter.name() + "." + component.elementName() + "()",
+                                              annotations));
+        }
+    }
+
+    private List<ClientParameter> annotatedParameters(List<ClientParameter> parameters, TypeName annotation) {
+        return parameters.stream()
+                .filter(it -> Annotations.findFirst(annotation, it.annotations()).isPresent())
+                .toList();
+    }
+
+    private boolean hasParameterValueHelper(ClientEndpoint endpoint) {
+        return endpoint.methods()
+                .stream()
+                .map(this::clientParameters)
+                .flatMap(List::stream)
+                .anyMatch(this::isValueParameter);
+    }
+
+    private boolean isValueParameter(ClientParameter parameter) {
+        return Annotations.findFirst(HTTP_HEADER_PARAM_ANNOTATION, parameter.annotations()).isPresent()
+                || Annotations.findFirst(HTTP_QUERY_PARAM_ANNOTATION, parameter.annotations()).isPresent()
+                || Annotations.findFirst(HTTP_PATH_PARAM_ANNOTATION, parameter.annotations()).isPresent()
+                || Annotations.findFirst(HTTP_COOKIE_PARAM_ANNOTATION, parameter.annotations()).isPresent()
+                || Annotations.findFirst(HTTP_FORM_PARAM_ANNOTATION, parameter.annotations()).isPresent();
+    }
+
+    private void addRequestParamsNullChecks(Method.Builder method, RestMethod restMethod) {
+        restMethod.parameters()
+                .stream()
+                .filter(parameter -> Annotations.findFirst(HTTP_REQUEST_PARAMS_ANNOTATION, parameter.annotations()).isPresent())
+                .forEach(parameter -> method.addContent(Objects.class)
+                        .addContent(".requireNonNull(")
+                        .addContent(parameter.name())
+                        .addContent(", ")
+                        .addContentLiteral("@Http.RequestParams parameter " + parameter.name() + " must not be null.")
+                        .addContentLine(");"));
+    }
+
+    private boolean hasCookieHeaders(RestMethod method,
+                                     List<ClientParameter> headerParameters,
+                                     List<ClientParameter> cookieParameters) {
+        return !cookieParameters.isEmpty()
+                || method.headers()
+                        .stream()
+                        .map(HeaderValue::name)
+                        .anyMatch(this::isCookieHeader)
+                || method.computedHeaders()
+                        .stream()
+                        .map(ComputedHeader::headerName)
+                        .anyMatch(this::isCookieHeader)
+                || headerParameters.stream()
+                        .map(this::headerNameFromHeaderParam)
+                        .anyMatch(this::isCookieHeader);
+    }
+
+    private boolean isCookieHeader(String headerName) {
+        return "cookie".equals(headerName.toLowerCase(Locale.ROOT));
+    }
+
+    private void addParameterValueHelper(ClassModel.Builder classModel) {
+        classModel.addMethod(method -> method
+                .accessModifier(AccessModifier.PRIVATE)
+                .isStatic(true)
+                .returnType(TypeNames.STRING)
+                .name("declarative__parameterValue")
+                .addParameter(param -> param
+                        .type(TypeNames.STRING)
+                        .name("source"))
+                .addParameter(param -> param
+                        .type(TypeNames.STRING)
+                        .name("name"))
+                .addParameter(param -> param
+                        .type(TypeNames.OBJECT)
+                        .name("value"))
+                .addContent("return String.valueOf(")
+                .addContent(Objects.class)
+                .addContentLine(".requireNonNull(value, source + \" \" + name + \" must not be null.\"));"));
+    }
+
+    private void addHeaderParameter(Method.Builder method, FieldHandler fieldHandler, ClientParameter parameter) {
+        String headerName = headerNameFromHeaderParam(parameter);
+        addBuilderParameter(method,
+                            parameter,
+                            "Header",
+                            headerName,
+                            "declarative__builder.header("
+                                    + HttpFields.ensureHeaderNameConstant(fieldHandler, headerName) + ", ",
+                            ")");
+    }
+
+    private void addCookieHeaderParameter(Method.Builder method, ClientParameter parameter) {
+        String headerName = headerNameFromHeaderParam(parameter);
+        TypeName type = parameter.typeName();
+        if (type.isOptional()) {
+            TypeName optionalType = type.typeArguments().getFirst();
+            if (optionalType.isList()) {
+                addRequireNonNull(method, "Header", headerName, parameter.expression());
+                method
+                        .addContent(".ifPresent(declarative__it -> declarative__it.stream()")
+                        .addContent(".map(declarative__value -> ");
+                addParameterValue(method, "Header", headerName, "declarative__value");
+                method.addContent(")")
+                        .addContentLine(".forEach(declarative__cookies::add));");
+            } else {
+                addRequireNonNull(method, "Header", headerName, parameter.expression());
+                method
+                        .addContent(".ifPresent(declarative__it -> declarative__cookies.add(");
+                addParameterValue(method, "Header", headerName, "declarative__it");
+                method.addContent("))")
+                        .addContentLine(";");
+            }
+        } else if (type.isList()) {
+            addRequireNonNull(method, "Header", headerName, parameter.expression());
+            method.addContent(".stream().map(declarative__value -> ");
+            addParameterValue(method, "Header", headerName, "declarative__value");
+            method.addContent(")")
+                    .addContentLine(".forEach(declarative__cookies::add);");
+        } else {
+            method.addContent("declarative__cookies.add(");
+            addParameterValue(method, "Header", headerName, parameter.expression());
+            method.addContentLine(");");
+        }
+    }
+
+    private void addCookieParameter(Method.Builder method, ClientParameter parameter) {
+        String cookieName = cookieParamName(parameter);
+        TypeName type = parameter.typeName();
+        if (type.isOptional()) {
+            TypeName optionalType = type.typeArguments().getFirst();
+            if (optionalType.isList()) {
+                addRequireNonNull(method, "Cookie parameter", cookieName, parameter.expression());
+                method
+                        .addContent(".ifPresent(declarative__it -> declarative__it.stream()")
+                        .addContent(".map(declarative__value -> ")
+                        .addContent(HTTP_SUPPORT)
+                        .addContent(".cookie(")
+                        .addContentLiteral(cookieName)
+                        .addContent(", ");
+                addParameterValue(method, "Cookie parameter", cookieName, "declarative__value");
+                method.addContent("))")
+                        .addContentLine(".forEach(declarative__cookies::add));");
+            } else {
+                addRequireNonNull(method, "Cookie parameter", cookieName, parameter.expression());
+                method
+                        .addContent(".ifPresent(declarative__it -> declarative__cookies.add(")
+                        .addContent(HTTP_SUPPORT)
+                        .addContent(".cookie(")
+                        .addContentLiteral(cookieName)
+                        .addContent(", ");
+                addParameterValue(method, "Cookie parameter", cookieName, "declarative__it");
+                method.addContentLine(")));");
+            }
+        } else if (type.isList()) {
+            method.addContent("if (")
+                    .update(it -> addRequireNonNull(it, "Cookie parameter", cookieName, parameter.expression()))
+                    .addContentLine(".isEmpty()) {")
+                    .increaseContentPadding()
+                    .addContent("throw new IllegalArgumentException(")
+                    .addContentLiteral("Cookie parameter " + cookieName + " has no values.")
+                    .addContentLine(");")
+                    .decreaseContentPadding()
+                    .addContentLine("}");
+            addRequireNonNull(method, "Cookie parameter", cookieName, parameter.expression());
+            method
+                    .addContent(".stream().map(declarative__it -> ")
+                    .addContent(HTTP_SUPPORT)
+                    .addContent(".cookie(")
+                    .addContentLiteral(cookieName)
+                    .addContent(", ");
+            addParameterValue(method, "Cookie parameter", cookieName, "declarative__it");
+            method.addContent("))")
+                    .addContentLine(".forEach(declarative__cookies::add);");
+        } else {
+            method.addContent("declarative__cookies.add(")
+                    .addContent(HTTP_SUPPORT)
+                    .addContent(".cookie(")
+                    .addContentLiteral(cookieName)
+                    .addContent(", ");
+            addParameterValue(method, "Cookie parameter", cookieName, parameter.expression());
+            method
+                    .addContentLine("));");
+        }
+    }
+
+    private void addQueryParameter(Method.Builder method, ClientParameter parameter) {
+        String queryName = queryParameterName(parameter);
+        TypeName type = parameter.typeName();
+        if (type.isOptional()) {
+            TypeName optionalType = type.typeArguments().getFirst();
+            if (optionalType.isList()) {
+                addRequireNonNull(method, "Query parameter", queryName, parameter.expression());
+                method.addContent(".ifPresent(declarative__it -> ");
+                addQueryParameterStart(method, queryName);
+                method.addContent("declarative__it.stream().map(declarative__value -> ");
+                addParameterValue(method, "Query parameter", queryName, "declarative__value");
+                method.addContent(").toArray(String[]::new))")
+                        .addContentLine(");");
+            } else {
+                addRequireNonNull(method, "Query parameter", queryName, parameter.expression());
+                method.addContent(".ifPresent(declarative__it -> ");
+                addQueryParameterStart(method, queryName);
+                addParameterValue(method, "Query parameter", queryName, "declarative__it");
+                method.addContentLine("));");
+            }
+        } else if (type.isList()) {
+            addQueryParameterStart(method, queryName);
+            addRequireNonNull(method, "Query parameter", queryName, parameter.expression());
+            method.addContent(".stream().map(declarative__value -> ");
+            addParameterValue(method, "Query parameter", queryName, "declarative__value");
+            method.addContent(").toArray(String[]::new))")
+                    .addContentLine(";");
+        } else {
+            addQueryParameterStart(method, queryName);
+            addParameterValue(method, "Query parameter", queryName, parameter.expression());
+            method.addContentLine(");");
+        }
+    }
+
+    private void addQueryParameterStart(Method.Builder method, String queryName) {
+        method.addContent("declarative__builder.queryParam(")
+                .addContentLiteral(queryName)
+                .addContent(", ");
+    }
+
+    private void addFormParameter(Method.Builder method, ClientParameter parameter) {
+        String formName = formParamName(parameter);
+        TypeName type = parameter.typeName();
+        if (type.isOptional()) {
+            TypeName optionalType = type.typeArguments().getFirst();
+            if (optionalType.isList()) {
+                addRequireNonNull(method, "Form parameter", formName, parameter.expression());
+                method
+                        .addContent(".ifPresent(declarative__it -> declarative__formParams.add(")
+                        .addContentLiteral(formName)
+                        .addContent(", declarative__it.stream()")
+                        .addContent(".map(declarative__value -> declarative__parameterValue(\"Form parameter\", ")
+                        .addContentLiteral(formName)
+                        .addContent(", declarative__value))")
+                        .addContentLine(".toArray(String[]::new)));");
+            } else {
+                addRequireNonNull(method, "Form parameter", formName, parameter.expression());
+                method
+                        .addContent(".ifPresent(declarative__it -> declarative__formParams.add(")
+                        .addContentLiteral(formName)
+                        .addContent(", declarative__parameterValue(\"Form parameter\", ")
+                        .addContentLiteral(formName)
+                        .addContentLine(", declarative__it)));");
+            }
+        } else if (type.isList()) {
+            method.addContent("declarative__formParams.add(")
+                    .addContentLiteral(formName)
+                    .addContent(", ")
+                    .update(it -> addRequireNonNull(it, "Form parameter", formName, parameter.expression()))
+                    .addContent(".stream().map(declarative__it -> declarative__parameterValue(\"Form parameter\", ")
+                    .addContentLiteral(formName)
+                    .addContent(", declarative__it))")
+                    .addContentLine(".toArray(String[]::new));");
+        } else {
+            method.addContent("declarative__formParams.add(")
+                    .addContentLiteral(formName)
+                    .addContent(", declarative__parameterValue(\"Form parameter\", ")
+                    .addContentLiteral(formName)
+                    .addContent(", ")
+                    .addContent(parameter.expression())
+                    .addContentLine("));");
+        }
+    }
+
+    private void addBuilderParameter(Method.Builder method,
+                                     ClientParameter parameter,
+                                     String source,
+                                     String name,
+                                     String prefix,
+                                     String suffix) {
+        TypeName type = parameter.typeName();
+        if (type.isOptional()) {
+            TypeName optionalType = type.typeArguments().getFirst();
+            if (optionalType.isList()) {
+                addRequireNonNull(method, source, name, parameter.expression());
+                method
+                        .addContent(".ifPresent(declarative__it -> ")
+                        .addContent(prefix)
+                        .addContent("declarative__it.stream().map(declarative__value -> ");
+                addParameterValue(method, source, name, "declarative__value");
+                method
+                        .addContent(").toArray(String[]::new)")
+                        .addContent(suffix)
+                        .addContentLine(");");
+            } else {
+                addRequireNonNull(method, source, name, parameter.expression());
+                method
+                        .addContent(".ifPresent(declarative__it -> ")
+                        .addContent(prefix);
+                addParameterValue(method, source, name, "declarative__it");
+                method
+                        .addContent(suffix)
+                        .addContentLine(");");
+            }
+        } else if (type.isList()) {
+            method.addContent(prefix)
+                    .update(it -> addRequireNonNull(it, source, name, parameter.expression()))
+                    .addContent(".stream().map(declarative__value -> ");
+            addParameterValue(method, source, name, "declarative__value");
+            method
+                    .addContent(").toArray(String[]::new)")
+                    .addContent(suffix)
+                    .addContentLine(";");
+        } else {
+            method.addContent(prefix);
+            addParameterValue(method, source, name, parameter.expression());
+            method
+                    .addContent(suffix)
+                    .addContentLine(";");
+        }
+    }
+
+    private void addParameterValue(Method.Builder method, String source, String name, String valueExpression) {
+        method.addContent("declarative__parameterValue(")
+                .addContentLiteral(source)
+                .addContent(", ")
+                .addContentLiteral(name)
+                .addContent(", ")
+                .addContent(valueExpression)
+                .addContent(")");
+    }
+
+    private void addRequireNonNull(Method.Builder method, String source, String name, String valueExpression) {
+        method.addContent(Objects.class)
+                .addContent(".requireNonNull(")
+                .addContent(valueExpression)
+                .addContent(", ")
+                .addContentLiteral(source + " " + name + " must not be null.")
+                .addContent(")");
+    }
+
+    private String entityExpression(List<ClientParameter> entityParameters, List<ClientParameter> formParameters) {
+        if (!formParameters.isEmpty()) {
+            return "declarative__formParams.build()";
+        }
+        return entityParameters.getFirst().expression();
+    }
+
+    private String valueExpression(ClientParameter parameter) {
+        String name = pathParamNameFromPathParam(parameter);
+        if (parameter.typeName().isOptional()) {
+            return parameterValueExpression("Path parameter",
+                                            name,
+                                            requireNonNullExpression("Path parameter",
+                                                                     name,
+                                                                     parameter.expression()) + ".orElseThrow()");
+        }
+        return parameterValueExpression("Path parameter", name, parameter.expression());
+    }
+
+    private String parameterValueExpression(String source, String name, String valueExpression) {
+        return "declarative__parameterValue(" + javaStringLiteral(source) + ", " + javaStringLiteral(name) + ", "
+                + valueExpression + ")";
+    }
+
+    private String requireNonNullExpression(String source, String name, String valueExpression) {
+        return "Objects.requireNonNull(" + valueExpression + ", " + javaStringLiteral(source + " " + name
+                + " must not be null.") + ")";
+    }
+
+    private String javaStringLiteral(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+
+    private String queryParameterName(ClientParameter parameter) {
+        return annotationValue(parameter, HTTP_QUERY_PARAM_ANNOTATION, "@Http.QueryParam");
+    }
+
+    private String pathParamNameFromPathParam(ClientParameter parameter) {
+        return annotationValue(parameter, HTTP_PATH_PARAM_ANNOTATION, "@Http.PathParam");
+    }
+
+    private String headerNameFromHeaderParam(ClientParameter parameter) {
+        return annotationValue(parameter, HTTP_HEADER_PARAM_ANNOTATION, "@Http.HeaderParam");
+    }
+
+    private String cookieParamName(ClientParameter parameter) {
+        String cookieParamName = annotationValue(parameter, HTTP_COOKIE_PARAM_ANNOTATION, "@Http.CookieParam");
+        HttpCodegenValidation.validateCookieName(cookieParamName,
+                                                 "@Http.CookieParam",
+                                                 parameter.originatingElement().originatingElementValue());
+        return cookieParamName;
+    }
+
+    private String formParamName(ClientParameter parameter) {
+        return annotationValue(parameter, HTTP_FORM_PARAM_ANNOTATION, "@Http.FormParam");
+    }
+
+    private String annotationValue(ClientParameter parameter, TypeName annotationType, String annotationName) {
+        return Annotations.findFirst(annotationType, parameter.annotations())
+                .flatMap(Annotation::value)
+                .orElseThrow(() -> new CodegenException("Parameter is recognized as " + annotationName
+                                                                + " yet it is not annotated: " + parameter.name(),
+                                                        parameter.originatingElement().originatingElementValue()));
     }
 
     private Constructor.Builder constructor(ClassModel.Builder classModel,
@@ -647,6 +1113,30 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
     }
 
     private record MethodOrigin(TypeInfo type, TypedElementInfo method) { }
+
+    private record ClientParameter(Set<Annotation> annotations,
+                                   String name,
+                                   String expression,
+                                   TypeName typeName,
+                                   TypedElementInfo originatingElement) {
+        static ClientParameter create(RestMethodParameter parameter) {
+            return new ClientParameter(parameter.annotations(),
+                                       parameter.name(),
+                                       parameter.name(),
+                                       parameter.typeName(),
+                                       parameter.parameter());
+        }
+
+        static ClientParameter create(TypedElementInfo component,
+                                      String expression,
+                                      Set<Annotation> annotations) {
+            return new ClientParameter(annotations,
+                                       component.elementName(),
+                                       expression,
+                                       component.typeName(),
+                                       component);
+        }
+    }
 
     private record StringPart(String value) implements PathParamPart {
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/AbstractParametersProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/AbstractParametersProvider.java
@@ -16,7 +16,6 @@
 
 package io.helidon.declarative.codegen.http.webserver;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,6 +28,7 @@ import io.helidon.service.codegen.FieldHandler;
 
 import static io.helidon.declarative.codegen.DeclarativeTypes.COMMON_MAPPERS;
 import static io.helidon.declarative.codegen.http.HttpTypes.BAD_REQUEST_EXCEPTION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_SUPPORT;
 
 /**
  * A provider of parameters when code generating call of methods with annotated parameter, such
@@ -59,40 +59,15 @@ public abstract class AbstractParametersProvider {
         if (optional) {
             TypeName realType = parameterType.isOptional() ? parameterType.typeArguments().getFirst() : parameterType;
             if (realType.isList()) {
-                contentBuilder
-                        .addContent("(")
-                        .addContent(source.accessor())
-                        .addContent(".contains(\"")
-                        .addContent(paramName)
-                        .addContentLine("\")")
-                        .increaseContentPadding()
-                        .increaseContentPadding()
-                        .addContent("? ")
-                        .addContent(Optional.class)
-                        .addContent(".of(");
-                addListValueExpression(ctx,
-                                       contentBuilder,
-                                       realType.typeArguments().getFirst(),
-                                       paramName,
-                                       source.accessor(),
-                                       source.filterEmptyStringValues(),
-                                       source.mapperQualifier());
-                contentBuilder.addContent(") : ")
-                        .addContent(Optional.class)
-                        .addContent(".<")
-                        .addContent(realType)
-                        .addContent(">empty())");
-                contentBuilder
-                        .decreaseContentPadding()
-                        .decreaseContentPadding();
+                addOptionalListValueExpression(ctx,
+                                               contentBuilder,
+                                               realType.typeArguments().getFirst(),
+                                               paramName,
+                                               source);
                 return;
             }
             // optional
-            contentBuilder
-                    .addContent(source.accessor())
-                    .addContent(".first(\"")
-                    .addContent(paramName)
-                    .addContentLine("\")");
+            addOptionalValueExpression(contentBuilder, paramName, source);
             if (requiresMapper(realType)) {
                 contentBuilder.addContent(".map(it -> ");
                 mapStringValue(ctx,
@@ -102,50 +77,61 @@ public abstract class AbstractParametersProvider {
                                paramName,
                                source.mapperQualifier());
                 contentBuilder.addContent(")");
-            } else {
-                contentBuilder.addContent(".asOptional()");
             }
         } else if (parameterType.isList()) {
             TypeName realType = parameterType.typeArguments().getFirst();
             // list
-            addListValueExpression(ctx,
-                                   contentBuilder,
-                                   realType,
-                                   paramName,
-                                   source.accessor(),
-                                   source.filterEmptyStringValues(),
-                                   source.mapperQualifier());
+            addMandatoryListValueExpression(ctx,
+                                            contentBuilder,
+                                            realType,
+                                            paramName,
+                                            source);
         } else {
             // direct type
-            contentBuilder
-                    .addContent(source.accessor())
-                    .addContent(".first(\"")
-                    .addContent(paramName)
-                    .addContentLine("\")")
-                    .increaseContentPadding()
-                    .increaseContentPadding();
             if (requiresMapper(parameterType)) {
-                contentBuilder.addContent(".map(it -> ");
-                mapStringValue(ctx,
-                               contentBuilder,
-                               parameterType,
-                               "it",
-                               paramName,
-                               source.mapperQualifier());
+                ensureMapperField(ctx.fieldHandler());
+                contentBuilder.addContent("mappers.map(");
+                addValueExpression(contentBuilder, paramName, source);
+                contentBuilder.addContent(", ")
+                        .addContent(TypeNames.GENERIC_TYPE)
+                        .addContent(".STRING, ")
+                        .addContent(genericTypeConstant(ctx, parameterType.boxed()))
+                        .addContent(", me -> new ")
+                        .addContent(BAD_REQUEST_EXCEPTION)
+                        .addContent("(")
+                        .addContentLiteral(providerType() + " " + paramName + " has invalid value.")
+                        .addContent(", me)");
+                addMapperQualifiers(contentBuilder, source.mapperQualifier());
                 contentBuilder.addContent(")");
+            } else {
+                addValueExpression(contentBuilder, paramName, source);
             }
-            // add .orElseThrow() in case the parameter is missing
-            contentBuilder.addContentLine()
-                    .addContent(".orElseThrow(() -> new ")
-                    .addContent(BAD_REQUEST_EXCEPTION)
-                    .addContent("(\"")
-                    .addContent(providerType())
-                    .addContent(" ")
-                    .addContent(paramName)
-                    .addContentLine(" is not present in the request.\"));")
-                    .decreaseContentPadding()
-                    .decreaseContentPadding();
+            contentBuilder.addContentLine(";");
         }
+    }
+
+    private void addValueExpression(ContentBuilder<?> contentBuilder,
+                                    String paramName,
+                                    ParametersSource source) {
+        contentBuilder.addContent(HTTP_SUPPORT)
+                .addContent(".paramValue(")
+                .addContent(source.accessor())
+                .addContent(", ")
+                .addContentLiteral(paramName)
+                .addContent(", ")
+                .addContentLiteral(providerType())
+                .addContent(")");
+    }
+
+    private void addOptionalValueExpression(ContentBuilder<?> contentBuilder,
+                                            String paramName,
+                                            ParametersSource source) {
+        contentBuilder.addContent(HTTP_SUPPORT)
+                .addContent(".paramOptionalValue(")
+                .addContent(source.accessor())
+                .addContent(", ")
+                .addContentLiteral(paramName)
+                .addContent(")");
     }
 
     /**
@@ -248,46 +234,97 @@ public abstract class AbstractParametersProvider {
                 .addContent(", ")
                 .addContent("me -> new ")
                 .addContent(BAD_REQUEST_EXCEPTION)
-                .addContent("(\"")
-                .addContent(providerType())
-                .addContent(" ")
-                .addContent(paramName)
-                .addContent(" has invalid value.\", me)");
+                .addContent("(")
+                .addContentLiteral(providerType() + " " + paramName + " has invalid value.")
+                .addContent(", me)");
         addMapperQualifiers(content, qualifier);
         content.addContent(")");
     }
 
-    void addListValueExpression(ParameterCodegenContext ctx,
-                                ContentBuilder<?> contentBuilder,
-                                TypeName itemType,
-                                String paramName,
-                                String parametersAccessor,
-                                boolean filterEmptyStringValues,
-                                String mapperQualifier) {
-        contentBuilder.addContent(parametersAccessor)
-                .addContent(".all(\"")
-                .addContent(paramName)
-                .addContent("\")");
+    void addMandatoryListValueExpression(ParameterCodegenContext ctx,
+                                         ContentBuilder<?> contentBuilder,
+                                         TypeName itemType,
+                                         String paramName,
+                                         ParametersSource source) {
+        contentBuilder.addContent(HTTP_SUPPORT)
+                .addContent(".paramList(")
+                .addContent(source.accessor())
+                .addContent(", ")
+                .addContentLiteral(paramName)
+                .addContent(", ")
+                .addContentLiteral(providerType())
+                .addContent(")");
+        addListPostProcessing(ctx,
+                              contentBuilder,
+                              itemType,
+                              paramName,
+                              source.filterEmptyStringValues(),
+                              source.mapperQualifier());
+    }
 
+    void addOptionalListValueExpression(ParameterCodegenContext ctx,
+                                        ContentBuilder<?> contentBuilder,
+                                        TypeName itemType,
+                                        String paramName,
+                                        ParametersSource source) {
+        contentBuilder.addContent(HTTP_SUPPORT)
+                .addContent(".paramOptionalList(")
+                .addContent(source.accessor())
+                .addContent(", ")
+                .addContentLiteral(paramName)
+                .addContent(")");
+
+        if (source.filterEmptyStringValues() || requiresMapper(itemType)) {
+            contentBuilder.addContent(".map(values -> values.stream()");
+            addListStreamPostProcessing(ctx,
+                                        contentBuilder,
+                                        itemType,
+                                        paramName,
+                                        source.filterEmptyStringValues(),
+                                        source.mapperQualifier());
+            contentBuilder.addContent(")");
+        }
+    }
+
+    private void addListPostProcessing(ParameterCodegenContext ctx,
+                                       ContentBuilder<?> contentBuilder,
+                                       TypeName itemType,
+                                       String paramName,
+                                       boolean filterEmptyStringValues,
+                                       String mapperQualifier) {
         if (filterEmptyStringValues || requiresMapper(itemType)) {
             contentBuilder.addContent(".stream()");
-            if (filterEmptyStringValues) {
-                contentBuilder.addContent(".filter(it -> !it.isEmpty())");
-            }
-            if (requiresMapper(itemType)) {
-                contentBuilder.addContent(".map(it -> ");
-                mapStringValue(ctx,
-                               contentBuilder,
-                               itemType,
-                               "it",
-                               paramName,
-                               mapperQualifier);
-                contentBuilder.addContent(")");
-            }
-            contentBuilder.addContent(".collect(")
-                    .addContent(Collectors.class)
-                    .addContent(".toList())");
+            addListStreamPostProcessing(ctx,
+                                        contentBuilder,
+                                        itemType,
+                                        paramName,
+                                        filterEmptyStringValues,
+                                        mapperQualifier);
         }
+    }
+
+    private void addListStreamPostProcessing(ParameterCodegenContext ctx,
+                                             ContentBuilder<?> contentBuilder,
+                                             TypeName itemType,
+                                             String paramName,
+                                             boolean filterEmptyStringValues,
+                                             String mapperQualifier) {
+        if (filterEmptyStringValues) {
+            contentBuilder.addContent(".filter(it -> !it.isEmpty())");
+        }
+        if (requiresMapper(itemType)) {
+            contentBuilder.addContent(".map(it -> ");
+            mapStringValue(ctx,
+                           contentBuilder,
+                           itemType,
+                           "it",
+                           paramName,
+                           mapperQualifier);
+            contentBuilder.addContent(")");
+        }
+        contentBuilder.addContent(".collect(")
+                .addContent(Collectors.class)
+                .addContent(".toList())");
     }
 
     void addTypeArgument(ParameterCodegenContext ctx, ContentBuilder<?> content, TypeName type) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/ParamProviderHttpCookie.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/ParamProviderHttpCookie.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.webserver;
+
+import java.util.Optional;
+
+import io.helidon.codegen.CodegenException;
+import io.helidon.codegen.classmodel.ContentBuilder;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeName;
+import io.helidon.declarative.codegen.http.HttpCodegenValidation;
+import io.helidon.declarative.codegen.http.webserver.spi.HttpParameterCodegenProvider;
+import io.helidon.service.codegen.DefaultsCodegen;
+import io.helidon.service.codegen.DefaultsParams;
+
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_COOKIE_PARAM_ANNOTATION;
+
+class ParamProviderHttpCookie extends AbstractParametersProvider implements HttpParameterCodegenProvider {
+    @Override
+    public boolean codegen(ParameterCodegenContext ctx) {
+        Optional<Annotation> first = ctx.annotations().stream()
+                .filter(it -> HTTP_COOKIE_PARAM_ANNOTATION.equals(it.typeName()))
+                .findFirst();
+
+        if (first.isEmpty()) {
+            return false;
+        }
+
+        Annotation cookieParam = first.get();
+        String cookieParamName = cookieParam.value()
+                .orElseThrow(() -> new CodegenException("@CookieParam annotation must have a value."));
+        HttpCodegenValidation.validateCookieName(cookieParamName,
+                                                 "@Http.CookieParam",
+                                                 cookieParam.originatingElement().orElse(null));
+
+        TypeName parameterType = ctx.parameterType();
+        TypeName realType = parameterType.isOptional() ? parameterType.typeArguments().getFirst() : parameterType;
+        Optional<DefaultsCodegen.DefaultCode> defaultCode = DefaultsCodegen.findDefault(ctx.annotations(), realType);
+
+        ContentBuilder<?> contentBuilder = ctx.contentBuilder();
+
+        codegenFromParameters(ctx,
+                              parameterType,
+                              cookieParamName,
+                              parameterType.isOptional() || defaultCode.isPresent(),
+                              new ParametersSource(ctx.serverRequestParamName() + ".headers().cookies()",
+                                                   false,
+                                                   "http/cookies"));
+
+        if (defaultCode.isPresent()) {
+            var defaultInfo = defaultCode.get();
+            if (defaultInfo.requiresMapper()) {
+                ensureMapperField(ctx.fieldHandler());
+            }
+
+            var params = DefaultsParams.builder()
+                    .contextField(ctx.serverRequestParamName() + ".headers().cookies()")
+                    .mapperQualifier("http/cookies")
+                    .mappersField("mappers")
+                    .build();
+            DefaultsCodegen.codegenOptional(contentBuilder,
+                                            defaultInfo,
+                                            ctx.fieldHandler(),
+                                            params);
+        }
+
+        contentBuilder.addContentLine(";");
+
+        return true;
+    }
+
+    @Override
+    protected String providerType() {
+        return "Cookie";
+    }
+}

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/ParamProviderHttpForm.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/ParamProviderHttpForm.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.webserver;
+
+import java.util.Optional;
+
+import io.helidon.codegen.CodegenException;
+import io.helidon.codegen.classmodel.ContentBuilder;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeName;
+import io.helidon.declarative.codegen.http.webserver.spi.HttpParameterCodegenProvider;
+import io.helidon.service.codegen.DefaultsCodegen;
+import io.helidon.service.codegen.DefaultsParams;
+
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
+
+class ParamProviderHttpForm extends AbstractParametersProvider implements HttpParameterCodegenProvider {
+    private static final TypeName LAZY_VALUE = TypeName.create("io.helidon.common.LazyValue");
+    private static final TypeName PARAMETERS = TypeName.create("io.helidon.common.parameters.Parameters");
+
+    static final String FORM_PARAMS = "declarative__formParams";
+    static final String FORM_PARAMS_ACCESSOR = FORM_PARAMS + ".get()";
+    static final String FORM_PARAMS_COMPONENT = "form-params";
+    static final TypeName LAZY_FORM_PARAMS = TypeName.builder(LAZY_VALUE)
+            .addTypeArgument(PARAMETERS)
+            .build();
+
+    @Override
+    public boolean codegen(ParameterCodegenContext ctx) {
+        Optional<Annotation> first = ctx.annotations().stream()
+                .filter(it -> HTTP_FORM_PARAM_ANNOTATION.equals(it.typeName()))
+                .findFirst();
+
+        if (first.isEmpty()) {
+            return false;
+        }
+
+        Annotation formParam = first.get();
+        String formParamName = formParam.value()
+                .orElseThrow(() -> new CodegenException("@FormParam annotation must have a value."));
+
+        TypeName parameterType = ctx.parameterType();
+        TypeName realType = parameterType.isOptional() ? parameterType.typeArguments().getFirst() : parameterType;
+        Optional<DefaultsCodegen.DefaultCode> defaultCode = DefaultsCodegen.findDefault(ctx.annotations(), realType);
+        ContentBuilder<?> contentBuilder = ctx.contentBuilder();
+
+        codegenFromParameters(ctx,
+                              parameterType,
+                              formParamName,
+                              parameterType.isOptional() || defaultCode.isPresent(),
+                              new ParametersSource(FORM_PARAMS_ACCESSOR,
+                                                   true,
+                                                   FORM_PARAMS_COMPONENT));
+
+        if (defaultCode.isPresent()) {
+            var defaultInfo = defaultCode.get();
+            if (defaultInfo.requiresMapper()) {
+                ensureMapperField(ctx.fieldHandler());
+            }
+
+            var params = DefaultsParams.builder()
+                    .contextField(FORM_PARAMS_ACCESSOR)
+                    .mapperQualifier(FORM_PARAMS_COMPONENT)
+                    .mappersField("mappers")
+                    .build();
+            DefaultsCodegen.codegenOptional(contentBuilder,
+                                            defaultInfo,
+                                            ctx.fieldHandler(),
+                                            params);
+        }
+
+        contentBuilder.addContentLine(";");
+
+        return true;
+    }
+
+    @Override
+    protected String providerType() {
+        return "Form parameter";
+    }
+}

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/ParamProviderHttpRequestParams.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/ParamProviderHttpRequestParams.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.webserver;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.codegen.CodegenException;
+import io.helidon.codegen.classmodel.Method;
+import io.helidon.common.types.AccessModifier;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypedElementInfo;
+import io.helidon.declarative.codegen.http.HttpCodegenValidation;
+import io.helidon.declarative.codegen.http.webserver.spi.HttpParameterCodegenProvider;
+import io.helidon.service.codegen.RegistryCodegenContext;
+
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_REQUEST_PARAMS_ANNOTATION;
+
+class ParamProviderHttpRequestParams implements HttpParameterCodegenProvider {
+    private static final TypeName PARAMETERS = TypeName.create("io.helidon.common.parameters.Parameters");
+
+    private final RegistryCodegenContext codegenContext;
+    private final List<HttpParameterCodegenProvider> componentProviders;
+
+    ParamProviderHttpRequestParams(RegistryCodegenContext codegenContext,
+                                   List<HttpParameterCodegenProvider> componentProviders) {
+        this.codegenContext = codegenContext;
+        this.componentProviders = List.copyOf(componentProviders);
+    }
+
+    @Override
+    public boolean codegen(ParameterCodegenContext ctx) {
+        Optional<Annotation> first = ctx.annotations().stream()
+                .filter(it -> HTTP_REQUEST_PARAMS_ANNOTATION.equals(it.typeName()))
+                .findFirst();
+
+        if (first.isEmpty()) {
+            return false;
+        }
+
+        TypeInfo requestParamsType = HttpCodegenValidation.requestParamsRecordType(codegenContext::typeInfo,
+                                                                                  ctx.parameterType(),
+                                                                                  null);
+
+        HttpCodegenValidation.validateRequestParamsBodyComponents(requestParamsType);
+
+        boolean hasFormParams = hasComponentAnnotation(requestParamsType, HTTP_FORM_PARAM_ANNOTATION);
+        String methodName = "requestParams_" + ctx.methodIndex() + "_" + ctx.paramIndex();
+        addRequestParamsMethod(ctx, requestParamsType, methodName, hasFormParams);
+
+        ctx.contentBuilder()
+                .addContent(methodName)
+                .addContent("(")
+                .addContent(ctx.serverRequestParamName())
+                .addContent(", ")
+                .addContent(ctx.serverResponseParamName());
+        if (hasFormParams) {
+            ctx.contentBuilder()
+                    .addContent(", ")
+                    .addContent(ParamProviderHttpForm.FORM_PARAMS);
+        }
+        ctx.contentBuilder().addContent(");");
+
+        return true;
+    }
+
+    private void addRequestParamsMethod(ParameterCodegenContext ctx,
+                                        TypeInfo requestParamsType,
+                                        String methodName,
+                                        boolean hasFormParams) {
+        ctx.classBuilder()
+                .addMethod(method -> method
+                        .accessModifier(AccessModifier.PRIVATE)
+                        .returnType(ctx.parameterType())
+                        .name(methodName)
+                        .addParameter(req -> req
+                                .type(WebServerCodegenTypes.SERVER_REQUEST)
+                                .name(ctx.serverRequestParamName()))
+                        .addParameter(res -> res
+                                .type(WebServerCodegenTypes.SERVER_RESPONSE)
+                                .name(ctx.serverResponseParamName()))
+                        .update(it -> {
+                            if (hasFormParams) {
+                                it.addParameter(formParams -> formParams
+                                        .type(ParamProviderHttpForm.LAZY_FORM_PARAMS)
+                                        .name(ParamProviderHttpForm.FORM_PARAMS));
+                            }
+                        })
+                        .update(it -> requestParamsMethodBody(ctx, it, requestParamsType)));
+    }
+
+    private void requestParamsMethodBody(ParameterCodegenContext ctx,
+                                         Method.Builder method,
+                                         TypeInfo requestParamsType) {
+        List<TypedElementInfo> components = HttpCodegenValidation.requestParamsComponents(requestParamsType);
+
+        for (TypedElementInfo component : components) {
+            method.addContent("var ")
+                    .addContent(componentName(component))
+                    .addContent(" = ");
+            codegenComponentParameter(ctx, method, component);
+            method.addContentLine();
+        }
+
+        method.addContent("return new ")
+                .addContent(ctx.parameterType())
+                .addContentLine("(")
+                .increaseContentPadding()
+                .increaseContentPadding();
+
+        for (int i = 0; i < components.size(); i++) {
+            method.addContent(componentName(components.get(i)));
+            if (i + 1 < components.size()) {
+                method.addContentLine(",");
+            }
+        }
+
+        method.addContentLine(");")
+                .decreaseContentPadding()
+                .decreaseContentPadding();
+    }
+
+    private void codegenComponentParameter(ParameterCodegenContext ctx,
+                                           Method.Builder method,
+                                           TypedElementInfo component) {
+        Set<Annotation> annotations = new HashSet<>(component.annotations());
+        var componentContext = new ParamCodegenContextImpl(ctx.fieldHandler(),
+                                                           annotations,
+                                                           component.typeName(),
+                                                           ctx.classBuilder(),
+                                                           method,
+                                                           ctx.serverRequestParamName(),
+                                                           ctx.serverResponseParamName(),
+                                                           ctx.endpointType(),
+                                                           ctx.methodName(),
+                                                           component.elementName(),
+                                                           ctx.methodIndex(),
+                                                           ctx.paramIndex());
+        for (HttpParameterCodegenProvider provider : componentProviders) {
+            if (provider.codegen(componentContext)) {
+                return;
+            }
+        }
+
+        throw new CodegenException("Record component '" + component.elementName()
+                                           + "' of @Http.RequestParams type " + ctx.parameterType().fqName()
+                                           + " is not annotated with a supported request parameter annotation"
+                                           + " and is not a supported typed parameter.",
+                                   component.originatingElementValue());
+    }
+
+    private boolean hasComponentAnnotation(TypeInfo requestParamsType, TypeName annotation) {
+        return HttpCodegenValidation.requestParamsComponents(requestParamsType)
+                .stream()
+                .anyMatch(it -> HttpCodegenValidation.hasAnnotation(it.annotations(), annotation));
+    }
+
+    private String componentName(TypedElementInfo component) {
+        return "requestParam_" + component.elementName();
+    }
+}

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
@@ -16,6 +16,7 @@
 
 package io.helidon.declarative.codegen.http.webserver;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -45,6 +46,7 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 import io.helidon.declarative.codegen.DeclarativeTypes;
 import io.helidon.declarative.codegen.DeclarativeUtils;
+import io.helidon.declarative.codegen.http.HttpCodegenValidation;
 import io.helidon.declarative.codegen.http.HttpFields;
 import io.helidon.declarative.codegen.http.RestExtensionBase;
 import io.helidon.declarative.codegen.http.webserver.spi.HttpParameterCodegenProvider;
@@ -64,11 +66,14 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 import static io.helidon.codegen.CodegenUtil.toConstantName;
 import static io.helidon.declarative.codegen.DeclarativeTypes.SINGLETON_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_ENTITY_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PATH_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_QUERY_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_REQUEST_PARAMS_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_SUPPORT;
 import static io.helidon.declarative.codegen.http.webserver.WebServerCodegenTypes.REST_SERVER_COMPUTED_HEADER;
 import static io.helidon.declarative.codegen.http.webserver.WebServerCodegenTypes.REST_SERVER_COMPUTED_HEADERS;
 import static io.helidon.declarative.codegen.http.webserver.WebServerCodegenTypes.REST_SERVER_ENDPOINT;
@@ -84,16 +89,17 @@ Generates:
  */
 class RestServerExtension extends RestExtensionBase implements RegistryCodegenExtension {
     private static final TypeName GENERATOR = TypeName.create(RestServerExtension.class);
+    private static final TypeName PARAMETERS = TypeName.create("io.helidon.common.parameters.Parameters");
     private static final String REQUEST_PARAM_NAME = "req";
     private static final String RESPONSE_PARAM_NAME = "res";
     private static final String METHOD_RESPONSE_NAME = "response";
-    private static final List<HttpParameterCodegenProvider> PARAM_PROVIDERS =
-            loadParamProviders(RestServerExtension.class.getClassLoader());
 
     private final RegistryCodegenContext ctx;
+    private final List<HttpParameterCodegenProvider> paramProviders;
 
     RestServerExtension(RegistryCodegenContext ctx) {
         this.ctx = ctx;
+        this.paramProviders = loadParamProviders(RestServerExtension.class.getClassLoader(), ctx);
     }
 
     @Override
@@ -111,16 +117,31 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
     }
 
     static List<HttpParameterCodegenProvider> loadParamProviders(ClassLoader classLoader) {
-        return HelidonServiceLoader.builder(ServiceLoader.load(HttpParameterCodegenProvider.class, classLoader))
+        return loadParamProviders(classLoader, null);
+    }
+
+    static List<HttpParameterCodegenProvider> loadParamProviders(ClassLoader classLoader,
+                                                                 RegistryCodegenContext ctx) {
+        var builder = HelidonServiceLoader.builder(ServiceLoader.load(HttpParameterCodegenProvider.class, classLoader))
                 .addService(new ParamProviderHttpEntity())
                 .addService(new ParamProviderHttpHeader())
+                .addService(new ParamProviderHttpCookie())
                 .addService(new ParamProviderHttpPathParam())
                 .addService(new ParamProviderHttpQuery())
+                .addService(new ParamProviderHttpForm())
                 .addService(new ParamProviderHttpReqRes())
                 .addService(new ParamProviderSecurityContext())
-                .addService(new ParamProviderContext())
-                .build()
-                .asList();
+                .addService(new ParamProviderContext());
+
+        List<HttpParameterCodegenProvider> providers = builder.build().asList();
+        if (ctx == null) {
+            return providers;
+        }
+
+        var result = new ArrayList<HttpParameterCodegenProvider>();
+        result.add(new ParamProviderHttpRequestParams(ctx, providers));
+        result.addAll(providers);
+        return List.copyOf(result);
     }
 
     private static String userVariableName(String userName) {
@@ -310,6 +331,12 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                                                                                        methodInfo,
                                                                                        parameterInfo,
                                                                                        index));
+        HttpCodegenValidation.validateMethodParameterAnnotationCount(
+                annotations,
+                "Parameter '" + parameterInfo.elementName() + "' of declarative server method "
+                        + typeInfo.typeName().fqName() + "." + methodInfo.elementName()
+                        + "() must have at most one supported request parameter annotation.",
+                parameterInfo.originatingElementValue());
         var parameter = RestMethodParameter.builder()
                 .annotations(annotations)
                 .name(parameterInfo.elementName())
@@ -382,7 +409,6 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
         addSocketMethods(classModel, endpoint);
         // private void routing(HttpRules rules)
         addRoutingMethod(fieldHandler, classModel, endpoint);
-
         int methodIndex = 0;
 
         Map<String, String> headerProducerFields = headerProducers(fieldHandler, endpoint);
@@ -465,6 +491,22 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                                     RestMethod restMethod,
                                     Map<String, String> headerProducers,
                                     int methodIndex) {
+        validateBodyParameters(restMethod);
+        if (methodUsesFormParams(restMethod)) {
+            method.addContent("var ")
+                    .addContent(ParamProviderHttpForm.FORM_PARAMS)
+                    .addContent(" = ")
+                    .addContent(HTTP_SUPPORT)
+                    .addContentLine(".lazyFormParams(() -> req.content()")
+                    .increaseContentPadding()
+                    .increaseContentPadding()
+                    .addContent(".asOptional(")
+                    .addContent(PARAMETERS)
+                    .addContentLine(".GENERIC_TYPE));")
+                    .decreaseContentPadding()
+                    .decreaseContentPadding();
+        }
+
         // parameters
         for (RestMethodParameter parameter : restMethod.parameters()) {
             String paramName = userVariableName(parameter.name());
@@ -574,7 +616,7 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                                     RestMethod restMethod,
                                     RestMethodParameter param,
                                     int methodIndex) {
-        for (HttpParameterCodegenProvider paramProvider : PARAM_PROVIDERS) {
+        for (HttpParameterCodegenProvider paramProvider : paramProviders) {
             try {
                 if (paramProvider.codegen(new ParamCodegenContextImpl(fieldHandler,
                                                                       param.annotations(),
@@ -595,7 +637,8 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                                                    + param.name() + "' that is " + (param.index() + 1) + " parameter of method "
                                                    + endpointType.fqName() + "." + restMethod.name()
                                                    + ", as the parameter handler ("
-                                                   + paramProvider.getClass().getName() + ") threw an exception.",
+                                                   + paramProvider.getClass().getName() + ") threw an exception: "
+                                                   + e.getMessage(),
                                            e);
             }
         }
@@ -632,6 +675,60 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                 addHttpRoute(fieldHandler, method, restMethod);
             }
         }
+    }
+
+    private void validateBodyParameters(RestMethod restMethod) {
+        BodyParameters bodyParameters = bodyParameters(restMethod);
+        if (bodyParameters.entityCount() > 1) {
+            throw new CodegenException("Only one @Http.Entity parameter is supported on declarative server method "
+                                               + restMethod.type().typeName().fqName() + "." + restMethod.name() + "().",
+                                       bodyParameters.firstOriginatingElement());
+        }
+        if (bodyParameters.entityCount() > 0 && bodyParameters.formCount() > 0) {
+            throw new CodegenException("@Http.Entity and @Http.FormParam cannot be combined on declarative server method "
+                                               + restMethod.type().typeName().fqName() + "." + restMethod.name() + "().",
+                                       bodyParameters.firstOriginatingElement());
+        }
+    }
+
+    private boolean methodUsesFormParams(RestMethod restMethod) {
+        return bodyParameters(restMethod).formCount() > 0;
+    }
+
+    private BodyParameters bodyParameters(RestMethod restMethod) {
+        int entityCount = 0;
+        int formCount = 0;
+        Object firstOriginatingElement = restMethod.method().originatingElementValue();
+
+        for (RestMethodParameter parameter : restMethod.parameters()) {
+            if (HttpCodegenValidation.hasAnnotation(parameter.annotations(), HTTP_ENTITY_ANNOTATION)) {
+                entityCount++;
+                firstOriginatingElement = parameter.parameter().originatingElementValue();
+            }
+            if (HttpCodegenValidation.hasAnnotation(parameter.annotations(), HTTP_FORM_PARAM_ANNOTATION)) {
+                formCount++;
+                firstOriginatingElement = parameter.parameter().originatingElementValue();
+            }
+            if (HttpCodegenValidation.hasAnnotation(parameter.annotations(), HTTP_REQUEST_PARAMS_ANNOTATION)) {
+                TypeInfo requestParamsType = HttpCodegenValidation.requestParamsRecordType(
+                        ctx::typeInfo,
+                        parameter.typeName(),
+                        parameter.parameter().originatingElementValue());
+                HttpCodegenValidation.validateRequestParamsBodyComponents(requestParamsType);
+                for (TypedElementInfo component : HttpCodegenValidation.requestParamsComponents(requestParamsType)) {
+                    if (HttpCodegenValidation.hasAnnotation(component.annotations(), HTTP_ENTITY_ANNOTATION)) {
+                        entityCount++;
+                        firstOriginatingElement = component.originatingElementValue();
+                    }
+                    if (HttpCodegenValidation.hasAnnotation(component.annotations(), HTTP_FORM_PARAM_ANNOTATION)) {
+                        formCount++;
+                        firstOriginatingElement = component.originatingElementValue();
+                    }
+                }
+            }
+        }
+
+        return new BodyParameters(entityCount, formCount, firstOriginatingElement);
     }
 
     private void addSimpleRoute(FieldHandler fieldHandler, Method.Builder routing, RestMethod restMethod) {
@@ -715,5 +812,10 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
         routing.addContentLine(".build());")
                 .decreaseContentPadding()
                 .decreaseContentPadding();
+    }
+
+    private record BodyParameters(int entityCount,
+                                  int formCount,
+                                  Object firstOriginatingElement) {
     }
 }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/server/WebSocketListenerGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/websocket/server/WebSocketListenerGenerator.java
@@ -44,6 +44,7 @@ import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
+import io.helidon.declarative.codegen.DeclarativeTypes;
 import io.helidon.declarative.codegen.http.webserver.AbstractParametersProvider;
 import io.helidon.service.codegen.FieldHandler;
 import io.helidon.service.codegen.RegistryRoundContext;
@@ -99,6 +100,7 @@ class WebSocketListenerGenerator extends AbstractParametersProvider {
                                                                generatedListener,
                                                                "1",
                                                                ""))
+                .addAnnotation(DeclarativeTypes.SUPPRESS_API)
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                 .type(generatedListener)
                 .superType(WS_LISTENER_BASE);

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/DeclarativeCodegenHttpTypesTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/DeclarativeCodegenHttpTypesTest.java
@@ -33,6 +33,7 @@ import io.helidon.http.Headers;
 import io.helidon.http.Http;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.HttpPrologue;
+import io.helidon.http.HttpSupport;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 
@@ -76,14 +77,18 @@ class DeclarativeCodegenHttpTypesTest {
         checkField(toCheck, checked, fields, "HTTP_HEADER_NAMES", HeaderNames.class);
         checkField(toCheck, checked, fields, "HTTP_HEADER", Header.class);
         checkField(toCheck, checked, fields, "HTTP_HEADER_VALUES", HeaderValues.class);
+        checkField(toCheck, checked, fields, "HTTP_SUPPORT", HttpSupport.class);
         checkField(toCheck, checked, fields, "HTTP_PATH_ANNOTATION", Http.Path.class);
         checkField(toCheck, checked, fields, "HTTP_METHOD_ANNOTATION", Http.HttpMethod.class);
         checkField(toCheck, checked, fields, "HTTP_PRODUCES_ANNOTATION", Http.Produces.class);
         checkField(toCheck, checked, fields, "HTTP_CONSUMES_ANNOTATION", Http.Consumes.class);
         checkField(toCheck, checked, fields, "HTTP_PATH_PARAM_ANNOTATION", Http.PathParam.class);
+        checkField(toCheck, checked, fields, "HTTP_COOKIE_PARAM_ANNOTATION", Http.CookieParam.class);
         checkField(toCheck, checked, fields, "HTTP_QUERY_PARAM_ANNOTATION", Http.QueryParam.class);
+        checkField(toCheck, checked, fields, "HTTP_FORM_PARAM_ANNOTATION", Http.FormParam.class);
         checkField(toCheck, checked, fields, "HTTP_HEADER_PARAM_ANNOTATION", Http.HeaderParam.class);
         checkField(toCheck, checked, fields, "HTTP_ENTITY_ANNOTATION", Http.Entity.class);
+        checkField(toCheck, checked, fields, "HTTP_REQUEST_PARAMS_ANNOTATION", Http.RequestParams.class);
         checkField(toCheck, checked, fields, "HTTP_HEADER_FUNCTION", Http.HeaderFunction.class);
         checkField(toCheck, checked, fields, "HTTP_MEDIA_TYPE", HttpMediaType.class);
         checkField(toCheck, checked, fields, "HTTP_HEADERS", Headers.class);

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/RestClientCookieParamCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/RestClientCookieParamCodegenTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.restclient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.builder.api.RuntimeType;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.types.TypeName;
+import io.helidon.config.Config;
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.webclient.api.RestClient;
+import io.helidon.webclient.api.WebClient;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RestClientCookieParamCodegenTest {
+    @Test
+    void generatedCookieParametersUseHttpSupport() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Generated.class,
+                        Prototype.class,
+                        RuntimeType.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-cookie-params"))
+                .addSource("CookieClient.java", """
+                        package com.example;
+
+                        import java.util.List;
+                        import java.util.Optional;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface CookieClient {
+                            @Http.GET
+                            @Http.Path("/cookies")
+                            String cookies(@Http.CookieParam("first") String first,
+                                           @Http.CookieParam("tag") List<String> tags,
+                                           @Http.CookieParam("optional") Optional<List<String>> optionalTags);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedClient = result.sourceOutput().resolve("com/example/CookieClient__DeclarativeClient.java");
+        assertThat(diagnostics, Files.exists(generatedClient), is(true));
+
+        String generated = Files.readString(generatedClient, StandardCharsets.UTF_8);
+        assertThat(generated, containsString("import java.util.Objects;"));
+        assertThat(generated,
+                   containsString("return String.valueOf(Objects.requireNonNull(value, source + \" \" + name"
+                                          + " + \" must not be null.\"));"));
+        assertThat(generated,
+                   containsString("declarative__cookies.add(HttpSupport.cookie(\"first\", "
+                                          + "declarative__parameterValue(\"Cookie parameter\", \"first\", first)));"));
+        assertThat(generated,
+                   containsString("if (Objects.requireNonNull(tags, \"Cookie parameter tag must not be null.\").isEmpty())"));
+        assertThat(generated, containsString("throw new IllegalArgumentException(\"Cookie parameter tag has no values.\");"));
+        assertThat(generated,
+                   containsString("Objects.requireNonNull(tags, \"Cookie parameter tag must not be null.\")"));
+        assertThat(generated,
+                   containsString(".map(declarative__it -> HttpSupport.cookie(\"tag\", "
+                                          + "declarative__parameterValue(\"Cookie parameter\", \"tag\","
+                                          + " declarative__it)))"));
+        assertThat(generated,
+                   containsString(".map(declarative__value -> HttpSupport.cookie(\"optional\", "
+                                          + "declarative__parameterValue(\"Cookie parameter\", \"optional\","
+                                          + " declarative__value)))"));
+        assertThat(generated,
+                   containsString("Objects.requireNonNull(optionalTags, \"Cookie parameter optional must not be null.\")"));
+        assertThat(generated, not(containsString("if (optionalTags.isEmpty())")));
+        assertThat(generated,
+                   containsString("declarative__builder.header(HeaderNames.COOKIE, "
+                                          + "HttpSupport.cookieHeader(declarative__cookies));"));
+        assertThat(generated, not(containsString("declarative__cookieHeader")));
+    }
+
+    @Test
+    void invalidCookieParameterNameIsRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-invalid-cookie-param-name"))
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.GET
+                            String invalid(@Http.CookieParam("bad;name") String value);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString("@Http.CookieParam value must be a valid cookie name."));
+    }
+
+    @Test
+    void invalidRequestParamsCookieParameterNameIsRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-request-params-invalid-cookie-param-name"))
+                .addSource("CookieParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record CookieParams(@Http.CookieParam("bad;name") String value) {
+                        }
+                        """)
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.GET
+                            String invalid(@Http.RequestParams CookieParams params);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString("@Http.CookieParam value must be a valid cookie name."));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/RestClientFormParamCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/RestClientFormParamCodegenTest.java
@@ -1,0 +1,570 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.restclient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.builder.api.RuntimeType;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.types.TypeName;
+import io.helidon.config.Config;
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.webclient.api.RestClient;
+import io.helidon.webclient.api.WebClient;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RestClientFormParamCodegenTest {
+    @Test
+    void generatedFormParamsEscapeParameterNames() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        Prototype.class,
+                        RuntimeType.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-form-params-escaped-name"))
+                .addSource("FormClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface FormClient {
+                            @Http.POST
+                            String form(@Http.FormParam("quoted\\\"and\\\\slash") String value);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedClient = result.sourceOutput().resolve("com/example/FormClient__DeclarativeClient.java");
+        assertThat(diagnostics, Files.exists(generatedClient), is(true));
+
+        String generated = Files.readString(generatedClient, StandardCharsets.UTF_8);
+        assertThat(generated, containsString("declarative__formParams.add(\"quoted\\\"and\\\\slash\", "));
+    }
+
+    @Test
+    void methodEntityAndFormParametersAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-form-entity-method-conflict"))
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.POST
+                            String invalid(@Http.Entity String entity,
+                                           @Http.FormParam("field") String field);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("@Http.Entity and @Http.FormParam cannot be combined on declarative client method "
+                                          + "com.example.InvalidClient.invalid()."));
+    }
+
+    @Test
+    void methodMultipleEntityParametersAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-method-multiple-entity-params"))
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.POST
+                            String invalid(@Http.Entity String first,
+                                           @Http.Entity String second);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Only one @Http.Entity parameter is supported on declarative client method "
+                                          + "com.example.InvalidClient.invalid()."));
+    }
+
+    @Test
+    void methodEntityAndRequestParamsFormComponentsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-entity-request-params-form-conflict"))
+                .addSource("FormParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record FormParams(@Http.FormParam("field") String field) {
+                        }
+                        """)
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.POST
+                            String invalid(@Http.Entity String entity,
+                                           @Http.RequestParams FormParams params);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("@Http.Entity and @Http.FormParam cannot be combined on declarative client method "
+                                          + "com.example.InvalidClient.invalid()."));
+    }
+
+    @Test
+    void requestParamsEntityAndFormComponentsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-request-params-body-conflict"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record InvalidParams(@Http.Entity String entity,
+                                             @Http.FormParam("field") String field) {
+                        }
+                        """)
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.POST
+                            String invalid(@Http.RequestParams InvalidParams params);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("@Http.Entity and @Http.FormParam record components cannot be combined in "
+                                          + "@Http.RequestParams type com.example.InvalidParams."));
+    }
+
+    @Test
+    void requestParamsMultipleEntityComponentsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-request-params-entity-conflict"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record InvalidParams(@Http.Entity String first,
+                                             @Http.Entity String second) {
+                        }
+                        """)
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.POST
+                            String invalid(@Http.RequestParams InvalidParams params);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Only one @Http.Entity record component is supported in @Http.RequestParams type "
+                                          + "com.example.InvalidParams."));
+    }
+
+    @Test
+    void methodMultipleParameterAnnotationsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-method-multiple-annotations"))
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.GET
+                            String invalid(@Http.HeaderParam("X-CUSTOM")
+                                           @Http.QueryParam("custom")
+                                           String value);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Parameter 'value' of declarative client method com.example.InvalidClient.invalid() "
+                                          + "must have at most one supported request parameter annotation."));
+    }
+
+    @Test
+    void requestParamsMultipleComponentAnnotationsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-request-params-multiple-annotations"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record InvalidParams(@Http.HeaderParam("X-CUSTOM")
+                                             @Http.QueryParam("custom")
+                                             String value) {
+                        }
+                        """)
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.GET
+                            String invalid(@Http.RequestParams InvalidParams params);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Record component 'value' of @Http.RequestParams type com.example.InvalidParams "
+                                          + "must have at most one supported request parameter annotation."));
+    }
+
+    @Test
+    void requestParamsTypeMustBeRecord() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-request-params-non-record"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        class InvalidParams {
+                        }
+                        """)
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.GET
+                            String invalid(@Http.RequestParams InvalidParams params);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("@Http.RequestParams type must be a record. Type com.example.InvalidParams is CLASS."));
+    }
+
+    @Test
+    void requestParamsComponentsMustBeAnnotated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-request-params-unannotated-component"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        record InvalidParams(String value) {
+                        }
+                        """)
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.GET
+                            String invalid(@Http.RequestParams InvalidParams params);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Record component 'value' of @Http.RequestParams type com.example.InvalidParams "
+                                          + "is not annotated with a supported request parameter annotation."));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/RestClientFormParamCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/RestClientFormParamCodegenTest.java
@@ -142,6 +142,101 @@ class RestClientFormParamCodegenTest {
     }
 
     @Test
+    void methodUnannotatedParameterWithFormParameterIsRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-form-unannotated-parameter"))
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.POST
+                            String invalid(String body,
+                                           @Http.FormParam("field") String field);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Parameter 'body' of declarative client method com.example.InvalidClient.invalid() "
+                                          + "must be annotated with a supported request parameter annotation."));
+    }
+
+    @Test
+    void methodUnannotatedParameterIsRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Generated.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-unannotated-parameter"))
+                .addSource("InvalidClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface InvalidClient {
+                            @Http.POST
+                            String invalid(String body);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Parameter 'body' of declarative client method com.example.InvalidClient.invalid() "
+                                          + "must be annotated with a supported request parameter annotation."));
+    }
+
+    @Test
     void methodMultipleEntityParametersAreRejected() {
         var result = TestCompiler.builder()
                 .currentRelease()

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/RestClientParameterNullCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/RestClientParameterNullCodegenTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.restclient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.builder.api.RuntimeType;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.types.TypeName;
+import io.helidon.config.Config;
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.webclient.api.RestClient;
+import io.helidon.webclient.api.WebClient;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RestClientParameterNullCodegenTest {
+    @Test
+    void generatedClientRejectsNullParameterValues() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Generated.class,
+                        Prototype.class,
+                        RuntimeType.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-null-params"))
+                .addSource("ParamClient.java", """
+                        package com.example;
+
+                        import java.util.List;
+                        import java.util.Optional;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface ParamClient {
+                            @Http.GET
+                            @Http.Path("/items/{id}")
+                            String get(@Http.HeaderParam("X-CUSTOM") String header,
+                                       @Http.QueryParam("q") Optional<List<String>> query,
+                                       @Http.PathParam("id") String id);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedClient = result.sourceOutput().resolve("com/example/ParamClient__DeclarativeClient.java");
+        assertThat(diagnostics, Files.exists(generatedClient), is(true));
+
+        String generated = Files.readString(generatedClient, StandardCharsets.UTF_8);
+        assertThat(generated, containsString("import java.util.Objects;"));
+        assertThat(generated, containsString("declarative__parameterValue(\"Path parameter\", \"id\", id)"));
+        assertThat(generated, containsString("declarative__parameterValue(\"Header\", \"X-CUSTOM\", header)"));
+        assertThat(generated,
+                   containsString("Objects.requireNonNull(query, \"Query parameter q must not be null.\")"));
+        assertThat(generated,
+                   containsString("declarative__parameterValue(\"Query parameter\", \"q\", declarative__value)"));
+    }
+
+    @Test
+    void generatedClientEscapesQueryParameterNames() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Generated.class,
+                        Prototype.class,
+                        RuntimeType.class,
+                        TypeName.class,
+                        Config.class,
+                        Http.class,
+                        Service.class,
+                        RestClient.class,
+                        WebClient.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-query-param-literal"))
+                .addSource("QueryClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface QueryClient {
+                            @Http.GET
+                            String query(@Http.QueryParam("quoted\\\"and\\\\slash") String value);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedClient = result.sourceOutput().resolve("com/example/QueryClient__DeclarativeClient.java");
+        assertThat(diagnostics, Files.exists(generatedClient), is(true));
+
+        String generated = Files.readString(generatedClient, StandardCharsets.UTF_8);
+        assertThat(generated,
+                   containsString("declarative__builder.queryParam(\"quoted\\\"and\\\\slash\", "
+                                          + "declarative__parameterValue(\"Query parameter\", "
+                                          + "\"quoted\\\"and\\\\slash\", value));"));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/CookieParamCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/CookieParamCodegenTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.webserver;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.Mappers;
+import io.helidon.common.parameters.Parameters;
+import io.helidon.common.types.Annotation;
+import io.helidon.config.Config;
+import io.helidon.http.Http;
+import io.helidon.http.media.ReadableEntity;
+import io.helidon.service.registry.Dependency;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceDescriptor;
+import io.helidon.webserver.http.Handler;
+import io.helidon.webserver.http.HttpEntryPoint;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRoute;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.RestServer;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class CookieParamCodegenTest {
+    @Test
+    void invalidCookieParameterNameIsRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-invalid-cookie-param-name"))
+                .addSource("CookieEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/cookies")
+                        class CookieEndpoint {
+                            @Http.GET
+                            String invalid(@Http.CookieParam("bad;name") String value) {
+                                return value;
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString("@Http.CookieParam value must be a valid cookie name."));
+    }
+
+    @Test
+    void invalidRequestParamsCookieParameterNameIsRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-invalid-cookie-param-name"))
+                .addSource("CookieParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record CookieParams(@Http.CookieParam("bad;name") String value) {
+                        }
+                        """)
+                .addSource("CookieEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/cookies")
+                        class CookieEndpoint {
+                            @Http.GET
+                            String invalid(@Http.RequestParams CookieParams params) {
+                                return params.value();
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString("@Http.CookieParam value must be a valid cookie name."));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/FormParamCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/FormParamCodegenTest.java
@@ -1,0 +1,1155 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.webserver;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.GenericType;
+import io.helidon.common.LazyValue;
+import io.helidon.common.mapper.Mappers;
+import io.helidon.common.parameters.Parameters;
+import io.helidon.common.types.Annotation;
+import io.helidon.config.Config;
+import io.helidon.http.Http;
+import io.helidon.http.media.ReadableEntity;
+import io.helidon.service.registry.Dependency;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceDescriptor;
+import io.helidon.webserver.http.Handler;
+import io.helidon.webserver.http.HttpEntryPoint;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRoute;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.RestServer;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class FormParamCodegenTest {
+    @Test
+    void generatedFormParamsUseSingleParsedParameters() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        LazyValue.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-form-params"))
+                .addSource("FormEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/form")
+                        class FormEndpoint {
+                            @Http.POST
+                            String form(@Http.FormParam("first") String first,
+                                        @Http.FormParam("second") String second,
+                                        @Http.FormParam("count") int count) {
+                                return first + second + count;
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedSources = Files.walk(result.sourceOutput())
+                .filter(it -> it.getFileName().toString().endsWith(".java"))
+                .toList();
+
+        StringBuilder generatedContent = new StringBuilder();
+        for (Path generatedSource : generatedSources) {
+            generatedContent.append(Files.readString(generatedSource, StandardCharsets.UTF_8));
+            generatedContent.append('\n');
+        }
+
+        String generated = generatedContent.toString();
+        String formRead = ".asOptional(Parameters.GENERIC_TYPE)";
+        int occurrences = 0;
+        int index = 0;
+        while ((index = generated.indexOf(formRead, index)) != -1) {
+            occurrences++;
+            index += formRead.length();
+        }
+
+        assertThat(occurrences, is(1));
+        assertThat(generated, containsString("var declarative__formParams = HttpSupport.lazyFormParams(() -> req.content()"));
+        assertThat(generated, not(containsString("declarative__readFormParams")));
+        assertThat(generated,
+                   containsString("HttpSupport.paramValue(declarative__formParams.get(), \"first\", \"Form parameter\")"));
+        assertThat(generated,
+                   containsString("HttpSupport.paramValue(declarative__formParams.get(), \"second\", \"Form parameter\")"));
+        assertThat(generated,
+                   containsString("HttpSupport.paramValue(declarative__formParams.get(), \"count\", \"Form parameter\")"));
+        assertThat(generated,
+                   containsString("mappers.map(HttpSupport.paramValue(declarative__formParams.get(), \"count\","
+                                          + " \"Form parameter\"), GenericType.STRING, GTYPE, me -> new"
+                                          + " BadRequestException(\"Form parameter count has invalid value.\", me),"
+                                          + " \"form-params\")"));
+        assertThat(generated, not(containsString("\", \"form\")")));
+    }
+
+    @Test
+    void generatedFormParamsEscapeParameterNames() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        LazyValue.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-form-params-escaped-name"))
+                .addSource("FormEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/form")
+                        class FormEndpoint {
+                            @Http.POST
+                            String form(@Http.FormParam("quoted\\\"and\\\\slash") String value) {
+                                return value;
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedSources = Files.walk(result.sourceOutput())
+                .filter(it -> it.getFileName().toString().endsWith(".java"))
+                .toList();
+
+        StringBuilder generatedContent = new StringBuilder();
+        for (Path generatedSource : generatedSources) {
+            generatedContent.append(Files.readString(generatedSource, StandardCharsets.UTF_8));
+            generatedContent.append('\n');
+        }
+
+        String generated = generatedContent.toString();
+        assertThat(generated,
+                   containsString("HttpSupport.paramValue(declarative__formParams.get(), \"quoted\\\"and\\\\slash\","
+                                          + " \"Form parameter\")"));
+    }
+
+    @Test
+    void generatedRequestParamsFormUsesSingleParsedParameters() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        LazyValue.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-form"))
+                .addSource("FormParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record FormParams(@Http.FormParam("first") String first,
+                                          @Http.FormParam("second") String second) {
+                        }
+                        """)
+                .addSource("FormEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/form")
+                        class FormEndpoint {
+                            @Http.POST
+                            String form(@Http.RequestParams FormParams params) {
+                                return params.first() + params.second();
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedSources = Files.walk(result.sourceOutput())
+                .filter(it -> it.getFileName().toString().endsWith(".java"))
+                .toList();
+
+        StringBuilder generatedContent = new StringBuilder();
+        for (Path generatedSource : generatedSources) {
+            generatedContent.append(Files.readString(generatedSource, StandardCharsets.UTF_8));
+            generatedContent.append('\n');
+        }
+
+        String generated = generatedContent.toString();
+        String formRead = ".asOptional(Parameters.GENERIC_TYPE)";
+        int occurrences = 0;
+        int index = 0;
+        while ((index = generated.indexOf(formRead, index)) != -1) {
+            occurrences++;
+            index += formRead.length();
+        }
+
+        assertThat(occurrences, is(1));
+        assertThat(generated, containsString("var declarative__formParams = HttpSupport.lazyFormParams(() -> req.content()"));
+        assertThat(generated, not(containsString("declarative__readFormParams")));
+        assertThat(generated,
+                   containsString("requestParams_0_0(ServerRequest req, ServerResponse res, "
+                                          + "LazyValue<Parameters> declarative__formParams)"));
+        assertThat(generated, containsString("requestParams_0_0(req, res, declarative__formParams);"));
+    }
+
+    @Test
+    void generatedRequestParamsTypedParameterUsesServerRequest() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-typed"))
+                .addSource("TypedParams.java", """
+                        package com.example;
+
+                        import io.helidon.webserver.http.ServerRequest;
+
+                        record TypedParams(ServerRequest request) {
+                        }
+                        """)
+                .addSource("TypedEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/typed")
+                        class TypedEndpoint {
+                            @Http.GET
+                            String typed(@Http.RequestParams TypedParams params) {
+                                return String.valueOf(params.request());
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedSources = Files.walk(result.sourceOutput())
+                .filter(it -> it.getFileName().toString().endsWith(".java"))
+                .toList();
+
+        StringBuilder generatedContent = new StringBuilder();
+        for (Path generatedSource : generatedSources) {
+            generatedContent.append(Files.readString(generatedSource, StandardCharsets.UTF_8));
+            generatedContent.append('\n');
+        }
+
+        String generated = generatedContent.toString();
+        assertThat(generated, containsString("var requestParam_request = req;"));
+        assertThat(generated, containsString("return new TypedParams("));
+    }
+
+    @Test
+    void generatedRequestParamsTypedParameterUsesServerResponse() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-typed-response"))
+                .addSource("TypedParams.java", """
+                        package com.example;
+
+                        import io.helidon.webserver.http.ServerResponse;
+
+                        record TypedParams(ServerResponse response) {
+                        }
+                        """)
+                .addSource("TypedEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/typed")
+                        class TypedEndpoint {
+                            @Http.GET
+                            String typed(@Http.RequestParams TypedParams params) {
+                                return String.valueOf(params.response());
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedSources = Files.walk(result.sourceOutput())
+                .filter(it -> it.getFileName().toString().endsWith(".java"))
+                .toList();
+
+        StringBuilder generatedContent = new StringBuilder();
+        for (Path generatedSource : generatedSources) {
+            generatedContent.append(Files.readString(generatedSource, StandardCharsets.UTF_8));
+            generatedContent.append('\n');
+        }
+
+        String generated = generatedContent.toString();
+        assertThat(generated, containsString("var requestParam_response = res;"));
+        assertThat(generated, containsString("return new TypedParams("));
+    }
+
+    @Test
+    void methodEntityAndFormParametersAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-form-entity-method-conflict"))
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.POST
+                            String invalid(@Http.Entity String entity,
+                                           @Http.FormParam("field") String field) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("@Http.Entity and @Http.FormParam cannot be combined on declarative server method "
+                                          + "com.example.InvalidEndpoint.invalid()."));
+    }
+
+    @Test
+    void methodMultipleEntityParametersAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-method-multiple-entity-params"))
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.POST
+                            String invalid(@Http.Entity String first,
+                                           @Http.Entity String second) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Only one @Http.Entity parameter is supported on declarative server method "
+                                          + "com.example.InvalidEndpoint.invalid()."));
+    }
+
+    @Test
+    void methodEntityAndRequestParamsFormComponentsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-entity-request-params-form-conflict"))
+                .addSource("FormParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record FormParams(@Http.FormParam("field") String field) {
+                        }
+                        """)
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.POST
+                            String invalid(@Http.Entity String entity,
+                                           @Http.RequestParams FormParams params) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("@Http.Entity and @Http.FormParam cannot be combined on declarative server method "
+                                          + "com.example.InvalidEndpoint.invalid()."));
+    }
+
+    @Test
+    void requestParamsEntityAndFormComponentsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-body-conflict"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record InvalidParams(@Http.Entity String entity,
+                                             @Http.FormParam("field") String field) {
+                        }
+                        """)
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.POST
+                            String invalid(@Http.RequestParams InvalidParams params) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("@Http.Entity and @Http.FormParam record components cannot be combined in "
+                                          + "@Http.RequestParams type com.example.InvalidParams."));
+    }
+
+    @Test
+    void requestParamsMultipleEntityComponentsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-entity-conflict"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record InvalidParams(@Http.Entity String first,
+                                             @Http.Entity String second) {
+                        }
+                        """)
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.POST
+                            String invalid(@Http.RequestParams InvalidParams params) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Only one @Http.Entity record component is supported in @Http.RequestParams type "
+                                          + "com.example.InvalidParams."));
+    }
+
+    @Test
+    void requestParamsMultipleComponentAnnotationsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-multiple-annotations"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+
+                        record InvalidParams(@Http.HeaderParam("X-CUSTOM")
+                                             @Http.QueryParam("custom")
+                                             String value) {
+                        }
+                        """)
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.GET
+                            String invalid(@Http.RequestParams InvalidParams params) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Record component 'value' of @Http.RequestParams type com.example.InvalidParams "
+                                          + "must have at most one supported request parameter annotation."));
+    }
+
+    @Test
+    void methodMultipleParameterAnnotationsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-method-multiple-annotations"))
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.GET
+                            String invalid(@Http.HeaderParam("X-CUSTOM")
+                                           @Http.QueryParam("custom")
+                                           String value) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Parameter 'value' of declarative server method com.example.InvalidEndpoint.invalid() "
+                                          + "must have at most one supported request parameter annotation."));
+    }
+
+    @Test
+    void requestParamsTypeMustBeRecord() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-non-record"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        class InvalidParams {
+                        }
+                        """)
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.POST
+                            String invalid(@Http.RequestParams InvalidParams params) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("@Http.RequestParams type must be a record. Type com.example.InvalidParams is CLASS."));
+    }
+
+    @Test
+    void requestParamsComponentsMustBeAnnotated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(
+                        Annotation.class,
+                        Config.class,
+                        Dependency.class,
+                        Generated.class,
+                        GenericType.class,
+                        Handler.class,
+                        Http.class,
+                        HttpEntryPoint.class,
+                        HttpFeature.class,
+                        HttpRoute.class,
+                        HttpRouting.class,
+                        HttpRules.class,
+                        Mappers.class,
+                        Parameters.class,
+                        Prototype.class,
+                        ReadableEntity.class,
+                        RestServer.class,
+                        ServerRequest.class,
+                        ServerResponse.class,
+                        Service.class,
+                        ServiceDescriptor.class
+                ))
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-request-params-unannotated-component"))
+                .addSource("InvalidParams.java", """
+                        package com.example;
+
+                        record InvalidParams(String value) {
+                        }
+                        """)
+                .addSource("InvalidEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/invalid")
+                        class InvalidEndpoint {
+                            @Http.POST
+                            String invalid(@Http.RequestParams InvalidParams params) {
+                                return "invalid";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics,
+                   containsString("Record component 'value' of @Http.RequestParams type com.example.InvalidParams "
+                                          + "is not annotated with a supported request parameter annotation and is not "
+                                          + "a supported typed parameter."));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/PathParamMappedCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/PathParamMappedCodegenTest.java
@@ -34,6 +34,7 @@ import io.helidon.common.types.Annotation;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.config.Config;
 import io.helidon.http.Http;
+import io.helidon.http.HttpSupport;
 import io.helidon.service.registry.Dependency;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceDescriptor;
@@ -66,6 +67,7 @@ class PathParamMappedCodegenTest {
             Http.class,
             HttpEntryPoint.class,
             HttpFeature.class,
+            HttpSupport.class,
             HttpRoute.class,
             HttpRouting.class,
             HttpRules.class,
@@ -121,7 +123,9 @@ class PathParamMappedCodegenTest {
         assertThat(diagnostics, result.success(), is(true));
 
         String generated = generatedContent(result);
-        assertThat(generated, containsString(".path().pathParameters().first(\"name\")"));
+        assertThat(generated,
+                   containsString("var u_name = HttpSupport.paramValue(req.path().pathParameters(), "
+                                          + "\"name\", \"Path parameter\")"));
         assertThat(generated, not(containsString("helidonDeclarative__")));
         assertThat(generated, not(containsString("Value.create(mappers, \"name\"")));
     }
@@ -168,8 +172,11 @@ class PathParamMappedCodegenTest {
 
         String generated = generatedContent(result);
         assertThat(generated,
-                   containsString("mappers.map(it, GenericType.STRING, GTYPE, me -> new BadRequestException(\"Path"
-                                          + " parameter id has invalid value.\", me), \"http\", \"path\")"));
+                   containsString("mappers.map(HttpSupport.paramValue(req.path().pathParameters(), \"id\", "
+                                          + "\"Path parameter\"), GenericType.STRING, GTYPE, "
+                                          + "me -> new BadRequestException(\"Path parameter id has invalid value.\", "
+                                          + "me), "
+                                          + "\"http\", \"path\")"));
         assertThat(generated, not(containsString("\"http/path\"")));
         assertThat(generated, not(containsString("Value.create(")));
         assertThat(generated, not(containsString("helidonDeclarative__")));

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/QueryParamDefaultValueCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/QueryParamDefaultValueCodegenTest.java
@@ -202,7 +202,8 @@ class QueryParamDefaultValueCodegenTest {
 
         String generated = generatedContent.toString();
         assertThat(generated, containsString("LazyValue<List<Integer>> defaultValue"));
-        assertThat(generated, containsString("Optional.<List<Integer>>empty()).orElseGet(defaultValue::get)"));
+        assertThat(generated, containsString("HttpSupport.paramOptionalList(req.query(), \"ids\")"));
+        assertThat(generated, containsString(").orElseGet(defaultValue::get)"));
         assertThat(generated, not(containsString("Optional.<List<Integer>>empty().orElseGet(defaultValue::get)")));
     }
 }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/QueryParamOptionalListCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/QueryParamOptionalListCodegenTest.java
@@ -134,10 +134,10 @@ class QueryParamOptionalListCodegenTest {
         }
 
         String generated = generatedContent.toString();
-        assertThat(generated, containsString(".contains(\"fieldNames\")"));
-        assertThat(generated, containsString("? Optional.of(req.query().all(\"fieldNames\")"));
+        assertThat(generated, containsString("HttpSupport.paramOptionalList(req.query(), \"fieldNames\")"));
         assertThat(generated, containsString(".filter(it -> !it.isEmpty())"));
         assertThat(generated, containsString(".collect(Collectors.toList()))"));
+        assertThat(generated, not(containsString(".contains(\"fieldNames\")")));
         assertThat(generated, not(containsString("values.isEmpty() ? Optional")));
         assertThat(generated, not(containsString("helidonDeclarative__")));
         assertThat(generated, not(containsString("Value.create(mappers, \"fieldNames\"")));
@@ -198,13 +198,13 @@ class QueryParamOptionalListCodegenTest {
         }
 
         String generated = generatedContent.toString();
-        assertThat(generated, containsString(".contains(\"ids\")"));
-        assertThat(generated, containsString("? Optional.of(req.query().all(\"ids\")"));
+        assertThat(generated, containsString("HttpSupport.paramOptionalList(req.query(), \"ids\")"));
         assertThat(generated, containsString(".filter(it -> !it.isEmpty())"));
         assertThat(generated,
                    containsString("mappers.map(it, GenericType.STRING, GTYPE, me -> new BadRequestException(\"Query parameter"
                                           + " ids has invalid value.\", me), \"uri\", \"query\")"));
         assertThat(generated, not(containsString("\"uri/query\"")));
+        assertThat(generated, not(containsString(".contains(\"ids\")")));
         assertThat(generated,
                    not(containsString("catch (MapperException e)")));
         assertThat(generated, not(containsString("values.isEmpty() ? Optional")));

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/VariableNamingCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/VariableNamingCodegenTest.java
@@ -34,6 +34,7 @@ import io.helidon.common.types.Annotation;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.config.Config;
 import io.helidon.http.Http;
+import io.helidon.http.HttpSupport;
 import io.helidon.service.registry.Dependency;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceDescriptor;
@@ -66,6 +67,7 @@ class VariableNamingCodegenTest {
             Http.class,
             HttpEntryPoint.class,
             HttpFeature.class,
+            HttpSupport.class,
             HttpRoute.class,
             HttpRouting.class,
             HttpRules.class,
@@ -135,9 +137,15 @@ class VariableNamingCodegenTest {
         String generated = generatedContent.toString();
         assertThat(generated, containsString("ServerRequest req"));
         assertThat(generated, containsString("ServerResponse res"));
-        assertThat(generated, containsString("var u_req = req.query().first(\"req\")"));
-        assertThat(generated, containsString("var u_res = req.query().first(\"res\")"));
-        assertThat(generated, containsString("var u_response = req.query().first(\"response\")"));
+        assertThat(generated,
+                   containsString("var u_req = HttpSupport.paramValue(req.query(), \"req\", "
+                                          + "\"Query parameter\")"));
+        assertThat(generated,
+                   containsString("var u_res = HttpSupport.paramValue(req.query(), \"res\", "
+                                          + "\"Query parameter\")"));
+        assertThat(generated,
+                   containsString("var u_response = HttpSupport.paramValue(req.query(), \"response\", "
+                                          + "\"Query parameter\")"));
         assertThat(generated, containsString("var response = this.endpoint.names("));
         assertThat(generated, containsString("u_req,"));
         assertThat(generated, containsString("u_res,"));

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/websocket/server/WebSocketServerMappedPathParamCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/websocket/server/WebSocketServerMappedPathParamCodegenTest.java
@@ -123,10 +123,12 @@ class WebSocketServerMappedPathParamCodegenTest {
         assertThat(diagnostics, Files.exists(generatedListener), is(true));
 
         String listenerContent = Files.readString(generatedListener, StandardCharsets.UTF_8);
+        assertThat(listenerContent, containsString("@SuppressWarnings(\"helidon:api\")"));
         assertThat(listenerContent, containsString("var params = matched.path().pathParameters();"));
         assertThat(listenerContent,
-                   containsString("mappers.map(it, GenericType.STRING, GTYPE, me -> new BadRequestException(\"Path"
-                                          + " Param id has invalid value.\", me), \"http\", \"path\")"));
+                   containsString("mappers.map(HttpSupport.paramValue(params, \"id\", \"Path Param\"), GenericType.STRING,"
+                                          + " GTYPE, me -> new BadRequestException(\"Path Param id has invalid value.\", me),"
+                                          + " \"http\", \"path\")"));
         assertThat(listenerContent, not(containsString("\"http/path\"")));
         assertThat(diagnostics, result.success(), is(true));
     }

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/CustomFormParams.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/CustomFormParams.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import io.helidon.http.Http;
+
+record CustomFormParams(
+        @Http.FormParam("first") String first,
+        @Http.FormParam("second") String second) {
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/CustomPathParams.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/CustomPathParams.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import io.helidon.http.Http;
+
+record CustomPathParams(
+        @Http.PathParam("value") String value) {
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/CustomRequestParams.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/CustomRequestParams.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.http.Http;
+
+record CustomRequestParams(
+        @Http.HeaderParam("X-CUSTOM") String customHeader,
+        @Http.QueryParam("param") Optional<List<String>> queryParams,
+        @Http.CookieParam("myCookie") String cookie,
+        @Http.Entity String entity) {
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/RequestParamsClient.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/RequestParamsClient.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import java.util.List;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.Http;
+import io.helidon.webclient.api.RestClient;
+
+@RestClient.Endpoint("${greet-service.client.uri:http://localhost:8080}")
+@Http.Path("/request-params")
+interface RequestParamsClient {
+
+    @Http.POST
+    @Http.Path("/grouped")
+    @Http.Consumes(MediaTypes.TEXT_PLAIN_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String grouped(@Http.RequestParams CustomRequestParams params);
+
+    @Http.GET
+    @Http.Path("/path/{value}")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String path(@Http.RequestParams CustomPathParams params);
+
+    @Http.POST
+    @Http.Path("/form")
+    @Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String form(@Http.FormParam("first") String first,
+                @Http.FormParam("second") String second);
+
+    @Http.POST
+    @Http.Path("/form-list")
+    @Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String formList(@Http.FormParam("tag") List<String> tags);
+
+    @Http.POST
+    @Http.Path("/grouped-form")
+    @Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String groupedForm(@Http.RequestParams CustomFormParams params);
+
+    @Http.GET
+    @Http.Path("/cookies")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String cookies(@Http.CookieParam("first") String first,
+                   @Http.CookieParam("second") String second);
+
+    @Http.GET
+    @Http.Path("/cookies-list")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String cookiesList(@Http.CookieParam("tag") List<String> tags);
+
+    @RestClient.Header(name = "Cookie", value = "static=Expected-static")
+    @Http.GET
+    @Http.Path("/cookies-static")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String cookiesWithStatic(@Http.CookieParam("first") String first,
+                             @Http.CookieParam("second") String second);
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/RequestParamsEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/RequestParamsEndpoint.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import java.util.List;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@Http.Path("/request-params")
+@RestServer.Listener("@default")
+@RestServer.Endpoint
+@Service.Singleton
+class RequestParamsEndpoint {
+
+    @Http.POST
+    @Http.Path("/grouped")
+    @Http.Consumes(MediaTypes.TEXT_PLAIN_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String grouped(@Http.RequestParams CustomRequestParams params) {
+        return params.customHeader()
+                + "|" + params.queryParams().orElseGet(List::of)
+                + "|" + params.cookie()
+                + "|" + params.entity();
+    }
+
+    @Http.GET
+    @Http.Path("/path/{value}")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String path(@Http.RequestParams CustomPathParams params) {
+        return params.value();
+    }
+
+    @Http.POST
+    @Http.Path("/form")
+    @Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String form(@Http.FormParam("first") String first,
+                @Http.FormParam("second") String second) {
+        return first + "|" + second;
+    }
+
+    @Http.POST
+    @Http.Path("/form-list")
+    @Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String formList(@Http.FormParam("tag") List<String> tags) {
+        return tags.toString();
+    }
+
+    @Http.POST
+    @Http.Path("/grouped-form")
+    @Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String groupedForm(@Http.RequestParams CustomFormParams params) {
+        return params.first() + "|" + params.second();
+    }
+
+    @Http.GET
+    @Http.Path("/cookies")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String cookies(@Http.CookieParam("first") String first,
+                   @Http.CookieParam("second") String second) {
+        return first + "|" + second;
+    }
+
+    @Http.GET
+    @Http.Path("/cookies-static")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String cookiesStatic(@Http.CookieParam("static") String staticCookie,
+                         @Http.CookieParam("first") String first,
+                         @Http.CookieParam("second") String second) {
+        return staticCookie + "|" + first + "|" + second;
+    }
+
+    @Http.GET
+    @Http.Path("/cookies-list")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String cookiesList(@Http.CookieParam("tag") List<String> tags) {
+        return tags.toString();
+    }
+}

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -17,9 +17,12 @@
 package io.helidon.declarative.tests.http;
 
 import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -169,6 +172,25 @@ class DeclarativeHttpTest {
     }
 
     @Test
+    void testQueryListAbsent() {
+        var response = client.get("/greet/query-list")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Query parameter param is not present in the request."));
+    }
+
+    @Test
+    void testQueryListWithoutValue() {
+        var response = client.get()
+                .uri(URI.create("/greet/query-list?param"))
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("[]"));
+    }
+
+    @Test
     void testQueryOptionalListAbsent() {
         var response = client.get("/greet/query-optional-list")
                 .request(String.class);
@@ -240,6 +262,337 @@ class DeclarativeHttpTest {
     }
 
     @Test
+    void testRequestParams() {
+        var response = client.post("/request-params/grouped")
+                .header(HeaderValues.create(HeaderNames.create("X-CUSTOM"), "Expected-header"))
+                .header(HeaderValues.create(HeaderNames.COOKIE, "myCookie=Expected-cookie"))
+                .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)
+                .queryParam("param", "first", "second")
+                .submit("Expected-entity", String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("Expected-header|[first, second]|Expected-cookie|Expected-entity"));
+    }
+
+    @Test
+    void testRequestParamsPath() {
+        var response = client.get("/request-params/path/Expected-path")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("Expected-path"));
+    }
+
+    @Test
+    void testFormParam() {
+        var response = client.post("/request-params/form")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("first=Expected+form&second=Second+form", String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("Expected form|Second form"));
+    }
+
+    @Test
+    void testFormParamEmptyStringPreserved() {
+        var response = client.post("/request-params/form")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("first=&second=Second+form", String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("|Second form"));
+    }
+
+    @Test
+    void testMissingFormParam() {
+        var response = client.post("/request-params/form")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("first=Expected+form", String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Form parameter second is not present in the request."));
+    }
+
+    @Test
+    void testMissingFormEntity() {
+        var response = client.post("/request-params/form")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Form parameter first is not present in the request."));
+    }
+
+    @Test
+    void testInvalidFormEntity() {
+        var response = client.post("/request-params/form")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("first=%zz&second=Second+form", String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Failed to read form parameters."));
+    }
+
+    @Test
+    void testMissingFormListParam() {
+        var response = client.post("/request-params/form-list")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("", String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Form parameter tag is not present in the request."));
+    }
+
+    @Test
+    void testFormListParam() {
+        var response = client.post("/request-params/form-list")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("tag=first&tag=second", String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("[first, second]"));
+    }
+
+    @Test
+    void testGroupedFormParam() {
+        var response = client.post("/request-params/grouped-form")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("first=Expected+form&second=Second+form", String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("Expected form|Second form"));
+    }
+
+    @Test
+    void testGroupedFormParamEmptyStringPreserved() {
+        var response = client.post("/request-params/grouped-form")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("first=&second=Second+form", String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("|Second form"));
+    }
+
+    @Test
+    void testMissingGroupedFormParam() {
+        var response = client.post("/request-params/grouped-form")
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
+                .submit("first=Expected+form", String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Form parameter second is not present in the request."));
+    }
+
+    @Test
+    void testRequestParamsClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        String response = typedClient.grouped(new CustomRequestParams("Expected-header",
+                                                                      Optional.of(List.of("first", "second")),
+                                                                      "Expected-cookie",
+                                                                      "Expected-entity"));
+        assertThat(response, is("Expected-header|[first, second]|Expected-cookie|Expected-entity"));
+    }
+
+    @Test
+    void testRequestParamsPathClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        assertThat(typedClient.path(new CustomPathParams("Expected-path")), is("Expected-path"));
+    }
+
+    @Test
+    void testFormParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        assertThat(typedClient.form("Expected form", "Second form"), is("Expected form|Second form"));
+    }
+
+    @Test
+    void testFormParamClientEmptyStringPreserved() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        assertThat(typedClient.form("", "Second form"), is("|Second form"));
+    }
+
+    @Test
+    void testFormListParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        assertThat(typedClient.formList(List.of("first", "second")), is("[first, second]"));
+    }
+
+    @Test
+    void testGroupedFormParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        assertThat(typedClient.groupedForm(new CustomFormParams("Expected form", "Second form")),
+                   is("Expected form|Second form"));
+    }
+
+    @Test
+    void testCookieParamsClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        assertThat(typedClient.cookies("Expected-first", "Expected-second"),
+                   is("Expected-first|Expected-second"));
+    }
+
+    @Test
+    void testCookieListParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        assertThat(typedClient.cookiesList(List.of("first", "second")), is("[first, second]"));
+    }
+
+    @Test
+    void testEmptyCookieListParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        var thrown = assertThrows(IllegalArgumentException.class, () -> typedClient.cookiesList(List.of()));
+
+        assertThat(thrown.getMessage(), is("Cookie parameter tag has no values."));
+    }
+
+    @Test
+    void testCookieParamsClientMergesStaticCookieHeader() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        assertThat(typedClient.cookiesWithStatic("Expected-first", "Expected-second"),
+                   is("Expected-static|Expected-first|Expected-second"));
+    }
+
+    @Test
+    void testInvalidCookieParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        var exception = assertThrows(IllegalArgumentException.class,
+                                     () -> typedClient.cookies("Expected-first; injected=true", "Expected-second"));
+        assertThat(exception.getMessage(), is("Cookie parameter first has invalid value."));
+    }
+
+    @Test
+    void testNullCookieParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        var exception = assertThrows(NullPointerException.class,
+                                     () -> typedClient.cookies(null, "Expected-second"));
+        assertThat(exception.getMessage(), is("Cookie parameter first must not be null."));
+    }
+
+    @Test
+    void testNullFormParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        var exception = assertThrows(NullPointerException.class,
+                                     () -> typedClient.form(null, "Second form"));
+        assertThat(exception.getMessage(), is("Form parameter first must not be null."));
+    }
+
+    @Test
+    void testNullListParamClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        var exception = assertThrows(NullPointerException.class, () -> typedClient.formList(null));
+        assertThat(exception.getMessage(), is("Form parameter tag must not be null."));
+
+        exception = assertThrows(NullPointerException.class, () -> typedClient.cookiesList(null));
+        assertThat(exception.getMessage(), is("Cookie parameter tag must not be null."));
+
+        exception = assertThrows(NullPointerException.class, () -> typedClient.cookiesList(Arrays.asList("first", null)));
+        assertThat(exception.getMessage(), is("Cookie parameter tag must not be null."));
+    }
+
+    @Test
+    void testNullRequestParamsClient() {
+        RequestParamsClient typedClient = registry.get(Lookup.builder()
+                                                               .addContract(RequestParamsClient.class)
+                                                               .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                               .build());
+
+        var exception = assertThrows(NullPointerException.class, () -> typedClient.grouped(null));
+        assertThat(exception.getMessage(), is("@Http.RequestParams parameter params must not be null."));
+
+        exception = assertThrows(NullPointerException.class,
+                                 () -> typedClient.grouped(new CustomRequestParams(null,
+                                                                                   Optional.of(List.of("first")),
+                                                                                   "Expected-cookie",
+                                                                                   "Expected-entity")));
+        assertThat(exception.getMessage(), is("Header X-CUSTOM must not be null."));
+
+        exception = assertThrows(NullPointerException.class,
+                                 () -> typedClient.grouped(new CustomRequestParams("Expected-header",
+                                                                                   null,
+                                                                                   "Expected-cookie",
+                                                                                   "Expected-entity")));
+        assertThat(exception.getMessage(), is("Query parameter param must not be null."));
+
+        exception = assertThrows(NullPointerException.class, () -> typedClient.path(new CustomPathParams(null)));
+        assertThat(exception.getMessage(), is("Path parameter value must not be null."));
+    }
+
+    @Test
+    void testCookieListParam() {
+        var response = client.get("/request-params/cookies-list")
+                .header(HeaderValues.create(HeaderNames.COOKIE, "tag=first; tag=second"))
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("[first, second]"));
+    }
+
+    @Test
+    void testMissingCookieListParam() {
+        var response = client.get("/request-params/cookies-list")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Cookie tag is not present in the request."));
+    }
+
+    @Test
     void testTypedClient() {
         GreetServiceClient typedClient = registry.get(Lookup.builder()
                                                               .addContract(GreetServiceClient.class)
@@ -280,6 +633,23 @@ class DeclarativeHttpTest {
                 .build();
         jsonMessage = typedClient.updateGreetingHandlerReturningCurrent(newGreeting);
         assertThat(jsonMessage.stringValue("message", "bad"), is("Ahoj World!"));
+    }
+
+    @Test
+    void testTypedClientNullParams() {
+        GreetServiceClient typedClient = registry.get(Lookup.builder()
+                                                              .addContract(GreetServiceClient.class)
+                                                              .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                              .build());
+
+        var exception = assertThrows(NullPointerException.class, () -> typedClient.failingFallback(null));
+        assertThat(exception.getMessage(), is("Header Host must not be null."));
+
+        exception = assertThrows(NullPointerException.class, () -> typedClient.timeout(null));
+        assertThat(exception.getMessage(), is("Query parameter sleepSeconds must not be null."));
+
+        exception = assertThrows(NullPointerException.class, () -> typedClient.getMessageHandler(null));
+        assertThat(exception.getMessage(), is("Path parameter name must not be null."));
     }
 
     @Test

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -155,13 +155,41 @@ Annotations on method parameters:
 
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Entity.html[`io.helidon.http.Http.Entity`] - Request entity, a typed parameter is expected, will use HTTP media type modules to coerce into the correct type
 - link:{http-javadoc-base-url}/io/helidon/http/Http.HeaderParam.html[`io.helidon.http.Http.HeaderParam`] - Typed HTTP request header value
+- link:{http-javadoc-base-url}/io/helidon/http/Http.CookieParam.html[`io.helidon.http.Http.CookieParam`] - Typed HTTP request cookie value
 - link:{http-javadoc-base-url}/io/helidon/http/Http.QueryParam.html[`io.helidon.http.Http.QueryParam`] - Typed HTTP query value
+- link:{http-javadoc-base-url}/io/helidon/http/Http.FormParam.html[`io.helidon.http.Http.FormParam`] - Typed URL encoded form value from the request entity
 - link:{http-javadoc-base-url}/io/helidon/http/Http.PathParam.html[`io.helidon.http.Http.PathParam`] - Typed parameter from path template
+- link:{http-javadoc-base-url}/io/helidon/http/Http.RequestParams.html[`io.helidon.http.Http.RequestParams`] - Grouped request parameters in a record type
+
+`Http.FormParam` is backed by the request entity and should be used with
+`@Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)`. It cannot be combined with `Http.Entity` on the same
+declarative method. Each endpoint method parameter may have at most one supported request parameter annotation.
+
+`Http.RequestParams` is supported only for record parameter types. This is a restriction on the parameter types supported
+by declarative code generation. Each record component must either be a supported typed parameter that does not require an
+annotation, such as `ServerRequest`, or have one of these component annotations: `Http.HeaderParam`, `Http.CookieParam`,
+`Http.QueryParam`, `Http.FormParam`, `Http.PathParam`, or `Http.Entity`. Components must not combine supported request
+parameter annotations. At most one `Http.Entity` component is supported, and `Http.Entity` cannot be combined with
+`Http.FormParam` components.
+
+The named value annotations, such as `Http.HeaderParam`, `Http.CookieParam`, `Http.QueryParam`, `Http.FormParam`, and
+`Http.PathParam`, support scalar values, `Optional<T>`, `List<T>`, and `Optional<List<T>>`. For server endpoints,
+`List<T>` is mandatory and the request fails if the named value is missing.
+`Optional<List<T>>` is optional and is empty when the named value is missing. If the named value is present but has no
+values, the injected list is empty. Cookies are an exception: cookies are not represented as `Parameters`, so a named
+cookie cannot be present with no values. Cookie parameter names are validated during declarative code generation.
+Server path parameters are obtained from the routed request path.
 
 [source,java]
 .Example of an HTTP Server Endpoint
 ----
 include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_2, indent=0]
+----
+
+[source,java]
+.Example of Grouped HTTP Server Parameters
+----
+include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_19, indent=0]
 ----
 
 === Typed HTTP Client [[Dec-HTTP-Client]]
@@ -191,13 +219,47 @@ Annotations on method parameters:
 
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Entity.html[`io.helidon.http.Http.Entity`] - Request entity, a typed parameter is expected, will use HTTP media type modules to write to the request
 - link:{http-javadoc-base-url}/io/helidon/http/Http.HeaderParam.html[`io.helidon.http.Http.HeaderParam`] - Typed HTTP header value to send
+- link:{http-javadoc-base-url}/io/helidon/http/Http.CookieParam.html[`io.helidon.http.Http.CookieParam`] - Typed HTTP cookie value to send
 - link:{http-javadoc-base-url}/io/helidon/http/Http.QueryParam.html[`io.helidon.http.Http.QueryParam`] - Typed HTTP query value to send
+- link:{http-javadoc-base-url}/io/helidon/http/Http.FormParam.html[`io.helidon.http.Http.FormParam`] - Typed URL encoded form value to send in the request entity
 - link:{http-javadoc-base-url}/io/helidon/http/Http.PathParam.html[`io.helidon.http.Http.PathParam`] - Typed parameter from path template to construct the request URI
+- link:{http-javadoc-base-url}/io/helidon/http/Http.RequestParams.html[`io.helidon.http.Http.RequestParams`] - Grouped request parameters in a record type
+
+`Http.FormParam` is backed by the request entity and should be used with
+`@Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)`. It cannot be combined with `Http.Entity` on the same
+declarative method. Each client method parameter may have at most one supported request parameter annotation.
+
+`Http.RequestParams` is supported only for record parameter types. This is a restriction on the parameter types supported
+by declarative code generation. Each client record component must use one of these component annotations:
+`Http.HeaderParam`, `Http.CookieParam`, `Http.QueryParam`, `Http.FormParam`, `Http.PathParam`, or `Http.Entity`.
+Components must not combine supported request parameter annotations. At most one `Http.Entity` component is supported,
+and `Http.Entity` cannot be combined with `Http.FormParam` components.
+
+The `Http.HeaderParam`, `Http.CookieParam`, `Http.QueryParam`, and `Http.FormParam` annotations support scalar values,
+`Optional<T>`, `List<T>`, and `Optional<List<T>>`. Declarative clients send every value from `List<T>`, and send
+`Optional<List<T>>` only when the optional is present.
+Declarative client named-value parameters must not be `null`; use `Optional.empty()` to omit optional values. List values
+must not contain `null` elements. The same nullability rule applies to named-value components of `Http.RequestParams`
+records, and the request-params argument itself must not be `null`.
+Cookie parameter names are validated during declarative code generation. Declarative clients send cookie parameters as a
+single `Cookie` header and do not escape cookie values; each cookie parameter value must already be a valid cookie-octet
+value. Cookies are not represented as `Parameters`, so a named cookie cannot be present with no values. A mandatory
+client `List<T>` cookie parameter must contain at least one value.
+
+Declarative clients use `Http.PathParam` values as URI path text when constructing the request URI. They do not encode
+each value as a single path segment, so reserved path characters such as `/` keep their WebClient URI meaning. Path
+parameter values must not be `null`.
 
 [source,java]
 .Example of a Typed HTTP Client
 ----
 include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_3, indent=0]
+----
+
+[source,java]
+.Example of Grouped HTTP Client Parameters
+----
+include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_20, indent=0]
 ----
 
 

--- a/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
+++ b/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
@@ -66,6 +66,30 @@ public class DeclarativeExample {
     }
     // end::snippet_3[]
 
+    // tag::snippet_20[]
+    record MessageParams(
+            @Http.PathParam("id") String id,
+            @Http.QueryParam("lang") String language,
+            @Http.CookieParam("theme") String theme) {
+    }
+
+    @RestClient.Endpoint("${message-service.client.uri:http://localhost:8080}")
+    @Http.Path("/messages")
+    interface MessageClient {
+        @Http.GET
+        @Http.Path("/{id}")
+        @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+        String message(@Http.RequestParams MessageParams params);
+
+        @Http.POST
+        @Http.Path("/form")
+        @Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)
+        @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+        String submit(@Http.FormParam("message") String message,
+                      @Http.CookieParam("session") String session);
+    }
+    // end::snippet_20[]
+
     // tag::snippet_1[]
     @Service.GenerateBinding // generated binding to bypass discovery and runtime binding
     public static class Main {
@@ -102,6 +126,29 @@ public class DeclarativeExample {
         }
     }
     // end::snippet_2[]
+
+    // tag::snippet_19[]
+    @RestServer.Endpoint
+    @Http.Path("/messages")
+    @Service.Singleton
+    static class MessageEndpoint {
+        @Http.GET
+        @Http.Path("/{id}")
+        @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+        String message(@Http.RequestParams MessageParams params) {
+            return params.id() + ":" + params.language() + ":" + params.theme();
+        }
+
+        @Http.POST
+        @Http.Path("/form")
+        @Http.Consumes(MediaTypes.APPLICATION_FORM_URLENCODED_VALUE)
+        @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+        String submit(@Http.FormParam("message") String message,
+                      @Http.CookieParam("session") String session) {
+            return session + ":" + message;
+        }
+    }
+    // end::snippet_19[]
 
     // tag::snippet_4[]
     @Service.Singleton

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -82,8 +82,10 @@ public final class Http {
 
     /**
      * Inject entity into a method parameter.
+     * <p>
+     * Can also be used on {@link RequestParams} record components.
      */
-    @Target(ElementType.PARAMETER)
+    @Target({ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
     @Retention(RetentionPolicy.CLASS)
     @Documented
     @Service.Qualifier
@@ -91,9 +93,23 @@ public final class Http {
     }
 
     /**
-     * Inject header into a method parameter.
+     * Inject a request header into a server method parameter, or send a header from a declarative client method
+     * parameter.
+     * <p>
+     * Can also be used on {@link RequestParams} record components.
+     * <p>
+     * Declarative server endpoints support {@code List<T>} for mandatory multi-value headers and
+     * {@code Optional<List<T>>} for optional multi-value headers. A mandatory list is rejected when the named header is
+     * missing, while an optional list is empty when the named header is missing. If the named header is present with no
+     * values, the injected list is empty.
+     * <p>
+     * Declarative clients send every value from {@code List<T>} and send {@code Optional<List<T>>} only when the
+     * optional is present.
+     * <p>
+     * Declarative client values must not be {@code null}. Use {@code Optional.empty()} to omit optional values.
+     * Client list values must not contain {@code null} elements.
      */
-    @Target(ElementType.PARAMETER)
+    @Target({ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
     @Retention(RetentionPolicy.CLASS)
     @Documented
     @Service.Qualifier
@@ -107,9 +123,54 @@ public final class Http {
     }
 
     /**
-     * Inject query parameter into a method parameter.
+     * Inject a request cookie into a server method parameter, or send a cookie from a declarative client method
+     * parameter. Cookie names are validated during declarative code generation. Declarative clients do not escape
+     * cookie values; each value must already be a valid cookie-octet value.
+     * <p>
+     * Can also be used on {@link RequestParams} record components.
+     * <p>
+     * Declarative server endpoints support {@code List<T>} for mandatory multi-value cookies and
+     * {@code Optional<List<T>>} for optional multi-value cookies. A mandatory list is rejected when the named cookie is
+     * missing, while an optional list is empty when the named cookie is missing. Cookies are not represented as
+     * {@code Parameters}; a named cookie cannot be present with no values.
+     * <p>
+     * Declarative clients send cookie parameters as a single {@code Cookie} header. They send every value from
+     * {@code List<T>} and send {@code Optional<List<T>>} only when the optional is present. A mandatory client
+     * {@code List<T>} cookie parameter must contain at least one value.
+     * <p>
+     * Declarative client values must not be {@code null}. Use {@code Optional.empty()} to omit optional values.
+     * Client list values must not contain {@code null} elements.
      */
-    @Target(ElementType.PARAMETER)
+    @Target({ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
+    @Retention(RetentionPolicy.CLASS)
+    @Documented
+    @Service.Qualifier
+    public @interface CookieParam {
+        /**
+         * Name of the cookie.
+         *
+         * @return name of the cookie
+         */
+        String value();
+    }
+
+    /**
+     * Inject query parameter into a method parameter.
+     * <p>
+     * Can also be used on {@link RequestParams} record components.
+     * <p>
+     * Declarative server endpoints support {@code List<T>} for mandatory multi-value query parameters and
+     * {@code Optional<List<T>>} for optional multi-value query parameters. A mandatory list is rejected when the named
+     * query parameter is missing, while an optional list is empty when the named query parameter is missing. If the
+     * query parameter name is present without any values, the injected list is empty.
+     * <p>
+     * Declarative clients send every value from {@code List<T>} and send {@code Optional<List<T>>} only when the
+     * optional is present.
+     * <p>
+     * Declarative client values must not be {@code null}. Use {@code Optional.empty()} to omit optional values.
+     * Client list values must not contain {@code null} elements.
+     */
+    @Target({ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
     @Retention(RetentionPolicy.CLASS)
     @Documented
     @Service.Qualifier
@@ -122,12 +183,63 @@ public final class Http {
         String value();
     }
 
+    /**
+     * Inject a URL encoded form parameter into a server method parameter, or send a form parameter from a declarative
+     * client method parameter.
+     * <p>
+     * Can also be used on {@link RequestParams} record components.
+     * <p>
+     * Declarative endpoints and clients should use this annotation with
+     * {@code @Http.Consumes("application/x-www-form-urlencoded")}. Form parameters use the request entity and cannot be
+     * combined with {@link Entity} on the same declarative method.
+     * <p>
+     * Declarative server endpoints support {@code List<T>} for mandatory multi-value form parameters and
+     * {@code Optional<List<T>>} for optional multi-value form parameters. A mandatory list is rejected when the named
+     * form parameter is missing, while an optional list is empty when the named form parameter is missing. If the form
+     * parameter name is present without any values, the injected list is empty.
+     * <p>
+     * Declarative clients send every value from {@code List<T>} and send {@code Optional<List<T>>} only when the
+     * optional is present.
+     * <p>
+     * Declarative client values must not be {@code null}. Use {@code Optional.empty()} to omit optional values.
+     * Client list values must not contain {@code null} elements.
+     */
+    @Target({ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
+    @Retention(RetentionPolicy.CLASS)
+    @Documented
+    @Service.Qualifier
+    public @interface FormParam {
+        /**
+         * Name of the form parameter.
+         *
+         * @return name of the form parameter
+         */
+        String value();
+    }
 
     /**
-     * Inject path parameter into a method parameter.
-     * Path parameters are obtained from the path template of the routing method.
+     * Inject a path parameter into a server method parameter, or provide a path template value from a declarative
+     * client method parameter.
+     * <p>
+     * Server path parameters are obtained from the path template of the routing method.
+     * <p>
+     * Declarative server endpoints may use {@code Optional<T>}, but the optional cannot be empty for a matched route;
+     * if the path parameter were missing, the route would not match.
+     * <p>
+     * Declarative clients use path parameter values as URI path text. They do not encode each value as a single path
+     * segment before constructing the request URI.
+     * <p>
+     * Declarative client path parameter values must not be {@code null}. If {@code Optional<T>} is used, the optional
+     * value itself must not be {@code null} and must be present; empty optional path values are rejected.
+     * <p>
+     * Can also be used on {@link RequestParams} record components.
+     * <p>
+     * Declarative server endpoints support {@code List<T>} for mandatory multi-value path parameters and
+     * {@code Optional<List<T>>} for optional multi-value path parameters. A matched route provides the named path
+     * parameter; if it were missing, the route would not match. If the named path parameter is present with no values,
+     * the injected list is empty.
      */
-    @Target(ElementType.PARAMETER)
+    @Target({ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
     @Retention(RetentionPolicy.CLASS)
     @Documented
     @Service.Qualifier
@@ -138,6 +250,30 @@ public final class Http {
          * @return name of the path parameter
          */
         String value();
+    }
+
+    /**
+     * Inject grouped request parameters into a method parameter.
+     * <p>
+     * The annotated parameter type must be a record. This is a restriction on the supported parameter types for
+     * declarative code generation. Each record component may have at most one supported request parameter annotation:
+     * {@link HeaderParam}, {@link CookieParam}, {@link QueryParam}, {@link FormParam}, {@link PathParam}, or
+     * {@link Entity}. At most one {@link Entity} component is supported. Form parameter components use the request
+     * entity and cannot be combined with an entity component.
+     * <p>
+     * Declarative server endpoints may also use annotation-free record components whose type is a supported typed
+     * endpoint parameter, such as {@code ServerRequest} or {@code ServerResponse}. Declarative clients require every
+     * record component to use one supported request parameter annotation.
+     * <p>
+     * List-valued record components follow the same rules as list-valued endpoint method parameters.
+     * Declarative client request-params arguments and named-value component values must not be {@code null}; use
+     * {@code Optional.empty()} to omit optional named values.
+     */
+    @Target(ElementType.PARAMETER)
+    @Retention(RetentionPolicy.CLASS)
+    @Documented
+    @Service.Qualifier
+    public @interface RequestParams {
     }
 
     /**

--- a/http/http/src/main/java/io/helidon/http/HttpSupport.java
+++ b/http/http/src/main/java/io/helidon/http/HttpSupport.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.common.Api;
+import io.helidon.common.LazyValue;
+import io.helidon.common.parameters.Parameters;
+
+/**
+ * HTTP support methods used from generated code.
+ */
+@Api.Internal
+public final class HttpSupport {
+    private HttpSupport() {
+    }
+
+    /**
+     * Read form parameters.
+     *
+     * @param formParams form parameters supplier
+     * @return form parameters, or empty form parameters if none were supplied
+     * @throws HttpException if reading form parameters fails with a specific HTTP status
+     * @throws BadRequestException if reading form parameters fails
+     */
+    public static Parameters formParams(Supplier<Optional<Parameters>> formParams) {
+        Objects.requireNonNull(formParams);
+
+        try {
+            return formParams.get()
+                    .orElseGet(() -> Parameters.empty("form-params"));
+        } catch (HttpException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new BadRequestException("Failed to read form parameters.", e);
+        }
+    }
+
+    /**
+     * Lazily read form parameters.
+     *
+     * @param formParams form parameters supplier
+     * @return lazy form parameters
+     */
+    public static LazyValue<Parameters> lazyFormParams(Supplier<Optional<Parameters>> formParams) {
+        Objects.requireNonNull(formParams);
+
+        return LazyValue.create(() -> formParams(formParams));
+    }
+
+    /**
+     * Create a single cookie pair for the {@code Cookie} header.
+     *
+     * @param name cookie name
+     * @param value cookie value
+     * @return cookie pair
+     * @throws IllegalArgumentException if the name or value cannot be sent as a cookie pair
+     */
+    public static String cookie(String name, Object value) {
+        validateCookieName(name);
+        if (value == null) {
+            throw new IllegalArgumentException("Cookie parameter " + name + " has invalid value.");
+        }
+
+        String cookieValue = String.valueOf(value);
+        validateCookieValue(name, cookieValue);
+        return name + "=" + cookieValue;
+    }
+
+    /**
+     * Create a single {@code Cookie} header from cookie pairs.
+     *
+     * @param cookies cookie pairs
+     * @return cookie header value
+     */
+    public static String cookieHeader(List<String> cookies) {
+        Objects.requireNonNull(cookies);
+
+        return String.join("; ", cookies);
+    }
+
+    /**
+     * Get a mandatory list parameter.
+     *
+     * @param parameters parameter source
+     * @param name parameter name
+     * @param source source description for error reporting
+     * @return parameter values
+     * @throws BadRequestException if the named parameter is missing
+     */
+    public static List<String> paramList(Parameters parameters, String name, String source) {
+        Objects.requireNonNull(parameters);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(source);
+
+        if (parameters.contains(name)) {
+            return parameters.all(name);
+        }
+        throw new BadRequestException(source + " " + name + " is not present in the request.");
+    }
+
+    /**
+     * Get an optional list parameter.
+     *
+     * @param parameters parameter source
+     * @param name parameter name
+     * @return parameter values if the named parameter is present, empty otherwise
+     */
+    public static Optional<List<String>> paramOptionalList(Parameters parameters, String name) {
+        Objects.requireNonNull(parameters);
+        Objects.requireNonNull(name);
+
+        if (parameters.contains(name)) {
+            return Optional.of(parameters.all(name));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Get a mandatory scalar parameter.
+     *
+     * @param parameters parameter source
+     * @param name parameter name
+     * @param source source description for error reporting
+     * @return parameter value, or empty string if the named parameter is present without values
+     * @throws BadRequestException if the named parameter is missing
+     */
+    public static String paramValue(Parameters parameters, String name, String source) {
+        Objects.requireNonNull(parameters);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(source);
+
+        if (parameters.contains(name)) {
+            return parameters.first(name).orElse("");
+        }
+        throw new BadRequestException(source + " " + name + " is not present in the request.");
+    }
+
+    /**
+     * Get an optional scalar parameter.
+     *
+     * @param parameters parameter source
+     * @param name parameter name
+     * @return parameter value if the named parameter is present, empty otherwise
+     */
+    public static Optional<String> paramOptionalValue(Parameters parameters, String name) {
+        Objects.requireNonNull(parameters);
+        Objects.requireNonNull(name);
+
+        if (parameters.contains(name)) {
+            return Optional.of(parameters.first(name).orElse(""));
+        }
+        return Optional.empty();
+    }
+
+    private static void validateCookieName(String name) {
+        Objects.requireNonNull(name);
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("Cookie parameter name has invalid value.");
+        }
+
+        try {
+            HttpToken.validate(name);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Cookie parameter name has invalid value.", e);
+        }
+    }
+
+    private static void validateCookieValue(String name, String cookieValue) {
+        for (int i = 0; i < cookieValue.length(); i++) {
+            char c = cookieValue.charAt(i);
+            if (c <= 0x20 || c >= 0x7f || c == '"' || c == ',' || c == ';' || c == '\\') {
+                throw new IllegalArgumentException("Cookie parameter " + name + " has invalid value.");
+            }
+        }
+    }
+}

--- a/http/http/src/test/java/io/helidon/http/HttpSupportTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpSupportTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.parameters.Parameters;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HttpSupportTest {
+    @Test
+    void formParamsReturnsSuppliedParameters() {
+        var params = Parameters.builder("form-params")
+                .add("name", "value")
+                .build();
+
+        assertThat(HttpSupport.formParams(() -> Optional.of(params)), sameInstance(params));
+    }
+
+    @Test
+    void formParamsReturnsEmptyParametersWhenMissing() {
+        Parameters params = HttpSupport.formParams(Optional::empty);
+
+        assertThat(params.component(), is("form-params"));
+        assertThat(params.isEmpty(), is(true));
+    }
+
+    @Test
+    void formParamsPreservesHttpException() {
+        var cause = new HttpException("too large", Status.REQUEST_ENTITY_TOO_LARGE_413);
+
+        var thrown = assertThrows(HttpException.class,
+                                  () -> HttpSupport.formParams(() -> {
+                                      throw cause;
+                                  }));
+
+        assertThat(thrown, sameInstance(cause));
+    }
+
+    @Test
+    void formParamsWrapsRuntimeExceptionAsBadRequest() {
+        var cause = new IllegalStateException("broken");
+
+        var thrown = assertThrows(BadRequestException.class,
+                                  () -> HttpSupport.formParams(() -> {
+                                      throw cause;
+                                  }));
+
+        assertThat(thrown.getMessage(), is("Failed to read form parameters."));
+        assertThat(thrown.getCause(), sameInstance(cause));
+    }
+
+    @Test
+    void lazyFormParamsReadsOnceOnAccess() {
+        var reads = new AtomicInteger();
+        var params = Parameters.builder("form-params")
+                .add("name", "value")
+                .build();
+
+        var lazy = HttpSupport.lazyFormParams(() -> {
+            reads.incrementAndGet();
+            return Optional.of(params);
+        });
+
+        assertThat(reads.get(), is(0));
+        assertThat(lazy.get(), sameInstance(params));
+        assertThat(lazy.get(), sameInstance(params));
+        assertThat(reads.get(), is(1));
+    }
+
+    @Test
+    void cookieCreatesCookiePair() {
+        assertThat(HttpSupport.cookie("name", "value"), is("name=value"));
+    }
+
+    @Test
+    void cookieRejectsInvalidName() {
+        var thrown = assertThrows(IllegalArgumentException.class, () -> HttpSupport.cookie("bad;name", "value"));
+
+        assertThat(thrown.getMessage(), is("Cookie parameter name has invalid value."));
+    }
+
+    @Test
+    void cookieRejectsInvalidValue() {
+        var thrown = assertThrows(IllegalArgumentException.class, () -> HttpSupport.cookie("session", "bad;value"));
+
+        assertThat(thrown.getMessage(), is("Cookie parameter session has invalid value."));
+    }
+
+    @Test
+    void cookieHeaderJoinsCookiePairs() {
+        assertThat(HttpSupport.cookieHeader(List.of("first=one", "second=two")), is("first=one; second=two"));
+    }
+
+    @Test
+    void paramValueReturnsFirstValue() {
+        var params = Parameters.builder("test")
+                .add("name", "value")
+                .build();
+
+        assertThat(HttpSupport.paramValue(params, "name", "Test parameter"), is("value"));
+    }
+
+    @Test
+    void paramValueReturnsEmptyStringWhenPresentWithoutValues() {
+        var params = Parameters.builder("test")
+                .add("name")
+                .build();
+
+        assertThat(HttpSupport.paramValue(params, "name", "Test parameter"), is(""));
+    }
+
+    @Test
+    void paramValueFailsWhenMissing() {
+        var params = Parameters.empty("test");
+
+        var thrown = assertThrows(BadRequestException.class,
+                                  () -> HttpSupport.paramValue(params, "name", "Test parameter"));
+
+        assertThat(thrown.getMessage(), is("Test parameter name is not present in the request."));
+    }
+
+    @Test
+    void paramOptionalValueReturnsEmptyStringWhenPresentWithoutValues() {
+        var params = Parameters.builder("test")
+                .add("name")
+                .build();
+
+        assertThat(HttpSupport.paramOptionalValue(params, "name"), is(Optional.of("")));
+    }
+
+    @Test
+    void paramOptionalValueIsEmptyWhenMissing() {
+        var params = Parameters.empty("test");
+
+        assertThat(HttpSupport.paramOptionalValue(params, "name"), is(Optional.empty()));
+    }
+}

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
@@ -415,7 +415,7 @@ public class ServiceDescriptorCodegen {
 
     private static void addAnnotationValue(ContentBuilder<?> contentBuilder, Object objectValue) {
         switch (objectValue) {
-        case String value -> contentBuilder.addContent("\"" + value + "\"");
+        case String value -> contentBuilder.addContentLiteral(value);
         case Boolean value -> contentBuilder.addContent(String.valueOf(value));
         case Long value -> contentBuilder.addContent(String.valueOf(value) + 'L');
         case Double value -> contentBuilder.addContent(String.valueOf(value) + 'D');


### PR DESCRIPTION
Resolves #11612

Adds declarative support for CookieParam, FormParam, and request parameter record types on server endpoints and the declarative WebClient, including validation, helper support, tests, Javadocs, and user documentation.
