### PR TITLE
Forward-port declarative validation constraints from service interfaces (27.x)

### DIFF
--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
@@ -384,7 +385,8 @@ public final class TypeHierarchy {
      * @param typeName type name to scan
      * @return nested annotation instances
      */
-    static List<Annotation> typeNameAnnotations(TypeName typeName) {
+    @Api.Internal
+    public static List<Annotation> typeNameAnnotations(TypeName typeName) {
         List<Annotation> result = new ArrayList<>();
         result.addAll(typeName.annotations());
         result.addAll(typeName.inheritedAnnotations());
@@ -415,7 +417,8 @@ public final class TypeHierarchy {
      * @param sourceTypeName source type name
      * @return type name with annotations merged from the source
      */
-    static TypeName mergeTypeNameAnnotations(TypeName typeName, TypeName sourceTypeName) {
+    @Api.Internal
+    public static TypeName mergeTypeNameAnnotations(TypeName typeName, TypeName sourceTypeName) {
         if (!sameStructure(typeName, sourceTypeName)) {
             return typeName;
         }

--- a/declarative/README.md
+++ b/declarative/README.md
@@ -65,7 +65,7 @@ For each Helidon feature, we need a namespace class to contain the annotations a
 | LRA              | `LRA`                                | `Lra` cannot be freed                                     |
 | Transactions     | `Tx`                                 | `Transaction` is the interface                            |
 | Service Registry | `Service`, `Interception`            | OK                                                        |
-| Validation       | `Validation`, `Check`                | OK                                                        |
+| Validation       | `Validation`                         | OK                                                        |
 
 ## Integrations
 
@@ -357,14 +357,16 @@ Both features require code-generation.
 Type validation code-generation of type validators is triggered by the presence of the `@Validation.Validated` annotation on a type.
 
 Method validation code-generation of interceptors is triggered by the presence of an annotation "meta-annotated"
-with `@Validation.Constraint` on a method, its parameter, or type arguments of its parameters or return type.
-In addition the `Check.Valid` annotation also triggers code-generation, and can be used to validate against a type validator
+with `@Validation.Constraint` on a service method, its implemented service-contract method, its parameter, or type
+arguments of its parameters or return type.
+In addition the `@Validation.Valid` annotation also triggers code-generation, and can be used to validate against a type validator
 mentioned above.
 
 ### Declaration
 
 Annotations:
-- All annotations from `io.helidon.validation.Check` class to trigger validation using an interceptor
+- All built-in constraint annotations from `io.helidon.validation.Validation` to trigger validation using an interceptor
+- `@Validation.Valid` - to trigger validation against a generated type validator
 - `@Validation.Validated` - on a type to generate type validator for a type
 
 ### Configuration
@@ -388,8 +390,7 @@ The type validation works as follows:
 3. the type validator validates the type and returns response with possible constraint violations
 
 Important types:
-- `Check` - a container class for all constraint annotations
-- `Validation` - a container class for validation annotations that are not constraints
+- `Validation` - a container class for validation annotations and built-in constraint annotations
 - `ValidationException` - throws when validation fails in an interceptor
 - `Validator` - programmatic API to validate instances and their properties (only for validated types), can be obtained from service registry
 - `ConstraintValidatorProvider` - service registry service that validates a single constraint annotation type
@@ -399,10 +400,16 @@ Important types:
 Supported concepts:
 - any service method annotated with a constraint annotation will be intercepted and validated
 - any service method that has parameters with at least one constraint annotation will be intercepted and validated
-- for identification of "what to validate", `@Check.Valid` is a constraint annotation
-- annotations on type arguments of method parameters and method return type are supported, as long as they are on 
-    `Optional`, `Map`, `Collection` - i.e. `List<@Check.Valid String>` will trigger an interceptor and will be validated
-- types annotated with `@Validation.Validated` will be validated when used in a method or constructor that uses `@Check.Valid` on the typed parameter
+- any service method that implements a non-private service-contract method with constraint annotations or `@Validation.Valid`
+    will be intercepted and validated
+- services returned by registry-managed factories such as `Supplier`, `Service.ServicesFactory`,
+    `Service.InjectionPointFactory`, and `Service.QualifiedFactory` follow the same service-contract validation rules
+- `@Validation.Valid` identifies what to validate using a generated type validator
+- annotations on method parameter and return types are supported on nested `Optional`, `Collection`, `List`, `Set`, `Map`
+    key/value types, array component types, and wildcard bounds - i.e. `List<@Validation.Valid MyType>` will trigger an
+    interceptor and will be validated
+- types annotated with `@Validation.Validated` will be validated when used in a method or constructor that uses
+    `@Validation.Valid` on the typed parameter
 - same rules as for generation of interceptors apply for type validation: constraints are honored, including getters,
     fields, and type arguments
 - a user may create a "compound annotation" - an annotation that has one or more constraint annotations, these will be honored as

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -17,7 +17,10 @@
 package io.helidon.declarative.codegen.validation;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -74,8 +77,16 @@ class InterceptorGenerator {
             // ignore annotations, these are good
             return;
         }
+        if (factoryInterceptionWrapper(type)) {
+            // The original factory provider owns the element interceptors used by the generated wrapper.
+            return;
+        }
 
         if (!isService(type)) {
+            if (hasOnlyNonPrivateInterfaceMethodValidation(type)) {
+                // Interface method constraints are validated by interceptors generated for service implementations.
+                return;
+            }
             if (!type.hasAnnotation(VALIDATION_VALIDATED)) {
                 throw new CodegenException(VALIDATION_VALIDATED.fqName()
                                                    + " annotation is required on non-service type that has constraints "
@@ -123,19 +134,69 @@ class InterceptorGenerator {
         }
 
         // and finally annotated methods
+        Set<String> generatedMethodTargets = new HashSet<>();
         type.elementInfo()
                 .stream()
                 .filter(ElementInfoPredicates::isMethod)
                 .filter(Predicate.not(ElementInfoPredicates::isPrivate))
                 .filter(Predicate.not(ElementInfoPredicates::isStatic))
                 .forEach(element -> {
-                    generateInterceptor(type, interceptorCounter, element, "METHOD");
+                    String target = elementTarget(type, element);
+                    if (generatedMethodTargets.contains(target)) {
+                        return;
+                    }
+                    if (generateInterceptor(type, interceptorCounter, element, "METHOD")) {
+                        generatedMethodTargets.add(target);
+                    }
                 });
     }
 
+    private boolean factoryInterceptionWrapper(TypeInfo type) {
+        return type.superTypeInfo()
+                .map(TypeInfo::typeName)
+                .map(TypeName::genericTypeName)
+                .filter(it -> it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY)
+                        || it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY)
+                        || it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SERVICES_FACTORY)
+                        || it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_IP_FACTORY)
+                        || it.equals(ServiceCodegenTypes.INTERCEPT_G_WRAPPER_QUALIFIED_FACTORY))
+                .isPresent();
+    }
+
+    private boolean hasOnlyNonPrivateInterfaceMethodValidation(TypeInfo type) {
+        if (type.kind() != ElementKind.INTERFACE) {
+            return false;
+        }
+        if (!type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_CONTRACT)) {
+            return false;
+        }
+
+        List<TypedElementInfo> elementsWithValidation = type.elementInfo()
+                .stream()
+                .filter(it -> ValidationHelper.needsWork(constraintAnnotations, it))
+                .toList();
+
+        return !elementsWithValidation.isEmpty()
+                && elementsWithValidation.stream()
+                .allMatch(it -> ElementInfoPredicates.isMethod(it)
+                        && !ElementInfoPredicates.isPrivate(it)
+                        && !ElementInfoPredicates.isStatic(it));
+    }
+
     private boolean isService(TypeInfo type) {
-        // must be annotated with a scope annotation
+        // must be annotated with a scope annotation, @Service.Describe, or @Service.PerInstance
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_DESCRIBE)) {
+            return true;
+        }
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE)) {
+            return true;
+        }
         if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE)) {
+            return true;
+        }
+        if (type.elementInfo()
+                .stream()
+                .anyMatch(ElementInfoPredicates.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT))) {
             return true;
         }
         for (Annotation annotation : type.annotations()) {
@@ -146,12 +207,12 @@ class InterceptorGenerator {
         return false;
     }
 
-    private void generateInterceptor(TypeInfo interceptedType,
-                                     AtomicInteger interceptorCounter,
-                                     TypedElementInfo element,
-                                     String location) {
+    private boolean generateInterceptor(TypeInfo interceptedType,
+                                        AtomicInteger interceptorCounter,
+                                        TypedElementInfo element,
+                                        String location) {
         if (!ValidationHelper.needsWork(constraintAnnotations, element)) {
-            return;
+            return false;
         }
 
         TypeName typeName = interceptedType.typeName();
@@ -168,7 +229,7 @@ class InterceptorGenerator {
                 .addAnnotation(DeclarativeTypes.SINGLETON_ANNOTATION)
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                 .addAnnotation(Annotation.create(ServiceCodegenTypes.SERVICE_ANNOTATION_NAMED,
-                                                 typeName.fqName() + "." + element.signature().text()))
+                                                 elementTarget(interceptedType, element)))
                 .addInterface(ServiceCodegenTypes.INTERCEPTION_ELEMENT_INTERCEPTOR);
 
         Constructor.Builder constructor = Constructor.builder()
@@ -279,6 +340,7 @@ class InterceptorGenerator {
         classModel.addConstructor(constructor);
         classModel.addMethod(proceedMethod.addContentLine());
         roundContext.addGeneratedType(generatedType, classModel, GENERATOR);
+        return true;
     }
 
     private void addValidators(TypeName generatedType,
@@ -322,5 +384,11 @@ class InterceptorGenerator {
                                      localVariableName);
 
         proceedMethod.addContentLine("}");
+    }
+
+    private String elementTarget(TypeInfo type, TypedElementInfo element) {
+        return element.enclosingType()
+                .orElse(type.typeName())
+                .fqName() + "." + element.signature().text();
     }
 }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -167,9 +167,6 @@ class InterceptorGenerator {
         if (type.kind() != ElementKind.INTERFACE) {
             return false;
         }
-        if (!type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_CONTRACT)) {
-            return false;
-        }
 
         List<TypedElementInfo> elementsWithValidation = type.elementInfo()
                 .stream()
@@ -326,7 +323,7 @@ class InterceptorGenerator {
                           fieldHandler,
                           element,
                           "RETURN_VALUE",
-                          "interception__res");
+                          returnValueLocal(proceedMethod, element));
             // leave method on response
             proceedMethod.addContentLine("}");
         }
@@ -343,12 +340,48 @@ class InterceptorGenerator {
         return true;
     }
 
