### PR TITLE
Fix MP tracing startup without telemetry config (4.x)

### DIFF
--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/HelidonOpenTelemetryServiceFactory.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/HelidonOpenTelemetryServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.telemetry.otelconfig;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.helidon.config.Config;
@@ -26,7 +27,7 @@ import io.opentelemetry.api.OpenTelemetry;
 
 @Service.Singleton
 @Service.RunLevel(Service.RunLevel.STARTUP)
-class HelidonOpenTelemetryServiceFactory implements Supplier<OpenTelemetry> {
+class HelidonOpenTelemetryServiceFactory implements Supplier<Optional<OpenTelemetry>> {
 
     private final Config config;
 
@@ -36,9 +37,14 @@ class HelidonOpenTelemetryServiceFactory implements Supplier<OpenTelemetry> {
     }
 
     @Override
-    public OpenTelemetry get() {
+    public Optional<OpenTelemetry> get() {
+        var telemetryConfig = config.get(HelidonOpenTelemetry.CONFIG_KEY);
+        if (!telemetryConfig.exists()) {
+            return Optional.empty();
+        }
+
         OpenTelemetry result;
-        var otelConfig = OpenTelemetryConfig.create(config.get(HelidonOpenTelemetry.CONFIG_KEY));
+        var otelConfig = OpenTelemetryConfig.create(telemetryConfig);
         try {
             result = HelidonOpenTelemetry.create(otelConfig)
                     .openTelemetry();
@@ -52,6 +58,6 @@ class HelidonOpenTelemetryServiceFactory implements Supplier<OpenTelemetry> {
             result = GlobalOpenTelemetry.get();
         }
 
-        return result;
+        return Optional.of(result);
     }
 }

--- a/tests/integration/mp-tracing-no-telemetry/pom.xml
+++ b/tests/integration/mp-tracing-no-telemetry/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration-project</artifactId>
+        <version>4.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-tracing-no-telemetry</artifactId>
+    <name>Helidon Tests Integration MP Tracing Without Telemetry</name>
+    <description>Verifies MP observe tracing starts without MP telemetry and without telemetry service config.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-tracing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing.providers</groupId>
+            <artifactId>helidon-tracing-providers-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.telemetry</groupId>
+            <artifactId>helidon-telemetry-opentelemetry-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-tracing-no-telemetry/src/main/java/io/helidon/tests/integration/mptracingnotelemetry/PingResource.java
+++ b/tests/integration/mp-tracing-no-telemetry/src/main/java/io/helidon/tests/integration/mptracingnotelemetry/PingResource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.mptracingnotelemetry;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/ping")
+public class PingResource {
+
+    @GET
+    public String ping() {
+        return "pong";
+    }
+}

--- a/tests/integration/mp-tracing-no-telemetry/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-tracing-no-telemetry/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="annotated"
+       version="4.0">
+</beans>

--- a/tests/integration/mp-tracing-no-telemetry/src/test/java/io/helidon/tests/integration/mptracingnotelemetry/ObserveTracingNoTelemetryTest.java
+++ b/tests/integration/mp-tracing-no-telemetry/src/test/java/io/helidon/tests/integration/mptracingnotelemetry/ObserveTracingNoTelemetryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.mptracingnotelemetry;
+
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+class ObserveTracingNoTelemetryTest {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void shouldStartWithoutMpTelemetryOrTelemetryServiceName() {
+        String response = webTarget.path("ping")
+                .request()
+                .get(String.class);
+
+        assertThat(response, is("pong"));
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -70,6 +70,7 @@
         <module>mp-telemetry</module>
         <module>mp-jaxrs-preserve-headers</module>
         <module>mp-metrics-gh-9995</module>
+        <module>mp-tracing-no-telemetry</module>
         <module>context-http-propagation</module>
     </modules>
 


### PR DESCRIPTION
Resolves #12048

Allow the OpenTelemetry config-backed service factory to abstain when no root telemetry config exists, so MP observe tracing can fall back without requiring MP telemetry. Adds a standalone integration regression for MP tracing startup without MP telemetry or `telemetry.service`.
