### PR TITLE
Replace JSON-P with Helidon JSON in JSON-RPC

### DIFF
--- a/docs/src/main/asciidoc/se/json/json.adoc
+++ b/docs/src/main/asciidoc/se/json/json.adoc
@@ -119,7 +119,7 @@ Configure the annotation processors in your Maven build:
                         <version>${helidon.version}</version>
                     </path>
                     <path>
-                        <groupId>io.helidon.json.codegen</groupId>
+                        <groupId>io.helidon.json</groupId>
                         <artifactId>helidon-json-codegen</artifactId>
                         <version>${helidon.version}</version>
                     </path>

--- a/docs/src/main/asciidoc/se/jsonrpc/client.adoc
+++ b/docs/src/main/asciidoc/se/jsonrpc/client.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -93,9 +93,14 @@ a JSON-RPC error response.
 
 Every JSON-RPC response contains either a result or an error, and that is
 the reason why `res.result()` returns an optional value. The last step
-shows how the result is mapped to a `StartStopResult` instance using JSON-B.
-See xref:{rootdir}/se/jsonrpc/server.adoc[JSON-RPC Server] for more
-information on these types.
+shows how the result is mapped to a `StartStopResult` instance using Helidon
+JSON binding. See xref:{rootdir}/se/jsonrpc/server.adoc[JSON-RPC Server] for
+more information on these types.
+
+NOTE: Custom types used with Helidon JSON binding must be annotated with
+`@Json.Entity` and compiled with the Helidon JSON annotation processor. See
+xref:{rootdir}/se/json/json.adoc#_enabling_code_generation[Enabling Code
+Generation] for the Maven annotation processor setup.
 
 === Batch Requests
 
@@ -117,7 +122,7 @@ The response of type `JsonClientBatchResponse` shall include an entry
 for each of the invocations in the request. In this example, we can test
 that the response returned HTTP status 200 and has a size of 2, and
 then verify the results by binding them to `StartStopResult` instances
-using JSON-B.
+using Helidon JSON binding.
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/se/jsonrpc/server.adoc
+++ b/docs/src/main/asciidoc/se/jsonrpc/server.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -91,17 +91,20 @@ URI to send requests &mdash;see `JsonRpcRouting` instance creation above.
 The logic for the two methods `start` and `stop` is very similar. First, they
 inspect parameters, then they decide to return either a
 result or an error, and finally they call `send()` on the response. Parameters,
-as well as results, can be either JSON-P instances or JSON-B objects. In this
-example, we defined some simple records to bind and serialize data using JSON-B.
+as well as results, can be either Helidon JSON instances or Java objects
+bound using Helidon JSON binding. In this example, we define some simple
+records annotated with `@Json.Entity`.
 
 [source,java]
 ----
 include::{sourcedir}/se/jsonrpc/ServerSnippets.java[tag=snippet_3, indent=0]
 ----
 
-NOTE: These record types used during serialization must be public for the
-JSON-B implementation (Eclipse Yasson in our example) to have access to
-them.
+NOTE: Custom types used during serialization and deserialization must be
+annotated with `@Json.Entity` and compiled with the Helidon JSON annotation
+processor. See
+xref:{rootdir}/se/json/json.adoc#_enabling_code_generation[Enabling Code
+Generation] for the Maven annotation processor setup.
 
 == Configuration
 

--- a/docs/src/main/java/io/helidon/docs/se/jsonrpc/ClientSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/jsonrpc/ClientSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.docs.se.jsonrpc;
 import java.time.Duration;
 import java.util.Optional;
 
+import io.helidon.json.binding.Json;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
@@ -89,7 +90,7 @@ class ClientSnippets {
                 // successful start!
             }
             Optional<JsonRpcResult> result1 = batchRes.get(1).result();
-            if (result0.get().as(StartStopResult.class).status().equals("STOPPED")) {
+            if (result1.get().as(StartStopResult.class).status().equals("STOPPED")) {
                 // successful stop!
             }
         }
@@ -97,9 +98,11 @@ class ClientSnippets {
     }
 
     // tag::snippet_6[]
+    @Json.Entity
     public record StartStopParams(String when, Duration duration) {
     }
 
+    @Json.Entity
     public record StartStopResult(String status) {
     }
     // end::snippet_6[]

--- a/docs/src/main/java/io/helidon/docs/se/jsonrpc/ServerSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/jsonrpc/ServerSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.docs.se.jsonrpc;
 
 import java.time.Duration;
 
