### PR TITLE
Forward-port service registry codegen interface-contract validation (27.x)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -173,11 +173,29 @@ class InterceptorGenerator {
                 .filter(it -> ValidationHelper.needsWork(constraintAnnotations, it))
                 .toList();
 
-        return !elementsWithValidation.isEmpty()
-                && elementsWithValidation.stream()
+        if (elementsWithValidation.isEmpty()) {
+            return false;
+        }
+        if (!elementsWithValidation.stream()
                 .allMatch(it -> ElementInfoPredicates.isMethod(it)
                         && !ElementInfoPredicates.isPrivate(it)
-                        && !ElementInfoPredicates.isStatic(it));
+                        && !ElementInfoPredicates.isStatic(it))) {
+            return false;
+        }
+        return isServiceContract(type);
+    }
+
+    private boolean isServiceContract(TypeInfo type) {
+        if (roundContext.serviceContracts(type).isEligible(type)) {
+            return true;
+        }
+
+        TypeName contractType = type.typeName();
+        return roundContext.types()
+                .stream()
+                .filter(this::isService)
+                .map(roundContext::serviceContracts)
+                .anyMatch(serviceContracts -> serviceContracts.isEligible(contractType));
     }
 
     private boolean isService(TypeInfo type) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -167,10 +167,6 @@ class InterceptorGenerator {
         if (type.kind() != ElementKind.INTERFACE) {
             return false;
         }
-        if (!type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_CONTRACT)) {
-            return false;
-        }
-
         List<TypedElementInfo> elementsWithValidation = type.elementInfo()
                 .stream()
                 .filter(it -> ValidationHelper.needsWork(constraintAnnotations, it))
@@ -182,7 +178,21 @@ class InterceptorGenerator {
         return elementsWithValidation.stream()
                 .allMatch(it -> ElementInfoPredicates.isMethod(it)
                         && !ElementInfoPredicates.isPrivate(it)
-                        && !ElementInfoPredicates.isStatic(it));
+                        && !ElementInfoPredicates.isStatic(it))
+                && isServiceContract(type);
+    }
+
+    private boolean isServiceContract(TypeInfo type) {
+        if (roundContext.serviceContracts(type).isEligible(type)) {
+            return true;
+        }
+
+        TypeName contractType = type.typeName();
+        return roundContext.types()
+                .stream()
+                .filter(this::isService)
+                .map(roundContext::serviceContracts)
+                .anyMatch(serviceContracts -> serviceContracts.isEligible(contractType));
     }
 
     private boolean isService(TypeInfo type) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -167,6 +167,9 @@ class InterceptorGenerator {
         if (type.kind() != ElementKind.INTERFACE) {
             return false;
         }
+        if (!type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_CONTRACT)) {
+            return false;
+        }
 
         List<TypedElementInfo> elementsWithValidation = type.elementInfo()
                 .stream()
