### PR TITLE
Add URI host and authority normalization

### DIFF
--- a/common/uri/src/main/java/io/helidon/common/uri/UriAuthority.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriAuthority.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.uri;
+
+import java.util.Objects;
+
+/**
+ * Normalized URI authority.
+ * <p>
+ * URI authority is a host plus an optional port. Userinfo is not supported.
+ */
+public final class UriAuthority {
+    /**
+     * Undefined port value.
+     */
+    public static final int UNDEFINED_PORT = -1;
+
+    private final UriHost host;
+    private final int port;
+
+    private UriAuthority(UriHost host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    /**
+     * Create a normalized authority from a host and optional port.
+     *
+     * @param host normalized host
+     * @param port port, or {@value #UNDEFINED_PORT} when absent
+     * @return normalized authority
+     * @throws NullPointerException     in case the host is {@code null}
+     * @throws IllegalArgumentException in case the port is invalid
+     */
+    public static UriAuthority create(UriHost host, int port) {
+        Objects.requireNonNull(host, "host");
+        validatePort(port);
+        return new UriAuthority(host, port);
+    }
+
+    /**
+     * Parse and normalize authority text.
+     * <p>
+     * DNS hosts are normalized to lower-case ASCII. IPv6 authorities must use brackets.
+     *
+     * @param authority authority text containing a host and optional port
+     * @return normalized authority
+     * @throws NullPointerException     in case the authority is {@code null}
+     * @throws IllegalArgumentException in case the authority is invalid
+     */
+    public static UriAuthority create(String authority) {
+        Objects.requireNonNull(authority, "authority");
+        if (authority.isBlank()) {
+            throw new IllegalArgumentException("Authority cannot be blank");
+        }
+        if (authority.indexOf('@') >= 0) {
+            throw new IllegalArgumentException("Authority must not contain userinfo");
+        }
+
+        if (authority.charAt(0) == '[') {
+            return createBracketed(authority);
+        }
+
+        int firstColon = authority.indexOf(':');
+        if (firstColon == -1) {
+            return new UriAuthority(UriHost.create(authority), UNDEFINED_PORT);
+        }
+        if (authority.indexOf(':', firstColon + 1) != -1) {
+            throw new IllegalArgumentException("IPv6 authority must use square brackets");
+        }
+        return new UriAuthority(UriHost.create(authority.substring(0, firstColon)),
+                                parsePort(authority, firstColon + 1));
+    }
+
+    /**
+     * Host.
+     *
+     * @return normalized host
+     */
+    public UriHost host() {
+        return host;
+    }
+
+    /**
+     * Port.
+     *
+     * @return port, or {@value #UNDEFINED_PORT} when absent
+     */
+    public int port() {
+        return port;
+    }
+
+    /**
+     * Whether the authority has a port.
+     *
+     * @return whether a port is defined
+     */
+    public boolean hasPort() {
+        return port != UNDEFINED_PORT;
+    }
+
+    /**
+     * Port or a default value.
+     *
+     * @param defaultPort default port to use when the authority has no port
+     * @return authority port or the provided default port
+     */
+    public int portOrDefault(int defaultPort) {
+        return hasPort() ? port : defaultPort;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof UriAuthority that)) {
+            return false;
+        }
+        return port == that.port && host.equals(that.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(host, port);
+    }
+
+    @Override
+    public String toString() {
+        if (!hasPort()) {
+            return hostText();
+        }
+        return hostText() + ":" + port;
+    }
+
+    private static UriAuthority createBracketed(String authority) {
+        int closingBracket = authority.indexOf(']');
+        if (closingBracket == -1) {
+            throw new IllegalArgumentException("IPv6 authority is missing a closing bracket");
+        }
+        String host = authority.substring(1, closingBracket);
+        if (host.isEmpty()) {
+            throw new IllegalArgumentException("IPv6 authority host cannot be blank");
+        }
+        UriHost uriHost = UriHost.create(host);
+        if (uriHost.kind() != UriHost.Kind.IPV6) {
+            throw new IllegalArgumentException("Bracketed authority host must be an IPv6 literal");
+        }
+        return new UriAuthority(uriHost, bracketedPort(authority, closingBracket));
+    }
+
+    private static int bracketedPort(String authority, int closingBracket) {
+        if (closingBracket == authority.length() - 1) {
+            return UNDEFINED_PORT;
+        }
+        if (authority.charAt(closingBracket + 1) != ':') {
+            throw new IllegalArgumentException("Authority contains unexpected content after IPv6 host");
+        }
+        return parsePort(authority, closingBracket + 2);
+    }
+
+    private static int parsePort(String authority, int offset) {
+        if (offset == authority.length()) {
+            throw new IllegalArgumentException("Authority port cannot be blank");
+        }
+        int result = 0;
+        for (int i = offset; i < authority.length(); i++) {
+            char c = authority.charAt(i);
+            if (c < '0' || c > '9') {
+                throw new IllegalArgumentException("Authority port must contain only digits");
+            }
+            result = result * 10 + c - '0';
+            if (result > 65535) {
+                throw new IllegalArgumentException("Authority port must be between 0 and 65535");
+            }
+        }
+        return result;
+    }
+
+    private static void validatePort(int port) {
+        if (port == UNDEFINED_PORT) {
+            return;
+        }
+        if (port < 0 || port > 65535) {
+            throw new IllegalArgumentException("Authority port must be between 0 and 65535, or -1 when absent");
+        }
+    }
+
+    private String hostText() {
+        if (host.kind() == UriHost.Kind.IPV6) {
+            return "[" + host.value() + "]";
+        }
+        return host.value();
+    }
+}

