### PR TITLE
Fix MP config service registry warning (4.x)

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,11 +172,14 @@ public class MpConfigProviderResolver extends ConfigProviderResolver {
             config = delegate.delegate();
         }
 
-        if (null != currentConfig) {
+        ConfigDelegate newConfig;
+        if (null == currentConfig) {
+            newConfig = new ConfigDelegate(config);
+        } else {
             currentConfig.set(config);
+            newConfig = currentConfig;
         }
 
-        ConfigDelegate newConfig = new ConfigDelegate(config);
         CONFIGS.put(classLoader, newConfig);
 
         if (classLoader == Thread.currentThread().getContextClassLoader()) {

--- a/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigTest.java
+++ b/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -235,6 +236,40 @@ public class MpConfigTest {
                 .build();
 
         assertThat(mpConfig.getValue("foo", String.class), is("bar"));
+    }
+
+    @Test
+    void reRegisterConfigAfterServiceRegistryAccess() {
+        ConfigProviderResolver resolver = ConfigProviderResolver.instance();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Config original = resolver.getConfig(classLoader);
+        if (original instanceof MpConfigProviderResolver.ConfigDelegate delegate) {
+            original = delegate.delegate();
+        }
+
+        try {
+            Config first = resolver.getBuilder()
+                    .withSources(MpConfigSources.create(io.helidon.config.Config.builder()
+                                                                .sources(ConfigSources.create(Map.of("foo", "bar")))
+                                                                .build()))
+                    .build();
+            Config second = resolver.getBuilder()
+                    .withSources(MpConfigSources.create(io.helidon.config.Config.builder()
+                                                                .sources(ConfigSources.create(Map.of("foo", "baz")))
+                                                                .build()))
+                    .build();
+
+            resolver.registerConfig(first, classLoader);
+            io.helidon.config.Config registryConfig = Services.get(io.helidon.config.Config.class);
+            resolver.registerConfig(second, classLoader);
+
+            Config current = resolver.getConfig(classLoader);
+            assertThat(current, sameInstance(registryConfig));
+            assertThat(current.getValue("foo", String.class), is("baz"));
+            assertThat(registryConfig.get("foo").asString().get(), is("baz"));
+        } finally {
+            resolver.registerConfig(original, classLoader);
+        }
     }
 
     @Test


### PR DESCRIPTION
Resolves #12038

Reuses the existing MP config delegate when re-registering config for the same class loader, so existing service-registry config lookups see the updated config instead of retaining a stale delegate. Adds regression coverage for re-registering config after resolving `io.helidon.config.Config` from `Services`.
