### PR TITLE
Remove deprecated tracing baggage APIs (27.x)

### DIFF
--- a/docs/src/main/asciidoc/includes/tracing/tracer-otel.adoc
+++ b/docs/src/main/asciidoc/includes/tracing/tracer-otel.adoc
@@ -24,7 +24,7 @@ ifndef::rootdir[:rootdir: {docdir}/../..]
 // tag::intro[]
 Helidon supports configuration of OpenTelemetry and OpenTelemetry tracing in two primary ways: using tracing or using telemetry.
 ifdef::se-flavor[]
-This page describes support for controlling OpenTelemetry tracing using the `tracing` config section and link:{javadoc-base-url}/io.helidon.tracing.providers.opentelemetry/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerConfig.html[`OpenTelemetryConfig` builder]. Users typically adopt this approach to ease migration from other tracing providers (such as Jaeger) to OpenTelemetry because the tracing settings supported for OpenTelemetry are very similar to those for Jaeger.
+This page describes support for controlling OpenTelemetry tracing using the `tracing` config section and link:{javadoc-base-url}/io.helidon.tracing.providers.opentelemetry/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerConfig.html[`OpenTelemetryConfig` builder]. Users typically adopt this approach to ease migration from older tracing configuration to OpenTelemetry.
 
 That said, Helidon's support for OpenTelemetry using _tracing_ does not afford as much control as do the Helidon _telemetry_ settings. For example, using OpenTelemetry `tracing` config you can choose either the OTLP gRPC span exporter or the OTLP HTTP one; additional span exporters are available only using the `telemetry` settings.
 

--- a/docs/src/main/asciidoc/se/guides/tracing.adoc
+++ b/docs/src/main/asciidoc/se/guides/tracing.adoc
@@ -460,7 +460,8 @@ tracing: # <1>
   service: helidon-se-1
   host: jaeger
 ----
-<1> Helidon service `helidon-se-1` will connect to the Jaeger server at host name `jaeger`.
+<1> Helidon service `helidon-se-1` will connect to the Jaeger server at host name `jaeger` using the default
+OTLP gRPC port, `4317`.
 
 [source,bash]
 .Stop the application and build the docker image for your application:
@@ -479,7 +480,13 @@ metadata:
   name: jaeger
 spec:
   ports:
-    - port: 16686
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: ui
+      port: 16686
+      targetPort: 16686
       protocol: TCP
   selector:
     app: jaeger
@@ -495,7 +502,11 @@ spec:
     - name: jaeger
       image: jaegertracing/all-in-one
       imagePullPolicy: IfNotPresent
+      env:
+        - name: COLLECTOR_OTLP_ENABLED
+          value: "true"
       ports:
+        - containerPort: 4317
         - containerPort: 16686
 ----
 
@@ -506,7 +517,7 @@ kubectl apply -f ./jaeger.yaml
 ----
 
 [source,bash]
-.Create a Jaeger external server to view the UI and expose it on port 9142:
+.Create a Jaeger external server to view the UI and expose it on port 16687:
 ----
 kubectl expose pod  jaeger --name=jaeger-external --port=16687 --target-port=16686 --type=LoadBalancer
 ----
@@ -595,7 +606,7 @@ curl http://localhost:31143/greet
 }
 ----
 
-Access the Jaeger UI at http://localhost:9412/jaeger and click on the refresh icon to see the trace that was just created.
+Access the Jaeger UI at http://localhost:16687/jaeger and click on the refresh icon to see the trace that was just created.
 
 
 === Cleanup

--- a/docs/src/main/asciidoc/se/guides/tracing.adoc
+++ b/docs/src/main/asciidoc/se/guides/tracing.adoc
@@ -516,8 +516,11 @@ spec:
 kubectl apply -f ./jaeger.yaml
 ----
 
+The ClusterIP service `jaeger` exposes the OTLP gRPC port `4317` for Helidon to export spans to Jaeger.
+To access the Jaeger UI from outside Kubernetes, expose the UI separately.
+
 [source,bash]
-.Create a Jaeger external server to view the UI and expose it on port 16687:
+.Create an external Jaeger UI service on port 16687:
 ----
 kubectl expose pod  jaeger --name=jaeger-external --port=16687 --target-port=16686 --type=LoadBalancer
 ----

--- a/docs/src/main/asciidoc/se/guides/tracing.adoc
+++ b/docs/src/main/asciidoc/se/guides/tracing.adoc
@@ -38,9 +38,8 @@ include::{rootdir}/includes/prerequisites.adoc[tag=prerequisites]
 
 Distributed tracing is a critical feature of microservice-based applications, since it traces workflow both
 within a service and across multiple services.  This provides insight to sequence and timing data for specific blocks of work,