--- a/common/uri/src/main/java/io/helidon/common/uri/UriHost.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriHost.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.uri;
+
+import java.net.IDN;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Normalized host value.
+ * <p>
+ * The value never contains a port or IPv6 brackets. DNS names are normalized to lower-case ASCII, IPv4 literals to
+ * decimal dotted-quad form, and IPv6 literals to canonical compressed lower-case text form.
+ */
+public final class UriHost {
+    private final String value;
+    private final Kind kind;
+
+    private UriHost(String value, Kind kind) {
+        this.value = value;
+        this.kind = kind;
+    }
+
+    /**
+     * Create a normalized host.
+     *
+     * @param host host text, without a port; IPv6 literals must not use authority brackets, use {@link UriAuthority}
+     *             for authority text
+     * @return normalized host
+     * @throws NullPointerException     in case the host is {@code null}
+     * @throws IllegalArgumentException in case the host is invalid
+     */
+    public static UriHost create(String host) {
+        Objects.requireNonNull(host, "host");
+
+        if (host.isBlank()) {
+            throw new IllegalArgumentException("Host cannot be blank");
+        }
+
+        if (host.indexOf(':') >= 0) {
+            return ipv6(host);
+        }
+
+        if (UriValidator.isIpv4Address(host)) {
+            return ipv4(host);
+        }
+
+        return dns(host);
+    }
+
+    /**
+     * Normalized host value.
+     *
+     * @return normalized host value
+     */
+    public String value() {
+        return value;
+    }
+
+    /**
+     * Host kind.
+     *
+     * @return host kind
+     */
+    public Kind kind() {
+        return kind;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof UriHost that)) {
+            return false;
+        }
+        return kind == that.kind && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, kind);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    private static UriHost ipv4(String host) {
+        if (!UriValidator.isIpv4Address(host)) {
+            throw new IllegalArgumentException("Host is not a valid IPv4 address");
+        }
+        UriValidator.validateNonIpLiteral(host);
+
+        StringBuilder normalized = new StringBuilder(host.length());
+        int start = 0;
+        int part = 0;
+        while (start <= host.length()) {
+            int dot = host.indexOf('.', start);
+            int end = dot == -1 ? host.length() : dot;
+            if (end == start) {
+                throw new IllegalArgumentException("IPv4 address contains an empty segment");
+            }
+            int value = parseIpv4Segment(host, start, end);
+            if (value > 255) {
+                throw new IllegalArgumentException("IPv4 segment is greater than 255");
+            }
+            if (part > 0) {
+                normalized.append('.');
+            }
+            normalized.append(value);
+            part++;
+            if (dot == -1) {
+                break;
+            }
+            start = dot + 1;
+        }
+        if (part != 4) {
+            throw new IllegalArgumentException("IPv4 address must contain exactly four segments");
+        }
+        return new UriHost(normalized.toString(), Kind.IPV4);
+    }
+
+    private static int parseIpv4Segment(String host, int start, int end) {
+        int value = 0;
+        for (int i = start; i < end; i++) {
+            char c = host.charAt(i);
+            if (c < '0' || c > '9') {
+                throw new IllegalArgumentException("IPv4 address contains a non-digit character");
+            }
+            value = value * 10 + c - '0';
+            if (value > 255) {
+                return value;
+            }
+        }
+        return value;
+    }
+
+    private static UriHost ipv6(String host) {
+        return new UriHost(UriValidator.normalizeIpv6Literal("[" + host + "]"), Kind.IPV6);
+    }
+
+    private static UriHost dns(String host) {
+        String normalized = stripTerminalDot(host);
+        if (normalized.isBlank()) {
+            throw new IllegalArgumentException("Host cannot be blank");
+        }
+        String ascii;
+        try {
+            ascii = IDN.toASCII(normalized, IDN.USE_STD3_ASCII_RULES);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Host is not a valid DNS name", e);
+        }
+        if (ascii.isBlank()) {
+            throw new IllegalArgumentException("Host cannot be blank");
+        }
+        ascii = ascii.toLowerCase(Locale.ROOT);
+        UriValidator.validateNonIpLiteral(ascii);
+        validateDnsName(ascii);
+        return new UriHost(ascii, Kind.DNS);
+    }
+
+    private static void validateDnsName(String host) {
+        // RFC 1035, 2.3.4 limits a domain name to 255 octets on the wire; without the root label and label-length
+        // octets, the textual host name is at most 253 characters.
+        if (host.length() > 253) {
+            throw new IllegalArgumentException("Host DNS name is too long");
+        }
+
+        int labelStart = 0;
+        for (int i = 0; i <= host.length(); i++) {
+            if (i == host.length() || host.charAt(i) == '.') {
+                validateDnsLabel(host, labelStart, i);
+                labelStart = i + 1;
+            }
+        }
+    }
+
+    private static void validateDnsLabel(String host, int start, int end) {
+        // RFC 1035, 2.3.1 defines labels as non-empty components.
+        if (start == end) {
+            throw new IllegalArgumentException("Host DNS name contains an empty label");
+        }
+        // RFC 1035, 2.3.4 limits a DNS label to 63 octets.
+        if (end - start > 63) {
+            throw new IllegalArgumentException("Host DNS label is too long");
+        }
+        // RFC 1035, 2.3.1 defines the preferred name syntax; RFC 1123, 2.1 relaxes the first character to also
+        // allow digits, but labels still do not start or end with a hyphen.
+        if (host.charAt(start) == '-' || host.charAt(end - 1) == '-') {
+            throw new IllegalArgumentException("Host DNS label must not start or end with a hyphen");
+        }
+        // RFC 1035, 2.3.1 plus RFC 1123, 2.1 allow letters, digits, and hyphen in DNS host labels.
+        for (int i = start; i < end; i++) {
+            char c = host.charAt(i);
+            if (c >= 'a' && c <= 'z') {
+                continue;
+            }
+            if (c >= '0' && c <= '9') {
+                continue;
+            }
+            if (c == '-') {
+                continue;
+            }
+            throw new IllegalArgumentException("Host is not a valid DNS name");
+        }
+    }
+
+    private static String stripTerminalDot(String host) {
+        if (host.endsWith(".")) {
+            return host.substring(0, host.length() - 1);
+        }
+        return host;
+    }
+
+    /**
+     * Host kind.
+     */
+    public enum Kind {
+        /**
+         * DNS name.
+         */
+        DNS,
+        /**
+         * IPv4 literal.
+         */
+        IPV4,
+        /**
+         * IPv6 literal.
+         */
+        IPV6
+    }
+}

