### PR TITLE
Replace JSON-P with Helidon JSON in MongoDB dbclient

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -137,7 +137,7 @@ See full text at the bottom of this document for license: GPLv2-CPE
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 Eclipse Parsson  Eclipse Foundation
 Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-dbclient-mongodb, helidon-graal-native-image-extension, helidon-http-media-jsonp, helidon-lra-coordinator-server, helidon-mp-graal-native-image-extension, helidon-security-jwt]
+Used by: [helidon-graal-native-image-extension, helidon-http-media-jsonp, helidon-lra-coordinator-server, helidon-mp-graal-native-image-extension, helidon-security-jwt]
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 Eclipse Parsson (org.eclipse.parsson:parsson)
  Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.

--- a/dbclient/mongodb/pom.xml
+++ b/dbclient/mongodb/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>helidon-common-mapper</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
         </dependency>

--- a/dbclient/mongodb/pom.xml
+++ b/dbclient/mongodb/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>mongodb-driver-sync</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.parsson</groupId>
-            <artifactId>parsson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatement.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatement.java
@@ -254,8 +254,7 @@ abstract class MongoDbStatement<S extends DbStatement<S>> extends DbStatementBas
                 || value instanceof Boolean
                 || value instanceof Character
                 || value instanceof Enum<?>
-                || value instanceof JsonValue
-                || value instanceof jakarta.json.JsonValue;
+                || value instanceof JsonValue;
     }
 
     private record NamedParameter(Object value, Map<String, Object> flattenedValues) {

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatement.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatement.java
@@ -17,6 +17,7 @@ package io.helidon.dbclient.mongodb;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,9 +34,12 @@ import io.helidon.dbclient.DbStatement;
 import io.helidon.dbclient.DbStatementBase;
 import io.helidon.dbclient.DbStatementParameters;
 import io.helidon.dbclient.DbStatementType;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonNull;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 
 import com.mongodb.client.MongoDatabase;
-import jakarta.json.Json;
 import org.bson.Document;
 
 import static io.helidon.dbclient.mongodb.MongoDbStatement.MongoOperation.COMMAND;
@@ -56,7 +60,7 @@ abstract class MongoDbStatement<S extends DbStatement<S>> extends DbStatementBas
     /**
      * Empty JSON object.
      */
-    static final Document EMPTY = Document.parse(Json.createObjectBuilder().build().toString());
+    static final Document EMPTY = new Document();
 
     /**
      * Operation JSON parameter name.
@@ -122,6 +126,20 @@ abstract class MongoDbStatement<S extends DbStatement<S>> extends DbStatementBas
             return StatementParsers.namedParser(statement, prepareNamedParameters(named)).convert();
         }
         return statement;
+    }
+
+    @Override
+    public S params(Object... parameters) {
+        if (parameters.length == 1) {
+            Object parameter = parameters[0];
+            if (parameter instanceof JsonObject jsonObject) {
+                return paramsJsonObject(jsonObject);
+            }
+            if (parameter instanceof JsonArray jsonArray) {
+                return paramsJsonArray(jsonArray);
+            }
+        }
+        return params(Arrays.asList(parameters));
     }
 
     private Map<String, Object> prepareNamedParameters(DbNamedStatementParameters named) {
@@ -194,6 +212,17 @@ abstract class MongoDbStatement<S extends DbStatement<S>> extends DbStatementBas
         return normalized;
     }
 
+    private S paramsJsonObject(JsonObject parameters) {
+        parameters.keysAsStrings()
+                .forEach(name -> addParam(name, parameters.value(name).orElse(JsonNull.instance())));
+        return identity();
+    }
+
+    private S paramsJsonArray(JsonArray parameters) {
+        parameters.values().forEach(this::addParam);
+        return identity();
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> mappedValue(Object value) {
         Class<Object> valueClass = (Class<Object>) value.getClass();
@@ -225,6 +254,7 @@ abstract class MongoDbStatement<S extends DbStatement<S>> extends DbStatementBas
                 || value instanceof Boolean
                 || value instanceof Character
                 || value instanceof Enum<?>
+                || value instanceof JsonValue
                 || value instanceof jakarta.json.JsonValue;
     }
 

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatement.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatement.java
@@ -17,7 +17,6 @@ package io.helidon.dbclient.mongodb;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,9 +33,6 @@ import io.helidon.dbclient.DbStatement;
 import io.helidon.dbclient.DbStatementBase;
 import io.helidon.dbclient.DbStatementParameters;
 import io.helidon.dbclient.DbStatementType;
-import io.helidon.json.JsonArray;
-import io.helidon.json.JsonNull;
-import io.helidon.json.JsonObject;
 import io.helidon.json.JsonValue;
 
 import com.mongodb.client.MongoDatabase;
@@ -128,20 +124,6 @@ abstract class MongoDbStatement<S extends DbStatement<S>> extends DbStatementBas
         return statement;
     }
 
-    @Override
-    public S params(Object... parameters) {
-        if (parameters.length == 1) {
-            Object parameter = parameters[0];
-            if (parameter instanceof JsonObject jsonObject) {
-                return paramsJsonObject(jsonObject);
-            }
-            if (parameter instanceof JsonArray jsonArray) {
-                return paramsJsonArray(jsonArray);
-            }
-        }
-        return params(Arrays.asList(parameters));
-    }
-
     private Map<String, Object> prepareNamedParameters(DbNamedStatementParameters named) {
         Map<String, Object> params = new LinkedHashMap<>(named.parameters().size());
         Map<String, Object> flattened = new LinkedHashMap<>();
@@ -210,17 +192,6 @@ abstract class MongoDbStatement<S extends DbStatement<S>> extends DbStatementBas
             normalized.add(normalizeParameter(Array.get(value, i)));
         }
         return normalized;
-    }
-
-    private S paramsJsonObject(JsonObject parameters) {
-        parameters.keysAsStrings()
-                .forEach(name -> addParam(name, parameters.value(name).orElse(JsonNull.instance())));
-        return identity();
-    }
-
-    private S paramsJsonArray(JsonArray parameters) {
-        parameters.values().forEach(this::addParam);
-        return identity();
     }
 
     @SuppressWarnings("unchecked")

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatementGet.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatementGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,12 @@ public class MongoDbStatementGet extends MongoDbStatement<DbStatementGet> implem
 
     @Override
     public MongoDbStatementGet params(Map<String, ?> parameters) {
+        theQuery.params(parameters);
+        return this;
+    }
+
+    @Override
+    public MongoDbStatementGet params(Object... parameters) {
         theQuery.params(parameters);
         return this;
     }

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatementGet.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbStatementGet.java
@@ -62,12 +62,6 @@ public class MongoDbStatementGet extends MongoDbStatement<DbStatementGet> implem
     }
 
     @Override
-    public MongoDbStatementGet params(Object... parameters) {
-        theQuery.params(parameters);
-        return this;
-    }
-
-    @Override
     public MongoDbStatementGet namedParam(Object parameters) {
         theQuery.namedParam(parameters);
         return this;

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/StatementParsers.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/StatementParsers.java
@@ -25,8 +25,10 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import jakarta.json.Json;
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonNull;
+import io.helidon.json.JsonNumber;
+import io.helidon.json.JsonString;
+import io.helidon.json.JsonValue;
 
 /**
  * Statement parameter parsers.
@@ -46,9 +48,12 @@ final class StatementParsers {
      */
     static String toJson(Object value) {
         if (value == null) {
-            return JsonValue.NULL.toString();
+            return JsonNull.instance().toString();
         }
         if (value instanceof JsonValue jsonValue) {
+            return jsonValue.toString();
+        }
+        if (value instanceof jakarta.json.JsonValue jsonValue) {
             return jsonValue.toString();
         }
         if (value instanceof Map<?, ?> map) {
@@ -61,19 +66,19 @@ final class StatementParsers {
             return toJsonArray(value);
         }
         if ((value instanceof Integer) || (value instanceof Short) || (value instanceof Byte)) {
-            return Json.createValue(((Number) value).intValue()).toString();
+            return JsonNumber.create(((Number) value).longValue()).toString();
         }
         if (value instanceof Long) {
-            return Json.createValue((Long) value).toString();
+            return JsonNumber.create((Long) value).toString();
         }
         if ((value instanceof Double) || (value instanceof Float)) {
-            return Json.createValue(((Number) value).doubleValue()).toString();
+            return JsonNumber.create(((Number) value).doubleValue()).toString();
         }
         if (value instanceof BigInteger) {
-            return Json.createValue((BigInteger) value).toString();
+            return value.toString();
         }
         if (value instanceof BigDecimal) {
-            return Json.createValue((BigDecimal) value).toString();
+            return value.toString();
         }
         if (value instanceof Boolean) {
             return value.toString();
@@ -83,7 +88,7 @@ final class StatementParsers {
             return value.toString();
         }
         // String.valueOf handles null value
-        return Json.createValue(String.valueOf(value)).toString();
+        return JsonString.create(String.valueOf(value)).toString();
     }
 
     private static String toJsonObject(Map<?, ?> value) {
@@ -91,7 +96,7 @@ final class StatementParsers {
         Iterator<? extends Map.Entry<?, ?>> iterator = value.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<?, ?> entry = iterator.next();
-            builder.append(Json.createValue(String.valueOf(entry.getKey())));
+            builder.append(JsonString.create(String.valueOf(entry.getKey())));
             builder.append(':');
             builder.append(toJson(entry.getValue()));
             if (iterator.hasNext()) {

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/StatementParsers.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/StatementParsers.java
@@ -53,9 +53,6 @@ final class StatementParsers {
         if (value instanceof JsonValue jsonValue) {
             return jsonValue.toString();
         }
-        if (value instanceof jakarta.json.JsonValue jsonValue) {
-            return jsonValue.toString();
-        }
         if (value instanceof Map<?, ?> map) {
             return toJsonObject(map);
         }

--- a/dbclient/mongodb/src/main/java/module-info.java
+++ b/dbclient/mongodb/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ module io.helidon.dbclient.mongodb {
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.dbclient;
+    requires io.helidon.json;
     requires transitive jakarta.json;
 
     exports io.helidon.dbclient.mongodb;

--- a/dbclient/mongodb/src/main/java/module-info.java
+++ b/dbclient/mongodb/src/main/java/module-info.java
@@ -35,7 +35,6 @@ module io.helidon.dbclient.mongodb {
 
     requires transitive io.helidon.dbclient;
     requires io.helidon.json;
-    requires transitive jakarta.json;
 
     exports io.helidon.dbclient.mongodb;
 

--- a/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/MongoDbClientTest.java
+++ b/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/MongoDbClientTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
-import io.helidon.dbclient.DbClient;
 import io.helidon.dbclient.DbClientService;
 import io.helidon.dbclient.DbClientServiceContext;
 import io.helidon.dbclient.DbExecute;
@@ -304,7 +303,7 @@ class MongoDbClientTest {
                 .set("id", 54)
                 .set("name", "Psyduck")
                 .build();
-        DbClient dbClient = createClient(collection, null);
+        MongoDbClient dbClient = createClient(collection, null);
         long result = dbClient.execute()
                 .createInsert("""
                                       {
@@ -326,64 +325,13 @@ class MongoDbClientTest {
     }
 
     @Test
-    void testHelidonJsonParamsDml() {
-        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
-        JsonObject parameters = JsonObject.builder()
-                .set("id", 143)
-                .set("name", "Snorlax")
-                .build();
-        DbClient dbClient = createClient(collection, null);
-        long result = dbClient.execute()
-                .createInsert("""
-                                      {
-                                        "collection": "foo",
-                                        "operation": "insert",
-                                        "value": {
-                                          "id": $id,
-                                          "name": $name
-                                        }
-                                      }
-                                      """)
-                .params(parameters)
-                .execute();
-
-        assertThat(result, is(1L));
-        assertInsertedPokemon(collection, 143, "Snorlax");
-    }
-
-    @Test
-    void testHelidonJsonIndexedParamsDml() {
-        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
-        JsonArray parameters = JsonArray.create(
-                JsonNumber.create(7),
-                JsonString.create("Squirtle"));
-        DbClient dbClient = createClient(collection, null);
-        long result = dbClient.execute()
-                .createInsert("""
-                                      {
-                                        "collection": "foo",
-                                        "operation": "insert",
-                                        "value": {
-                                          "id": ?,
-                                          "name": ?
-                                        }
-                                      }
-                                      """)
-                .params(parameters)
-                .execute();
-
-        assertThat(result, is(1L));
-        assertInsertedPokemon(collection, 7, "Squirtle");
-    }
-
-    @Test
     void testHelidonJsonAddParamDml() {
         MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
         JsonObject pokemon = JsonObject.builder()
                 .set("id", 175)
                 .set("name", "Togepi")
                 .build();
-        DbClient dbClient = createClient(collection, null);
+        MongoDbClient dbClient = createClient(collection, null);
         long result = dbClient.execute()
                 .createInsert("""
                                       {
@@ -400,26 +348,73 @@ class MongoDbClientTest {
     }
 
     @Test
-    void testHelidonJsonParamsGet() {
+    void testHelidonJsonParamsObjectDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        JsonObject pokemon = JsonObject.builder()
+                .set("id", 143)
+                .set("name", "Snorlax")
+                .build();
+        MongoDbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": ?
+                                      }
+                                      """)
+                .params(pokemon)
+                .execute();
+
+        assertThat(result, is(1L));
+        assertInsertedPokemon(collection, 143, "Snorlax");
+    }
+
+    @Test
+    void testHelidonJsonParamsArrayDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        JsonArray team = JsonArray.create(
+                JsonNumber.create(25),
+                JsonString.create("Pikachu"));
+        MongoDbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": { "team": ? }
+                                      }
+                                      """)
+                .params(team)
+                .execute();
+
+        assertThat(result, is(1L));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(collection).insertOne(captor.capture());
+        assertThat(captor.getValue().getList("team", Object.class), is(List.of(25, "Pikachu")));
+    }
+
+    @Test
+    void testHelidonJsonParamsObjectGet() {
         MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
         FindIterable<Document> finder = Mockito.mock(FindIterable.class);
         MongoCursor<Document> cursor = Mockito.mock(MongoCursor.class);
         when(collection.find(any(Bson.class))).thenReturn(finder);
         when(finder.iterator()).thenReturn(cursor);
         when(cursor.hasNext()).thenReturn(false);
-        JsonObject parameters = JsonObject.builder()
+        JsonObject query = JsonObject.builder()
                 .set("id", 133)
                 .build();
-        DbClient dbClient = createClient(collection, null);
-        Optional<DbRow> result = dbClient.execute()
+        Optional<DbRow> result = createClient(collection, null).execute()
                 .createGet("""
                                    {
                                      "collection": "foo",
                                      "operation": "query",
-                                     "query": { "id": $id }
+                                     "query": ?
                                    }
                                    """)
-                .params(parameters)
+                .params(query)
                 .execute();
 
         assertThat(result.isEmpty(), is(true));
@@ -427,40 +422,6 @@ class MongoDbClientTest {
         ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
         verify(collection).find(captor.capture());
         assertThat(captor.getValue().getInteger("id"), is(133));
-    }
-
-    @Test
-    void testHelidonJsonIndexedParamsGet() {
-        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
-        FindIterable<Document> finder = Mockito.mock(FindIterable.class);
-        MongoCursor<Document> cursor = Mockito.mock(MongoCursor.class);
-        when(collection.find(any(Bson.class))).thenReturn(finder);
-        when(finder.iterator()).thenReturn(cursor);
-        when(cursor.hasNext()).thenReturn(false);
-        JsonArray parameters = JsonArray.create(
-                JsonNumber.create(25),
-                JsonString.create("Pikachu"));
-        DbClient dbClient = createClient(collection, null);
-        Optional<DbRow> result = dbClient.execute()
-                .createGet("""
-                                   {
-                                     "collection": "foo",
-                                     "operation": "query",
-                                     "query": {
-                                       "id": ?,
-                                       "name": ?
-                                     }
-                                   }
-                                   """)
-                .params(parameters)
-                .execute();
-
-        assertThat(result.isEmpty(), is(true));
-
-        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
-        verify(collection).find(captor.capture());
-        assertThat(captor.getValue().getInteger("id"), is(25));
-        assertThat(captor.getValue().getString("name"), is("Pikachu"));
     }
 
     @Test

--- a/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/MongoDbClientTest.java
+++ b/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/MongoDbClientTest.java
@@ -46,7 +46,6 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 
-import jakarta.json.Json;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.BeforeAll;
@@ -462,81 +461,6 @@ class MongoDbClientTest {
         verify(collection).find(captor.capture());
         assertThat(captor.getValue().getInteger("id"), is(25));
         assertThat(captor.getValue().getString("name"), is("Pikachu"));
-    }
-
-    @Test
-    void testJsonProcessingParamsDml() {
-        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
-        jakarta.json.JsonObject parameters = Json.createObjectBuilder()
-                .add("id", 94)
-                .add("name", "Gengar")
-                .build();
-        DbClient dbClient = createClient(collection, null);
-        long result = dbClient.execute()
-                .createInsert("""
-                                      {
-                                        "collection": "foo",
-                                        "operation": "insert",
-                                        "value": {
-                                          "id": $id,
-                                          "name": $name
-                                        }
-                                      }
-                                      """)
-                .params(parameters)
-                .execute();
-
-        assertThat(result, is(1L));
-        assertInsertedPokemon(collection, 94, "Gengar");
-    }
-
-    @Test
-    void testJsonProcessingIndexedParamsDml() {
-        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
-        jakarta.json.JsonArray parameters = Json.createArrayBuilder()
-                .add(129)
-                .add("Magikarp")
-                .build();
-        DbClient dbClient = createClient(collection, null);
-        long result = dbClient.execute()
-                .createInsert("""
-                                      {
-                                        "collection": "foo",
-                                        "operation": "insert",
-                                        "value": {
-                                          "id": ?,
-                                          "name": ?
-                                        }
-                                      }
-                                      """)
-                .params(parameters)
-                .execute();
-
-        assertThat(result, is(1L));
-        assertInsertedPokemon(collection, 129, "Magikarp");
-    }
-
-    @Test
-    void testJsonProcessingAddParamDml() {
-        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
-        jakarta.json.JsonValue parameter = Json.createObjectBuilder()
-                .add("id", 147)
-                .add("name", "Dratini")
-                .build();
-        DbClient dbClient = createClient(collection, null);
-        long result = dbClient.execute()
-                .createInsert("""
-                                      {
-                                        "collection": "foo",
-                                        "operation": "insert",
-                                        "value": ?
-                                      }
-                                      """)
-                .addParam(parameter)
-                .execute();
-
-        assertThat(result, is(1L));
-        assertInsertedPokemon(collection, 147, "Dratini");
     }
 
     @Test

--- a/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/MongoDbClientTest.java
+++ b/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/MongoDbClientTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
+import io.helidon.dbclient.DbClient;
 import io.helidon.dbclient.DbClientService;
 import io.helidon.dbclient.DbClientServiceContext;
 import io.helidon.dbclient.DbExecute;
@@ -34,11 +35,20 @@ import io.helidon.dbclient.DbMapper;
 import io.helidon.dbclient.DbMapperManager;
 import io.helidon.dbclient.DbRow;
 import io.helidon.dbclient.spi.DbMapperProvider;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonNumber;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
 
+import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+
+import jakarta.json.Json;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -286,6 +296,247 @@ class MongoDbClientTest {
         assertThat(team.get(0).getString("name"), is("Bulbasaur"));
         assertThat(team.get(1).getInteger("id"), is(4));
         assertThat(team.get(1).getString("name"), is("Charmander"));
+    }
+
+    @Test
+    void testHelidonJsonNamedParamDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        JsonObject pokemon = JsonObject.builder()
+                .set("id", 54)
+                .set("name", "Psyduck")
+                .build();
+        DbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": { "pokemon": $pokemon }
+                                      }
+                                      """)
+                .addParam("pokemon", pokemon)
+                .execute();
+
+        assertThat(result, is(1L));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(collection).insertOne(captor.capture());
+        Document inserted = captor.getValue().get("pokemon", Document.class);
+        assertThat(inserted.getInteger("id"), is(54));
+        assertThat(inserted.getString("name"), is("Psyduck"));
+    }
+
+    @Test
+    void testHelidonJsonParamsDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        JsonObject parameters = JsonObject.builder()
+                .set("id", 143)
+                .set("name", "Snorlax")
+                .build();
+        DbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": {
+                                          "id": $id,
+                                          "name": $name
+                                        }
+                                      }
+                                      """)
+                .params(parameters)
+                .execute();
+
+        assertThat(result, is(1L));
+        assertInsertedPokemon(collection, 143, "Snorlax");
+    }
+
+    @Test
+    void testHelidonJsonIndexedParamsDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        JsonArray parameters = JsonArray.create(
+                JsonNumber.create(7),
+                JsonString.create("Squirtle"));
+        DbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": {
+                                          "id": ?,
+                                          "name": ?
+                                        }
+                                      }
+                                      """)
+                .params(parameters)
+                .execute();
+
+        assertThat(result, is(1L));
+        assertInsertedPokemon(collection, 7, "Squirtle");
+    }
+
+    @Test
+    void testHelidonJsonAddParamDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        JsonObject pokemon = JsonObject.builder()
+                .set("id", 175)
+                .set("name", "Togepi")
+                .build();
+        DbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": ?
+                                      }
+                                      """)
+                .addParam(pokemon)
+                .execute();
+
+        assertThat(result, is(1L));
+        assertInsertedPokemon(collection, 175, "Togepi");
+    }
+
+    @Test
+    void testHelidonJsonParamsGet() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        FindIterable<Document> finder = Mockito.mock(FindIterable.class);
+        MongoCursor<Document> cursor = Mockito.mock(MongoCursor.class);
+        when(collection.find(any(Bson.class))).thenReturn(finder);
+        when(finder.iterator()).thenReturn(cursor);
+        when(cursor.hasNext()).thenReturn(false);
+        JsonObject parameters = JsonObject.builder()
+                .set("id", 133)
+                .build();
+        DbClient dbClient = createClient(collection, null);
+        Optional<DbRow> result = dbClient.execute()
+                .createGet("""
+                                   {
+                                     "collection": "foo",
+                                     "operation": "query",
+                                     "query": { "id": $id }
+                                   }
+                                   """)
+                .params(parameters)
+                .execute();
+
+        assertThat(result.isEmpty(), is(true));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(collection).find(captor.capture());
+        assertThat(captor.getValue().getInteger("id"), is(133));
+    }
+
+    @Test
+    void testHelidonJsonIndexedParamsGet() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        FindIterable<Document> finder = Mockito.mock(FindIterable.class);
+        MongoCursor<Document> cursor = Mockito.mock(MongoCursor.class);
+        when(collection.find(any(Bson.class))).thenReturn(finder);
+        when(finder.iterator()).thenReturn(cursor);
+        when(cursor.hasNext()).thenReturn(false);
+        JsonArray parameters = JsonArray.create(
+                JsonNumber.create(25),
+                JsonString.create("Pikachu"));
+        DbClient dbClient = createClient(collection, null);
+        Optional<DbRow> result = dbClient.execute()
+                .createGet("""
+                                   {
+                                     "collection": "foo",
+                                     "operation": "query",
+                                     "query": {
+                                       "id": ?,
+                                       "name": ?
+                                     }
+                                   }
+                                   """)
+                .params(parameters)
+                .execute();
+
+        assertThat(result.isEmpty(), is(true));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        verify(collection).find(captor.capture());
+        assertThat(captor.getValue().getInteger("id"), is(25));
+        assertThat(captor.getValue().getString("name"), is("Pikachu"));
+    }
+
+    @Test
+    void testJsonProcessingParamsDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        jakarta.json.JsonObject parameters = Json.createObjectBuilder()
+                .add("id", 94)
+                .add("name", "Gengar")
+                .build();
+        DbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": {
+                                          "id": $id,
+                                          "name": $name
+                                        }
+                                      }
+                                      """)
+                .params(parameters)
+                .execute();
+
+        assertThat(result, is(1L));
+        assertInsertedPokemon(collection, 94, "Gengar");
+    }
+
+    @Test
+    void testJsonProcessingIndexedParamsDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        jakarta.json.JsonArray parameters = Json.createArrayBuilder()
+                .add(129)
+                .add("Magikarp")
+                .build();
+        DbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": {
+                                          "id": ?,
+                                          "name": ?
+                                        }
+                                      }
+                                      """)
+                .params(parameters)
+                .execute();
+
+        assertThat(result, is(1L));
+        assertInsertedPokemon(collection, 129, "Magikarp");
+    }
+
+    @Test
+    void testJsonProcessingAddParamDml() {
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        jakarta.json.JsonValue parameter = Json.createObjectBuilder()
+                .add("id", 147)
+                .add("name", "Dratini")
+                .build();
+        DbClient dbClient = createClient(collection, null);
+        long result = dbClient.execute()
+                .createInsert("""
+                                      {
+                                        "collection": "foo",
+                                        "operation": "insert",
+                                        "value": ?
+                                      }
+                                      """)
+                .addParam(parameter)
+                .execute();
+
+        assertThat(result, is(1L));
+        assertInsertedPokemon(collection, 147, "Dratini");
     }
 
     @Test

