### PR TITLE
Optimize JSON media writers for fixed-length entities

### DIFF
--- a/http/media/jackson/src/main/java/io/helidon/http/media/jackson/JacksonWriter.java
+++ b/http/media/jackson/src/main/java/io/helidon/http/media/jackson/JacksonWriter.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.media.jackson;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -23,11 +24,15 @@ import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ByteArrayInstanceWriter;
 import io.helidon.http.media.EntityWriterBase;
+import io.helidon.http.media.InstanceWriter;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,6 +44,27 @@ class JacksonWriter<T> extends EntityWriterBase<T> {
     JacksonWriter(JacksonSupportConfig config, ObjectMapper objectMapper) {
         super(config);
         this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public boolean supportsInstanceWriter() {
+        return true;
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type, T object, WritableHeaders<?> requestHeaders) {
+        return ByteArrayInstanceWriter.create(toBytes(type,
+                                                      object,
+                                                      clientRequestContentTypeAndCharset(requestHeaders)));
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type,
+                                         T object,
+                                         Headers requestHeaders,
+                                         WritableHeaders<?> responseHeaders) {
+        var charset = serverResponseContentTypeAndCharset(requestHeaders, responseHeaders);
+        return ByteArrayInstanceWriter.create(toBytes(type, object, charset));
     }
 
     @Override
@@ -99,5 +125,20 @@ class JacksonWriter<T> extends EntityWriterBase<T> {
         } else {
             return objectMapper.writerFor(type.rawType());
         }
+    }
+
+    private byte[] toBytes(GenericType<T> type, T object, Optional<Charset> charset) {
+        if (charset.isEmpty()) {
+            try {
+                return writer(type).writeValueAsBytes(object);
+            } catch (IOException e) {
+                throw new JacksonRuntimeException("Failed to serialize to JSON: " + type, e);
+            }
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        write(type, object, new OutputStreamWriter(baos, charset.get()));
+        return baos.toByteArray();
     }
 }

--- a/http/media/jackson/src/test/java/io/helidon/http/media/jackson/JacksonMediaTest.java
+++ b/http/media/jackson/src/test/java/io/helidon/http/media/jackson/JacksonMediaTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.media.type.MediaTypes;
@@ -36,6 +37,8 @@ import io.helidon.http.HttpMediaType;
 import io.helidon.http.HttpMediaTypes;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaSupport;
 
@@ -48,6 +51,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
@@ -75,11 +79,13 @@ class JacksonMediaTest {
 
         MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, headers);
         assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+        EntityWriter<Book> writer = res.supplier().get();
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(BOOK_TYPE, new Book("test-title"), headers), "test-title");
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-        res.supplier().get()
-                .write(BOOK_TYPE, new Book("test-title"), os, headers);
+        writer.write(BOOK_TYPE, new Book("test-title"), os, headers);
 
         assertThat(headers, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_JSON));
         String result = os.toString(StandardCharsets.UTF_8);
@@ -93,6 +99,24 @@ class JacksonMediaTest {
                 .read(BOOK_TYPE, new ByteArrayInputStream(os.toByteArray()), headers);
 
         assertThat(sanity.getTitle(), is("test-title"));
+    }
+
+    @Test
+    void testWriteServerInstance() {
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+
+        MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, requestHeaders, responseHeaders);
+        assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+        EntityWriter<Book> writer = res.supplier().get();
+
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(BOOK_TYPE,
+                                                   new Book("server-title"),
+                                                   requestHeaders,
+                                                   responseHeaders),
+                             "server-title");
+        assertThat(responseHeaders, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_JSON));
     }
 
     @Test
@@ -292,6 +316,20 @@ class JacksonMediaTest {
                 .read(BOOK_TYPE, is, requestHeaders, responseHeaders));
 
         assertThat(httpException.status(), is(Status.UNSUPPORTED_MEDIA_TYPE_415));