--- a/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,13 @@ import io.helidon.common.uri.UriValidationException.Segment;
 public final class UriValidator {
     private static final Pattern IP_V4_PATTERN =
             Pattern.compile("^([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})$");
+    private static final String IP_V4_DEC_OCTET = "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])";
+    private static final Pattern IP_V4_ADDRESS_PATTERN =
+            Pattern.compile("^" + IP_V4_DEC_OCTET
+                                    + "\\." + IP_V4_DEC_OCTET
+                                    + "\\." + IP_V4_DEC_OCTET
+                                    + "\\." + IP_V4_DEC_OCTET
+                                    + "$");
     private static final boolean[] HEXDIGIT = new boolean[256];
     private static final boolean[] UNRESERVED = new boolean[256];
     private static final boolean[] SUB_DELIMS = new boolean[256];
@@ -333,6 +340,40 @@ public final class UriValidator {
         }
     }
 
+    static String normalizeIpv6Literal(String ipLiteral) {
+        Objects.requireNonNull(ipLiteral);
+        checkNotBlank(Segment.HOST, "IP Literal", ipLiteral, ipLiteral);
+
+        if (ipLiteral.charAt(0) != '[') {
+            throw new UriValidationException(Segment.HOST,
+                                             ipLiteral.toCharArray(),
+                                             "Invalid IP literal, missing square bracket(s)",
+                                             0,
+                                             ipLiteral.charAt(0));
+        }
+        int lastIndex = ipLiteral.length() - 1;
+        if (ipLiteral.charAt(lastIndex) != ']') {
+            throw new UriValidationException(Segment.HOST,
+                                             ipLiteral.toCharArray(),
+                                             "Invalid IP literal, missing square bracket(s)",
+                                             lastIndex,
+                                             ipLiteral.charAt(lastIndex));
+        }
+
+        String host = ipLiteral.substring(1, ipLiteral.length() - 1);
+        checkNotBlank(Segment.HOST, "Host", ipLiteral, host);
+        if (host.charAt(0) == 'v') {
+            throw new UriValidationException(Segment.HOST,
+                                             ipLiteral.toCharArray(),
+                                             "IP Future is not an IPv6 literal");
+        }
+        return formatIpv6(parseIpv6Address(ipLiteral, host));
+    }
+
+    static boolean isIpv4Address(String host) {
+        return IP_V4_ADDRESS_PATTERN.matcher(host).matches();
+    }
+
     /**
      * Validate IPv4 address or a registered name.
      *
@@ -582,6 +623,177 @@ public final class UriValidator {
         if (octetInt > 255) {
             throw new UriValidationException(Segment.HOST, host.toCharArray(), message);
         }
+    }
+
+    private static int[] parseIpv6Address(String ipLiteral, String host) {
+        int[] segments = new int[8];
+        int doubleColon = host.indexOf("::");
+
+        if (doubleColon == -1) {
+            int count = parseIpv6Segments(ipLiteral, host, 0, host.length(), segments, 0);
+            if (count != 8) {
+                throw new UriValidationException(Segment.HOST,
+                                                 ipLiteral.toCharArray(),
+                                                 "Host is not a valid IPv6 literal");
+            }
+            return segments;
+        }
+
+        int leftCount = parseIpv6Segments(ipLiteral, host, 0, doubleColon, segments, 0);
+        int[] right = new int[8];
+        int rightCount = parseIpv6Segments(ipLiteral, host, doubleColon + 2, host.length(), right, 0);
+        int compressedCount = 8 - leftCount - rightCount;
+        if (compressedCount < 1) {
+            throw new UriValidationException(Segment.HOST,
+                                             ipLiteral.toCharArray(),
+                                             "Host is not a valid IPv6 literal");
+        }
+        System.arraycopy(right, 0, segments, leftCount + compressedCount, rightCount);
+        return segments;
+    }
+
+    private static int parseIpv6Segments(String ipLiteral,
+                                         String host,
+                                         int start,
+                                         int end,
+                                         int[] segments,
+                                         int offset) {
+        if (start == end) {
+            return 0;
+        }
+
+        int count = 0;
+        int segmentStart = start;
+        while (segmentStart < end) {
+            int segmentEnd = host.indexOf(':', segmentStart);
+            if (segmentEnd == -1 || segmentEnd > end) {
+                segmentEnd = end;
+            }
+            if (segmentEnd == segmentStart) {
+                throw new UriValidationException(Segment.HOST,
+                                                 ipLiteral.toCharArray(),
+                                                 "Host is not a valid IPv6 literal");
+            }
+            int dot = host.indexOf('.', segmentStart);
+            if (dot != -1 && dot < segmentEnd) {
+                if (segmentEnd != end) {
+                    throw new UriValidationException(Segment.HOST,
+                                                     ipLiteral.toCharArray(),
+                                                     "Host is not a valid IPv6 literal");
+                }
+                count += parseIpv4Tail(ipLiteral, host, segmentStart, segmentEnd, segments, offset + count);
+            } else {
+                if (offset + count >= segments.length) {
+                    throw new UriValidationException(Segment.HOST,
+                                                     ipLiteral.toCharArray(),
+                                                     "Host is not a valid IPv6 literal");
+                }
+                segments[offset + count] = parseIpv6Hextet(ipLiteral, host, segmentStart, segmentEnd);
+                count++;
+            }
+            segmentStart = segmentEnd + 1;
+        }
+        return count;
+    }
+
+    private static int parseIpv4Tail(String ipLiteral, String host, int start, int end, int[] segments, int offset) {
+        if (offset + 1 >= segments.length) {
+            throw new UriValidationException(Segment.HOST,
+                                             ipLiteral.toCharArray(),
+                                             "Host is not a valid IPv6 literal");
+        }
+
+        Matcher matcher = IP_V4_ADDRESS_PATTERN.matcher(host.substring(start, end));
+        if (!matcher.matches()) {
+            throw new UriValidationException(Segment.HOST,
+                                             ipLiteral.toCharArray(),
+                                             "Host IPv6 dual address contains invalid IPv4 address");
+        }
+
+        int first = (Integer.parseInt(matcher.group(1)) << 8) | Integer.parseInt(matcher.group(2));
+        int second = (Integer.parseInt(matcher.group(3)) << 8) | Integer.parseInt(matcher.group(4));
+        segments[offset] = first;
+        segments[offset + 1] = second;
+        return 2;
+    }
+
+    private static int parseIpv6Hextet(String ipLiteral, String host, int start, int end) {
+        if (end - start > 4) {
+            throw new UriValidationException(Segment.HOST,
+                                             ipLiteral.toCharArray(),
+                                             host.substring(start, end).toCharArray(),
+                                             "IPv6 segment has more than 4 chars");
+        }
+
+        int value = 0;
+        for (int i = start; i < end; i++) {
+            char c = host.charAt(i);
+            int digit = hexDigit(c);
+            if (digit == -1) {
+                throw new UriValidationException(Segment.HOST,
+                                                 ipLiteral.toCharArray(),
+                                                 host.substring(start, end).toCharArray(),
+                                                 "IPv6 segment has non hexadecimal char",
+                                                 i - start,
+                                                 c);
+            }
+            value = (value << 4) | digit;
+        }
+        return value;
+    }
+
+    private static int hexDigit(char c) {
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        }
+        if (c >= 'a' && c <= 'f') {
+            return c - 'a' + 10;
+        }
+        if (c >= 'A' && c <= 'F') {
+            return c - 'A' + 10;
+        }
+        return -1;
+    }
+
+    private static String formatIpv6(int[] segments) {
+        int bestStart = -1;
+        int bestLength = 0;
+        int currentStart = -1;
+        int currentLength = 0;
+
+        for (int i = 0; i < segments.length; i++) {
+            if (segments[i] == 0) {
+                if (currentStart == -1) {
+                    currentStart = i;
+                }
+                currentLength++;
+                continue;
+            }
+            if (currentLength > bestLength && currentLength > 1) {
+                bestStart = currentStart;
+                bestLength = currentLength;
+            }
+            currentStart = -1;
+            currentLength = 0;
+        }
+        if (currentLength > bestLength && currentLength > 1) {
+            bestStart = currentStart;
+            bestLength = currentLength;
+        }
+
+        StringBuilder result = new StringBuilder(39);
+        for (int i = 0; i < segments.length; i++) {
+            if (i == bestStart) {
+                result.append("::");
+                i += bestLength - 1;
+                continue;
+            }
+            if (i > 0 && i != bestStart + bestLength) {
+                result.append(':');
+            }
+            result.append(Integer.toHexString(segments[i]));
+        }
+        return result.toString();
     }
 
     private static void validateIpFuture(String ipLiteral, String host) {

--- a/common/uri/src/test/java/io/helidon/common/uri/UriAuthorityTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriAuthorityTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.uri;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UriAuthorityTest {
+    @Test
+    void hostOnlyAuthority() {
+        UriAuthority authority = UriAuthority.create("Api.Example.COM.");
+
+        assertThat(authority.host(), is(UriHost.create("api.example.com")));
+        assertThat(authority.port(), is(UriAuthority.UNDEFINED_PORT));
+        assertThat(authority.hasPort(), is(false));
+        assertThat(authority.portOrDefault(443), is(443));
+        assertThat(authority.toString(), is("api.example.com"));
+    }
+
+    @Test
+    void hostAndPortAuthority() {
+        UriAuthority authority = UriAuthority.create("api.example.com:8443");
+
+        assertThat(authority.host(), is(UriHost.create("api.example.com")));
+        assertThat(authority.port(), is(8443));
+        assertThat(authority.hasPort(), is(true));
+        assertThat(authority.portOrDefault(443), is(8443));
+        assertThat(authority.toString(), is("api.example.com:8443"));
+    }
+
+    @Test
+    void ipv4Authority() {
+        UriAuthority authority = UriAuthority.create("192.0.2.10:8080");
+
+        assertThat(authority.host().kind(), is(UriHost.Kind.IPV4));
+        assertThat(authority.host().value(), is("192.0.2.10"));
+        assertThat(authority.port(), is(8080));
+    }
+
+    @Test
+    void ipv6Authority() {
+        UriAuthority authority = UriAuthority.create("[2001:DB8::1]:8443");
+
+        assertThat(authority.host().kind(), is(UriHost.Kind.IPV6));
+        assertThat(authority.host().value(), is("2001:db8::1"));
+        assertThat(authority.port(), is(8443));
+        assertThat(authority.toString(), is("[2001:db8::1]:8443"));
+    }
+
+    @Test
+    void explicitCreate() {
+        UriAuthority authority = UriAuthority.create(UriHost.create("api.example.com"), UriAuthority.UNDEFINED_PORT);
+
+        assertThat(authority.host().value(), is("api.example.com"));
+        assertThat(authority.hasPort(), is(false));
+    }
+
+    @Test
+    void rejectsInvalidAuthority() {
+        assertThrows(NullPointerException.class, () -> UriAuthority.create((String) null));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create(""));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("user@example.com"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("example.com:"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("example.com:-1"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("example.com:65536"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("example.com:abc"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("2001:db8::1"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("[::1"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("[::1]extra"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("[api.example.com]:443"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("[\uFF21::1]"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create("[::ffff:192.000.002.128]"));
+        assertThrows(IllegalArgumentException.class, () -> UriAuthority.create(UriHost.create("api.example.com"), -2));
+    }
+
+    @Test
+    void equalityUsesNormalizedValue() {
+        assertThat(UriAuthority.create("EXAMPLE.com:443"), is(UriAuthority.create("example.com.:443")));
+    }
+}

--- a/common/uri/src/test/java/io/helidon/common/uri/UriHostTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriHostTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.uri;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UriHostTest {
+    @Test
+    void dnsHostIsNormalized() {
+        UriHost host = UriHost.create("Api.Example.COM.");
+
+        assertThat(host.value(), is("api.example.com"));
+        assertThat(host.kind(), is(UriHost.Kind.DNS));
+        assertThat(host.toString(), is("api.example.com"));
+    }
+
+    @Test
+    void idnHostIsNormalized() {
+        UriHost host = UriHost.create("Bücher.example");
+
+        assertThat(host.value(), is("xn--bcher-kva.example"));
+        assertThat(host.kind(), is(UriHost.Kind.DNS));
+    }
+
+    @Test
+    void ipv4HostIsNormalized() {
+        UriHost host = UriHost.create("192.0.2.10");
+
+        assertThat(host.value(), is("192.0.2.10"));
+        assertThat(host.kind(), is(UriHost.Kind.IPV4));
+    }
+
+    @Test
+    void dottedNumericHostThatIsNotIpv4IsDns() {
+        UriHost host = UriHost.create("192.000.002.010");
+
+        assertThat(host.value(), is("192.000.002.010"));
+        assertThat(host.kind(), is(UriHost.Kind.DNS));
+        assertThat(UriHost.create("192.0.2.999").kind(), is(UriHost.Kind.DNS));
+    }
+
+    @Test
+    void ipv6HostIsNormalizedWithoutBrackets() {
+        UriHost host = UriHost.create("2001:DB8::1");
+
+        assertThat(host.value(), is("2001:db8::1"));
+        assertThat(host.kind(), is(UriHost.Kind.IPV6));
+        assertThat(UriHost.create("::ffff:192.0.2.128").value(), is("::ffff:c000:280"));
+    }
+
+    @Test
+    void rejectsInvalidHost() {
+        assertThrows(NullPointerException.class, () -> UriHost.create(null));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create(""));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create("   "));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create("user@example.com"));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create("*.example.com"));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create("[::1]"));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create("example.com:443"));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create("2001:db8::1%eth0"));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create("\uFF21::1"));
+        assertThrows(IllegalArgumentException.class, () -> UriHost.create("::ffff:192.000.002.128"));
+    }
+
+    @Test
+    void equalityUsesNormalizedValueAndKind() {
+        assertThat(UriHost.create("EXAMPLE.com"), is(UriHost.create("example.com.")));
+        assertThat(UriHost.create("2001:DB8::1"), is(UriHost.create("2001:db8:0:0:0:0:0:1")));
+    }
+}

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-uri</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/UriAuthorityNormalizationJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/UriAuthorityNormalizationJmhTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class UriAuthorityNormalizationJmhTest {
+    private static final String DNS = "api.example.com";
+    private static final String DNS_WITH_PORT = "api.example.com:443";
+    private static final String MIXED_CASE_DNS = "Api.Example.COM.";
+    private static final String IDN = "bücher.example";
+    private static final String IPV4 = "192.0.2.10:8443";
+    private static final String IPV6 = "[2001:db8::1]:8443";
+
+    @Benchmark
+    public UriHost hostDns() {
+        return UriHost.create(DNS);
+    }
+
+    @Benchmark
+    public UriAuthority authorityDns() {
+        return UriAuthority.create(DNS);
+    }
+
+    @Benchmark
+    public UriAuthority authorityDnsWithPort() {
+        return UriAuthority.create(DNS_WITH_PORT);
+    }
+
+    @Benchmark
+    public UriAuthority authorityMixedCaseDns() {
+        return UriAuthority.create(MIXED_CASE_DNS);
+    }
+
+    @Benchmark
+    public UriAuthority authorityIdn() {
+        return UriAuthority.create(IDN);
+    }
+
+    @Benchmark
+    public UriAuthority authorityIpv4() {
+        return UriAuthority.create(IPV4);
+    }
+
+    @Benchmark
+    public UriAuthority authorityIpv6() {
+        return UriAuthority.create(IPV6);
+    }
+
+    @Benchmark
+    public int authorityPortOrDefault() {
+        return UriAuthority.create(DNS).portOrDefault(443);
+    }
+}


### PR DESCRIPTION
Related to #6183
Related to #11811
Related to #4294

This adds shared URI host and authority normalization primitives needed by the planned SNI and listener-binding work. `UriHost` provides normalized DNS, IPv4, and IPv6 host values with host kind metadata. `UriAuthority` parses authority text into a normalized host plus optional port while rejecting userinfo.

Keeping these types in `common/uri` gives follow-up WebClient SNI, server SNI authority checks, virtual-host lookup, and connection cache key code a single validation and normalization point instead of each layer reimplementing host parsing rules.