--- a/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/StatementParsersTest.java
+++ b/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/StatementParsersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,14 @@
 package io.helidon.dbclient.mongodb;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.helidon.dbclient.mongodb.StatementParsers.NamedParser;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonNumber;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +51,28 @@ public class StatementParsersTest {
         NamedParser parser = new NamedParser(stmtIn, mapping);
         String stmtOut = parser.convert();
         assertThat(stmtOut, is(stmtExp));
+    }
+
+    @Test
+    void testStatementWithHelidonJsonNamedParameter() {
+        JsonObject pokemon = JsonObject.builder()
+                .set("id", 25)
+                .set("name", "Pika\"chu")
+                .build();
+        NamedParser parser = new NamedParser("{ pokemon: $pokemon }", Map.of("pokemon", pokemon));
+
+        assertThat(parser.convert(), is("{ pokemon: {\"id\":25,\"name\":\"Pika\\\"chu\"} }"));
+    }
+
+    @Test
+    void testStatementWithHelidonJsonIndexedParameter() {
+        JsonArray team = JsonArray.create(
+                JsonString.create("Bulbasaur"),
+                JsonNumber.create(4));
+
+        String stmtOut = StatementParsers.indexedParser("{ team: ? }", List.of(team)).convert();
+
+        assertThat(stmtOut, is("{ team: [\"Bulbasaur\",4] }"));
     }
 
 }

--- a/etc/HELIDON_THIRD_PARTY_LICENSES.xml
+++ b/etc/HELIDON_THIRD_PARTY_LICENSES.xml
@@ -169,7 +169,6 @@ See full text at the bottom of this document for license: GPLv2-CPE
             <licensor>Eclipse Foundation</licensor>
             <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
             <consumers>
-                <consumer>helidon-dbclient-mongodb</consumer>
                 <consumer>helidon-graal-native-image-extension</consumer>
                 <consumer>helidon-http-media-jsonp</consumer>
                 <consumer>helidon-lra-coordinator-server</consumer>


### PR DESCRIPTION
Resolves #11378

Replaces MongoDB dbclient JSON-P statement parameter handling with Helidon JSON, removes the MongoDB module's JSON-P dependency surface, and updates third-party license consumers after removing Parsson from this module.