+    }
+
+    private void assertInstanceWriter(InstanceWriter writer, String expectedTitle) {
+        byte[] bytes = writer.instanceBytes();
+        assertThat(writer.alwaysInMemory(), is(true));
+        assertThat(writer.contentLength(), is(OptionalLong.of(bytes.length)));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        writer.write(os);
+        assertArrayEquals(bytes, os.toByteArray());
+
+        String result = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(result, containsString("\"title\""));
+        assertThat(result, containsString("\"" + expectedTitle + "\""));
     }
 
     public static class Book {

--- a/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingWriter.java
+++ b/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingWriter.java
@@ -16,18 +16,22 @@
 
 package io.helidon.http.media.json.binding;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ByteArrayInstanceWriter;
 import io.helidon.http.media.EntityWriterBase;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.json.binding.JsonBinding;
 
 import static java.util.function.Predicate.not;
@@ -39,6 +43,27 @@ class JsonBindingWriter<T> extends EntityWriterBase<T> {
     JsonBindingWriter(JsonBindingSupportConfig config, JsonBinding jsonBinding) {
         super(config);
         this.jsonBinding = jsonBinding;
+    }
+
+    @Override
+    public boolean supportsInstanceWriter() {
+        return true;
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type, T object, WritableHeaders<?> requestHeaders) {
+        return ByteArrayInstanceWriter.create(toBytes(type,
+                                                      object,
+                                                      clientRequestContentTypeAndCharset(requestHeaders)));
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type,
+                                         T object,
+                                         Headers requestHeaders,
+                                         WritableHeaders<?> responseHeaders) {
+        var charset = serverResponseContentTypeAndCharset(requestHeaders, responseHeaders);
+        return ByteArrayInstanceWriter.create(toBytes(type, object, charset));
     }
 
     @Override
@@ -85,5 +110,15 @@ class JsonBindingWriter<T> extends EntityWriterBase<T> {
         }  catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private byte[] toBytes(GenericType<T> type, T object, Optional<Charset> charset) {
+        if (charset.isEmpty() || StandardCharsets.UTF_8.equals(charset.get())) {
+            return jsonBinding.serializeToBytes(object, type);
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        write(type, object, new OutputStreamWriter(baos, charset.get()));
+        return baos.toByteArray();
     }
 }

--- a/http/media/json-binding/src/test/java/io/helidon/http/media/json/binding/JsonBindingMediaTest.java
+++ b/http/media/json-binding/src/test/java/io/helidon/http/media/json/binding/JsonBindingMediaTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.media.type.MediaTypes;
@@ -32,6 +33,8 @@ import io.helidon.http.HttpException;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaSupport;
 import io.helidon.json.binding.Json;
@@ -42,6 +45,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
@@ -68,11 +72,13 @@ class JsonBindingMediaTest {
 
         MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, headers);
         assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+        EntityWriter<Book> writer = res.supplier().get();
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(BOOK_TYPE, new Book("test-title"), headers), "test-title");
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-        res.supplier().get()
-                .write(BOOK_TYPE, new Book("test-title"), os, headers);
+        writer.write(BOOK_TYPE, new Book("test-title"), os, headers);
 
         assertThat(headers, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_JSON));
         String result = os.toString(StandardCharsets.UTF_8);
@@ -86,6 +92,24 @@ class JsonBindingMediaTest {
                 .read(BOOK_TYPE, new ByteArrayInputStream(os.toByteArray()), headers);
 
         assertThat(sanity.getTitle(), is("test-title"));
+    }
+
+    @Test
+    void testWriteServerInstance() {
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+
+        MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, requestHeaders, responseHeaders);
+        assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+        EntityWriter<Book> writer = res.supplier().get();
+
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(BOOK_TYPE,
+                                                   new Book("server-title"),
+                                                   requestHeaders,
+                                                   responseHeaders),
+                             "server-title");
+        assertThat(responseHeaders, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_JSON));
     }
 
     @Test
@@ -228,6 +252,20 @@ class JsonBindingMediaTest {
                 .read(BOOK_TYPE, is, requestHeaders, responseHeaders));
 
         assertThat(httpException.status(), is(Status.UNSUPPORTED_MEDIA_TYPE_415));
+    }
+
+    private void assertInstanceWriter(InstanceWriter writer, String expectedTitle) {
+        byte[] bytes = writer.instanceBytes();
+        assertThat(writer.alwaysInMemory(), is(true));
+        assertThat(writer.contentLength(), is(OptionalLong.of(bytes.length)));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        writer.write(os);
+        assertArrayEquals(bytes, os.toByteArray());
+
+        String result = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(result, containsString("\"title\""));
+        assertThat(result, containsString("\"" + expectedTitle + "\""));
     }
 
     @Json.Entity