-which helps you identify performance and operational issues. Helidon includes support for distributed tracing through its own API, backed by either
-through the https://opentelemetry.io/docs/instrumentation/js/api/tracing/[OpenTelemetry API], or by
-https://opentracing.io[OpenTracing API].
+which helps you identify performance and operational issues. Helidon includes support for distributed tracing through its own API, backed by
+the https://opentelemetry.io/docs/languages/java/api/[OpenTelemetry API].
 
 === Tracing Concepts
 
@@ -137,7 +136,7 @@ default host and port, `localhost:4317`.
 <2> Observability features for tracing.
 <3> OpenTelemetry tracing provider.
 
-Helidon offers several tracing providers: OpenTelemetry, Zipkin, and Jaeger (deprecated).
+Helidon offers tracing through OpenTelemetry.
 All spans sent by Helidon to the backend need to be associated with a service, assigned by the `tracing.service` setting in the example below.
 
 [source,bash]
@@ -253,7 +252,7 @@ Note the row for `mychildSpan`--the custom span created by the added code.
 Helidon automatically traces across services if the services propagate span information.
 This means a single trace can include spans from multiple services and hosts. Helidon uses a `SpanContext` to
 propagate tracing information across process boundaries.  When you make client API calls, Helidon will
-internally call OpenTelemetry APIs or OpenTracing APIs to propagate the `SpanContext`. There is nothing you need to do in your application to make this work.
+internally call OpenTelemetry APIs to propagate the `SpanContext`. There is nothing you need to do in your application to make this work.
 
 To demonstrate distributed tracing, create a second project where the server listens to on port 8081.
 Create a new directory to hold this new project, then do the following steps, similar to

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -2,16 +2,14 @@ Distributed Tracing
 ---
 
 Module `helidon-tracing` defines tracing API and SPI that is used throughout Helidon.
-As we need to support both OpenTracing and OpenTelemetry tracing, this abstraction is required to keep tracing an integral part 
-of Helidon.
+The API is backed by OpenTelemetry through the `helidon-tracing-providers-opentelemetry` provider.
 
-Module `helidon-tracing-providers-opentracing` adds support for opentracing based tracers (such as Zipkin).
-Module `helidon-tracing-providers-opentelemetry` adds support for opentelemetry based tracers (such as Jaeger).
+Module `helidon-tracing-providers-opentelemetry` adds OpenTelemetry tracing support.
 
 # Usage
 
 To use tracing in SE, add a dependency on `helidon-tracing` and a tracer
-implementation and register tracer with server configuration.
+implementation, then register the tracer with server configuration.
 
 pom.xml:
 ```xml
@@ -21,68 +19,67 @@ pom.xml:
     <artifactId>helidon-tracing</artifactId>
 </dependency>
 <dependency>
-    <!-- to add zipkin support -->
-    <groupId>io.helidon.tracing</groupId>
-    <artifactId>helidon-tracing-providers-zipkin</artifactId>
+    <!-- to add tracing observability support to WebServer -->
+    <groupId>io.helidon.webserver.observe</groupId>
+    <artifactId>helidon-webserver-observe-tracing</artifactId>
+</dependency>
+<dependency>
+    <!-- to add OpenTelemetry support -->
+    <groupId>io.helidon.tracing.providers</groupId>
+    <artifactId>helidon-tracing-providers-opentelemetry</artifactId>
 </dependency>
 ```
 
 code using config:
 ```java
+Tracer tracer = TracerBuilder.create(config.get("tracing"))
+        .build();
+
 return WebServer.builder()
-                .config(config.get("webserver"))
-                .tracer(TracerBuilder.create(config.get("tracing"))
-                                        .buildAndRegister())
-                .build();
+        .config(config.get("webserver"))
+        .addFeature(ObserveFeature.just(TracingObserver.create(tracer)))
+        .build();
 ```
 
-To customize configuration of zipkin, see `ZipkinTracerBuilder` javadoc. Basics:
+Basic tracing configuration:
 ```yaml
 tracing:
   # required
   service: "service-name"
   # default is "localhost"
-  host: "zipkin"
+  host: "otel-collector"
 ```
 
 # Modules
 
 ## Module `helidon-tracing`