+    private String returnValueLocal(Method.Builder proceedMethod, TypedElementInfo element) {
+        if (!returnValueNeedsWork(element)) {
+            return "interception__res";
+        }
+        if (ElementInfoPredicates.isVoid(element)) {
+            throw new CodegenException("Validation annotations cannot constrain a void method return value.",
+                                       element.originatingElementValue());
+        }
+
+        proceedMethod.addContent("var validation__return = (")
+                .addContent(element.typeName())
+                .addContentLine(") interception__res;");
+        return "validation__return";
+    }
+
+    private boolean returnValueNeedsWork(TypedElementInfo element) {
+        if (element.hasAnnotation(VALIDATION_VALID) || metaAnnotated(element, VALIDATION_VALID)) {
+            return true;
+        }
+        if (ValidationHelper.needsWork(constraintAnnotations, element.annotations())) {
+            return true;
+        }
+        for (TypeName constraintAnnotation : constraintAnnotations) {
+            if (element.hasAnnotation(constraintAnnotation)) {
+                return true;
+            }
+        }
+
+        return ValidationHelper.needsWork(constraintAnnotations, element.typeName());
+    }
+
     private void addValidators(TypeName generatedType,
                                Method.Builder proceedMethod,
                                FieldHandler fieldHandler,
                                TypedElementInfo element,
                                String location,
                                String localVariableName) {
+        var validationContext = ValidationHelper.validationContext(generatedType,
+                                                                   constraintAnnotations,
+                                                                   proceedMethod,
+                                                                   fieldHandler,
+                                                                   element);
         proceedMethod.addContent("try (var scope__" + location.toLowerCase(Locale.ROOT) + " = validation__ctx.scope(")
                 .addContent(CONSTRAINT_VIOLATION_LOCATION)
                 .addContent(".")
@@ -367,21 +400,14 @@ class InterceptorGenerator {
 
         // we must honor order of declaration on the element
         for (Annotation annotation : ValidationHelper.findConstraintAnnotations(constraintAnnotations, element)) {
-            addValidationOfConstraint(generatedType,
-                                      fieldHandler,
-                                      proceedMethod,
+            addValidationOfConstraint(validationContext,
                                       annotation,
                                       location,
-                                      element,
+                                      element.typeName(),
                                       localVariableName);
         }
 
-        addValidationOfTypeArguments(generatedType,
-                                     constraintAnnotations,
-                                     proceedMethod,
-                                     fieldHandler,
-                                     element,
-                                     localVariableName);
+        addValidationOfTypeArguments(validationContext, localVariableName);
 
         proceedMethod.addContentLine("}");
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidatedTypeGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidatedTypeGenerator.java
@@ -488,13 +488,13 @@ class ValidatedTypeGenerator {
                 .addContentLine(")) {");
 
         TypeName typeName = element.typeName();
+        var validationContext = ValidationHelper.validationContext(generatedType,
+                                                                   constraintAnnotations,
+                                                                   checkMethod,
+                                                                   fieldHandler,
+                                                                   element);
 
-        addValidationOfTypeArguments(generatedType,
-                                     constraintAnnotations,
-                                     checkMethod,
-                                     fieldHandler,
-                                     element,
-                                     "value");
+        addValidationOfTypeArguments(validationContext, "value");
 
         if (element.hasAnnotation(VALIDATION_VALID)) {
 
@@ -505,12 +505,10 @@ class ValidatedTypeGenerator {
 
         // we must honor order of declaration on the element
         for (Annotation annotation : ValidationHelper.findConstraintAnnotations(constraintAnnotations, element)) {
-            addValidationOfConstraint(generatedType,
-                                      fieldHandler,
-                                      checkMethod,
+            addValidationOfConstraint(validationContext,
                                       annotation,
                                       location,
-                                      element,
+                                      typeName,
                                       "value");
         }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.declarative.codegen.validation;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
@@ -40,7 +41,10 @@ class ValidationExtension implements RegistryCodegenExtension {
         // we want both, as we must not add interceptors to types that are marked as validated
         // also constraints are valid (outside validated types) only on interceptable services
         Collection<TypeInfo> validated = roundContext.annotatedTypes(ValidationTypes.VALIDATION_VALIDATED);
-        Collection<TypeName> constraintAnnotations = roundContext.annotatedAnnotations(VALIDATION_CONSTRAINT);
+        Collection<TypeName> constraintAnnotations = roundContext.annotatedAnnotations(VALIDATION_CONSTRAINT)
+                .stream()
+                .filter(this::isConstraintAnnotation)
+                .toList();
 
         var validatedGenerator = new ValidatedTypeGenerator(roundContext, constraintAnnotations);
         for (TypeInfo validate : validated) {
@@ -51,5 +55,16 @@ class ValidationExtension implements RegistryCodegenExtension {
         for (TypeInfo type : roundContext.types()) {
             interceptorGenerator.process(type);
         }
+    }
+
+    private boolean isConstraintAnnotation(TypeName typeName) {
+        return roundContextTypeInfo(typeName)
+                .map(it -> it.hasAnnotation(VALIDATION_CONSTRAINT))
+                .orElse(true);
+    }
+
+    private Optional<TypeInfo> roundContextTypeInfo(TypeName typeName) {
+        return ctx.typeInfo(typeName)
+                .or(() -> ctx.typeInfo(typeName.genericTypeName()));
     }
 }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtension.java
@@ -59,7 +59,10 @@ class ValidationExtension implements RegistryCodegenExtension {
 
     private boolean isConstraintAnnotation(TypeName typeName) {
         return roundContextTypeInfo(typeName)
-                .map(it -> it.hasAnnotation(VALIDATION_CONSTRAINT))
+                .map(it -> it.hasAnnotation(VALIDATION_CONSTRAINT)
+                        || it.annotations()
+                                .stream()
+                                .anyMatch(annotation -> annotation.hasMetaAnnotation(VALIDATION_CONSTRAINT)))
                 .orElse(true);
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationExtensionProvider.java
@@ -56,6 +56,11 @@ public class ValidationExtensionProvider implements RegistryCodegenExtensionProv
     }
 
     @Override
+    public boolean supportsServiceContractAnnotations() {
+        return true;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new ValidationExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
@@ -282,8 +282,7 @@ final class ValidationHelper {
         for (Annotation annotation : annotations) {
             if (processed.add(annotation)) {
                 // a constraint itself
-                if (constraintAnnotations.contains(annotation.typeName())
-                        && isConstraintAnnotation(annotation)) {
+                if (isConstraintAnnotation(constraintAnnotations, annotation)) {
                     result.add(annotation);
                 }
                 // maybe meta-annotated with a constraint
@@ -292,11 +291,22 @@ final class ValidationHelper {
         }
     }
 
+    private static boolean isConstraintAnnotation(Collection<TypeName> constraintAnnotations, Annotation annotation) {
+        if (constraintAnnotations.contains(annotation.typeName())) {
+            return isConstraintAnnotation(annotation);
+        }
+        return hasDirectConstraintMetaAnnotation(annotation);
+    }
+
     private static boolean isConstraintAnnotation(Annotation annotation) {
         return annotation.metaAnnotations().isEmpty()
-                || annotation.metaAnnotations()
-                        .stream()
-                        .anyMatch(it -> it.typeName().equals(ValidationTypes.VALIDATION_CONSTRAINT));
+                || hasDirectConstraintMetaAnnotation(annotation);
+    }
+
+    private static boolean hasDirectConstraintMetaAnnotation(Annotation annotation) {
+        return annotation.metaAnnotations()
+                .stream()
+                .anyMatch(it -> it.typeName().equals(ValidationTypes.VALIDATION_CONSTRAINT));
     }
 
     private static void addValidationOfContainerType(ValidationContext context,

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
@@ -20,12 +20,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.codegen.TypeHierarchy;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.AnnotationProperty;
+import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
@@ -85,85 +89,67 @@ final class ValidationHelper {
                 .addContentLine(");");
     }
 
-    static void addValidationOfTypeArguments(TypeName generatedType,
-                                             Collection<TypeName> constraintAnnotations,
-                                             ContentBuilder<?> contentBuilder,
-                                             FieldHandler fieldHandler,
-                                             TypedElementInfo element,
-                                             String localVariableName) {
-        TypeName typeName = element.typeName();
+    static ValidationContext validationContext(TypeName generatedType,
+                                               Collection<TypeName> constraintAnnotations,
+                                               ContentBuilder<?> contentBuilder,
+                                               FieldHandler fieldHandler,
+                                               TypedElementInfo element) {
+        return new ValidationContext(generatedType, constraintAnnotations, contentBuilder, fieldHandler, element);
+    }
 
-        // check for types that we support that
-        if (typeName.equals(TypeNames.SET)
-                || typeName.equals(TypeNames.LIST)
-                || typeName.equals(TypeNames.COLLECTION)
-                || typeName.equals(TypeNames.OPTIONAL)) {
-            addValidationForSingleTypeArgument(generatedType,
-                                               constraintAnnotations,
-                                               contentBuilder,
-                                               fieldHandler,
-                                               element,
-                                               localVariableName,
-                                               typeName);
-        } else if (typeName.equals(TypeNames.MAP)) {
-            addValidationOfMap(generatedType,
-                               constraintAnnotations,
-                               contentBuilder,
-                               fieldHandler,
-                               element,
-                               localVariableName,
-                               typeName);
-        }
+    static void addValidationOfTypeArguments(ValidationContext context, String localVariableName) {
+        addValidationOfContainerType(context,
+                                     context.element().typeName(),
+                                     localVariableName,
+                                     0);
     }
 
     /**
      *
-     * @param generatedType  type of the generated class
-     * @param fieldHandler   field handler for the processed type
-     * @param contentBuilder content where we should add the constraint validation code
-     * @param constraint     the constraint - must be an annotation of the element or its type parameters
-     * @param location       location of the check (i.e. parameter, return value etc.)
-     * @param element        the element that is annotated, or contains this annotation
-     * @param varName        name of the variable to check using the constraint validator
+     * @param context       validation code generation context
+     * @param constraint    the constraint - must be an annotation of the element or its type parameters
+     * @param location      location of the check (i.e. parameter, return value etc.)
+     * @param annotatedType type that carries the constraint annotation
+     * @param varName       name of the variable to check using the constraint validator
      */
-    static void addValidationOfConstraint(TypeName generatedType,
-                                          FieldHandler fieldHandler,
-                                          ContentBuilder<?> contentBuilder,
+    static void addValidationOfConstraint(ValidationContext context,
                                           Annotation constraint,
                                           String location,
-                                          TypedElementInfo element,
+                                          TypeName annotatedType,
                                           String varName) {
 
         // create a constant with the fully qualified name of the constraint
-        String constraintType = fieldHandler.constant("CONSTRAINT",
-                                                      TypeNames.STRING,
-                                                      constraint.typeName(),
-                                                      it -> it.addContentLiteral(constraint.typeName().fqName()));
+        String constraintType = context.fieldHandler()
+                .constant("CONSTRAINT",
+                          TypeNames.STRING,
+                          constraint.typeName(),
+                          it -> it.addContentLiteral(constraint.typeName().fqName()));
 
-        String validator = fieldHandler.field(CONSTRAINT_VALIDATOR,
-                                              "constraintValidator",
-                                              AccessModifier.PRIVATE,
-                                              constraint,
-                                              it -> {
-                                              },
-                                              (ctr, name) -> {
-                                                  ctr.addParameter(param -> param
-                                                                  .name(name + "_provider")
-                                                                  .addAnnotation(namedByConstant(generatedType,
-                                                                                                 constraintType))
-                                                                  .type(CONSTRAINT_VALIDATOR_PROVIDER))
-                                                          .addContent("this.")
-                                                          .addContent(name)
-                                                          .addContent(" = ")
-                                                          .addContent(name + "_provider")
-                                                          .addContent(".create(")
-                                                          .addContentCreate(element.typeName())
-                                                          .addContent(", ")
-                                                          .addContentCreate(constraint)
-                                                          .addContentLine(");");
-                                              });
+        String validator = context.fieldHandler()
+                .field(CONSTRAINT_VALIDATOR,
+                       "constraintValidator",
+                       AccessModifier.PRIVATE,
+                       new ValidatorKey(ResolvedType.create(annotatedType), constraint),
+                       it -> {
+                       },
+                       (ctr, name) -> {
+                           ctr.addParameter(param -> param
+                                           .name(name + "_provider")
+                                           .addAnnotation(namedByConstant(context.generatedType(), constraintType))
+                                           .type(CONSTRAINT_VALIDATOR_PROVIDER))
+                                   .addContent("this.")
+                                   .addContent(name)
+                                   .addContent(" = ")
+                                   .addContent(name + "_provider")
+                                   .addContent(".create(")
+                                   .addContentCreate(annotatedType)
+                                   .addContent(", ")
+                                   .addContentCreate(constraint)
+                                   .addContentLine(");");
+                       });
 
-        contentBuilder.addContent("validation__ctx.check(")
+        context.contentBuilder()
+                .addContent("validation__ctx.check(")
                 .addContent(validator)
                 .addContent(", ")
                 .addContent(varName)
@@ -181,6 +167,16 @@ final class ValidationHelper {
         return result;
     }
 
+    private static List<Annotation> findConstraintAnnotations(Collection<TypeName> constraintAnnotations,
+                                                              List<Annotation> annotations) {
+        List<Annotation> result = new ArrayList<>();
+        Set<Annotation> processed = new HashSet<>();
+
+        findConstraintAnnotations(constraintAnnotations, annotations, result, processed);
+
+        return result;
+    }
+
     static boolean needsWork(Collection<TypeName> constraintAnnotations, TypedElementInfo element) {
         return needsWork(constraintAnnotations, element, true);
     }
@@ -189,7 +185,7 @@ final class ValidationHelper {
                              TypedElementInfo element,
                              boolean includeParameters) {
         // the element itself is annotated either with valid or one of the constraints
-        // a type parameter is annotated in the same way (only first level)
+        // a type parameter is annotated in the same way
 
         if (element.hasAnnotation(VALIDATION_VALID)) {
             return true;
@@ -203,21 +199,8 @@ final class ValidationHelper {
             return true;
         }
 
-        // now type parameters of the element itself, or its parameters
-        // (valid only for methods, but not present on fields so no problem to check)
-        TypeName elementType = element.typeName();
-        for (TypeName typeName : elementType.typeArguments()) {
-            if (typeName.hasAnnotation(VALIDATION_VALID)) {
-                return true;
-            }
-            for (TypeName constraintAnnotation : constraintAnnotations) {
-                if (typeName.hasAnnotation(constraintAnnotation)) {
-                    return true;
-                }
-            }
-            if (needsWork(constraintAnnotations, typeName.annotations())) {
-                return true;
-            }
+        if (needsWork(constraintAnnotations, element.typeName())) {
+            return true;
         }
 
         if (includeParameters) {
@@ -231,8 +214,20 @@ final class ValidationHelper {
         return false;
     }
 
+    static boolean needsWork(Collection<TypeName> constraintAnnotations, TypeName typeName) {
+        return needsWork(constraintAnnotations, TypeHierarchy.typeNameAnnotations(typeName));
+    }
+
     static boolean needsWork(Collection<TypeName> constraintAnnotations, List<Annotation> annotations) {
         for (Annotation annotation : annotations) {
+            if (annotation.typeName().equals(VALIDATION_VALID)) {
+                return true;
+            }
+            for (TypeName constraintAnnotation : constraintAnnotations) {
+                if (annotation.typeName().equals(constraintAnnotation)) {
+                    return true;
+                }
+            }
             if (annotation.hasMetaAnnotation(VALIDATION_VALID)) {
                 return true;
             }
@@ -287,8 +282,8 @@ final class ValidationHelper {
         for (Annotation annotation : annotations) {
             if (processed.add(annotation)) {
                 // a constraint itself
-                if (constraintAnnotations.contains(annotation.typeName())) {
-
+                if (constraintAnnotations.contains(annotation.typeName())
+                        && isConstraintAnnotation(annotation)) {
                     result.add(annotation);
                 }
                 // maybe meta-annotated with a constraint
@@ -297,171 +292,308 @@ final class ValidationHelper {
         }
     }
 
-    private static void addValidationOfMap(TypeName generatedType,
-                                           Collection<TypeName> constraintAnnotations,
-                                           ContentBuilder<?> contentBuilder,
-                                           FieldHandler fieldHandler,
-                                           TypedElementInfo element,
-                                           String localVariableName,
-                                           TypeName typeName) {
-        // handle map keys and values
-        if (typeName.typeArguments().size() == 2) {
-            TypeName keyType = typeName.typeArguments().get(0);
-            TypeName valueType = typeName.typeArguments().get(1);
+    private static boolean isConstraintAnnotation(Annotation annotation) {
+        return annotation.metaAnnotations().isEmpty()
+                || annotation.metaAnnotations()
+                        .stream()
+                        .anyMatch(it -> it.typeName().equals(ValidationTypes.VALIDATION_CONSTRAINT));
+    }
 
-            boolean keyHasValid = keyType.hasAnnotation(VALIDATION_VALID);
-            List<Annotation> keyConstraints = new ArrayList<>();
-            boolean valueHasValid = valueType.hasAnnotation(VALIDATION_VALID);
-            List<Annotation> valueConstraints = new ArrayList<>();
-
-            // now for each constraint annotation...
-            // we must honor order of declaration on the element
-            for (Annotation annotation : keyType.annotations()) {
-                if (constraintAnnotations.contains(annotation.typeName())) {
-                    keyConstraints.add(annotation);
-                }
-            }
-            // we must honor order of declaration on the element
-            for (Annotation annotation : valueType.annotations()) {
-                if (constraintAnnotations.contains(annotation.typeName())) {
-                    valueConstraints.add(annotation);
-                }
-            }
-
-            if (keyHasValid || valueHasValid || !keyConstraints.isEmpty() || !valueConstraints.isEmpty()) {
-                // need to go through the collection/optional
-                contentBuilder.addContent("if (")
-                        .addContent(localVariableName)
-                        .addContentLine(" != null) {");
-
-                contentBuilder.addContent("for (var validation__entry : ")
-                        .addContent(localVariableName)
-                        .addContentLine(".entrySet()) {")
-                        .addContentLine("var validation__key = validation__entry.getKey();")
-                        .addContentLine("var validation__value = validation__entry.getValue();");
-
-                if (keyHasValid || !keyConstraints.isEmpty()) {
-                    contentBuilder.addContent("try (var scope__mapkey = validation__ctx.scope(")
-                            .addContent(CONSTRAINT_VIOLATION_LOCATION)
-                            .addContent(".KEY, ")
-                            .addContentLiteral("key")
-                            .addContentLine(")) {");
-                }
-                if (keyHasValid) {
-                    String validatorField = addTypeValidator(fieldHandler, keyType);
-                    addValidationOfValid(contentBuilder, validatorField, "validation__key");
-                }
-                for (Annotation constraint : keyConstraints) {
-                    addValidationOfConstraint(generatedType,
-                                              fieldHandler,
-                                              contentBuilder,
-                                              constraint,
-                                              "KEY",
-                                              element,
-                                              "validation__key");
-                }
-
-                if (keyHasValid || !keyConstraints.isEmpty()) {
-                    contentBuilder.addContentLine("}");
-                }
-
-                if (valueHasValid || !valueConstraints.isEmpty()) {
-                    contentBuilder.addContent("try (var scope__mapelement = validation__ctx.scope(")
-                            .addContent(CONSTRAINT_VIOLATION_LOCATION)
-                            .addContent(".ELEMENT, ")
-                            .addContentLiteral("value")
-                            .addContentLine(")) {");
-                }
-                if (valueHasValid) {
-                    String validatorField = addTypeValidator(fieldHandler, valueType);
-                    addValidationOfValid(contentBuilder, validatorField, "validation__value");
-                }
-
-                for (Annotation constraint : valueConstraints) {
-                    addValidationOfConstraint(generatedType,
-                                              fieldHandler,
-                                              contentBuilder,
-                                              constraint,
-                                              "ELEMENT",
-                                              element,
-                                              "validation__value");
-                }
-
-                if (valueHasValid || !valueConstraints.isEmpty()) {
-                    contentBuilder.addContentLine("}");
-                }
-
-                contentBuilder.addContentLine("}");
-                contentBuilder.addContentLine("}");
-            }
+    private static void addValidationOfContainerType(ValidationContext context,
+                                                     TypeName typeName,
+                                                     String localVariableName,
+                                                     int depth) {
+        if (typeName.equals(TypeNames.SET)
+                || typeName.equals(TypeNames.LIST)
+                || typeName.equals(TypeNames.COLLECTION)
+                || typeName.equals(TypeNames.OPTIONAL)) {
+            addValidationOfSingleTypeArgument(context,
+                                              typeName,
+                                              localVariableName,
+                                              depth);
+        } else if (typeName.equals(TypeNames.MAP)) {
+            addValidationOfMap(context,
+                               typeName,
+                               localVariableName,
+                               depth);
+        } else if (typeName.array()) {
+            addValidationOfArrayComponent(context,
+                                          typeName,
+                                          localVariableName,
+                                          depth);
         }
     }
 
-    private static void addValidationForSingleTypeArgument(TypeName generatedType,
-                                                           Collection<TypeName> constraintAnnotations,
-                                                           ContentBuilder<?> contentBuilder,
-                                                           FieldHandler fieldHandler,
-                                                           TypedElementInfo element,
-                                                           String localVariableName,
-                                                           TypeName typeName) {
-        // handle collection type argument annotations
-        if (!typeName.typeArguments().isEmpty()) {
-            boolean isOptional = typeName.equals(TypeNames.OPTIONAL);
-            TypeName maybeAnnotated = typeName.typeArguments().getFirst();
-            boolean hasValid = maybeAnnotated.hasAnnotation(VALIDATION_VALID)
-                    || !findMetaAnnotations(maybeAnnotated.annotations(), VALIDATION_VALID).isEmpty();
-            List<Annotation> constraints = new ArrayList<>();
+    private static void addValidationOfArrayComponent(ValidationContext context,
+                                                      TypeName typeName,
+                                                      String localVariableName,
+                                                      int depth) {
+        Optional<TypeName> componentType = typeName.componentType();
+        if (componentType.isEmpty() || !needsWork(context.constraintAnnotations(), componentType.get())) {
+            return;
+        }
 
-            // now for each constraint annotation...
-            // we must honor order of declaration on the element
-            for (Annotation annotation : maybeAnnotated.annotations()) {
-                if (constraintAnnotations.contains(annotation.typeName())) {
-                    constraints.add(annotation);
-                }
-            }
+        String elementVar = "validation__element" + depth;
+        context.contentBuilder()
+                .addContent("if (")
+                .addContent(localVariableName)
+                .addContentLine(" != null) {");
+        context.contentBuilder()
+                .addContent("for (var ")
+                .addContent(elementVar)
+                .addContent(" : ")
+                .addContent(localVariableName)
+                .addContentLine(") {");
+        addValidationOfTypeName(context,
+                                new TypeValidation(componentType.get(),
+                                                   elementVar,
+                                                   "ELEMENT",
+                                                   "element",
+                                                   depth + 1,
+                                                   false,
+                                                   false));
+        context.contentBuilder().addContentLine("}");
+        context.contentBuilder().addContentLine("}");
+    }
 
-            if (hasValid || !constraints.isEmpty()) {
-                // need to go through the collection/optional
-                contentBuilder.addContent("if (")
-                        .addContent(localVariableName)
-                        .addContentLine(" != null) {");
-                if (isOptional) {
-                    contentBuilder.addContent("if (")
-                            .addContent(localVariableName)
-                            .addContentLine(".isPresent()) {")
-                            .addContent("var validation__element = ")
-                            .addContent(localVariableName)
-                            .addContentLine(".get();");
-                } else {
-                    contentBuilder.addContent("for (var validation__element : ")
-                            .addContent(localVariableName)
-                            .addContentLine(") {");
-                }
-                contentBuilder.addContent("try (var scope__element = validation__ctx.scope(")
-                        .addContent(CONSTRAINT_VIOLATION_LOCATION)
-                        .addContent(".")
-                        .addContent("ELEMENT")
-                        .addContentLine(", \"element\")) {");
+    private static void addValidationOfMap(ValidationContext context,
+                                           TypeName typeName,
+                                           String localVariableName,
+                                           int depth) {
+        if (typeName.typeArguments().size() != 2) {
+            return;
+        }
 
-                if (hasValid) {
-                    String validatorField = addTypeValidator(fieldHandler, maybeAnnotated);
-                    addValidationOfValid(contentBuilder, validatorField, "validation__element");
-                }
+        TypeName keyType = typeName.typeArguments().get(0);
+        TypeName valueType = typeName.typeArguments().get(1);
+        boolean keyNeedsWork = needsWork(context.constraintAnnotations(), keyType);
+        boolean valueNeedsWork = needsWork(context.constraintAnnotations(), valueType);
+        if (!keyNeedsWork && !valueNeedsWork) {
+            return;
+        }
 
-                for (Annotation constraint : constraints) {
-                    addValidationOfConstraint(generatedType,
-                                              fieldHandler,
-                                              contentBuilder,
-                                              constraint,
-                                              "ELEMENT",
-                                              element,
-                                              "validation__element");
-                }
+        String entryVar = "validation__entry" + depth;
+        String keyVar = "validation__key" + depth;
+        String valueVar = "validation__value" + depth;
 
-                contentBuilder.addContentLine("}");
-                contentBuilder.addContentLine("}");
-                contentBuilder.addContentLine("}");
+        context.contentBuilder()
+                .addContent("if (")
+                .addContent(localVariableName)
+                .addContentLine(" != null) {");
+        context.contentBuilder()
+                .addContent("for (var ")
+                .addContent(entryVar)
+                .addContent(" : ")
+                .addContent(localVariableName)
+                .addContentLine(".entrySet()) {")
+                .addContent("var ")
+                .addContent(keyVar)
+                .addContent(" = ")
+                .addContent(entryVar)
+                .addContentLine(".getKey();")
+                .addContent("var ")
+                .addContent(valueVar)
+                .addContent(" = ")
+                .addContent(entryVar)
+                .addContentLine(".getValue();");
+
+        if (keyNeedsWork) {
+            addValidationOfTypeName(context,
+                                    new TypeValidation(keyType,
+                                                       keyVar,
+                                                       "KEY",
+                                                       "key",
+                                                       depth + 1,
+                                                       false,
+                                                       true));
+        }
+        if (valueNeedsWork) {
+            addValidationOfTypeName(context,
+                                    new TypeValidation(valueType,
+                                                       valueVar,
+                                                       "ELEMENT",
+                                                       "value",
+                                                       depth + 1,
+                                                       false,
+                                                       true));
+        }
+
+        context.contentBuilder().addContentLine("}");
+        context.contentBuilder().addContentLine("}");
+    }
+
+    private static void addValidationOfSingleTypeArgument(ValidationContext context,
+                                                          TypeName typeName,
+                                                          String localVariableName,
+                                                          int depth) {
+        if (typeName.typeArguments().isEmpty()) {
+            return;
+        }
+
+        TypeName typeArgument = typeName.typeArguments().getFirst();
+        if (!needsWork(context.constraintAnnotations(), typeArgument)) {
+            return;
+        }
+
+        String elementVar = "validation__element" + depth;
+
+        context.contentBuilder()
+                .addContent("if (")
+                .addContent(localVariableName)
+                .addContentLine(" != null) {");
+        if (typeName.equals(TypeNames.OPTIONAL)) {
+            context.contentBuilder()
+                    .addContent("if (")
+                    .addContent(localVariableName)
+                    .addContentLine(".isPresent()) {")
+                    .addContent("var ")
+                    .addContent(elementVar)
+                    .addContent(" = ")
+                    .addContent(localVariableName)
+                    .addContentLine(".get();");
+        } else {
+            context.contentBuilder()
+                    .addContent("for (var ")
+                    .addContent(elementVar)
+                    .addContent(" : ")
+                    .addContent(localVariableName)
+                    .addContentLine(") {");
+        }
+
+        addValidationOfTypeName(context,
+                                new TypeValidation(typeArgument,
+                                                   elementVar,
+                                                   "ELEMENT",
+                                                   "element",
+                                                   depth + 1,
+                                                   false,
+                                                   false));
+
+        context.contentBuilder().addContentLine("}");
+        context.contentBuilder().addContentLine("}");
+    }
+
+    private static void addValidationOfTypeName(ValidationContext context, TypeValidation validation) {
+        List<Annotation> annotations = directTypeAnnotations(validation.typeName());
+        boolean hasValid = annotations.stream()
+                .anyMatch(it -> it.typeName().equals(VALIDATION_VALID) || it.hasMetaAnnotation(VALIDATION_VALID));
+        List<Annotation> constraints = findConstraintAnnotations(context.constraintAnnotations(), annotations);
+        boolean currentNeedsWork = hasValid || !constraints.isEmpty();
+
+        if (validation.forceScope() && needsWork(context.constraintAnnotations(), validation.typeName())) {
+            scope(context.contentBuilder(), validation.location(), validation.locationName(), validation.depth());
+            addCurrentTypeValidation(context, validation, hasValid, constraints);
+            addNestedTypeValidation(context, validation);
+            context.contentBuilder().addContentLine("}");
+            return;
+        }
+
+        if (currentNeedsWork) {
+            scope(context.contentBuilder(), validation.location(), validation.locationName(), validation.depth());
+            addCurrentTypeValidation(context, validation, hasValid, constraints);
+            context.contentBuilder().addContentLine("}");
+        }
+
+        addNestedTypeValidation(context, validation);
+    }
+
+    private static void scope(ContentBuilder<?> contentBuilder, String location, String locationName, int depth) {
+        contentBuilder.addContent("try (var scope__")
+                .addContent(location.toLowerCase(Locale.ROOT))
+                .addContent(String.valueOf(depth))
+                .addContent(" = validation__ctx.scope(")
+                .addContent(CONSTRAINT_VIOLATION_LOCATION)
+                .addContent(".")
+                .addContent(location)
+                .addContent(", ")
+                .addContentLiteral(locationName)
+                .addContentLine(")) {");
+    }
+
+    private static void addCurrentTypeValidation(ValidationContext context,
+                                                 TypeValidation validation,
+                                                 boolean hasValid,
+                                                 List<Annotation> constraints) {
+        if (hasValid) {
+            String validatorField = addTypeValidator(context.fieldHandler(), validation.typeName());
+            if (validation.guardValidType()) {
+                String validVar = "validation__valid" + validation.depth();
+                context.contentBuilder()
+                        .addContent("if (")
+                        .addContent(validation.localVariableName())
+                        .addContent(" instanceof ")
+                        .addContent(validation.typeName().genericTypeName())
+                        .addContent(" ")
+                        .addContent(validVar)
+                        .addContentLine(") {");
+                addValidationOfValid(context.contentBuilder(), validatorField, validVar);
+                context.contentBuilder().addContentLine("}");
+            } else {
+                addValidationOfValid(context.contentBuilder(), validatorField, validation.localVariableName());
             }
         }
+
+        for (Annotation constraint : constraints) {
+            addValidationOfConstraint(context,
+                                      constraint,
+                                      validation.location(),
+                                      validation.typeName(),
+                                      validation.localVariableName());
+        }
+    }
+
+    private static void addNestedTypeValidation(ValidationContext context, TypeValidation validation) {
+        addValidationOfContainerType(context,
+                                     validation.typeName(),
+                                     validation.localVariableName(),
+                                     validation.depth());
+        for (TypeName lowerBound : validation.typeName().lowerBounds()) {
+            addValidationOfTypeName(context,
+                                    new TypeValidation(lowerBound,
+                                                       validation.localVariableName(),
+                                                       validation.location(),
+                                                       validation.locationName(),
+                                                       validation.depth() + 1,
+                                                       true,
+                                                       false));
+        }
+        for (TypeName upperBound : validation.typeName().upperBounds()) {
+            addValidationOfTypeName(context,
+                                    new TypeValidation(upperBound,
+                                                       validation.localVariableName(),
+                                                       validation.location(),
+                                                       validation.locationName(),
+                                                       validation.depth() + 1,
+                                                       false,
+                                                       false));
+        }
+    }
+
+    private static List<Annotation> directTypeAnnotations(TypeName typeName) {
+        if (typeName.inheritedAnnotations().isEmpty()) {
+            return typeName.annotations();
+        }
+        List<Annotation> annotations = new ArrayList<>(typeName.annotations());
+        annotations.addAll(typeName.inheritedAnnotations());
+        return annotations;
+    }
+
+    private record ValidatorKey(ResolvedType annotatedType, Annotation constraint) {
+    }
+
+    record ValidationContext(TypeName generatedType,
+                             Collection<TypeName> constraintAnnotations,
+                             ContentBuilder<?> contentBuilder,
+                             FieldHandler fieldHandler,
+                             TypedElementInfo element) {
+    }
+
+    private record TypeValidation(TypeName typeName,
+                                  String localVariableName,
+                                  String location,
+                                  String locationName,
+                                  int depth,
+                                  boolean guardValidType,
+                                  boolean forceScope) {
     }
 }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -24,8 +24,11 @@ import java.util.List;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.apt.AptProcessor;
 import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.GenericType;
 import io.helidon.common.Generated;
 import io.helidon.common.types.Annotation;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
@@ -44,6 +47,9 @@ class ValidationCodegenTest {
             Generated.class,
             Validation.Constraint.class,
             Annotation.class,
+            GenericType.class,
+            Lookup.class,
+            Qualifier.class,
             Service.class,
             Prototype.class
     );
@@ -117,6 +123,339 @@ class ValidationCodegenTest {
                                             //...
                                             }
                                             """));
+    }
+
+    @Test
+    void testServiceContractConstraintGeneratesInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        assertThat(Files.exists(result.sourceOutput().resolve("com/example/DefaultApiImpl__Validated.java")),
+                   is(false));
+
+        var content = Files.readString(interceptor, StandardCharsets.UTF_8);
+        assertThat(content, containsString("\"com.example.DefaultApiImpl.validate(java.lang.String)\""));
+        assertThat(content, containsString("validation__ctx.check("));
+    }
+
+    @Test
+    void testDescribeServiceContractConstraintGeneratesInterceptor() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DescribedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Describe
+                        class DescribedApi implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DescribedApi__ValidationInterceptor_0.java")),
+                   is(true));
+    }
+
+    @Test
+    void testSupplierProvidedContractSameSignatureGeneratesInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface ProvidedApi {
+                            @Validation.String.NotBlank
+                            String get();
+                        }
+                        """)
+                .addSource("ProvidedApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class ProvidedApiSupplier implements Supplier<ProvidedApi> {
+                            @Override
+                            public ProvidedApi get() {
+                                return () -> "value";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/ProvidedApiSupplier__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        assertThat(Files.readString(interceptor, StandardCharsets.UTF_8),
+                   containsString("\"com.example.ProvidedApi.get()\""));
+    }
+
+    @Test
+    void testInjectionPointFactoryDelegateKeepsCustomizedFirst() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("IpProvidedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface IpProvidedApi {
+                            @Validation.String.NotBlank
+                            String value();
+                        }
+                        """)
+                .addSource("IpProvider.java", """
+                        package com.example;
+
+                        import java.util.List;
+                        import java.util.Optional;
+
+                        import io.helidon.service.registry.Lookup;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        class IpProvider implements Service.InjectionPointFactory<IpProvidedApi> {
+                            @Override
+                            public Optional<Service.QualifiedInstance<IpProvidedApi>> first(Lookup lookup) {
+                                return Optional.of(Service.QualifiedInstance.create(() -> "first"));
+                            }
+
+                            @Override
+                            @Validation.Collection.Size(min = 1)
+                            public List<Service.QualifiedInstance<IpProvidedApi>> list(Lookup lookup) {
+                                return List.of(Service.QualifiedInstance.create(() -> "list"));
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var wrapper = result.sourceOutput().resolve("com/example/IpProvider__Interception_Wrapper.java");
+        assertThat(Files.exists(wrapper), is(true));
+        assertThat(Files.readString(wrapper, StandardCharsets.UTF_8),
+                   containsString("return helidonInject__delegate.first(lookup);"));
+    }
+
+    @Test
+    void testQualifiedFactoryDelegateKeepsCustomizedFirst() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("TestQualifier.java", """
+                        package com.example;
+
+                        import java.lang.annotation.ElementType;
+                        import java.lang.annotation.Retention;
+                        import java.lang.annotation.RetentionPolicy;
+                        import java.lang.annotation.Target;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Qualifier
+                        @Retention(RetentionPolicy.CLASS)
+                        @Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.FIELD})
+                        public @interface TestQualifier {
+                            String value() default "";
+                        }
+                        """)
+                .addSource("QualifiedProvidedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        public interface QualifiedProvidedApi {
+                            @Validation.String.NotBlank
+                            String value();
+                        }
+                        """)
+                .addSource("QualifiedProvider.java", """
+                        package com.example;
+
+                        import java.util.List;
+                        import java.util.Optional;
+
+                        import io.helidon.common.GenericType;
+                        import io.helidon.service.registry.Lookup;
+                        import io.helidon.service.registry.Qualifier;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        @TestQualifier("first")
+                        class QualifiedProvider implements Service.QualifiedFactory<QualifiedProvidedApi, TestQualifier> {
+                            @Override
+                            public Optional<Service.QualifiedInstance<QualifiedProvidedApi>> first(
+                                    Qualifier qualifier,
+                                    Lookup lookup,
+                                    GenericType<QualifiedProvidedApi> type) {
+                                return Optional.of(Service.QualifiedInstance.create(() -> "first", qualifier));
+                            }
+
+                            @Override
+                            @Validation.Collection.Size(min = 1)
+                            public List<Service.QualifiedInstance<QualifiedProvidedApi>> list(
+                                    Qualifier qualifier,
+                                    Lookup lookup,
+                                    GenericType<QualifiedProvidedApi> type) {
+                                return List.of(Service.QualifiedInstance.create(() -> "list", qualifier));
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var wrapper = result.sourceOutput().resolve("com/example/QualifiedProvider__Interception_Wrapper.java");
+        assertThat(Files.exists(wrapper), is(true));
+        assertThat(Files.readString(wrapper, StandardCharsets.UTF_8),
+                   containsString("return helidonInject__delegate.first(qualifier, lookup, type);"));
+    }
+
+    @Test
+    void testValidatedServiceContractDoesNotMarkImplementationAsValidated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Contract
+                        @Validation.Validated
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java")),
+                   is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApiImpl__Validated.java")),
+                   is(false));
+    }
+
+    @Test
+    void testNonServiceInterfaceMethodConstraintRequiresValidated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString(ValidationTypes.VALIDATION_VALIDATED.fqName()
+                                                      + " annotation is required on non-service type"));
     }
 
     @Test

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -27,6 +27,7 @@ import io.helidon.codegen.testing.TestCompiler;
 import io.helidon.common.GenericType;
 import io.helidon.common.Generated;
 import io.helidon.common.types.Annotation;
+import io.helidon.service.codegen.ServiceCodegenTypes;
 import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
@@ -53,6 +54,18 @@ class ValidationCodegenTest {
             Service.class,
             Prototype.class
     );
+
+    @Test
+    void testValidationProviderUsesServiceContractTrigger() {
+        var provider = new ValidationExtensionProvider();
+
+        assertThat(provider.supportsServiceContractAnnotations(), is(true));
+        assertThat(provider.supportedAnnotations().contains(ValidationTypes.VALIDATION_VALIDATED), is(true));
+        assertThat(provider.supportedAnnotations().contains(ValidationTypes.VALIDATION_VALID), is(true));
+        assertThat(provider.supportedAnnotations().contains(ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE), is(false));
+        assertThat(provider.supportedAnnotations().contains(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT), is(false));
+        assertThat(provider.supportedMetaAnnotations().contains(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE), is(false));
+    }
 
     @Test
     void testSupportedClassElements() throws IOException {
@@ -435,7 +448,7 @@ class ValidationCodegenTest {
     }
 
     @Test
-    void testNonServiceInterfaceMethodConstraintRequiresValidated() {
+    void testPlainInterfaceMethodConstraintDoesNotRequireValidated() {
         var result = TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(CLASSPATH)
@@ -453,9 +466,270 @@ class ValidationCodegenTest {
                 .compile();
 
         String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApi__ValidationInterceptor_0.java")),
+                   is(false));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApi__Validated.java")),
+                   is(false));
+    }
+
+    @Test
+    void testInterfaceStaticMethodParameterConstraintRequiresValidated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            static String validate(@Validation.String.NotBlank String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
         assertThat(diagnostics, result.success(), is(false));
         assertThat(diagnostics, containsString(ValidationTypes.VALIDATION_VALIDATED.fqName()
                                                       + " annotation is required on non-service type"));
+    }
+
+    @Test
+    void testInterfacePrivateMethodParameterConstraintRequiresValidated() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            private String validate(@Validation.String.NotBlank String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString(ValidationTypes.VALIDATION_VALIDATED.fqName()
+                                                      + " annotation is required on non-service type"));
+    }
+
+    @Test
+    void testMetaAnnotatedContractConstraintTriggersServiceProcessing() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("CustomConstraint.java", """
+                        package com.example;
+
+                        import java.lang.annotation.ElementType;
+                        import java.lang.annotation.Target;
+
+                        import io.helidon.validation.Validation;
+
+                        @Target(ElementType.PARAMETER)
+                        @Validation.String.NotBlank
+                        public @interface CustomConstraint {
+                        }
+                        """)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        public interface DefaultApi {
+                            String validate(@CustomConstraint String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java")),
+                   is(true));
+    }
+
+    @Test
+    void testNestedConstraintUsesAnnotatedTypeForValidatorProvider() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import java.util.List;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        class DefaultApiImpl {
+                            void validate(@Validation.Integer.Min(10) Long count,
+                                          List<@Validation.Integer.Min(10) Integer> values) {
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        var interceptor = result.sourceOutput()
+                .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        var content = Files.readString(interceptor, StandardCharsets.UTF_8);
+        assertThat(content, containsString(".packageName(\"java.lang\")"));
+        assertThat(content, containsString(".className(\"Long\")"));
+        assertThat(content, containsString(".className(\"Integer\")"));
+    }
+
+    @Test
+    void testVoidMethodReturnConstraintFailsClearly() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        class DefaultApi {
+                            @Validation.NotNull
+                            void reset() {
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString("Validation annotations cannot constrain a void method return value."));
+        assertThat(diagnostics, not(containsString("(void)")));
+    }
+
+    @Test
+    void testLowerBoundValidTypeUseCompiles() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ValidatedType.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        @Validation.Validated
+                        record ValidatedType(@Validation.String.NotBlank String name) {
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import java.util.List;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.validation.Validation;
+
+                        @Service.Singleton
+                        class DefaultApiImpl {
+                            void validate(List<? super @Validation.Valid ValidatedType> values) {
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        var interceptor = result.sourceOutput()
+                .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        var content = Files.readString(interceptor, StandardCharsets.UTF_8);
+        assertThat(content, containsString("instanceof ValidatedType validation__valid"));
+        assertThat(content, containsString(".check(validation__ctx, validation__valid"));
+        assertThat(content, not(containsString(".check(validation__ctx, validation__element")));
+    }
+
+    @Test
+    void testSameSignatureInterfaceConstraintsAreMerged() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("LowApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        interface LowApi {
+                            String validate(@Validation.Integer.Min(1) int count);
+                        }
+                        """)
+                .addSource("HighApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        interface HighApi {
+                            String validate(@Validation.Integer.Min(10) int count);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements LowApi, HighApi {
+                            @Override
+                            public String validate(int count) {
+                                return String.valueOf(count);
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+
+        var content = Files.readString(interceptor, StandardCharsets.UTF_8);
+        assertThat(content.lines().filter(it -> it.contains("validation__ctx.check(")).count(), is(2L));
     }
 
     @Test

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -373,6 +373,9 @@ include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_7, indent=0]
 
 Constraint annotations and `@Validation.Valid` can also be declared on non-private instance methods of service interfaces.
 They are applied when the service instance is obtained from the service registry.
+Constraints declared on matching service interface and implementation methods are combined. Implementation constraints do not
+replace or loosen constraints declared by the service interface, even when both methods use the same constraint type with
+different values.
 The same applies to instances returned by registry-managed service factories, including `Supplier`,
 `Service.ServicesFactory`, `Service.InjectionPointFactory`, and `Service.QualifiedFactory` services.
 This can change runtime behavior for services that already declared interface validation: invalid calls through

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -267,7 +267,7 @@ Helidon validation module:
 
 ==== Constraint Annotations
 
-A "Constraint Annotation" is any annotation directly annotated with `io.helidon.validation.Validation`.
+A "Constraint Annotation" is any annotation directly annotated with `io.helidon.validation.Validation.Constraint`.
 Helidon Validation provides a set of built-in validation constraints, though custom constraints can be created, or existing constraints can be combined.
 
 Existing constraints:
@@ -354,6 +354,8 @@ A type annotated with `@Validation.Validated` will have validation code generate
 `@Validation.Valid` - if such an annotation is present, and it is on a field of another validated type, or it is a parameter,
 return type, or a type argument of a parameter/return type of a service method, the object instance will be validated using
 a generated interceptor.
+Type-use validation is supported on nested `Optional`, `Collection`, `List`, `Set`, `Map` key/value types, array component
+types, and wildcard bounds.
 
 ==== Usage
 
@@ -367,6 +369,19 @@ include::{sourcedir}/se/ValidationSnippets.java[tag=snippet_1, indent=0]
 .Example of a validated method call using a validated type
 ----
 include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_7, indent=0]
+----
+
+Constraint annotations and `@Validation.Valid` can also be declared on non-private instance methods of service interfaces.
+They are applied when the service instance is obtained from the service registry.
+The same applies to instances returned by registry-managed service factories, including `Supplier`,
+`Service.ServicesFactory`, `Service.InjectionPointFactory`, and `Service.QualifiedFactory` services.
+This can change runtime behavior for services that already declared interface validation: invalid calls through
+registry-obtained services may now fail with a `ValidationException`, while directly constructed objects are not intercepted.
+
+[source,java]
+.Example of a validated service contract
+----
+include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_7b, indent=0]
 ----
 
 A custom "compound" annotation can be created to simplify usage.

--- a/docs/src/main/asciidoc/se/injection/injection.adoc
+++ b/docs/src/main/asciidoc/se/injection/injection.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -570,6 +570,9 @@ link:{service-registry-base-url}/io/helidon/service/registry/Interception.Delega
 However, keep in mind that usage of this annotation doesn’t add the ability to intercept constructor calls.
 To enable interception, this annotation must be present on the class that the factory produces.
 While it is not required on interfaces, it will still work correctly if applied there.
+If the produced type is an interface, Helidon can generate the required delegation wrapper for registry-managed factories
+without `@Interception.Delegate` on the produced implementation class. This is the path used by declarative validation
+when method constraints are declared on service interfaces.
 
 If you need to enable interception for classes using delegation, you should make sure about the following:
 

--- a/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
+++ b/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
@@ -146,6 +146,20 @@ public class DeclarativeExample {
     }
     // end::snippet_7[]
 
+    // tag::snippet_7b[]
+    interface ValidatedServiceContract {
+        String process(@Validation.String.NotBlank String value);
+    }
+
+    @Service.Singleton
+    static class ContractValidatedService implements ValidatedServiceContract {
+        @Override
+        public String process(String value) {
+            return value;
+        }
+    }
+    // end::snippet_7b[]
+
     // tag::snippet_8[]
     @Validation.NotNull
     @Validation.String.NotBlank

--- a/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,9 @@ package io.helidon.service.codegen;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.helidon.codegen.CodegenException;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.ResolvedType;
@@ -33,6 +31,7 @@ import io.helidon.common.types.TypeNames;
 
 import static io.helidon.service.codegen.ServiceCodegenAnnotations.WILDCARD_NAMED;
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_IP_FACTORY;
+import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_QUALIFIED_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SERVICES_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY;
@@ -53,9 +52,14 @@ class DescribedService {
 
     /*
      the following is only relevant on service itself (not on provided type)
-     */
+    */
     // type of provider (if this is a provider at all)
     private final FactoryType providerType;
+    // generic provider interface implemented by the service, such as Supplier<Optional<MyContract>>
+    private final TypeName factoryTypeName;
+    private final Set<ResolvedType> directProviderContracts;
+    private final Set<ResolvedType> providerFactoryContracts;
+    private final boolean factoryInterceptionWrapper;
     // qualifiers of provided type are inherited from service
     private final Set<Annotation> qualifiers;
     // provided type does not have a descriptor, only service does
@@ -74,6 +78,10 @@ class DescribedService {
                              TypeName descriptorType,
                              Set<Annotation> qualifiers,
                              FactoryType providerType,
+                             TypeName factoryTypeName,
+                             Set<ResolvedType> directProviderContracts,
+                             Set<ResolvedType> providerFactoryContracts,
+                             boolean factoryInterceptionWrapper,
                              TypeName qualifiedProviderQualifier) {
 
         this.serviceType = serviceType;
@@ -83,6 +91,10 @@ class DescribedService {
         this.scope = scope;
         this.qualifiers = Set.copyOf(qualifiers);
         this.providerType = providerType;
+        this.factoryTypeName = factoryTypeName;
+        this.directProviderContracts = Set.copyOf(directProviderContracts);
+        this.providerFactoryContracts = Set.copyOf(providerFactoryContracts);
+        this.factoryInterceptionWrapper = factoryInterceptionWrapper;
         this.qualifiedProviderQualifier = qualifiedProviderQualifier;
     }
 
@@ -96,6 +108,7 @@ class DescribedService {
         TypeName descriptorType = ctx.descriptorType(serviceType);
 
         Set<ResolvedType> directContracts = new HashSet<>();
+        Set<ResolvedType> serviceElementContracts = new HashSet<>();
         Set<ResolvedType> providedContracts = new HashSet<>();
         FactoryType providerType = FactoryType.SERVICE;
         TypeName qualifiedProviderQualifier = null;
@@ -105,73 +118,20 @@ class DescribedService {
         ServiceContracts serviceContracts = roundContext.serviceContracts(serviceInfo);
         if (serviceInfo.kind() == ElementKind.INTERFACE) {
             directContracts.add(ResolvedType.create(serviceInfo.typeName()));
+            serviceElementContracts.add(ResolvedType.create(serviceInfo.typeName()));
         }
 
-        // now we know which contracts are OK to use, and we can check the service types and real contracts
-        // service is a factory only if it implements the interface directly; this is never inherited
-        List<TypeInfo> typeInfos = serviceInfo.interfaceTypeInfo();
-        Map<TypeName, TypeInfo> implementedInterfaceTypes = new HashMap<>();
-        typeInfos.forEach(it -> implementedInterfaceTypes.put(it.typeName(), it));
-
-        /*
-        For each service type we support, gather contracts
-         */
-        var response = serviceContracts.analyseFactory(TypeNames.SUPPLIER);
-        if (response.valid()) {
-            providerType = FactoryType.SUPPLIER;
-            directContracts.add(ResolvedType.create(response.factoryType()));
-            providedContracts.addAll(response.providedContracts());
-            providedTypeName = response.providedType();
-            providedTypeInfo = response.providedTypeInfo();
-            implementedInterfaceTypes.remove(TypeNames.SUPPLIER);
-        }
-        response = serviceContracts.analyseFactory(SERVICE_SERVICES_FACTORY);
-        if (response.valid()) {
-            // if this is not a service type, throw
-            if (providerType != FactoryType.SERVICE) {
-                throw new CodegenException("Service implements more than one provider type: "
-                                                   + providerType + ", and services provider.",
-                                           serviceInfo.originatingElementValue());
-            }
-            providerType = FactoryType.SERVICES;
-            directContracts.add(ResolvedType.create(response.providedType()));
-            providedContracts.addAll(response.providedContracts());
-            providedTypeName = response.providedType();
-            providedTypeInfo = response.providedTypeInfo();
-            implementedInterfaceTypes.remove(SERVICE_SERVICES_FACTORY);
-        }
-        response = serviceContracts.analyseFactory(SERVICE_INJECTION_POINT_FACTORY);
-        if (response.valid()) {
-            // if this is not a service type, throw
-            if (providerType != FactoryType.SERVICE) {
-                throw new CodegenException("Service implements more than one provider type: "
-                                                   + providerType + ", and injection point provider.",
-                                           serviceInfo.originatingElementValue());
-            }
-            providerType = FactoryType.INJECTION_POINT;
-            directContracts.add(ResolvedType.create(response.providedType()));
-            providedContracts.addAll(response.providedContracts());
-            providedTypeName = response.providedType();
-            providedTypeInfo = response.providedTypeInfo();
-            implementedInterfaceTypes.remove(SERVICE_INJECTION_POINT_FACTORY);
-        }
-        response = serviceContracts.analyseFactory(SERVICE_QUALIFIED_FACTORY);
-        if (response.valid()) {
-            // if this is not a service type, throw
-            if (providerType != FactoryType.SERVICE) {
-                throw new CodegenException("Service implements more than one provider type: "
-                                                   + providerType + ", and qualified provider.",
-                                           serviceInfo.originatingElementValue());
-            }
-            providerType = FactoryType.QUALIFIED;
-            directContracts.add(ResolvedType.create(response.providedType()));
-            providedContracts.addAll(response.providedContracts());
-            qualifiedProviderQualifier = ServiceContracts
-                    .requiredTypeArgument(implementedInterfaceTypes.remove(SERVICE_QUALIFIED_FACTORY), 1);
-            providedTypeName = response.providedType();
-            providedTypeInfo = response.providedTypeInfo();
-            implementedInterfaceTypes.remove(SERVICE_QUALIFIED_FACTORY);
-        }
+        ServiceTypes.FactoryInfo factoryInfo = ServiceTypes.factoryInfo(serviceContracts, serviceInfo);
+        providerType = factoryInfo.providerType();
+        TypeName factoryTypeName = factoryInfo.factoryTypeName();
+        Set<ResolvedType> providerFactoryContracts = new HashSet<>(factoryInfo.directContracts());
+        directContracts.addAll(providerFactoryContracts);
+        providedContracts.addAll(factoryInfo.providedContracts());
+        qualifiedProviderQualifier = factoryInfo.qualifiedProviderQualifier();
+        providedTypeName = factoryInfo.providedTypeName();
+        providedTypeInfo = factoryInfo.providedTypeInfo();
+        providerFactoryContracts.removeAll(providedContracts);
+        Map<TypeName, TypeInfo> implementedInterfaceTypes = new HashMap<>(factoryInfo.remainingImplementedInterfaces());
 
         // add direct contracts
         HashSet<ResolvedType> processedDirectContracts = new HashSet<>();
@@ -179,11 +139,19 @@ class DescribedService {
             serviceContracts.addContracts(directContracts,
                                           processedDirectContracts,
                                           typeInfo);
+            serviceContracts.addContracts(serviceElementContracts,
+                                          new HashSet<>(),
+                                          typeInfo);
         });
         // add contracts from super type(s)
-        serviceInfo.superTypeInfo().ifPresent(it -> serviceContracts.addContracts(directContracts,
-                                                                                  processedDirectContracts,
-                                                                                  it));
+        serviceInfo.superTypeInfo().ifPresent(it -> {
+            serviceContracts.addContracts(directContracts,
+                                          processedDirectContracts,
+                                          it);
+            serviceContracts.addContracts(serviceElementContracts,
+                                          new HashSet<>(),
+                                          it);
+        });
 
         Map<ResolvedType, Set<ResolvedType>> contractMap = new HashMap<>();
         directContracts.forEach(directContract -> addContractToMap(roundContext,
@@ -195,11 +163,15 @@ class DescribedService {
                                                                        contractMap,
                                                                        providedContract));
 
+        Set<ResolvedType> directProviderContracts = new HashSet<>(directContracts);
+        directProviderContracts.removeAll(providerFactoryContracts);
+        directProviderContracts.removeAll(providedContracts);
+
         DescribedType serviceDescriptor;
         DescribedType providedDescriptor;
 
         if (providerType == FactoryType.SERVICE) {
-            var serviceElements = DescribedElements.create(ctx, interception, directContracts, serviceInfo);
+            var serviceElements = DescribedElements.create(ctx, interception, serviceElementContracts, serviceInfo);
             serviceDescriptor = new DescribedType(serviceInfo,
                                                   serviceInfo.typeName(),
                                                   directContracts,
@@ -208,7 +180,7 @@ class DescribedService {
 
             providedDescriptor = null;
         } else {
-            var serviceElements = DescribedElements.create(ctx, interception, Set.of(), serviceInfo);
+            var serviceElements = DescribedElements.create(ctx, interception, serviceElementContracts, serviceInfo);
             serviceDescriptor = new DescribedType(serviceInfo,
                                                   serviceInfo.typeName(),
                                                   directContracts,
@@ -231,8 +203,24 @@ class DescribedService {
                 descriptorType,
                 gatherQualifiers(serviceInfo),
                 providerType,
+                factoryTypeName,
+                directProviderContracts,
+                providerFactoryContracts,
+                factoryInterceptionWrapper(serviceInfo),
                 qualifiedProviderQualifier
         );
+    }
+
+    private static boolean factoryInterceptionWrapper(TypeInfo serviceInfo) {
+        return serviceInfo.superTypeInfo()
+                .map(TypeInfo::typeName)
+                .map(TypeName::genericTypeName)
+                .filter(it -> it.equals(INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY)
+                        || it.equals(INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY)
+                        || it.equals(INTERCEPT_G_WRAPPER_SERVICES_FACTORY)
+                        || it.equals(INTERCEPT_G_WRAPPER_IP_FACTORY)
+                        || it.equals(INTERCEPT_G_WRAPPER_QUALIFIED_FACTORY))
+                .isPresent();
     }
 
     private static void addContractToMap(RegistryRoundContext ctx,
@@ -261,7 +249,9 @@ class DescribedService {
     TypeName interceptionWrapperSuperType() {
         return switch (providerType()) {
             case NONE, SERVICE -> serviceType.typeName();
-            case SUPPLIER -> createType(INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY, providedType.typeName());
+            case SUPPLIER -> optionalSupplier()
+                    ? createType(INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY, providedType.typeName())
+                    : createType(INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY, providedType.typeName());
             case SERVICES -> createType(INTERCEPT_G_WRAPPER_SERVICES_FACTORY, providedType.typeName());
             case INJECTION_POINT -> createType(INTERCEPT_G_WRAPPER_IP_FACTORY, providedType.typeName());
             case QUALIFIED ->
@@ -272,11 +262,20 @@ class DescribedService {
     TypeName providerInterface() {
         return switch (providerType()) {
             case NONE, SERVICE -> serviceType.typeName();
-            case SUPPLIER -> createType(TypeNames.SUPPLIER, providedType.typeName());
+            case SUPPLIER -> optionalSupplier()
+                    ? createType(TypeNames.SUPPLIER, createType(TypeNames.OPTIONAL, providedType.typeName()))
+                    : createType(TypeNames.SUPPLIER, providedType.typeName());
             case SERVICES -> createType(SERVICE_SERVICES_FACTORY, providedType.typeName());
             case INJECTION_POINT -> createType(SERVICE_INJECTION_POINT_FACTORY, providedType.typeName());
             case QUALIFIED -> createType(SERVICE_QUALIFIED_FACTORY, providedType.typeName(), qualifiedProviderQualifier);
         };
+    }
+
+    private boolean optionalSupplier() {
+        return providerType == FactoryType.SUPPLIER
+                && factoryTypeName != null
+                && !factoryTypeName.typeArguments().isEmpty()
+                && factoryTypeName.typeArguments().getFirst().isOptional();
     }
 
     boolean isFactory() {
@@ -289,6 +288,18 @@ class DescribedService {
 
     DescribedType serviceDescriptor() {
         return serviceType;
+    }
+
+    Set<ResolvedType> directProviderContracts() {
+        return directProviderContracts;
+    }
+
+    Set<ResolvedType> providerFactoryContracts() {
+        return providerFactoryContracts;
+    }
+
+    boolean factoryInterceptionWrapper() {
+        return factoryInterceptionWrapper;
     }
 
     ServiceSuperType superType() {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
@@ -131,6 +131,9 @@ class DescribedService {
         providedTypeName = factoryInfo.providedTypeName();
         providedTypeInfo = factoryInfo.providedTypeInfo();
         providerFactoryContracts.removeAll(providedContracts);
+        if (providedTypeName != null) {
+            providerFactoryContracts.remove(ResolvedType.create(providedTypeName));
+        }
         Map<TypeName, TypeInfo> implementedInterfaceTypes = new HashMap<>(factoryInfo.remainingImplementedInterfaces());
 
         // add direct contracts
@@ -290,12 +293,10 @@ class DescribedService {
         return serviceType;
     }
 
-    Set<ResolvedType> directProviderContracts() {
-        return directProviderContracts;
-    }
-
-    Set<ResolvedType> providerFactoryContracts() {
-        return providerFactoryContracts;
+    Set<ResolvedType> providerContracts() {
+        Set<ResolvedType> result = new HashSet<>(directProviderContracts);
+        result.addAll(providerFactoryContracts);
+        return Set.copyOf(result);
     }
 
     boolean factoryInterceptionWrapper() {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/InterceptedTypeGenerator.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/InterceptedTypeGenerator.java
@@ -114,7 +114,8 @@ class InterceptedTypeGenerator {
                         String invokeLine = invoker
                                 + ".invoke("
                                 + info.parameterArguments()
-                                .stream().map(TypedElementInfo::elementName)
+                                .stream()
+                                .map(InterceptedTypeGenerator::invokerArgument)
                                 .collect(Collectors.joining(", "))
                                 + ");";
                         // body of the method
@@ -147,6 +148,42 @@ class InterceptedTypeGenerator {
 
                     }));
 
+        }
+    }
+
+    static void generateDelegateMethods(ClassModel.Builder classModel, List<MethodDefinition> interceptedMethods) {
+        for (MethodDefinition interceptedMethod : interceptedMethods) {
+            TypedElementInfo info = interceptedMethod.info();
+
+            classModel.addMethod(method -> method
+                    .accessModifier(AccessModifier.PACKAGE_PRIVATE)
+                    .name(interceptedMethod.delegateName())
+                    .returnType(info.typeName())
+                    .update(it -> info.parameterArguments().forEach(arg -> it.addParameter(param -> param.type(arg.typeName())
+                            .name(arg.elementName()))))
+                    .update(it -> {
+                        if (!interceptedMethod.exceptionTypes().isEmpty()) {
+                            for (TypeName exceptionType : interceptedMethod.exceptionTypes()) {
+                                it.addThrows(exceptionType, "thrown by intercepted method");
+                            }
+                        }
+                    })
+                    .update(it -> {
+                        String invokeLine = "super."
+                                + info.elementName()
+                                + "("
+                                + info.parameterArguments()
+                                .stream()
+                                .map(TypedElementInfo::elementName)
+                                .collect(Collectors.joining(", "))
+                                + ");";
+                        if (interceptedMethod.isVoid()) {
+                            it.addContentLine(invokeLine);
+                        } else {
+                            it.addContent("return ")
+                                    .addContentLine(invokeLine);
+                        }
+                    }));
         }
     }
 
@@ -258,6 +295,7 @@ class InterceptedTypeGenerator {
 
         generateConstructor(classModel);
 
+        generateDelegateMethods(classModel, interceptedMethods);
         generateInterceptedMethods(classModel, interceptedMethods);
 
         return classModel;
@@ -267,6 +305,13 @@ class InterceptedTypeGenerator {
         return TypeName.builder(INTERCEPT_INVOKER)
                 .addTypeArgument(type.boxed())
                 .build();
+    }
+
+    private static String invokerArgument(TypedElementInfo arg) {
+        if (arg.typeName().array()) {
+            return "(Object) " + arg.elementName();
+        }
+        return arg.elementName();
     }
 
     private void generateConstructor(ClassModel.Builder classModel) {
@@ -329,13 +374,8 @@ class InterceptedTypeGenerator {
             for (int i = 0; i < sortedMethods.size(); i++) {
                 TypedElements.ElementMeta elementMeta = sortedMethods.get(i);
 
-                List<Annotation> elementAnnotations = new ArrayList<>(elementMeta.element().annotations());
-                addInterfaceAnnotations(elementAnnotations, elementMeta.abstractMethods());
-
-                TypedElementInfo typedElementInfo = TypedElementInfo.builder()
-                        .from(elementMeta.element())
-                        .annotations(elementAnnotations)
-                        .build();
+                TypedElementInfo typedElementInfo = TypedElements.mergeAbstractMethods(elementMeta.element(),
+                                                                                       elementMeta.abstractMethods());
 
                 String constantName = "METHOD_" + toConstantName(ctx.uniqueName(typeInfo, elementMeta.element()));
                 String invokerName = typedElementInfo.elementName() + "_" + i + "_invoker";
@@ -350,21 +390,9 @@ class InterceptedTypeGenerator {
             return result;
         }
 
-        private static void addInterfaceAnnotations(List<Annotation> elementAnnotations,
-                                                    List<TypedElements.DeclaredElement> declaredElements) {
-
-            for (TypedElements.DeclaredElement declaredElement : declaredElements) {
-                declaredElement.element()
-                        .annotations()
-                        .forEach(it -> addInterfaceAnnotation(elementAnnotations, it));
-            }
+        String delegateName() {
+            return "helidonInject__" + invokerName.substring(0, invokerName.length() - "_invoker".length());
         }
 
-        private static void addInterfaceAnnotation(List<Annotation> elementAnnotations, Annotation annotation) {
-            // only add if not already there
-            if (!elementAnnotations.contains(annotation)) {
-                elementAnnotations.add(annotation);
-            }
-        }
     }
 }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/Interception.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/Interception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,7 +152,9 @@ final class Interception {
             return true;
         }
         for (TypedElements.DeclaredElement interfaceMethod : methodMeta.abstractMethods()) {
-            return hasInterceptTrigger(interfaceMethod.abstractType(), interfaceMethod.element());
+            if (hasInterceptTrigger(interfaceMethod.abstractType(), interfaceMethod.element())) {
+                return true;
+            }
         }
 
         return false;
@@ -174,12 +176,10 @@ final class Interception {
     }
 
     private boolean hasInterceptTriggerOnParams(TypeInfo typeInfo, TypedElementInfo tei) {
-        // we currently cannot retrieve annotations on generics, i.e. List<@NotBlank String>
         if (hasInterceptTriggerOnTypeArguments(typeInfo, tei.typeName())) {
             return true;
         }
 
-        // so for now, just support direct annotations on parameters
         for (TypedElementInfo parameter : tei.parameterArguments()) {
             if (hasInterceptTrigger(typeInfo, parameter)) {
                 return true;
@@ -200,6 +200,21 @@ final class Interception {
             if (hasInterceptTriggerOnTypeArguments(typeInfo, typeArgument)) {
                 return true;
             }
+        }
+        for (TypeName lowerBound : typeName.lowerBounds()) {
+            if (hasInterceptTriggerOnTypeArguments(typeInfo, lowerBound)) {
+                return true;
+            }
+        }
+        for (TypeName upperBound : typeName.upperBounds()) {
+            if (hasInterceptTriggerOnTypeArguments(typeInfo, upperBound)) {
+                return true;
+            }
+        }
+        if (typeName.componentType()
+                .map(componentType -> hasInterceptTriggerOnTypeArguments(typeInfo, componentType))
+                .orElse(false)) {
+            return true;
         }
         return false;
     }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/RegistryRoundContext.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/RegistryRoundContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/codegen/src/main/java/io/helidon/service/codegen/RoundContextImpl.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/RoundContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 
 import io.helidon.codegen.ClassCode;
 import io.helidon.codegen.RoundContext;
+import io.helidon.codegen.TypeHierarchy;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
@@ -96,9 +97,10 @@ class RoundContextImpl implements RegistryRoundContext {
         }
 
         List<TypeInfo> result = new ArrayList<>();
-
         for (TypeInfo typeInfo : typeInfos) {
-            if (typeInfo.hasAnnotation(annotationType)) {
+            if (typeInfo.hasAnnotation(annotationType) || TypeHierarchy.hierarchyAnnotations(ctx, typeInfo)
+                    .stream()
+                    .anyMatch(it -> it.typeName().equals(annotationType))) {
                 result.add(typeInfo);
             }
         }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
@@ -321,6 +321,12 @@ public final class ServiceCodegenTypes {
             TypeName.create("io.helidon.service.registry.GeneratedService.SupplierFactoryInterceptionWrapper");
     /**
      * {@link io.helidon.common.types.TypeName} for
+     * {@code io.helidon.service.registry.GeneratedService.OptionalSupplierFactoryInterceptionWrapper}.
+     */
+    public static final TypeName INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY =
+            TypeName.create("io.helidon.service.registry.GeneratedService.OptionalSupplierFactoryInterceptionWrapper");
+    /**
+     * {@link io.helidon.common.types.TypeName} for
      * {@code io.helidon.service.registry.GeneratedService.ServicesFactoryInterceptionWrapper}.
      */
     public static final TypeName INTERCEPT_G_WRAPPER_SERVICES_FACTORY =

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
@@ -86,6 +86,11 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_DEPENDENC
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_PER_INSTANCE_DESCRIPTOR;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_QUALIFIED_FACTORY_DESCRIPTOR;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_G_SCOPE_HANDLER_DESCRIPTOR;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_LOOKUP;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIED_INSTANCE;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIER;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_SCOPE_HANDLER;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_SERVICE_INSTANCE;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SET_OF_QUALIFIERS;
@@ -213,9 +218,9 @@ public class ServiceDescriptorCodegen {
         Set<ResolvedType> factoryContracts;
 
         if (service.isFactory()) {
-            if (serviceTypeName.className().endsWith("__Interception_Wrapper")) {
+            if (service.factoryInterceptionWrapper()) {
                 contracts = service.providedDescriptor().contracts();
-                factoryContracts = service.serviceDescriptor().contracts();
+                factoryContracts = service.providerFactoryContracts();
             } else {
                 // check if contracts are intercepted
                 var providedElements = service.providedDescriptor().elements();
@@ -223,7 +228,7 @@ public class ServiceDescriptorCodegen {
                 if (providedElements.methodsIntercepted()) {
                     // remove contracts from the original service, service descriptor will only be used to instantiate provider
                     contracts = Set.of();
-                    factoryContracts = Set.of();
+                    factoryContracts = service.directProviderContracts();
                     // generate delegate injection (unless already generated) in current package
                     TypeName delegateType = generateProvidedInterceptionDelegate(roundCtx, service);
                     // then generate a service that injects the original service, and wraps provider method(s) using delegation
@@ -447,23 +452,6 @@ public class ServiceDescriptorCodegen {
         contentBuilder.addContent(enumValue.getDeclaringClass())
                 .addContent(".")
                 .addContent(enumValue.name());
-    }
-
-    private static void addInterfaceAnnotations(List<Annotation> elementAnnotations,
-                                                List<TypedElements.DeclaredElement> declaredElements) {
-
-        for (TypedElements.DeclaredElement declaredElement : declaredElements) {
-            declaredElement.element()
-                    .annotations()
-                    .forEach(it -> addInterfaceAnnotation(elementAnnotations, it));
-        }
-    }
-
-    private static void addInterfaceAnnotation(List<Annotation> elementAnnotations, Annotation annotation) {
-        // only add if not already there
-        if (!elementAnnotations.contains(annotation)) {
-            elementAnnotations.add(annotation);
-        }
     }
 
     private static List<ParamDefinition> declareCtrParamsAndGetThem(Method.Builder method, List<ParamDefinition> params) {
@@ -1756,7 +1744,7 @@ public class ServiceDescriptorCodegen {
                 .decreaseContentPadding()
                 .addContent(".invoke(")
                 .addContent(constructorParams.stream()
-                                    .map(ParamDefinition::ipParamName)
+                                    .map(ServiceDescriptorCodegen::invokerArgument)
                                     .collect(Collectors.joining(", ")))
                 .addContentLine(");")
                 .decreaseContentPadding()
@@ -2044,8 +2032,10 @@ public class ServiceDescriptorCodegen {
             // assign the instance
             methodBuilder.addContent("instance__helidonInject.")
                     .addContent(field.ipParamName())
-                    .addContent(" = config__invoker.invoke(")
-                    .addContent(field.ipParamName())
+                    .addContent(" = ")
+                    .addContent(invokerName)
+                    .addContent(".invoke(")
+                    .addContent(invokerArgument(field))
                     .addContentLine(");")
                     .decreaseContentPadding();
             // end try/catch block
@@ -2315,6 +2305,10 @@ public class ServiceDescriptorCodegen {
                                            DescribedService service,
                                            TypeName delegateType) {
         TypeName typeName = service.serviceDescriptor().typeName();
+        TypeName descriptorType = service.descriptorType();
+        List<InterceptedTypeGenerator.MethodDefinition> factoryMethods = factoryMethods(service);
+        List<InterceptedTypeGenerator.MethodDefinition> interceptedFactoryMethods = interceptedFactoryMethods(service,
+                                                                                                             factoryMethods);
 
         String typeNameSuffix = "__Interception_Wrapper";
         TypeName wrapperType = TypeName.builder()
@@ -2339,12 +2333,20 @@ public class ServiceDescriptorCodegen {
 
         service.qualifiers()
                 .forEach(classModel::addAnnotation);
+        serviceOrderAnnotations(service.serviceDescriptor().typeInfo())
+                .forEach(classModel::addAnnotation);
 
         classModel.addField(interceptMeta -> interceptMeta
                 .type(INTERCEPT_METADATA)
                 .name("interceptMeta")
                 .isFinal(true)
                 .accessModifier(AccessModifier.PRIVATE));
+
+        if (!interceptedFactoryMethods.isEmpty()) {
+            Qualifiers.generateQualifiersConstant(classModel, service.qualifiers());
+            annotationsField(classModel, service.serviceDescriptor().typeInfo());
+            InterceptedTypeGenerator.generateInvokerFields(classModel, interceptedFactoryMethods);
+        }
 
         classModel.addConstructor(ctr -> ctr
                 .addAnnotation(Annotation.create(SERVICE_ANNOTATION_INJECT))
@@ -2355,11 +2357,21 @@ public class ServiceDescriptorCodegen {
                 .addParameter(interceptMeta -> interceptMeta
                         .type(INTERCEPT_METADATA)
                         .name("interceptMeta"))
-                .addContentLine("super(delegate);")
+                .addContent("super(")
+                .update(it -> factoryDelegate(it, service))
+                .addContentLine(");")
                 .addContentLine("this.interceptMeta = interceptMeta;")
+                .update(it -> InterceptedTypeGenerator.createInvokers(it,
+                                                                       descriptorType,
+                                                                       interceptedFactoryMethods,
+                                                                       true,
+                                                                       "interceptMeta",
+                                                                       descriptorType.fqName() + ".INSTANCE",
+                                                                       "QUALIFIERS",
+                                                                       "ANNOTATIONS",
+                                                                       "super"))
         );
 
-        TypeName descriptorType = service.descriptorType();
         classModel.addMethod(wrap -> wrap
                 .addAnnotation(Annotations.OVERRIDE)
                 .accessModifier(AccessModifier.PROTECTED)
@@ -2379,10 +2391,434 @@ public class ServiceDescriptorCodegen {
                 .addContentLine("instance);")
         );
 
+        InterceptedTypeGenerator.generateInterceptedMethods(classModel, interceptedFactoryMethods);
+
         roundContext.addGeneratedType(wrapperType,
                                       classModel,
                                       typeName,
                                       service.serviceDescriptor().typeInfo().originatingElementValue());
+    }
+
+    private List<Annotation> serviceOrderAnnotations(TypeInfo typeInfo) {
+        List<Annotation> annotations = new ArrayList<>();
+        typeInfo.findAnnotation(TypeName.create(Weight.class))
+                .ifPresent(annotations::add);
+        typeInfo.findAnnotation(SERVICE_ANNOTATION_RUN_LEVEL)
+                .ifPresent(annotations::add);
+        return annotations;
+    }
+
+    private void factoryDelegate(ContentBuilder<?> content, DescribedService service) {
+        List<InterceptedTypeGenerator.MethodDefinition> factoryMethods = factoryMethods(service);
+        if (factoryMethods.isEmpty()) {
+            content.addContent("delegate");
+            return;
+        }
+
+        TypeName interceptedType = interceptedTypeName(service.serviceDescriptor().typeName());
+        switch (service.providerType()) {
+        case INJECTION_POINT -> injectionPointFactoryDelegate(content, service, interceptedType, factoryMethods);
+        case QUALIFIED -> qualifiedFactoryDelegate(content, service, interceptedType, factoryMethods);
+        default -> methodReferenceFactoryDelegate(content, service, interceptedType, factoryMethods);
+        }
+    }
+
+    private List<InterceptedTypeGenerator.MethodDefinition> interceptedFactoryMethods(
+            DescribedService service,
+            List<InterceptedTypeGenerator.MethodDefinition> factoryMethods) {
+        List<InterceptedTypeGenerator.MethodDefinition> result = new ArrayList<>();
+        switch (service.providerType()) {
+        case SUPPLIER -> factoryMethod(factoryMethods, "get")
+                .ifPresent(result::add);
+        case SERVICES -> factoryMethod(factoryMethods, "services")
+                .ifPresent(result::add);
+        case INJECTION_POINT -> {
+            factoryMethod(factoryMethods, "first", SERVICE_LOOKUP)
+                    .ifPresent(result::add);
+            factoryMethod(factoryMethods, "list", SERVICE_LOOKUP)
+                    .ifPresent(result::add);
+        }
+        case QUALIFIED -> {
+            TypeName genericProvidedType = TypeName.builder(TypeNames.GENERIC_TYPE)
+                    .addTypeArgument(service.providedDescriptor().typeName())
+                    .build();
+            factoryMethod(factoryMethods,
+                          "first",
+                          SERVICE_QUALIFIER,
+                          SERVICE_LOOKUP,
+                          genericProvidedType)
+                    .ifPresent(result::add);
+            factoryMethod(factoryMethods,
+                          "list",
+                          SERVICE_QUALIFIER,
+                          SERVICE_LOOKUP,
+                          genericProvidedType)
+                    .ifPresent(result::add);
+        }
+        default -> {
+        }
+        }
+        return List.copyOf(result);
+    }
+
+    private void methodReferenceFactoryDelegate(ContentBuilder<?> content,
+                                                DescribedService service,
+                                                TypeName interceptedType,
+                                                List<InterceptedTypeGenerator.MethodDefinition> factoryMethods) {
+        String factoryMethodName = switch (service.providerType()) {
+            case SUPPLIER -> "get";
+            case SERVICES -> "services";
+            case NONE, SERVICE, INJECTION_POINT, QUALIFIED -> "";
+        };
+        if (factoryMethodName.isEmpty()) {
+            content.addContent("delegate");
+            return;
+        }
+
+        Optional<InterceptedTypeGenerator.MethodDefinition> factoryMethod =
+                factoryMethod(factoryMethods, factoryMethodName);
+        if (factoryMethod.isEmpty()) {
+            content.addContent("delegate");
+            return;
+        }
+
+        content.addContent("delegate instanceof ")
+                .addContent(interceptedType)
+                .addContent(" helidonInject__delegate ? helidonInject__delegate::")
+                .addContent(factoryMethod.get().delegateName())
+                .addContent(" : delegate");
+    }
+
+    private void injectionPointFactoryDelegate(ContentBuilder<?> content,
+                                               DescribedService service,
+                                               TypeName interceptedType,
+                                               List<InterceptedTypeGenerator.MethodDefinition> factoryMethods) {
+        Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod = factoryMethod(factoryMethods,
+                                                                                       "first",
+                                                                                       SERVICE_LOOKUP);
+        Optional<InterceptedTypeGenerator.MethodDefinition> listMethod = factoryMethod(factoryMethods,
+                                                                                      "list",
+                                                                                      SERVICE_LOOKUP);
+
+        factoryDelegateHeader(content, service, interceptedType);
+        content.addContentLine(" {")
+                .increaseContentPadding();
+
+        TypeName optionalQualifiedInstance = optionalQualifiedInstanceType(service);
+        content.addContentLine("@Override")
+                .addContent("public ")
+                .addContent(optionalQualifiedInstance)
+                .addContentLine(" first(")
+                .increaseContentPadding()
+                .addContent(SERVICE_LOOKUP)
+                .addContentLine(" lookup) {");
+        injectionPointFactoryFirstBody(content, service, firstMethod, listMethod);
+        content.addContentLine("}")
+                .decreaseContentPadding()
+                .addContentLine();
+
+        TypeName listQualifiedInstance = listQualifiedInstanceType(service);
+        content.addContentLine("@Override")
+                .addContent("public ")
+                .addContent(listQualifiedInstance)
+                .addContentLine(" list(")
+                .increaseContentPadding()
+                .addContent(SERVICE_LOOKUP)
+                .addContentLine(" lookup) {");
+        injectionPointFactoryListBody(content, service, firstMethod, listMethod);
+        content.addContentLine("}")
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .addContent("} : delegate");
+    }
+
+    private void injectionPointFactoryFirstBody(ContentBuilder<?> content,
+                                                DescribedService service,
+                                                Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
+                                                Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
+        if (firstMethod.isPresent()) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(firstMethod.get().delegateName())
+                    .addContentLine("(lookup);");
+            return;
+        }
+        if (listMethod.isPresent() && !factoryMethodCustomized(service, "first", SERVICE_LOOKUP)) {
+            // Raw first(...) may still dispatch to the intercepted list(...) override from the provider implementation.
+            content.addContent(listQualifiedInstanceType(service))
+                    .addContent(" helidonInject__list = helidonInject__delegate.")
+                    .addContent(listMethod.get().delegateName())
+                    .addContentLine("(lookup);")
+                    .addContent("return helidonInject__list.isEmpty() ? ")
+                    .addContent(Optional.class)
+                    .addContent(".empty() : ")
+                    .addContent(Optional.class)
+                    .addContentLine(".of(helidonInject__list.getFirst());");
+            return;
+        }
+        content.addContent("return helidonInject__delegate.")
+                .addContentLine("first(lookup);");
+    }
+
+    private void injectionPointFactoryListBody(ContentBuilder<?> content,
+                                               DescribedService service,
+                                               Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
+                                               Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
+        if (listMethod.isPresent()) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(listMethod.get().delegateName())
+                    .addContentLine("(lookup);");
+            return;
+        }
+        if (firstMethod.isPresent() && !factoryMethodCustomized(service, "list", SERVICE_LOOKUP)) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(firstMethod.get().delegateName())
+                    .addContentLine("(lookup).map(List::of).orElseGet(List::of);");
+            return;
+        }
+        content.addContentLine("return helidonInject__delegate.list(lookup);");
+    }
+
+    private void qualifiedFactoryDelegate(ContentBuilder<?> content,
+                                          DescribedService service,
+                                          TypeName interceptedType,
+                                          List<InterceptedTypeGenerator.MethodDefinition> factoryMethods) {
+        TypeName genericProvidedType = TypeName.builder(TypeNames.GENERIC_TYPE)
+                .addTypeArgument(service.providedDescriptor().typeName())
+                .build();
+        Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod = factoryMethod(factoryMethods,
+                                                                                       "first",
+                                                                                       SERVICE_QUALIFIER,
+                                                                                       SERVICE_LOOKUP,
+                                                                                       genericProvidedType);
+        Optional<InterceptedTypeGenerator.MethodDefinition> listMethod = factoryMethod(factoryMethods,
+                                                                                      "list",
+                                                                                      SERVICE_QUALIFIER,
+                                                                                      SERVICE_LOOKUP,
+                                                                                      genericProvidedType);
+
+        factoryDelegateHeader(content, service, interceptedType);
+        content.addContentLine(" {")
+                .increaseContentPadding();
+
+        TypeName optionalQualifiedInstance = optionalQualifiedInstanceType(service);
+        content.addContentLine("@Override")
+                .addContent("public ")
+                .addContent(optionalQualifiedInstance)
+                .addContentLine(" first(")
+                .increaseContentPadding()
+                .addContent(SERVICE_QUALIFIER)
+                .addContentLine(" qualifier,")
+                .addContent(SERVICE_LOOKUP)
+                .addContentLine(" lookup,")
+                .addContent(genericProvidedType)
+                .addContentLine(" type) {");
+        qualifiedFactoryFirstBody(content, service, genericProvidedType, firstMethod, listMethod);
+        content.addContentLine("}")
+                .decreaseContentPadding()
+                .addContentLine();
+
+        TypeName listQualifiedInstance = listQualifiedInstanceType(service);
+        content.addContentLine("@Override")
+                .addContent("public ")
+                .addContent(listQualifiedInstance)
+                .addContentLine(" list(")
+                .increaseContentPadding()
+                .addContent(SERVICE_QUALIFIER)
+                .addContentLine(" qualifier,")
+                .addContent(SERVICE_LOOKUP)
+                .addContentLine(" lookup,")
+                .addContent(genericProvidedType)
+                .addContentLine(" type) {");
+        qualifiedFactoryListBody(content, service, genericProvidedType, firstMethod, listMethod);
+        content.addContentLine("}")
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .addContent("} : delegate");
+    }
+
+    private void qualifiedFactoryFirstBody(ContentBuilder<?> content,
+                                           DescribedService service,
+                                           TypeName genericProvidedType,
+                                           Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
+                                           Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
+        if (firstMethod.isPresent()) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(firstMethod.get().delegateName())
+                    .addContentLine("(qualifier, lookup, type);");
+            return;
+        }
+        if (listMethod.isPresent()
+                && !factoryMethodCustomized(service, "first", SERVICE_QUALIFIER, SERVICE_LOOKUP, genericProvidedType)) {
+            // Raw first(...) may still dispatch to the intercepted list(...) override from the provider implementation.
+            content.addContent(listQualifiedInstanceType(service))
+                    .addContent(" helidonInject__list = helidonInject__delegate.")
+                    .addContent(listMethod.get().delegateName())
+                    .addContentLine("(qualifier, lookup, type);")
+                    .addContent("return helidonInject__list.isEmpty() ? ")
+                    .addContent(Optional.class)
+                    .addContent(".empty() : ")
+                    .addContent(Optional.class)
+                    .addContentLine(".of(helidonInject__list.getFirst());");
+            return;
+        }
+        content.addContent("return helidonInject__delegate.")
+                .addContentLine("first(qualifier, lookup, type);");
+    }
+
+    private void qualifiedFactoryListBody(ContentBuilder<?> content,
+                                          DescribedService service,
+                                          TypeName genericProvidedType,
+                                          Optional<InterceptedTypeGenerator.MethodDefinition> firstMethod,
+                                          Optional<InterceptedTypeGenerator.MethodDefinition> listMethod) {
+        if (listMethod.isPresent()) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(listMethod.get().delegateName())
+                    .addContentLine("(qualifier, lookup, type);");
+            return;
+        }
+        if (firstMethod.isPresent()
+                && !factoryMethodCustomized(service, "list", SERVICE_QUALIFIER, SERVICE_LOOKUP, genericProvidedType)) {
+            content.addContent("return helidonInject__delegate.")
+                    .addContent(firstMethod.get().delegateName())
+                    .addContentLine("(qualifier, lookup, type).map(List::of).orElseGet(List::of);");
+            return;
+        }
+        content.addContentLine("return helidonInject__delegate.list(qualifier, lookup, type);");
+    }
+
+    private void factoryDelegateHeader(ContentBuilder<?> content,
+                                       DescribedService service,
+                                       TypeName interceptedType) {
+        content.addContent("delegate instanceof ")
+                .addContent(interceptedType)
+                .addContent(" helidonInject__delegate ? new ")
+                .addContent(service.providerInterface())
+                .addContent("()");
+    }
+
+    private TypeName optionalQualifiedInstanceType(DescribedService service) {
+        return TypeName.builder(TypeNames.OPTIONAL)
+                .addTypeArgument(qualifiedInstanceType(service))
+                .build();
+    }
+
+    private TypeName listQualifiedInstanceType(DescribedService service) {
+        return TypeName.builder(TypeNames.LIST)
+                .addTypeArgument(qualifiedInstanceType(service))
+                .build();
+    }
+
+    private TypeName qualifiedInstanceType(DescribedService service) {
+        return TypeName.builder(SERVICE_QUALIFIED_INSTANCE)
+                .addTypeArgument(service.providedDescriptor().typeName())
+                .build();
+    }
+
+    private List<InterceptedTypeGenerator.MethodDefinition> factoryMethods(DescribedService service) {
+        if (!service.serviceDescriptor().elements().methodsIntercepted()) {
+            return List.of();
+        }
+
+        return InterceptedTypeGenerator.MethodDefinition.toDefinitions(
+                        ctx,
+                        service.serviceDescriptor().typeInfo(),
+                        service.serviceDescriptor()
+                                .elements()
+                                .interceptedElements()
+                                .stream()
+                                .filter(it -> it.element().kind() == ElementKind.METHOD)
+                                .toList());
+    }
+
+    private boolean factoryMethodCustomized(DescribedService service, String factoryMethodName, TypeName... parameterTypes) {
+        return factoryMethodCustomized(service.serviceDescriptor().typeInfo(),
+                                       new HashSet<>(),
+                                       factoryMethodName,
+                                       parameterTypes);
+    }
+
+    private boolean factoryMethodCustomized(TypeInfo typeInfo,
+                                            Set<TypeName> processedTypes,
+                                            String factoryMethodName,
+                                            TypeName... parameterTypes) {
+        if (!processedTypes.add(typeInfo.typeName().genericTypeName())) {
+            return false;
+        }
+        if (!defaultFactoryInterface(typeInfo)
+                && typeInfo.elementInfo()
+                        .stream()
+                        .filter(it -> it.kind() == ElementKind.METHOD)
+                        .filter(not(ElementInfoPredicates::isPrivate))
+                        .filter(not(ElementInfoPredicates::isStatic))
+                        .filter(it -> it.elementName().equals(factoryMethodName))
+                        .anyMatch(it -> hasFactoryParameters(it, parameterTypes))) {
+            return true;
+        }
+
+        if (typeInfo.superTypeInfo()
+                .map(it -> factoryMethodCustomized(it, processedTypes, factoryMethodName, parameterTypes))
+                .orElse(false)) {
+            return true;
+        }
+
+        return typeInfo.interfaceTypeInfo()
+                .stream()
+                .anyMatch(it -> factoryMethodCustomized(it, processedTypes, factoryMethodName, parameterTypes));
+    }
+
+    private boolean defaultFactoryInterface(TypeInfo typeInfo) {
+        TypeName genericType = typeInfo.typeName().genericTypeName();
+        return genericType.equals(SERVICE_INJECTION_POINT_FACTORY) || genericType.equals(SERVICE_QUALIFIED_FACTORY);
+    }
+
+    private Optional<InterceptedTypeGenerator.MethodDefinition> factoryMethod(
+            List<InterceptedTypeGenerator.MethodDefinition> factoryMethods,
+            String factoryMethodName,
+            TypeName... parameterTypes) {
+        return factoryMethods
+                .stream()
+                .filter(it -> it.info().elementName().equals(factoryMethodName))
+                .filter(it -> hasParameters(it, parameterTypes))
+                .findFirst();
+    }
+
+    private boolean hasParameters(InterceptedTypeGenerator.MethodDefinition method, TypeName... parameterTypes) {
+        List<TypedElementInfo> parameterArguments = method.info().parameterArguments();
+        if (parameterArguments.size() != parameterTypes.length) {
+            return false;
+        }
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            if (!parameterArguments.get(i).typeName().equals(parameterTypes[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean hasFactoryParameters(TypedElementInfo method, TypeName... parameterTypes) {
+        List<TypedElementInfo> parameterArguments = method.parameterArguments();
+        if (parameterArguments.size() != parameterTypes.length) {
+            return false;
+        }
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            TypeName actualType = parameterArguments.get(i).typeName();
+            TypeName expectedType = parameterTypes[i];
+            if (!actualType.equals(expectedType) && !actualType.genericTypeName().equals(expectedType.genericTypeName())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static String invokerArgument(ParamDefinition param) {
+        if (param.declaredType().array()) {
+            return "(Object) " + param.ipParamName();
+        }
+        return param.ipParamName();
     }
 
     private void factoryType(ClassModel.Builder classModel, DescribedService service, FactoryType factoryType) {
@@ -2442,10 +2878,7 @@ public class ServiceDescriptorCodegen {
         if (ElementInfoPredicates.isStatic(method)) {
             return false;
         }
-        List<Annotation> elementAnnotations = new ArrayList<>(method.annotations());
-        addInterfaceAnnotations(elementAnnotations, element.abstractMethods());
-
-        for (Annotation elementAnnotation : elementAnnotations) {
+        for (Annotation elementAnnotation : element.effectiveElement().annotations()) {
             if (elementAnnotation.hasMetaAnnotation(SERVICE_ANNOTATION_ENTRY_POINT)) {
                 return true;
             }
@@ -2461,13 +2894,6 @@ public class ServiceDescriptorCodegen {
         String uniqueName = ctx.uniqueName(typeInfo, method);
         String constantName = "METHOD_" + toConstantName(uniqueName);
 
-        // add inherited annotations from interfaces
-        List<Annotation> elementAnnotations = new ArrayList<>(method.annotations());
-        addInterfaceAnnotations(elementAnnotations, element.abstractMethods());
-        TypedElementInfo typedElementInfo = TypedElementInfo.builder()
-                .from(method)
-                .annotations(elementAnnotations)
-                .build();
         classModel.addField(constant -> constant
                 .description("Element info for method: {@code " + method.signature() + "}.")
                 .accessModifier(AccessModifier.PUBLIC)
@@ -2475,7 +2901,7 @@ public class ServiceDescriptorCodegen {
                 .isFinal(true)
                 .type(TypeNames.TYPED_ELEMENT_INFO)
                 .name(constantName)
-                .addContentCreate(typedElementInfo));
+                .addContentCreate(element.effectiveElement()));
     }
 
     private void generateInterceptedType(RegistryRoundContext roundContext,

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
@@ -220,7 +220,7 @@ public class ServiceDescriptorCodegen {
         if (service.isFactory()) {
             if (service.factoryInterceptionWrapper()) {
                 contracts = service.providedDescriptor().contracts();
-                factoryContracts = service.providerFactoryContracts();
+                factoryContracts = service.providerContracts();
             } else {
                 // check if contracts are intercepted
                 var providedElements = service.providedDescriptor().elements();
@@ -228,14 +228,14 @@ public class ServiceDescriptorCodegen {
                 if (providedElements.methodsIntercepted()) {
                     // remove contracts from the original service, service descriptor will only be used to instantiate provider
                     contracts = Set.of();
-                    factoryContracts = service.directProviderContracts();
+                    factoryContracts = service.providerContracts();
                     // generate delegate injection (unless already generated) in current package
                     TypeName delegateType = generateProvidedInterceptionDelegate(roundCtx, service);
                     // then generate a service that injects the original service, and wraps provider method(s) using delegation
                     generateDelegationService(roundCtx, service, delegateType);
                 } else {
                     contracts = service.providedDescriptor().contracts();
-                    factoryContracts = service.serviceDescriptor().contracts();
+                    factoryContracts = service.providerContracts();
                 }
             }
         } else {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,10 +36,13 @@ import io.helidon.codegen.TypeHierarchy;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.ElementSignature;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
 import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 import io.helidon.service.metadata.DescriptorMetadata;
@@ -65,7 +68,8 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                     return new ExtensionInfo(extension,
                                              discoveryPredicate(it.supportedAnnotations(),
                                                                 it.supportedAnnotationPackages()),
-                                             it.supportedMetaAnnotations());
+                                             it.supportedMetaAnnotations(),
+                                             it.supportsServiceContractAnnotations());
                 })
                 .toList();
     }
@@ -216,15 +220,26 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
 
         Set<TypeName> availableAnnotations = new HashSet<>();
         Map<TypeName, List<TypeInfo>> annotationToTypes = new HashMap<>();
+        Map<TypeName, Set<TypeName>> supportedAnnotationsCache = new HashMap<>();
+        Map<TypeName, Set<TypeName>> metaAnnotationsCache = new HashMap<>();
+        Map<TypeName, Boolean> metaAnnotatedCache = new HashMap<>();
+        Map<TypeName, Set<TypeName>> metaAnnotated = new HashMap<>();
         Map<TypeName, TypeInfo> processedTypes = new HashMap<>();
+
+        for (TypeName typeName : extension.supportedMetaAnnotations()) {
+            metaAnnotated.put(typeName, new HashSet<>(roundContext.annotatedAnnotations(typeName)));
+        }
 
         for (TypeInfoAndAnnotations annotatedType : annotatedTypes) {
             for (TypeName annotationType : annotatedType.annotations()) {
                 // first check if directly supported
                 if (extension.supportedAnnotationsPredicate.test(annotationType)
-                        || isMetaAnnotated(roundContext, extension, annotationType)) {
+                        || isMetaAnnotated(roundContext, extension, annotationType, metaAnnotationsCache, metaAnnotatedCache)) {
 
                     availableAnnotations.add(annotationType);
+                    addMetaAnnotated(metaAnnotated,
+                                     annotationType,
+                                     metaAnnotations(roundContext, extension, annotationType, metaAnnotationsCache));
                     processedTypes.put(annotatedType.typeInfo().typeName(), annotatedType.typeInfo());
                     annotationToTypes.computeIfAbsent(annotationType, k -> new ArrayList<>())
                             .add(annotatedType.typeInfo());
@@ -232,12 +247,27 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                     // or we support the annotation type, or it is prefixed by the package prefix
                 }
             }
+            Set<TypeName> contractAnnotations = supportedServiceContractAnnotations(roundContext,
+                                                                                    extension,
+                                                                                    annotatedType.typeInfo(),
+                                                                                    supportedAnnotationsCache,
+                                                                                    metaAnnotationsCache,
+                                                                                    metaAnnotatedCache);
+            if (!contractAnnotations.isEmpty()) {
+                processedTypes.put(annotatedType.typeInfo().typeName(),
+                                   effectiveServiceType(roundContext, annotatedType.typeInfo()));
+                availableAnnotations.addAll(contractAnnotations);
+                contractAnnotations.forEach(it -> addMetaAnnotated(metaAnnotated,
+                                                                    it,
+                                                                    metaAnnotations(roundContext,
+                                                                                    extension,
+                                                                                    it,
+                                                                                    metaAnnotationsCache)));
+            }
         }
 
-        Map<TypeName, Set<TypeName>> metaAnnotated = new HashMap<>();
-        for (TypeName typeName : extension.supportedMetaAnnotations()) {
-            metaAnnotated.put(typeName, Set.copyOf(roundContext.annotatedAnnotations(typeName)));
-        }
+        Map<TypeName, Set<TypeName>> metaAnnotatedCopy = new HashMap<>();
+        metaAnnotated.forEach((key, value) -> metaAnnotatedCopy.put(key, Set.copyOf(value)));
 
         return new RoundContextImpl(
                 ctx,
@@ -245,17 +275,211 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                 newDescriptors::add,
                 Set.copyOf(availableAnnotations),
                 Map.copyOf(annotationToTypes),
-                Map.copyOf(metaAnnotated),
+                Map.copyOf(metaAnnotatedCopy),
                 List.copyOf(processedTypes.values()));
     }
 
-    private boolean isMetaAnnotated(RoundContext roundContext, ExtensionInfo extension, TypeName annotationType) {
+    private TypeInfo effectiveServiceType(RoundContext roundContext, TypeInfo serviceType) {
+        ServiceContracts serviceContracts = ServiceContracts.create(ctx.options(), roundContext::typeInfo, serviceType);
+        Set<ResolvedType> contracts = new HashSet<>();
+        serviceContracts.addContracts(contracts, new HashSet<>(), serviceType);
+
+        List<TypedElementInfo> elements = new ArrayList<>();
+        Set<ElementKey> signatures = new HashSet<>();
+        addEffectiveElements(elements, signatures, TypedElements.gatherElements(ctx, contracts, serviceType));
+
+        ServiceTypes.FactoryInfo factoryInfo = ServiceTypes.factoryInfo(serviceContracts, serviceType);
+        if (factoryInfo.providerType() != FactoryType.SERVICE && factoryInfo.providedTypeInfo() != null) {
+            addEffectiveMethodElements(elements,
+                                       signatures,
+                                       TypedElements.gatherElements(ctx,
+                                                                    factoryInfo.providedContracts(),
+                                                                    factoryInfo.providedTypeInfo()));
+        }
+
+        return TypeInfo.builder(serviceType)
+                .elementInfo(elements)
+                .build();
+    }
+
+    private void addEffectiveElements(List<TypedElementInfo> elements,
+                                      Set<ElementKey> signatures,
+                                      List<TypedElements.ElementMeta> elementMetas) {
+        for (TypedElements.ElementMeta elementMeta : elementMetas) {
+            TypedElementInfo element = elementMeta.effectiveElement();
+            if (signatures.add(ElementKey.create(element))) {
+                elements.add(element);
+            }
+        }
+    }
+
+    private void addEffectiveMethodElements(List<TypedElementInfo> elements,
+                                            Set<ElementKey> signatures,
+                                            List<TypedElements.ElementMeta> elementMetas) {
+        for (TypedElements.ElementMeta elementMeta : elementMetas) {
+            TypedElementInfo element = elementMeta.effectiveElement();
+            if (element.kind() == ElementKind.METHOD && signatures.add(ElementKey.create(element))) {
+                elements.add(element);
+            }
+        }
+    }
+
+    private Set<TypeName> supportedServiceContractAnnotations(RoundContext roundContext,
+                                                              ExtensionInfo extension,
+                                                              TypeInfo serviceType,
+                                                              Map<TypeName, Set<TypeName>> supportedAnnotationsCache,
+                                                              Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                                              Map<TypeName, Boolean> metaAnnotatedCache) {
+        if (!extension.supportsServiceContractAnnotations() || !ServiceTypes.isService(serviceType)) {
+            return Set.of();
+        }
+
+        ServiceContracts serviceContracts = ServiceContracts.create(ctx.options(), roundContext::typeInfo, serviceType);
+        Set<ResolvedType> contracts = new HashSet<>();
+        serviceContracts.addContracts(contracts, new HashSet<>(), serviceType);
+
+        Set<TypeName> result = new HashSet<>(supportedAnnotationsOnContracts(roundContext,
+                                                                             extension,
+                                                                             contracts,
+                                                                             supportedAnnotationsCache,
+                                                                             metaAnnotationsCache,
+                                                                             metaAnnotatedCache));
+        result.addAll(supportedAnnotationsOnContracts(roundContext,
+                                                      extension,
+                                                      ServiceTypes.factoryProvidedContracts(serviceContracts, serviceType),
+                                                      supportedAnnotationsCache,
+                                                      metaAnnotationsCache,
+                                                      metaAnnotatedCache));
+
+        return Set.copyOf(result);
+    }
+
+    private Set<TypeName> supportedAnnotationsOnContracts(RoundContext roundContext,
+                                                          ExtensionInfo extension,
+                                                          Set<ResolvedType> contracts,
+                                                          Map<TypeName, Set<TypeName>> supportedAnnotationsCache,
+                                                          Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                                          Map<TypeName, Boolean> metaAnnotatedCache) {
+        Set<TypeName> result = new HashSet<>();
+        for (ResolvedType contract : contracts) {
+            TypeName contractType = contract.type();
+            result.addAll(supportedAnnotationsCache.computeIfAbsent(contractType,
+                                                                    it -> supportedAnnotations(roundContext,
+                                                                                               extension,
+                                                                                               contractType,
+                                                                                               metaAnnotationsCache,
+                                                                                               metaAnnotatedCache)));
+        }
+
+        return result;
+    }
+
+    private Set<TypeName> supportedAnnotations(RoundContext roundContext,
+                                               ExtensionInfo extension,
+                                               TypeName typeName,
+                                               Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                               Map<TypeName, Boolean> metaAnnotatedCache) {
+        Optional<TypeInfo> typeInfo = roundContext.typeInfo(typeName)
+                .or(() -> roundContext.typeInfo(typeName.genericTypeName()));
+        return typeInfo.map(it -> supportedAnnotations(roundContext,
+                                                       extension,
+                                                       it,
+                                                       metaAnnotationsCache,
+                                                       metaAnnotatedCache))
+                .orElseGet(Set::of);
+    }
+
+    private Set<TypeName> supportedAnnotations(RoundContext roundContext,
+                                               ExtensionInfo extension,
+                                               TypeInfo typeInfo,
+                                               Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                               Map<TypeName, Boolean> metaAnnotatedCache) {
+        Set<TypeName> result = new HashSet<>();
+        for (TypeName annotationType : TypeHierarchy.nestedAnnotations(ctx, typeInfo)) {
+            if (extension.supportedAnnotationsPredicate.test(annotationType)
+                    || isMetaAnnotated(roundContext,
+                                       extension,
+                                       annotationType,
+                                       metaAnnotationsCache,
+                                       metaAnnotatedCache)) {
+                result.add(annotationType);
+            }
+        }
+
+        return result;
+    }
+
+    private boolean isMetaAnnotated(RoundContext roundContext,
+                                    ExtensionInfo extension,
+                                    TypeName annotationType,
+                                    Map<TypeName, Set<TypeName>> metaAnnotationsCache,
+                                    Map<TypeName, Boolean> metaAnnotatedCache) {
+        return metaAnnotatedCache.computeIfAbsent(annotationType,
+                                                  it -> !metaAnnotations(roundContext,
+                                                                         extension,
+                                                                         annotationType,
+                                                                         metaAnnotationsCache).isEmpty());
+    }
+
+    private Set<TypeName> metaAnnotations(RoundContext roundContext,
+                                          ExtensionInfo extension,
+                                          TypeName annotationType,
+                                          Map<TypeName, Set<TypeName>> metaAnnotationsCache) {
+        return metaAnnotationsCache.computeIfAbsent(annotationType,
+                                                    it -> metaAnnotations(roundContext, extension, annotationType));
+    }
+
+    private Set<TypeName> metaAnnotations(RoundContext roundContext, ExtensionInfo extension, TypeName annotationType) {
+        Set<TypeName> result = new HashSet<>();
         for (TypeName typeName : extension.supportedMetaAnnotations()) {
-            if (roundContext.annotatedAnnotations(typeName)
-                    .contains(annotationType)) {
+            if (roundContext.annotatedAnnotations(typeName).contains(annotationType)) {
+                result.add(typeName);
+            }
+        }
+        Optional<TypeInfo> annotationInfo = ctx.typeInfo(annotationType);
+        if (annotationInfo.isEmpty()) {
+            return Set.copyOf(result);
+        }
+        for (TypeName supportedMetaAnnotation : extension.supportedMetaAnnotations()) {
+            if (!result.contains(supportedMetaAnnotation)
+                    && isMetaAnnotated(annotationInfo.get(), Set.of(supportedMetaAnnotation), new HashSet<>())) {
+                result.add(supportedMetaAnnotation);
+            }
+        }
+
+        return Set.copyOf(result);
+    }
+
+    private void addMetaAnnotated(Map<TypeName, Set<TypeName>> metaAnnotated,
+                                  TypeName annotationType,
+                                  Set<TypeName> metaAnnotations) {
+        for (TypeName metaAnnotation : metaAnnotations) {
+            metaAnnotated.computeIfAbsent(metaAnnotation, ignored -> new HashSet<>())
+                    .add(annotationType);
+        }
+    }
+
+    private boolean isMetaAnnotated(TypeInfo annotationType, Set<TypeName> supportedMetaAnnotations, Set<TypeName> processed) {
+        if (!processed.add(annotationType.typeName())) {
+            return false;
+        }
+
+        for (Annotation annotation : annotationType.annotations()) {
+            if (supportedMetaAnnotations.contains(annotation.typeName())) {
+                return true;
+            }
+            for (TypeName supportedMetaAnnotation : supportedMetaAnnotations) {
+                if (annotation.hasMetaAnnotation(supportedMetaAnnotation)) {
+                    return true;
+                }
+            }
+            if (ctx.typeInfo(annotation.typeName())
+                    .map(it -> isMetaAnnotated(it, supportedMetaAnnotations, processed))
+                    .orElse(false)) {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -277,6 +501,16 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
 
     private record ExtensionInfo(RegistryCodegenExtension extension,
                                  Predicate<TypeName> supportedAnnotationsPredicate,
-                                 Set<TypeName> supportedMetaAnnotations) {
+                                 Set<TypeName> supportedMetaAnnotations,
+                                 boolean supportsServiceContractAnnotations) {
+    }
+
+    private record ElementKey(TypeName owner, ElementSignature signature) {
+        static ElementKey create(TypedElementInfo element) {
+            return new ElementKey(element.enclosingType()
+                                          .map(TypeName::genericTypeName)
+                                          .orElse(TypeNames.OBJECT),
+                                  element.signature());
+        }
     }
 }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceTypes.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.codegen;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.helidon.codegen.CodegenException;
+import io.helidon.codegen.ElementInfoPredicates;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+
+final class ServiceTypes {
+    private static final List<TypeName> FACTORY_TYPES = List.of(TypeNames.SUPPLIER,
+                                                                ServiceCodegenTypes.SERVICE_SERVICES_FACTORY,
+                                                                ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY,
+                                                                ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY);
+
+    private ServiceTypes() {
+    }
+
+    /**
+     * Whether the type is a Helidon service type.
+     *
+     * @param type type to check
+     * @return whether the type is a service
+     */
+    static boolean isService(TypeInfo type) {
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_DESCRIBE)) {
+            return true;
+        }
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE)) {
+            return true;
+        }
+        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE)) {
+            return true;
+        }
+        if (type.elementInfo()
+                .stream()
+                .anyMatch(ElementInfoPredicates.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT))) {
+            return true;
+        }
+        for (Annotation annotation : type.annotations()) {
+            if (annotation.hasMetaAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Analyze all supported service factory contracts.
+     *
+     * @param serviceContracts service contracts
+     * @param serviceInfo      service type
+     * @return full factory analysis
+     */
+    static FactoryInfo factoryInfo(ServiceContracts serviceContracts, TypeInfo serviceInfo) {
+        List<TypeInfo> typeInfos = serviceInfo.interfaceTypeInfo();
+        Map<TypeName, TypeInfo> implementedInterfaceTypes = new HashMap<>();
+        typeInfos.forEach(it -> implementedInterfaceTypes.put(it.typeName(), it));
+
+        Set<ResolvedType> directContracts = new HashSet<>();
+        Set<ResolvedType> providedContracts = new HashSet<>();
+        FactoryType providerType = FactoryType.SERVICE;
+        TypeName factoryTypeName = null;
+        TypeName qualifiedProviderQualifier = null;
+        TypeInfo providedTypeInfo = null;
+        TypeName providedTypeName = null;
+
+        for (TypeName factoryType : FACTORY_TYPES) {
+            var response = serviceContracts.analyseFactory(factoryType);
+            if (!response.valid()) {
+                continue;
+            }
+
+            if (factoryType.equals(TypeNames.SUPPLIER)) {
+                if (providerType != FactoryType.SERVICE) {
+                    throw new CodegenException("Service implements more than one provider type: "
+                                                       + providerType + ", and supplier.",
+                                               serviceInfo.originatingElementValue());
+                }
+                providerType = FactoryType.SUPPLIER;
+                factoryTypeName = response.factoryType();
+                directContracts.add(ResolvedType.create(response.factoryType()));
+                providedContracts.addAll(response.providedContracts());
+                providedTypeName = response.providedType();
+                providedTypeInfo = response.providedTypeInfo();
+                implementedInterfaceTypes.remove(TypeNames.SUPPLIER);
+            } else if (factoryType.equals(ServiceCodegenTypes.SERVICE_SERVICES_FACTORY)) {
+                if (providerType != FactoryType.SERVICE) {
+                    throw new CodegenException("Service implements more than one provider type: "
+                                                       + providerType + ", and services provider.",
+                                               serviceInfo.originatingElementValue());
+                }
+                providerType = FactoryType.SERVICES;
+                factoryTypeName = response.factoryType();
+                directContracts.add(ResolvedType.create(response.providedType()));
+                providedContracts.addAll(response.providedContracts());
+                providedTypeName = response.providedType();
+                providedTypeInfo = response.providedTypeInfo();
+                implementedInterfaceTypes.remove(ServiceCodegenTypes.SERVICE_SERVICES_FACTORY);
+            } else if (factoryType.equals(ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY)) {
+                if (providerType != FactoryType.SERVICE) {
+                    throw new CodegenException("Service implements more than one provider type: "
+                                                       + providerType + ", and injection point provider.",
+                                               serviceInfo.originatingElementValue());
+                }
+                providerType = FactoryType.INJECTION_POINT;
+                factoryTypeName = response.factoryType();
+                directContracts.add(ResolvedType.create(response.providedType()));
+                providedContracts.addAll(response.providedContracts());
+                providedTypeName = response.providedType();
+                providedTypeInfo = response.providedTypeInfo();
+                implementedInterfaceTypes.remove(ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY);
+            } else if (factoryType.equals(ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY)) {
+                if (providerType != FactoryType.SERVICE) {
+                    throw new CodegenException("Service implements more than one provider type: "
+                                                       + providerType + ", and qualified provider.",
+                                               serviceInfo.originatingElementValue());
+                }
+                providerType = FactoryType.QUALIFIED;
+                factoryTypeName = response.factoryType();
+                directContracts.add(ResolvedType.create(response.providedType()));
+                providedContracts.addAll(response.providedContracts());
+                qualifiedProviderQualifier = ServiceContracts
+                        .requiredTypeArgument(implementedInterfaceTypes.remove(ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY),
+                                              1);
+                providedTypeName = response.providedType();
+                providedTypeInfo = response.providedTypeInfo();
+            }
+        }
+
+        return new FactoryInfo(providerType,
+                               factoryTypeName,
+                               providedTypeName,
+                               providedTypeInfo,
+                               qualifiedProviderQualifier,
+                               Set.copyOf(directContracts),
+                               Set.copyOf(providedContracts),
+                               Map.copyOf(implementedInterfaceTypes));
+    }
+
+    /**
+     * Contracts provided by the service factory interface implemented by a service.
+     *
+     * @param serviceContracts service contracts
+     * @param serviceInfo      service type
+     * @return provided contracts
+     */
+    static Set<ResolvedType> factoryProvidedContracts(ServiceContracts serviceContracts, TypeInfo serviceInfo) {
+        return factoryInfo(serviceContracts, serviceInfo).providedContracts();
+    }
+
+    record FactoryInfo(FactoryType providerType,
+                       TypeName factoryTypeName,
+                       TypeName providedTypeName,
+                       TypeInfo providedTypeInfo,
+                       TypeName qualifiedProviderQualifier,
+                       Set<ResolvedType> directContracts,
+                       Set<ResolvedType> providedContracts,
+                       Map<TypeName, TypeInfo> remainingImplementedInterfaces) {
+    }
+}

--- a/service/codegen/src/main/java/io/helidon/service/codegen/TypedElements.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/TypedElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,24 @@ package io.helidon.service.codegen;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.ElementInfoPredicates;
+import io.helidon.codegen.TypeHierarchy;
 import io.helidon.common.types.AccessModifier;
+import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.ElementSignature;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
@@ -37,10 +43,10 @@ import static java.util.function.Predicate.not;
 
 final class TypedElements {
     static final ElementMeta DEFAULT_CONSTRUCTOR = new ElementMeta(TypedElementInfo.builder()
-                                                                           .typeName(TypeNames.OBJECT)
-                                                                           .accessModifier(AccessModifier.PUBLIC)
-                                                                           .kind(ElementKind.CONSTRUCTOR)
-                                                                           .build());
+                                                                          .typeName(TypeNames.OBJECT)
+                                                                          .accessModifier(AccessModifier.PUBLIC)
+                                                                          .kind(ElementKind.CONSTRUCTOR)
+                                                                          .build());
 
     private TypedElements() {
     }
@@ -53,6 +59,7 @@ final class TypedElements {
                 .toList();
 
         for (TypedElementInfo declaredElement : declaredElements) {
+            declaredElement = withTargetEnclosingType(declaredElement, typeInfo.typeName());
             List<TypedElements.DeclaredElement> abstractMethods = new ArrayList<>();
 
             if (declaredElement.kind() == ElementKind.METHOD) {
@@ -77,24 +84,30 @@ final class TypedElements {
     static List<TypedElements.ElementMeta> gatherElements(CodegenContext ctx,
                                                           Collection<ResolvedType> contracts,
                                                           TypeInfo typeInfo) {
+        return gatherElements(ctx::typeInfo, contracts, typeInfo);
+    }
+
+    private static List<TypedElements.ElementMeta> gatherElements(TypeInfoFactory typeInfoFactory,
+                                                                  Collection<ResolvedType> contracts,
+                                                                  TypeInfo typeInfo) {
         List<TypedElements.ElementMeta> result = new ArrayList<>();
         Set<ElementSignature> processedSignatures = new HashSet<>();
+        List<ContractInfo> contractInfos = contractInfos(typeInfoFactory, contracts);
 
         typeInfo.elementInfo()
                 .stream()
                 .filter(it -> it.kind() != ElementKind.CLASS)
                 .forEach(declaredElement -> {
+                    declaredElement = withTargetEnclosingType(declaredElement, typeInfo.typeName());
                     List<TypedElements.DeclaredElement> abstractMethods = new ArrayList<>();
 
                     if (declaredElement.kind() == ElementKind.METHOD) {
                         // now find the same method on any interface (if declared there)
-                        for (TypeInfo info : typeInfo.interfaceTypeInfo()) {
-                            if (!contracts.contains(ResolvedType.create(info.typeName()))) {
-                                // only interested in contracts
-                                continue;
-                            }
-
-                            findAbstractMethod(info, declaredElement, abstractMethods);
+                        for (ContractInfo contractInfo : contractInfos) {
+                            findAbstractMethod(contractInfo.typeInfo(),
+                                               contractInfo.resolvedType().type(),
+                                               declaredElement,
+                                               abstractMethods);
                         }
 
                         // and on any super class (must be abstract)
@@ -110,33 +123,160 @@ final class TypedElements {
                 });
 
         // we have gathered all the declared elements, now let's gather inherited elements (default methods etc.)
-        for (ResolvedType contract : contracts) {
-            Optional<TypeInfo> contractTypeInfo = ctx.typeInfo(contract.type());
-            if (contractTypeInfo.isPresent()) {
-                TypeInfo inheritedContract = contractTypeInfo.get();
-                inheritedContract.elementInfo()
-                        .stream()
-                        .filter(it -> it.kind() != ElementKind.CLASS)
-                        .forEach(superElement -> {
-                            if (!processedSignatures.add(superElement.signature())) {
-                                // already processed
-                                return;
-                            }
-                            List<TypedElements.DeclaredElement> interfaceMethods = new ArrayList<>();
-                            if (superElement.kind() == ElementKind.METHOD) {
-                                interfaceMethods.add(new DeclaredElement(inheritedContract, superElement));
-                            }
-                            result.add(new TypedElements.ElementMeta(superElement, interfaceMethods));
-                        });
-            }
+        Map<ElementSignature, List<DeclaredElement>> inheritedMethods = new LinkedHashMap<>();
+        for (ContractInfo contract : contractInfos) {
+            TypeInfo inheritedContract = contract.typeInfo();
+            Map<String, TypeName> typeArguments = typeArgumentMapping(inheritedContract, contract.resolvedType().type());
+            inheritedContract.elementInfo()
+                    .stream()
+                    .filter(it -> it.kind() != ElementKind.CLASS)
+                    .filter(it -> it.kind() != ElementKind.METHOD
+                            || (!ElementInfoPredicates.isStatic(it) && !ElementInfoPredicates.isPrivate(it)))
+                    .map(it -> withEnclosingType(resolveTypeArguments(it, typeArguments), inheritedContract.typeName()))
+                    .forEach(superElement -> {
+                        TypedElementInfo targetElement = withTargetEnclosingType(superElement, typeInfo.typeName());
+                        if (processedSignatures.contains(targetElement.signature())) {
+                            // already processed
+                            return;
+                        }
+                        if (targetElement.kind() == ElementKind.METHOD) {
+                            inheritedMethods.computeIfAbsent(targetElement.signature(), ignored -> new ArrayList<>())
+                                    .add(new DeclaredElement(inheritedContract, superElement));
+                            return;
+                        }
+                        processedSignatures.add(targetElement.signature());
+                        result.add(new TypedElements.ElementMeta(targetElement, List.of()));
+                    });
+        }
+        for (List<DeclaredElement> abstractMethods : inheritedMethods.values()) {
+            TypedElementInfo element = withTargetEnclosingType(abstractMethods.getFirst().element(), typeInfo.typeName());
+            element = mergeAbstractMethods(element,
+                                           abstractMethods.subList(1, abstractMethods.size()));
+            result.add(new TypedElements.ElementMeta(element, abstractMethods));
+            processedSignatures.add(element.signature());
         }
 
         return result;
     }
 
+    private static List<ContractInfo> contractInfos(TypeInfoFactory typeInfoFactory, Collection<ResolvedType> contracts) {
+        List<ContractInfo> contractInfos = contracts.stream()
+                .sorted(Comparator.comparing(it -> it.type().toString()))
+                .flatMap(it -> {
+                    TypeName resolvedType = resolveContractType(typeInfoFactory, contracts, it.type());
+                    return typeInfoFactory.typeInfo(resolvedType)
+                            .or(() -> typeInfoFactory.typeInfo(it.type()))
+                            .map(typeInfo -> new ContractInfo(ResolvedType.create(resolvedType), typeInfo))
+                            .stream();
+                })
+                .toList();
+
+        Map<TypeName, ContractInfo> result = new LinkedHashMap<>();
+        contractInfos.stream()
+                .filter(it -> !lessSpecificGenericContract(contractInfos, it))
+                .forEach(it -> result.putIfAbsent(it.resolvedType().type(), it));
+
+        return List.copyOf(result.values());
+    }
+
+    private static boolean lessSpecificGenericContract(Collection<ContractInfo> contracts, ContractInfo contract) {
+        TypeName typeName = contract.resolvedType().type();
+        if (!genericContract(contract.typeInfo())) {
+            return false;
+        }
+        if (!typeName.typeArguments().isEmpty() && !hasGenericTypeArgument(typeName)) {
+            return false;
+        }
+
+        return contracts.stream()
+                .map(it -> it.resolvedType().type())
+                .anyMatch(it -> typeName.genericTypeName().equals(it.genericTypeName())
+                        && !it.typeArguments().isEmpty()
+                        && !hasGenericTypeArgument(it));
+    }
+
+    private static boolean genericContract(TypeInfo info) {
+        return !info.typeName().typeParameters().isEmpty()
+                || !typeParameterNames(info.declaredType().typeArguments()).isEmpty();
+    }
+
+    private static boolean rawGenericContract(TypeInfoFactory typeInfoFactory, TypeName typeName) {
+        if (!typeName.typeArguments().isEmpty()) {
+            return false;
+        }
+
+        return typeInfoFactory.typeInfo(typeName)
+                .map(TypedElements::genericContract)
+                .orElse(false);
+    }
+
+    private static TypeName resolveContractType(TypeInfoFactory typeInfoFactory,
+                                                Collection<ResolvedType> contracts,
+                                                TypeName typeName) {
+        if (!hasGenericTypeArgument(typeName) && !rawGenericContract(typeInfoFactory, typeName)) {
+            return typeName;
+        }
+
+        for (ResolvedType candidate : contracts) {
+            TypeName candidateType = candidate.type();
+            if (candidateType.typeArguments().isEmpty()
+                    || hasGenericTypeArgument(candidateType)
+                    || candidateType.genericTypeName().equals(typeName.genericTypeName())) {
+                continue;
+            }
+
+            Optional<TypeName> resolvedType = typeInfoFactory.typeInfo(candidateType)
+                    .flatMap(it -> resolveInheritedType(it, candidateType, typeName.genericTypeName(), new HashSet<>()));
+            if (resolvedType.isPresent() && !hasGenericTypeArgument(resolvedType.get())) {
+                return resolvedType.get();
+            }
+        }
+
+        return typeName;
+    }
+
+    private static Optional<TypeName> resolveInheritedType(TypeInfo info,
+                                                           TypeName resolvedInfoType,
+                                                           TypeName targetType,
+                                                           Set<TypeName> processed) {
+        if (!processed.add(resolvedInfoType)) {
+            return Optional.empty();
+        }
+
+        Map<String, TypeName> typeArguments = typeArgumentMapping(info, resolvedInfoType);
+        for (TypeInfo interfaceInfo : info.interfaceTypeInfo()) {
+            TypeName interfaceType = resolveTypeArguments(interfaceInfo.typeName(), typeArguments);
+            if (interfaceType.genericTypeName().equals(targetType)) {
+                return Optional.of(interfaceType);
+            }
+            Optional<TypeName> resolvedType = resolveInheritedType(interfaceInfo, interfaceType, targetType, processed);
+            if (resolvedType.isPresent()) {
+                return resolvedType;
+            }
+        }
+
+        return info.superTypeInfo()
+                .flatMap(superInfo -> {
+                    TypeName superType = resolveTypeArguments(superInfo.typeName(), typeArguments);
+                    if (superType.genericTypeName().equals(targetType)) {
+                        return Optional.of(superType);
+                    }
+                    return resolveInheritedType(superInfo, superType, targetType, processed);
+                });
+    }
+
     private static void findAbstractMethod(TypeInfo info,
                                            TypedElementInfo declaredElement,
                                            List<DeclaredElement> abstractMethods) {
+        findAbstractMethod(info, info.typeName(), declaredElement, abstractMethods);
+    }
+
+    private static void findAbstractMethod(TypeInfo info,
+                                           TypeName resolvedType,
+                                           TypedElementInfo declaredElement,
+                                           List<DeclaredElement> abstractMethods) {
+        Map<String, TypeName> typeArguments = typeArgumentMapping(info, resolvedType);
+
         info.elementInfo()
                 .stream()
                 .filter(ElementInfoPredicates::isMethod)
@@ -144,22 +284,211 @@ final class TypedElements {
                 .filter(not(ElementInfoPredicates::isPrivate))
                 // we want all methods from interfaces, but only abstract methods from abstract classes
                 .filter(it -> ElementInfoPredicates.isAbstract(it) || ElementInfoPredicates.isDefault(it))
+                .map(it -> withEnclosingType(resolveTypeArguments(it, typeArguments), resolvedType))
                 .filter(it -> declaredElement.signature().equals(it.signature()))
                 .findFirst()
                 .ifPresent(it -> abstractMethods.add(new TypedElements.DeclaredElement(info, it)));
+    }
+
+    private static TypedElementInfo withEnclosingType(TypedElementInfo element, TypeName enclosingType) {
+        if (element.enclosingType().isPresent()) {
+            return element;
+        }
+        return TypedElementInfo.builder(element)
+                .enclosingType(enclosingType.genericTypeName())
+                .build();
+    }
+
+    private static TypedElementInfo withTargetEnclosingType(TypedElementInfo element, TypeName enclosingType) {
+        TypeName targetType = enclosingType.genericTypeName();
+        if (element.enclosingType()
+                .map(targetType::equals)
+                .orElse(false)) {
+            return element;
+        }
+        return TypedElementInfo.builder(element)
+                .enclosingType(targetType)
+                .build();
+    }
+
+    private static TypedElementInfo resolveTypeArguments(TypedElementInfo element,
+                                                         Map<String, TypeName> typeArguments) {
+        if (typeArguments.isEmpty()) {
+            return element;
+        }
+
+        List<TypedElementInfo> parameters = element.parameterArguments()
+                .stream()
+                .map(it -> TypedElementInfo.builder(it)
+                        .typeName(resolveTypeArguments(it.typeName(), typeArguments))
+                        .build())
+                .toList();
+
+        return TypedElementInfo.builder(element)
+                .typeName(resolveTypeArguments(element.typeName(), typeArguments))
+                .parameterArguments(parameters)
+                .build();
+    }
+
+    static TypedElementInfo mergeAbstractMethods(TypedElementInfo element, List<DeclaredElement> abstractMethods) {
+        if (abstractMethods.isEmpty()) {
+            return element;
+        }
+
+        List<TypedElementInfo> contractMethods = abstractMethods.stream()
+                .map(DeclaredElement::element)
+                .toList();
+
+        List<Annotation> annotations = new ArrayList<>(element.annotations());
+        contractMethods.stream()
+                .map(TypedElementInfo::annotations)
+                .flatMap(List::stream)
+                .forEach(it -> addAnnotationIfAbsent(annotations, it));
+
+        List<TypedElementInfo> parameters = new ArrayList<>();
+        List<TypedElementInfo> elementParameters = element.parameterArguments();
+        for (int i = 0; i < elementParameters.size(); i++) {
+            TypedElementInfo parameter = elementParameters.get(i);
+            List<Annotation> parameterAnnotations = new ArrayList<>(parameter.annotations());
+            TypeName parameterType = parameter.typeName();
+            for (TypedElementInfo contractMethod : contractMethods) {
+                List<TypedElementInfo> contractParameters = contractMethod.parameterArguments();
+                if (contractParameters.size() > i) {
+                    TypedElementInfo contractParameter = contractParameters.get(i);
+                    contractParameter.annotations().forEach(it -> addAnnotationIfAbsent(parameterAnnotations, it));
+                    parameterType = mergeTypeName(parameterType, contractParameter.typeName());
+                }
+            }
+            parameters.add(TypedElementInfo.builder(parameter)
+                                   .annotations(parameterAnnotations)
+                                   .typeName(parameterType)
+                                   .build());
+        }
+
+        TypeName returnType = element.typeName();
+        for (TypedElementInfo contractMethod : contractMethods) {
+            returnType = mergeTypeName(returnType, contractMethod.typeName());
+        }
+
+        return TypedElementInfo.builder(element)
+                .annotations(annotations)
+                .typeName(returnType)
+                .parameterArguments(parameters)
+                .build();
+    }
+
+    private static TypeName resolveTypeArguments(TypeName typeName, Map<String, TypeName> typeArguments) {
+        if (typeName.generic()) {
+            TypeName resolved = typeArguments.get(typeName.className().trim());
+            if (resolved != null) {
+                return mergeTypeName(resolved, typeName);
+            }
+        }
+
+        List<TypeName> resolvedTypeArguments = typeName.typeArguments()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        List<TypeName> resolvedLowerBounds = typeName.lowerBounds()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        List<TypeName> resolvedUpperBounds = typeName.upperBounds()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        Optional<TypeName> resolvedComponentType = typeName.componentType()
+                .map(it -> resolveTypeArguments(it, typeArguments));
+
+        if (resolvedTypeArguments.equals(typeName.typeArguments())
+                && resolvedLowerBounds.equals(typeName.lowerBounds())
+                && resolvedUpperBounds.equals(typeName.upperBounds())
+                && resolvedComponentType.equals(typeName.componentType())) {
+            return typeName;
+        }
+
+        TypeName.Builder builder = TypeName.builder(typeName)
+                .typeArguments(resolvedTypeArguments)
+                .lowerBounds(resolvedLowerBounds)
+                .upperBounds(resolvedUpperBounds);
+        resolvedComponentType.ifPresent(builder::componentType);
+        return builder.build();
+    }
+
+    private static TypeName mergeTypeName(TypeName typeName, TypeName contractTypeName) {
+        return TypeHierarchy.mergeTypeNameAnnotations(typeName, contractTypeName);
+    }
+
+    private static void addAnnotationIfAbsent(List<Annotation> annotations, Annotation annotation) {
+        if (!annotations.contains(annotation)) {
+            annotations.add(annotation);
+        }
+    }
+
+    private static Map<String, TypeName> typeArgumentMapping(TypeInfo info, TypeName resolvedType) {
+        TypeName typeName = info.typeName();
+        List<String> typeParameters = typeName.typeParameters();
+        List<TypeName> typeArguments = resolvedType.typeArguments();
+        if (typeArguments.isEmpty()) {
+            typeArguments = typeName.typeArguments();
+        }
+        if (typeParameters.isEmpty()) {
+            typeParameters = typeParameterNames(info.declaredType().typeArguments());
+        }
+        if (typeParameters.isEmpty() || typeArguments.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, TypeName> result = new LinkedHashMap<>();
+        for (int i = 0; i < Math.min(typeParameters.size(), typeArguments.size()); i++) {
+            result.put(genericTypeName(typeParameters.get(i)), typeArguments.get(i));
+        }
+        return result;
+    }
+
+    private static List<String> typeParameterNames(List<TypeName> typeParameters) {
+        return typeParameters.stream()
+                .filter(TypeName::generic)
+                .filter(not(TypeName::wildcard))
+                .map(TypeName::className)
+                .map(TypedElements::genericTypeName)
+                .toList();
+    }
+
+    private static String genericTypeName(String typeParameter) {
+        String name = typeParameter.trim();
+        int index = name.indexOf(' ');
+        return index == -1 ? name : name.substring(0, index);
+    }
+
+    private static boolean hasGenericTypeArgument(TypeName typeName) {
+        for (TypeName typeArgument : typeName.typeArguments()) {
+            if (typeArgument.generic() || typeArgument.wildcard() || hasGenericTypeArgument(typeArgument)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
      * Metadata of an element (field, constructor, method).
      *
      * @param element         element declared on a type
-     * @param abstractMethods if the element is a method, this list contains all interface / abstract class abstract methods that
-     *                        define the contract of the method
+     * @param abstractMethods interface or abstract class methods that define the contract of this method
      */
     record ElementMeta(TypedElementInfo element,
                        List<DeclaredElement> abstractMethods) {
         ElementMeta(TypedElementInfo element) {
             this(element, List.of());
+        }
+
+        /**
+         * Element with annotations and type-use annotations merged from matching service-contract methods.
+         *
+         * @return effective element
+         */
+        TypedElementInfo effectiveElement() {
+            return mergeAbstractMethods(element, abstractMethods);
         }
     }
 
@@ -171,5 +500,13 @@ final class TypedElements {
      */
     record DeclaredElement(TypeInfo abstractType,
                            TypedElementInfo element) {
+    }
+
+    private record ContractInfo(ResolvedType resolvedType,
+                                TypeInfo typeInfo) {
+    }
+
+    private interface TypeInfoFactory {
+        Optional<TypeInfo> typeInfo(TypeName typeName);
     }
 }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/spi/RegistryCodegenExtensionProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/spi/RegistryCodegenExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,26 @@ import io.helidon.service.codegen.RegistryCodegenContext;
  * this provider has access to {@link io.helidon.service.codegen.RegistryCodegenContext}.
  */
 public interface RegistryCodegenExtensionProvider extends CodegenProvider {
+    /**
+     * Whether this extension should also process services whose service contracts contain annotations
+     * supported by this extension.
+     * <p>
+     * Service contracts include direct service contracts and contracts provided by factory services. Contract annotations
+     * are discovered from nested contract metadata, including annotations on the contract type, methods, method parameters,
+     * parameter and return type arguments, and annotations matched through {@link #supportedMetaAnnotations()}.
+     * <p>
+     * Matching services are passed to the extension through {@link io.helidon.service.codegen.RegistryRoundContext#types()}.
+     * <p>
+     * Contract annotations do not make the implementation itself appear from
+     * {@link io.helidon.service.codegen.RegistryRoundContext#annotatedTypes(io.helidon.common.types.TypeName)} unless the
+     * implementation also has that annotation directly or through normal annotation inheritance.
+     *
+     * @return whether services with supported service-contract annotations should be processed
+     */
+    default boolean supportsServiceContractAnnotations() {
+        return false;
+    }
+
     /**
      * Create a new extension based on the context.
      *

--- a/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public interface DescriptorMetadata {
     Set<ResolvedType> contracts();
 
     /**
-     * Contracts of the factory service, if this describes a factory, empty otherwise.
+     * Contracts that identify the factory provider itself, if this describes a factory, empty otherwise.
      *
      * @return factory contracts
      */

--- a/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
@@ -32,7 +32,7 @@ public interface DescriptorMetadata {
      * @param descriptor       type of the service descriptor (the generated file from {@code helidon-service-codegen})
      * @param weight           weight of the service descriptor
      * @param contracts        contracts the service implements
-     * @param factoryContracts factory contracts the service instance implements
+     * @param factoryContracts contracts that identify the factory provider itself, empty otherwise
      * @return a new descriptor metadata instance
      */
     static DescriptorMetadata create(TypeName descriptor,

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -331,27 +331,8 @@ final class Activators {
          * @param providerType type of provider this type implements
          * @return whether the provider itself should be returned
          */
-        boolean requestedProvider(Lookup lookup, FactoryType providerType) {
-            if (lookup.factoryTypes().contains(providerType)) {
-                return true;
-            }
-            if (lookup.contracts().size() == 1) {
-                ResolvedType requestedContract = lookup.contracts().iterator().next();
-                if (requestedContract.equals(ResolvedType.create(descriptor().serviceType()))) {
-                    // requested actual service
-                    return true;
-                }
-                if (descriptor().factoryContracts().contains(requestedContract)
-                        && !descriptor().contracts().contains(requestedContract)) {
-                    // requested a contract satisfied by the factory only
-                    return true;
-                }
-            }
-            if (lookup.serviceType().isPresent() && lookup.serviceType().get().equals(descriptor().serviceType())) {
-                return true;
-            }
-
-            return false;
+        protected boolean requestedProvider(Lookup lookup, FactoryType providerType) {
+            return Contracts.requestedProvider(lookup, descriptor(), providerType);
         }
 
         private void stateTransitionStart(ActivationResult.Builder res, ActivationPhase phase) {
@@ -624,6 +605,11 @@ final class Activators {
         Optional<List<QualifiedInstance<T>>> targetInstances(Lookup lookup) {
             if (serviceInstance == null) {
                 return Optional.empty();
+            }
+
+            if (requestedProvider(lookup, FactoryType.QUALIFIED)) {
+                T instance = serviceInstance.get();
+                return Optional.of(List.of(QualifiedInstance.create(instance, provider.descriptor().qualifiers())));
             }
 
             return lookup.qualifiers()

--- a/service/registry/src/main/java/io/helidon/service/registry/ActivatorsPerLookup.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ActivatorsPerLookup.java
@@ -150,6 +150,11 @@ final class ActivatorsPerLookup {
                 return Optional.empty();
             }
 
+            if (requestedProvider(lookup, FactoryType.QUALIFIED)) {
+                T instance = serviceInstance.get(currentPhase);
+                return Optional.of(List.of(QualifiedInstance.create(instance, provider.descriptor().qualifiers())));
+            }
+
             return lookup.qualifiers()
                     .stream()
                     .filter(it -> this.supportedQualifier.equals(it.typeName()))

--- a/service/registry/src/main/java/io/helidon/service/registry/Contracts.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Contracts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 package io.helidon.service.registry;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
 
 /*
 Management of contracts, to return correct contracts for services created from other services,
@@ -33,8 +35,42 @@ final class Contracts {
 
         return switch (descriptor.factoryType()) {
             case NONE, SERVICE -> new FixedContracts(contracts);
-            default -> new ProviderContracts(contracts, descriptor.factoryContracts());
+            default -> new ProviderContracts(descriptor.serviceType(),
+                                             descriptor.factoryType(),
+                                             contracts,
+                                             descriptor.factoryContracts());
         };
+    }
+
+    static boolean requestedProvider(Lookup lookup, ServiceInfo descriptor, FactoryType factoryType) {
+        return requestedProvider(lookup,
+                                 descriptor.serviceType(),
+                                 factoryType,
+                                 descriptor.contracts(),
+                                 descriptor.factoryContracts());
+    }
+
+    private static boolean requestedProvider(Lookup lookup,
+                                             TypeName serviceType,
+                                             FactoryType factoryType,
+                                             Set<ResolvedType> contracts,
+                                             Set<ResolvedType> factoryContracts) {
+        if (lookup.factoryTypes().contains(factoryType)) {
+            return true;
+        }
+        if (lookup.contracts().size() == 1) {
+            ResolvedType requestedContract = lookup.contracts().iterator().next();
+            if (requestedContract.equals(ResolvedType.create(serviceType))) {
+                return true;
+            }
+            if (factoryContracts.contains(requestedContract)
+                    && !contracts.contains(requestedContract)) {
+                return true;
+            }
+        }
+        return lookup.serviceType()
+                .map(serviceType::equals)
+                .orElse(false);
     }
 
     interface ContractLookup {
@@ -55,16 +91,30 @@ final class Contracts {
     }
 
     private static final class ProviderContracts implements ContractLookup {
+        private final TypeName serviceType;
+        private final FactoryType factoryType;
         private final Set<ResolvedType> contracts;
         private final Set<ResolvedType> factoryContracts;
+        private final Set<ResolvedType> providerContracts;
 
-        ProviderContracts(Set<ResolvedType> contracts, Set<ResolvedType> factoryContracts) {
+        ProviderContracts(TypeName serviceType,
+                          FactoryType factoryType,
+                          Set<ResolvedType> contracts,
+                          Set<ResolvedType> factoryContracts) {
+            this.serviceType = serviceType;
+            this.factoryType = factoryType;
             this.contracts = contracts;
             this.factoryContracts = factoryContracts;
+            HashSet<ResolvedType> providerContracts = new HashSet<>(factoryContracts);
+            providerContracts.add(ResolvedType.create(serviceType));
+            this.providerContracts = Set.copyOf(providerContracts);
         }
 
         @Override
         public Set<ResolvedType> contracts(Lookup lookup) {
+            if (requestedProvider(lookup, serviceType, factoryType, contracts, factoryContracts)) {
+                return providerContracts;
+            }
             return contracts;
         }
     }

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -900,7 +900,6 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
         return actualContracts;
     }
 
-
     private record ScopeImpl(TypeName scopeType,
                              Service.ScopeHandler handler,
                              ScopedRegistry registry) implements Scope {

--- a/service/registry/src/main/java/io/helidon/service/registry/GeneratedService.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/GeneratedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@ package io.helidon.service.registry;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.helidon.common.GenericType;
+import io.helidon.common.LazyValue;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
 
@@ -143,7 +145,7 @@ public final class GeneratedService {
          * @return qualified instance with wrapped instance
          */
         protected Service.QualifiedInstance<T> wrapQualifiedInstance(Service.QualifiedInstance<T> qualifiedInstance) {
-            return Service.QualifiedInstance.create(wrap(qualifiedInstance.get()), qualifiedInstance.qualifiers());
+            return new LazyQualifiedInstance<>(qualifiedInstance, this);
         }
 
         /**
@@ -154,6 +156,26 @@ public final class GeneratedService {
          * @return wrapped instance
          */
         protected abstract T wrap(T originalInstance);
+
+        private static final class LazyQualifiedInstance<T> implements Service.QualifiedInstance<T> {
+            private final Service.QualifiedInstance<T> delegate;
+            private final LazyValue<T> instance;
+
+            private LazyQualifiedInstance(Service.QualifiedInstance<T> delegate, InterceptionWrapper<T> wrapper) {
+                this.delegate = delegate;
+                this.instance = LazyValue.create(() -> wrapper.wrap(delegate.get()));
+            }
+
+            @Override
+            public Set<Qualifier> qualifiers() {
+                return delegate.qualifiers();
+            }
+
+            @Override
+            public T get() {
+                return instance.get();
+            }
+        }
     }
 
     /**
@@ -169,14 +191,41 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided supplier.
          *
          * @param delegate used to obtain service instance that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected SupplierFactoryInterceptionWrapper(Supplier<T> delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override
         public T get() {
             return wrap(delegate.get());
+        }
+    }
+
+    /**
+     * Wrapper for generated Service factories that implement a {@link java.util.function.Supplier} of an optional service.
+     *
+     * @param <T> type of the provided contract
+     */
+    public abstract static class OptionalSupplierFactoryInterceptionWrapper<T> extends InterceptionWrapper<T>
+            implements Supplier<Optional<T>> {
+        private final Supplier<Optional<T>> delegate;
+
+        /**
+         * Creates a new instance delegating service instantiation to the provided supplier.
+         *
+         * @param delegate used to obtain optional service instance that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
+         */
+        protected OptionalSupplierFactoryInterceptionWrapper(Supplier<Optional<T>> delegate) {
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
+        }
+
+        @Override
+        public Optional<T> get() {
+            return delegate.get()
+                    .map(this::wrap);
         }
     }
 
@@ -194,9 +243,10 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided services factory.
          *
          * @param delegate used to obtain service instances that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected ServicesFactoryInterceptionWrapper(Service.ServicesFactory<T> delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override
@@ -222,14 +272,15 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided injection point factory.
          *
          * @param delegate used to obtain service instances that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected IpFactoryInterceptionWrapper(Service.InjectionPointFactory<T> delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override
         public List<Service.QualifiedInstance<T>> list(Lookup lookup) {
-            return delegate.first(lookup)
+            return delegate.list(lookup)
                     .stream()
                     .map(this::wrapQualifiedInstance)
                     .collect(Collectors.toUnmodifiableList());
@@ -257,9 +308,10 @@ public final class GeneratedService {
          * Creates a new instance delegating service instantiation to the provided qualified factory.
          *
          * @param delegate used to obtain service instances that will be {@link #wrap(Object) wrapped} for interception
+         * @throws NullPointerException when delegate is {@code null}
          */
         protected QualifiedFactoryInterceptionWrapper(Service.QualifiedFactory<T, A> delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override

--- a/service/registry/src/main/java/io/helidon/service/registry/InterceptionMetadataImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/InterceptionMetadataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,13 +112,15 @@ class InterceptionMetadataImpl implements InterceptionMetadata {
                                                                   TypedElementInfo element) {
         // need to find all interceptors for the providers (ordered by weight)
         List<ServiceManager<Interception.Interceptor>> allInterceptors = registry.interceptors();
+        String elementSignature = element.enclosingType()
+                .orElse(descriptor.serviceType())
+                .fqName() + "." + element.signature().text();
 
         List<Supplier<Interception.Interceptor>> result = new ArrayList<>();
 
         for (ServiceManager<Interception.Interceptor> interceptor : allInterceptors) {
             if (interceptor.descriptor().contracts().contains(ELEMENT_INTERCEPTOR)) {
                 // interceptors of specific elements (methods, constructors)
-                String elementSignature = descriptor.serviceType().fqName() + "." + element.signature().text();
                 if (applicableElement(elementSignature, interceptor.descriptor())) {
                     result.add(new ServiceSupply<>(Lookup.EMPTY, List.of(interceptor)));
                 }

--- a/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,6 +116,8 @@ interface LookupBlueprint {
      * If configured, the lookup will return service factories of the
      * chosen types.
      * If no factory types are defined, service instances are returned.
+     * Factory types alone do not expose hidden raw factory-provider descriptors; use a service type or a contract when
+     * the factory provider itself is requested.
      * <p>
      * Otherwise only service factories of the chosen types are returned, as follows:
      * <ul>
@@ -163,13 +165,16 @@ interface LookupBlueprint {
      */
     default boolean matches(ServiceInfo serviceInfo) {
         if (this == LookupSupport.CustomMethods.EMPTY) {
-            return !serviceInfo.isAbstract();
+            return !serviceInfo.isAbstract() && !hiddenFactoryProviderDescriptor(serviceInfo);
         }
 
         boolean matches = matches(serviceInfo.serviceType(), this.serviceType());
+        if (matches && this.serviceType().isEmpty() && hiddenFactoryProviderDescriptor(serviceInfo)) {
+            matches = !this.contracts().isEmpty();
+        }
         if (matches && this.serviceType().isEmpty()) {
             matches = serviceInfo.contracts().containsAll(this.contracts())
-                    || this.contracts().contains(ResolvedType.create(serviceInfo.serviceType()))
+                    || matchesConcreteServiceType(serviceInfo)
                     || serviceInfo.factoryContracts().containsAll(this.contracts());
         }
         matches = matches
@@ -208,6 +213,12 @@ interface LookupBlueprint {
         return matches;
     }
 
+    private boolean hiddenFactoryProviderDescriptor(ServiceInfo serviceInfo) {
+        return serviceInfo.contracts().isEmpty()
+                && serviceInfo.factoryType() != FactoryType.NONE
+                && serviceInfo.factoryType() != FactoryType.SERVICE;
+    }
+
     /**
      * Determines whether the provided qualifiers are matched by this lookup criteria.
      *
@@ -234,6 +245,10 @@ interface LookupBlueprint {
             return true;
         }
         return Objects.equals(src, criteria.get());
+    }
+
+    private boolean matchesConcreteServiceType(ServiceInfo serviceInfo) {
+        return this.contracts().contains(ResolvedType.create(serviceInfo.serviceType()));
     }
 
     private boolean matchesProviderTypes(Set<FactoryType> providerTypes, FactoryType providerType) {

--- a/service/registry/src/main/java/io/helidon/service/registry/LookupSupport.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/LookupSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ final class LookupSupport {
 
     static final class CustomMethods {
         /**
-         * Empty lookup matches anything and everything except for abstract types.
+         * Empty lookup matches anything and everything except for abstract types and hidden raw factory providers.
          */
         @Prototype.Constant
         static final Lookup EMPTY = createEmpty();

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceInfo.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,8 @@ public interface ServiceInfo extends Weighted {
     }
 
     /**
-     * Set of contracts the described service implements directly. If the service is not a factory,
-     * this set is empty.
+     * Set of contracts that identify the factory provider itself. These contracts are distinct from contracts of services
+     * provided by the factory. If the service is not a factory, this set is empty.
      *
      * @return set of factory contracts
      */

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceInstance.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,11 @@ public interface ServiceInstance<T> extends Service.QualifiedInstance<T> {
     TypeName TYPE = TypeName.create(ServiceInstance.class);
 
     /**
-     * Contracts of the service instance.
+     * Contracts associated with this service instance for the lookup that produced it.
+     * For factory-backed services, provided-service lookups return the provided service contracts, while provider-targeted
+     * lookups return the provider or factory contracts.
      *
-     * @return contracts the service instance implements
+     * @return contracts associated with this service instance for the current lookup
      */
     Set<ResolvedType> contracts();
 

--- a/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
+++ b/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
@@ -173,6 +173,8 @@ class ServiceCodegenTypesTest {
         // generated interception types
         checkField(toCheck, checked, fields, "INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY",
                    GeneratedService.SupplierFactoryInterceptionWrapper.class);
+        checkField(toCheck, checked, fields, "INTERCEPT_G_WRAPPER_OPTIONAL_SUPPLIER_FACTORY",
+                   GeneratedService.OptionalSupplierFactoryInterceptionWrapper.class);
         checkField(toCheck, checked, fields, "INTERCEPT_G_WRAPPER_SERVICES_FACTORY",
                    GeneratedService.ServicesFactoryInterceptionWrapper.class);
         checkField(toCheck, checked, fields, "INTERCEPT_G_WRAPPER_IP_FACTORY",

--- a/service/tests/interception/src/main/java/io/helidon/service/tests/interception/AbstractClassTypes.java
+++ b/service/tests/interception/src/main/java/io/helidon/service/tests/interception/AbstractClassTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,16 @@ import io.helidon.service.registry.Service;
  * An example that illustrates usages of {@link io.helidon.service.registry.Interception.Interceptor}.
  */
 class AbstractClassTypes {
+    static final String ABSTRACT_DIRECT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.MyAbstractClassContract.sayHelloDirect(java.lang.String)";
+    static final String IMPL_DIRECT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.MyAbstractClassContractImpl.sayHelloDirect(java.lang.String)";
+    static final String DEFAULT_CONTRACT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.DefaultMethodContract.sayHelloDefault(java.lang.String)";
+    static final String FIRST_DEFAULT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.FirstDefaultMethodService.sayHelloDefault(java.lang.String)";
+    static final String SECOND_DEFAULT_METHOD = "io.helidon.service.tests.interception."
+            + "AbstractClassTypes.SecondDefaultMethodService.sayHelloDefault(java.lang.String)";
 
     /**
      * An annotation to mark methods to be intercepted.
@@ -73,6 +83,96 @@ class AbstractClassTypes {
     }
 
     /**
+     * Element interceptor named after the abstract class method. This must not match the subtype service.
+     */
+    @Service.Singleton
+    @Service.Named(ABSTRACT_DIRECT_METHOD)
+    static class AbstractDirectMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
+     * Element interceptor named after the concrete subtype service method.
+     */
+    @Service.Singleton
+    @Service.Named(IMPL_DIRECT_METHOD)
+    static class ImplDirectMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
+     * Element interceptor named after the default interface method. This must not match implementing services.
+     */
+    @Service.Singleton
+    @Service.Named(DEFAULT_CONTRACT_METHOD)
+    static class DefaultContractMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
+     * Element interceptor named after the first default-method service.
+     */
+    @Service.Singleton
+    @Service.Named(FIRST_DEFAULT_METHOD)
+    static class FirstDefaultMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
+     * Element interceptor named after the second default-method service.
+     */
+    @Service.Singleton
+    @Service.Named(SECOND_DEFAULT_METHOD)
+    static class SecondDefaultMethodInterceptor implements Interception.ElementInterceptor {
+        static final List<String> INVOKED = new ArrayList<>();
+
+        @Override
+        public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+            INVOKED.add("%s.%s: %s".formatted(
+                    ctx.serviceInfo().serviceType().declaredName(),
+                    ctx.elementInfo().elementName(),
+                    Arrays.asList(args)));
+            return chain.proceed(args);
+        }
+    }
+
+    /**
      * A service that extends an abstract class contract with an intercepted method.
      */
     @Service.Singleton
@@ -82,5 +182,30 @@ class AbstractClassTypes {
         public String sayHello(String name) {
             return "Hello %s!".formatted(name);
         }
+    }
+
+    /**
+     * A service contract with an intercepted default method.
+     */
+    @Service.Contract
+    interface DefaultMethodContract {
+        @Traced
+        default String sayHelloDefault(String name) {
+            return "Hello %s!".formatted(name);
+        }
+    }
+
+    /**
+     * First service that inherits the default method.
+     */
+    @Service.Singleton
+    static class FirstDefaultMethodService implements DefaultMethodContract {
+    }
+
+    /**
+     * Second service that inherits the default method.
+     */
+    @Service.Singleton
+    static class SecondDefaultMethodService implements DefaultMethodContract {
     }
 }

--- a/service/tests/interception/src/test/java/io/helidon/service/tests/interception/AbstractClassInterceptionTest.java
+++ b/service/tests/interception/src/test/java/io/helidon/service/tests/interception/AbstractClassInterceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,16 @@ import java.util.List;
 
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.tests.interception.AbstractClassTypes.AbstractDirectMethodInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.DefaultContractMethodInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.FirstDefaultMethodInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.FirstDefaultMethodService;
+import io.helidon.service.tests.interception.AbstractClassTypes.ImplDirectMethodInterceptor;
 import io.helidon.service.tests.interception.AbstractClassTypes.MyAbstractClassContract;
 import io.helidon.service.tests.interception.AbstractClassTypes.MyAbstractClassContractImpl;
 import io.helidon.service.tests.interception.AbstractClassTypes.MyServiceInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.SecondDefaultMethodInterceptor;
+import io.helidon.service.tests.interception.AbstractClassTypes.SecondDefaultMethodService;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -52,15 +59,32 @@ class AbstractClassInterceptionTest {
     @Test
     void testInterceptor() {
         MyServiceInterceptor.INVOKED.clear();
+        AbstractDirectMethodInterceptor.INVOKED.clear();
+        ImplDirectMethodInterceptor.INVOKED.clear();
+        DefaultContractMethodInterceptor.INVOKED.clear();
+        FirstDefaultMethodInterceptor.INVOKED.clear();
+        SecondDefaultMethodInterceptor.INVOKED.clear();
 
         var myAbstractClassContract = registry.get(MyAbstractClassContract.class);
         assertThat(myAbstractClassContract.sayHello("Jessica"), is("Hello Jessica!"));
         assertThat(myAbstractClassContract.sayHello("Juliet"), is("Hello Juliet!"));
         assertThat(myAbstractClassContract.sayHelloDirect("John"), is("Hello John!"));
+        assertThat(registry.get(FirstDefaultMethodService.class).sayHelloDefault("Jane"), is("Hello Jane!"));
+        assertThat(registry.get(SecondDefaultMethodService.class).sayHelloDefault("Jill"), is("Hello Jill!"));
 
         assertThat(MyServiceInterceptor.INVOKED, is(List.of(
                 "%s.sayHello: [Jessica]".formatted(MyAbstractClassContractImpl.class.getName()),
                 "%s.sayHello: [Juliet]".formatted(MyAbstractClassContractImpl.class.getName()),
+                "%s.sayHelloDirect: [John]".formatted(MyAbstractClassContractImpl.class.getName()),
+                "%s.sayHelloDefault: [Jane]".formatted(FirstDefaultMethodService.class.getName()),
+                "%s.sayHelloDefault: [Jill]".formatted(SecondDefaultMethodService.class.getName()))));
+        assertThat(AbstractDirectMethodInterceptor.INVOKED, is(List.of()));
+        assertThat(ImplDirectMethodInterceptor.INVOKED, is(List.of(
                 "%s.sayHelloDirect: [John]".formatted(MyAbstractClassContractImpl.class.getName()))));
+        assertThat(DefaultContractMethodInterceptor.INVOKED, is(List.of()));
+        assertThat(FirstDefaultMethodInterceptor.INVOKED, is(List.of(
+                "%s.sayHelloDefault: [Jane]".formatted(FirstDefaultMethodService.class.getName()))));
+        assertThat(SecondDefaultMethodInterceptor.INVOKED, is(List.of(
+                "%s.sayHelloDefault: [Jill]".formatted(SecondDefaultMethodService.class.getName()))));
     }
 }

--- a/service/tests/qualified-providers/src/main/java/io/helidon/service/tests/qualified/providers/SecondQualifiedProvider.java
+++ b/service/tests/qualified-providers/src/main/java/io/helidon/service/tests/qualified/providers/SecondQualifiedProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import io.helidon.service.registry.Service;
 import io.helidon.service.registry.Service.QualifiedFactory;
 import io.helidon.service.registry.Service.QualifiedInstance;
 
-@Service.Singleton
+@Service.PerLookup
 class SecondQualifiedProvider implements QualifiedFactory<QualifiedContract, SecondQualifier> {
     private final Map<String, QualifiedContract> values = Map.of("first", new QualifiedContractImpl("first"),
                                                                  "second", new QualifiedContractImpl("second"));

--- a/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
+++ b/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,15 @@
 
 package io.helidon.service.tests.qualified.providers;
 
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.types.ResolvedType;
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInstance;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
@@ -23,7 +32,11 @@ import io.helidon.service.registry.ServiceRegistryManager;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 public class QualifiedProvidersTest {
     @Test
@@ -57,5 +70,44 @@ public class QualifiedProvidersTest {
         assertThat(theService.second(), is(49));
         assertThat(theService.firstContract().name(), is("first"));
         assertThat(theService.secondContract().name(), is("second"));
+
+        Lookup singletonProviderLookup = Lookup.builder()
+                .serviceType(FirstQualifiedProvider.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        Service.QualifiedFactory<?, ?> singletonProvider = registry.get(singletonProviderLookup);
+        assertThat(singletonProvider, instanceOf(FirstQualifiedProvider.class));
+        assertThat(registry.get(singletonProviderLookup), sameInstance(singletonProvider));
+        List<ServiceInstance<Service.QualifiedFactory<?, ?>>> singletonProviderInstances =
+                registry.lookupInstances(singletonProviderLookup);
+        assertThat(singletonProviderInstances, hasSize(1));
+        assertThat(singletonProviderInstances.getFirst().get(), sameInstance(singletonProvider));
+        assertThat(singletonProviderInstances.getFirst().contracts(),
+                   is(Set.of(ResolvedType.create(Object.class),
+                             ResolvedType.create(FirstQualifiedProvider.class))));
+
+        Lookup perLookupProviderLookup = Lookup.builder()
+                .serviceType(SecondQualifiedProvider.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        Service.QualifiedFactory<?, ?> perLookupProvider = registry.get(perLookupProviderLookup);
+        assertThat(perLookupProvider, instanceOf(SecondQualifiedProvider.class));
+        assertThat(registry.get(perLookupProviderLookup), not(sameInstance(perLookupProvider)));
+        List<ServiceInstance<Service.QualifiedFactory<?, ?>>> perLookupProviderInstances =
+                registry.lookupInstances(perLookupProviderLookup);
+        assertThat(perLookupProviderInstances, hasSize(1));
+        assertThat(perLookupProviderInstances.getFirst().get(), instanceOf(SecondQualifiedProvider.class));
+        assertThat(perLookupProviderInstances.getFirst().contracts(),
+                   is(Set.of(ResolvedType.create(QualifiedContract.class),
+                             ResolvedType.create(SecondQualifiedProvider.class))));
+
+        Lookup providedLookup = Lookup.builder()
+                .addContract(QualifiedContract.class)
+                .addQualifier(Qualifier.create(SecondQualifier.class, "first"))
+                .build();
+        List<ServiceInstance<QualifiedContract>> providedInstances = registry.lookupInstances(providedLookup);
+        assertThat(providedInstances, hasSize(1));
+        assertThat(providedInstances.getFirst().get().name(), is("first"));
+        assertThat(providedInstances.getFirst().contracts(), is(Set.of(ResolvedType.create(QualifiedContract.class))));
     }
 }

--- a/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
+++ b/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
@@ -83,8 +83,7 @@ public class QualifiedProvidersTest {
         assertThat(singletonProviderInstances, hasSize(1));
         assertThat(singletonProviderInstances.getFirst().get(), sameInstance(singletonProvider));
         assertThat(singletonProviderInstances.getFirst().contracts(),
-                   is(Set.of(ResolvedType.create(Object.class),
-                             ResolvedType.create(FirstQualifiedProvider.class))));
+                   is(Set.of(ResolvedType.create(FirstQualifiedProvider.class))));
 
         Lookup perLookupProviderLookup = Lookup.builder()
                 .serviceType(SecondQualifiedProvider.class)
@@ -98,8 +97,7 @@ public class QualifiedProvidersTest {
         assertThat(perLookupProviderInstances, hasSize(1));
         assertThat(perLookupProviderInstances.getFirst().get(), instanceOf(SecondQualifiedProvider.class));
         assertThat(perLookupProviderInstances.getFirst().contracts(),
-                   is(Set.of(ResolvedType.create(QualifiedContract.class),
-                             ResolvedType.create(SecondQualifiedProvider.class))));
+                   is(Set.of(ResolvedType.create(SecondQualifiedProvider.class))));
 
         Lookup providedLookup = Lookup.builder()
                 .addContract(QualifiedContract.class)

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/GeneratedServiceTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/GeneratedServiceTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.GeneratedService;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GeneratedServiceTest {
+    @Test
+    void optionalSupplierFactoryInterceptionWrapperRejectsNullDelegate() {
+        NullPointerException e = assertThrows(NullPointerException.class, () -> new TestOptionalSupplierWrapper(null));
+
+        assertThat(e.getMessage(), is("delegate"));
+    }
+
+    @Test
+    void factoryInterceptionWrappersRejectNullDelegates() {
+        assertNullDelegate(() -> new TestSupplierWrapper(null));
+        assertNullDelegate(() -> new TestServicesFactoryWrapper(null, new AtomicInteger()));
+        assertNullDelegate(() -> new TestIpFactoryWrapper(null));
+        assertNullDelegate(() -> new TestQualifiedFactoryWrapper(null));
+    }
+
+    @Test
+    void broadLookupsSkipHiddenFactoryProviderDescriptors() {
+        var descriptor = new HiddenFactoryProviderInfo();
+
+        assertThat(Lookup.EMPTY.matches(descriptor), is(false));
+        assertThat(Lookup.builder()
+                           .addScope(Service.Singleton.TYPE)
+                           .runLevel(Service.RunLevel.NORMAL)
+                           .build()
+                           .matches(descriptor),
+                   is(false));
+        assertThat(Lookup.builder()
+                           .addFactoryType(FactoryType.NONE)
+                           .build()
+                           .matches(descriptor),
+                   is(false));
+        assertThat(Lookup.builder()
+                           .addFactoryType(FactoryType.SUPPLIER)
+                           .build()
+                           .matches(descriptor),
+                   is(false));
+        assertThat(Lookup.builder()
+                           .addContract(HiddenFactoryProviderInfo.PROVIDER_CONTRACT)
+                           .addFactoryType(FactoryType.SUPPLIER)
+                           .build()
+                           .matches(descriptor),
+                   is(true));
+        assertThat(Lookup.builder()
+                           .serviceType(HiddenFactoryProviderInfo.SERVICE_TYPE)
+                           .build()
+                           .matches(descriptor),
+                   is(true));
+    }
+
+    @Test
+    void servicesFactoryInterceptionWrapperWrapsQualifiedInstanceLazily() {
+        Qualifier qualifier = Qualifier.createNamed("test");
+        Set<Qualifier> qualifiers = Set.of(qualifier);
+        AtomicInteger gets = new AtomicInteger();
+        AtomicInteger wraps = new AtomicInteger();
+        Service.QualifiedInstance<String> qualifiedInstance = new Service.QualifiedInstance<>() {
+            @Override
+            public String get() {
+                gets.incrementAndGet();
+                return "value";
+            }
+
+            @Override
+            public Set<Qualifier> qualifiers() {
+                return qualifiers;
+            }
+        };
+        TestServicesFactoryWrapper wrapper = new TestServicesFactoryWrapper(() -> List.of(qualifiedInstance), wraps);
+
+        List<Service.QualifiedInstance<String>> wrappedInstances = wrapper.services();
+
+        assertThat(wrappedInstances, is(List.of(wrappedInstances.getFirst())));
+        assertThat(wrappedInstances.getFirst().qualifiers(), is(qualifiers));
+        assertThat(gets.get(), is(0));
+        assertThat(wraps.get(), is(0));
+
+        assertThat(wrappedInstances.getFirst().get(), is("wrapped-value"));
+        assertThat(wrappedInstances.getFirst().get(), is("wrapped-value"));
+        assertThat(gets.get(), is(1));
+        assertThat(wraps.get(), is(1));
+    }
+
+    @Test
+    void servicesFactoryInterceptionWrapperWrapsQualifiedInstanceOnceUnderContention() throws Exception {
+        AtomicInteger gets = new AtomicInteger();
+        AtomicInteger wraps = new AtomicInteger();
+        CountDownLatch delegateEntered = new CountDownLatch(1);
+        CountDownLatch releaseDelegate = new CountDownLatch(1);
+        Service.QualifiedInstance<String> qualifiedInstance = new Service.QualifiedInstance<>() {
+            @Override
+            public String get() {
+                gets.incrementAndGet();
+                try {
+                    delegateEntered.countDown();
+                    assertThat(releaseDelegate.await(5, TimeUnit.SECONDS), is(true));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+                return "value";
+            }
+
+            @Override
+            public Set<Qualifier> qualifiers() {
+                return Set.of();
+            }
+        };
+        TestServicesFactoryWrapper wrapper = new TestServicesFactoryWrapper(() -> List.of(qualifiedInstance), wraps);
+        Service.QualifiedInstance<String> wrappedInstance = wrapper.services().getFirst();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(2);
+        try {
+            var first = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                return wrappedInstance.get();
+            });
+            var second = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                return wrappedInstance.get();
+            });
+
+            assertThat(ready.await(5, TimeUnit.SECONDS), is(true));
+            start.countDown();
+            assertThat(delegateEntered.await(5, TimeUnit.SECONDS), is(true));
+            releaseDelegate.countDown();
+
+            assertThat(first.get(5, TimeUnit.SECONDS), is("wrapped-value"));
+            assertThat(second.get(5, TimeUnit.SECONDS), is("wrapped-value"));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(gets.get(), is(1));
+        assertThat(wraps.get(), is(1));
+    }
+
+    private static void assertNullDelegate(Runnable runnable) {
+        NullPointerException e = assertThrows(NullPointerException.class, runnable::run);
+
+        assertThat(e.getMessage(), is("delegate"));
+    }
+
+    private static final class TestSupplierWrapper extends GeneratedService.SupplierFactoryInterceptionWrapper<String> {
+        private TestSupplierWrapper(Supplier<String> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            return originalInstance;
+        }
+    }
+
+    private static final class TestOptionalSupplierWrapper
+            extends GeneratedService.OptionalSupplierFactoryInterceptionWrapper<String> {
+        private TestOptionalSupplierWrapper(Supplier<Optional<String>> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            return originalInstance;
+        }
+    }
+
+    private static final class TestIpFactoryWrapper extends GeneratedService.IpFactoryInterceptionWrapper<String> {
+        private TestIpFactoryWrapper(Service.InjectionPointFactory<String> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            return originalInstance;
+        }
+    }
+
+    private static final class TestQualifiedFactoryWrapper
+            extends GeneratedService.QualifiedFactoryInterceptionWrapper<String, Annotation> {
+        private TestQualifiedFactoryWrapper(Service.QualifiedFactory<String, Annotation> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            return originalInstance;
+        }
+    }
+
+    private static final class HiddenFactoryProviderInfo implements ServiceInfo {
+        private static final TypeName SERVICE_TYPE = TypeName.create("io.helidon.service.test.registry.HiddenProvider");
+        private static final TypeName DESCRIPTOR_TYPE =
+                TypeName.create("io.helidon.service.test.registry.HiddenProvider__ServiceDescriptor");
+        private static final ResolvedType PROVIDER_CONTRACT = ResolvedType.create(Supplier.class);
+
+        @Override
+        public TypeName serviceType() {
+            return SERVICE_TYPE;
+        }
+
+        @Override
+        public TypeName descriptorType() {
+            return DESCRIPTOR_TYPE;
+        }
+
+        @Override
+        public Set<ResolvedType> factoryContracts() {
+            return Set.of(PROVIDER_CONTRACT);
+        }
+
+        @Override
+        public Optional<Double> runLevel() {
+            return Optional.of(Service.RunLevel.NORMAL);
+        }
+
+        @Override
+        public FactoryType factoryType() {
+            return FactoryType.SUPPLIER;
+        }
+
+        @Override
+        public TypeName scope() {
+            return Service.Singleton.TYPE;
+        }
+    }
+
+    private static final class TestServicesFactoryWrapper
+            extends GeneratedService.ServicesFactoryInterceptionWrapper<String> {
+        private final AtomicInteger wraps;
+
+        private TestServicesFactoryWrapper(Service.ServicesFactory<String> delegate, AtomicInteger wraps) {
+            super(delegate);
+            this.wraps = wraps;
+        }
+
+        @Override
+        protected String wrap(String originalInstance) {
+            wraps.incrementAndGet();
+            return "wrapped-" + originalInstance;
+        }
+    }
+}

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>helidon-tests-benchmark-jmh</artifactId>
-    <name>Helidon WebServer Benchmarks JMH</name>
+    <name>Helidon Benchmarks JMH</name>
 
     <dependencies>
         <dependency>
@@ -63,6 +63,10 @@
         <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media-json-smile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/tests/benchmark/jmh/service/registry/ServiceRegistryJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/tests/benchmark/jmh/service/registry/ServiceRegistryJmhBenchmark.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.benchmark.jmh.service.registry;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.DependencyContext;
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.GeneratedService;
+import io.helidon.service.registry.InterceptionMetadata;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceDescriptor;
+import io.helidon.service.registry.ServiceInfo;
+import io.helidon.service.registry.ServiceInstance;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Service registry benchmarks for lookup matching and generated interception wrappers.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(1)
+public class ServiceRegistryJmhBenchmark {
+    private static final int DIRECT_SERVICE_COUNT = 128;
+    private static final int HIDDEN_FACTORY_COUNT = 32;
+    private static final int WRAPPED_INSTANCE_COUNT = 16;
+    private static final TypeName DIRECT_CONTRACT_TYPE = TypeName.create(DirectContract.class);
+    private static final ResolvedType DIRECT_CONTRACT = ResolvedType.create(DIRECT_CONTRACT_TYPE);
+    private static final ResolvedType SERVICES_FACTORY_CONTRACT = ResolvedType.create(Service.ServicesFactory.TYPE);
+    private static final Qualifier WRAPPER_QUALIFIER = Qualifier.createNamed("wrapped");
+    private static final GenericType<Payload> PAYLOAD_TYPE = GenericType.create(Payload.class);
+
+    @Benchmark
+    public List<ServiceInfo> lookupEmptyCriteriaDescriptorsNoCache(RegistryState state) {
+        return state.noCacheRegistry.lookupServices(Lookup.EMPTY);
+    }
+
+    @Benchmark
+    public List<ServiceInfo> lookupDirectContractNoCache(RegistryState state) {
+        return state.noCacheRegistry.lookupServices(state.directContractLookup);
+    }
+
+    @Benchmark
+    public List<ServiceInfo> lookupHiddenFactoryContractNoCache(RegistryState state) {
+        return state.noCacheRegistry.lookupServices(state.servicesFactoryContractLookup);
+    }
+
+    @Benchmark
+    public List<ServiceInfo> lookupHiddenFactoryServiceTypeNoCache(RegistryState state) {
+        return state.noCacheRegistry.lookupServices(state.hiddenFactoryServiceTypeLookup);
+    }
+
+    @Benchmark
+    public List<ServiceInstance<Object>> lookupHiddenFactoryContractInstancesNoCache(RegistryState state) {
+        return state.noCacheRegistry.lookupInstances(state.servicesFactoryContractLookup);
+    }
+
+    @Benchmark
+    public List<ServiceInstance<Object>> lookupHiddenFactoryServiceTypeInstancesNoCache(RegistryState state) {
+        return state.noCacheRegistry.lookupInstances(state.hiddenFactoryServiceTypeLookup);
+    }
+
+    @Benchmark
+    public List<ServiceInfo> lookupDirectContractCacheHit(RegistryState state) {
+        return state.cacheRegistry.lookupServices(state.directContractLookup);
+    }
+
+    @Benchmark
+    public DirectContract getDirectSingleton(RegistryState state) {
+        return state.noCacheRegistry.get(state.directContractLookup);
+    }
+
+    @Benchmark
+    public Payload supplierFactoryWrapperGet(WrapperState state) {
+        return state.supplierWrapper.get();
+    }
+
+    @Benchmark
+    public Optional<Service.QualifiedInstance<Payload>> injectionPointFactoryWrapperFirstOnly(WrapperState state) {
+        return state.injectionPointFactoryWrapper.first(state.lookup);
+    }
+
+    @Benchmark
+    public void injectionPointFactoryWrapperFirstAndGet(WrapperState state, Blackhole blackhole) {
+        state.injectionPointFactoryWrapper.first(state.lookup)
+                .ifPresent(it -> blackhole.consume(it.get()));
+    }
+
+    @Benchmark
+    public List<Service.QualifiedInstance<Payload>> injectionPointFactoryWrapperSingleListOnly(WrapperState state) {
+        return state.singleInjectionPointFactoryWrapper.list(state.lookup);
+    }
+
+    @Benchmark
+    public void injectionPointFactoryWrapperSingleListAndGet(WrapperState state, Blackhole blackhole) {
+        for (Service.QualifiedInstance<Payload> instance : state.singleInjectionPointFactoryWrapper.list(state.lookup)) {
+            blackhole.consume(instance.get());
+        }
+    }
+
+    @Benchmark
+    public List<Service.QualifiedInstance<Payload>> injectionPointFactoryWrapperMultiListOnly(WrapperState state) {
+        return state.multiInjectionPointFactoryWrapper.list(state.lookup);
+    }
+
+    @Benchmark
+    public void injectionPointFactoryWrapperMultiListAndGet(WrapperState state, Blackhole blackhole) {
+        for (Service.QualifiedInstance<Payload> instance : state.multiInjectionPointFactoryWrapper.list(state.lookup)) {
+            blackhole.consume(instance.get());
+        }
+    }
+
+    @Benchmark
+    public List<Service.QualifiedInstance<Payload>> servicesFactoryWrapperListOnly(WrapperState state) {
+        return state.servicesFactoryWrapper.services();
+    }
+
+    @Benchmark
+    public void servicesFactoryWrapperListAndGet(WrapperState state, Blackhole blackhole) {
+        for (Service.QualifiedInstance<Payload> instance : state.servicesFactoryWrapper.services()) {
+            blackhole.consume(instance.get());
+        }
+    }
+
+    @Benchmark
+    public List<Service.QualifiedInstance<Payload>> qualifiedFactoryWrapperListOnly(WrapperState state) {
+        return state.qualifiedFactoryWrapper.list(WRAPPER_QUALIFIER, state.lookup, PAYLOAD_TYPE);
+    }
+
+    @Benchmark
+    public void qualifiedFactoryWrapperListAndGet(WrapperState state, Blackhole blackhole) {
+        for (Service.QualifiedInstance<Payload> instance
+                : state.qualifiedFactoryWrapper.list(WRAPPER_QUALIFIER, state.lookup, PAYLOAD_TYPE)) {
+            blackhole.consume(instance.get());
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class RegistryState {
+        private ServiceRegistryManager noCacheManager;
+        private ServiceRegistryManager cacheManager;
+        private ServiceRegistry noCacheRegistry;
+        private ServiceRegistry cacheRegistry;
+        private Lookup directContractLookup;
+        private Lookup servicesFactoryContractLookup;
+        private Lookup hiddenFactoryServiceTypeLookup;
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            directContractLookup = Lookup.create(DIRECT_CONTRACT_TYPE);
+            servicesFactoryContractLookup = Lookup.create(Service.ServicesFactory.TYPE);
+            hiddenFactoryServiceTypeLookup = Lookup.builder()
+                    .serviceType(hiddenFactoryType(0))
+                    .build();
+
+            List<ServiceDescriptor<?>> descriptors = descriptors();
+            noCacheManager = manager(descriptors, false);
+            noCacheRegistry = noCacheManager.registry();
+            cacheManager = manager(descriptors, true);
+            cacheRegistry = cacheManager.registry();
+
+            cacheRegistry.lookupServices(directContractLookup);
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            if (noCacheManager != null) {
+                noCacheManager.shutdown();
+            }
+            if (cacheManager != null) {
+                cacheManager.shutdown();
+            }
+        }
+
+        private static ServiceRegistryManager manager(List<ServiceDescriptor<?>> descriptors, boolean cacheEnabled) {
+            ServiceRegistryConfig config = ServiceRegistryConfig.builder()
+                    .discoverServices(false)
+                    .discoverServicesFromServiceLoader(false)
+                    .lookupCacheEnabled(cacheEnabled)
+                    .serviceDescriptors(descriptors)
+                    .build();
+            return ServiceRegistryManager.create(config);
+        }
+
+        private static List<ServiceDescriptor<?>> descriptors() {
+            List<ServiceDescriptor<?>> result = new ArrayList<>(DIRECT_SERVICE_COUNT + HIDDEN_FACTORY_COUNT);
+            for (int i = 0; i < DIRECT_SERVICE_COUNT; i++) {
+                result.add(BenchmarkDescriptor.direct(i));
+            }
+            for (int i = 0; i < HIDDEN_FACTORY_COUNT; i++) {
+                result.add(BenchmarkDescriptor.hiddenServicesFactory(i));
+            }
+            return result;
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class WrapperState {
+        private Lookup lookup;
+        private SupplierWrapper supplierWrapper;
+        private InjectionPointFactoryWrapper injectionPointFactoryWrapper;
+        private InjectionPointFactoryWrapper singleInjectionPointFactoryWrapper;
+        private InjectionPointFactoryWrapper multiInjectionPointFactoryWrapper;
+        private ServicesFactoryWrapper servicesFactoryWrapper;
+        private QualifiedFactoryWrapper qualifiedFactoryWrapper;
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            lookup = Lookup.create(Payload.class);
+            supplierWrapper = new SupplierWrapper(() -> new Payload(0));
+            injectionPointFactoryWrapper = new InjectionPointFactoryWrapper(new BenchmarkInjectionPointFactory());
+            singleInjectionPointFactoryWrapper = new InjectionPointFactoryWrapper(new BenchmarkInjectionPointFactory(1));
+            multiInjectionPointFactoryWrapper = new InjectionPointFactoryWrapper(
+                    new BenchmarkInjectionPointFactory(WRAPPED_INSTANCE_COUNT));
+            servicesFactoryWrapper = new ServicesFactoryWrapper(new BenchmarkServicesFactory());
+            qualifiedFactoryWrapper = new QualifiedFactoryWrapper(new BenchmarkQualifiedFactory());
+        }
+    }
+
+    private interface DirectContract {
+        int value();
+    }
+
+    private record DirectService(int value) implements DirectContract {
+    }
+
+    private record Payload(int value) {
+    }
+
+    private record BenchmarkQualifiedInstance<T>(Supplier<T> supplier, Set<Qualifier> qualifiers)
+            implements Service.QualifiedInstance<T> {
+        @Override
+        public T get() {
+            return supplier.get();
+        }
+    }
+
+    private static final class BenchmarkDescriptor<T> implements ServiceDescriptor<T> {
+        private final TypeName serviceType;
+        private final TypeName descriptorType;
+        private final Set<ResolvedType> contracts;
+        private final Set<ResolvedType> factoryContracts;
+        private final FactoryType factoryType;
+        private final double weight;
+        private final Supplier<? extends T> supplier;
+
+        private BenchmarkDescriptor(TypeName serviceType,
+                                    TypeName descriptorType,
+                                    Set<ResolvedType> contracts,
+                                    Set<ResolvedType> factoryContracts,
+                                    FactoryType factoryType,
+                                    double weight,
+                                    Supplier<? extends T> supplier) {
+            this.serviceType = serviceType;
+            this.descriptorType = descriptorType;
+            this.contracts = contracts;
+            this.factoryContracts = factoryContracts;
+            this.factoryType = factoryType;
+            this.weight = weight;
+            this.supplier = supplier;
+        }
+
+        static BenchmarkDescriptor<DirectContract> direct(int index) {
+            return new BenchmarkDescriptor<>(
+                    TypeName.create(ServiceRegistryJmhBenchmark.class.getName() + ".DirectService" + index),
+                    TypeName.create(ServiceRegistryJmhBenchmark.class.getName() + ".DirectService" + index
+                                            + "__ServiceDescriptor"),
+                    Set.of(DIRECT_CONTRACT),
+                    Set.of(),
+                    FactoryType.SERVICE,
+                    DIRECT_SERVICE_COUNT - index,
+                    () -> new DirectService(index));
+        }
+
+        static BenchmarkDescriptor<Service.ServicesFactory<DirectContract>> hiddenServicesFactory(int index) {
+            return new BenchmarkDescriptor<>(
+                    hiddenFactoryType(index),
+                    TypeName.create(ServiceRegistryJmhBenchmark.class.getName() + ".HiddenFactory" + index
+                                            + "__ServiceDescriptor"),
+                    Set.of(),
+                    Set.of(SERVICES_FACTORY_CONTRACT),
+                    FactoryType.SERVICES,
+                    HIDDEN_FACTORY_COUNT - index,
+                    () -> () -> List.of(Service.QualifiedInstance.create(new DirectService(index))));
+        }
+
+        @Override
+        public TypeName serviceType() {
+            return serviceType;
+        }
+
+        @Override
+        public TypeName descriptorType() {
+            return descriptorType;
+        }
+
+        @Override
+        public Set<ResolvedType> contracts() {
+            return contracts;
+        }
+
+        @Override
+        public Set<ResolvedType> factoryContracts() {
+            return factoryContracts;
+        }
+
+        @Override
+        public FactoryType factoryType() {
+            return factoryType;
+        }
+
+        @Override
+        public TypeName scope() {
+            return Service.Singleton.TYPE;
+        }
+
+        @Override
+        public double weight() {
+            return weight;
+        }
+
+        @Override
+        public Object instantiate(DependencyContext ctx, InterceptionMetadata interceptionMetadata) {
+            return supplier.get();
+        }
+    }
+
+    private static final class BenchmarkServicesFactory implements Service.ServicesFactory<Payload> {
+        @Override
+        public List<Service.QualifiedInstance<Payload>> services() {
+            List<Service.QualifiedInstance<Payload>> result = new ArrayList<>(WRAPPED_INSTANCE_COUNT);
+            for (int i = 0; i < WRAPPED_INSTANCE_COUNT; i++) {
+                int value = i;
+                result.add(new BenchmarkQualifiedInstance<>(() -> new Payload(value), Set.of(WRAPPER_QUALIFIER)));
+            }
+            return result;
+        }
+    }
+
+    private static final class BenchmarkInjectionPointFactory implements Service.InjectionPointFactory<Payload> {
+        private final int instanceCount;
+
+        private BenchmarkInjectionPointFactory() {
+            this(WRAPPED_INSTANCE_COUNT);
+        }
+
+        private BenchmarkInjectionPointFactory(int instanceCount) {
+            this.instanceCount = instanceCount;
+        }
+
+        @Override
+        public Optional<Service.QualifiedInstance<Payload>> first(Lookup lookup) {
+            return Optional.of(new BenchmarkQualifiedInstance<>(() -> new Payload(0), Set.of()));
+        }
+
+        @Override
+        public List<Service.QualifiedInstance<Payload>> list(Lookup lookup) {
+            List<Service.QualifiedInstance<Payload>> result = new ArrayList<>(instanceCount);
+            for (int i = 0; i < instanceCount; i++) {
+                int value = i;
+                result.add(new BenchmarkQualifiedInstance<>(() -> new Payload(value), Set.of()));
+            }
+            return result;
+        }
+    }
+
+    private static final class BenchmarkQualifiedFactory implements Service.QualifiedFactory<Payload, Annotation> {
+        @Override
+        public Optional<Service.QualifiedInstance<Payload>> first(Qualifier qualifier,
+                                                                  Lookup lookup,
+                                                                  GenericType<Payload> type) {
+            return Optional.of(new BenchmarkQualifiedInstance<>(() -> new Payload(0), Set.of(qualifier)));
+        }
+
+        @Override
+        public List<Service.QualifiedInstance<Payload>> list(Qualifier qualifier,
+                                                             Lookup lookup,
+                                                             GenericType<Payload> type) {
+            List<Service.QualifiedInstance<Payload>> result = new ArrayList<>(WRAPPED_INSTANCE_COUNT);
+            for (int i = 0; i < WRAPPED_INSTANCE_COUNT; i++) {
+                int value = i;
+                result.add(new BenchmarkQualifiedInstance<>(() -> new Payload(value), Set.of(qualifier)));
+            }
+            return result;
+        }
+    }
+
+    private static final class SupplierWrapper extends GeneratedService.SupplierFactoryInterceptionWrapper<Payload> {
+        private SupplierWrapper(Supplier<Payload> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected Payload wrap(Payload originalInstance) {
+            return new Payload(originalInstance.value() + 1);
+        }
+    }
+
+    private static final class InjectionPointFactoryWrapper
+            extends GeneratedService.IpFactoryInterceptionWrapper<Payload> {
+        private InjectionPointFactoryWrapper(Service.InjectionPointFactory<Payload> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected Payload wrap(Payload originalInstance) {
+            return new Payload(originalInstance.value() + 1);
+        }
+    }
+
+    private static final class ServicesFactoryWrapper extends GeneratedService.ServicesFactoryInterceptionWrapper<Payload> {
+        private ServicesFactoryWrapper(Service.ServicesFactory<Payload> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected Payload wrap(Payload originalInstance) {
+            return new Payload(originalInstance.value() + 1);
+        }
+    }
+
+    private static final class QualifiedFactoryWrapper
+            extends GeneratedService.QualifiedFactoryInterceptionWrapper<Payload, Annotation> {
+        private QualifiedFactoryWrapper(Service.QualifiedFactory<Payload, Annotation> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected Payload wrap(Payload originalInstance) {
+            return new Payload(originalInstance.value() + 1);
+        }
+    }
+
+    private static TypeName hiddenFactoryType(int index) {
+        return TypeName.create(ServiceRegistryJmhBenchmark.class.getName() + ".HiddenFactory" + index);
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/tests/benchmark/jmh/service/registry/ServiceRegistryJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/tests/benchmark/jmh/service/registry/ServiceRegistryJmhRunnerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.benchmark.jmh.service.registry;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class ServiceRegistryJmhRunnerTest {
+    @Test
+    void run() throws RunnerException {
+        String include = System.getProperty("service.registry.jmh.include", ".*ServiceRegistryJmhBenchmark.*");
+        String result = System.getProperty("service.registry.jmh.result", "./target/service-registry-jmh-result.json");
+
+        Options options = new OptionsBuilder()
+                .include(include)
+                .forks(Integer.getInteger("service.registry.jmh.forks", 1))
+                .threads(Integer.getInteger("service.registry.jmh.threads", 1))
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .warmupIterations(Integer.getInteger("service.registry.jmh.warmupIterations", 3))
+                .warmupTime(TimeValue.milliseconds(Long.getLong("service.registry.jmh.warmupMillis", 500)))
+                .measurementIterations(Integer.getInteger("service.registry.jmh.measurementIterations", 5))
+                .measurementTime(TimeValue.milliseconds(Long.getLong("service.registry.jmh.measurementMillis", 1000)))
+                .shouldFailOnError(true)
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ChildGenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ChildGenericInterfaceConstrainedService.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+interface ChildGenericInterfaceConstrainedService<T> extends ParentGenericInterfaceConstrainedService<T> {
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ConstrainedDefaultInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ConstrainedDefaultInterfaceConstrainedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface ConstrainedDefaultInterfaceConstrainedService extends UnconstrainedDefaultInterfaceConstrainedService {
+    @Override
+    default String validateInheritedDefault(@Validation.String.NotBlank String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/CustomConstraintValidatorProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/CustomConstraintValidatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.validation.tests.validation;
 
+import java.util.List;
+
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.registry.Service;
@@ -29,13 +31,15 @@ import io.helidon.validation.spi.ConstraintValidatorProvider;
 public class CustomConstraintValidatorProvider implements ConstraintValidatorProvider {
     @Override
     public ConstraintValidator create(TypeName typeName, Annotation constraintAnnotation) {
-        return new CustomValidator(constraintAnnotation);
+        return new CustomValidator(typeName, constraintAnnotation);
     }
 
     private static class CustomValidator implements ConstraintValidator {
+        private final TypeName typeName;
         private final Annotation annotation;
 
-        private CustomValidator(Annotation annotation) {
+        private CustomValidator(TypeName typeName, Annotation annotation) {
+            this.typeName = typeName;
             this.annotation = annotation;
         }
 
@@ -47,6 +51,15 @@ public class CustomConstraintValidatorProvider implements ConstraintValidatorPro
 
             if (value instanceof String str) {
                 if (str.equals("good")) {
+                    return ValidatorResponse.create();
+                }
+            }
+            if (value instanceof List<?> values) {
+                String resolvedName = typeName.resolvedName();
+                if (resolvedName.equals("java.util.List<java.lang.String>") && values.equals(List.of("good"))) {
+                    return ValidatorResponse.create();
+                }
+                if (resolvedName.equals("java.util.List<java.lang.Integer>") && values.equals(List.of(42))) {
                     return ValidatorResponse.create();
                 }
             }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/DefaultInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/DefaultInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class DefaultInterfaceConstrainedServiceImpl implements ConstrainedDefaultInterfaceConstrainedService {
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/FactoryProviderGetInterceptor.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/FactoryProviderGetInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.service.registry.Interception;
+import io.helidon.service.registry.InterceptionContext;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Named("io.helidon.validation.tests.validation.SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.get()")
+class FactoryProviderGetInterceptor implements Interception.ElementInterceptor {
+    private static final AtomicInteger CALLS = new AtomicInteger();
+
+    static void reset() {
+        CALLS.set(0);
+    }
+
+    static int count() {
+        return CALLS.get();
+    }
+
+    @Override
+    public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+        CALLS.incrementAndGet();
+        return chain.proceed(args);
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/FactoryProviderLegacyValidateInterceptor.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/FactoryProviderLegacyValidateInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.service.registry.Interception;
+import io.helidon.service.registry.InterceptionContext;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Named("io.helidon.validation.tests.validation.QualifiedFactoryProvidedInterfaceConstrainedServiceProvider"
+        + ".validate(java.lang.String)")
+class FactoryProviderLegacyValidateInterceptor implements Interception.ElementInterceptor {
+    private static final AtomicInteger CALLS = new AtomicInteger();
+
+    static void reset() {
+        CALLS.set(0);
+    }
+
+    static int count() {
+        return CALLS.get();
+    }
+
+    @Override
+    public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+        CALLS.incrementAndGet();
+        return chain.proceed(args);
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/GenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/GenericInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface GenericInterfaceConstrainedService<T> {
+    T validateGeneric(@Validation.String.NotBlank T value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface InjectOnlyInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+class InjectOnlyInterfaceConstrainedServiceImpl implements InjectOnlyInterfaceConstrainedService {
+    @Service.Inject
+    InjectOnlyInterfaceConstrainedServiceImpl() {
+    }
+
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryDirectContract.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryDirectContract {
+    @Validation.NotNull
+    Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(
+            @Validation.NotNull Lookup lookup);
+
+    @Validation.NotNull
+    @Validation.Collection.Size(2)
+    List<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> list(
+            @Validation.NotNull Lookup lookup);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyBaseProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyBaseProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+
+abstract class InjectionPointFactoryFirstOnlyBaseProvider
+        implements Service.InjectionPointFactory<InjectionPointFactoryFirstOnlyProvidedService> {
+    @Override
+    public List<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> list(Lookup lookup) {
+        return List.of(Service.QualifiedInstance.create(new InjectionPointFactoryFirstOnlyProvidedServiceImpl()),
+                       Service.QualifiedInstance.create(new InjectionPointFactoryFirstOnlyProvidedServiceImpl()));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyDirectContract.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryFirstOnlyDirectContract {
+    @Validation.NotNull
+    Optional<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> first(Lookup lookup);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryFirstOnlyProvidedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class InjectionPointFactoryFirstOnlyProvidedServiceImpl implements InjectionPointFactoryFirstOnlyProvidedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedServiceProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class InjectionPointFactoryFirstOnlyProvidedServiceProvider
+        extends InjectionPointFactoryFirstOnlyBaseProvider
+        implements Service.InjectionPointFactory<InjectionPointFactoryFirstOnlyProvidedService>,
+                   InjectionPointFactoryFirstOnlyDirectContract {
+    @Override
+    public Optional<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> first(Lookup lookup) {
+        return Optional.of(list(lookup).getFirst());
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryOverloadedDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryOverloadedDirectContract.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryOverloadedDirectContract {
+    Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(
+            @Validation.NotNull String name);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface InjectionPointFactoryProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl
+        implements InjectionPointFactoryProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider
+        implements Service.InjectionPointFactory<InjectionPointFactoryProvidedInterfaceConstrainedService>,
+                   InjectionPointFactoryDirectContract,
+                   InjectionPointFactoryOverloadedDirectContract {
+    @Override
+    public Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(String name) {
+        return Optional.of(Service.QualifiedInstance.create(new InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl(),
+                                                           Qualifier.createNamed(name)));
+    }
+
+    @Override
+    public Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(
+            Lookup lookup) {
+        return Optional.of(list(lookup).getFirst());
+    }
+
+    @Override
+    public List<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> list(Lookup lookup) {
+        return List.of(Service.QualifiedInstance.create(new InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl()),
+                       Service.QualifiedInstance.create(new InjectionPointFactoryProvidedInterfaceConstrainedServiceImpl()));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Contract
+interface InterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
@@ -16,10 +16,44 @@
 
 package io.helidon.validation.tests.validation;
 
-import io.helidon.service.registry.Service;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import io.helidon.validation.Validation;
 
-@Service.Contract
 interface InterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
+
+    default String validateDefault(@Validation.String.NotBlank String value) {
+        return value;
+    }
+
+    List<String> validateList(List<@Validation.String.NotBlank String> values);
+
+    List<List<String>> validateNestedList(List<List<@Validation.String.NotBlank String>> values);
+
+    Map<String, String> validateMap(Map<@Validation.String.NotBlank String, @Validation.String.NotBlank String> values);
+
+    Map<List<String>, String> validateNestedMapKey(Map<List<@Validation.String.NotBlank String>, String> values);
+
+    Map<String, List<String>> validateNestedMapValue(Map<String, List<@Validation.String.NotBlank String>> values);
+
+    Optional<String> validateOptional(Optional<@Validation.String.NotBlank String> value);
+
+    @TypeUseNotBlank String[] validateArray(@TypeUseNotBlank String[] values);
+
+    List<Integer> validateIntegerList(List<@Validation.Integer.Min(10) Integer> values);
+
+    List<@Validation.String.NotBlank String> invalidNames();
+
+    int validateMinimum(@Validation.Integer.Min(10) int value);
+
+    String validateShared(@Validation.String.NotBlank String value);
+
+    String validateDuplicate(@Validation.String.NotBlank String value);
+
+    List<String> validateCustomStringList(@CustomConstraint List<String> values);
+
+    List<Integer> validateCustomIntegerList(@CustomConstraint List<Integer> values);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
@@ -53,6 +53,8 @@ interface InterfaceConstrainedService {
 
     String validateDuplicate(@Validation.String.NotBlank String value);
 
+    String validateCustomGroup(@CustomGroup String value);
+
     List<String> validateCustomStringList(@CustomConstraint List<String> values);
 
     List<Integer> validateCustomIntegerList(@CustomConstraint List<Integer> values);

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class InterfaceConstrainedServiceImpl implements InterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
@@ -16,12 +16,108 @@
 
 package io.helidon.validation.tests.validation;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
 
 @Service.Singleton
-class InterfaceConstrainedServiceImpl implements InterfaceConstrainedService {
+class InterfaceConstrainedServiceImpl
+        implements UnconstrainedInterfaceConstrainedService,
+                   InterfaceConstrainedService,
+                   LowerMinimumInterfaceConstrainedService,
+                   GenericInterfaceConstrainedService<String>,
+                   OrderedGenericInterfaceConstrainedService<String, Integer>,
+                   ChildGenericInterfaceConstrainedService<String> {
     @Override
     public String validate(String value) {
+        return value;
+    }
+
+    @Override
+    public List<String> validateList(List<String> values) {
+        return values;
+    }
+
+    @Override
+    public List<List<String>> validateNestedList(List<List<String>> values) {
+        return values;
+    }
+
+    @Override
+    public Map<String, String> validateMap(Map<String, String> values) {
+        return values;
+    }
+
+    @Override
+    public Map<List<String>, String> validateNestedMapKey(Map<List<String>, String> values) {
+        return values;
+    }
+
+    @Override
+    public Map<String, List<String>> validateNestedMapValue(Map<String, List<String>> values) {
+        return values;
+    }
+
+    @Override
+    public Optional<String> validateOptional(Optional<String> value) {
+        return value;
+    }
+
+    @Override
+    public String[] validateArray(String[] values) {
+        return values;
+    }
+
+    @Override
+    public List<Integer> validateIntegerList(List<Integer> values) {
+        return values;
+    }
+
+    @Override
+    public List<String> invalidNames() {
+        return List.of("");
+    }
+
+    @Override
+    public int validateMinimum(@Validation.Integer.Min(1) int value) {
+        return value;
+    }
+
+    @Override
+    public String validateShared(String value) {
+        return value;
+    }
+
+    @Override
+    public String validateDuplicate(@Validation.String.NotBlank String value) {
+        return value;
+    }
+
+    @Override
+    public List<String> validateCustomStringList(List<String> values) {
+        return values;
+    }
+
+    @Override
+    public List<Integer> validateCustomIntegerList(List<Integer> values) {
+        return values;
+    }
+
+    @Override
+    public String validateGeneric(String value) {
+        return value;
+    }
+
+    @Override
+    public Integer validateOrderedGeneric(String key, Integer value) {
+        return value;
+    }
+
+    @Override
+    public String validateInheritedGeneric(String value) {
         return value;
     }
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedServiceImpl.java
@@ -97,6 +97,11 @@ class InterfaceConstrainedServiceImpl
     }
 
     @Override
+    public String validateCustomGroup(String value) {
+        return value;
+    }
+
+    @Override
     public List<String> validateCustomStringList(List<String> values) {
         return values;
     }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceMethodValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceMethodValidationTest.java
@@ -1,0 +1,988 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInstance;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.testing.junit5.Testing;
+import io.helidon.validation.ConstraintViolation.Location;
+import io.helidon.validation.ConstraintViolation.PathElement;
+import io.helidon.validation.Validation;
+import io.helidon.validation.ValidationException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Testing.Test
+class InterfaceMethodValidationTest {
+    private final ServiceRegistry registry;
+
+    InterfaceMethodValidationTest(ServiceRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Test
+    void interfaceParameterConstraintIsAppliedFromRegistryService() {
+        assertThat(new InterfaceConstrainedServiceImpl().validate(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateDefault(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateList(List.of("")), is(List.of("")));
+        assertThat(new InterfaceConstrainedServiceImpl().validateNestedList(List.of(List.of(""))), is(List.of(List.of(""))));
+        assertThat(new InterfaceConstrainedServiceImpl().validateMap(Map.of("", "valid")), is(Map.of("", "valid")));
+        assertThat(new InterfaceConstrainedServiceImpl().validateNestedMapKey(Map.of(List.of(""), "valid")),
+                   is(Map.of(List.of(""), "valid")));
+        assertThat(new InterfaceConstrainedServiceImpl().validateNestedMapValue(Map.of("key", List.of(""))),
+                   is(Map.of("key", List.of(""))));
+        assertThat(new InterfaceConstrainedServiceImpl().validateOptional(Optional.of("")), is(Optional.of("")));
+        String[] array = {""};
+        assertThat(new InterfaceConstrainedServiceImpl().validateArray(array), sameInstance(array));
+        assertThat(new InterfaceConstrainedServiceImpl().validateIntegerList(List.of(5)), is(List.of(5)));
+        assertThat(new InterfaceConstrainedServiceImpl().invalidNames(), is(List.of("")));
+        assertThat(new InterfaceConstrainedServiceImpl().validateMinimum(5), is(5));
+        assertThat(new InterfaceConstrainedServiceImpl().validateShared(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateDuplicate(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateGeneric(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateOrderedGeneric("", 42), is(42));
+        assertThat(new InterfaceConstrainedServiceImpl().validateInheritedGeneric(""), is(""));
+        assertThat(new DefaultInterfaceConstrainedServiceImpl().validateInheritedDefault(""), is(""));
+
+        InterfaceConstrainedService service = registry.get(InterfaceConstrainedService.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        GenericInterfaceConstrainedService<String> genericService =
+                (GenericInterfaceConstrainedService) registry.get(GenericInterfaceConstrainedService.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        OrderedGenericInterfaceConstrainedService<String, Integer> orderedGenericService =
+                (OrderedGenericInterfaceConstrainedService) registry.get(OrderedGenericInterfaceConstrainedService.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ParentGenericInterfaceConstrainedService<String> parentGenericService =
+                (ParentGenericInterfaceConstrainedService) registry.get(ParentGenericInterfaceConstrainedService.class);
+        ConstrainedDefaultInterfaceConstrainedService defaultMethodService =
+                registry.get(ConstrainedDefaultInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+        LegacyValidateDefaultInterceptor.reset();
+        assertThat(service.validateDefault("valid"), is("valid"));
+        assertThat(LegacyValidateDefaultInterceptor.count(), is(1));
+        assertThat(service.validateList(List.of("valid")), is(List.of("valid")));
+        assertThat(service.validateNestedList(List.of(List.of("valid"))), is(List.of(List.of("valid"))));
+        assertThat(service.validateMap(Map.of("key", "valid")), is(Map.of("key", "valid")));
+        assertThat(service.validateNestedMapKey(Map.of(List.of("valid"), "valid")),
+                   is(Map.of(List.of("valid"), "valid")));
+        assertThat(service.validateNestedMapValue(Map.of("key", List.of("valid"))),
+                   is(Map.of("key", List.of("valid"))));
+        assertThat(service.validateOptional(Optional.of("valid")), is(Optional.of("valid")));
+        array = new String[] {"valid"};
+        assertThat(service.validateArray(array), sameInstance(array));
+        assertThat(service.validateIntegerList(List.of(10)), is(List.of(10)));
+        assertThat(service.validateMinimum(10), is(10));
+        assertThat(service.validateShared("valid"), is("valid"));
+        assertThat(service.validateDuplicate("valid"), is("valid"));
+        assertThat(service.validateCustomStringList(List.of("good")), is(List.of("good")));
+        assertThat(service.validateCustomIntegerList(List.of(42)), is(List.of(42)));
+        assertThat(genericService.validateGeneric("valid"), is("valid"));
+        assertThat(orderedGenericService.validateOrderedGeneric("valid", 42), is(42));
+        assertThat(parentGenericService.validateInheritedGeneric("valid"), is("valid"));
+        assertThat(defaultMethodService.validateInheritedDefault("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateCustomStringList(List.of("bad")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateCustomStringList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values")),
+                        "Must be \"good\" string",
+                        List.of("bad"),
+                        TypeName.create(CustomConstraint.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateCustomIntegerList(List.of(41)));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateCustomIntegerList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values")),
+                        "Must be \"good\" string",
+                        List.of(41),
+                        TypeName.create(CustomConstraint.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateDefault(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateDefault(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateList(List.of("")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateNestedList(List.of(List.of(""))));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateNestedList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateMap(Map.of("", "valid")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateMap(java.util.Map)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.KEY, "key")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateMap(Map.of("key", "")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateMap(java.util.Map)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateNestedMapKey(Map.of(List.of(""), "valid")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateNestedMapKey(java.util.Map)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.KEY, "key"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class,
+                              () -> service.validateNestedMapValue(Map.of("key", List.of(""))));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateNestedMapValue(java.util.Map)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "value"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateOptional(Optional.of("")));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateOptional(java.util.Optional)"),
+                                PathElement.create(Location.PARAMETER, "value"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateArray(new String[] {""}));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateArray(java.lang.String[])"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateIntegerList(List.of(5)));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateIntegerList(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is less than 10",
+                        5,
+                        TypeName.create(Validation.Integer.Min.class));
+
+        result = assertThrows(ValidationException.class, service::invalidNames);
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "invalidNames()"),
+                                PathElement.create(Location.RETURN_VALUE, "List"),
+                                PathElement.create(Location.ELEMENT, "element")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateMinimum(5));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateMinimum(int)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is less than 10",
+                        5,
+                        TypeName.create(Validation.Integer.Min.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateShared(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateShared(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateDuplicate(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateDuplicate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> genericService.validateGeneric(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateGeneric(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> orderedGenericService.validateOrderedGeneric("", 42));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD,
+                                                   "validateOrderedGeneric(java.lang.String,java.lang.Integer)"),
+                                PathElement.create(Location.PARAMETER, "key")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> parentGenericService.validateInheritedGeneric(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateInheritedGeneric(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> defaultMethodService.validateInheritedDefault(""));
+        assertViolation(result,
+                        DefaultInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, DefaultInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateInheritedDefault(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void injectOnlyServiceUsesInterfaceParameterConstraint() {
+        assertThat(new InjectOnlyInterfaceConstrainedServiceImpl().validate(""), is(""));
+
+        InjectOnlyInterfaceConstrainedService service = registry.get(InjectOnlyInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        InjectOnlyInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectOnlyInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void supplierProvidedServiceUsesInterfaceParameterConstraint() {
+        assertThat(new SupplierProvidedInterfaceConstrainedServiceProvider().get().validate(""), is(""));
+
+        SupplierProvidedInterfaceConstrainedService service =
+                registry.get(SupplierProvidedInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        SupplierProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProvidedInterfaceConstrainedServiceProvider.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void supplierProvidedServiceUsesInterfaceReturnConstraintOnSameSignatureMethod() {
+        assertThat(new SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider().get().get(), is(""));
+
+        SupplierProvidedSameSignatureInterfaceConstrainedService service =
+                registry.get(SupplierProvidedSameSignatureInterfaceConstrainedService.class);
+
+        var result = assertThrows(ValidationException.class, service::get);
+        assertViolation(result,
+                        SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "get()"),
+                                PathElement.create(Location.RETURN_VALUE, "String")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        Lookup supplierLookup = Lookup.builder()
+                .addContract(SupplierProvidedSameSignatureInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.SUPPLIER)
+                .build();
+        Supplier<SupplierProvidedSameSignatureInterfaceConstrainedService> supplier = registry.get(supplierLookup);
+
+        FactoryProviderGetInterceptor.reset();
+        SupplierProvidedSameSignatureInterfaceConstrainedService suppliedService = supplier.get();
+        assertThat(FactoryProviderGetInterceptor.count(), is(1));
+
+        result = assertThrows(ValidationException.class, suppliedService::get);
+        assertViolation(result,
+                        SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "get()"),
+                                PathElement.create(Location.RETURN_VALUE, "String")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        SupplierProvidedSameSignatureProviderContract providerContract =
+                registry.get(SupplierProvidedSameSignatureProviderContract.class);
+
+        FactoryProviderGetInterceptor.reset();
+        assertThat(providerContract.get(), instanceOf(SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl.class));
+        assertThat(FactoryProviderGetInterceptor.count(), is(1));
+    }
+
+    @Test
+    void supplierProviderDirectContractAndProvidedContractUseIndependentSameSignatureConstraints() {
+        assertThat(new SupplierProviderSameSignatureConstrainedServiceProvider().get().validate(""), is(""));
+        assertThat(new SupplierProviderSameSignatureConstrainedServiceProvider().validate("abc"), is("abc"));
+
+        SupplierProviderSameSignatureConstrainedService service =
+                registry.get(SupplierProviderSameSignatureConstrainedService.class);
+
+        assertThat(service.validate("abc"), is("abc"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        SupplierProviderSameSignatureConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProviderSameSignatureConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        SupplierProviderSameSignatureConstrainedServiceProvider provider =
+                registry.get(SupplierProviderSameSignatureConstrainedServiceProvider.class);
+
+        assertThat(provider.validate("123"), is("123"));
+
+        result = assertThrows(ValidationException.class, () -> provider.validate("abc"));
+        assertViolation(result,
+                        SupplierProviderSameSignatureConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProviderSameSignatureConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "pattern",
+                        "abc",
+                        TypeName.create(Validation.String.Pattern.class));
+
+        SupplierProviderSameSignatureDirectService directService =
+                registry.get(SupplierProviderSameSignatureDirectService.class);
+        List<ServiceInstance<SupplierProviderSameSignatureDirectService>> directInstances =
+                registry.lookupInstances(Lookup.create(SupplierProviderSameSignatureDirectService.class));
+
+        assertThat(directService.validate("123"), is("123"));
+        assertThat(directInstances, hasSize(1));
+        assertThat(directInstances.getFirst()
+                           .contracts()
+                           .contains(ResolvedType.create(SupplierProviderSameSignatureDirectService.class)),
+                   is(true));
+
+        result = assertThrows(ValidationException.class, () -> directService.validate("abc"));
+        assertViolation(result,
+                        SupplierProviderSameSignatureConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   SupplierProviderSameSignatureConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "pattern",
+                        "abc",
+                        TypeName.create(Validation.String.Pattern.class));
+    }
+
+    @Test
+    void optionalSupplierProvidedServiceUsesInterfaceParameterConstraint() {
+        assertThat(new OptionalSupplierProvidedInterfaceConstrainedServiceProvider()
+                           .get()
+                           .orElseThrow()
+                           .validate(""),
+                   is(""));
+
+        OptionalSupplierProvidedInterfaceConstrainedService service =
+                registry.get(OptionalSupplierProvidedInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        Lookup supplierLookup = Lookup.builder()
+                .addContract(OptionalSupplierProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.SUPPLIER)
+                .build();
+        Supplier<Optional<OptionalSupplierProvidedInterfaceConstrainedService>> supplier = registry.get(supplierLookup);
+
+        assertThat(supplier.get().orElseThrow().validate("valid"), is("valid"));
+
+        result = assertThrows(ValidationException.class, () -> supplier.get().orElseThrow().validate(""));
+        assertViolation(result,
+                        OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void concreteFactoryProviderLookupRemainsAvailable() {
+        assertConcreteProviderIsAvailable(SupplierProvidedInterfaceConstrainedServiceProvider.class, FactoryType.SUPPLIER);
+        assertConcreteProviderIsAvailable(OptionalSupplierProvidedInterfaceConstrainedServiceProvider.class,
+                                          FactoryType.SUPPLIER);
+        assertConcreteProviderIsAvailable(ServicesFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                                          FactoryType.SERVICES);
+        assertConcreteProviderIsAvailable(InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                                          FactoryType.INJECTION_POINT);
+        assertConcreteProviderIsAvailable(QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                                          FactoryType.QUALIFIED);
+
+        Lookup supplierLookup = Lookup.builder()
+                .addContract(SupplierProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.SUPPLIER)
+                .build();
+        Supplier<SupplierProvidedInterfaceConstrainedService> supplier = registry.get(supplierLookup);
+        assertThrows(ValidationException.class, () -> supplier.get().validate(""));
+    }
+
+    @Test
+    void servicesFactoryProvidedServiceUsesInterfaceParameterConstraint() {
+        assertThat(new ServicesFactoryProvidedInterfaceConstrainedServiceProvider()
+                           .services()
+                           .getFirst()
+                           .get()
+                           .validate(""),
+                   is(""));
+
+        ServicesFactoryProvidedInterfaceConstrainedService service =
+                registry.get(ServicesFactoryProvidedInterfaceConstrainedService.class);
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(ServicesFactoryProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.SERVICES)
+                .build();
+        Service.ServicesFactory<ServicesFactoryProvidedInterfaceConstrainedService> factory = registry.get(factoryLookup);
+        List<Service.QualifiedInstance<ServicesFactoryProvidedInterfaceConstrainedService>> factoryServices =
+                factory.services();
+
+        assertThat(service.validate("valid"), is("valid"));
+        assertThat(factoryServices, hasSize(1));
+        assertThat(factoryServices.getFirst().get().validate("valid"), is("valid"));
+        assertThrows(ValidationException.class, () -> factoryServices.getFirst().get().validate(""));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        ServicesFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   ServicesFactoryProvidedInterfaceConstrainedServiceProvider.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void broadLookupDoesNotBypassFactoryInterceptionWrappers() {
+        List<Object> allServices = registry.all(Lookup.EMPTY);
+        List<SupplierProvidedInterfaceConstrainedService> supplierServices =
+                allServices.stream()
+                        .filter(SupplierProvidedInterfaceConstrainedService.class::isInstance)
+                        .map(SupplierProvidedInterfaceConstrainedService.class::cast)
+                        .toList();
+        List<OptionalSupplierProvidedInterfaceConstrainedService> optionalSupplierServices =
+                allServices.stream()
+                        .filter(OptionalSupplierProvidedInterfaceConstrainedService.class::isInstance)
+                        .map(OptionalSupplierProvidedInterfaceConstrainedService.class::cast)
+                        .toList();
+        List<ServicesFactoryProvidedInterfaceConstrainedService> servicesFactoryServices =
+                allServices.stream()
+                        .filter(ServicesFactoryProvidedInterfaceConstrainedService.class::isInstance)
+                        .map(ServicesFactoryProvidedInterfaceConstrainedService.class::cast)
+                        .toList();
+
+        assertThat(supplierServices.isEmpty(), is(false));
+        assertThat(optionalSupplierServices.isEmpty(), is(false));
+        assertThat(servicesFactoryServices.isEmpty(), is(false));
+        supplierServices.forEach(it -> assertThrows(ValidationException.class, () -> it.validate("")));
+        optionalSupplierServices.forEach(it -> assertThrows(ValidationException.class, () -> it.validate("")));
+        servicesFactoryServices.forEach(it -> assertThrows(ValidationException.class, () -> it.validate("")));
+    }
+
+    @Test
+    void injectionPointFactoryProvidedServiceUsesInterfaceParameterConstraint() {
+        assertThat(new InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider()
+                           .first(Lookup.create(InjectionPointFactoryProvidedInterfaceConstrainedService.class))
+                           .orElseThrow()
+                           .get()
+                           .validate(""),
+                   is(""));
+
+        InjectionPointFactoryProvidedInterfaceConstrainedService service =
+                registry.get(InjectionPointFactoryProvidedInterfaceConstrainedService.class);
+        List<InjectionPointFactoryProvidedInterfaceConstrainedService> services =
+                registry.all(InjectionPointFactoryProvidedInterfaceConstrainedService.class);
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(InjectionPointFactoryProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.INJECTION_POINT)
+                .build();
+        Service.InjectionPointFactory<InjectionPointFactoryProvidedInterfaceConstrainedService> factory =
+                registry.get(factoryLookup);
+        InjectionPointFactoryDirectContract directFactory = registry.get(InjectionPointFactoryDirectContract.class);
+        Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService> factoryFirst =
+                factory.first(Lookup.create(InjectionPointFactoryProvidedInterfaceConstrainedService.class))
+                        .orElseThrow();
+        List<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> factoryServices =
+                factory.list(Lookup.create(InjectionPointFactoryProvidedInterfaceConstrainedService.class));
+        InjectionPointFactoryOverloadedDirectContract overloadedFactory = registry.get(
+                InjectionPointFactoryOverloadedDirectContract.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+        assertThat(services, hasSize(2));
+        assertThat(factoryFirst.get().validate("valid"), is("valid"));
+        assertThat(factoryServices, hasSize(2));
+        assertThat(overloadedFactory.first("overloaded").orElseThrow().get().validate("valid"), is("valid"));
+        for (InjectionPointFactoryProvidedInterfaceConstrainedService listedService : services) {
+            assertThat(listedService.validate("valid"), is("valid"));
+            assertThrows(ValidationException.class, () -> listedService.validate(""));
+        }
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> factory.list(null));
+        assertViolation(result,
+                        InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "list(io.helidon.service.registry.Lookup)"),
+                                PathElement.create(Location.PARAMETER, "lookup")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+
+        result = assertThrows(ValidationException.class, () -> directFactory.list(null));
+        assertViolation(result,
+                        InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "list(io.helidon.service.registry.Lookup)"),
+                                PathElement.create(Location.PARAMETER, "lookup")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+
+        result = assertThrows(ValidationException.class, () -> overloadedFactory.first(null));
+        assertViolation(result,
+                        InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   InjectionPointFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "first(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "name")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+    }
+
+    @Test
+    void injectionPointFactoryListPreservesCustomListWhenOnlyFirstIsIntercepted() {
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(InjectionPointFactoryFirstOnlyProvidedService.class)
+                .addFactoryType(FactoryType.INJECTION_POINT)
+                .build();
+        Service.InjectionPointFactory<InjectionPointFactoryFirstOnlyProvidedService> factory = registry.get(factoryLookup);
+
+        List<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> factoryServices =
+                factory.list(Lookup.create(InjectionPointFactoryFirstOnlyProvidedService.class));
+
+        assertThat(factoryServices, hasSize(2));
+        for (Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService> factoryService : factoryServices) {
+            assertThat(factoryService.get().validate("valid"), is("valid"));
+            assertThrows(ValidationException.class, () -> factoryService.get().validate(""));
+        }
+    }
+
+    @Test
+    void qualifiedFactoryListPreservesCustomListWhenOnlyFirstIsIntercepted() {
+        Qualifier qualifier = Qualifier.createNamed("qualified-first-only");
+        Lookup lookup = Lookup.builder()
+                .addQualifier(qualifier)
+                .addContract(QualifiedFactoryFirstOnlyProvidedService.class)
+                .build();
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(QualifiedFactoryFirstOnlyProvidedService.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        Service.QualifiedFactory<QualifiedFactoryFirstOnlyProvidedService, Service.Named> factory =
+                registry.get(factoryLookup);
+        GenericType<QualifiedFactoryFirstOnlyProvidedService> contractType =
+                GenericType.create(QualifiedFactoryFirstOnlyProvidedService.class);
+
+        List<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> factoryServices =
+                factory.list(qualifier, lookup, contractType);
+
+        assertThat(factoryServices, hasSize(2));
+        for (Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService> factoryService : factoryServices) {
+            assertThat(factoryService.get().validate("valid"), is("valid"));
+            assertThrows(ValidationException.class, () -> factoryService.get().validate(""));
+        }
+    }
+
+    @Test
+    void qualifiedFactoryProvidedServiceUsesInterfaceParameterConstraint() {
+        Qualifier qualifier = Qualifier.createNamed("qualified");
+        Lookup lookup = Lookup.builder()
+                .addQualifier(qualifier)
+                .addContract(QualifiedFactoryProvidedInterfaceConstrainedService.class)
+                .build();
+        GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> contractType =
+                GenericType.create(QualifiedFactoryProvidedInterfaceConstrainedService.class);
+        assertThat(new QualifiedFactoryProvidedInterfaceConstrainedServiceProvider()
+                           .first(qualifier,
+                                  lookup,
+                                  contractType)
+                           .orElseThrow()
+                           .get()
+                           .validate(""),
+                   is(""));
+
+        QualifiedFactoryProvidedInterfaceConstrainedService service = registry.get(lookup);
+        var serviceInfo = registry.lookupServices(lookup).getFirst();
+        Lookup factoryLookup = Lookup.builder()
+                .addQualifier(qualifier)
+                .addContract(QualifiedFactoryProvidedInterfaceConstrainedService.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        Service.QualifiedFactory<QualifiedFactoryProvidedInterfaceConstrainedService, Service.Named> factory =
+                registry.get(factoryLookup);
+        QualifiedFactoryDirectContract directFactory = registry.get(QualifiedFactoryDirectContract.class);
+        Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService> factoryFirst =
+                factory.first(qualifier, lookup, contractType).orElseThrow();
+        List<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> factoryServices =
+                factory.list(qualifier, lookup, contractType);
+
+        FactoryProviderLegacyValidateInterceptor.reset();
+        assertThat(service.validate("valid"), is("valid"));
+        assertThat(FactoryProviderLegacyValidateInterceptor.count(), is(0));
+        assertThat(serviceInfo.weight(), is(42.0));
+        assertThat(serviceInfo.runLevel(), is(Optional.of(43.0)));
+        assertThat(factoryFirst.get().validate("valid"), is("valid"));
+        assertThat(factoryServices, hasSize(2));
+        assertThat(factoryServices.getFirst().get().validate("valid"), is("valid"));
+        assertThrows(ValidationException.class, () -> factoryFirst.get().validate(""));
+        assertThrows(ValidationException.class, () -> factoryServices.getFirst().get().validate(""));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> factory.list(null, lookup, contractType));
+        assertViolation(result,
+                        QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD,
+                                                   "list(io.helidon.service.registry.Qualifier,"
+                                                           + "io.helidon.service.registry.Lookup,"
+                                                           + "io.helidon.common.GenericType)"),
+                                PathElement.create(Location.PARAMETER, "qualifier")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+
+        result = assertThrows(ValidationException.class, () -> directFactory.list(null, lookup, contractType));
+        assertViolation(result,
+                        QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.class
+                                                           .getName()),
+                                PathElement.create(Location.METHOD,
+                                                   "list(io.helidon.service.registry.Qualifier,"
+                                                           + "io.helidon.service.registry.Lookup,"
+                                                           + "io.helidon.common.GenericType)"),
+                                PathElement.create(Location.PARAMETER, "qualifier")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
+    }
+
+    @Test
+    void perInstanceServiceUsesInterfaceParameterConstraint() {
+        var directService = new PerInstanceInterfaceConstrainedServiceImpl(new PerInstanceInterfaceConstrainedConfig());
+        assertThat(directService.validate(""),
+                   is(""));
+
+        PerInstanceInterfaceConstrainedService service = registry.get(PerInstanceInterfaceConstrainedService.class);
+
+        assertThat(service.validate("valid"), is("valid"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(""));
+        assertViolation(result,
+                        PerInstanceInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE,
+                                                   PerInstanceInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validate(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+    }
+
+    @Test
+    void validInterfaceParameterTriggersValidation() {
+        ValidatedType invalidValue = new ValidatedType("invalid_text", 42, new BigDecimal("1.10"));
+        assertThat(new ValidInterfaceConstrainedServiceImpl().validate(invalidValue), is("ok"));
+        assertThat(new ValidInterfaceConstrainedServiceImpl().validateAll(List.of(invalidValue)), is("ok"));
+
+        ValidInterfaceConstrainedService service = registry.get(ValidInterfaceConstrainedService.class);
+
+        assertThat(service.validate(new ValidatedType("good_test_value", 42, new BigDecimal("1.10"))), is("ok"));
+        assertThat(service.validateAll(List.of(new ValidatedType("good_test_value", 42, new BigDecimal("1.10")))), is("ok"));
+
+        var result = assertThrows(ValidationException.class, () -> service.validate(invalidValue));
+        assertViolation(result,
+                        ValidInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, ValidInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD,
+                                                   "validate(io.helidon.validation.tests.validation.ValidatedType)"),
+                                PathElement.create(Location.PARAMETER, "value"),
+                                PathElement.create(Location.TYPE, ValidatedType.class.getName()),
+                                PathElement.create(Location.RECORD_COMPONENT, "first")),
+                        "pattern",
+                        "invalid_text",
+                        TypeName.create(Validation.String.Pattern.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateAll(List.of(invalidValue)));
+        assertViolation(result,
+                        ValidInterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, ValidInterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateAll(java.util.List)"),
+                                PathElement.create(Location.PARAMETER, "values"),
+                                PathElement.create(Location.ELEMENT, "element"),
+                                PathElement.create(Location.TYPE, ValidatedType.class.getName()),
+                                PathElement.create(Location.RECORD_COMPONENT, "first")),
+                        "pattern",
+                        "invalid_text",
+                        TypeName.create(Validation.String.Pattern.class));
+    }
+
+    @Test
+    void serviceDescriptorMetadataIncludesInterfaceMethodConstraints() {
+        TypeName notBlank = TypeName.create(Validation.String.NotBlank.class);
+        TypeName min = TypeName.create(Validation.Integer.Min.class);
+
+        var validateParameter = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_VALIDATE
+                .parameterArguments()
+                .getFirst();
+        assertThat(validateParameter.hasAnnotation(notBlank), is(true));
+
+        var validateListElementType = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_VALIDATE_LIST
+                .parameterArguments()
+                .getFirst()
+                .typeName()
+                .typeArguments()
+                .getFirst();
+        assertThat(validateListElementType.hasAnnotation(notBlank), is(true));
+
+        var invalidNamesElementType = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_INVALID_NAMES
+                .typeName()
+                .typeArguments()
+                .getFirst();
+        assertThat(invalidNamesElementType.hasAnnotation(notBlank), is(true));
+
+        var inheritedGenericParameter = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_VALIDATE_INHERITED_GENERIC
+                .parameterArguments()
+                .getFirst();
+        assertThat(inheritedGenericParameter.typeName(), is(TypeName.create(String.class)));
+        assertThat(inheritedGenericParameter.hasAnnotation(notBlank), is(true));
+
+        var validateMinimumParameter = InterfaceConstrainedServiceImpl__ServiceDescriptor.METHOD_VALIDATE_MINIMUM
+                .parameterArguments()
+                .getFirst();
+        assertThat(validateMinimumParameter.annotation(min).objectValue(), is(Optional.of(1)));
+        assertThat(validateMinimumParameter.annotations()
+                           .stream()
+                           .filter(it -> it.typeName().equals(min))
+                           .map(it -> it.objectValue().orElseThrow())
+                           .toList(),
+                   contains(1, 10));
+    }
+
+    private void assertConcreteProviderIsAvailable(Class<?> providerType, FactoryType factoryType) {
+        assertThat(providerType.isInstance(registry.first(providerType).orElseThrow()), is(true));
+
+        Lookup serviceTypeLookup = Lookup.builder()
+                .serviceType(providerType)
+                .build();
+        assertThat(providerType.isInstance(registry.first(serviceTypeLookup).orElseThrow()), is(true));
+
+        Lookup factoryServiceTypeLookup = Lookup.builder()
+                .serviceType(providerType)
+                .addFactoryType(factoryType)
+                .build();
+        assertThat(providerType.isInstance(registry.first(factoryServiceTypeLookup).orElseThrow()), is(true));
+        List<ServiceInstance<Object>> factoryServiceTypeInstances = registry.lookupInstances(factoryServiceTypeLookup);
+        assertThat(factoryServiceTypeInstances, hasSize(1));
+        assertThat(providerType.isInstance(factoryServiceTypeInstances.getFirst().get()), is(true));
+        assertThat(factoryServiceTypeInstances.getFirst()
+                           .contracts()
+                           .contains(ResolvedType.create(providerType)),
+                   is(true));
+    }
+
+    private static void assertViolation(ValidationException result,
+                                        Class<?> serviceType,
+                                        List<PathElement> expectedLocation,
+                                        String expectedMessage,
+                                        Object expectedInvalidValue,
+                                        TypeName expectedAnnotation) {
+        var violations = result.violations();
+
+        assertThat(violations, hasSize(1));
+        var violation = violations.getFirst();
+
+        assertThat(violation.location(), contains(expectedLocation.toArray(PathElement[]::new)));
+        assertThat(violation.message(), containsString(expectedMessage));
+        assertThat(violation.invalidValue(), is(expectedInvalidValue));
+        assertThat(violation.rootType(), sameInstance(serviceType));
+        assertThat(violation.annotation().typeName(), is(expectedAnnotation));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceMethodValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceMethodValidationTest.java
@@ -75,6 +75,7 @@ class InterfaceMethodValidationTest {
         assertThat(new InterfaceConstrainedServiceImpl().validateMinimum(5), is(5));
         assertThat(new InterfaceConstrainedServiceImpl().validateShared(""), is(""));
         assertThat(new InterfaceConstrainedServiceImpl().validateDuplicate(""), is(""));
+        assertThat(new InterfaceConstrainedServiceImpl().validateCustomGroup(""), is(""));
         assertThat(new InterfaceConstrainedServiceImpl().validateGeneric(""), is(""));
         assertThat(new InterfaceConstrainedServiceImpl().validateOrderedGeneric("", 42), is(42));
         assertThat(new InterfaceConstrainedServiceImpl().validateInheritedGeneric(""), is(""));
@@ -111,6 +112,7 @@ class InterfaceMethodValidationTest {
         assertThat(service.validateMinimum(10), is(10));
         assertThat(service.validateShared("valid"), is("valid"));
         assertThat(service.validateDuplicate("valid"), is("valid"));
+        assertThat(service.validateCustomGroup("valid"), is("valid"));
         assertThat(service.validateCustomStringList(List.of("good")), is(List.of("good")));
         assertThat(service.validateCustomIntegerList(List.of(42)), is(List.of(42)));
         assertThat(genericService.validateGeneric("valid"), is("valid"));
@@ -127,6 +129,26 @@ class InterfaceMethodValidationTest {
                         "is blank",
                         "",
                         TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateCustomGroup(""));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateCustomGroup(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is blank",
+                        "",
+                        TypeName.create(Validation.String.NotBlank.class));
+
+        result = assertThrows(ValidationException.class, () -> service.validateCustomGroup(null));
+        assertViolation(result,
+                        InterfaceConstrainedServiceImpl.class,
+                        List.of(PathElement.create(Location.TYPE, InterfaceConstrainedServiceImpl.class.getName()),
+                                PathElement.create(Location.METHOD, "validateCustomGroup(java.lang.String)"),
+                                PathElement.create(Location.PARAMETER, "value")),
+                        "is null",
+                        null,
+                        TypeName.create(Validation.NotNull.class));
 
         result = assertThrows(ValidationException.class, () -> service.validateCustomStringList(List.of("bad")));
         assertViolation(result,

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/IpFactoryProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/IpFactoryProvidedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Contract
+interface IpFactoryProvidedService {
+    @Validation.String.NotBlank
+    String value();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/IpFactoryProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/IpFactoryProvidedServiceProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Singleton
+class IpFactoryProvidedServiceProvider implements Service.InjectionPointFactory<IpFactoryProvidedService> {
+    @Override
+    public Optional<Service.QualifiedInstance<IpFactoryProvidedService>> first(Lookup lookup) {
+        return Optional.of(Service.QualifiedInstance.create(() -> "first"));
+    }
+
+    @Override
+    @Validation.Collection.Size(min = 1)
+    public List<Service.QualifiedInstance<IpFactoryProvidedService>> list(Lookup lookup) {
+        return List.of(Service.QualifiedInstance.create(() -> "list"));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LegacyValidateDefaultInterceptor.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LegacyValidateDefaultInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.service.registry.Interception;
+import io.helidon.service.registry.InterceptionContext;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Named("io.helidon.validation.tests.validation.InterfaceConstrainedServiceImpl.validateDefault(java.lang.String)")
+class LegacyValidateDefaultInterceptor implements Interception.ElementInterceptor {
+    private static final AtomicInteger CALLS = new AtomicInteger();
+
+    static void reset() {
+        CALLS.set(0);
+    }
+
+    static int count() {
+        return CALLS.get();
+    }
+
+    @Override
+    public <V> V proceed(InterceptionContext ctx, Chain<V> chain, Object... args) throws Exception {
+        CALLS.incrementAndGet();
+        return chain.proceed(args);
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LowerMinimumInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LowerMinimumInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface LowerMinimumInterfaceConstrainedService {
+    int validateMinimum(@Validation.Integer.Min(1) int value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface OptionalSupplierProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class OptionalSupplierProvidedInterfaceConstrainedServiceImpl
+        implements OptionalSupplierProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class OptionalSupplierProvidedInterfaceConstrainedServiceProvider
+        implements Supplier<Optional<OptionalSupplierProvidedInterfaceConstrainedService>> {
+    @Override
+    public Optional<OptionalSupplierProvidedInterfaceConstrainedService> get() {
+        return Optional.of(new OptionalSupplierProvidedInterfaceConstrainedServiceImpl());
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OrderedGenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OrderedGenericInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface OrderedGenericInterfaceConstrainedService<K, V> {
+    V validateOrderedGeneric(@Validation.String.NotBlank K key, V value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ParentGenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ParentGenericInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface ParentGenericInterfaceConstrainedService<T> {
+    T validateInheritedGeneric(@Validation.String.NotBlank T value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedConfig.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class PerInstanceInterfaceConstrainedConfig {
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface PerInstanceInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.PerInstance(PerInstanceInterfaceConstrainedConfig.class)
+class PerInstanceInterfaceConstrainedServiceImpl implements PerInstanceInterfaceConstrainedService {
+    @Service.Inject
+    PerInstanceInterfaceConstrainedServiceImpl(PerInstanceInterfaceConstrainedConfig config) {
+    }
+
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryDirectContract.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface QualifiedFactoryDirectContract {
+    Optional<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> first(
+            @Validation.NotNull Qualifier qualifier,
+            @Validation.NotNull Lookup lookup,
+            @Validation.NotNull GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> type);
+
+    @Validation.Collection.Size(2)
+    List<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> list(
+            @Validation.NotNull Qualifier qualifier,
+            @Validation.NotNull Lookup lookup,
+            @Validation.NotNull GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> type);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyBaseProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyBaseProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+abstract class QualifiedFactoryFirstOnlyBaseProvider
+        implements Service.QualifiedFactory<QualifiedFactoryFirstOnlyProvidedService, Service.Named> {
+    @Override
+    public List<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> list(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryFirstOnlyProvidedService> type) {
+        return List.of(Service.QualifiedInstance.create(new QualifiedFactoryFirstOnlyProvidedServiceImpl(), qualifier),
+                       Service.QualifiedInstance.create(new QualifiedFactoryFirstOnlyProvidedServiceImpl(), qualifier));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyDirectContract.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+interface QualifiedFactoryFirstOnlyDirectContract {
+    @Validation.NotNull
+    Optional<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> first(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryFirstOnlyProvidedService> type);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface QualifiedFactoryFirstOnlyProvidedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class QualifiedFactoryFirstOnlyProvidedServiceImpl implements QualifiedFactoryFirstOnlyProvidedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedServiceProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class QualifiedFactoryFirstOnlyProvidedServiceProvider
+        extends QualifiedFactoryFirstOnlyBaseProvider
+        implements Service.QualifiedFactory<QualifiedFactoryFirstOnlyProvidedService, Service.Named>,
+                   QualifiedFactoryFirstOnlyDirectContract {
+    @Override
+    public Optional<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> first(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryFirstOnlyProvidedService> type) {
+        return Optional.of(list(qualifier, lookup, type).getFirst());
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface QualifiedFactoryProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class QualifiedFactoryProvidedInterfaceConstrainedServiceImpl
+        implements QualifiedFactoryProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.Weight;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.RunLevel(43.0)
+@Weight(42.0)
+class QualifiedFactoryProvidedInterfaceConstrainedServiceProvider
+        implements Service.QualifiedFactory<QualifiedFactoryProvidedInterfaceConstrainedService, Service.Named>,
+                   QualifiedFactoryDirectContract {
+    @Override
+    public Optional<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> first(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> type) {
+        return Optional.of(list(qualifier, lookup, type).getFirst());
+    }
+
+    @Override
+    public List<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> list(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryProvidedInterfaceConstrainedService> type) {
+        return List.of(Service.QualifiedInstance.create(new QualifiedFactoryProvidedInterfaceConstrainedServiceImpl(),
+                                                        qualifier),
+                       Service.QualifiedInstance.create(new QualifiedFactoryProvidedInterfaceConstrainedServiceImpl(),
+                                                        qualifier));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Contract
+interface QualifiedFactoryProvidedService {
+    @Validation.String.NotBlank
+    String value();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedServiceProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Singleton
+class QualifiedFactoryProvidedServiceProvider
+        implements Service.QualifiedFactory<QualifiedFactoryProvidedService, QualifiedFactoryQualifier> {
+    @Override
+    public Optional<Service.QualifiedInstance<QualifiedFactoryProvidedService>> first(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryProvidedService> type) {
+        return Optional.of(Service.QualifiedInstance.create(() -> "first", qualifier));
+    }
+
+    @Override
+    @Validation.Collection.Size(min = 1)
+    public List<Service.QualifiedInstance<QualifiedFactoryProvidedService>> list(
+            Qualifier qualifier,
+            Lookup lookup,
+            GenericType<QualifiedFactoryProvidedService> type) {
+        return List.of(Service.QualifiedInstance.create(() -> "list", qualifier));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryQualifier.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryQualifier.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.helidon.service.registry.Service;
+
+@Service.Qualifier
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@interface QualifiedFactoryQualifier {
+    String value();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface ServicesFactoryProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class ServicesFactoryProvidedInterfaceConstrainedServiceImpl
+        implements ServicesFactoryProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class ServicesFactoryProvidedInterfaceConstrainedServiceProvider
+        implements Service.ServicesFactory<ServicesFactoryProvidedInterfaceConstrainedService> {
+    @Override
+    public List<Service.QualifiedInstance<ServicesFactoryProvidedInterfaceConstrainedService>> services() {
+        return List.of(Service.QualifiedInstance.create(new ServicesFactoryProvidedInterfaceConstrainedServiceImpl()));
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProvidedInterfaceConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class SupplierProvidedInterfaceConstrainedServiceImpl implements SupplierProvidedInterfaceConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class SupplierProvidedInterfaceConstrainedServiceProvider
+        implements Supplier<SupplierProvidedInterfaceConstrainedService> {
+    @Override
+    public SupplierProvidedInterfaceConstrainedService get() {
+        return new SupplierProvidedInterfaceConstrainedServiceImpl();
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProvidedSameSignatureInterfaceConstrainedService {
+    @Validation.String.NotBlank
+    String get();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl
+        implements SupplierProvidedSameSignatureInterfaceConstrainedService {
+    @Override
+    public String get() {
+        return "";
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class SupplierProvidedSameSignatureInterfaceConstrainedServiceProvider
+        implements Supplier<SupplierProvidedSameSignatureInterfaceConstrainedService>,
+                   SupplierProvidedSameSignatureProviderContract {
+    @Override
+    public SupplierProvidedSameSignatureInterfaceConstrainedService get() {
+        return new SupplierProvidedSameSignatureInterfaceConstrainedServiceImpl();
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureProviderContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureProviderContract.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProvidedSameSignatureProviderContract {
+    @Validation.NotNull
+    SupplierProvidedSameSignatureInterfaceConstrainedService get();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+
+@Service.Contract
+interface SupplierProvidedService {
+    @Validation.String.NotBlank
+    String get();
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedServiceProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class SupplierProvidedServiceProvider implements Supplier<SupplierProvidedService> {
+    @Override
+    public SupplierProvidedService get() {
+        return () -> "";
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProviderSameSignatureConstrainedService {
+    String validate(@Validation.String.NotBlank String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+class SupplierProviderSameSignatureConstrainedServiceImpl implements SupplierProviderSameSignatureConstrainedService {
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedServiceProvider.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedServiceProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class SupplierProviderSameSignatureConstrainedServiceProvider
+        implements Supplier<SupplierProviderSameSignatureConstrainedService>, SupplierProviderSameSignatureDirectService {
+    @Override
+    public SupplierProviderSameSignatureConstrainedService get() {
+        return new SupplierProviderSameSignatureConstrainedServiceImpl();
+    }
+
+    @Override
+    public String validate(String value) {
+        return value;
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureDirectService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureDirectService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import io.helidon.validation.Validation;
+
+interface SupplierProviderSameSignatureDirectService {
+    String validate(@Validation.String.Pattern("[0-9]+") String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeUseNotBlank.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeUseNotBlank.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import io.helidon.validation.Validation;
+
+@Target(ElementType.TYPE_USE)
+@Validation.String.NotBlank
+@interface TypeUseNotBlank {
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/UnconstrainedDefaultInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/UnconstrainedDefaultInterfaceConstrainedService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+interface UnconstrainedDefaultInterfaceConstrainedService {
+    String validateInheritedDefault(String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/UnconstrainedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/UnconstrainedInterfaceConstrainedService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+interface UnconstrainedInterfaceConstrainedService {
+    String validateShared(String value);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.validation.Validation;
+
+interface ValidInterfaceConstrainedService {
+    String validate(@Validation.Valid ValidatedType value);
+
+    String validateAll(List<? super @Validation.Valid ValidatedType> values);
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedServiceImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.tests.validation;
+
+import java.util.List;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class ValidInterfaceConstrainedServiceImpl implements ValidInterfaceConstrainedService {
+    @Override
+    public String validate(ValidatedType value) {
+        return "ok";
+    }
+
+    @Override
+    public String validateAll(List<? super ValidatedType> values) {
+        return "ok";
+    }
+}

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
@@ -20,7 +20,13 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.GenericType;
 import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.FactoryType;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.testing.junit5.Testing;
 import io.helidon.validation.ConstraintViolation.Location;
 import io.helidon.validation.ConstraintViolation.PathElement;
@@ -40,9 +46,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Testing.Test
 public class ValidationTest {
     private final ValidatedService service;
+    private final InterfaceConstrainedService interfaceConstrainedService;
+    private final SupplierProvidedService supplierProvidedService;
+    private final ServiceRegistry registry;
 
-    public ValidationTest(ValidatedService service) {
+    public ValidationTest(ValidatedService service,
+                          InterfaceConstrainedService interfaceConstrainedService,
+                          SupplierProvidedService supplierProvidedService,
+                          ServiceRegistry registry) {
         this.service = service;
+        this.interfaceConstrainedService = interfaceConstrainedService;
+        this.supplierProvidedService = supplierProvidedService;
+        this.registry = registry;
     }
 
     @Test
@@ -50,6 +65,65 @@ public class ValidationTest {
         var response = service.process(new ValidatedType("good_test_value", 42, new BigDecimal("1.10")));
 
         assertThat(response, is("Good"));
+    }
+
+    @Test
+    public void testInterfaceMethodConstraint() {
+        var response = interfaceConstrainedService.validate("value");
+
+        assertThat(response, is("value"));
+
+        var result = assertThrows(ValidationException.class, () -> interfaceConstrainedService.validate(""));
+
+        assertThat(result.violations(), hasSize(1));
+        assertThat(result.violations().getFirst().message(), containsString("is blank"));
+    }
+
+    @Test
+    public void testSupplierProvidedSameSignatureConstraint() {
+        var result = assertThrows(ValidationException.class, supplierProvidedService::get);
+
+        assertThat(result.violations(), hasSize(1));
+        assertThat(result.violations().getFirst().message(), containsString("is blank"));
+    }
+
+    @Test
+    public void testInjectionPointFactoryUsesCustomizedFirst() {
+        Lookup factoryLookup = Lookup.builder()
+                .addContract(IpFactoryProvidedService.class)
+                .addFactoryType(FactoryType.INJECTION_POINT)
+                .build();
+        @SuppressWarnings("unchecked")
+        Service.InjectionPointFactory<IpFactoryProvidedService> factory = registry.get(factoryLookup);
+
+        Lookup providedLookup = Lookup.builder()
+                .addContract(IpFactoryProvidedService.class)
+                .build();
+
+        assertThat(factory.first(providedLookup).orElseThrow().get().value(), is("first"));
+        assertThat(factory.list(providedLookup).getFirst().get().value(), is("list"));
+    }
+
+    @Test
+    public void testQualifiedFactoryUsesCustomizedFirst() {
+        Lookup factoryLookup = Lookup.builder()
+                .serviceType(QualifiedFactoryProvidedServiceProvider.class)
+                .addFactoryType(FactoryType.QUALIFIED)
+                .build();
+        @SuppressWarnings("unchecked")
+        Service.QualifiedFactory<QualifiedFactoryProvidedService, QualifiedFactoryQualifier> factory =
+                registry.get(factoryLookup);
+
+        Qualifier qualifier = Qualifier.create(QualifiedFactoryQualifier.class, "test");
+        Lookup providedLookup = Lookup.builder()
+                .addContract(QualifiedFactoryProvidedService.class)
+                .addQualifier(qualifier)
+                .build();
+        GenericType<QualifiedFactoryProvidedService> providedType =
+                GenericType.create(QualifiedFactoryProvidedService.class);
+
+        assertThat(factory.first(qualifier, providedLookup, providedType).orElseThrow().get().value(), is("first"));
+        assertThat(factory.list(qualifier, providedLookup, providedType).getFirst().get().value(), is("list"));
     }
 
     @Test

--- a/validation/validation/src/main/java/module-info.java
+++ b/validation/validation/src/main/java/module-info.java
@@ -35,7 +35,9 @@ import io.helidon.common.features.api.HelidonFlavor;
  * <p>
  * To enable interception of validated methods, the method, its parameter, or a generic type argument must be annotated with
  * one of the constraints in {@link io.helidon.validation.Validation} class, or the {@link io.helidon.validation.Validation.Valid}
- * annotation, and the same codegen module must be on the annotation processor path.
+ * annotation, and the same codegen module must be on the annotation processor path. For registry-managed services and
+ * service factories, these annotations may also be declared on non-private instance methods of implemented service contracts.
+ * Validation is applied to instances obtained from the service registry; directly constructed instances are not intercepted.
  * <p>
  * The constraints are grouped (through container classes) based on types that can be constrained.
  * Some constraints are for convenience - such as {@link io.helidon.validation.Validation.Integer.Max} and


### PR DESCRIPTION
Resolves #11866

Forward-ports interface-declared declarative validation support to main, including service-contract constraint discovery, generated validation/interception metadata updates, registry factory wrapper routing, docs, and focused service-registry JMH coverage.