--- a/http/media/json/src/main/java/io/helidon/http/media/json/JsonValueWriter.java
+++ b/http/media/json/src/main/java/io/helidon/http/media/json/JsonValueWriter.java
@@ -16,18 +16,22 @@
 
 package io.helidon.http.media.json;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ByteArrayInstanceWriter;
 import io.helidon.http.media.EntityWriterBase;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.json.JsonGenerator;
 import io.helidon.json.JsonValue;
 
@@ -37,6 +41,26 @@ class JsonValueWriter<T extends JsonValue> extends EntityWriterBase<T> {
 
     JsonValueWriter(JsonSupportConfig config) {
         super(config);
+    }
+
+    @Override
+    public boolean supportsInstanceWriter() {
+        return true;
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type, T object, WritableHeaders<?> requestHeaders) {
+        return ByteArrayInstanceWriter.create(toBytes(object,
+                                                      clientRequestContentTypeAndCharset(requestHeaders)));
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type,
+                                         T object,
+                                         Headers requestHeaders,
+                                         WritableHeaders<?> responseHeaders) {
+        var charset = serverResponseContentTypeAndCharset(requestHeaders, responseHeaders);
+        return ByteArrayInstanceWriter.create(toBytes(object, charset));
     }
 
     @Override
@@ -90,5 +114,19 @@ class JsonValueWriter<T extends JsonValue> extends EntityWriterBase<T> {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private byte[] toBytes(T object, Optional<Charset> charset) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Optional<OutputStreamWriter> writer = charset
+                .filter(not(StandardCharsets.UTF_8::equals)) // We don't need writer to be applied for UTF-8
+                .map(it -> new OutputStreamWriter(baos, it));
+
+        if (writer.isPresent()) {
+            write(object, writer.get());
+        } else {
+            write(object, baos);
+        }
+        return baos.toByteArray();
     }
 }

--- a/http/media/json/src/test/java/io/helidon/http/media/json/JsonMediaTest.java
+++ b/http/media/json/src/test/java/io/helidon/http/media/json/JsonMediaTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalLong;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.media.type.MediaTypes;
@@ -33,6 +34,8 @@ import io.helidon.http.HttpMediaType;
 import io.helidon.http.HttpMediaTypes;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaSupport;
 import io.helidon.json.JsonArray;
@@ -43,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
@@ -71,11 +75,16 @@ class JsonMediaTest {
 
         MediaSupport.WriterResponse<JsonObject> res = provider.writer(JSON_OBJECT_TYPE, headers);
         assertThat(res.support(), is(MediaSupport.SupportLevel.SUPPORTED));
+        EntityWriter<JsonObject> writer = res.supplier().get();
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(JSON_OBJECT_TYPE,
+                                                   createObject("test-title"),
+                                                   headers),
+                             "test-title");
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-        res.supplier().get()
-                .write(JSON_OBJECT_TYPE, createObject("test-title"), os, headers);
+        writer.write(JSON_OBJECT_TYPE, createObject("test-title"), os, headers);
 
         assertThat(headers, HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_TYPE, HttpMediaTypes.JSON.text()));
         String result = os.toString(StandardCharsets.UTF_8);
@@ -89,6 +98,26 @@ class JsonMediaTest {
                 .read(JSON_OBJECT_TYPE, new ByteArrayInputStream(os.toByteArray()), headers);
 
         assertThat(sanity.stringValue("title", "wrong"), is("test-title"));
+    }
+
+    @Test
+    void testWriteServerInstance() {
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+
+        MediaSupport.WriterResponse<JsonObject> res = provider.writer(JSON_OBJECT_TYPE,
+                                                                      requestHeaders,
+                                                                      responseHeaders);
+        assertThat(res.support(), is(MediaSupport.SupportLevel.SUPPORTED));
+        EntityWriter<JsonObject> writer = res.supplier().get();
+
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(JSON_OBJECT_TYPE,
+                                                   createObject("server-title"),
+                                                   requestHeaders,
+                                                   responseHeaders),
+                             "server-title");
+        assertThat(responseHeaders, HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_TYPE, HttpMediaTypes.JSON.text()));
     }
 
     @Test
@@ -244,5 +273,19 @@ class JsonMediaTest {
             objects.add(createObject(title));
         }
         return JsonArray.create(objects);