+import io.helidon.json.binding.Json;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
@@ -85,9 +86,11 @@ class ServerSnippets {
     // end::snippet_2[]
 
     // tag::snippet_3[]
+    @Json.Entity
     public record StartStopParams(String when, Duration duration) {
     }
 
+    @Json.Entity
     public record StartStopResult(String status) {
     }
     // end::snippet_3[]

--- a/json/json/src/main/java/io/helidon/json/JsonArray.java
+++ b/json/json/src/main/java/io/helidon/json/JsonArray.java
@@ -109,6 +109,15 @@ public final class JsonArray extends JsonValue {
     }
 
     /**
+     * Return the number of values in this array.
+     *
+     * @return array size
+     */
+    public int size() {
+        return jsonValues.size();
+    }
+
+    /**
      * Return the JsonValue at the specified index as an Optional.
      *
      * @param index the index of the element to return

--- a/json/json/src/test/java/io/helidon/json/JsonValueParserTest.java
+++ b/json/json/src/test/java/io/helidon/json/JsonValueParserTest.java
@@ -126,7 +126,7 @@ class JsonValueParserTest {
         JsonParser parser = JsonParser.create(original);
 
         JsonArray result = parser.readJsonArray();
-        assertThat(result.values().size(), is(3));
+        assertThat(result.size(), is(3));
         assertThat(result.get(0, JsonNull.instance()).asString().value(), is("item1"));
         assertThat(result.get(1, JsonNull.instance()).asNumber().intValue(), is(123));
         assertThat(result.get(2, JsonNull.instance()).asBoolean().value(), is(true));
@@ -298,7 +298,7 @@ class JsonValueParserTest {
         JsonObject result = parser.readJsonObject();
         JsonArray users = result.arrayValue("users").orElseThrow();
 
-        assertThat(users.values().size(), is(2));
+        assertThat(users.size(), is(2));
 
         JsonObject alice = users.get(0, JsonNull.instance()).asObject();
         assertThat(alice.stringValue("name").orElseThrow(), is("Alice"));

--- a/jsonrpc/core/pom.xml
+++ b/jsonrpc/core/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
         <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
     </properties>
 
     <dependencies>
@@ -38,12 +39,12 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.features</groupId>
@@ -60,10 +61,60 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.json</groupId>
+                            <artifactId>helidon-json-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.json</groupId>
+                        <artifactId>helidon-json-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jsonrpc/core/pom.xml
+++ b/jsonrpc/core/pom.xml
@@ -30,7 +30,6 @@
 
     <properties>
         <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
-        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
     </properties>
 
     <dependencies>

--- a/jsonrpc/core/pom.xml
+++ b/jsonrpc/core/pom.xml
@@ -46,9 +46,24 @@
             <artifactId>helidon-json-binding</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-buffers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-types</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcError.java
+++ b/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,8 @@ package io.helidon.jsonrpc.core;
 import java.util.Objects;
 import java.util.Optional;
 
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonValue;
-
-import static io.helidon.jsonrpc.core.JsonUtil.JSON_BUILDER_FACTORY;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 
 /**
  * A representation of a JSON-RPC error.
@@ -74,10 +71,10 @@ public interface JsonRpcError {
      */
     static JsonRpcError create(int code, String message) {
         Objects.requireNonNull(message, "message is null");
-        JsonObjectBuilder builder = JSON_BUILDER_FACTORY.createObjectBuilder();
-        builder.add("code", code);
-        builder.add("message", message);
-        return new JsonRpcErrorImpl(builder.build());
+        return new JsonRpcErrorImpl(JsonObject.builder()
+                                           .set("code", code)
+                                           .set("message", message)
+                                           .build());
     }
 
     /**
@@ -91,11 +88,11 @@ public interface JsonRpcError {
     static JsonRpcError create(int code, String message, JsonValue data) {
         Objects.requireNonNull(message, "message is null");
         Objects.requireNonNull(data, "data is null");
-        JsonObjectBuilder builder = JSON_BUILDER_FACTORY.createObjectBuilder();
-        builder.add("code", code);
-        builder.add("message", message);
-        builder.add("data", data);
-        return new JsonRpcErrorImpl(builder.build());
+        return new JsonRpcErrorImpl(JsonObject.builder()
+                                           .set("code", code)
+                                           .set("message", message)
+                                           .set("data", data)
+                                           .build());
     }
 
     /**
@@ -120,14 +117,13 @@ public interface JsonRpcError {
     Optional<JsonValue> data();
 
     /**
-     * Get the data associated with this error as an object, if defined.
-     * This method will use JSONB for binding.
+     * Get the data associated with this error as a Java object, if defined.
+     * This method uses Helidon JSON binding.
      *
      * @param type the bean class
      * @param <T>  the bean type
      * @return optional data
-     * @throws ClassCastException if the data is not a JSON object
-     * @throws jakarta.json.bind.JsonbException if an error occurs during mapping
+     * @throws io.helidon.json.binding.JsonBindingException if an error occurs during mapping
      */
     <T> Optional<T> dataAs(Class<T> type);
 

--- a/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcErrorImpl.java
+++ b/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcErrorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package io.helidon.jsonrpc.core;
 import java.util.Objects;
 import java.util.Optional;
 
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 
 /**
  * An implementation of a JSON-RPC error.
@@ -35,24 +35,24 @@ class JsonRpcErrorImpl implements JsonRpcError {
 
     @Override
     public int code() {
-        return error.getInt("code");
+        return error.intValue("code")
+                .orElseThrow(() -> new IllegalStateException("Unable to find property code"));
     }
 
     @Override
     public String message() {
-        return error.getString("message");
+        return error.stringValue("message")
+                .orElseThrow(() -> new IllegalStateException("Unable to find property message"));
     }
 
     @Override
     public Optional<JsonValue> data() {
-        return Optional.ofNullable(error.get("data"));
+        return error.value("data");
     }
 
     @Override
     public <T> Optional<T> dataAs(Class<T> type) {
-        JsonValue data = error.get("data");
-        return data == null ? Optional.empty()
-                : Optional.of(JsonUtil.jsonpToJsonb(data.asJsonObject(), type));
+        return data().map(jsonValue -> JsonUtil.fromJson(jsonValue, type));
     }
 
     @Override

--- a/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcParams.java
+++ b/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,9 @@ package io.helidon.jsonrpc.core;
 
 import java.util.Optional;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonStructure;
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 
 /**
  * A representation of a JSON-RPC params.
@@ -28,12 +27,13 @@ import jakarta.json.JsonValue;
 public interface JsonRpcParams {
 
     /**
-     * Create an instance from a JSON structure.
+     * Create an instance from JSON-RPC params.
      *
-     * @param params the structure
+     * @param params the object or array value
      * @return a new instance of this class
+     * @throws IllegalArgumentException if params is not a JSON object or array
      */
-    static JsonRpcParams create(JsonStructure params) {
+    static JsonRpcParams create(JsonValue params) {
         return new JsonRpcParamsImpl(params);
     }
 
@@ -41,7 +41,7 @@ public interface JsonRpcParams {
      * Access all request params as a single JSON object.
      *
      * @return a JSON object
-     * @throws ClassCastException if not a JSON object
+     * @throws io.helidon.json.JsonException if not a JSON object
      */
     JsonObject asJsonObject();
 
@@ -49,23 +49,23 @@ public interface JsonRpcParams {
      * Access all request params as a single JSON array.
      *
      * @return a JSON array
-     * @throws ClassCastException if not a JSON array
+     * @throws io.helidon.json.JsonException if not a JSON array
      */
     JsonArray asJsonArray();
 
     /**
-     * Access all request params as a single JSON structure.
+     * Access all request params as a single JSON value.
      *
-     * @return a JSON structure
+     * @return a JSON value
      */
-    JsonStructure asJsonStructure();
+    JsonValue asJsonValue();
 
     /**
      * Get a single param by name as a JSON value.
      *
      * @param name param name
      * @return the param value
-     * @throws ClassCastException       if not a JSON object
+     * @throws io.helidon.json.JsonException if not a JSON object
      * @throws IllegalArgumentException if the param does not exist
      */
     JsonValue get(String name);
@@ -75,7 +75,7 @@ public interface JsonRpcParams {
      *
      * @param name param name
      * @return the param value as a string
-     * @throws ClassCastException       if not a JSON object or value not a string
+     * @throws io.helidon.json.JsonException if not a JSON object or value not a string
      * @throws IllegalArgumentException if the param does not exist
      */
     String getString(String name);
@@ -85,7 +85,7 @@ public interface JsonRpcParams {
      *
      * @param name param name
      * @return an optional param value
-     * @throws ClassCastException if not a JSON object
+     * @throws io.helidon.json.JsonException if not a JSON object
      */
     Optional<JsonValue> find(String name);
 
@@ -94,7 +94,7 @@ public interface JsonRpcParams {
      *
      * @param index the index
      * @return the param value
-     * @throws ClassCastException        if not a JSON array
+     * @throws io.helidon.json.JsonException if not a JSON array
      * @throws IndexOutOfBoundsException if index is out of bounds
      */
     JsonValue get(int index);
@@ -104,7 +104,7 @@ public interface JsonRpcParams {
      *
      * @param index the index
      * @return the param value as a string
-     * @throws ClassCastException        if not a JSON array or value not a string
+     * @throws io.helidon.json.JsonException if not a JSON array or value not a string
      * @throws IndexOutOfBoundsException if index is out of bounds
      */
     String getString(int index);
@@ -114,18 +114,17 @@ public interface JsonRpcParams {
      *
      * @param index the index
      * @return an optional param value
-     * @throws ClassCastException        if not a JSON array
-     * @throws IndexOutOfBoundsException if index is out of bounds
+     * @throws io.helidon.json.JsonException if not a JSON array
      */
     Optional<JsonValue> find(int index);
 
     /**
-     * Map all request params to a bean class type using JSONB.
+     * Map all request params to a Java type using Helidon JSON binding.
      *
      * @param type the bean class
      * @param <T>  the bean type
      * @return an instance of the bean type
-     * @throws jakarta.json.bind.JsonbException if an error occurs during mapping
+     * @throws io.helidon.json.binding.JsonBindingException if an error occurs during mapping
      */
     <T> T as(Class<T> type);
 }

--- a/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcParamsImpl.java
+++ b/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcParamsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,78 +18,74 @@ package io.helidon.jsonrpc.core;
 import java.util.Objects;
 import java.util.Optional;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonStructure;
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
+import io.helidon.json.JsonValueType;
 
 /**
  * An implementation of {@link io.helidon.jsonrpc.core.JsonRpcParams}.
  */
 class JsonRpcParamsImpl implements JsonRpcParams {
 
-    private final JsonStructure params;
+    private final JsonValue params;
 
-    JsonRpcParamsImpl(JsonStructure params) {
+    JsonRpcParamsImpl(JsonValue params) {
         this.params = Objects.requireNonNull(params);
+        if (this.params.type() != JsonValueType.OBJECT && this.params.type() != JsonValueType.ARRAY) {
+            throw new IllegalArgumentException("JSON-RPC params must be a JSON object or array");
+        }
     }
 
     @Override
-    public JsonStructure asJsonStructure() {
+    public JsonValue asJsonValue() {
         return params;
     }
 
     @Override
     public JsonObject asJsonObject() {
-        return params.asJsonObject();
+        return params.asObject();
     }
 
     @Override
     public JsonArray asJsonArray() {
-        return params.asJsonArray();
+        return params.asArray();
     }
 
     @Override
     public JsonValue get(String name) {
-        JsonValue value = asJsonObject().get(name);
-        if (value == null) {
-            throw new IllegalArgumentException("Unable to find param " + name);
-        }
-        return value;
+        return asJsonObject().value(name)
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find param " + name));
     }
 
     @Override
     public String getString(String name) {
-        return ((JsonString) get(name)).getString();
+        return get(name).asString().value();
     }
 
     @Override
     public Optional<JsonValue> find(String name) {
-        return Optional.ofNullable(asJsonObject().get(name));
+        return asJsonObject().value(name);
     }
 
     @Override
     public JsonValue get(int index) {
-        return asJsonArray().get(index);
+        return asJsonArray().get(index)
+                .orElseThrow(() -> new IndexOutOfBoundsException("Unable to find param " + index));
     }
 
     @Override
     public String getString(int index) {
-        return ((JsonString) get(index)).getString();
+        return get(index).asString().value();
     }
 
     @Override
     public Optional<JsonValue> find(int index) {
-        JsonArray array = asJsonArray();
-        if (index >= 0 && index < array.size()) {
-            return Optional.of(array.get(index));
-        }
-        return Optional.empty();
+        return asJsonArray().get(index);
     }
 
     @Override
     public <T> T as(Class<T> type) {
-        return JsonUtil.jsonpToJsonb(asJsonObject(), type);
+        return JsonUtil.fromJson(asJsonValue(), type);
     }
 }

--- a/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcResult.java
+++ b/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package io.helidon.jsonrpc.core;
 
 import java.util.Optional;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 
 /**
  * A representation of a JSON-RPC response result.
@@ -40,7 +40,7 @@ public interface JsonRpcResult {
      * Access a response result as a JSON object.
      *
      * @return a JSON object
-     * @throws ClassCastException if not a JSON object
+     * @throws io.helidon.json.JsonException if not a JSON object
      */
     JsonObject asJsonObject();
 
@@ -48,14 +48,14 @@ public interface JsonRpcResult {
      * Access a response result as a JSON array.
      *
      * @return a JSON array
-     * @throws ClassCastException if not a JSON array
+     * @throws io.helidon.json.JsonException if not a JSON array
      */
     JsonArray asJsonArray();
 
     /**
      * Access a response result as a JSON value.
      *
-     * @return a JSON structure
+     * @return a JSON value
      */
     JsonValue asJsonValue();
 
@@ -64,7 +64,7 @@ public interface JsonRpcResult {
      *
      * @param name property name
      * @return the property value
-     * @throws ClassCastException       if not a JSON object
+     * @throws io.helidon.json.JsonException if not a JSON object
      * @throws IllegalArgumentException if the property does not exist
      */
     JsonValue get(String name);
@@ -74,17 +74,17 @@ public interface JsonRpcResult {
      *
      * @param name property name
      * @return the property value as a string
-     * @throws ClassCastException       if not a JSON object or value not a string
+     * @throws io.helidon.json.JsonException if not a JSON object or value not a string
      * @throws IllegalArgumentException if the property does not exist
      */
     String getString(String name);
 
     /**
-     * Get a JSON object property value as a string, if present.
+     * Get a JSON object property value as a JSON value, if present.
      *
      * @param name property name
      * @return an optional property value
-     * @throws ClassCastException if not a JSON object or value not a string
+     * @throws io.helidon.json.JsonException if not a JSON object
      */
     Optional<JsonValue> find(String name);
 
@@ -93,7 +93,7 @@ public interface JsonRpcResult {
      *
      * @param index the index
      * @return the JSON value
-     * @throws ClassCastException        if not a JSON array
+     * @throws io.helidon.json.JsonException if not a JSON array
      * @throws IndexOutOfBoundsException if index is out of bounds
      */
     JsonValue get(int index);
@@ -103,29 +103,28 @@ public interface JsonRpcResult {
      *
      * @param index the index
      * @return the property value as a string
-     * @throws ClassCastException        if not a JSON array or value not a string
+     * @throws io.helidon.json.JsonException if not a JSON array or value not a string
      * @throws IndexOutOfBoundsException if index is out of bounds
      */
     String getString(int index);
 
     /**
-     * Get a JSON array value by index as a string, if present.
+     * Get a JSON array value by index as a JSON value, if present.
      *
      * @param index the index
-     * @return the optional property value as a string
-     * @throws ClassCastException        if not a JSON array or value not a string
-     * @throws IndexOutOfBoundsException if index is out of bounds
+     * @return the optional property value
+     * @throws io.helidon.json.JsonException if not a JSON array
      */
     Optional<JsonValue> find(int index);
 
     /**
-     * Access a response result as a Java object. This method will bind the result
-     * using JSONB.
+     * Access a response result as a Java object. This method binds the result
+     * using Helidon JSON binding.
      *
      * @param type the bean class
      * @param <T>  the bean type
      * @return an instance of the bean type
-     * @throws jakarta.json.bind.JsonbException if an error occurs during mapping
+     * @throws io.helidon.json.binding.JsonBindingException if an error occurs during mapping
      */
     <T> T as(Class<T> type);
 }

--- a/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcResultImpl.java
+++ b/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonRpcResultImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,9 @@ package io.helidon.jsonrpc.core;
 import java.util.Objects;
 import java.util.Optional;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonString;
-import jakarta.json.JsonValue;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 
 /**
  * An implementation of a JSON-RPC response result.
@@ -36,12 +35,12 @@ class JsonRpcResultImpl implements JsonRpcResult {
 
     @Override
     public JsonObject asJsonObject() {
-        return result.asJsonObject();
+        return result.asObject();
     }
 
     @Override
     public JsonArray asJsonArray() {
-        return result.asJsonArray();
+        return result.asArray();
     }
 
     @Override
@@ -51,44 +50,38 @@ class JsonRpcResultImpl implements JsonRpcResult {
 
     @Override
     public JsonValue get(String name) {
-        JsonValue value = asJsonObject().get(name);
-        if (value == null) {
-            throw new IllegalArgumentException("Unable to find property " + name);
-        }
-        return value;
+        return asJsonObject().value(name)
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find property " + name));
     }
 
     @Override
     public String getString(String name) {
-        return ((JsonString) get(name)).getString();
+        return get(name).asString().value();
     }
 
     @Override
     public Optional<JsonValue> find(String name) {
-        return Optional.ofNullable(asJsonObject().get(name));
+        return asJsonObject().value(name);
     }
 
     @Override
     public JsonValue get(int index) {
-        return asJsonArray().get(index);
+        return asJsonArray().get(index)
+                .orElseThrow(() -> new IndexOutOfBoundsException("Unable to find value " + index));
     }
 
     @Override
     public String getString(int index) {
-        return ((JsonString) get(index)).getString();
+        return get(index).asString().value();
     }
 
     @Override
     public Optional<JsonValue> find(int index) {
-        JsonArray array = asJsonArray();
-        if (index >= 0 && index < array.size()) {
-            return Optional.of(array.get(index));
-        }
-        return Optional.empty();
+        return asJsonArray().get(index);
     }
 
     @Override
     public <T> T as(Class<T> type) {
-        return JsonUtil.jsonpToJsonb(asJsonObject(), type);
+        return JsonUtil.fromJson(asJsonValue(), type);
     }
 }

--- a/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonUtil.java
+++ b/jsonrpc/core/src/main/java/io/helidon/jsonrpc/core/JsonUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,78 +15,59 @@
  */
 package io.helidon.jsonrpc.core;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.Objects;
 
 import io.helidon.common.LazyValue;
-
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonReaderFactory;
-import jakarta.json.JsonWriter;
-import jakarta.json.JsonWriterFactory;
-import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.JsonbBuilder;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.json.JsonValue;
+import io.helidon.json.binding.JsonBinding;
 
 /**
- * Provides JSONP to/from JSONB conversions. Not efficient, but simple and portable
- * for now. A more efficient implementation should avoid serialization.
+ * Provides JSON binding helpers used by JSON-RPC types.
  */
 public class JsonUtil {
 
-    /**
-     * Global JSON builder factory used by JSON-RPC implementation.
-     */
-    public static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(Map.of());
-
-    static final LazyValue<Jsonb> JSONB_BUILDER = LazyValue.create(JsonbBuilder::create);
-
-    static final LazyValue<JsonReaderFactory> JSON_READER_FACTORY
-            = LazyValue.create(() -> Json.createReaderFactory(Map.of()));
-
-    static final LazyValue<JsonWriterFactory> JSON_WRITER_FACTORY
-            = LazyValue.create(() -> Json.createWriterFactory(Map.of()));
+    static final LazyValue<JsonBinding> JSON_BINDING = LazyValue.create(JsonBinding::create);
 
     private JsonUtil() {
     }
 
     /**
-     * Convert a JSONB instance into a JSONP instance.
+     * Convert a bound Java object into a JSON object.
      *
      * @param object the object
-     * @return the JSON value
+     * @return the JSON object
      */
-    public static JsonObject jsonbToJsonp(Object object) {
-        Objects.requireNonNull(object, "json object is null");
-        String serialized = JSONB_BUILDER.get().toJson(object);
-        InputStream stream = new ByteArrayInputStream(serialized.getBytes(StandardCharsets.UTF_8));
-        try (JsonReader reader = JSON_READER_FACTORY.get().createReader(stream)) {
-            return reader.readValue().asJsonObject();
-        }
+    public static JsonObject toJsonObject(Object object) {
+        Objects.requireNonNull(object, "object is null");
+        byte[] serialized = JSON_BINDING.get().serializeToBytes(object);
+        return JsonParser.create(serialized).readJsonObject();
     }
 
     /**
-     * Convert a JSONP instance into a JSONB instance.
+     * Convert a JSON value into a Java object.
+     *
+     * @param value the JSON value
+     * @param type  the target type
+     * @param <T>   the type of the instance
+     * @return the Java instance
+     */
+    public static <T> T fromJson(JsonValue value, Class<T> type) {
+        Objects.requireNonNull(value, "json value is null");
+        Objects.requireNonNull(type, "type is null");
+        return JSON_BINDING.get().deserialize(value, type);
+    }
+
+    /**
+     * Convert a JSON object into a Java object.
      *
      * @param object the JSON object
-     * @param type   the JSONB type
+     * @param type   the target type
      * @param <T>    the type of the instance
-     * @return the JSONB instance
+     * @return the Java instance
      */
-    public static <T> T jsonpToJsonb(JsonObject object, Class<T> type) {
-        Objects.requireNonNull(object, "json object is null");
-        Objects.requireNonNull(type, "type is null");
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        try (JsonWriter writer = JSON_WRITER_FACTORY.get().createWriter(os, StandardCharsets.UTF_8)) {
-            writer.writeObject(object);
-        }
-        ByteArrayInputStream is = new ByteArrayInputStream(os.toByteArray());
-        return JSONB_BUILDER.get().fromJson(is, type);
+    public static <T> T fromJson(JsonObject object, Class<T> type) {
+        return fromJson((JsonValue) object, type);
     }
 }

--- a/jsonrpc/core/src/main/java/module-info.java
+++ b/jsonrpc/core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@
 module io.helidon.jsonrpc.core {
 
     requires io.helidon.common;
-    requires jakarta.json;
-    requires jakarta.json.bind;
+    requires transitive io.helidon.json;
+    requires io.helidon.json.binding;
     requires io.helidon.common.features.api;
 
     exports io.helidon.jsonrpc.core;

--- a/jsonrpc/core/src/test/java/io/helidon/jsonrpc/core/JsonRpcCoreTest.java
+++ b/jsonrpc/core/src/test/java/io/helidon/jsonrpc/core/JsonRpcCoreTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.jsonrpc.core;
+
+import java.time.Duration;
+
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonBoolean;
+import io.helidon.json.JsonNull;
+import io.helidon.json.JsonNumber;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
+import io.helidon.json.binding.Json;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JsonRpcCoreTest {
+
+    @Test
+    void testJsonUtilUsesHelidonJsonBinding() {
+        JsonObject jsonObject = JsonUtil.toJsonObject(new StartStopResult("RUNNING"));
+        StartStopResult actual = JsonUtil.fromJson(jsonObject, StartStopResult.class);
+
+        assertThat(jsonObject.stringValue("status").orElseThrow(), is("RUNNING"));
+        assertThat(actual.status(), is("RUNNING"));
+    }
+
+    @Test
+    void testParamsSupportHelidonJsonAccessAndBinding() {
+        JsonRpcParams objectParams = JsonRpcParams.create(JsonObject.builder()
+                                                                    .set("when", "NOW")
+                                                                    .set("duration", "PT0S")
+                                                                    .build());
+        StartStopParams params = objectParams.as(StartStopParams.class);
+
+        assertThat(objectParams.getString("when"), is("NOW"));
+        assertThat(params.when(), is("NOW"));
+        assertThat(params.duration(), is(Duration.ZERO));
+
+        JsonRpcParams arrayParams = JsonRpcParams.create(JsonArray.create(JsonString.create("NOW"),
+                                                                          JsonString.create("PT0S")));
+
+        assertThat(arrayParams.getString(0), is("NOW"));
+        assertThat(arrayParams.getString(1), is("PT0S"));
+    }
+
+    @Test
+    void testParamsRejectScalarValues() {
+        assertThat(assertThrows(IllegalArgumentException.class,
+                                () -> JsonRpcParams.create(JsonNumber.create(1))).getMessage(),
+                   is("JSON-RPC params must be a JSON object or array"));
+        assertThat(assertThrows(IllegalArgumentException.class,
+                                () -> JsonRpcParams.create(JsonString.create("one"))).getMessage(),
+                   is("JSON-RPC params must be a JSON object or array"));
+        assertThat(assertThrows(IllegalArgumentException.class,
+                                () -> JsonRpcParams.create(JsonBoolean.TRUE)).getMessage(),
+                   is("JSON-RPC params must be a JSON object or array"));
+        assertThat(assertThrows(IllegalArgumentException.class,
+                                () -> JsonRpcParams.create(JsonNull.instance())).getMessage(),
+                   is("JSON-RPC params must be a JSON object or array"));
+        assertThrows(NullPointerException.class, () -> JsonRpcParams.create(null));
+    }
+
+    @Test
+    void testResultAndErrorSupportHelidonJsonValues() {
+        JsonRpcResult arrayResult = JsonRpcResult.create(JsonArray.create(JsonString.create("ready"),
+                                                                          JsonNumber.create(7)));
+        JsonRpcResult objectResult = JsonRpcResult.create(JsonObject.builder()
+                                                                    .set("status", "RUNNING")
+                                                                    .build());
+        JsonRpcResult scalarResult = JsonRpcResult.create(JsonNumber.create(45));
+        JsonRpcError error = JsonRpcError.create(42, "failure", JsonUtil.toJsonObject(new ErrorData("alpha", 7)));
+        StartStopResult result = objectResult.as(StartStopResult.class);
+        ErrorData errorData = error.dataAs(ErrorData.class).orElseThrow();
+
+        assertThat(arrayResult.getString(0), is("ready"));
+        assertThat(arrayResult.get(1).asNumber().intValue(), is(7));
+        assertThat(result.status(), is("RUNNING"));
+        assertThat(scalarResult.as(Integer.class), is(45));
+        assertThat(errorData.name(), is("alpha"));
+        assertThat(errorData.count(), is(7));
+    }
+
+    @Json.Entity
+    record StartStopParams(String when, Duration duration) {
+    }
+
+    @Json.Entity
+    record StartStopResult(String status) {
+    }
+
+    @Json.Entity
+    record ErrorData(String name, int count) {
+    }
+}

--- a/webclient/jsonrpc/pom.xml
+++ b/webclient/jsonrpc/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.jsonrpc</groupId>
             <artifactId>helidon-jsonrpc-core</artifactId>
         </dependency>

--- a/webclient/jsonrpc/pom.xml
+++ b/webclient/jsonrpc/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.jsonrpc</groupId>
             <artifactId>helidon-jsonrpc-core</artifactId>
         </dependency>
@@ -52,14 +56,6 @@
             <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.features</groupId>
@@ -74,11 +70,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchRequest.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.helidon.webclient.jsonrpc;
 
-import jakarta.json.JsonArray;
+import io.helidon.json.JsonArray;
 
 /**
  * An interface representing a JSON-RPC batch request.

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchRequestImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,10 @@ import java.util.List;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.HeaderNames;
+import io.helidon.json.JsonArray;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
-
-import jakarta.json.JsonArray;
-import jakarta.json.JsonArrayBuilder;
-
-import static io.helidon.jsonrpc.core.JsonUtil.JSON_BUILDER_FACTORY;
 
 /**
  * An implementation of a JSON-RPC client batch request.
@@ -48,7 +44,6 @@ class JsonRpcClientBatchRequestImpl implements JsonRpcClientBatchRequest {
         return new JsonRpcClientRequestImpl(http1Client, rpcMethod, this);
     }
 
-
     @Override
     public JsonRpcClientBatchResponse submit() {
         HttpClientResponse res = delegate.header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_JSON_VALUE)
@@ -59,9 +54,9 @@ class JsonRpcClientBatchRequestImpl implements JsonRpcClientBatchRequest {
 
     @Override
     public JsonArray asJsonArray() {
-        JsonArrayBuilder arrayBuilder = JSON_BUILDER_FACTORY.createArrayBuilder();
-        requests.forEach(request -> arrayBuilder.add(request.asJsonObject()));
-        return  arrayBuilder.build();
+        return JsonArray.create(requests.stream()
+                                        .map(JsonRpcClientRequest::asJsonObject)
+                                        .toList());
     }
 
     void add(JsonRpcClientRequest request) {

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchResponse.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchResponseImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,20 +28,17 @@ import io.helidon.http.ClientResponseTrailers;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
 import io.helidon.http.media.ReadableEntity;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.spi.Source;
-
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-
-import static io.helidon.jsonrpc.core.JsonUtil.JSON_BUILDER_FACTORY;
 
 /**
  * A representation of JSON-RPC client batch response.
  */
 class JsonRpcClientBatchResponseImpl implements JsonRpcClientBatchResponse {
-    private static final JsonArray EMPTY_JSON_ARRAY = JSON_BUILDER_FACTORY.createArrayBuilder().build();
+    private static final JsonArray EMPTY_JSON_ARRAY = JsonArray.empty();
 
     private final HttpClientResponse delegate;
     private JsonArray jsonArray;
@@ -59,10 +56,11 @@ class JsonRpcClientBatchResponseImpl implements JsonRpcClientBatchResponse {
     @Override
     public JsonRpcClientResponse get(int index) {
         if (responses == null) {
-            responses = new ArrayList<>();
             JsonArray array = asJsonArray();
-            for (jakarta.json.JsonValue jsonValue : array) {
-                JsonObject object = jsonValue.asJsonObject();
+            int size = array.size();
+            responses = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                JsonObject object = array.get(i).orElseThrow().asObject();
                 responses.add(new JsonRpcClientResponseImpl(delegate, object));
             }
         }
@@ -71,13 +69,12 @@ class JsonRpcClientBatchResponseImpl implements JsonRpcClientBatchResponse {
 
     @Override
     public Iterator<JsonRpcClientResponse> iterator() {
-        JsonArray array = asJsonArray();
         return new Iterator<>() {
             private int index = 0;
 
             @Override
             public boolean hasNext() {
-                return array.size() > index;
+                return size() > index;
             }
 
             @Override

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientRequest.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package io.helidon.webclient.jsonrpc;
 
+import io.helidon.json.JsonNumber;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
+import io.helidon.json.JsonValue;
 import io.helidon.webclient.api.ClientRequest;
-
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 
 /**
  * A representation of JSON-RPC client request.
@@ -52,7 +52,7 @@ public interface JsonRpcClientRequest extends ClientRequest<JsonRpcClientRequest
      * @return this request
      */
     default JsonRpcClientRequest rpcId(int value) {
-        return rpcId(Json.createValue(value));
+        return rpcId(JsonNumber.create(value));
     }
 
     /**
@@ -62,7 +62,7 @@ public interface JsonRpcClientRequest extends ClientRequest<JsonRpcClientRequest
      * @return this request
      */
     default JsonRpcClientRequest rpcId(String value) {
-        return rpcId(Json.createValue(value));
+        return rpcId(JsonString.create(value));
     }
 
     /**
@@ -82,7 +82,7 @@ public interface JsonRpcClientRequest extends ClientRequest<JsonRpcClientRequest
      * @return this request
      */
     default JsonRpcClientRequest param(String name, String value) {
-        return param(name, Json.createValue(value));
+        return param(name, JsonString.create(value));
     }
 
     /**
@@ -93,7 +93,7 @@ public interface JsonRpcClientRequest extends ClientRequest<JsonRpcClientRequest
      * @return this request
      */
     default JsonRpcClientRequest param(String name, int value) {
-        return param(name, Json.createValue(value));
+        return param(name, JsonNumber.create(value));
     }
 
     /**
@@ -111,7 +111,7 @@ public interface JsonRpcClientRequest extends ClientRequest<JsonRpcClientRequest
      * @return this request
      */
     default JsonRpcClientRequest addParam(int value) {
-        return addParam(Json.createValue(value));
+        return addParam(JsonNumber.create(value));
     }
 
     /**
@@ -121,7 +121,7 @@ public interface JsonRpcClientRequest extends ClientRequest<JsonRpcClientRequest
      * @return this request
      */
     default JsonRpcClientRequest addParam(String value) {
-        return addParam(Json.createValue(value));
+        return addParam(JsonString.create(value));
     }
 
     /**

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientRequestImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientRequestImpl.java
@@ -36,6 +36,9 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpException;
 import io.helidon.http.HttpMediaType;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.api.ClientUri;
@@ -43,13 +46,6 @@ import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
-
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonValue;
-
-import static io.helidon.jsonrpc.core.JsonUtil.JSON_BUILDER_FACTORY;
 
 /**
  * An implementation of JSON-RPC client request.
@@ -113,26 +109,20 @@ class JsonRpcClientRequestImpl implements JsonRpcClientRequest {
 
     @Override
     public JsonObject asJsonObject() {
-        JsonObjectBuilder builder = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", "2.0");
+        JsonObject.Builder builder = JsonObject.builder()
+                .set("jsonrpc", "2.0");
         if (rpcId != null) {
-            builder.add("id", rpcId);
+            builder.set("id", rpcId);
         }
-        builder.add("method", rpcMethod);
+        builder.set("method", rpcMethod);
         if (namedParams != null) {
-            JsonObjectBuilder namedBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
-            for (Map.Entry<String, JsonValue> entry : namedParams.entrySet()) {
-                namedBuilder.add(entry.getKey(), entry.getValue());
-            }
-            builder.add("params", namedBuilder.build());
+            JsonObject.Builder namedBuilder = JsonObject.builder();
+            namedParams.forEach(namedBuilder::set);
+            builder.set("params", namedBuilder.build());
         } else if (arrayParams != null) {
-            JsonArrayBuilder arrayBuilder = JSON_BUILDER_FACTORY.createArrayBuilder();
-            for (JsonValue value : arrayParams) {
-                arrayBuilder.add(value);
-            }
-            builder.add("params", arrayBuilder.build());
+            builder.set("params", JsonArray.create(arrayParams));
         } else {
-            builder.add("params", JSON_BUILDER_FACTORY.createObjectBuilder().build());
+            builder.set("params", JsonObject.empty());
         }
         return builder.build();
     }

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponse.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,11 @@ package io.helidon.webclient.jsonrpc;
 
 import java.util.Optional;
 
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.jsonrpc.core.JsonRpcResult;
 import io.helidon.webclient.api.HttpClientResponse;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 
 /**
  * A representation of a JSON-RPC client response.

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseImpl.java
@@ -25,22 +25,20 @@ import io.helidon.http.ClientResponseTrailers;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
 import io.helidon.http.media.ReadableEntity;
+import io.helidon.json.JsonException;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.jsonrpc.core.JsonRpcResult;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.spi.Source;
 
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
-
-import static io.helidon.jsonrpc.core.JsonUtil.JSON_BUILDER_FACTORY;
-
 /**
  * An implementation of JSON-RPC client response.
  */
 class JsonRpcClientResponseImpl implements JsonRpcClientResponse {
-    private static final JsonObject EMPTY_JSON_OBJECT = JSON_BUILDER_FACTORY.createObjectBuilder().build();
+    private static final JsonObject EMPTY_JSON_OBJECT = JsonObject.empty();
 
     private final HttpClientResponse delegate;
     private JsonObject jsonObject;
@@ -56,22 +54,21 @@ class JsonRpcClientResponseImpl implements JsonRpcClientResponse {
 
     @Override
     public Optional<JsonValue> rpcId() {
-        JsonValue id = asJsonObject().get("id");
-        return Optional.ofNullable(id);
+        return asJsonObject().value("id");
     }
 
     @Override
     public Optional<JsonRpcResult> result() {
-        JsonValue result = asJsonObject().get("result");
-        return result == null ? Optional.empty() : Optional.of(JsonRpcResult.create(result));
+        return asJsonObject().value("result")
+                .map(JsonRpcResult::create);
     }
 
     @Override
     public Optional<JsonRpcError> error() {
         try {
-            JsonObject error = asJsonObject().getJsonObject("error");
-            return Optional.ofNullable(error == null ? null : JsonRpcError.create(error));
-        } catch (ClassCastException e) {
+            return asJsonObject().objectValue("error")
+                    .map(JsonRpcError::create);
+        } catch (JsonException e) {
             return Optional.empty();
         }
     }

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseImpl.java
@@ -65,8 +65,9 @@ class JsonRpcClientResponseImpl implements JsonRpcClientResponse {
 
     @Override
     public Optional<JsonRpcError> error() {
+        JsonObject object = asJsonObject();
         try {
-            return asJsonObject().objectValue("error")
+            return object.objectValue("error")
                     .map(JsonRpcError::create);
         } catch (JsonException e) {
             return Optional.empty();

--- a/webclient/jsonrpc/src/main/java/module-info.java
+++ b/webclient/jsonrpc/src/main/java/module-info.java
@@ -29,11 +29,10 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Since("4.3.0")
 module io.helidon.webclient.jsonrpc {
 
-    requires jakarta.json;
-    requires jakarta.json.bind;
-    requires io.helidon.jsonrpc.core;
+    requires transitive io.helidon.json;
+    requires transitive io.helidon.jsonrpc.core;
     requires io.helidon.builder.api;
-    requires io.helidon.webclient;
+    requires transitive io.helidon.webclient;
     requires io.helidon.common.features.api;
 
     requires static io.helidon.config.metadata;

--- a/webclient/jsonrpc/src/main/java/module-info.java
+++ b/webclient/jsonrpc/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module io.helidon.webclient.jsonrpc {
     requires transitive io.helidon.jsonrpc.core;
     requires io.helidon.builder.api;
     requires transitive io.helidon.webclient;
+    requires io.helidon.http.media.json;
     requires io.helidon.common.features.api;
 
     requires static io.helidon.config.metadata;

--- a/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientTest.java
+++ b/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
  */
 package io.helidon.webclient.jsonrpc;
 
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
 import io.helidon.webclient.api.WebClient;
 
-import jakarta.json.Json;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 class JsonRpcClientTest {
@@ -48,7 +50,15 @@ class JsonRpcClientTest {
         JsonRpcClientRequest req = client.rpcMethod("start")
                 .path("/machine")
                 .rpcId(1)
-                .param("foo", Json.createValue("bar"));
+                .param("foo", JsonString.create("bar"));
         assertThat(req, notNullValue());
+
+        JsonObject request = req.asJsonObject();
+        assertThat(request.value("id").orElseThrow().asNumber().intValue(), is(1));
+        assertThat(request.stringValue("method").orElseThrow(), is("start"));
+        assertThat(request.objectValue("params")
+                           .flatMap(it -> it.value("foo"))
+                           .orElseThrow(),
+                   is(JsonString.create("bar")));
     }
 }

--- a/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientTest.java
+++ b/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
+import io.helidon.json.JsonException;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonString;
 import io.helidon.webclient.api.WebClient;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
 class JsonRpcClientTest {
@@ -57,6 +59,12 @@ class JsonRpcClientTest {
             res.header(HeaderValues.CONTENT_TYPE_JSON);
             res.send("""
                     {"jsonrpc":"2.0","id":1,"result":{"status":"RUNNING"}}
+                    """.getBytes(StandardCharsets.UTF_8));
+        });
+        rules.post("/malformed", (req, res) -> {
+            res.header(HeaderValues.CONTENT_TYPE_JSON);
+            res.send("""
+                    {"jsonrpc":"2.0","id":1,"error":
                     """.getBytes(StandardCharsets.UTF_8));
         });
     }
@@ -110,6 +118,21 @@ class JsonRpcClientTest {
             assertThat(res.status(), is(Status.OK_200));
             assertThat(res.rpcId().map(value -> value.asNumber().intValue()), is(Optional.of(1)));
             assertThat(res.result().orElseThrow().getString("status"), is("RUNNING"));
+        }
+    }
+
+    @Test
+    void testMalformedResponseJsonPropagatesFromError() {
+        JsonRpcClient jsonRpcClient = JsonRpcClient.builder()
+                .baseUri(serverUri)
+                .build();
+
+        try (JsonRpcClientResponse res = jsonRpcClient.rpcMethod("start")
+                .path("/malformed")
+                .rpcId(1)
+                .submit()) {
+            assertThat(res.status(), is(Status.OK_200));
+            assertThrows(JsonException.class, res::error);
         }
     }
 }

--- a/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientTest.java
+++ b/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientTest.java
@@ -15,9 +15,18 @@
  */
 package io.helidon.webclient.jsonrpc;
 
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Status;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonString;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +34,32 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+@ServerTest
 class JsonRpcClientTest {
+    private final URI serverUri;
+
+    JsonRpcClientTest(URI serverUri) {
+        this.serverUri = serverUri;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.post("/rpc", (req, res) -> {
+            JsonObject request = req.content().as(JsonObject.class);
+
+            assertThat(request.value("id").orElseThrow().asNumber().intValue(), is(1));
+            assertThat(request.stringValue("method").orElseThrow(), is("start"));
+            assertThat(request.objectValue("params")
+                               .flatMap(it -> it.value("when"))
+                               .orElseThrow(),
+                       is(JsonString.create("NOW")));
+
+            res.header(HeaderValues.CONTENT_TYPE_JSON);
+            res.send("""
+                    {"jsonrpc":"2.0","id":1,"result":{"status":"RUNNING"}}
+                    """.getBytes(StandardCharsets.UTF_8));
+        });
+    }
 
     @Test
     void testCreate() {
@@ -60,5 +94,22 @@ class JsonRpcClientTest {
                            .flatMap(it -> it.value("foo"))
                            .orElseThrow(),
                    is(JsonString.create("bar")));
+    }
+
+    @Test
+    void testSubmitWithHelidonJsonMedia() {
+        JsonRpcClient jsonRpcClient = JsonRpcClient.builder()
+                .baseUri(serverUri)
+                .build();
+
+        try (JsonRpcClientResponse res = jsonRpcClient.rpcMethod("start")
+                .path("/rpc")
+                .rpcId(1)
+                .param("when", "NOW")
+                .submit()) {
+            assertThat(res.status(), is(Status.OK_200));
+            assertThat(res.rpcId().map(value -> value.asNumber().intValue()), is(Optional.of(1)));
+            assertThat(res.result().orElseThrow().getString("status"), is("RUNNING"));
+        }
     }
 }

--- a/webserver/jsonrpc/pom.xml
+++ b/webserver/jsonrpc/pom.xml
@@ -33,20 +33,16 @@
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.jsonrpc</groupId>
             <artifactId>helidon-jsonrpc-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonp</artifactId>
+            <artifactId>helidon-http-media-json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/webserver/jsonrpc/pom.xml
+++ b/webserver/jsonrpc/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcErrorHandler.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@ package io.helidon.webserver.jsonrpc;
 
 import java.util.Optional;
 
+import io.helidon.json.JsonObject;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.webserver.ServerLifecycle;
 import io.helidon.webserver.http.ServerRequest;
-
-import jakarta.json.JsonObject;
 
 /**
  * A JSON-RPC handler that can process invalid requests if registered.
@@ -32,7 +31,7 @@ public interface JsonRpcErrorHandler extends ServerLifecycle {
     /**
      * Handler for a JSON-RPC erroneous request.
      *
-     * @param req        the server request
+     * @param req the server request
      * @param jsonObject an invalid JSON-RPC request as a JSON object
      * @return an optional JSON-RPC error to be returned to the client. If empty,
      *         then no error is returned.

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRequest.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@ package io.helidon.webserver.jsonrpc;
 
 import java.util.Optional;
 
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 import io.helidon.webserver.http.ServerRequest;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 
 /**
  * A representation of a JSON-RPC request.
@@ -51,7 +50,7 @@ public interface JsonRpcRequest extends ServerRequest {
 
     /**
      * The params associated with the request. If omitted in the request, then
-     * internally initialized using {@link JsonValue#EMPTY_JSON_OBJECT}.
+     * internally initialized using {@link JsonObject#empty()}.
      *
      * @return the params
      */

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRequestImpl.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,15 +28,13 @@ import io.helidon.http.HttpPrologue;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.media.ReadableEntity;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcParams;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.ProxyProtocolData;
 import io.helidon.webserver.http.HttpSecurity;
 import io.helidon.webserver.http.ServerRequest;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonStructure;
-import jakarta.json.JsonValue;
 
 /**
  * An implementation of a JSON-RPC request.
@@ -53,26 +51,25 @@ class JsonRpcRequestImpl implements JsonRpcRequest {
 
     @Override
     public String version() {
-        return request.getString("jsonrpc");
+        return request.stringValue("jsonrpc")
+                .orElseThrow(() -> new IllegalStateException("JSON-RPC request is missing jsonrpc version"));
     }
 
     @Override
     public String rpcMethod() {
-        return request.getString("method");
+        return request.stringValue("method")
+                .orElseThrow(() -> new IllegalStateException("JSON-RPC request is missing method name"));
     }
 
     @Override
     public Optional<JsonValue> rpcId() {
-        return Optional.ofNullable(request.get("id"));
+        return request.value("id");
     }
 
     @Override
     public JsonRpcParams params() {
-        JsonValue value = request.get("params");
-        if (value == null) {
-            value = JsonValue.EMPTY_JSON_OBJECT;
-        }
-        return JsonRpcParams.create((JsonStructure) value);
+        JsonValue value = request.value("params").orElse(JsonObject.empty());
+        return JsonRpcParams.create(value);
     }
 
     @Override

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcResponse.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ package io.helidon.webserver.jsonrpc;
 import java.util.Optional;
 
 import io.helidon.http.Status;
+import io.helidon.json.JsonNumber;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonString;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.webserver.http.ServerResponse;
-
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 
 /**
  * A representation of a JSON-RPC response.
@@ -45,7 +45,7 @@ public interface JsonRpcResponse extends ServerResponse {
      * @return this response
      */
     default JsonRpcResponse rpcId(int rpcId) {
-        return rpcId(Json.createValue(rpcId));
+        return rpcId(JsonNumber.create(rpcId));
     }
 
     /**
@@ -55,7 +55,7 @@ public interface JsonRpcResponse extends ServerResponse {
      * @return this response
      */
     default JsonRpcResponse rpcId(String rpcId) {
-        return rpcId(Json.createValue(rpcId));
+        return rpcId(JsonString.create(rpcId));
     }
 
     /**
@@ -68,12 +68,15 @@ public interface JsonRpcResponse extends ServerResponse {
     JsonRpcResponse result(JsonValue result);
 
     /**
-     * Set a result as an arbitrary object that can be mapped to JSON. This
-     * method will serialize the parameter using JSONB.
+     * Set a result from an object that can be mapped to a JSON object by
+     * Helidon JSON binding.
+     * <p>
+     * Custom Java types passed to this method should be annotated with
+     * {@code io.helidon.json.binding.Json.Entity}.
      *
      * @param object the object
      * @return this response
-     * @throws jakarta.json.JsonException if an error occurs during serialization
+     * @throws io.helidon.json.binding.JsonBindingException if an error occurs during mapping
      * @see #error()
      */
     JsonRpcResponse result(Object object);

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcResponseImpl.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,16 +26,12 @@ import io.helidon.http.Header;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.ServerResponseTrailers;
 import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.jsonrpc.core.JsonUtil;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http.spi.Sink;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonValue;
-
-import static io.helidon.jsonrpc.core.JsonUtil.JSON_BUILDER_FACTORY;
 
 /**
  * An implementation of JSON-RPC response.
@@ -89,7 +85,7 @@ class JsonRpcResponseImpl implements JsonRpcResponse {
 
     @Override
     public JsonRpcResponse result(Object object) {
-        result = JsonUtil.jsonbToJsonp(object);
+        result = JsonUtil.toJsonObject(object);
         return this;
     }
 
@@ -121,15 +117,15 @@ class JsonRpcResponseImpl implements JsonRpcResponse {
 
     @Override
     public JsonObject asJsonObject() {
-        JsonObjectBuilder builder = JSON_BUILDER_FACTORY.createObjectBuilder()
-                .add("jsonrpc", "2.0");
+        JsonObject.Builder builder = JsonObject.builder()
+                .set("jsonrpc", "2.0");
         if (rpcId != null) {
-            builder.add("id", rpcId);
+            builder.set("id", rpcId);
         }
         if (result != null) {
-            builder.add("result", result);
+            builder.set("result", result);
         } else if (error != null) {
-            builder.add("error", error.asJsonObject());
+            builder.set("error", error.asJsonObject());
         }
         return builder.build();
     }

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRouting.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,24 +25,22 @@ import io.helidon.common.GenericType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonException;
+import io.helidon.json.JsonNull;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http.spi.Sink;
-
-import jakarta.json.JsonArray;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonStructure;
-import jakarta.json.JsonValue;
-import jakarta.json.stream.JsonParsingException;
 
 import static io.helidon.jsonrpc.core.JsonRpcError.INTERNAL_ERROR;
 import static io.helidon.jsonrpc.core.JsonRpcError.INVALID_REQUEST;
 import static io.helidon.jsonrpc.core.JsonRpcError.METHOD_NOT_FOUND;
 import static io.helidon.jsonrpc.core.JsonRpcError.PARSE_ERROR;
-import static io.helidon.jsonrpc.core.JsonUtil.JSON_BUILDER_FACTORY;
 
 /**
  * JSON-RPC routing is an HTTP Service, as it is based on HTTP protocol.
@@ -92,140 +90,137 @@ public class JsonRpcRouting implements HttpService {
 
             httpRules.post(pathPattern, (req, res) -> {
                 // attempt to parse request as JSON
-                JsonStructure jsonRequest;
+                JsonValue jsonRequest;
                 try {
-                    jsonRequest = req.content().as(JsonStructure.class);
-                } catch (JsonParsingException e) {
+                    jsonRequest = req.content().as(JsonValue.class);
+                } catch (JsonException e) {
                     JsonObject parseError = jsonRpcError(PARSE_ERROR_ERROR, res, null);
                     res.status(Status.OK_200).send(parseError);
                     return;
                 }
 
                 // is this a single request?
-                if (jsonRequest instanceof JsonObject jsonObject) {
-                    // if request fails verification, return JSON-RPC error
-                    JsonRpcError error = verifyJsonRpc(jsonObject, handlersMap);
-                    if (error != null) {
-                        // Use error if returned by error handler
-                        if (errorHandler != null) {
-                            Optional<JsonRpcError> userError = errorHandler.handle(req, jsonObject);
-                            if (userError.isPresent()) {
-                                res.status(Status.OK_200).send(jsonRpcError(userError.get(), res, jsonObject.get("id")));
-                            } else {
-                                res.status(Status.OK_200).send();
-                            }
-                        } else {
-                            // otherwise return error
-                            JsonObject verifyError = jsonRpcError(error, res, jsonObject);
-                            res.status(Status.OK_200).send(verifyError);
-                        }
-                        return;
-                    }
-
-                    // prepare and call method handler
-                    AtomicBoolean sendCalled = new AtomicBoolean();
-                    JsonRpcHandler handler = handlersMap.get(jsonObject.getString("method"));
-                    JsonRpcRequest jsonReq = new JsonRpcRequestImpl(req, jsonObject);
-                    JsonValue rpcId = jsonReq.rpcId().orElse(null);
-                    JsonRpcResponse jsonRes = new JsonRpcSingleResponse(rpcId, res, sendCalled);
-
-                    // invoke single handler
-                    try {
-                        handler.handle(jsonReq, jsonRes);
-                        // if send() not called, return empty HTTP response
-                        if (!sendCalled.get()) {
-                            res.status(jsonRes.status()).send();
-                        }
-                    } catch (Throwable throwable1) {
-                        try {
-                            // see if there is an exception handler defined
-                            Optional<JsonRpcError> mappedError = handleThrowable(handlers, jsonReq, jsonRes, throwable1);
-
-                            // use error if returned, otherwise internal error
-                            if (mappedError.isPresent()) {
-                                JsonObject jsonRpcError = jsonRpcError(mappedError.get(), res, jsonObject.get("id"));
-                                res.status(Status.OK_200).send(jsonRpcError);
-                                return;
-                            }
-                        } catch (Throwable throwable2) {
-                            // falls through
-                        }
-                        sendInternalError(res, jsonObject.get("id"));
-                    }
-                } else if (jsonRequest instanceof JsonArray jsonArray) {
-                    // we must receive at least one request
-                    int size = jsonArray.size();
-                    if (size == 0) {
-                        sendInvalidRequest(res);
-                        return;
-                    }
-
-                    // process batch requests
-                    JsonArrayBuilder arrayBuilder = JSON_BUILDER_FACTORY.createArrayBuilder();
-                    for (int i = 0; i < size; i++) {
-                        JsonValue jsonValue = jsonArray.get(i);
-
-                        // requests must be objects
-                        if (!(jsonValue instanceof JsonObject jsonObject)) {
-                            JsonObject invalidRequest = jsonRpcError(INVALID_REQUEST_ERROR, res, null);
-                            arrayBuilder.add(invalidRequest);
-                            continue;       // skip bad request
-                        }
-
-                        // check if request passes validation before proceeding
-                        JsonRpcError error = verifyJsonRpc(jsonObject, handlersMap);
-                        if (error != null) {
-                            // Use error if returned by error handler
-                            if (errorHandler != null) {
-                                Optional<JsonRpcError> userError = errorHandler.handle(req, jsonObject);
-                                userError.ifPresent(
-                                        e -> arrayBuilder.add(jsonRpcError(e, res, jsonObject.get("id"))));
-                            } else {
-                                JsonObject verifyError = jsonRpcError(error, res, jsonObject.get("id"));
-                                arrayBuilder.add(verifyError);
-                            }
-                            continue;
-                        }
-
-                        // prepare and call method handler
-                        JsonRpcHandler handler = handlersMap.get(jsonObject.getString("method"));
-                        JsonRpcRequest jsonReq = new JsonRpcRequestImpl(req, jsonObject);
-                        JsonValue rpcId = jsonReq.rpcId().orElse(null);
-                        JsonRpcResponse jsonRes = new MyJsonRpcBatchResponse(rpcId, res, arrayBuilder);
-
-                        // invoke handler
-                        try {
-                            handler.handle(jsonReq, jsonRes);
-                        } catch (Throwable throwable1) {
-                            try {
-                                // see if there is an exception handler defined
-                                Optional<JsonRpcError> mappedError = handleThrowable(handlers, jsonReq, jsonRes, throwable1);
-
-                                // use error if returned, otherwise internal error
-                                if (mappedError.isPresent()) {
-                                    JsonObject jsonRpcError = jsonRpcError(mappedError.get(), res, jsonObject.get("id"));
-                                    arrayBuilder.add(jsonRpcError);
-                                    continue;
-                                }
-                            } catch (Throwable throwable2) {
-                                // falls through
-                            }
-                            JsonObject internalError = jsonRpcError(INTERNAL_ERROR_ERROR, res, jsonObject.get("id"));
-                            arrayBuilder.add(internalError);
-                        }
-                    }
-
-                    // respond to batch request always with 200
-                    JsonArray result = arrayBuilder.build();
-                    if (result.isEmpty()) {
-                        res.status(Status.OK_200).send();
-                    } else {
-                        res.status(Status.OK_200).send(result);
-                    }
+                if (jsonRequest.type() == io.helidon.json.JsonValueType.OBJECT) {
+                    handleSingleRequest(req, res, jsonRequest.asObject(), handlers, handlersMap, errorHandler);
+                } else if (jsonRequest.type() == io.helidon.json.JsonValueType.ARRAY) {
+                    handleBatchRequest(req, res, jsonRequest.asArray(), handlers, handlersMap, errorHandler);
                 } else {
                     sendInvalidRequest(res);
                 }
             });
+        }
+    }
+
+    private void handleSingleRequest(ServerRequest req,
+                                     ServerResponse res,
+                                     JsonObject jsonObject,
+                                     JsonRpcHandlers handlers,
+                                     Map<String, JsonRpcHandler> handlersMap,
+                                     JsonRpcErrorHandler errorHandler) throws Exception {
+        JsonRpcError error = verifyJsonRpc(jsonObject, handlersMap);
+        if (error != null) {
+            if (errorHandler != null) {
+                Optional<JsonRpcError> userError = errorHandler.handle(req, jsonObject);
+                if (userError.isPresent()) {
+                    res.status(Status.OK_200).send(jsonRpcError(userError.get(),
+                                                                res,
+                                                                jsonObject.value("id").orElse(null)));
+                } else {
+                    res.status(Status.OK_200).send();
+                }
+            } else {
+                JsonObject verifyError = jsonRpcError(error, res, jsonObject.value("id").orElse(null));
+                res.status(Status.OK_200).send(verifyError);
+            }
+            return;
+        }
+
+        AtomicBoolean sendCalled = new AtomicBoolean();
+        JsonRpcHandler handler = handlersMap.get(jsonObject.stringValue("method").orElseThrow());
+        JsonRpcRequest jsonReq = new JsonRpcRequestImpl(req, jsonObject);
+        JsonValue rpcId = jsonReq.rpcId().orElse(null);
+        JsonRpcResponse jsonRes = new JsonRpcSingleResponse(rpcId, res, sendCalled);
+
+        try {
+            handler.handle(jsonReq, jsonRes);
+            if (!sendCalled.get()) {
+                res.status(jsonRes.status()).send();
+            }
+        } catch (Throwable throwable1) {
+            try {
+                Optional<JsonRpcError> mappedError = handleThrowable(handlers, jsonReq, jsonRes, throwable1);
+                if (mappedError.isPresent()) {
+                    JsonObject jsonRpcError = jsonRpcError(mappedError.get(),
+                                                           res,
+                                                           jsonObject.value("id").orElse(null));
+                    res.status(Status.OK_200).send(jsonRpcError);
+                    return;
+                }
+            } catch (Throwable throwable2) {
+                // falls through
+            }
+            sendInternalError(res, jsonObject.value("id").orElse(null));
+        }
+    }
+
+    private void handleBatchRequest(ServerRequest req,
+                                    ServerResponse res,
+                                    JsonArray jsonArray,
+                                    JsonRpcHandlers handlers,
+                                    Map<String, JsonRpcHandler> handlersMap,
+                                    JsonRpcErrorHandler errorHandler) throws Exception {
+        int size = jsonArray.size();
+        if (size == 0) {
+            sendInvalidRequest(res);
+            return;
+        }
+
+        List<JsonValue> responses = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            JsonValue jsonValue = jsonArray.get(i).orElseThrow();
+
+            if (jsonValue.type() != io.helidon.json.JsonValueType.OBJECT) {
+                responses.add(jsonRpcError(INVALID_REQUEST_ERROR, res, null));
+                continue;
+            }
+
+            JsonObject jsonObject = jsonValue.asObject();
+            JsonRpcError error = verifyJsonRpc(jsonObject, handlersMap);
+            if (error != null) {
+                if (errorHandler != null) {
+                    Optional<JsonRpcError> userError = errorHandler.handle(req, jsonObject);
+                    userError.ifPresent(e -> responses.add(jsonRpcError(e, res, jsonObject.value("id").orElse(null))));
+                } else {
+                    responses.add(jsonRpcError(error, res, jsonObject.value("id").orElse(null)));
+                }
+                continue;
+            }
+
+            JsonRpcHandler handler = handlersMap.get(jsonObject.stringValue("method").orElseThrow());
+            JsonRpcRequest jsonReq = new JsonRpcRequestImpl(req, jsonObject);
+            JsonValue rpcId = jsonReq.rpcId().orElse(null);
+            JsonRpcResponse jsonRes = new MyJsonRpcBatchResponse(rpcId, res, responses);
+
+            try {
+                handler.handle(jsonReq, jsonRes);
+            } catch (Throwable throwable1) {
+                try {
+                    Optional<JsonRpcError> mappedError = handleThrowable(handlers, jsonReq, jsonRes, throwable1);
+                    if (mappedError.isPresent()) {
+                        responses.add(jsonRpcError(mappedError.get(), res, jsonObject.value("id").orElse(null)));
+                        continue;
+                    }
+                } catch (Throwable throwable2) {
+                    // falls through
+                }
+                responses.add(jsonRpcError(INTERNAL_ERROR_ERROR, res, jsonObject.value("id").orElse(null)));
+            }
+        }
+
+        if (responses.isEmpty()) {
+            res.status(Status.OK_200).send();
+        } else {
+            res.status(Status.OK_200).send(JsonArray.create(responses));
         }
     }
 
@@ -245,27 +240,24 @@ public class JsonRpcRouting implements HttpService {
 
     private JsonRpcError verifyJsonRpc(JsonObject object, Map<String, JsonRpcHandler> handlersMap) {
         try {
-            String version = object.getString("jsonrpc");
+            String version = object.stringValue("jsonrpc").orElseThrow();
             if (!"2.0".equals(version)) {
                 return INVALID_REQUEST_ERROR;
             }
             if (object.containsKey("method")) {
-                String method = object.getString("method");
+                String method = object.stringValue("method").orElseThrow();
                 if (handlersMap.get(method) != null) {
                     return null;                // method found
                 }
             }
             return METHOD_NOT_FOUND_ERROR;
-        } catch (ClassCastException e) {
+        } catch (RuntimeException e) {
             return INVALID_REQUEST_ERROR;       // malformed
         }
     }
 
     private JsonObject jsonRpcError(JsonRpcError error, ServerResponse res, JsonValue id) {
-        JsonRpcResponse rpcRes = new JsonRpcResponseImpl(JsonValue.NULL, res);
-        if (id != null) {
-            rpcRes.rpcId(id);
-        }
+        JsonRpcResponse rpcRes = new JsonRpcResponseImpl(id == null ? JsonNull.instance() : id, res);
         if (error.data().isEmpty()) {
             rpcRes.error(error.code(), error.message());
         } else {
@@ -383,12 +375,12 @@ public class JsonRpcRouting implements HttpService {
 
     private class MyJsonRpcBatchResponse extends JsonRpcResponseImpl {
         private final ServerResponse res;
-        private final JsonArrayBuilder arrayBuilder;
+        private final List<JsonValue> responses;
 
-        MyJsonRpcBatchResponse(JsonValue rpcId, ServerResponse res, JsonArrayBuilder arrayBuilder) {
+        MyJsonRpcBatchResponse(JsonValue rpcId, ServerResponse res, List<JsonValue> responses) {
             super(rpcId, res);
             this.res = res;
-            this.arrayBuilder = arrayBuilder;
+            this.responses = responses;
         }
 
         @Override
@@ -396,7 +388,7 @@ public class JsonRpcRouting implements HttpService {
             try {
                 if (rpcId().isPresent()) {
                     res.header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_JSON_VALUE);
-                    arrayBuilder.add(asJsonObject());
+                    responses.add(asJsonObject());
                 }
             } catch (Exception e) {
                 sendInternalError(res, rpcId().orElse(null));

--- a/webserver/jsonrpc/src/main/java/module-info.java
+++ b/webserver/jsonrpc/src/main/java/module-info.java
@@ -30,11 +30,10 @@ import io.helidon.common.features.api.HelidonFlavor;
 module io.helidon.webserver.jsonrpc {
 
     requires io.helidon.builder.api;
-    requires io.helidon.webserver;
-    requires io.helidon.jsonrpc.core;
-    requires io.helidon.http.media.jsonp;
-    requires jakarta.json;
-    requires jakarta.json.bind;
+    requires io.helidon.http.media.json;
+    requires transitive io.helidon.json;
+    requires transitive io.helidon.jsonrpc.core;
+    requires transitive io.helidon.webserver;
     requires io.helidon.common.features.api;
 
     exports io.helidon.webserver.jsonrpc;

--- a/webserver/jsonrpc/src/test/java/io/helidon/webserver/jsonrpc/JsonRpcMediaDependencyTest.java
+++ b/webserver/jsonrpc/src/test/java/io/helidon/webserver/jsonrpc/JsonRpcMediaDependencyTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.jsonrpc;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.json.JsonNumber;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class JsonRpcMediaDependencyTest {
+    private final Http1Client client;
+
+    JsonRpcMediaDependencyTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder routing) {
+        JsonRpcRouting jsonRpcRouting = JsonRpcRouting.builder()
+                .register("/calculator", "add", (req, res) -> {
+                    int left = req.params().get(0).asNumber().intValue();
+                    int right = req.params().get(1).asNumber().intValue();
+
+                    res.result(JsonNumber.create(left + right))
+                            .send();
+                })
+                .build();
+
+        routing.register("/rpc", jsonRpcRouting);
+    }
+
+    @Test
+    void serverModuleProvidesJsonMediaSupport() {
+        try (Http1ClientResponse response = client.post("/rpc/calculator")
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit("""
+                        {"jsonrpc":"2.0","method":"add","params":[20,25],"id":1}
+                        """)) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers().first(HeaderNames.CONTENT_TYPE).orElseThrow(),
+                       is(MediaTypes.APPLICATION_JSON_VALUE));
+            assertThat(response.entity().as(String.class), containsString("\"result\":45"));
+        }
+    }
+}

--- a/webserver/tests/jsonrpc/pom.xml
+++ b/webserver/tests/jsonrpc/pom.xml
@@ -35,6 +35,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json-binding</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-jsonrpc</artifactId>
             <scope>test</scope>
@@ -55,11 +65,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-sse</artifactId>
             <scope>test</scope>
@@ -70,5 +75,60 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.json</groupId>
+                            <artifactId>helidon-json-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.json</groupId>
+                        <artifactId>helidon-json-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcBaseTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcBaseTest.java
@@ -21,6 +21,11 @@ import java.util.Optional;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
 import io.helidon.http.sse.SseEvent;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonNumber;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
+import io.helidon.json.binding.Json;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
@@ -34,11 +39,6 @@ import io.helidon.webserver.jsonrpc.JsonRpcRules;
 import io.helidon.webserver.jsonrpc.JsonRpcService;
 import io.helidon.webserver.sse.SseSink;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
-
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonStructure;
 
 class JsonRpcBaseTest {
 
@@ -98,26 +98,28 @@ class JsonRpcBaseTest {
         int left, right;
 
         // collect params either as array or object
-        JsonStructure params = req.params().asJsonStructure();
+        JsonValue params = req.params().asJsonValue();
         if (params instanceof JsonArray array) {
-            left = array.getInt(0);
-            right = array.getInt(1);
+            left = array.get(0).map(JsonValue::asNumber).orElseThrow().intValue();
+            right = array.get(1).map(JsonValue::asNumber).orElseThrow().intValue();
         } else if (params instanceof JsonObject object) {
-            left = object.getInt("left");
-            right = object.getInt("right");
+            left = object.intValue("left").orElseThrow();
+            right = object.intValue("right").orElseThrow();
         } else {
             throw new IllegalArgumentException("Should have failed JSON-RPC validation");
         }
 
         // send response
-        res.result(Json.createValue(left + right)).send();
+        res.result(JsonNumber.create(left + right)).send();
     }
 
     // -- Machine -------------------------------------------------------------
 
+    @Json.Entity
     public record StartStopParams(String when, Duration duration) {
     }
 
+    @Json.Entity
     public record StartStopResult(String status) {
     }
 
@@ -174,12 +176,12 @@ class JsonRpcBaseTest {
 
         Optional<JsonRpcError> error(ServerRequest req, JsonObject object) {
             try {
-                String version = object.getString("jsonrpc");
+                String version = object.stringValue("jsonrpc").orElseThrow();
                 if (!"2.0".equals(version)) {
                     return Optional.of(JsonRpcError.create(JsonRpcError.INVALID_REQUEST,
                                                            "Version is not valid"));
                 }
-                String method = object.getString("method");
+                String method = object.stringValue("method").orElseThrow();
                 if (!"expected".equalsIgnoreCase(method)) {
                     return Optional.of(JsonRpcError.create(JsonRpcError.METHOD_NOT_FOUND,
                                                            "Method not found"));

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcBatchTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcBatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ import java.util.Optional;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.Status;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.jsonrpc.core.JsonRpcResult;
 import io.helidon.webclient.http1.Http1Client;
@@ -26,8 +29,6 @@ import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webclient.jsonrpc.JsonRpcClientBatchRequest;
 import io.helidon.webserver.testing.junit5.ServerTest;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -61,10 +62,10 @@ class JsonRpcBatchTest extends JsonRpcBaseTest {
             assertThat(res.size(), is(2));
             Optional<JsonRpcResult> result0 = res.get(0).result();
             assertThat(result0.isPresent(), is(true));
-            assertThat(result0.get().asJsonObject().getString("status"), is("RUNNING"));
+            assertThat(result0.get().asJsonObject().stringValue("status").orElseThrow(), is("RUNNING"));
             Optional<JsonRpcResult> result1 = res.get(1).result();
             assertThat(result1.isPresent(), is(true));
-            assertThat(result1.get().asJsonObject().getString("status"), is("STOPPED"));
+            assertThat(result1.get().asJsonObject().stringValue("status").orElseThrow(), is("STOPPED"));
         }
     }
 
@@ -74,8 +75,8 @@ class JsonRpcBatchTest extends JsonRpcBaseTest {
         try (var res = batch.submit()) {
             assertThat(res.status(), is(Status.OK_200));
             JsonObject object = res.entity().as(JsonObject.class);      // not array
-            JsonObject error = object.getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.INVALID_REQUEST));
+            JsonObject error = object.objectValue("error").orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.INVALID_REQUEST));
         }
     }
 
@@ -86,8 +87,8 @@ class JsonRpcBatchTest extends JsonRpcBaseTest {
                 .submit(JSON_RPC_BATCH.replace("[", "("))) {
             assertThat(res.status(), is(Status.OK_200));
             JsonObject object = res.entity().as(JsonObject.class);      // not array
-            JsonObject error = object.getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.PARSE_ERROR));
+            JsonObject error = object.objectValue("error").orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.PARSE_ERROR));
         }
     }
 
@@ -98,11 +99,11 @@ class JsonRpcBatchTest extends JsonRpcBaseTest {
                 .submit(JSON_RPC_BATCH.replace("stop", "foo"))) {
             assertThat(res.status(), is(Status.OK_200));
             JsonArray array = res.entity().as(JsonArray.class);
-            assertThat(array.size(), is(2));
-            JsonObject object0 = array.getJsonObject(0).getJsonObject("result");
-            assertThat(object0.getString("status"), is("RUNNING"));
-            JsonObject error = array.getJsonObject(1).getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.METHOD_NOT_FOUND));
+            assertThat(array.values().size(), is(2));
+            JsonObject object0 = array.get(0).map(JsonValue::asObject).flatMap(it -> it.objectValue("result")).orElseThrow();
+            assertThat(object0.stringValue("status").orElseThrow(), is("RUNNING"));
+            JsonObject error = array.get(1).map(JsonValue::asObject).flatMap(it -> it.objectValue("error")).orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.METHOD_NOT_FOUND));
         }
     }
 
@@ -113,10 +114,10 @@ class JsonRpcBatchTest extends JsonRpcBaseTest {
                 .submit("[1, 2, 3]")) {
             assertThat(res.status(), is(Status.OK_200));
             JsonArray array = res.entity().as(JsonArray.class);
-            assertThat(array.size(), is(3));
-            for (int i = 0; i < array.size(); i++) {
-                JsonObject error = array.getJsonObject(i).getJsonObject("error");
-                assertThat(error.getInt("code"), is(JsonRpcError.INVALID_REQUEST));
+            assertThat(array.values().size(), is(3));
+            for (int i = 0; i < array.values().size(); i++) {
+                JsonObject error = array.get(i).map(JsonValue::asObject).flatMap(it -> it.objectValue("error")).orElseThrow();
+                assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.INVALID_REQUEST));
             }
         }
     }

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcErrorTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,13 @@ package io.helidon.webserver.tests.jsonrpc;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.Status;
+import io.helidon.json.JsonNull;
+import io.helidon.json.JsonObject;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webserver.testing.junit5.ServerTest;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,9 +50,9 @@ class JsonRpcErrorTest extends JsonRpcBaseTest {
                 .submit("Not an object or array")) {
             assertThat(res.status(), is(Status.OK_200));
             JsonObject object = res.entity().as(JsonObject.class);
-            assertThat(object.get("id"), is(JsonValue.NULL));
-            JsonObject error = object.getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.PARSE_ERROR));
+            assertThat(object.value("id").orElseThrow(), is(JsonNull.instance()));
+            JsonObject error = object.objectValue("error").orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.PARSE_ERROR));
         }
     }
 
@@ -64,9 +63,9 @@ class JsonRpcErrorTest extends JsonRpcBaseTest {
                 .submit(JSON_RPC_START_BAD_JSON)) {
             assertThat(res.status(), is(Status.OK_200));
             JsonObject object = res.entity().as(JsonObject.class);
-            assertThat(object.get("id"), is(JsonValue.NULL));
-            JsonObject error = object.getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.PARSE_ERROR));
+            assertThat(object.value("id").orElseThrow(), is(JsonNull.instance()));
+            JsonObject error = object.objectValue("error").orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.PARSE_ERROR));
         }
     }
 
@@ -77,9 +76,9 @@ class JsonRpcErrorTest extends JsonRpcBaseTest {
                 .submit(MACHINE_START.replace("2.0", "5.0"))) {
             assertThat(res.status(), is(Status.OK_200));
             JsonObject object = res.entity().as(JsonObject.class);
-            assertThat(object.get("id"), is(Json.createValue(1)));
-            JsonObject error = object.getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.INVALID_REQUEST));
+            assertThat(object.intValue("id").orElseThrow(), is(1));
+            JsonObject error = object.objectValue("error").orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.INVALID_REQUEST));
         }
     }
 
@@ -90,9 +89,9 @@ class JsonRpcErrorTest extends JsonRpcBaseTest {
                 .submit(MACHINE_START.replace("start", "badMethod"))) {
             assertThat(res.status(), is(Status.OK_200));
             JsonObject object = res.entity().as(JsonObject.class);
-            assertThat(object.get("id"), is(Json.createValue(1)));
-            JsonObject error = object.getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.METHOD_NOT_FOUND));
+            assertThat(object.intValue("id").orElseThrow(), is(1));
+            JsonObject error = object.objectValue("error").orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.METHOD_NOT_FOUND));
         }
     }
 
@@ -113,10 +112,10 @@ class JsonRpcErrorTest extends JsonRpcBaseTest {
                 .submit(MACHINE_START.replace("NOW", "LATER"))) {
             assertThat(res.status().code(), is(200));
             JsonObject object = res.entity().as(JsonObject.class);
-            assertThat(object.get("id"), is(Json.createValue(1)));
-            JsonObject error = object.getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.INVALID_PARAMS));
-            assertThat(error.getString("message"), is("Bad param"));
+            assertThat(object.intValue("id").orElseThrow(), is(1));
+            JsonObject error = object.objectValue("error").orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.INVALID_PARAMS));
+            assertThat(error.stringValue("message").orElseThrow(), is("Bad param"));
         }
     }
 
@@ -127,10 +126,10 @@ class JsonRpcErrorTest extends JsonRpcBaseTest {
                 .submit(MACHINE_STOP.replace("NOW", "LATER"))) {
             assertThat(res.status().code(), is(200));
             JsonObject object = res.entity().as(JsonObject.class);
-            assertThat(object.get("id"), is(Json.createValue(2)));
-            JsonObject error = object.getJsonObject("error");
-            assertThat(error.getInt("code"), is(JsonRpcError.INVALID_PARAMS));
-            assertThat(error.getString("message"), is("Bad param"));
+            assertThat(object.intValue("id").orElseThrow(), is(2));
+            JsonObject error = object.objectValue("error").orElseThrow();
+            assertThat(error.intValue("code").orElseThrow(), is(JsonRpcError.INVALID_PARAMS));
+            assertThat(error.stringValue("message").orElseThrow(), is("Bad param"));
         }
     }
 }

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcSseTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcSseTest.java
@@ -15,7 +15,6 @@
  */
 package io.helidon.webserver.tests.jsonrpc;
 
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -25,13 +24,13 @@ import java.util.concurrent.TimeoutException;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.sse.SseEvent;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webclient.sse.SseSource;
 import io.helidon.webserver.testing.junit5.ServerTest;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -67,8 +66,8 @@ class JsonRpcSseTest extends JsonRpcBaseTest {
                 @Override
                 public void onEvent(SseEvent value) {
                     String jsonRpc = value.data(String.class);
-                    JsonObject json = Json.createReader(new StringReader(jsonRpc)).readObject();
-                    methods.add(json.getString("method"));
+                    JsonObject json = JsonParser.create(jsonRpc).readJsonObject();
+                    methods.add(json.stringValue("method").orElseThrow());
                 }
 
                 @Override
@@ -100,8 +99,8 @@ class JsonRpcSseTest extends JsonRpcBaseTest {
                 @Override
                 public void onEvent(SseEvent value) {
                     String jsonRpc = value.data(String.class);
-                    JsonObject json = Json.createReader(new StringReader(jsonRpc)).readObject();
-                    results.add(json.getString("result"));
+                    JsonObject json = JsonParser.create(jsonRpc).readJsonObject();
+                    results.add(json.stringValue("result").orElseThrow());
                 }
 
                 @Override

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,11 @@ package io.helidon.webserver.tests.jsonrpc;
 import java.util.Optional;
 
 import io.helidon.http.Status;
+import io.helidon.json.JsonValue;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webserver.testing.junit5.ServerTest;
 
-import jakarta.json.Json;
-import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,7 +44,7 @@ class JsonRpcTest extends JsonRpcBaseTest {
                 .path("/rpc/machine")
                 .submit()) {
             assertThat(res.status(), is(Status.OK_200));
-            assertThat(res.rpcId(), is(Optional.of(Json.createValue(1))));
+            assertThat(res.rpcId().map(value -> value.asNumber().intValue()), is(Optional.of(1)));
             assertThat(res.result().isPresent(), is(true));
             StartStopResult result = res.result().get().as(StartStopResult.class);
             assertThat(result.status(), is("RUNNING"));
@@ -60,7 +59,7 @@ class JsonRpcTest extends JsonRpcBaseTest {
                 .path("/rpc/machine")
                 .submit()) {
             assertThat(res.status(), is(Status.OK_200));
-            assertThat(res.rpcId(), is(Optional.of(Json.createValue(2))));
+            assertThat(res.rpcId().map(value -> value.asNumber().intValue()), is(Optional.of(2)));
             assertThat(res.result().isPresent(), is(true));
             StartStopResult result = res.result().get().as(StartStopResult.class);
             assertThat(result.status(), is("STOPPED"));
@@ -76,10 +75,26 @@ class JsonRpcTest extends JsonRpcBaseTest {
                 .path("/rpc/calculator")
                 .submit()) {
             assertThat(res.status(), is(Status.OK_200));
-            assertThat(res.rpcId(), is(Optional.of(Json.createValue(1))));
+            assertThat(res.rpcId().map(value -> value.asNumber().intValue()), is(Optional.of(1)));
             assertThat(res.result().isPresent(), is(true));
             JsonValue result = res.result().get().asJsonValue();
-            assertThat(result, is(Json.createValue(45)));
+            assertThat(result.asNumber().intValue(), is(45));
+        }
+    }
+
+    @Test
+    void testAddObject() {
+        try (var res = jsonRpcClient().rpcMethod("add")
+                .rpcId(3)
+                .param("left", 20)
+                .param("right", 25)
+                .path("/rpc/calculator")
+                .submit()) {
+            assertThat(res.status(), is(Status.OK_200));
+            assertThat(res.rpcId().map(value -> value.asNumber().intValue()), is(Optional.of(3)));
+            assertThat(res.result().isPresent(), is(true));
+            JsonValue result = res.result().get().asJsonValue();
+            assertThat(result.asNumber().intValue(), is(45));
         }
     }
 


### PR DESCRIPTION
Resolves #11356

Replaces JSON-RPC JSON-P and JSON-B APIs with Helidon JSON APIs, adds the JSON media provider dependency where HTTP entity conversion needs it, and removes deprecated JSON-P/JSON-B compatibility API usage from the JSON-RPC modules.

Also restores JSON-RPC core dependency checks and adds regression coverage for standalone JSON media wiring and malformed client response JSON.