-Contains an abstracted Builder for tracers and an SPI
-to connect various tracer implementations.
+Contains the API, an abstracted builder for tracers, and an SPI to connect tracer implementations.
 
 Example:
 ```java
 // create a tracer for service "myService"
 Tracer tracer = TracerBuilder.create("myService")
-    // running on host "zipkin" - probably in docker or k8s
-    .collectorHost("zipkin")
-    // build the tracer and register as global tracer
-    .buildAndRegister();
+    // running on host "otel-collector" - probably in docker or k8s
+    .collectorHost("otel-collector")
+    // build the tracer
+    .build();
 ```
 
 Example using Config:
 ```java
 // create a tracer from configuration
-Tracer tracer = TracerBuilder.create(config.get("tracing"))    
-    // build the tracer and register as global tracer
-    .buildAndRegister();
+Tracer tracer = TracerBuilder.create(config.get("tracing"))
+    // build the tracer
+    .build();
 ```
 
 and associated configuration:
 ```yaml
 tracing:
   service: "myService"
-  host: "zipkin"
+  host: "otel-collector"
 ```
 
-## Module `helidon-tracing-providers-zipkin`
-Integration with Zipkin (https://zipkin.io/). Easiest approach is to use a docker image
-`zipkin` that, by default, runs on the expected hostname and port.
-
-When you add this module to classpath, the SPI is automatically picked up and Zipkin tracer 
-would be used.
-
-See class `ZipkinTracerBuilder` for documentation of supported configuration options. The classes
-in this module should not be used directly, use `helidon-tracing` module API instead (unless
-you want to create a hard source code dependency on Zipkin tracer).
+## Module `helidon-tracing-providers-opentelemetry`
+Integration with OpenTelemetry. When you add this module to the classpath, the tracing SPI picks up the
+OpenTelemetry tracer provider automatically.

--- a/tracing/config/src/main/java/io/helidon/tracing/config/TracingConfigUtil.java
+++ b/tracing/config/src/main/java/io/helidon/tracing/config/TracingConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ import io.helidon.common.context.Contexts;
  */
 public final class TracingConfigUtil {
     /**
-     * Qualifier for outbound {@code io.opentracing.SpanContext} as registered with {@link io.helidon.common.context.Context}.
+     * Qualifier for outbound {@code io.helidon.tracing.SpanContext} as registered with
+     * {@link io.helidon.common.context.Context}.
      */
     public static final Object OUTBOUND_SPAN_QUALIFIER = OutboundSpanQualifier.class;
 

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,22 +141,6 @@ class OpenTelemetrySpan implements Span {
         var result = new OpenTelemetryScope(this, scope, spanListeners);
         HelidonOpenTelemetry.invokeListeners(spanListeners, LOGGER, listener -> listener.activated(limited(), result.limited()));
         return result;
-    }
-
-    @Override
-    public Span baggage(String key, String value) {
-        if (baggage instanceof WritableBaggage writableBaggage) {
-            writableBaggage.set(key, value);
-        } else {
-            throw new SpanListener.ForbiddenOperationException(
-                    "Attempt to set baggage on a span with read-only baggage (perhaps from context");
-        }
-        return this;
-    }
-
-    @Override
-    public Optional<String> baggage(String key) {
-        return Optional.ofNullable(baggage.getEntryValue(key));
     }
 
     @Override
@@ -304,17 +288,6 @@ class OpenTelemetrySpan implements Span {
         @Override
         public Scope activate() {
             throw new SpanListener.ForbiddenOperationException();
-        }
-
-        @Override
-        public Span baggage(String key, String value) {
-            delegate.baggage().set(key, value);
-            return this;
-        }
-
-        @Override
-        public Optional<String> baggage(String key) {
-            return delegate.baggage().get(key);
         }
 
         @Override

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestBaggageApi.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestBaggageApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class TestBaggageApi {
     void testWritableBaggageFromSpan() {
         Span span = Tracer.global().spanBuilder("otel-span").start();
         WritableBaggage baggage = span.baggage();
-        span.baggage("keyA", "valA");
+        span.baggage().set("keyA", "valA");
         assertThat("Assigned baggage via span is present", baggage.containsKey("keyA"), is(true));
         assertThat("Assigned baggage via span value from baggage",
                    baggage.get("keyA"),

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestSpanAndBaggage.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestSpanAndBaggage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ class TestSpanAndBaggage {
                        currentJustAfterActivation.get().context().spanId(),
                        is(outerSpan.context().spanId()));
 
-            outerSpan.baggage("myItem", "myValue");
+            outerSpan.baggage().set("myItem", "myValue");
             outerSpan.end();
         } catch (Exception e) {
             outerSpan.end(e);

--- a/tracing/tracing/src/main/java/io/helidon/tracing/NoOpTracer.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/NoOpTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,16 +177,6 @@ class NoOpTracer implements Tracer {
         @Override
         public Scope activate() {
             return SCOPE;
-        }
-
-        @Override
-        public Span baggage(String key, String value) {
-            return this;
-        }
-
-        @Override
-        public Optional<String> baggage(String key) {
-            return Optional.empty();
         }
 
         @Override

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
@@ -142,27 +142,6 @@ public interface Span {
     Scope activate();
 
     /**
-     * Sets a baggage item in the Span (and its SpanContext) as a key/value pair.
-     *
-     * @param key String Key
-     * @param value String Value
-     * @return current Span instance
-     * @deprecated Use {@link #baggage()} and then {@link io.helidon.tracing.WritableBaggage#set(String, String)}.
-     */
-    @Deprecated(since = "4.0.5", forRemoval = true)
-    Span baggage(String key, String value);
-
-    /**
-     * Get Baggage Item by key.
-     *
-     * @param key String key
-     * @return {@link Optional} of the value of the baggage item
-     * @deprecated Use {@link #baggage()} and then {@link Baggage#get(String)}.
-     */
-    @Deprecated(since = "4.0.5", forRemoval = true)
-    Optional<String> baggage(String key);
-
-    /**
      * Returns writable baggage associated with this span.
      *
      * @return the mutable baggage instance for the span

--- a/tracing/tracing/src/main/java/io/helidon/tracing/TracerBuilder.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/TracerBuilder.java
@@ -29,8 +29,7 @@ import io.helidon.config.metadata.ConfiguredOption;
  * Each tracer implementation may use different options, though these are the common ones.
  * To keep service implementation abstracted from specific tracer, use {@link #config(Config)}
  * to load configuration of the tracer, as that supports externalization of
- * specific configuration options (e.g. you may use api-version for Zipkin tracer
- * and sampler-type for Jaeger).
+ * specific configuration options (e.g. you may use exporter-type and sampler-type for OpenTelemetry).
  * <p>
  * The following table lists common configuration options that must be honored by each integration (if supported by it).
  * <table class="config">
@@ -86,9 +85,9 @@ import io.helidon.config.metadata.ConfiguredOption;
  * tracing:
  *   # usually must be provided, as it is used as a service identifier
  *   service: "basket-service"
- *   # host of the collector server - example for zipkin in docker environment
+ *   # host of the collector server - example for an OpenTelemetry collector in docker environment
  *   #  would use default host, port and path
- *   host: "zipkin"
+ *   host: "otel-collector"
  *   # example of a tracer-wide tag
  *   tags:
  *      env: "stage-1"

--- a/tracing/tracing/src/main/java/io/helidon/tracing/package-info.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  */
 /**
  * Distributed tracing support for Helidon.
- * This module provides a full API for tracing, that abstract various tracing APIs, such as OpenTracing and OpenTelemetry
- * tracing.
+ * This module provides a full API for tracing backed by OpenTelemetry tracing.
  *
  * @see io.helidon.tracing.TracerBuilder#create(java.lang.String)
  * @see io.helidon.tracing.TracerBuilder#create(io.helidon.config.Config)

--- a/tracing/tracing/src/main/java/module-info.java
+++ b/tracing/tracing/src/main/java/module-info.java
@@ -18,7 +18,7 @@ import io.helidon.common.features.api.Features;
 import io.helidon.common.features.api.HelidonFlavor;
 
 /**
- * Opentracing support for helidon, with an abstraction API and SPI for tracing collectors.
+ * Tracing support for Helidon, with an abstraction API and SPI for tracing collectors.
  *
  * @see io.helidon.tracing.spi.TracerProvider
  * @see io.helidon.tracing.TracerBuilder

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserverConfigBlueprint.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserverConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ interface TracingObserverConfigBlueprint extends ObserverConfigBase, Prototype.F
     TracingConfig envConfig();
 
     /*
-     * OpenTracing spec states that certain MP paths need to be disabled by default.
+     * Certain observe endpoints need to be disabled by default.
      * Note that if a user changes the default location of any of these using
      * web-context's, then they would need to provide these exclusions manually.
      *


### PR DESCRIPTION
Resolves #11485

Removes the deprecated Span baggage getter/setter overloads and updates the OpenTelemetry/no-op implementations and tests to use the WritableBaggage API. Also cleans stale tracing docs and Javadocs from the removed OpenTracing-era provider modules.