+    }
+
+    private void assertInstanceWriter(InstanceWriter writer, String expectedTitle) {
+        byte[] bytes = writer.instanceBytes();
+        assertThat(writer.alwaysInMemory(), is(true));
+        assertThat(writer.contentLength(), is(OptionalLong.of(bytes.length)));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        writer.write(os);
+        assertArrayEquals(bytes, os.toByteArray());
+
+        String result = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(result, containsString("\"title\""));
+        assertThat(result, containsString("\"" + expectedTitle + "\""));
     }
 }

--- a/http/media/jsonb/src/main/java/io/helidon/http/media/jsonb/JsonbWriter.java
+++ b/http/media/jsonb/src/main/java/io/helidon/http/media/jsonb/JsonbWriter.java
@@ -16,17 +16,21 @@
 
 package io.helidon.http.media.jsonb;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ByteArrayInstanceWriter;
 import io.helidon.http.media.EntityWriterBase;
+import io.helidon.http.media.InstanceWriter;
 
 import jakarta.json.bind.Jsonb;
 
@@ -36,6 +40,27 @@ class JsonbWriter<T> extends EntityWriterBase<T> {
     JsonbWriter(JsonbSupportConfig config, Jsonb jsonb) {
         super(config);
         this.jsonb = jsonb;
+    }
+
+    @Override
+    public boolean supportsInstanceWriter() {
+        return true;
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type, T object, WritableHeaders<?> requestHeaders) {
+        return ByteArrayInstanceWriter.create(toBytes(type,
+                                                      object,
+                                                      clientRequestContentTypeAndCharset(requestHeaders)));
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type,
+                                         T object,
+                                         Headers requestHeaders,
+                                         WritableHeaders<?> responseHeaders) {
+        var charset = serverResponseContentTypeAndCharset(requestHeaders, responseHeaders);
+        return ByteArrayInstanceWriter.create(toBytes(type, object, charset));
     }
 
     @Override
@@ -81,5 +106,16 @@ class JsonbWriter<T> extends EntityWriterBase<T> {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private byte[] toBytes(GenericType<T> type, T object, Optional<Charset> charset) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        if (charset.isPresent()) {
+            write(type, object, new OutputStreamWriter(baos, charset.get()));
+        } else {
+            write(type, object, baos);
+        }
+        return baos.toByteArray();
     }
 }

--- a/http/media/jsonb/src/test/java/io/helidon/http/media/jsonb/JsonbMediaTest.java
+++ b/http/media/jsonb/src/test/java/io/helidon/http/media/jsonb/JsonbMediaTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.media.type.MediaTypes;
@@ -33,6 +34,8 @@ import io.helidon.http.HttpException;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaSupport;
 
@@ -44,6 +47,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
@@ -70,11 +74,13 @@ class JsonbMediaTest {
 
         MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, headers);
         assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+        EntityWriter<Book> writer = res.supplier().get();
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(BOOK_TYPE, new Book("test-title"), headers), "test-title");
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-        res.supplier().get()
-                .write(BOOK_TYPE, new Book("test-title"), os, headers);
+        writer.write(BOOK_TYPE, new Book("test-title"), os, headers);
 
         assertThat(headers, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_JSON));
         String result = os.toString(StandardCharsets.UTF_8);
@@ -88,6 +94,24 @@ class JsonbMediaTest {
                 .read(BOOK_TYPE, new ByteArrayInputStream(os.toByteArray()), headers);
 
         assertThat(sanity.getTitle(), is("test-title"));
+    }
+
+    @Test
+    void testWriteServerInstance() {
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+
+        MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, requestHeaders, responseHeaders);
+        assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+        EntityWriter<Book> writer = res.supplier().get();
+
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(BOOK_TYPE,
+                                                   new Book("server-title"),
+                                                   requestHeaders,
+                                                   responseHeaders),
+                             "server-title");
+        assertThat(responseHeaders, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_JSON));
     }
 
     @Test
@@ -248,6 +272,20 @@ class JsonbMediaTest {
                 .read(BOOK_TYPE, is, requestHeaders, responseHeaders));
 
         assertThat(httpException.status(), is(Status.UNSUPPORTED_MEDIA_TYPE_415));