@@ -176,26 +179,10 @@ class InterceptorGenerator {
         if (elementsWithValidation.isEmpty()) {
             return false;
         }
-        if (!elementsWithValidation.stream()
+        return elementsWithValidation.stream()
                 .allMatch(it -> ElementInfoPredicates.isMethod(it)
                         && !ElementInfoPredicates.isPrivate(it)
-                        && !ElementInfoPredicates.isStatic(it))) {
-            return false;
-        }
-        return isServiceContract(type);
-    }
-
-    private boolean isServiceContract(TypeInfo type) {
-        if (roundContext.serviceContracts(type).isEligible(type)) {
-            return true;
-        }
-
-        TypeName contractType = type.typeName();
-        return roundContext.types()
-                .stream()
-                .filter(this::isService)
-                .map(roundContext::serviceContracts)
-                .anyMatch(serviceContracts -> serviceContracts.isEligible(contractType));
+                        && !ElementInfoPredicates.isStatic(it));
     }
 
     private boolean isService(TypeInfo type) {

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -28,6 +28,7 @@ import io.helidon.common.GenericType;
 import io.helidon.common.Generated;
 import io.helidon.common.types.Annotation;
 import io.helidon.service.codegen.ServiceCodegenTypes;
+import io.helidon.service.codegen.ServiceOptions;
 import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
@@ -448,11 +449,40 @@ class ValidationCodegenTest {
     }
 
     @Test
-    void testNonServiceInterfaceMethodConstraintRequiresValidated() {
+    void testPlainInterfaceMethodConstraintDoesNotRequireValidated() {
         var result = TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(CLASSPATH)
                 .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApi__ValidationInterceptor_0.java")),
+                   is(false));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApi__Validated.java")),
+                   is(false));
+    }
+
+    @Test
+    void testNonServiceInterfaceMethodConstraintRequiresValidatedWhenImplicitContractsDisabled() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addOption("-A" + ServiceOptions.AUTO_ADD_NON_CONTRACT_INTERFACES.name() + "=false")
                 .addSource("DefaultApi.java", """
                         package com.example;
 
@@ -558,6 +588,46 @@ class ValidationCodegenTest {
                         import io.helidon.service.registry.Service;
 
                         @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java")),
+                   is(true));
+    }
+
+    @Test
+    void testExternalContractConstraintTriggersServiceProcessingWhenImplicitContractsDisabled() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addOption("-A" + ServiceOptions.AUTO_ADD_NON_CONTRACT_INTERFACES.name() + "=false")
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        @Service.ExternalContracts(DefaultApi.class)
                         class DefaultApiImpl implements DefaultApi {
                             @Override
                             public String validate(String name) {

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -28,7 +28,6 @@ import io.helidon.common.GenericType;
 import io.helidon.common.Generated;
 import io.helidon.common.types.Annotation;
 import io.helidon.service.codegen.ServiceCodegenTypes;
-import io.helidon.service.codegen.ServiceOptions;
 import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
@@ -454,7 +453,6 @@ class ValidationCodegenTest {
                 .currentRelease()
                 .addClasspath(CLASSPATH)
                 .addProcessor(AptProcessor::new)
-                .addOption("-A" + ServiceOptions.AUTO_ADD_NON_CONTRACT_INTERFACES.name() + "=false")
                 .addSource("DefaultApi.java", """
                         package com.example;
 
@@ -547,6 +545,9 @@ class ValidationCodegenTest {
                 .addSource("DefaultApi.java", """
                         package com.example;
 
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Contract
                         public interface DefaultApi {
                             String validate(@CustomConstraint String name);
                         }
@@ -557,46 +558,6 @@ class ValidationCodegenTest {
                         import io.helidon.service.registry.Service;
 
                         @Service.Singleton
-                        class DefaultApiImpl implements DefaultApi {
-                            @Override
-                            public String validate(String name) {
-                                return name;
-                            }
-                        }
-                        """)
-                .build()
-                .compile();
-
-        String diagnostics = String.join("\n", result.diagnostics());
-        assertThat(diagnostics, result.success(), is(true));
-        assertThat(Files.exists(result.sourceOutput()
-                                        .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java")),
-                   is(true));
-    }
-
-    @Test
-    void testExternalContractConstraintTriggersServiceProcessingWhenImplicitContractsDisabled() throws IOException {
-        var result = TestCompiler.builder()
-                .currentRelease()
-                .addClasspath(CLASSPATH)
-                .addProcessor(AptProcessor::new)
-                .addOption("-A" + ServiceOptions.AUTO_ADD_NON_CONTRACT_INTERFACES.name() + "=false")
-                .addSource("DefaultApi.java", """
-                        package com.example;
-
-                        import io.helidon.validation.Validation;
-
-                        public interface DefaultApi {
-                            String validate(@Validation.String.NotBlank String name);
-                        }
-                        """)
-                .addSource("DefaultApiImpl.java", """
-                        package com.example;
-
-                        import io.helidon.service.registry.Service;
-
-                        @Service.Singleton
-                        @Service.ExternalContracts(DefaultApi.class)
                         class DefaultApiImpl implements DefaultApi {
                             @Override
                             public String validate(String name) {

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -28,6 +28,7 @@ import io.helidon.common.GenericType;
 import io.helidon.common.Generated;
 import io.helidon.common.types.Annotation;
 import io.helidon.service.codegen.ServiceCodegenTypes;
+import io.helidon.service.codegen.ServiceOptions;
 import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
@@ -448,11 +449,12 @@ class ValidationCodegenTest {
     }
 
     @Test
-    void testPlainInterfaceMethodConstraintDoesNotRequireValidated() {
+    void testNonServiceInterfaceMethodConstraintRequiresValidated() {
         var result = TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(CLASSPATH)
                 .addProcessor(AptProcessor::new)
+                .addOption("-A" + ServiceOptions.AUTO_ADD_NON_CONTRACT_INTERFACES.name() + "=false")
                 .addSource("DefaultApi.java", """
                         package com.example;
 
@@ -466,13 +468,9 @@ class ValidationCodegenTest {
                 .compile();
 
         String diagnostics = String.join("\n", result.diagnostics());
-        assertThat(diagnostics, result.success(), is(true));
-        assertThat(Files.exists(result.sourceOutput()
-                                        .resolve("com/example/DefaultApi__ValidationInterceptor_0.java")),
-                   is(false));
-        assertThat(Files.exists(result.sourceOutput()
-                                        .resolve("com/example/DefaultApi__Validated.java")),
-                   is(false));
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString(ValidationTypes.VALIDATION_VALIDATED.fqName()
+                                                      + " annotation is required on non-service type"));
     }
 
     @Test
@@ -559,6 +557,46 @@ class ValidationCodegenTest {
                         import io.helidon.service.registry.Service;
 
                         @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput()
+                                        .resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java")),
+                   is(true));
+    }
+
+    @Test
+    void testExternalContractConstraintTriggersServiceProcessingWhenImplicitContractsDisabled() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addOption("-A" + ServiceOptions.AUTO_ADD_NON_CONTRACT_INTERFACES.name() + "=false")
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        @Service.ExternalContracts(DefaultApi.class)
                         class DefaultApiImpl implements DefaultApi {
                             @Override
                             public String validate(String name) {
@@ -691,8 +729,10 @@ class ValidationCodegenTest {
                 .addSource("LowApi.java", """
                         package com.example;
 
+                        import io.helidon.service.registry.Service;
                         import io.helidon.validation.Validation;
 
+                        @Service.Contract
                         interface LowApi {
                             String validate(@Validation.Integer.Min(1) int count);
                         }
@@ -700,8 +740,10 @@ class ValidationCodegenTest {
                 .addSource("HighApi.java", """
                         package com.example;
 
+                        import io.helidon.service.registry.Service;
                         import io.helidon.validation.Validation;
 
+                        @Service.Contract
                         interface HighApi {
                             String validate(@Validation.Integer.Min(10) int count);
                         }

--- a/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
+++ b/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
@@ -147,6 +147,7 @@ public class DeclarativeExample {
     // end::snippet_7[]
 
     // tag::snippet_7b[]
+    @Service.Contract
     interface ValidatedServiceContract {
         String process(@Validation.String.NotBlank String value);
     }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
@@ -293,6 +293,14 @@ class DescribedService {
         return serviceType;
     }
 
+    Set<ResolvedType> directProviderContracts() {
+        return directProviderContracts;
+    }
+
+    Set<ResolvedType> providerFactoryContracts() {
+        return providerFactoryContracts;
+    }
+
     Set<ResolvedType> providerContracts() {
         Set<ResolvedType> result = new HashSet<>(directProviderContracts);
         result.addAll(providerFactoryContracts);

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
@@ -220,7 +220,7 @@ public class ServiceDescriptorCodegen {
         if (service.isFactory()) {
             if (service.factoryInterceptionWrapper()) {
                 contracts = service.providedDescriptor().contracts();
-                factoryContracts = service.providerContracts();
+                factoryContracts = service.providerFactoryContracts();
             } else {
                 // check if contracts are intercepted
                 var providedElements = service.providedDescriptor().elements();
@@ -228,7 +228,7 @@ public class ServiceDescriptorCodegen {
                 if (providedElements.methodsIntercepted()) {
                     // remove contracts from the original service, service descriptor will only be used to instantiate provider
                     contracts = Set.of();
-                    factoryContracts = service.providerContracts();
+                    factoryContracts = service.directProviderContracts();
                     // generate delegate injection (unless already generated) in current package
                     TypeName delegateType = generateProvidedInterceptionDelegate(roundCtx, service);
                     // then generate a service that injects the original service, and wraps provider method(s) using delegation

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ConstrainedDefaultInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ConstrainedDefaultInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface ConstrainedDefaultInterfaceConstrainedService extends UnconstrainedDefaultInterfaceConstrainedService {
     @Override
     default String validateInheritedDefault(@Validation.String.NotBlank String value) {

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/GenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/GenericInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface GenericInterfaceConstrainedService<T> {
     T validateGeneric(@Validation.String.NotBlank T value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectOnlyInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface InjectOnlyInterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryDirectContract.java
@@ -23,6 +23,7 @@ import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface InjectionPointFactoryDirectContract {
     @Validation.NotNull
     Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyDirectContract.java
@@ -22,6 +22,7 @@ import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface InjectionPointFactoryFirstOnlyDirectContract {
     @Validation.NotNull
     Optional<Service.QualifiedInstance<InjectionPointFactoryFirstOnlyProvidedService>> first(Lookup lookup);

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryFirstOnlyProvidedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface InjectionPointFactoryFirstOnlyProvidedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryOverloadedDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryOverloadedDirectContract.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface InjectionPointFactoryOverloadedDirectContract {
     Optional<Service.QualifiedInstance<InjectionPointFactoryProvidedInterfaceConstrainedService>> first(
             @Validation.NotNull String name);

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InjectionPointFactoryProvidedInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface InjectionPointFactoryProvidedInterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceConstrainedService.java
@@ -20,8 +20,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface InterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LowerMinimumInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/LowerMinimumInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface LowerMinimumInterfaceConstrainedService {
     int validateMinimum(@Validation.Integer.Min(1) int value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OptionalSupplierProvidedInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface OptionalSupplierProvidedInterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OrderedGenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/OrderedGenericInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface OrderedGenericInterfaceConstrainedService<K, V> {
     V validateOrderedGeneric(@Validation.String.NotBlank K key, V value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ParentGenericInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ParentGenericInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface ParentGenericInterfaceConstrainedService<T> {
     T validateInheritedGeneric(@Validation.String.NotBlank T value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/PerInstanceInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface PerInstanceInterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryDirectContract.java
@@ -25,6 +25,7 @@ import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface QualifiedFactoryDirectContract {
     Optional<Service.QualifiedInstance<QualifiedFactoryProvidedInterfaceConstrainedService>> first(
             @Validation.NotNull Qualifier qualifier,

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyDirectContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyDirectContract.java
@@ -24,6 +24,7 @@ import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface QualifiedFactoryFirstOnlyDirectContract {
     @Validation.NotNull
     Optional<Service.QualifiedInstance<QualifiedFactoryFirstOnlyProvidedService>> first(

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryFirstOnlyProvidedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface QualifiedFactoryFirstOnlyProvidedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/QualifiedFactoryProvidedInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface QualifiedFactoryProvidedInterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ServicesFactoryProvidedInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface ServicesFactoryProvidedInterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface SupplierProvidedInterfaceConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureInterfaceConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface SupplierProvidedSameSignatureInterfaceConstrainedService {
     @Validation.String.NotBlank
     String get();

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureProviderContract.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProvidedSameSignatureProviderContract.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface SupplierProvidedSameSignatureProviderContract {
     @Validation.NotNull
     SupplierProvidedSameSignatureInterfaceConstrainedService get();

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureConstrainedService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface SupplierProviderSameSignatureConstrainedService {
     String validate(@Validation.String.NotBlank String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureDirectService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/SupplierProviderSameSignatureDirectService.java
@@ -16,8 +16,10 @@
 
 package io.helidon.validation.tests.validation;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface SupplierProviderSameSignatureDirectService {
     String validate(@Validation.String.Pattern("[0-9]+") String value);
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedService.java
@@ -18,8 +18,10 @@ package io.helidon.validation.tests.validation;
 
 import java.util.List;
 
+import io.helidon.service.registry.Service;
 import io.helidon.validation.Validation;
 
+@Service.Contract
 interface ValidInterfaceConstrainedService {
     String validate(@Validation.Valid ValidatedType value);
 


### PR DESCRIPTION
Resolves #11873

Forward-ports the service registry codegen interface-contract validation fix from #11875 to main. This keeps validation method constraints aligned with service contract discovery, preserves the 27.x factory-contract metadata behavior for providers, and updates validation fixtures and snippets for service-contract interfaces.