+    }
+
+    private void assertInstanceWriter(InstanceWriter writer, String expectedTitle) {
+        byte[] bytes = writer.instanceBytes();
+        assertThat(writer.alwaysInMemory(), is(true));
+        assertThat(writer.contentLength(), is(OptionalLong.of(bytes.length)));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        writer.write(os);
+        assertArrayEquals(bytes, os.toByteArray());
+
+        String result = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(result, containsString("\"title\""));
+        assertThat(result, containsString("\"" + expectedTitle + "\""));
     }
 
     public static class Book {

--- a/http/media/jsonp/src/main/java/io/helidon/http/media/jsonp/JsonpWriter.java
+++ b/http/media/jsonp/src/main/java/io/helidon/http/media/jsonp/JsonpWriter.java
@@ -16,16 +16,21 @@
 
 package io.helidon.http.media.jsonp;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ByteArrayInstanceWriter;
 import io.helidon.http.media.EntityWriterBase;
+import io.helidon.http.media.InstanceWriter;
 
 import jakarta.json.JsonStructure;
 import jakarta.json.JsonWriter;
@@ -38,6 +43,26 @@ class JsonpWriter<T extends JsonStructure> extends EntityWriterBase<T> {
         super(config);
 
         this.writerFactory = config.writerFactory();
+    }
+
+    @Override
+    public boolean supportsInstanceWriter() {
+        return true;
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type, T object, WritableHeaders<?> requestHeaders) {
+        return ByteArrayInstanceWriter.create(toBytes(object,
+                                                      clientRequestContentTypeAndCharset(requestHeaders)));
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type,
+                                         T object,
+                                         Headers requestHeaders,
+                                         WritableHeaders<?> responseHeaders) {
+        var charset = serverResponseContentTypeAndCharset(requestHeaders, responseHeaders);
+        return ByteArrayInstanceWriter.create(toBytes(object, charset));
     }
 
     @Override
@@ -79,5 +104,16 @@ class JsonpWriter<T extends JsonStructure> extends EntityWriterBase<T> {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private byte[] toBytes(T object, Optional<Charset> charset) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        if (charset.isPresent()) {
+            write(object, new OutputStreamWriter(baos, charset.get()));
+        } else {
+            write(object, baos);
+        }
+        return baos.toByteArray();
     }
 }

--- a/http/media/jsonp/src/test/java/io/helidon/http/media/jsonp/JsonpMediaTest.java
+++ b/http/media/jsonp/src/test/java/io/helidon/http/media/jsonp/JsonpMediaTest.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.OptionalLong;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
@@ -31,6 +32,8 @@ import io.helidon.http.HttpException;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaSupport;
 
@@ -46,6 +49,7 @@ import static io.helidon.http.media.jsonp.JsonpSupport.JSON_OBJECT_TYPE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
@@ -72,11 +76,16 @@ class JsonpMediaTest {
 
         MediaSupport.WriterResponse<JsonObject> res = provider.writer(JSON_OBJECT_TYPE, headers);
         assertThat(res.support(), is(MediaSupport.SupportLevel.SUPPORTED));
+        EntityWriter<JsonObject> writer = res.supplier().get();
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(JSON_OBJECT_TYPE,
+                                                   createObject("test-title"),
+                                                   headers),
+                             "test-title");
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-        res.supplier().get()
-                .write(JSON_OBJECT_TYPE, createObject("test-title"), os, headers);
+        writer.write(JSON_OBJECT_TYPE, createObject("test-title"), os, headers);
 
         assertThat(headers, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_JSON));
         String result = os.toString(StandardCharsets.UTF_8);
@@ -90,6 +99,26 @@ class JsonpMediaTest {
                 .read(JSON_OBJECT_TYPE, new ByteArrayInputStream(os.toByteArray()), headers);
 
         assertThat(sanity.getString("title"), is("test-title"));
+    }
+
+    @Test
+    void testWriteServerInstance() {
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+
+        MediaSupport.WriterResponse<JsonObject> res = provider.writer(JSON_OBJECT_TYPE,
+                                                                      requestHeaders,
+                                                                      responseHeaders);
+        assertThat(res.support(), is(MediaSupport.SupportLevel.SUPPORTED));
+        EntityWriter<JsonObject> writer = res.supplier().get();
+
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(JSON_OBJECT_TYPE,
+                                                   createObject("server-title"),
+                                                   requestHeaders,
+                                                   responseHeaders),
+                             "server-title");
+        assertThat(responseHeaders, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_JSON));
     }
 
     @Test
@@ -246,5 +275,19 @@ class JsonpMediaTest {
         }
 
         return arrayBuilder.build();
+    }
+
+    private void assertInstanceWriter(InstanceWriter writer, String expectedTitle) {
+        byte[] bytes = writer.instanceBytes();
+        assertThat(writer.alwaysInMemory(), is(true));
+        assertThat(writer.contentLength(), is(OptionalLong.of(bytes.length)));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        writer.write(os);
+        assertArrayEquals(bytes, os.toByteArray());
+
+        String result = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(result, containsString("\"title\""));
+        assertThat(result, containsString("\"" + expectedTitle + "\""));
     }
 }

--- a/http/media/media/src/main/java/io/helidon/http/media/ByteArrayInstanceWriter.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/ByteArrayInstanceWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.media;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/**
+ * {@link InstanceWriter} for bytes already materialized in memory.
+ */
+public final class ByteArrayInstanceWriter implements InstanceWriter {
+    private final byte[] instanceBytes;
+
+    private ByteArrayInstanceWriter(byte[] instanceBytes) {
+        this.instanceBytes = Objects.requireNonNull(instanceBytes);
+    }
+
+    /**
+     * Create a new instance writer for bytes already materialized in memory.
+     *
+     * @param instanceBytes bytes to write
+     * @return byte array instance writer
+     */
+    public static ByteArrayInstanceWriter create(byte[] instanceBytes) {
+        return new ByteArrayInstanceWriter(instanceBytes);
+    }
+
+    @Override
+    public OptionalLong contentLength() {
+        return OptionalLong.of(instanceBytes.length);
+    }
+
+    @Override
+    public boolean alwaysInMemory() {
+        return true;
+    }
+
+    @Override
+    public void write(OutputStream stream) {
+        try (stream) {
+            stream.write(instanceBytes);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public byte[] instanceBytes() {
+        return instanceBytes;
+    }
+}

--- a/http/media/smile/src/main/java/io/helidon/http/media/json/smile/SmileWriter.java
+++ b/http/media/smile/src/main/java/io/helidon/http/media/json/smile/SmileWriter.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.media.json.smile;
 
+import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 
 import io.helidon.common.GenericType;
@@ -24,7 +25,9 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ByteArrayInstanceWriter;
 import io.helidon.http.media.EntityWriterBase;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.json.JsonGenerator;
 import io.helidon.json.binding.JsonBinding;
 import io.helidon.json.smile.SmileConfig;
@@ -42,6 +45,26 @@ class SmileWriter<T> extends EntityWriterBase<T> {
         this.smileConfig = config.smileConfig();
         this.contentType = HeaderValues.create(HeaderNames.CONTENT_TYPE,
                                                config.contentType().text());
+    }
+
+    @Override
+    public boolean supportsInstanceWriter() {
+        return true;
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type, T object, WritableHeaders<?> requestHeaders) {
+        requestHeaders.setIfAbsent(contentType);
+        return ByteArrayInstanceWriter.create(toBytes(type, object));
+    }
+
+    @Override
+    public InstanceWriter instanceWriter(GenericType<T> type,
+                                         T object,
+                                         Headers requestHeaders,
+                                         WritableHeaders<?> responseHeaders) {
+        responseHeaders.setIfAbsent(contentType);
+        return ByteArrayInstanceWriter.create(toBytes(type, object));
     }
 
     @Override
@@ -64,5 +87,11 @@ class SmileWriter<T> extends EntityWriterBase<T> {
         try (JsonGenerator generator = SmileGenerator.create(out, smileConfig)) {
             jsonBinding.serialize(generator, object, type);
         }
+    }
+
+    private byte[] toBytes(GenericType<T> type, T object) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        write(object, baos, type);
+        return baos.toByteArray();
     }
 }

--- a/http/media/smile/src/test/java/io/helidon/http/media/json/smile/SmileMediaTest.java
+++ b/http/media/smile/src/test/java/io/helidon/http/media/json/smile/SmileMediaTest.java
@@ -21,12 +21,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaSupport;
 import io.helidon.json.JsonGenerator;
@@ -62,11 +65,13 @@ class SmileMediaTest {
 
         MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, headers);
         assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+        EntityWriter<Book> writer = res.supplier().get();
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(BOOK_TYPE, new Book("test-title"), headers), headers, "test-title");
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-        res.supplier().get()
-                .write(BOOK_TYPE, new Book("test-title"), os, headers);
+        writer.write(BOOK_TYPE, new Book("test-title"), os, headers);
 
         byte[] expected = concat(SMILE_HEADER_DEFAULT,
                                  new byte[] {(byte) 0xFA, (byte) 0x84, 't', 'i', 't', 'l', 'e', (byte) 0x49,
@@ -82,6 +87,25 @@ class SmileMediaTest {
                 .read(BOOK_TYPE, new ByteArrayInputStream(os.toByteArray()), headers);
 
         assertThat(sanity.getTitle(), is("test-title"));
+    }
+
+    @Test
+    void testWriteServerInstance() {
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+
+        MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, requestHeaders, responseHeaders);
+        assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+        EntityWriter<Book> writer = res.supplier().get();
+
+        assertThat(writer.supportsInstanceWriter(), is(true));
+        assertInstanceWriter(writer.instanceWriter(BOOK_TYPE,
+                                                   new Book("server-title"),
+                                                   requestHeaders,
+                                                   responseHeaders),
+                             responseHeaders,
+                             "server-title");
+        assertThat(responseHeaders, HttpHeaderMatcher.hasHeader(HeaderValues.CONTENT_TYPE_SMILE));
     }
 
     @Test
@@ -380,6 +404,23 @@ class SmileMediaTest {
         System.arraycopy(first, 0, out, 0, first.length);
         System.arraycopy(second, 0, out, first.length, second.length);
         return out;
+    }
+
+    private void assertInstanceWriter(InstanceWriter writer, WritableHeaders<?> headers, String expectedTitle) {
+        byte[] bytes = writer.instanceBytes();
+        assertThat(writer.alwaysInMemory(), is(true));
+        assertThat(writer.contentLength(), is(OptionalLong.of(bytes.length)));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        writer.write(os);
+        assertArrayEquals(bytes, os.toByteArray());
+
+        Book sanity = support.reader(BOOK_TYPE, headers)
+                .supplier()
+                .get()
+                .read(BOOK_TYPE, new ByteArrayInputStream(bytes), headers);
+
+        assertThat(sanity.getTitle(), is(expectedTitle));
     }
 
     @Json.Entity

--- a/http/tests/media/jsonb/src/test/java/io/helidon/http/tests/integration/media/jsonb/JsonbTest.java
+++ b/http/tests/media/jsonb/src/test/java/io/helidon/http/tests/integration/media/jsonb/JsonbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
@@ -49,6 +50,12 @@ class JsonbTest {
     @SetUpRoute
     static void routing(HttpRouting.Builder router) {
         router.get("/jsonb", (req, res) -> res.send(MESSAGE))
+                .post("/jsonb/request-framing", (req, res) -> {
+                    req.content().as(JsonbMessage.class);
+                    long contentLength = req.headers().contentLength().orElse(-1);
+                    boolean transferEncoding = req.headers().contains(HeaderNames.TRANSFER_ENCODING);
+                    res.send(new JsonbMessage(contentLength + ":" + transferEncoding));
+                })
                 .post("/jsonb", (req, res) -> {
                     JsonbMessage message = req.content().as(JsonbMessage.class);
                     res.send(new JsonbMessage(message.message));
@@ -65,6 +72,12 @@ class JsonbTest {
                 () -> assertThat("Should contain content type application/json",
                                  response.headers().contentType(),
                                  is(Optional.of(HttpMediaType.create(MediaTypes.APPLICATION_JSON)))),
+                () -> assertThat("Should contain content length",
+                                 response.headers().contentLength().isPresent(),
+                                 is(true)),
+                () -> assertThat("Should not use chunked encoding",
+                                 response.headers().contains(HeaderNames.TRANSFER_ENCODING),
+                                 is(false)),
                 () -> assertThat(response.as(JsonbMessage.class), is(MESSAGE)));
     }
 
@@ -80,6 +93,22 @@ class JsonbTest {
                                  response.headers().contentType(),
                                  is(Optional.of(HttpMediaType.create(MediaTypes.APPLICATION_JSON)))),
                 () -> assertThat(response.as(JsonbMessage.class), is(MESSAGE)));
+    }
+
+    @Test
+    void testPostUsesContentLength() {
+        Http1ClientResponse response = client.method(Method.POST)
+                .uri("/jsonb/request-framing")
+                .submit(MESSAGE);
+
+        String[] framing = response.as(JsonbMessage.class).message.split(":");
+
+        assertAll(
+                () -> assertThat(response.status(), is(Status.OK_200)),
+                () -> assertThat(Long.parseLong(framing[0]) > 0, is(true)),
+                () -> assertThat("Should not use chunked encoding",
+                                 Boolean.parseBoolean(framing[1]),
+                                 is(false)));
     }
 
     public static class JsonbMessage {

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -45,6 +45,22 @@
             <artifactId>helidon-webclient-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-json-binding</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-json-smile</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
         </dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/MediaWriterJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/MediaWriterJmhTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+import io.helidon.common.GenericType;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.MediaContext;
+import io.helidon.http.media.MediaSupport;
+import io.helidon.http.media.jackson.JacksonSupport;
+import io.helidon.http.media.json.binding.JsonBindingSupport;
+import io.helidon.http.media.json.smile.SmileSupport;
+import io.helidon.http.media.jsonb.JsonbSupport;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+public class MediaWriterJmhTest {
+    private static final GenericType<Map<String, String>> MESSAGE_TYPE = new GenericType<>() { };
+    private static final int SMALL_PAYLOAD_SIZE = 128;
+    private static final int LARGE_PAYLOAD_SIZE = 196_608;
+
+    @Param({"json-binding", "jsonb", "jackson", "smile"})
+    private String media;
+
+    @Param({"small", "large"})
+    private String payloadSize;
+
+    private EntityWriter<Map<String, String>> writer;
+    private Map<String, String> message;
+
+    @Setup
+    public void setup() {
+        MediaSupport support = mediaSupport();
+        support.init(MediaContext.create());
+
+        writer = support.writer(MESSAGE_TYPE, WritableHeaders.create()).supplier().get();
+        message = Map.of("framework", "json-binding",
+                         "media", media,
+                         "text", "a".repeat(payloadSize()),
+                         "index", "42");
+    }
+
+    @Benchmark
+    public void writeToStream(Blackhole bh) {
+        writer.write(MESSAGE_TYPE, message, new BlackholeOutputStream(bh), WritableHeaders.create());
+    }
+
+    @Benchmark
+    public void instanceBytes(Blackhole bh) {
+        bh.consume(writer.instanceWriter(MESSAGE_TYPE, message, WritableHeaders.create())
+                           .instanceBytes());
+    }
+
+    private MediaSupport mediaSupport() {
+        return switch (media) {
+            case "json-binding" -> JsonBindingSupport.create();
+            case "jsonb" -> JsonbSupport.create();
+            case "jackson" -> JacksonSupport.create();
+            case "smile" -> SmileSupport.create();
+            default -> throw new IllegalArgumentException("Unsupported media: " + media);
+        };
+    }
+
+    private int payloadSize() {
+        return switch (payloadSize) {
+            case "small" -> SMALL_PAYLOAD_SIZE;
+            case "large" -> LARGE_PAYLOAD_SIZE;
+            default -> throw new IllegalArgumentException("Unsupported payload size: " + payloadSize);
+        };
+    }
+
+    private static final class BlackholeOutputStream extends OutputStream {
+        private final Blackhole blackhole;
+        private long bytes;
+
+        private BlackholeOutputStream(Blackhole blackhole) {
+            this.blackhole = blackhole;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            bytes++;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            bytes += len;
+        }
+
+        @Override
+        public void close() throws IOException {
+            blackhole.consume(bytes);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #12037

Adds byte-backed instance writers for JSON media providers so JSON Binding, Helidon JSON, JSON-B, JSON-P, Jackson, and Smile can provide fixed-length HTTP entities when serialized bytes are materialized in memory.

This changes normal JSON and Smile request and response framing from chunked streaming to fixed-length framing when the writer can materialize bytes. The entity object is already in memory; the serialized bytes are retained long enough for the HTTP layer to send them, so large or encoded responses can temporarily hold additional materialized data.

HttpArena JSON Binding 45 second measurement:

| Variant | Framing | Throughput | Avg latency | p50 | p90 | p99 | 2xx responses |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Original | `Transfer-Encoding: chunked` | 82.93K req/s | 39.80ms | 41.00ms | 42.00ms | 43.90ms | 3,732,096 |
| Target solution | `Content-Length` | 368.91K req/s | 6.16ms | 59us | 41.00ms | 43.90ms | 16,602,357 |

Adds writer-level coverage for instance bytes, HTTP/1 JSON-B request and response framing checks, and JMH coverage for JSON Binding, JSON-B, Jackson, and Smile across small and large payloads.
