### PR TITLE
Add WebClient SNI support (27.x)

### DIFF
--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -26,12 +26,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
-import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509KeyManager;

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -206,7 +206,6 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
      *
      * @param alpnProtocols       protocol(s) to use (order is significant)
      * @param socket              existing socket
-     * @param address             physical peer address of the existing socket
      * @param tlsPeerHost         TLS peer host for SNI and endpoint identification
      * @param tlsPeerPort         TLS peer port for endpoint identification
      * @param serverNamesOverride server names to use for this socket
@@ -215,11 +214,9 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
     @Api.Internal
     public SSLSocket createSocket(List<String> alpnProtocols,
                                   Socket socket,
-                                  InetSocketAddress address,
                                   String tlsPeerHost,
                                   int tlsPeerPort,
                                   List<SNIServerName> serverNamesOverride) {
-        Objects.requireNonNull(address, "address");
         Objects.requireNonNull(tlsPeerHost, "tlsPeerHost");
         Objects.requireNonNull(serverNamesOverride, "serverNamesOverride");
         return createSocketInternal(alpnProtocols, socket, tlsPeerHost, tlsPeerPort, serverNamesOverride);

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -31,12 +31,14 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 
 /**
@@ -196,13 +198,48 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
      * @return a new socket ready for TLS communication
      */
     public SSLSocket createSocket(List<String> alpnProtocols, Socket socket, InetSocketAddress address) {
+        return createSocketInternal(alpnProtocols, socket, address.getHostName(), address.getPort(), null);
+    }
+
+    /**
+     * Create a SSLSocket for the chosen protocol and the given socket.
+     *
+     * @param alpnProtocols       protocol(s) to use (order is significant)
+     * @param socket              existing socket
+     * @param address             physical peer address of the existing socket
+     * @param tlsPeerHost         TLS peer host for SNI and endpoint identification
+     * @param tlsPeerPort         TLS peer port for endpoint identification
+     * @param serverNamesOverride server names to use for this socket
+     * @return a new socket ready for TLS communication
+     */
+    @Api.Internal
+    public SSLSocket createSocket(List<String> alpnProtocols,
+                                  Socket socket,
+                                  InetSocketAddress address,
+                                  String tlsPeerHost,
+                                  int tlsPeerPort,
+                                  List<SNIServerName> serverNamesOverride) {
+        Objects.requireNonNull(address, "address");
+        Objects.requireNonNull(tlsPeerHost, "tlsPeerHost");
+        Objects.requireNonNull(serverNamesOverride, "serverNamesOverride");
+        return createSocketInternal(alpnProtocols, socket, tlsPeerHost, tlsPeerPort, serverNamesOverride);
+    }
+
+    private SSLSocket createSocketInternal(List<String> alpnProtocols,
+                                           Socket socket,
+                                           String tlsPeerHost,
+                                           int tlsPeerPort,
+                                           List<SNIServerName> serverNamesOverride) {
         checkEnabled();
         try {
             SSLSocket sslSocket = (SSLSocket) sslSocketFactory
-                    .createSocket(socket, address.getHostName(), address.getPort(), true);
+                    .createSocket(socket, tlsPeerHost, tlsPeerPort, true);
 
             SSLParameters parameters = copySslParameters(sslParameters);
             parameters.setApplicationProtocols(alpnProtocols.toArray(new String[0]));
+            if (serverNamesOverride != null) {
+                parameters.setServerNames(serverNamesOverride);
+            }
 
             sslSocket.setSSLParameters(parameters);
             return sslSocket;

--- a/docs/src/main/asciidoc/se/grpc/client.adoc
+++ b/docs/src/main/asciidoc/se/grpc/client.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -283,12 +283,13 @@ include::{sourcedir}/se/grpc/ClientSnippets.java[tag=snippet_12, indent=0]
 == Configuration
 
 TLS can be configured externally, just like it is done when using the
-WebClient to access an HTTP endpoint. For more information, see
-https://helidon.io/docs/v4/se/webclient#_configuring_the_webclient[Configuring the WebClient].
+WebClient to access an HTTP endpoint. Common WebClient options, including
+SNI, also apply to gRPC clients. For more information, see
+xref:{rootdir}/se/webclient.adoc#_configuring_the_webclient[Configuring the WebClient]
+and xref:{rootdir}/se/webclient.adoc#_configuring_tls_sni[Configuring TLS SNI].
 
 There are a few configuration options (see table below) that are specific to a `GrpcClient` and
 can be configured using a `GrpcClientProtocolConfig` instance. See
 https://github.com/helidon-io/helidon-examples/blob/dev-4.x/examples/webserver/grpc-random/src/test/java/io/helidon/examples/webserver/grpc/random/RandomServiceTest.java[RandomServiceTest] for an example.
 
 include::{rootdir}/config/io_helidon_webclient_grpc_GrpcClientProtocolConfig.adoc[leveloffset=+1,tag=config]
-

--- a/docs/src/main/asciidoc/se/webclient.adoc
+++ b/docs/src/main/asciidoc/se/webclient.adoc
@@ -433,6 +433,8 @@ The `uri-host` mode uses the resolved request URI host.
 The `host-header` mode uses the effective HTTP `Host` authority.
 HTTP/2 requests use the same effective authority for the generated `:authority` pseudo header.
 The `explicit` mode uses `host` as the TLS peer host.
+Configure `host` only with `explicit` mode.
+The configured value must be a host without a port; bracketed IPv6 literals are accepted and normalized without brackets.
 The `disabled` mode clears the SNI server name.
 
 [source,yaml]

--- a/docs/src/main/asciidoc/se/webclient.adoc
+++ b/docs/src/main/asciidoc/se/webclient.adoc
@@ -236,6 +236,10 @@ The class responsible for WebClient configuration is:
 
 include::{rootdir}/config/io_helidon_webclient_api_WebClient.adoc[leveloffset=+1,tag=config]
 
+Common HTTP client configuration applies to WebClient instances and protocol-specific clients:
+
+include::{rootdir}/config/io_helidon_webclient_api_HttpClientConfig.adoc[leveloffset=+1,tag=config]
+
 === Protocol Specific Configuration
 
 Protocol specific configuration can be set using the  `protocol-configs` parameter. Webclient currently supports `HTTP/1.1.` and `HTTP/2`. Below are the options for each of the protocol type:
@@ -404,6 +408,41 @@ include::{sourcedir}/se/WebClientSnippets.java[tag=snippet_8,indent=0]
 ----
 <1> `application.yaml` is a default configuration source loaded when YAML support is on classpath, so we can just use `Config.create()`
 <2> Passing the client configuration node
+
+==== Configuring TLS SNI
+
+When `sni` is not configured, WebClient preserves the configured TLS `SSLParameters` server names and uses the JDK TLS
+defaults for server name indication.
+Configure `sni` when a client or request must choose the TLS peer host explicitly.
+Request-level SNI overrides client-level SNI.
+If `sni` is configured without a `mode`, WebClient uses the resolved request URI host.
+When WebClient chooses a DNS name, it also sends that name as SNI.
+When it chooses an IP literal, it uses the IP literal as the TLS peer host for endpoint identification but does not send a
+DNS SNI server name.
+The `disabled` mode clears the SNI server name without disabling endpoint identification.
+
+[source,yaml]
+.WebClient SNI configuration in `application.yaml`
+----
+client:
+  sni:
+    mode: "host-header" # uri-host, host-header, explicit, or disabled
+----
+
+The `uri-host` mode uses the resolved request URI host.
+The `host-header` mode uses the effective HTTP `Host` authority.
+HTTP/2 requests use the same effective authority for the generated `:authority` pseudo header.
+The `explicit` mode uses `host` as the TLS peer host.
+The `disabled` mode clears the SNI server name.
+
+[source,yaml]
+.WebClient explicit SNI configuration in `application.yaml`
+----
+client:
+  sni:
+    mode: "explicit"
+    host: "service.example"
+----
 
 ==== Configuring TLS over Unix Domain Sockets
 

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ConnectionKeyJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ConnectionKeyJmhTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.benchmark.jmh;
 
+import java.net.URI;
 import java.net.UnixDomainSocketAddress;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -24,10 +25,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import io.helidon.common.task.DeadlineGuard;
 import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.DefaultDnsResolver;
 import io.helidon.webclient.api.DnsAddressLookup;
 import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.SniConfig;
+import io.helidon.webclient.api.SniMode;
 import io.helidon.webclient.spi.DnsResolver;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -40,10 +47,25 @@ public class ConnectionKeyJmhTest {
     private static final String HOST = "service.example";
     private static final int PORT = 443;
     private static final Tls TLS = Tls.builder().enabled(false).build();
+    private static final Tls TLS_ENABLED = Tls.builder().build();
     private static final DnsResolver DNS_RESOLVER = DefaultDnsResolver.create();
     private static final DnsAddressLookup DNS_ADDRESS_LOOKUP = DnsAddressLookup.defaultLookup();
     private static final Proxy PROXY = Proxy.noProxy();
     private static final Duration DEADLINE_TIMEOUT = Duration.ofSeconds(30);
+    private static final ClientUri SNI_URI = ClientUri.create(URI.create("https://service.example:443/path"));
+    private static final ClientRequestHeaders EMPTY_HEADERS = ClientRequestHeaders.create(WritableHeaders.create());
+    private static final ClientRequestHeaders HOST_HEADERS = hostHeaders();
+    private static final SniConfig URI_HOST_SNI = SniConfig.create();
+    private static final SniConfig HOST_HEADER_SNI = SniConfig.builder()
+            .mode(SniMode.HOST_HEADER)
+            .build();
+    private static final SniConfig EXPLICIT_SNI = SniConfig.builder()
+            .mode(SniMode.EXPLICIT)
+            .host("explicit.example")
+            .build();
+    private static final SniConfig DISABLED_SNI = SniConfig.builder()
+            .mode(SniMode.DISABLED)
+            .build();
     private static final UnixDomainSocketAddress UDS_ADDRESS =
             UnixDomainSocketAddress.of(Path.of("/tmp/helidon-jmh.sock"));
     private static final UnixDomainSocketAddress UDS_MISS_ADDRESS =
@@ -76,6 +98,12 @@ public class ConnectionKeyJmhTest {
                                                                                           DNS_RESOLVER,
                                                                                           DNS_ADDRESS_LOOKUP,
                                                                                           UDS_MISS_ADDRESS);
+    private static final ConnectionKey SNI_KEY = sniKey(EXPLICIT_SNI, EMPTY_HEADERS);
+    private static final ConnectionKey SNI_MISS_KEY = sniKey(SniConfig.builder()
+                                                               .mode(SniMode.EXPLICIT)
+                                                               .host("miss.example")
+                                                               .build(),
+                                                            EMPTY_HEADERS);
     private static final Map<ConnectionKey, ConnectionKey> CONNECTION_CACHE = connectionCache();
 
     @Benchmark
@@ -95,6 +123,37 @@ public class ConnectionKeyJmhTest {
     }
 
     @Benchmark
+    public ConnectionKey tcpConnectionKeyUriHostSni() {
+        return sniKey(URI_HOST_SNI, EMPTY_HEADERS);
+    }
+
+    @Benchmark
+    public ConnectionKey tcpConnectionKeyHostHeaderSni() {
+        return sniKey(HOST_HEADER_SNI, HOST_HEADERS);
+    }
+
+    @Benchmark
+    public ConnectionKey tcpConnectionKeyExplicitSni() {
+        return sniKey(EXPLICIT_SNI, EMPTY_HEADERS);
+    }
+
+    @Benchmark
+    public ConnectionKey tcpConnectionKeyDisabledSni() {
+        return sniKey(DISABLED_SNI, EMPTY_HEADERS);
+    }
+
+    @Benchmark
+    public ConnectionKey udsConnectionKeyHostHeaderSni() {
+        return ConnectionKey.createUnixDomainSocket(SNI_URI,
+                                                   HOST_HEADER_SNI,
+                                                   TLS_ENABLED,
+                                                   DNS_RESOLVER,
+                                                   DNS_ADDRESS_LOOKUP,
+                                                   UDS_ADDRESS,
+                                                   HOST_HEADERS);
+    }
+
+    @Benchmark
     public int tcpConnectionKeyHashCode() {
         return TCP_KEY.hashCode();
     }
@@ -102,6 +161,11 @@ public class ConnectionKeyJmhTest {
     @Benchmark
     public int udsConnectionKeyHashCode() {
         return UDS_KEY.hashCode();
+    }
+
+    @Benchmark
+    public int sniConnectionKeyHashCode() {
+        return SNI_KEY.hashCode();
     }
 
     @Benchmark
@@ -118,6 +182,11 @@ public class ConnectionKeyJmhTest {
                                                                    DNS_RESOLVER,
                                                                    DNS_ADDRESS_LOOKUP,
                                                                    UDS_ADDRESS));
+    }
+
+    @Benchmark
+    public boolean sniConnectionKeyEquals() {
+        return SNI_KEY.equals(sniKey(EXPLICIT_SNI, EMPTY_HEADERS));
     }
 
     @Benchmark
@@ -141,6 +210,21 @@ public class ConnectionKeyJmhTest {
     }
 
     @Benchmark
+    public ConnectionKey sniConnectionKeyCacheHit() {
+        return CONNECTION_CACHE.get(SNI_KEY);
+    }
+
+    @Benchmark
+    public ConnectionKey sniConnectionKeyCreateAndCacheHit() {
+        return CONNECTION_CACHE.get(sniKey(EXPLICIT_SNI, EMPTY_HEADERS));
+    }
+
+    @Benchmark
+    public ConnectionKey sniConnectionKeyCacheMiss() {
+        return CONNECTION_CACHE.get(SNI_MISS_KEY);
+    }
+
+    @Benchmark
     public boolean deadlineGuardCreateAndCancel() {
         try (DeadlineGuard guard = DeadlineGuard.create(DEADLINE_TIMEOUT, () -> { })) {
             return guard.timedOut();
@@ -151,6 +235,23 @@ public class ConnectionKeyJmhTest {
         Map<ConnectionKey, ConnectionKey> cache = new ConcurrentHashMap<>();
         cache.put(TCP_KEY, TCP_KEY);
         cache.put(UDS_KEY, UDS_KEY);
+        cache.put(SNI_KEY, SNI_KEY);
         return cache;
+    }
+
+    private static ConnectionKey sniKey(SniConfig sni, ClientRequestHeaders headers) {
+        return ConnectionKey.create(SNI_URI,
+                                    sni,
+                                    TLS_ENABLED,
+                                    DNS_RESOLVER,
+                                    DNS_ADDRESS_LOOKUP,
+                                    PROXY,
+                                    headers);
+    }
+
+    private static ClientRequestHeaders hostHeaders() {
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        headers.set(HeaderNames.HOST, "authority.example:443");
+        return headers;
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import io.helidon.common.GenericType;
@@ -75,6 +76,36 @@ public interface ClientRequest<T extends ClientRequest<T>> {
      * @return updated request
      */
     T tls(Tls tls);
+
+    /**
+     * Configure client-side TLS SNI for this request.
+     * <p>
+     * Request-level SNI overrides client-level SNI. A configured SNI host is also used as the TLS peer host for
+     * endpoint identification.
+     *
+     * @param sni SNI configuration
+     * @return updated request
+     */
+    default T sni(SniConfig sni) {
+        Objects.requireNonNull(sni, "sni");
+        throw new UnsupportedOperationException("SNI configuration is not supported by this request implementation");
+    }
+
+    /**
+     * Configure client-side TLS SNI for this request.
+     * <p>
+     * Request-level SNI overrides client-level SNI. A configured SNI host is also used as the TLS peer host for
+     * endpoint identification.
+     *
+     * @param sni SNI configuration builder
+     * @return updated request
+     */
+    default T sni(Consumer<SniConfig.Builder> sni) {
+        Objects.requireNonNull(sni, "sni");
+        SniConfig.Builder builder = SniConfig.builder();
+        sni.accept(builder);
+        return sni(builder.buildPrototype());
+    }
 
     /**
      * Proxy configuration for this specific request.

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -92,6 +92,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private Duration readTimeout;
     private Duration readContinueTimeout;
     private Tls tls;
+    private SniConfig sni;
     private Proxy proxy;
     private boolean keepAlive;
     private ClientConnection connection;
@@ -190,6 +191,12 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T tls(Tls tls) {
         this.tls = tls;
+        return identity();
+    }
+
+    @Override
+    public T sni(SniConfig sni) {
+        this.sni = Objects.requireNonNull(sni);
         return identity();
     }
 
@@ -361,6 +368,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     public R outputStream(OutputStreamHandler outputStreamConsumer) {
         rejectHeadWithEntity();
         additionalHeaders();
+        validateRequest();
         return doOutputStream(outputStreamConsumer);
     }
 
@@ -410,6 +418,11 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public Tls tls() {
         return tls;
+    }
+
+    @Override
+    public Optional<SniConfig> sni() {
+        return Optional.ofNullable(sni);
     }
 
     @Override
@@ -510,7 +523,10 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                                                                         whenSent,
                                                                         properties);
 
-        WebClientService.Chain last = httpCallChain;
+        WebClientService.Chain last = request -> {
+            ClientRequestHeaderSupport.validate(request.headers());
+            return httpCallChain.proceed(request);
+        };
 
         List<WebClientService> services = clientConfig.services();
         ListIterator<WebClientService> serviceIterator = services.listIterator(services.size());
@@ -585,6 +601,11 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     }
 
     private R validateAndSubmit(Object entity) {
+        validateRequest();
+        return doSubmit(entity);
+    }
+
+    private void validateRequest() {
         String scheme = uri().scheme();
         if (scheme == null || !SUPPORTED_SCHEMES.contains(scheme.toLowerCase())) {
             throw new IllegalArgumentException(
@@ -594,7 +615,6 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                     )
             );
         }
-        return doSubmit(entity);
     }
 
     private String resolvePathParams(String path) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestHeaderSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestHeaderSupport.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+
+final class ClientRequestHeaderSupport {
+    private ClientRequestHeaderSupport() {
+    }
+
+    static void validate(ClientRequestHeaders headers) {
+        if (headers.contains(HeaderNames.HOST)) {
+            validateSingleValue(headers.get(HeaderNames.HOST));
+        }
+    }
+
+    static String hostAuthority(ClientUri uri, ClientRequestHeaders headers) {
+        if (!headers.contains(HeaderNames.HOST)) {
+            return uri.authority();
+        }
+
+        Header host = headers.get(HeaderNames.HOST);
+        validateSingleValue(host);
+        return host.get();
+    }
+
+    private static void validateSingleValue(Header header) {
+        int valueCount = header.valueCount();
+        if (valueCount != 1) {
+            throw new IllegalArgumentException("Request Host header must be single-valued, but found "
+                                                       + valueCount
+                                                       + " values");
+        }
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
@@ -17,9 +17,14 @@
 package io.helidon.webclient.api;
 
 import java.net.UnixDomainSocketAddress;
+import java.util.List;
 import java.util.Objects;
 
+import javax.net.ssl.SNIServerName;
+
+import io.helidon.common.Api;
 import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientRequestHeaders;
 import io.helidon.webclient.spi.DnsResolver;
 
 /**
@@ -34,6 +39,9 @@ public final class ConnectionKey {
     private final DnsAddressLookup dnsAddressLookup;
     private final Proxy proxy;
     private final Transport transport;
+    private final String tlsPeerHost;
+    private final int tlsPeerPort;
+    private final SniSupport.State sni;
 
     private ConnectionKey(String scheme,
                           String host,
@@ -53,6 +61,26 @@ public final class ConnectionKey {
                           DnsAddressLookup dnsAddressLookup,
                           Proxy proxy,
                           Transport transport) {
+        this(scheme,
+             host,
+             port,
+             tls,
+             dnsResolver,
+             dnsAddressLookup,
+             proxy,
+             transport,
+             SniSupport.tlsDefault(simpleUri(scheme, host, port), tls));
+    }
+
+    private ConnectionKey(String scheme,
+                          String host,
+                          int port,
+                          Tls tls,
+                          DnsResolver dnsResolver,
+                          DnsAddressLookup dnsAddressLookup,
+                          Proxy proxy,
+                          Transport transport,
+                          SniSupport.Selection sni) {
         this.scheme = scheme;
         this.host = host;
         this.port = port;
@@ -61,6 +89,9 @@ public final class ConnectionKey {
         this.dnsAddressLookup = dnsAddressLookup;
         this.proxy = proxy;
         this.transport = transport;
+        this.tlsPeerHost = sni.tlsPeerHost();
+        this.tlsPeerPort = sni.tlsPeerPort();
+        this.sni = sni.state();
     }
 
     /**
@@ -83,6 +114,72 @@ public final class ConnectionKey {
                                        DnsAddressLookup dnsAddressLookup,
                                        Proxy proxy) {
         return new ConnectionKey(scheme, host, port, tls, dnsResolver, dnsAddressLookup, proxy);
+    }
+
+    /**
+     * Create new instance of the {@link ConnectionKey}.
+     *
+     * @param uri              resolved URI
+     * @param tls              TLS to be used in connection
+     * @param dnsResolver      DNS resolver to be used
+     * @param dnsAddressLookup DNS address lookup strategy
+     * @param proxy            Proxy server to use for outgoing requests
+     * @return new instance
+     */
+    @Api.Internal
+    public static ConnectionKey create(ClientUri uri,
+                                       Tls tls,
+                                       DnsResolver dnsResolver,
+                                       DnsAddressLookup dnsAddressLookup,
+                                       Proxy proxy) {
+        ClientUri checkedUri = Objects.requireNonNull(uri, "uri");
+        Tls checkedTls = Objects.requireNonNull(tls, "tls");
+        return new ConnectionKey(checkedUri.scheme(),
+                                 checkedUri.host(),
+                                 checkedUri.port(),
+                                 checkedTls,
+                                 Objects.requireNonNull(dnsResolver, "dnsResolver"),
+                                 Objects.requireNonNull(dnsAddressLookup, "dnsAddressLookup"),
+                                 Objects.requireNonNull(proxy, "proxy"),
+                                 null,
+                                 SniSupport.tlsDefault(checkedUri, checkedTls));
+    }
+
+    /**
+     * Create new instance of the {@link ConnectionKey}.
+     *
+     * @param uri              resolved URI
+     * @param sni              effective SNI configuration
+     * @param tls              TLS to be used in connection
+     * @param dnsResolver      DNS resolver to be used
+     * @param dnsAddressLookup DNS address lookup strategy
+     * @param proxy            Proxy server to use for outgoing requests
+     * @param headers          final request headers available before connection acquisition
+     * @return new instance
+     */
+    @Api.Internal
+    public static ConnectionKey create(ClientUri uri,
+                                       SniConfig sni,
+                                       Tls tls,
+                                       DnsResolver dnsResolver,
+                                       DnsAddressLookup dnsAddressLookup,
+                                       Proxy proxy,
+                                       ClientRequestHeaders headers) {
+        ClientUri checkedUri = Objects.requireNonNull(uri, "uri");
+        Tls checkedTls = Objects.requireNonNull(tls, "tls");
+        SniSupport.Selection selection = SniSupport.resolve(checkedUri,
+                                                            Objects.requireNonNull(sni, "sni"),
+                                                            checkedTls,
+                                                            Objects.requireNonNull(headers, "headers"));
+        return new ConnectionKey(checkedUri.scheme(),
+                                 checkedUri.host(),
+                                 checkedUri.port(),
+                                 checkedTls,
+                                 Objects.requireNonNull(dnsResolver, "dnsResolver"),
+                                 Objects.requireNonNull(dnsAddressLookup, "dnsAddressLookup"),
+                                 Objects.requireNonNull(proxy, "proxy"),
+                                 null,
+                                 selection);
     }
 
     /**
@@ -113,6 +210,74 @@ public final class ConnectionKey {
                                  Objects.requireNonNull(dnsAddressLookup, "dnsAddressLookup"),
                                  Proxy.noProxy(),
                                  new Transport("unix", socketAddress.getPath().toString()));
+    }
+
+    /**
+     * Create new instance of the {@link ConnectionKey} for a Unix domain socket transport.
+     *
+     * @param uri              resolved URI
+     * @param tls              TLS to be used in connection
+     * @param dnsResolver      DNS resolver to be used
+     * @param dnsAddressLookup DNS address lookup strategy
+     * @param address          Unix domain socket transport address
+     * @return new instance
+     */
+    @Api.Internal
+    public static ConnectionKey createUnixDomainSocket(ClientUri uri,
+                                                       Tls tls,
+                                                       DnsResolver dnsResolver,
+                                                       DnsAddressLookup dnsAddressLookup,
+                                                       UnixDomainSocketAddress address) {
+        ClientUri checkedUri = Objects.requireNonNull(uri, "uri");
+        Tls checkedTls = Objects.requireNonNull(tls, "tls");
+        UnixDomainSocketAddress socketAddress = Objects.requireNonNull(address, "address");
+        return new ConnectionKey(Objects.requireNonNull(checkedUri.scheme(), "scheme"),
+                                 Objects.requireNonNull(checkedUri.host(), "host"),
+                                 checkedUri.port(),
+                                 checkedTls,
+                                 Objects.requireNonNull(dnsResolver, "dnsResolver"),
+                                 Objects.requireNonNull(dnsAddressLookup, "dnsAddressLookup"),
+                                 Proxy.noProxy(),
+                                 new Transport("unix", socketAddress.getPath().toString()),
+                                 SniSupport.tlsDefault(checkedUri, checkedTls));
+    }
+
+    /**
+     * Create new instance of the {@link ConnectionKey} for a Unix domain socket transport.
+     *
+     * @param uri              resolved URI
+     * @param sni              effective SNI configuration
+     * @param tls              TLS to be used in connection
+     * @param dnsResolver      DNS resolver to be used
+     * @param dnsAddressLookup DNS address lookup strategy
+     * @param address          Unix domain socket transport address
+     * @param headers          final request headers available before connection acquisition
+     * @return new instance
+     */
+    @Api.Internal
+    public static ConnectionKey createUnixDomainSocket(ClientUri uri,
+                                                       SniConfig sni,
+                                                       Tls tls,
+                                                       DnsResolver dnsResolver,
+                                                       DnsAddressLookup dnsAddressLookup,
+                                                       UnixDomainSocketAddress address,
+                                                       ClientRequestHeaders headers) {
+        ClientUri checkedUri = Objects.requireNonNull(uri, "uri");
+        Tls checkedTls = Objects.requireNonNull(tls, "tls");
+        UnixDomainSocketAddress socketAddress = Objects.requireNonNull(address, "address");
+        SniSupport.Selection selection = SniSupport.resolve(checkedUri,
+                                                            Objects.requireNonNull(sni, "sni"),
+                                                            checkedTls,
+                                                            Objects.requireNonNull(headers, "headers"));
+        return new ConnectionKey(Objects.requireNonNull(checkedUri.scheme(), "scheme"),
+                                 Objects.requireNonNull(checkedUri.host(), "host"),
+                                 checkedUri.port(),
+                                 checkedTls,
+                                 Objects.requireNonNull(dnsResolver, "dnsResolver"),
+                                 Objects.requireNonNull(dnsAddressLookup, "dnsAddressLookup"),
+                                 Proxy.noProxy(),
+                                 new Transport("unix", socketAddress.getPath().toString()),
+                                 selection);
     }
 
     /**
@@ -178,6 +343,30 @@ public final class ConnectionKey {
         return proxy;
     }
 
+    /**
+     * Host used as the TLS peer host for SNI and endpoint identification.
+     *
+     * @return TLS peer host
+     */
+    @Api.Internal
+    public String tlsPeerHost() {
+        return tlsPeerHost;
+    }
+
+    /**
+     * Port used as the TLS peer port for endpoint identification.
+     *
+     * @return TLS peer port
+     */
+    @Api.Internal
+    public int tlsPeerPort() {
+        return tlsPeerPort;
+    }
+
+    List<SNIServerName> serverNamesOverride() {
+        return SniSupport.serverNamesOverride(sni);
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -194,12 +383,16 @@ public final class ConnectionKey {
                 && Objects.equals(this.dnsResolver, that.dnsResolver)
                 && Objects.equals(this.dnsAddressLookup, that.dnsAddressLookup)
                 && Objects.equals(this.proxy, that.proxy)
-                && Objects.equals(this.transport, that.transport);
+                && Objects.equals(this.transport, that.transport)
+                && Objects.equals(this.tlsPeerHost, that.tlsPeerHost)
+                && this.tlsPeerPort == that.tlsPeerPort
+                && Objects.equals(this.sni, that.sni);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(scheme, host, port, tls, dnsResolver, dnsAddressLookup, proxy, transport);
+        return Objects.hash(scheme, host, port, tls, dnsResolver, dnsAddressLookup, proxy, transport, tlsPeerHost,
+                            tlsPeerPort, sni);
     }
 
     @Override
@@ -213,7 +406,17 @@ public final class ConnectionKey {
                 + "dnsAddressLookup=" + dnsAddressLookup + ", "
                 + "proxy=" + proxy
                 + (transport == null ? "" : ", transport=" + transport)
+                + ", tlsPeerHost=" + tlsPeerHost + ", "
+                + "tlsPeerPort=" + tlsPeerPort + ", "
+                + "sni=" + sni
                 + ']';
+    }
+
+    private static ClientUri simpleUri(String scheme, String host, int port) {
+        return ClientUri.create()
+                .scheme(scheme)
+                .host(host)
+                .port(port);
     }
 
     private record Transport(String type, String value) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
@@ -348,8 +348,7 @@ public final class ConnectionKey {
      *
      * @return TLS peer host
      */
-    @Api.Internal
-    public String tlsPeerHost() {
+    String tlsPeerHost() {
         return tlsPeerHost;
     }
 
@@ -358,8 +357,7 @@ public final class ConnectionKey {
      *
      * @return TLS peer port
      */
-    @Api.Internal
-    public int tlsPeerPort() {
+    int tlsPeerPort() {
         return tlsPeerPort;
     }
 

--- a/webclient/api/src/main/java/io/helidon/webclient/api/FullClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/FullClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,15 @@ public interface FullClientRequest<T extends ClientRequest<T>> extends ClientReq
      * @return TLS configuration
      */
     Tls tls();
+
+    /**
+     * Request-level SNI configuration.
+     *
+     * @return SNI configuration if configured
+     */
+    default Optional<SniConfig> sni() {
+        return Optional.empty();
+    }
 
     /**
      * Proxy configuration (may be no-proxy).

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -70,6 +70,17 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
     Optional<SocketAddress> baseAddress();
 
     /**
+     * Client-side TLS SNI configuration.
+     * <p>
+     * If this is not configured, WebClient preserves the configured {@link #tls()} SSL parameters and uses the JDK TLS
+     * defaults for SNI. If this is configured without an explicit {@code mode}, the resolved request URI host is used.
+     *
+     * @return SNI configuration
+     */
+    @Option.Configured
+    Optional<SniConfig> sni();
+
+    /**
      * Base query used by the client in all requests.
      *
      * @return base query of the client requests
@@ -248,6 +259,7 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      * Maximal size of the connection cache for a single connection key.
      * A connection key is formed by the scheme, host, port, TLS configuration, DNS resolver, DNS address lookup, and proxy.
      * For UNIX domain socket transports, the key also includes the socket path and does not include proxy configuration.
+     * For TLS connections, configured SNI can further split the cache by TLS peer host, TLS peer port, and SNI mode.
      * <p>
      * For most HTTP protocols, we may cache connections to various endpoints for keep alive (or stream reuse in case of HTTP/2).
      * This option limits the size. Setting this number lower than the "usual" number of target services will cause connections

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 
 import io.helidon.common.LruCache;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Method;
 import io.helidon.webclient.spi.HttpClientSpi;
 
@@ -33,6 +35,8 @@ import io.helidon.webclient.spi.HttpClientSpi;
  */
 public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, HttpClientResponse> {
     private static final System.Logger LOGGER = System.getLogger(HttpClientRequest.class.getName());
+    private static final Tls NO_TLS = Tls.builder().enabled(false).build();
+    private static final String GENERIC_TCP_PROTOCOL_IDS_PROPERTY = "io.helidon.webclient.generic.tcp-protocol-ids";
 
     private final LruCache<LoomClient.EndpointKey, HttpClientSpi> clientSpiCache;
     private final WebClient webClient;
@@ -102,6 +106,7 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
 
     private ClientRequest<?> discoverHttpImplementation() {
         ClientUri resolvedUri = resolvedUri();
+        ClientRequestHeaderSupport.validate(headers());
 
         if (preferredProtocolId != null) {
             /*
@@ -116,10 +121,19 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
         }
 
         String transportKey = transportKey();
+        HttpClientConfig clientConfig = clientConfig();
+        Tls effectiveTls = effectiveTls(resolvedUri, tls());
+        SniConfig effectiveSni = effectiveSni(clientConfig);
+        if (requiresFinalHeaders(resolvedUri, effectiveSni, effectiveTls)) {
+            return firstTcpProtocol(resolvedUri);
+        }
+
+        SniSupport.Selection sni = sniSelection(resolvedUri, effectiveSni, effectiveTls, headers());
         LoomClient.EndpointKey endpointKey = new LoomClient.EndpointKey(resolvedUri.scheme(),
                                                                         resolvedUri.authority(),
                                                                         transportKey,
-                                                                        tls(),
+                                                                        effectiveTls,
+                                                                        sni.state(),
                                                                         transportKey == null ? proxy() : Proxy.noProxy());
         Optional<HttpClientSpi> spi = clientSpiCache.get(endpointKey);
         if (spi.isPresent()) {
@@ -138,7 +152,9 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
             HttpClientSpi client = protocol.spi();
             HttpClientSpi.SupportLevel supports = client.supports(this, resolvedUri);
             if (supports == HttpClientSpi.SupportLevel.SUPPORTED) {
-                clientSpiCache.put(endpointKey, client);
+                if (endpointKey != null) {
+                    clientSpiCache.put(endpointKey, client);
+                }
                 return client.clientRequest(this, resolvedUri);
             }
             if (supports == HttpClientSpi.SupportLevel.COMPATIBLE && compatible == null) {
@@ -149,7 +165,7 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
             }
         }
 
-        if ("https".equals(resolvedUri.scheme()) && tls().enabled() && !tcpProtocols.isEmpty()) {
+        if ("https".equals(resolvedUri.scheme()) && effectiveTls.enabled() && !tcpProtocols.isEmpty()) {
             // we may use UNIX domain socket here
             UnixDomainSocketAddress unixSocketAddress = null;
             if (address().isPresent()) {
@@ -162,13 +178,12 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
 
             if (unixSocketAddress == null) {
                 // use ALPN
-                ConnectionKey connectionKey = ConnectionKey.create(resolvedUri.scheme(),
-                                                                   resolvedUri.host(),
-                                                                   resolvedUri.port(),
-                                                                   tls(),
-                                                                   clientConfig().dnsResolver(),
-                                                                   clientConfig().dnsAddressLookup(),
-                                                                   proxy());
+                ConnectionKey connectionKey = connectionKey(resolvedUri,
+                                                            effectiveSni,
+                                                            effectiveTls,
+                                                            clientConfig,
+                                                            proxy(),
+                                                            headers());
 
                 // this is a temporary connection, used to determine which protocol is supported, next
                 // call to the same remote location will be obtained from cache
@@ -179,12 +194,16 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
                                                         conn -> {
                                                         });
             } else {
+                ConnectionKey connectionKey = unixConnectionKey(resolvedUri,
+                                                                effectiveSni,
+                                                                effectiveTls,
+                                                                clientConfig,
+                                                                unixSocketAddress,
+                                                                headers());
                 connection = UnixDomainSocketClientConnection.create(webClient,
-                                                                     tls(),
+                                                                     connectionKey,
                                                                      tcpProtocolIds,
                                                                      unixSocketAddress,
-                                                                     resolvedUri.host(),
-                                                                     resolvedUri.port(),
                                                                      conn -> false,
                                                                      conn -> {
                                                                      });
@@ -217,7 +236,9 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
         }
 
         if (compatible != null) {
-            clientSpiCache.put(endpointKey, compatible);
+            if (endpointKey != null) {
+                clientSpiCache.put(endpointKey, compatible);
+            }
             return compatible.clientRequest(this, resolvedUri);
         }
 
@@ -236,5 +257,80 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
                 .map(UnixDomainSocketAddress.class::cast)
                 .map(address -> "unix:" + address.getPath())
                 .orElse(null);
+    }
+
+    private SniConfig effectiveSni(HttpClientConfig clientConfig) {
+        return sni().or(clientConfig::sni).orElse(null);
+    }
+
+    private Tls effectiveTls(ClientUri uri, Tls tls) {
+        return "https".equals(uri.scheme()) ? tls : NO_TLS;
+    }
+
+    private boolean requiresFinalHeaders(ClientUri uri, SniConfig sni, Tls tls) {
+        return "https".equals(uri.scheme())
+                && tls.enabled()
+                && sni != null
+                && sni.mode() == SniMode.HOST_HEADER;
+    }
+
+    private ClientRequest<?> firstTcpProtocol(ClientUri resolvedUri) {
+        if (tcpProtocols.isEmpty()) {
+            throw new IllegalArgumentException("Cannot handle request to " + resolvedUri + ", did not discover any HTTP version "
+                                                       + "willing to handle it. HTTP versions supported: " + clients.keySet());
+        }
+        property(GENERIC_TCP_PROTOCOL_IDS_PROPERTY, String.join(",", tcpProtocolIds));
+        return tcpProtocols.getFirst().spi().clientRequest(this, resolvedUri);
+    }
+
+    private static SniSupport.Selection sniSelection(ClientUri uri,
+                                                     SniConfig sni,
+                                                     Tls tls,
+                                                     ClientRequestHeaders headers) {
+        return sni == null ? SniSupport.tlsDefault(uri, tls) : SniSupport.resolve(uri, sni, tls, headers);
+    }
+
+    private static ConnectionKey connectionKey(ClientUri uri,
+                                               SniConfig sni,
+                                               Tls tls,
+                                               HttpClientConfig clientConfig,
+                                               Proxy proxy,
+                                               ClientRequestHeaders headers) {
+        if (sni == null) {
+            return ConnectionKey.create(uri,
+                                        tls,
+                                        clientConfig.dnsResolver(),
+                                        clientConfig.dnsAddressLookup(),
+                                        proxy);
+        }
+        return ConnectionKey.create(uri,
+                                    sni,
+                                    tls,
+                                    clientConfig.dnsResolver(),
+                                    clientConfig.dnsAddressLookup(),
+                                    proxy,
+                                    headers);
+    }
+
+    private static ConnectionKey unixConnectionKey(ClientUri uri,
+                                                   SniConfig sni,
+                                                   Tls tls,
+                                                   HttpClientConfig clientConfig,
+                                                   UnixDomainSocketAddress address,
+                                                   ClientRequestHeaders headers) {
+        if (sni == null) {
+            return ConnectionKey.createUnixDomainSocket(uri,
+                                                        tls,
+                                                        clientConfig.dnsResolver(),
+                                                        clientConfig.dnsAddressLookup(),
+                                                        address);
+        }
+        return ConnectionKey.createUnixDomainSocket(uri,
+                                                    sni,
+                                                    tls,
+                                                    clientConfig.dnsResolver(),
+                                                    clientConfig.dnsAddressLookup(),
+                                                    address,
+                                                    headers);
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
@@ -36,7 +36,6 @@ import io.helidon.webclient.spi.HttpClientSpi;
 public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, HttpClientResponse> {
     private static final System.Logger LOGGER = System.getLogger(HttpClientRequest.class.getName());
     private static final Tls NO_TLS = Tls.builder().enabled(false).build();
-    private static final String GENERIC_TCP_PROTOCOL_IDS_PROPERTY = "io.helidon.webclient.generic.tcp-protocol-ids";
 
     private final LruCache<LoomClient.EndpointKey, HttpClientSpi> clientSpiCache;
     private final WebClient webClient;
@@ -279,7 +278,6 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
             throw new IllegalArgumentException("Cannot handle request to " + resolvedUri + ", did not discover any HTTP version "
                                                        + "willing to handle it. HTTP versions supported: " + clients.keySet());
         }
-        property(GENERIC_TCP_PROTOCOL_IDS_PROPERTY, String.join(",", tcpProtocolIds));
         return tcpProtocols.getFirst().spi().clientRequest(this, resolvedUri);
     }
 

--- a/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
@@ -191,6 +191,7 @@ class LoomClient implements WebClient {
                        String authority, // myserver:80
                        String transportKey, // optional explicit transport address, such as a UDS path (may be null)
                        Tls tlsConfig, // TLS configuration (may be disabled, never null)
+                       SniSupport.State sni,
                        Proxy proxy) { // proxy, never null
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/SniConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/SniConfigBlueprint.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Client-side TLS SNI configuration.
+ */
+@Prototype.Configured
+@Prototype.Blueprint(decorator = SniConfigSupport.BuilderDecorator.class)
+interface SniConfigBlueprint {
+    /**
+     * TLS peer host source mode for SNI and endpoint identification: {@code uri-host}, {@code host-header},
+     * {@code explicit}, or {@code disabled}.
+     * <p>
+     * DNS names are sent as SNI server names. IP literals are used for endpoint identification without a DNS SNI
+     * server name. {@code disabled} clears the SNI server name without disabling endpoint identification.
+     *
+     * @return SNI mode
+     */
+    @Option.Configured
+    @Option.Default("URI_HOST")
+    SniMode mode();
+
+    /**
+     * Explicit TLS peer host used when {@code mode} is {@code explicit}.
+     * DNS hosts are sent as SNI server names and used for endpoint identification. IP literals are used for endpoint
+     * identification without a DNS SNI server name.
+     *
+     * @return explicit TLS peer host
+     */
+    @Option.Configured
+    Optional<String> host();
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/SniConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/SniConfigBlueprint.java
@@ -44,6 +44,9 @@ interface SniConfigBlueprint {
      * Explicit TLS peer host used when {@code mode} is {@code explicit}.
      * DNS hosts are sent as SNI server names and used for endpoint identification. IP literals are used for endpoint
      * identification without a DNS SNI server name.
+     * <p>
+     * The host must be configured only when {@code mode} is {@code explicit}, and it must not include a port.
+     * Bracketed IPv6 literals are accepted and normalized to the host value without brackets.
      *
      * @return explicit TLS peer host
      */

--- a/webclient/api/src/main/java/io/helidon/webclient/api/SniConfigSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/SniConfigSupport.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.uri.UriAuthority;
+
+final class SniConfigSupport {
+    private SniConfigSupport() {
+    }
+
+    static class BuilderDecorator implements Prototype.BuilderDecorator<SniConfig.BuilderBase<?, ?>> {
+        @Override
+        public void decorate(SniConfig.BuilderBase<?, ?> target) {
+            SniMode mode = target.mode();
+            Optional<String> host = target.host();
+
+            if (mode == SniMode.EXPLICIT) {
+                if (host.isEmpty() || host.get().isBlank()) {
+                    throw new IllegalArgumentException("SNI host must be configured when SNI mode is explicit");
+                }
+                UriAuthority authority = UriAuthority.create(host.get());
+                if (authority.hasPort()) {
+                    throw new IllegalArgumentException("SNI host must not include a port");
+                }
+                target.host(authority.host().value());
+                return;
+            }
+
+            if (host.isPresent()) {
+                throw new IllegalArgumentException("SNI host can only be configured when SNI mode is explicit");
+            }
+        }
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/SniConfigSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/SniConfigSupport.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import io.helidon.builder.api.Prototype;
 import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
 
 final class SniConfigSupport {
     private SniConfigSupport() {
@@ -35,11 +36,7 @@ final class SniConfigSupport {
                 if (host.isEmpty() || host.get().isBlank()) {
                     throw new IllegalArgumentException("SNI host must be configured when SNI mode is explicit");
                 }
-                UriAuthority authority = UriAuthority.create(host.get());
-                if (authority.hasPort()) {
-                    throw new IllegalArgumentException("SNI host must not include a port");
-                }
-                target.host(authority.host().value());
+                target.host(normalizeHost(host.get()).value());
                 return;
             }
 
@@ -47,5 +44,28 @@ final class SniConfigSupport {
                 throw new IllegalArgumentException("SNI host can only be configured when SNI mode is explicit");
             }
         }
+    }
+
+    private static UriHost normalizeHost(String host) {
+        if (host.startsWith("[")) {
+            return normalizeAuthority(host);
+        }
+        if (hasSingleColon(host)) {
+            throw new IllegalArgumentException("SNI host must not include a port");
+        }
+        return UriHost.create(host);
+    }
+
+    private static UriHost normalizeAuthority(String authorityText) {
+        UriAuthority authority = UriAuthority.create(authorityText);
+        if (authority.hasPort()) {
+            throw new IllegalArgumentException("SNI host must not include a port");
+        }
+        return authority.host();
+    }
+
+    private static boolean hasSingleColon(String host) {
+        int firstColon = host.indexOf(':');
+        return firstColon != -1 && host.indexOf(':', firstColon + 1) == -1;
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/SniMode.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/SniMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+/**
+ * Source of the client-side TLS SNI host.
+ */
+public enum SniMode {
+    /**
+     * Use the resolved request URI host.
+     */
+    URI_HOST,
+
+    /**
+     * Use the final outbound HTTP authority from the {@code Host} header.
+     */
+    HOST_HEADER,
+
+    /**
+     * Use the explicitly configured SNI host.
+     */
+    EXPLICIT,
+
+    /**
+     * Clear the SNI server name.
+     */
+    DISABLED
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/SniSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/SniSupport.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.List;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
+import io.helidon.http.ClientRequestHeaders;
+
+final class SniSupport {
+    private SniSupport() {
+    }
+
+    static Selection resolve(ClientUri uri,
+                             SniConfig sni,
+                             Tls tls,
+                             ClientRequestHeaders headers) {
+        if (!tls.enabled()) {
+            return cleartext(uri);
+        }
+
+        return resolveFirstClass(uri, sni, headers);
+    }
+
+    static Selection uriHost(ClientUri uri) {
+        UriHost host = normalizedUriHost(uri);
+        return selection(host, uri.port());
+    }
+
+    static Selection tlsDefault(ClientUri uri, Tls tls) {
+        if (!tls.enabled()) {
+            return cleartext(uri);
+        }
+        return new Selection(uri.host(), uri.port(), State.defaults());
+    }
+
+    private static Selection cleartext(ClientUri uri) {
+        return new Selection(uri.host(), uri.port(), State.disabled());
+    }
+
+    private static Selection disabled(ClientUri uri) {
+        UriHost host = normalizedUriHost(uri);
+        return new Selection(host.value(), uri.port(), State.disabled());
+    }
+
+    private static Selection resolveFirstClass(ClientUri uri, SniConfig sni, ClientRequestHeaders headers) {
+        SniMode mode = sni.mode();
+        return switch (mode) {
+        case URI_HOST -> uriHost(uri);
+        case HOST_HEADER -> {
+            String authority = ClientRequestHeaderSupport.hostAuthority(uri, headers);
+            UriAuthority normalized = UriAuthority.create(authority);
+            yield selection(normalized.host(), normalized.portOrDefault(uri.port()));
+        }
+        case EXPLICIT -> selection(normalizedHost(sni.host().orElseThrow()), uri.port());
+        case DISABLED -> disabled(uri);
+        };
+    }
+
+    private static Selection selection(UriHost host, int port) {
+        if (host.kind() == UriHost.Kind.DNS) {
+            return new Selection(host.value(), port, State.host(host.value()));
+        }
+        return new Selection(host.value(), port, State.empty(host.value()));
+    }
+
+    private static UriHost normalizedUriHost(ClientUri uri) {
+        return UriAuthority.create(uri.authority()).host();
+    }
+
+    private static UriHost normalizedHost(String host) {
+        if (host.startsWith("[")) {
+            return UriAuthority.create(host).host();
+        }
+        return UriHost.create(host);
+    }
+
+    static List<SNIServerName> serverNamesOverride(State state) {
+        return switch (state.kind()) {
+        case DEFAULT -> null;
+        case HOST -> List.of(new SNIHostName(state.host()));
+        case EMPTY, DISABLED -> List.of();
+        };
+    }
+
+    record Selection(String tlsPeerHost,
+                     int tlsPeerPort,
+                     State state) {
+    }
+
+    record State(Kind kind, String host) {
+        private static final State DEFAULT = new State(Kind.DEFAULT, "");
+        private static final State DISABLED = new State(Kind.DISABLED, "");
+
+        static State defaults() {
+            return DEFAULT;
+        }
+
+        static State host(String host) {
+            return new State(Kind.HOST, host);
+        }
+
+        static State empty(String host) {
+            return new State(Kind.EMPTY, host);
+        }
+
+        static State disabled() {
+            return DISABLED;
+        }
+    }
+
+    enum Kind {
+        DEFAULT,
+        HOST,
+        EMPTY,
+        DISABLED
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -144,7 +144,6 @@ public class TcpClientConnection implements ClientConnection {
                     ? tls.createSocket(tcpProtocolIds, socket, targetAddress)
                     : tls.createSocket(tcpProtocolIds,
                                        socket,
-                                       targetAddress,
                                        connectionKey.tlsPeerHost(),
                                        connectionKey.tlsPeerPort(),
                                        serverNamesOverride);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLSocket;
 
 import io.helidon.common.buffers.BufferData;
@@ -138,7 +139,15 @@ public class TcpClientConnection implements ClientConnection {
 
 
         if (tls.enabled()) {
-            SSLSocket sslSocket = tls.createSocket(tcpProtocolIds, socket, targetAddress);
+            List<SNIServerName> serverNamesOverride = connectionKey.serverNamesOverride();
+            SSLSocket sslSocket = serverNamesOverride == null
+                    ? tls.createSocket(tcpProtocolIds, socket, targetAddress)
+                    : tls.createSocket(tcpProtocolIds,
+                                       socket,
+                                       targetAddress,
+                                       connectionKey.tlsPeerHost(),
+                                       connectionKey.tlsPeerPort(),
+                                       serverNamesOverride);
             try {
                 sslSocket.startHandshake();
             } catch (IOException e) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -30,10 +30,10 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLSocket;
 
 import io.helidon.common.buffers.BufferData;

--- a/webclient/api/src/main/java/io/helidon/webclient/api/UnixDomainSocketClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/UnixDomainSocketClientConnection.java
@@ -29,8 +29,8 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 
 import io.helidon.common.Api;

--- a/webclient/api/src/main/java/io/helidon/webclient/api/UnixDomainSocketClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/UnixDomainSocketClientConnection.java
@@ -30,8 +30,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLParameters;
 
+import io.helidon.common.Api;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
@@ -56,6 +58,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
     private final List<String> alpnId;
     private final String tlsPeerHost;
     private final int tlsPeerPort;
+    private final List<SNIServerName> serverNamesOverride;
     private final Function<UnixDomainSocketClientConnection, Boolean> releaseFunction;
     private final Consumer<UnixDomainSocketClientConnection> closeConsumer;
 
@@ -73,6 +76,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
                                              List<String> alpnId,
                                              String tlsPeerHost,
                                              int tlsPeerPort,
+                                             List<SNIServerName> serverNamesOverride,
                                              Function<UnixDomainSocketClientConnection, Boolean> releaseFunction,
                                              Consumer<UnixDomainSocketClientConnection> closeConsumer) {
         this.webClient = Objects.requireNonNull(webClient, "webClient");
@@ -81,6 +85,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
         this.alpnId = Objects.requireNonNull(alpnId, "alpnId");
         this.tlsPeerHost = tlsPeerHost;
         this.tlsPeerPort = tlsPeerPort;
+        this.serverNamesOverride = serverNamesOverride;
         this.releaseFunction = Objects.requireNonNull(releaseFunction, "releaseFunction");
         this.closeConsumer = Objects.requireNonNull(closeConsumer, "closeConsumer");
     }
@@ -113,6 +118,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
                                                     tcpProtocolIds,
                                                     null,
                                                     -1,
+                                                    null,
                                                     releaseFunction,
                                                     closeConsumer);
     }
@@ -146,6 +152,37 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
                                                     tcpProtocolIds,
                                                     Objects.requireNonNull(tlsPeerHost, "tlsPeerHost"),
                                                     tlsPeerPort,
+                                                    null,
+                                                    releaseFunction,
+                                                    closeConsumer);
+    }
+
+    /**
+     * Create a new UNIX Domain Socket Connection.
+     *
+     * @param webClient       webclient, to get configuration
+     * @param connectionKey   connection key
+     * @param tcpProtocolIds  protocol IDs for ALPN (TLS protocol negotiation)
+     * @param address         address of the socket
+     * @param releaseFunction called when {@link #releaseResource()} is called, if {@code false} is returned, the connection will
+     *                        be closed instead kept open
+     * @param closeConsumer   called when {@link #closeResource()} is called, the connection is no longer usable after this moment
+     * @return a new UNIX domain socket connection, {@link #connect()} must be called to make it available for use
+     */
+    @Api.Internal
+    public static UnixDomainSocketClientConnection create(WebClient webClient,
+                                                          ConnectionKey connectionKey,
+                                                          List<String> tcpProtocolIds,
+                                                          UnixDomainSocketAddress address,
+                                                          Function<UnixDomainSocketClientConnection, Boolean> releaseFunction,
+                                                          Consumer<UnixDomainSocketClientConnection> closeConsumer) {
+        return new UnixDomainSocketClientConnection(webClient,
+                                                    connectionKey.tls(),
+                                                    address,
+                                                    tcpProtocolIds,
+                                                    connectionKey.tlsPeerHost(),
+                                                    connectionKey.tlsPeerPort(),
+                                                    connectionKey.serverNamesOverride(),
                                                     releaseFunction,
                                                     closeConsumer);
     }
@@ -327,6 +364,9 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
         SSLParameters source = this.tls.sslParameters();
         if (source.getServerNames() != null) {
             parameters.setServerNames(source.getServerNames());
+        }
+        if (serverNamesOverride != null) {
+            parameters.setServerNames(serverNamesOverride);
         }
         if (source.getCipherSuites() != null) {
             parameters.setCipherSuites(source.getCipherSuites());

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.spi.WebClientService;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClientRequestBaseTest {
+
+    @Test
+    void rejectsMultipleHostHeaderBeforeRequest() {
+        TestRequest request = new TestRequest(Method.GET, "http://service.example");
+        request.headers().add(HeaderValues.create(HeaderNames.HOST, "first.example", "second.example"));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, request::request);
+
+        assertThat(exception.getMessage(), containsString("Request Host header must be single-valued"));
+        assertThat(request.endpointCount(), is(0));
+    }
+
+    @Test
+    void rejectsMultipleHostHeaderBeforeSubmit() {
+        TestRequest request = new TestRequest(Method.POST, "http://service.example");
+        request.headers().add(HeaderValues.create(HeaderNames.HOST, "first.example", "second.example"));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                         () -> request.submit(BufferData.EMPTY_BYTES));
+
+        assertThat(exception.getMessage(), containsString("Request Host header must be single-valued"));
+        assertThat(request.endpointCount(), is(0));
+    }
+
+    @Test
+    void rejectsMultipleHostHeaderBeforeOutputStream() {
+        TestRequest request = new TestRequest(Method.POST, "http://service.example");
+        request.headers().add(HeaderValues.create(HeaderNames.HOST, "first.example", "second.example"));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                         () -> request.outputStream(out -> { }));
+
+        assertThat(exception.getMessage(), containsString("Request Host header must be single-valued"));
+        assertThat(request.endpointCount(), is(0));
+    }
+
+    @Test
+    void rejectsHostHeaderMadeMultipleByService() {
+        HttpClientConfig config = HttpClientConfig.builder()
+                .addService((chain, request) -> {
+                    request.headers().add(HeaderValues.create(HeaderNames.HOST, "first.example", "second.example"));
+                    return chain.proceed(request);
+                })
+                .build();
+        TestRequest request = new TestRequest(config, Method.GET, "http://service.example");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, request::request);
+
+        assertThat(exception.getMessage(), containsString("Request Host header must be single-valued"));
+        assertThat(request.endpointCount(), is(0));
+    }
+
+    private static final class TestRequest extends ClientRequestBase<TestRequest, HttpClientResponse> {
+        private final AtomicInteger endpointCount = new AtomicInteger();
+
+        private TestRequest(Method method, String uri) {
+            this(HttpClientConfig.builder().build(), method, uri);
+        }
+
+        private TestRequest(HttpClientConfig clientConfig, Method method, String uri) {
+            super(clientConfig,
+                  WebClientCookieManager.builder().build(),
+                  "test",
+                  method,
+                  ClientUri.create(URI.create(uri)),
+                  Map.of());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            invokeEndpoint();
+            return null;
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            invokeEndpoint();
+            return null;
+        }
+
+        private void invokeEndpoint() {
+            CompletableFuture<WebClientServiceRequest> whenSent = new CompletableFuture<>();
+            CompletableFuture<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
+            invokeServices(endpoint(), whenSent, whenComplete, resolvedUri());
+        }
+
+        private WebClientService.Chain endpoint() {
+            return serviceRequest -> {
+                endpointCount.incrementAndGet();
+                return WebClientServiceResponse.builder()
+                        .serviceRequest(serviceRequest)
+                        .whenComplete(new CompletableFuture<>())
+                        .connection(() -> { })
+                        .status(Status.OK_200)
+                        .headers(ClientResponseHeaders.create(WritableHeaders.create()))
+                        .build();
+            };
+        }
+
+        private int endpointCount() {
+            return endpointCount.get();
+        }
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ConnectionKeySniTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ConnectionKeySniTest.java
@@ -118,6 +118,36 @@ class ConnectionKeySniTest {
     }
 
     @Test
+    void hostHeaderModeSuppressesSniForIpLiteral() {
+        ClientRequestHeaders headers = emptyHeaders();
+        headers.set(HeaderNames.HOST, "127.0.0.1:9444");
+        SniConfig hostHeaderSni = SniConfig.builder()
+                .mode(SniMode.HOST_HEADER)
+                .build();
+
+        ConnectionKey key = key("https://service.example:443", hostHeaderSni, TLS, headers);
+
+        assertThat(key.tlsPeerHost(), is("127.0.0.1"));
+        assertThat(key.tlsPeerPort(), is(9444));
+        assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
+    void hostHeaderModeSuppressesSniForBracketedIpv6Literal() {
+        ClientRequestHeaders headers = emptyHeaders();
+        headers.set(HeaderNames.HOST, "[::1]:9444");
+        SniConfig hostHeaderSni = SniConfig.builder()
+                .mode(SniMode.HOST_HEADER)
+                .build();
+
+        ConnectionKey key = key("https://service.example:443", hostHeaderSni, TLS, headers);
+
+        assertThat(key.tlsPeerHost(), is("::1"));
+        assertThat(key.tlsPeerPort(), is(9444));
+        assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
     void hostHeaderModeFallsBackToUriAuthorityWhenHostIsAbsent() {
         ClientRequestHeaders headers = emptyHeaders();
         SniConfig hostHeaderSni = SniConfig.builder()
@@ -183,6 +213,30 @@ class ConnectionKeySniTest {
 
         assertThat(key, is(not(uriHostKey)));
         assertThat(key.tlsPeerHost(), is("service.example"));
+        assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
+    void explicitModeSuppressesSniForIpLiteral() {
+        ConnectionKey key = key("https://service.example:9443",
+                                explicit("127.0.0.1"),
+                                TLS,
+                                emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("127.0.0.1"));
+        assertThat(key.tlsPeerPort(), is(9443));
+        assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
+    void explicitModeSuppressesSniForBracketedIpv6Literal() {
+        ConnectionKey key = key("https://service.example:9443",
+                                explicit("[::1]"),
+                                TLS,
+                                emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("::1"));
+        assertThat(key.tlsPeerPort(), is(9443));
         assertThat(key.serverNamesOverride(), is(empty()));
     }
 

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ConnectionKeySniTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ConnectionKeySniTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLParameters;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.spi.DnsResolver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConnectionKeySniTest {
+    private static final Tls TLS = Tls.builder().build();
+    private static final Tls NO_TLS = Tls.builder().enabled(false).build();
+    private static final DnsResolver DNS_RESOLVER = DefaultDnsResolver.create();
+    private static final DnsAddressLookup DNS_LOOKUP = DnsAddressLookup.defaultLookup();
+    private static final Proxy NO_PROXY = Proxy.noProxy();
+
+    @Test
+    void uriHostModeUsesNormalizedDnsHost() {
+        ConnectionKey key = key("https://Example.COM:9443/path",
+                                SniConfig.create(),
+                                TLS,
+                                emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("example.com"));
+        assertThat(key.tlsPeerPort(), is(9443));
+        assertThat(serverName(key), is("example.com"));
+    }
+
+    @Test
+    void uriHostModeSuppressesSniForIpLiteral() {
+        ConnectionKey key = key("https://127.0.0.1:9443/path",
+                                SniConfig.create(),
+                                TLS,
+                                emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("127.0.0.1"));
+        assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
+    void uriHostModeSuppressesSniForBracketedIpv6Literal() {
+        ConnectionKey key = key("https://[::1]:9443/path",
+                                SniConfig.create(),
+                                TLS,
+                                emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("::1"));
+        assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
+    void defaultModePreservesTlsSocketDefaults() {
+        ConnectionKey key = key("https://service.example:443", null, TLS, emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("service.example"));
+        assertThat(key.serverNamesOverride(), is(nullValue()));
+    }
+
+    @Test
+    void defaultModeDoesNotNormalizeBracketedIpv6Host() {
+        ConnectionKey key = key("https://[::1]:443", null, TLS, emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("[::1]"));
+        assertThat(key.serverNamesOverride(), is(nullValue()));
+    }
+
+    @Test
+    void hostHeaderModeUsesFinalAuthority() {
+        ClientRequestHeaders headers = emptyHeaders();
+        headers.set(HeaderNames.HOST, "Backend.EXAMPLE:9444");
+        SniConfig hostHeaderSni = SniConfig.builder()
+                .mode(SniMode.HOST_HEADER)
+                .build();
+
+        ConnectionKey key = key("https://service.example:443", hostHeaderSni, TLS, headers);
+        ConnectionKey uriHostKey = key("https://service.example:443",
+                                       SniConfig.create(),
+                                       TLS,
+                                       headers);
+
+        assertThat(key, is(not(uriHostKey)));
+        assertThat(key.tlsPeerHost(), is("backend.example"));
+        assertThat(key.tlsPeerPort(), is(9444));
+        assertThat(serverName(key), is("backend.example"));
+    }
+
+    @Test
+    void hostHeaderModeFallsBackToUriAuthorityWhenHostIsAbsent() {
+        ClientRequestHeaders headers = emptyHeaders();
+        SniConfig hostHeaderSni = SniConfig.builder()
+                .mode(SniMode.HOST_HEADER)
+                .build();
+
+        ConnectionKey key = key("https://Service.EXAMPLE:9445", hostHeaderSni, TLS, headers);
+
+        assertThat(key.tlsPeerHost(), is("service.example"));
+        assertThat(key.tlsPeerPort(), is(9445));
+        assertThat(serverName(key), is("service.example"));
+    }
+
+    @Test
+    void hostHeaderModeRejectsMultipleHostValues() {
+        ClientRequestHeaders headers = emptyHeaders();
+        headers.add(HeaderValues.create(HeaderNames.HOST, "first.example", "second.example"));
+        SniConfig hostHeaderSni = SniConfig.builder()
+                .mode(SniMode.HOST_HEADER)
+                .build();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                         () -> key("https://service.example:443",
+                                                                   hostHeaderSni,
+                                                                   TLS,
+                                                                   headers));
+
+        assertThat(exception.getMessage(), containsString("Request Host header must be single-valued"));
+    }
+
+    @Test
+    void equivalentDnsSelectionsShareConnectionKey() {
+        ClientRequestHeaders headers = emptyHeaders();
+        headers.set(HeaderNames.HOST, "service.example:443");
+        ConnectionKey uriHost = key("https://service.example:443",
+                                    SniConfig.create(),
+                                    TLS,
+                                    headers);
+        ConnectionKey hostHeader = key("https://service.example:443",
+                                       SniConfig.builder().mode(SniMode.HOST_HEADER).build(),
+                                       TLS,
+                                       headers);
+        ConnectionKey explicit = key("https://service.example:443",
+                                     explicit("service.example"),
+                                     TLS,
+                                     headers);
+
+        assertThat(hostHeader, is(uriHost));
+        assertThat(explicit, is(uriHost));
+    }
+
+    @Test
+    void disabledModeClearsServerNames() {
+        SniConfig disabled = SniConfig.builder()
+                .mode(SniMode.DISABLED)
+                .build();
+
+        ConnectionKey key = key("https://service.example:443", disabled, TLS, emptyHeaders());
+        ConnectionKey uriHostKey = key("https://service.example:443",
+                                       SniConfig.create(),
+                                       TLS,
+                                       emptyHeaders());
+
+        assertThat(key, is(not(uriHostKey)));
+        assertThat(key.tlsPeerHost(), is("service.example"));
+        assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
+    void rawTlsServerNamesRemainConfiguredWhenNoSniConfigIsPresent() {
+        SSLParameters parameters = new SSLParameters();
+        parameters.setServerNames(List.of(new SNIHostName("configured.example")));
+        Tls tls = Tls.builder()
+                .sslParameters(parameters)
+                .build();
+
+        ConnectionKey key = key("https://service.example:443", null, tls, emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("service.example"));
+        assertThat(key.serverNamesOverride(), is(nullValue()));
+    }
+
+    @Test
+    void legacyFactoryPreservesTlsSocketDefaults() {
+        ConnectionKey key = ConnectionKey.create("https", "service.example", 443, TLS, DNS_RESOLVER, DNS_LOOKUP, NO_PROXY);
+
+        assertThat(key.tlsPeerHost(), is("service.example"));
+        assertThat(key.serverNamesOverride(), is(nullValue()));
+    }
+
+    @Test
+    void firstClassSniOverridesRawTlsServerNames() {
+        SSLParameters parameters = new SSLParameters();
+        parameters.setServerNames(List.of(new SNIHostName("configured.example")));
+        Tls tls = Tls.builder()
+                .sslParameters(parameters)
+                .build();
+
+        ConnectionKey key = key("https://service.example:443",
+                                explicit("explicit.example"),
+                                tls,
+                                emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("explicit.example"));
+        assertThat(serverName(key), is("explicit.example"));
+    }
+
+    @Test
+    void cleartextConnectionsIgnoreSniConfigForCacheKey() {
+        ConnectionKey explicit = key("http://service.example:8080",
+                                     explicit("explicit.example"),
+                                     NO_TLS,
+                                     emptyHeaders());
+        ConnectionKey hostHeader = key("http://service.example:8080",
+                                       SniConfig.builder().mode(SniMode.HOST_HEADER).build(),
+                                       NO_TLS,
+                                       emptyHeaders());
+
+        assertThat(explicit, is(hostHeader));
+        assertThat(explicit.tlsPeerHost(), is("service.example"));
+        assertThat(explicit.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
+    void cleartextConnectionsDoNotNormalizeSniHost() {
+        ConnectionKey key = key("http://[::1]:8080",
+                                explicit("explicit.example"),
+                                NO_TLS,
+                                emptyHeaders());
+
+        assertThat(key.tlsPeerHost(), is("[::1]"));
+        assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    private static ConnectionKey key(String uri,
+                                     SniConfig sni,
+                                     Tls tls,
+                                     ClientRequestHeaders headers) {
+        ClientUri clientUri = ClientUri.create(URI.create(uri));
+        if (sni == null) {
+            return ConnectionKey.create(clientUri,
+                                        tls,
+                                        DNS_RESOLVER,
+                                        DNS_LOOKUP,
+                                        NO_PROXY);
+        }
+        return ConnectionKey.create(clientUri,
+                                    sni,
+                                    tls,
+                                    DNS_RESOLVER,
+                                    DNS_LOOKUP,
+                                    NO_PROXY,
+                                    headers);
+    }
+
+    private static ClientRequestHeaders emptyHeaders() {
+        return ClientRequestHeaders.create(WritableHeaders.create());
+    }
+
+    private static SniConfig explicit(String host) {
+        return SniConfig.builder()
+                .mode(SniMode.EXPLICIT)
+                .host(host)
+                .build();
+    }
+
+    private static String serverName(ConnectionKey key) {
+        List<SNIServerName> serverNames = key.serverNamesOverride();
+        assertThat(serverNames.size(), is(1));
+        return ((SNIHostName) serverNames.get(0)).getAsciiName();
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/SniConfigTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/SniConfigTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SniConfigTest {
+    @Test
+    void defaultUsesUriHost() {
+        SniConfig config = SniConfig.create();
+
+        assertThat(config.mode(), is(SniMode.URI_HOST));
+        assertThat(config.host().isEmpty(), is(true));
+    }
+
+    @Test
+    void explicitModeRequiresHost() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> SniConfig.builder()
+                             .mode(SniMode.EXPLICIT)
+                             .build());
+    }
+
+    @Test
+    void explicitModeValidatesHost() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> SniConfig.builder()
+                             .mode(SniMode.EXPLICIT)
+                             .host("bad_host")
+                             .build());
+    }
+
+    @Test
+    void explicitModeAcceptsBracketedIpv6Host() {
+        SniConfig config = SniConfig.builder()
+                .mode(SniMode.EXPLICIT)
+                .host("[::1]")
+                .build();
+
+        assertThat(config.host().orElseThrow(), is("::1"));
+    }
+
+    @Test
+    void explicitModeRejectsPort() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> SniConfig.builder()
+                             .mode(SniMode.EXPLICIT)
+                             .host("authority.example:443")
+                             .build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> SniConfig.builder()
+                             .mode(SniMode.EXPLICIT)
+                             .host("[::1]:443")
+                             .build());
+    }
+
+    @Test
+    void hostIsOnlyAllowedForExplicitMode() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> SniConfig.builder()
+                             .mode(SniMode.HOST_HEADER)
+                             .host("authority.example")
+                             .build());
+    }
+
+    @Test
+    void configUsesHyphenatedModeNames() {
+        SniConfig hostHeader = SniConfig.create(Config.just(ConfigSources.create(Map.of("mode", "host-header"))));
+        SniConfig explicit = SniConfig.create(Config.just(ConfigSources.create(Map.of("mode", "explicit",
+                                                                                      "host", "authority.example"))));
+
+        assertThat(hostHeader.mode(), is(SniMode.HOST_HEADER));
+        assertThat(explicit.mode(), is(SniMode.EXPLICIT));
+        assertThat(explicit.host().orElseThrow(), is("authority.example"));
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/SniConfigTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/SniConfigTest.java
@@ -64,6 +64,17 @@ class SniConfigTest {
     }
 
     @Test
+    void explicitModeBracketedIpv6HostIsCopyBuildable() {
+        SniConfig config = SniConfig.builder()
+                .mode(SniMode.EXPLICIT)
+                .host("[::1]")
+                .build();
+        SniConfig copy = SniConfig.builder(config).build();
+
+        assertThat(copy.host().orElseThrow(), is("::1"));
+    }
+
+    @Test
     void explicitModeRejectsPort() {
         assertThrows(IllegalArgumentException.class,
                      () -> SniConfig.builder()

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -33,6 +33,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.CompositeBufferData;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.grpc.core.GrpcHeadersUtil;
+import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -55,6 +56,7 @@ import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.DefaultDnsResolver;
 import io.helidon.webclient.api.DnsAddressLookup;
 import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.SniConfig;
 import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.UnixDomainSocketClientConnection;
 import io.helidon.webclient.api.WebClient;
@@ -296,34 +298,63 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
     ClientConnection clientConnection(ClientUri clientUri) {
         WebClient webClient = grpcClient.webClient();
         GrpcClientConfig clientConfig = grpcClient.prototype();
+        SniConfig sni = clientConfig.sni().orElse(null);
 
         if (clientConfig.baseAddress().isPresent()
             && clientConfig.baseAddress().get() instanceof UnixDomainSocketAddress udsAddress) {
+            ConnectionKey connectionKey;
+            if (sni == null) {
+                connectionKey = ConnectionKey.createUnixDomainSocket(clientUri,
+                                                                     clientConfig.tls(),
+                                                                     clientConfig.dnsResolver(),
+                                                                     clientConfig.dnsAddressLookup(),
+                                                                     udsAddress);
+            } else {
+                connectionKey = ConnectionKey.createUnixDomainSocket(clientUri,
+                                                                     sni,
+                                                                     clientConfig.tls(),
+                                                                     clientConfig.dnsResolver(),
+                                                                     clientConfig.dnsAddressLookup(),
+                                                                     udsAddress,
+                                                                     emptyHeaders());
+            }
             return UnixDomainSocketClientConnection.create(
                 webClient,
-                clientConfig.tls(),
+                connectionKey,
                 List.of(Http2Client.PROTOCOL_ID),
                 udsAddress,
-                clientUri.host(),
-                clientUri.port(),
                 connection -> false,
                 connection -> {}).connect();
         }
 
-        ConnectionKey connectionKey = ConnectionKey.create(
-                clientUri.scheme(),
-                clientUri.host(),
-                clientUri.port(),
-                clientConfig.tls(),
-                DefaultDnsResolver.create(),
-                DnsAddressLookup.defaultLookup(),
-                Proxy.noProxy());
+        ConnectionKey connectionKey;
+        if (sni == null) {
+            connectionKey = ConnectionKey.create(
+                    clientUri,
+                    clientConfig.tls(),
+                    DefaultDnsResolver.create(),
+                    DnsAddressLookup.defaultLookup(),
+                    Proxy.noProxy());
+        } else {
+            connectionKey = ConnectionKey.create(
+                    clientUri,
+                    sni,
+                    clientConfig.tls(),
+                    DefaultDnsResolver.create(),
+                    DnsAddressLookup.defaultLookup(),
+                    Proxy.noProxy(),
+                    emptyHeaders());
+        }
         return TcpClientConnection.create(webClient,
                                           connectionKey,
                                           List.of(Http2Client.PROTOCOL_ID),
                                           connection -> false,
                                           connection -> {
                                           }).connect();
+    }
+
+    private static ClientRequestHeaders emptyHeaders() {
+        return ClientRequestHeaders.create(WritableHeaders.create());
     }
 
     boolean isRemoteOpen() {

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -162,7 +162,8 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
 
         // obtain HTTP2 connection
         ClientUri clientUri = nextClientUri();
-        ClientConnection clientConnection = clientConnection(clientUri);
+        String authority = authority(clientUri);
+        ClientConnection clientConnection = clientConnection(clientUri, authority);
         socket = clientConnection.helidonSocket();
         connection = Http2ClientConnection.create((Http2ClientImpl) grpcClient.http2Client(),
                                                   clientConnection, true);
@@ -202,7 +203,7 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         startStreamingThreads();
 
         // send HEADERS frame
-        WritableHeaders<?> headers = setupHeaders(metadata, clientUri.authority(), methodDescriptor.getFullMethodName());
+        WritableHeaders<?> headers = setupHeaders(metadata, authority, methodDescriptor.getFullMethodName());
         clientStream.writeHeaders(Http2Headers.create(headers), false);
     }
 
@@ -295,7 +296,7 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         return grpcClient;
     }
 
-    ClientConnection clientConnection(ClientUri clientUri) {
+    ClientConnection clientConnection(ClientUri clientUri, String authority) {
         WebClient webClient = grpcClient.webClient();
         GrpcClientConfig clientConfig = grpcClient.prototype();
         SniConfig sni = clientConfig.sni().orElse(null);
@@ -316,7 +317,7 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
                                                                      clientConfig.dnsResolver(),
                                                                      clientConfig.dnsAddressLookup(),
                                                                      udsAddress,
-                                                                     emptyHeaders());
+                                                                     authorityHeaders(authority));
             }
             return UnixDomainSocketClientConnection.create(
                 webClient,
@@ -343,7 +344,7 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
                     DefaultDnsResolver.create(),
                     DnsAddressLookup.defaultLookup(),
                     Proxy.noProxy(),
-                    emptyHeaders());
+                    authorityHeaders(authority));
         }
         return TcpClientConnection.create(webClient,
                                           connectionKey,
@@ -353,8 +354,18 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
                                           }).connect();
     }
 
-    private static ClientRequestHeaders emptyHeaders() {
-        return ClientRequestHeaders.create(WritableHeaders.create());
+    private String authority(ClientUri clientUri) {
+        String authority = callOptions.getAuthority();
+        if (authority != null) {
+            return authority;
+        }
+        return clientUri.authority();
+    }
+
+    private static ClientRequestHeaders authorityHeaders(String authority) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.set(HeaderValues.create(HeaderNames.HOST, authority));
+        return ClientRequestHeaders.create(headers);
     }
 
     boolean isRemoteOpen() {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -32,7 +32,6 @@ import io.helidon.common.buffers.Bytes;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
-import io.helidon.common.tls.Tls;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.Header;
@@ -77,7 +76,6 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     private final Http1ClientProtocolConfig protocolConfig;
     private final ClientConnection connection;
     private final Http1ClientRequestImpl originalRequest;
-    private final Tls tls;
     private final Proxy proxy;
     private final boolean keepAlive;
     private final CompletableFuture<WebClientServiceResponse> whenComplete;
@@ -93,7 +91,6 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         this.originalRequest = clientRequest;
         this.timeout = clientRequest.readTimeout();
         this.connection = clientRequest.connection().orElse(null);
-        this.tls = clientRequest.tls();
         this.proxy = clientRequest.effectiveProxy();
         this.keepAlive = clientRequest.keepAlive();
         this.http1Client = clientRequest.http1Client();
@@ -147,19 +144,21 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
 
     @Override
     public WebClientServiceResponse proceed(WebClientServiceRequest serviceRequest) {
+        ClientUri uri = serviceRequest.uri();
+        ClientRequestHeaders headers = serviceRequest.headers();
+
+        writeBuffer.clear();
+        originalRequest.sanitizeRedirectHeaders(uri, headers);
+        headers.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
+
         // either use the explicit connection, or obtain one (keep alive or one-off)
         effectiveConnection = connection == null ? obtainConnection(serviceRequest) : connection;
         effectiveConnection.readTimeout(this.timeout);
 
         DataWriter writer = effectiveConnection.writer();
         DataReader reader = effectiveConnection.reader();
-        ClientUri uri = serviceRequest.uri();
-        ClientRequestHeaders headers = serviceRequest.headers();
 
-        writeBuffer.clear();
-        originalRequest.sanitizeRedirectHeaders(uri, headers);
         prologue(effectiveConnection, writeBuffer, serviceRequest, uri);
-        headers.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
 
         return doProceed(effectiveConnection, serviceRequest, headers, writer, reader, writeBuffer);
     }
@@ -325,15 +324,14 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         if (udsAddress == null) {
             return http1Client.connectionCache()
                     .connection(http1Client,
-                                tls,
-                                proxy,
+                                originalRequest,
                                 request.uri(),
                                 request.headers(),
                                 keepAlive);
         } else {
             return http1Client.connectionCache()
                     .connection(http1Client,
-                                tls,
+                                originalRequest,
                                 request.uri(),
                                 request.headers(),
                                 keepAlive,

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,7 @@ class Http1ClientImpl implements Http1Client, HttpClientSpi {
         clientRequest.connection().ifPresent(request::connection);
         clientRequest.pathParams().forEach(request::pathParam);
         clientRequest.address().ifPresent(request::address);
+        clientRequest.sni().ifPresent(request::sni);
 
         return request.readTimeout(clientRequest.readTimeout())
                 .followRedirects(clientRequest.followRedirects())

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -96,6 +96,7 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
         tls(request.tls());
+        request.sni().ifPresent(this::sni);
         if (sameOrigin(request.resolvedUri(), clientUri)) {
             request.address().ifPresent(this::address);
         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -39,7 +39,8 @@ import io.helidon.webclient.api.Proxy.ProxyType;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 
-class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1ClientResponse> implements Http1ClientRequest {
+class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1ClientResponse>
+        implements Http1ClientRequest {
     private static final System.Logger LOGGER = System.getLogger(Http1ClientRequestImpl.class.getName());
     private final Http1ClientImpl http1Client;
     private final FullClientRequest<?> delegate;

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -32,7 +32,8 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
-import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.FullClientRequest;
+import io.helidon.webclient.api.SniConfig;
 import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.UnixDomainSocketClientConnection;
 import io.helidon.webclient.api.WebClient;
@@ -66,23 +67,22 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     ClientConnection connection(Http1ClientImpl http1Client,
-                                Tls tls,
+                                FullClientRequest<?> request,
                                 ClientUri uri,
                                 ClientRequestHeaders headers,
                                 boolean defaultKeepAlive,
                                 UnixDomainSocketAddress address) {
 
         boolean keepAlive = handleKeepAlive(defaultKeepAlive, headers);
-        Tls effectiveTls = HTTPS.equals(uri.scheme()) ? tls : NO_TLS;
+        Tls effectiveTls = HTTPS.equals(uri.scheme()) ? request.tls() : NO_TLS;
         if (keepAlive) {
-            return keepAliveUnixDomainConnection(http1Client, effectiveTls, uri, address);
+            return keepAliveUnixDomainConnection(http1Client, request, effectiveTls, uri, headers, address);
         } else {
+            ConnectionKey connectionKey = unixConnectionKey(request, effectiveTls, uri, headers, address, http1Client.clientConfig());
             return UnixDomainSocketClientConnection.create(http1Client.webClient(),
-                                                           effectiveTls,
+                                                           connectionKey,
                                                            ALPN_ID,
                                                            address,
-                                                           uri.host(),
-                                                           uri.port(),
                                                            it -> false,
                                                            it -> {
                                                            })
@@ -91,17 +91,16 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     ClientConnection connection(Http1ClientImpl http1Client,
-                                Tls tls,
-                                Proxy proxy,
+                                FullClientRequest<?> request,
                                 ClientUri uri,
                                 ClientRequestHeaders headers,
                                 boolean defaultKeepAlive) {
         boolean keepAlive = handleKeepAlive(defaultKeepAlive, headers);
-        Tls effectiveTls = HTTPS.equals(uri.scheme()) ? tls : NO_TLS;
+        Tls effectiveTls = HTTPS.equals(uri.scheme()) ? request.tls() : NO_TLS;
         if (keepAlive) {
-            return keepAliveConnection(http1Client, effectiveTls, uri, proxy);
+            return keepAliveConnection(http1Client, request, effectiveTls, uri, headers);
         } else {
-            return oneOffConnection(http1Client, effectiveTls, uri, proxy);
+            return oneOffConnection(http1Client, request, effectiveTls, uri, headers);
         }
     }
 
@@ -136,8 +135,10 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     private ClientConnection keepAliveUnixDomainConnection(Http1ClientImpl http1Client,
+                                                           FullClientRequest<?> request,
                                                            Tls tls,
                                                            ClientUri uri,
+                                                           ClientRequestHeaders headers,
                                                            UnixDomainSocketAddress address) {
         if (closed.get()) {
             throw new IllegalStateException("Connection cache is closed");
@@ -145,7 +146,7 @@ class Http1ConnectionCache extends ClientConnectionCache {
 
         Http1ClientConfig clientConfig = http1Client.clientConfig();
 
-        ConnectionKey connectionKey = unixConnectionKey(tls, uri, address, clientConfig);
+        ConnectionKey connectionKey = unixConnectionKey(request, tls, uri, headers, address, clientConfig);
 
         LinkedBlockingDeque<ClientConnection> connectionQueue =
                 cache.computeIfAbsent(connectionKey,
@@ -157,11 +158,9 @@ class Http1ConnectionCache extends ClientConnectionCache {
 
         if (connection == null) {
             connection = UnixDomainSocketClientConnection.create(http1Client.webClient(),
-                                                                 tls,
+                                                                 connectionKey,
                                                                  ALPN_ID,
                                                                  address,
-                                                                 uri.host(),
-                                                                 uri.port(),
                                                                  conn -> finishRequest(connectionQueue, conn),
                                                                  conn -> {
                                                                  })
@@ -176,23 +175,34 @@ class Http1ConnectionCache extends ClientConnectionCache {
         return connection;
     }
 
-    private static ConnectionKey unixConnectionKey(Tls tls,
+    private static ConnectionKey unixConnectionKey(FullClientRequest<?> request,
+                                                   Tls tls,
                                                    ClientUri uri,
+                                                   ClientRequestHeaders headers,
                                                    UnixDomainSocketAddress address,
                                                    Http1ClientConfig clientConfig) {
-        return ConnectionKey.createUnixDomainSocket(uri.scheme(),
-                                                    uri.host(),
-                                                    uri.port(),
+        SniConfig sni = effectiveSni(request, clientConfig);
+        if (sni == null) {
+            return ConnectionKey.createUnixDomainSocket(uri,
+                                                        tls,
+                                                        clientConfig.dnsResolver(),
+                                                        clientConfig.dnsAddressLookup(),
+                                                        address);
+        }
+        return ConnectionKey.createUnixDomainSocket(uri,
+                                                    sni,
                                                     tls,
                                                     clientConfig.dnsResolver(),
                                                     clientConfig.dnsAddressLookup(),
-                                                    address);
+                                                    address,
+                                                    headers);
     }
 
     private ClientConnection keepAliveConnection(Http1ClientImpl http1Client,
+                                                 FullClientRequest<?> request,
                                                  Tls tls,
                                                  ClientUri uri,
-                                                 Proxy proxy) {
+                                                 ClientRequestHeaders headers) {
 
         if (closed.get()) {
             throw new IllegalStateException("Connection cache is closed");
@@ -200,13 +210,7 @@ class Http1ConnectionCache extends ClientConnectionCache {
 
         Http1ClientConfig clientConfig = http1Client.clientConfig();
 
-        ConnectionKey connectionKey = ConnectionKey.create(uri.scheme(),
-                                                           uri.host(),
-                                                           uri.port(),
-                                                           tls,
-                                                           clientConfig.dnsResolver(),
-                                                           clientConfig.dnsAddressLookup(),
-                                                           proxy);
+        ConnectionKey connectionKey = connectionKey(request, tls, uri, headers, clientConfig);
 
         Queue<ClientConnection> connectionQueue =
                 cache.computeIfAbsent(connectionKey,
@@ -235,27 +239,48 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     private ClientConnection oneOffConnection(Http1ClientImpl http1Client,
+                                              FullClientRequest<?> request,
                                               Tls tls,
                                               ClientUri uri,
-                                              Proxy proxy) {
+                                              ClientRequestHeaders headers) {
 
         WebClient webClient = http1Client.webClient();
         Http1ClientConfig clientConfig = http1Client.clientConfig();
 
         return TcpClientConnection.create(webClient,
-                                          ConnectionKey.create(uri.scheme(),
-                                                               uri.host(),
-                                                               uri.port(),
-                                                               tls,
-                                                               clientConfig.dnsResolver(),
-                                                               clientConfig.dnsAddressLookup(),
-                                                               proxy),
+                                          connectionKey(request, tls, uri, headers, clientConfig),
                                           ALPN_ID,
                                           conn -> false, // always close connection
                                           conn -> {
                                           })
 
                 .connect();
+    }
+
+    private static ConnectionKey connectionKey(FullClientRequest<?> request,
+                                               Tls tls,
+                                               ClientUri uri,
+                                               ClientRequestHeaders headers,
+                                               Http1ClientConfig clientConfig) {
+        SniConfig sni = effectiveSni(request, clientConfig);
+        if (sni == null) {
+            return ConnectionKey.create(uri,
+                                        tls,
+                                        clientConfig.dnsResolver(),
+                                        clientConfig.dnsAddressLookup(),
+                                        request.proxy());
+        }
+        return ConnectionKey.create(uri,
+                                    sni,
+                                    tls,
+                                    clientConfig.dnsResolver(),
+                                    clientConfig.dnsAddressLookup(),
+                                    request.proxy(),
+                                    headers);
+    }
+
+    private static SniConfig effectiveSni(FullClientRequest<?> request, Http1ClientConfig clientConfig) {
+        return request.sni().or(clientConfig::sni).orElse(null);
     }
 
     private boolean finishRequest(Queue<ClientConnection> connectionQueue, ClientConnection conn) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -78,7 +78,12 @@ class Http1ConnectionCache extends ClientConnectionCache {
         if (keepAlive) {
             return keepAliveUnixDomainConnection(http1Client, request, effectiveTls, uri, headers, address);
         } else {
-            ConnectionKey connectionKey = unixConnectionKey(request, effectiveTls, uri, headers, address, http1Client.clientConfig());
+            ConnectionKey connectionKey = unixConnectionKey(request,
+                                                            effectiveTls,
+                                                            uri,
+                                                            headers,
+                                                            address,
+                                                            http1Client.clientConfig());
             return UnixDomainSocketClientConnection.create(http1Client.webClient(),
                                                            connectionKey,
                                                            ALPN_ID,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.http1.Http1ClientRequest;
+import io.helidon.webclient.http1.Http1ClientResponse;
+
+final class Http1FallbackHandler {
+    private final CompletableFuture<WebClientServiceRequest> whenSent;
+    private final Function<Http1ClientRequest, Http1ClientResponse> responseFunction;
+    private final boolean upgradeFailureResponseAllowed;
+
+    Http1FallbackHandler(CompletableFuture<WebClientServiceRequest> whenSent,
+                         Function<Http1ClientRequest, Http1ClientResponse> responseFunction,
+                         boolean upgradeFailureResponseAllowed) {
+        this.whenSent = whenSent;
+        this.responseFunction = responseFunction;
+        this.upgradeFailureResponseAllowed = upgradeFailureResponseAllowed;
+    }
+
+    Http1ClientResponse apply(Http1ClientRequest request, WebClientServiceRequest serviceRequest) {
+        return invoke(request, serviceRequest, () -> responseFunction.apply(request));
+    }
+
+    <T> T invoke(Http1ClientRequest request,
+                 WebClientServiceRequest serviceRequest,
+                 Supplier<T> responseSupplier) {
+        Context context = Http1FallbackService.context(serviceRequest, whenSent);
+        copyFinalHeaders(request, serviceRequest);
+        try {
+            return Contexts.runInContext(context, responseSupplier::get);
+        } catch (RuntimeException | Error e) {
+            whenSent.completeExceptionally(e);
+            throw e;
+        }
+    }
+
+    void completeSent(WebClientServiceRequest serviceRequest) {
+        whenSent.complete(serviceRequest);
+    }
+
+    void completeSentExceptionally(Throwable throwable) {
+        whenSent.completeExceptionally(throwable);
+    }
+
+    boolean upgradeFailureResponseAllowed() {
+        return upgradeFailureResponseAllowed;
+    }
+
+    static void copyFinalHeaders(Http1ClientRequest request, WebClientServiceRequest serviceRequest) {
+        request.headers().clear();
+        request.headers(serviceRequest.headers());
+    }
+}

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackService.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.helidon.common.context.Context;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+import io.helidon.webclient.spi.WebClientService;
+
+final class Http1FallbackService implements WebClientService {
+    private static final Object CONTEXT_KEY = new Object();
+
+    @Override
+    public WebClientServiceResponse handle(Chain chain, WebClientServiceRequest clientRequest) {
+        clientRequest.context()
+                .get(CONTEXT_KEY, FallbackContext.class)
+                .ifPresent(fallback -> clientRequest.whenSent()
+                        .whenComplete((ignored, throwable) -> {
+                            if (throwable == null) {
+                                fallback.whenSent().complete(fallback.serviceRequest());
+                            } else {
+                                fallback.whenSent().completeExceptionally(throwable);
+                            }
+                        }));
+
+        return chain.proceed(clientRequest);
+    }
+
+    static Context context(WebClientServiceRequest serviceRequest,
+                           CompletableFuture<WebClientServiceRequest> whenSent) {
+        Context context = Context.create(serviceRequest.context());
+        context.register(CONTEXT_KEY, new FallbackContext(serviceRequest, whenSent));
+        return context;
+    }
+
+    private record FallbackContext(WebClientServiceRequest serviceRequest,
+                                   CompletableFuture<WebClientServiceRequest> whenSent) {
+    }
+}

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -104,7 +104,7 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
         requestHeaders = serviceRequest.headers();
 
         clientRequest.sanitizeRedirectHeaders(uri, requestHeaders);
-        requestHeaders.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
+        alignHostHeader(uri, requestHeaders);
         requestHeaders.remove(HeaderNames.CONNECTION, LogHeaderConsumer.INSTANCE);
         requestHeaders.setIfAbsent(USER_AGENT_HEADER);
 
@@ -274,7 +274,13 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
     }
 
     private ConnectionKey connectionKey(WebClientServiceRequest serviceRequest) {
-        return Http2ConnectionKeys.create(serviceRequest.uri(), clientRequest, clientConfig);
+        return Http2ConnectionKeys.create(serviceRequest.uri(), clientRequest, clientConfig, serviceRequest.headers());
+    }
+
+    static void alignHostHeader(ClientUri uri, ClientRequestHeaders requestHeaders) {
+        requestHeaders.first(Http2Headers.AUTHORITY_NAME)
+                .ifPresentOrElse(authority -> requestHeaders.set(HeaderValues.create(HeaderNames.HOST, authority)),
+                                 () -> requestHeaders.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority())));
     }
 
     private static final class LogHeaderConsumer implements Consumer<Header> {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -41,8 +41,6 @@ import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.ReleasableResource;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
-import io.helidon.webclient.http1.Http1ClientRequest;
-import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.spi.WebClientService;
 
 import static io.helidon.http.HeaderNames.CONTENT_ENCODING;
@@ -52,7 +50,7 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
     private final Http2ClientImpl http2Client;
     private final HttpClientConfig clientConfig;
     private final Http2ClientRequestImpl clientRequest;
-    private final Function<Http1ClientRequest, Http1ClientResponse> http1EntityHandler;
+    private final Http1FallbackHandler http1FallbackHandler;
     private final CompletableFuture<WebClientServiceResponse> whenComplete;
     private Http2ClientStream stream;
     private HttpClientResponse response;
@@ -62,13 +60,13 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
     Http2CallChainBase(Http2ClientImpl http2Client,
                        Http2ClientRequestImpl clientRequest,
                        CompletableFuture<WebClientServiceResponse> whenComplete,
-                       Function<Http1ClientRequest, Http1ClientResponse> http1EntityHandler) {
+                       Http1FallbackHandler http1FallbackHandler) {
 
         this.http2Client = http2Client;
         this.clientConfig = http2Client.clientConfig();
         this.clientRequest = clientRequest;
         this.whenComplete = whenComplete;
-        this.http1EntityHandler = http1EntityHandler;
+        this.http1FallbackHandler = http1FallbackHandler;
     }
 
     static WebClientServiceResponse createServiceResponse(WebClientServiceRequest serviceRequest,
@@ -111,7 +109,7 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
         ConnectionKey connectionKey = connectionKey(serviceRequest);
 
         Http2ConnectionAttemptResult result = http2Client.connectionCache()
-                .newStream(http2Client, connectionKey, clientRequest, uri, http1EntityHandler);
+                .newStream(http2Client, connectionKey, clientRequest, uri, serviceRequest, http1FallbackHandler);
 
         try {
             if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,12 @@ class Http2CallEntityChain extends Http2CallChainBase {
                          CompletableFuture<WebClientServiceRequest> whenSent,
                          CompletableFuture<WebClientServiceResponse> whenComplete,
                          Object entity) {
-        super(http2Client, request, whenComplete, it -> it.submit(entity));
+        super(http2Client,
+              request,
+              whenComplete,
+              new Http1FallbackHandler(whenSent,
+                                       http1Request -> http1Request.submit(entity),
+                                       bodyless(entity)));
         this.whenSent = whenSent;
         this.entity = entity;
     }
@@ -90,5 +95,10 @@ class Http2CallEntityChain extends Http2CallChainBase {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         writer.write(genericType, entity, bos, headers);
         return bos.toByteArray();
+    }
+
+    private static boolean bodyless(Object entity) {
+        return entity == BufferData.EMPTY_BYTES
+                || entity instanceof byte[] bytes && bytes.length == 0;
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -55,7 +55,9 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
         super(http2Client,
               http2ClientRequest,
               whenComplete,
-              req -> req.outputStream(streamHandler));
+              new Http1FallbackHandler(whenSent,
+                                       http1Request -> http1Request.outputStream(streamHandler),
+                                       false));
 
         this.whenSent = whenSent;
         this.streamHandler = streamHandler;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Function;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Header;
@@ -43,9 +42,9 @@ import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.UnixDomainSocketClientConnection;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
-import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.http1.UpgradeResponse;
 import io.helidon.webclient.http2.Http2ConnectionAttemptResult.Result;
 
@@ -61,7 +60,6 @@ class Http2ClientConnectionHandler {
     // h2c stands for HTTP/2 plaintext protocol (only used without TLS)
     private static final Header UPGRADE_HEADER = HeaderValues.createCached(HeaderNames.UPGRADE, "h2c");
     private static final HeaderName HTTP2_SETTINGS_HEADER = HeaderNames.create("HTTP2-Settings");
-    private static final String GENERIC_TCP_PROTOCOL_IDS_PROPERTY = "io.helidon.webclient.generic.tcp-protocol-ids";
 
     // todo requires handling of timeouts and removal from this queue
     private final Map<ClientConnection, Http2ClientConnection> h2ConnByConn =
@@ -95,27 +93,40 @@ class Http2ClientConnectionHandler {
     Http2ConnectionAttemptResult newStream(Http2ClientImpl http2Client,
                                            Http2ClientRequestImpl request,
                                            ClientUri initialUri,
-                                           Function<Http1ClientRequest, Http1ClientResponse> http1EntityHandler) {
+                                           WebClientServiceRequest serviceRequest,
+                                           Http1FallbackHandler http1FallbackHandler) {
+        try {
+            Optional<ClientConnection> maybeConnection = request.connection();
+            if (maybeConnection.isPresent()) {
+                return explicitConnection(http2Client,
+                                          request,
+                                          initialUri,
+                                          serviceRequest,
+                                          http1FallbackHandler,
+                                          maybeConnection.get());
+            }
 
-        Optional<ClientConnection> maybeConnection = request.connection();
-        if (maybeConnection.isPresent()) {
-            return explicitConnection(http2Client,
-                                      request,
-                                      initialUri,
-                                      http1EntityHandler,
-                                      maybeConnection.get());
+            return switch (result.get()) {
+                case HTTP_1 -> {
+                    if (!http1FallbackAllowed(request)) {
+                        throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
+                    }
+                    yield http1(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                }
+                case HTTP_2 -> http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                case UNKNOWN -> httpX(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+            };
+        } catch (RuntimeException | Error e) {
+            http1FallbackHandler.completeSentExceptionally(e);
+            throw e;
         }
-
-        return switch (result.get()) {
-            case HTTP_1 -> http1(http2Client, request, initialUri, http1EntityHandler);
-            case HTTP_2 -> http2(http2Client, request, initialUri);
-            case UNKNOWN -> httpX(http2Client, request, initialUri, http1EntityHandler);
-        };
     }
 
     Http2ConnectionAttemptResult http2(Http2ClientImpl http2Client,
                                        Http2ClientRequestImpl request,
-                                       ClientUri initialUri) {
+                                       ClientUri initialUri,
+                                       WebClientServiceRequest serviceRequest,
+                                       Http1FallbackHandler http1FallbackHandler) {
         try {
             lock.lockInterruptibly();
         } catch (InterruptedException e) {
@@ -126,14 +137,14 @@ class Http2ClientConnectionHandler {
             Http2ClientConnection conn = activeConnection.updateAndGet(c -> c != null && c.closed() ? null : c);
             Http2ClientStream stream;
             if (conn == null) {
-                conn = createConnection(http2Client, request, initialUri);
+                conn = createConnection(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
                 // we must assume that a new connection can handle a new stream
                 stream = createStreamOnNewConnection(conn, request);
             } else {
                 stream = conn.tryStream(request);
                 if (stream == null) {
                     // either the connection is closed, or it ran out of streams
-                    conn = createConnection(http2Client, request, initialUri);
+                    conn = createConnection(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
                     stream = createStreamOnNewConnection(conn, request);
                 }
             }
@@ -147,7 +158,8 @@ class Http2ClientConnectionHandler {
     private Http2ConnectionAttemptResult httpX(Http2ClientImpl http2Client,
                                                Http2ClientRequestImpl request,
                                                ClientUri initialUri,
-                                               Function<Http1ClientRequest, Http1ClientResponse> http1EntityHandler) {
+                                               WebClientServiceRequest serviceRequest,
+                                               Http1FallbackHandler http1FallbackHandler) {
         try {
             lock.lockInterruptibly();
         } catch (InterruptedException e) {
@@ -156,13 +168,8 @@ class Http2ClientConnectionHandler {
         try {
             WebClient webClient = http2Client.webClient();
             if (request.tls().enabled() && "https".equals(initialUri.scheme())) {
-                // use ALPN, not upgrade, if prior, only h2, otherwise both
-                List<String> alpn;
-                if (request.priorKnowledge()) {
-                    alpn = List.of(Http2Client.PROTOCOL_ID);
-                } else {
-                    alpn = List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID);
-                }
+                // use ALPN, not upgrade
+                List<String> alpn = alpnProtocolIds(request);
                 ClientConnection clientConnection = connectClient(webClient, request, initialUri, alpn);
                 if (clientConnection.helidonSocket().protocolNegotiated()) {
                     if (Http2Client.PROTOCOL_ID.equals(clientConnection.helidonSocket().protocol())) {
@@ -174,52 +181,77 @@ class Http2ClientConnectionHandler {
                         allConnections.put(connection, true);
                         h2ConnByConn.put(clientConnection, connection);
                         this.activeConnection.set(connection);
-                        return http2(http2Client, request, initialUri);
+                        return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
                     } else {
                         if (!http1FallbackAllowed(request)) {
                             closeClientConnection(clientConnection);
-                            throw unsupportedHttp1Fallback(initialUri, request);
+                            throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
                         }
                         result.set(Result.HTTP_1);
-                        request.connection(clientConnection);
-                        return http1(http2Client, request, initialUri, http1EntityHandler);
+                        return http1WithProbeConnection(http2Client,
+                                                        request,
+                                                        initialUri,
+                                                        serviceRequest,
+                                                        http1FallbackHandler,
+                                                        clientConnection);
                     }
                 } else {
                     if (!request.priorKnowledge()) {
                         if (!http1FallbackAllowed(request)) {
                             closeClientConnection(clientConnection);
-                            throw unsupportedHttp1Fallback(initialUri, request);
+                            throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
                         }
-                        request.connection(clientConnection);
                         result.set(Result.HTTP_1);
-                        return http1(http2Client, request, initialUri, http1EntityHandler);
+                        return http1WithProbeConnection(http2Client,
+                                                        request,
+                                                        initialUri,
+                                                        serviceRequest,
+                                                        http1FallbackHandler,
+                                                        clientConnection);
                     }
+                    result.set(Result.HTTP_2);
+                    Http2ClientConnection connection = createHttp2Connection(http2Client,
+                                                                             clientConnection,
+                                                                             true);
+                    allConnections.put(connection, true);
+                    h2ConnByConn.put(clientConnection, connection);
+                    this.activeConnection.set(connection);
+                    return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
                 }
             }
 
             if (result.get() != Result.UNKNOWN) {
-                return http2(http2Client, request, initialUri);
+                return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
             }
             // we need to connect
             if (request.priorKnowledge()) {
                 // there is no fallback to HTTP/1 with prior knowledge - it must work or fail
-                return http2(http2Client, request, initialUri);
+                return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
             }
             // attempt an upgrade to HTTP/2
-            UpgradeResponse upgradeResponse = http1Request(webClient, request, initialUri)
-                    .header(UPGRADE_HEADER)
-                    .header(CONNECTION_UPGRADE_HEADER)
-                    .header(HTTP2_SETTINGS_HEADER, settingsForUpgrade(http2Client.protocolConfig()))
-                    .upgrade("h2c");
+            UpgradeResponse upgradeResponse = upgrade(http2Client,
+                                                      request,
+                                                      initialUri,
+                                                      serviceRequest,
+                                                      http1FallbackHandler,
+                                                      http2Client.protocolConfig());
             if (upgradeResponse.isUpgraded()) {
                 result.set(Result.HTTP_2);
                 Http2ClientConnection conn = createHttp2Connection(http2Client,
                                                                    upgradeResponse.connection(),
                                                                    false);
                 activeConnection.set(conn);
-                return http2(http2Client, request, initialUri);
+                return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
             } else {
+                if (!http1FallbackHandler.upgradeFailureResponseAllowed()) {
+                    try (HttpClientResponse response = upgradeResponse.response()) {
+                        IllegalStateException failure = unsupportedUpgradeFallback(request, response);
+                        http1FallbackHandler.completeSentExceptionally(failure);
+                        throw failure;
+                    }
+                }
                 result.set(Result.HTTP_1);
+                http1FallbackHandler.completeSent(serviceRequest);
                 return new Http2ConnectionAttemptResult(Result.HTTP_1,
                                                         null,
                                                         upgradeResponse.response());
@@ -229,15 +261,53 @@ class Http2ClientConnectionHandler {
         }
     }
 
+    private Http2ConnectionAttemptResult http1WithProbeConnection(Http2ClientImpl http2Client,
+                                                                  Http2ClientRequestImpl request,
+                                                                  ClientUri initialUri,
+                                                                  WebClientServiceRequest serviceRequest,
+                                                                  Http1FallbackHandler http1FallbackHandler,
+                                                                  ClientConnection clientConnection) {
+        request.connection(clientConnection);
+        try {
+            return http1(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+        } catch (RuntimeException | Error e) {
+            closeClientConnection(clientConnection);
+            throw e;
+        }
+    }
+
+    private UpgradeResponse upgrade(Http2ClientImpl http2Client,
+                                    Http2ClientRequestImpl request,
+                                    ClientUri requestUri,
+                                    WebClientServiceRequest serviceRequest,
+                                    Http1FallbackHandler http1FallbackHandler,
+                                    Http2ClientProtocolConfig protocolConfig) {
+        try {
+            Http1ClientRequest upgradeRequest = http1Request(http2Client.http1FallbackClient(), request, requestUri);
+            Http1FallbackHandler.copyFinalHeaders(upgradeRequest, serviceRequest);
+            UpgradeResponse upgradeResponse = upgradeRequest.header(UPGRADE_HEADER)
+                    .header(CONNECTION_UPGRADE_HEADER)
+                    .header(HTTP2_SETTINGS_HEADER, settingsForUpgrade(protocolConfig))
+                    .upgrade("h2c");
+            return upgradeResponse;
+        } catch (RuntimeException | Error e) {
+            http1FallbackHandler.completeSentExceptionally(e);
+            throw e;
+        }
+    }
+
     private Http2ConnectionAttemptResult explicitConnection(Http2ClientImpl http2Client,
                                                             Http2ClientRequestImpl request,
                                                             ClientUri initialUri,
-                                                            Function<Http1ClientRequest,
-                                                                    Http1ClientResponse> http1EntityHandler,
+                                                            WebClientServiceRequest serviceRequest,
+                                                            Http1FallbackHandler http1FallbackHandler,
                                                             ClientConnection clientConnection) {
         if (clientConnection.helidonSocket().protocolNegotiated()
                 && !Http2Client.PROTOCOL_ID.equals(clientConnection.helidonSocket().protocol())) {
-            return http1(http2Client, request, initialUri, http1EntityHandler);
+            if (!http1FallbackAllowed(request)) {
+                throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
+            }
+            return http1(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
         }
         return http2ExplicitConnection(http2Client, request, clientConnection);
     }
@@ -297,18 +367,21 @@ class Http2ClientConnectionHandler {
 
     private Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
                                                Http2ClientRequestImpl request, ClientUri initialUri,
-                                               Function<Http1ClientRequest, Http1ClientResponse> http1EntityHandler) {
-        return new Http2ConnectionAttemptResult(Result.HTTP_1,
-                                                null,
-                                                http1EntityHandler.apply(http1Request(
-                                                        http2Client.webClient(),
-                                                        request,
-                                                        initialUri)));
+                                               WebClientServiceRequest serviceRequest,
+                                               Http1FallbackHandler http1FallbackHandler) {
+        try {
+            Http1ClientRequest http1Request = http1Request(http2Client.http1FallbackClient(), request, initialUri);
+            return new Http2ConnectionAttemptResult(Result.HTTP_1,
+                                                    null,
+                                                    http1FallbackHandler.apply(http1Request, serviceRequest));
+        } catch (RuntimeException | Error e) {
+            http1FallbackHandler.completeSentExceptionally(e);
+            throw e;
+        }
     }
 
-    private Http1ClientRequest http1Request(WebClient webClient, Http2ClientRequestImpl request, ClientUri initialUri) {
-        Http1ClientRequest http1Request = webClient.client(Http1Client.PROTOCOL)
-                .method(request.method())
+    private Http1ClientRequest http1Request(Http1Client http1Client, Http2ClientRequestImpl request, ClientUri initialUri) {
+        Http1ClientRequest http1Request = http1Client.method(request.method())
                 .uri(initialUri)
                 .keepAlive(request.keepAlive())
                 .headers(request.headers())
@@ -326,7 +399,9 @@ class Http2ClientConnectionHandler {
 
     private Http2ClientConnection createConnection(Http2ClientImpl http2Client,
                                                    Http2ClientRequestImpl request,
-                                                   ClientUri requestUri) {
+                                                   ClientUri requestUri,
+                                                   WebClientServiceRequest serviceRequest,
+                                                   Http1FallbackHandler http1FallbackHandler) {
         WebClient webClient = http2Client.webClient();
         Http2ClientProtocolConfig protocolConfig = http2Client.protocolConfig();
         Optional<ClientConnection> maybeConnection = request.connection();
@@ -349,11 +424,12 @@ class Http2ClientConnectionHandler {
                     usedConnection = createHttp2Connection(http2Client, connection, true);
                 } else {
                     // attempt an upgrade to HTTP/2
-                    UpgradeResponse upgradeResponse = http1Request(webClient, request, requestUri)
-                            .header(UPGRADE_HEADER)
-                            .header(CONNECTION_UPGRADE_HEADER)
-                            .header(HTTP2_SETTINGS_HEADER, settingsForUpgrade(protocolConfig))
-                            .upgrade("h2c");
+                    UpgradeResponse upgradeResponse = upgrade(http2Client,
+                                                              request,
+                                                              requestUri,
+                                                              serviceRequest,
+                                                              http1FallbackHandler,
+                                                              protocolConfig);
                     if (upgradeResponse.isUpgraded()) {
                         result.set(Result.HTTP_2);
                         connection = upgradeResponse.connection();
@@ -361,13 +437,13 @@ class Http2ClientConnectionHandler {
                     } else {
                         try (HttpClientResponse response = upgradeResponse.response()) {
                             if (LOGGER.isLoggable(TRACE)) {
-                                upgradeResponse.connection().helidonSocket()
-                                        .log(LOGGER, TRACE, "Failed to upgrade to HTTP/2");
+                                LOGGER.log(TRACE, "Failed to upgrade to HTTP/2");
                             }
-                            upgradeResponse.connection().closeResource();
-                            throw new IllegalStateException(
+                            IllegalStateException failure = new IllegalStateException(
                                     "Failed to upgrade to HTTP/2, even though it succeeded before. Status: "
                                             + response.status());
+                            http1FallbackHandler.completeSentExceptionally(failure);
+                            throw failure;
                         }
                     }
                 }
@@ -422,22 +498,33 @@ class Http2ClientConnectionHandler {
     }
 
     private static boolean http1FallbackAllowed(Http2ClientRequestImpl request) {
-        String protocolIds = request.properties().get(GENERIC_TCP_PROTOCOL_IDS_PROPERTY);
-        if (protocolIds == null) {
-            return true;
-        }
-        for (String protocolId : protocolIds.split(",")) {
-            if (Http1Client.PROTOCOL_ID.equals(protocolId)) {
-                return true;
-            }
-        }
-        return false;
+        return request.tcpProtocolIds().contains(Http1Client.PROTOCOL_ID);
     }
 
     private static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri, Http2ClientRequestImpl request) {
         return new IllegalArgumentException("Cannot handle request to " + uri
                                                    + ", negotiated HTTP/1.1 fallback is not enabled. HTTP versions supported: "
-                                                   + request.properties().get(GENERIC_TCP_PROTOCOL_IDS_PROPERTY));
+                                                   + request.tcpProtocolIds());
+    }
+
+    private static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri,
+                                                                     Http2ClientRequestImpl request,
+                                                                     Http1FallbackHandler http1FallbackHandler) {
+        IllegalArgumentException failure = unsupportedHttp1Fallback(uri, request);
+        http1FallbackHandler.completeSentExceptionally(failure);
+        return failure;
+    }
+
+    private static IllegalStateException unsupportedUpgradeFallback(Http2ClientRequestImpl request,
+                                                                    HttpClientResponse response) {
+        return new IllegalStateException("Cannot use failed h2c upgrade response as HTTP/1.1 fallback for "
+                                                 + request.method()
+                                                 + " request with an entity. Status: "
+                                                 + response.status());
+    }
+
+    private static List<String> alpnProtocolIds(Http2ClientRequestImpl request) {
+        return request.priorKnowledge() ? List.of(Http2Client.PROTOCOL_ID) : request.tcpProtocolIds();
     }
 
     private ClientConnection connectClient(WebClient webClient,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -61,6 +61,7 @@ class Http2ClientConnectionHandler {
     // h2c stands for HTTP/2 plaintext protocol (only used without TLS)
     private static final Header UPGRADE_HEADER = HeaderValues.createCached(HeaderNames.UPGRADE, "h2c");
     private static final HeaderName HTTP2_SETTINGS_HEADER = HeaderNames.create("HTTP2-Settings");
+    private static final String GENERIC_TCP_PROTOCOL_IDS_PROPERTY = "io.helidon.webclient.generic.tcp-protocol-ids";
 
     // todo requires handling of timeouts and removal from this queue
     private final Map<ClientConnection, Http2ClientConnection> h2ConnByConn =
@@ -175,14 +176,24 @@ class Http2ClientConnectionHandler {
                         this.activeConnection.set(connection);
                         return http2(http2Client, request, initialUri);
                     } else {
+                        if (!http1FallbackAllowed(request)) {
+                            closeClientConnection(clientConnection);
+                            throw unsupportedHttp1Fallback(initialUri, request);
+                        }
                         result.set(Result.HTTP_1);
                         request.connection(clientConnection);
                         return http1(http2Client, request, initialUri, http1EntityHandler);
                     }
                 } else {
-                    // this should not really happen, as H2 is depending on ALPN, but let's support it anyway, and hope we can
-                    // do this later
-                    request.connection(clientConnection);
+                    if (!request.priorKnowledge()) {
+                        if (!http1FallbackAllowed(request)) {
+                            closeClientConnection(clientConnection);
+                            throw unsupportedHttp1Fallback(initialUri, request);
+                        }
+                        request.connection(clientConnection);
+                        result.set(Result.HTTP_1);
+                        return http1(http2Client, request, initialUri, http1EntityHandler);
+                    }
                 }
             }
 
@@ -309,6 +320,7 @@ class Http2ClientConnectionHandler {
                 .followRedirects(request.followRedirects());
         request.connection().ifPresent(http1Request::connection);
         request.address().ifPresent(http1Request::address);
+        request.sni().ifPresent(http1Request::sni);
         return http1Request;
     }
 
@@ -409,6 +421,25 @@ class Http2ClientConnectionHandler {
         }
     }
 
+    private static boolean http1FallbackAllowed(Http2ClientRequestImpl request) {
+        String protocolIds = request.properties().get(GENERIC_TCP_PROTOCOL_IDS_PROPERTY);
+        if (protocolIds == null) {
+            return true;
+        }
+        for (String protocolId : protocolIds.split(",")) {
+            if (Http1Client.PROTOCOL_ID.equals(protocolId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri, Http2ClientRequestImpl request) {
+        return new IllegalArgumentException("Cannot handle request to " + uri
+                                                   + ", negotiated HTTP/1.1 fallback is not enabled. HTTP versions supported: "
+                                                   + request.properties().get(GENERIC_TCP_PROTOCOL_IDS_PROPERTY));
+    }
+
     private ClientConnection connectClient(WebClient webClient,
                                            Http2ClientRequestImpl request,
                                            ClientUri uri,
@@ -416,11 +447,9 @@ class Http2ClientConnectionHandler {
         var address = request.address();
         if (address.isPresent() && address.get() instanceof UnixDomainSocketAddress udsAddress) {
             return UnixDomainSocketClientConnection.create(webClient,
-                                                          connectionKey.tls(),
+                                                          connectionKey,
                                                           alpn,
                                                           udsAddress,
-                                                          uri.host(),
-                                                          uri.port(),
                                                           connection -> false,
                                                           connection -> {
                                                               Http2ClientConnection h2conn = h2ConnByConn.remove(

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -161,6 +161,7 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
                     .addService(new Http1FallbackService())
                     .cookieManager(WebClientCookieManager.builder().build())
                     .protocolPreference(List.of(Http1Client.PROTOCOL_ID))
+                    .shareConnectionCache(false)
                     .build();
             try {
                 Http1Client http1Client = fallbackWebClient.client(Http1Client.PROTOCOL);
@@ -196,7 +197,19 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
         return connectionCache;
     }
 
-    private record Http1FallbackResources(WebClient webClient, Http1Client http1Client) {
+    private static final class Http1FallbackResources {
+        private final WebClient webClient;
+        private final Http1Client http1Client;
+
+        private Http1FallbackResources(WebClient webClient, Http1Client http1Client) {
+            this.webClient = webClient;
+            this.http1Client = http1Client;
+        }
+
+        private Http1Client http1Client() {
+            return http1Client;
+        }
+
         void closeResource() {
             try {
                 http1Client.closeResource();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -84,6 +84,7 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
         clientRequest.connection().ifPresent(request::connection);
         clientRequest.pathParams().forEach(request::pathParam);
         clientRequest.address().ifPresent(request::address);
+        clientRequest.sni().ifPresent(request::sni);
 
         return request.readTimeout(clientRequest.readTimeout())
                 .followRedirects(clientRequest.followRedirects())

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -16,12 +16,19 @@
 
 package io.helidon.webclient.http2;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
 import io.helidon.common.uri.UriQueryWriteable;
 import io.helidon.http.Method;
 import io.helidon.webclient.api.ClientRequest;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.api.WebClientConfig;
+import io.helidon.webclient.api.WebClientCookieManager;
+import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.spi.HttpClientSpi;
 
 /**
@@ -33,6 +40,9 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
     private final Http2ClientProtocolConfig protocolConfig;
     private final Http2ConnectionCache connectionCache;
     private final Http2ConnectionCache clientCache;
+    private final AtomicReference<Http1FallbackResources> http1FallbackResources = new AtomicReference<>();
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
+    private volatile boolean closed;
 
     Http2ClientImpl(WebClient webClient, Http2ClientConfig clientConfig) {
         this.webClient = webClient;
@@ -75,11 +85,12 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
 
     @Override
     public ClientRequest<?> clientRequest(FullClientRequest<?> clientRequest, ClientUri clientUri) {
-        Http2ClientRequest request = new Http2ClientRequestImpl(this,
-                                                                clientRequest,
-                                                                clientRequest.method(),
-                                                                clientUri,
-                                                                clientRequest.properties());
+        Http2ClientRequestImpl request = new Http2ClientRequestImpl(this,
+                                                                    clientRequest,
+                                                                    clientRequest.method(),
+                                                                    clientUri,
+                                                                    clientRequest.properties(),
+                                                                    genericTcpProtocolIds());
 
         clientRequest.connection().ifPresent(request::connection);
         clientRequest.pathParams().forEach(request::pathParam);
@@ -97,13 +108,80 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
 
     @Override
     public void closeResource() {
-        if (clientCache != null) {
-            this.clientCache.closeResource();
+        Http1FallbackResources fallbackResources;
+        lifecycleLock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            fallbackResources = http1FallbackResources.getAndSet(null);
+        } finally {
+            lifecycleLock.unlock();
+        }
+
+        try {
+            if (fallbackResources != null) {
+                fallbackResources.closeResource();
+            }
+        } finally {
+            if (clientCache != null) {
+                this.clientCache.closeResource();
+            }
         }
     }
 
     WebClient webClient() {
         return webClient;
+    }
+
+    Http1Client http1FallbackClient() {
+        if (closed) {
+            throw new IllegalStateException("HTTP/2 client is closed");
+        }
+
+        Http1FallbackResources fallbackResources = http1FallbackResources.get();
+        if (fallbackResources != null) {
+            return fallbackResources.http1Client();
+        }
+
+        lifecycleLock.lock();
+        try {
+            if (closed) {
+                throw new IllegalStateException("HTTP/2 client is closed");
+            }
+            fallbackResources = http1FallbackResources.get();
+            if (fallbackResources != null) {
+                return fallbackResources.http1Client();
+            }
+
+            WebClient fallbackWebClient = WebClientConfig.builder(webClient.prototype())
+                    .clearServices()
+                    .servicesDiscoverServices(false)
+                    .addService(new Http1FallbackService())
+                    .cookieManager(WebClientCookieManager.builder().build())
+                    .protocolPreference(List.of(Http1Client.PROTOCOL_ID))
+                    .build();
+            try {
+                Http1Client http1Client = fallbackWebClient.client(Http1Client.PROTOCOL);
+                fallbackResources = new Http1FallbackResources(fallbackWebClient, http1Client);
+                http1FallbackResources.set(fallbackResources);
+                return http1Client;
+            } catch (RuntimeException | Error e) {
+                fallbackWebClient.closeResource();
+                throw e;
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    List<String> genericTcpProtocolIds() {
+        List<String> protocolPreference = webClient.prototype().protocolPreference();
+        if (protocolPreference.isEmpty()) {
+            return List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID);
+        }
+        return protocolPreference;
     }
 
     Http2ClientConfig clientConfig() {
@@ -114,7 +192,17 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
         return protocolConfig;
     }
 
-    Http2ConnectionCache connectionCache(){
+    Http2ConnectionCache connectionCache() {
         return connectionCache;
+    }
+
+    private record Http1FallbackResources(WebClient webClient, Http1Client http1Client) {
+        void closeResource() {
+            try {
+                http1Client.closeResource();
+            } finally {
+                webClient.closeResource();
+            }
+        }
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.http2;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -27,6 +28,7 @@ import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
+import io.helidon.webclient.http1.Http1Client;
 
 class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2ClientResponse>
         implements Http2ClientRequest, Http2StreamConfig, FullClientRequest<Http2ClientRequest> {
@@ -38,13 +40,23 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
     private Duration flowControlTimeout = Duration.ofMillis(100);
     private boolean outputStreamRedirect = false;
     private final FullClientRequest<?> delegate;
+    private final List<String> tcpProtocolIds;
 
     Http2ClientRequestImpl(Http2ClientImpl http2Client,
                            FullClientRequest<?> delegate,
                            Method method,
                            ClientUri clientUri,
                            Map<String, String> properties) {
-        this(http2Client, delegate, method, clientUri, properties, null);
+        this(http2Client, delegate, method, clientUri, properties, null, defaultTcpProtocolIds());
+    }
+
+    Http2ClientRequestImpl(Http2ClientImpl http2Client,
+                           FullClientRequest<?> delegate,
+                           Method method,
+                           ClientUri clientUri,
+                           Map<String, String> properties,
+                           List<String> tcpProtocolIds) {
+        this(http2Client, delegate, method, clientUri, properties, null, tcpProtocolIds);
     }
 
     private Http2ClientRequestImpl(Http2ClientImpl http2Client,
@@ -52,7 +64,8 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
                                    Method method,
                                    ClientUri clientUri,
                                    Map<String, String> properties,
-                                   ClientUri redirectSourceUri) {
+                                   ClientUri redirectSourceUri,
+                                   List<String> tcpProtocolIds) {
         super(http2Client.clientConfig(),
                 http2Client.webClient().cookieManager(),
                 Http2Client.PROTOCOL_ID,
@@ -66,13 +79,20 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         Http2ClientProtocolConfig protocolConfig = http2Client.protocolConfig();
         this.priorKnowledge = protocolConfig.priorKnowledge();
         this.delegate = delegate;
+        this.tcpProtocolIds = List.copyOf(tcpProtocolIds);
     }
 
     Http2ClientRequestImpl(Http2ClientRequestImpl request,
                            Method method,
                            ClientUri clientUri,
                            Map<String, String> properties) {
-        this(request.http2Client, request.delegate, method, clientUri, properties, request.resolvedUri());
+        this(request.http2Client,
+             request.delegate,
+             method,
+             clientUri,
+             properties,
+             request.resolvedUri(),
+             request.tcpProtocolIds);
 
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
@@ -178,6 +198,10 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         return delegate != null && delegate.connection().isEmpty() && connection().isPresent();
     }
 
+    List<String> tcpProtocolIds() {
+        return tcpProtocolIds;
+    }
+
     void sanitizeRedirectHeaders(ClientUri requestUri, ClientRequestHeaders requestHeaders) {
         super.sanitizeRedirectSensitiveHeaders(requestUri, requestHeaders);
     }
@@ -186,6 +210,10 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         return sourceUri.scheme().equalsIgnoreCase(targetUri.scheme())
                 && sourceUri.host().equalsIgnoreCase(targetUri.host())
                 && sourceUri.port() == targetUri.port();
+    }
+
+    private static List<String> defaultTcpProtocolIds() {
+        return List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID);
     }
 
     Http2ClientResponseImpl invokeEntity(Object entity) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -77,6 +77,7 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
         tls(request.tls());
+        request.sni().ifPresent(this::sni);
         if (sameOrigin(request.resolvedUri(), clientUri)) {
             request.address().ifPresent(this::address);
         }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -20,13 +20,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 import io.helidon.common.LruCache;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
-import io.helidon.webclient.http1.Http1ClientRequest;
-import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.spi.ClientConnectionCache;
 
 /**
@@ -87,7 +85,8 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                                            ConnectionKey connectionKey,
                                            Http2ClientRequestImpl request,
                                            ClientUri initialUri,
-                                           Function<Http1ClientRequest, Http1ClientResponse> http1EntityHandler) {
+                                           WebClientServiceRequest serviceRequest,
+                                           Http1FallbackHandler http1FallbackHandler) {
 
         if (closed.get()) {
             throw new IllegalStateException("Connection cache is closed");
@@ -100,7 +99,8 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                 .newStream(http2Client,
                            request,
                            initialUri,
-                           http1EntityHandler);
+                           serviceRequest,
+                           http1FallbackHandler);
         if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2
                 && (request.connection().isEmpty()
                         || Http2ClientConnectionHandler.ownsExplicitConnection(request))) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionKeys.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionKeys.java
@@ -18,47 +18,78 @@ package io.helidon.webclient.http2;
 
 import java.net.SocketAddress;
 import java.net.UnixDomainSocketAddress;
-import java.util.Optional;
 
 import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.WritableHeaders;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.HttpClientConfig;
 import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.SniConfig;
 
 final class Http2ConnectionKeys {
     private static final Tls NO_TLS = Tls.builder().enabled(false).build();
+    private static final ClientRequestHeaders EMPTY_HEADERS = ClientRequestHeaders.create(WritableHeaders.create());
 
     private Http2ConnectionKeys() {
     }
 
     static ConnectionKey create(ClientUri uri, FullClientRequest<?> request, HttpClientConfig clientConfig) {
-        return create(uri, request.address(), request.tls(), request.proxy(), clientConfig);
+        return create(uri, request, clientConfig, EMPTY_HEADERS);
     }
 
     static ConnectionKey create(ClientUri uri,
-                                Optional<SocketAddress> address,
+                                FullClientRequest<?> request,
+                                HttpClientConfig clientConfig,
+                                ClientRequestHeaders headers) {
+        return create(uri,
+                      request.address().orElse(null),
+                      request.sni().or(clientConfig::sni).orElse(null),
+                      request.tls(),
+                      request.proxy(),
+                      clientConfig,
+                      headers);
+    }
+
+    static ConnectionKey create(ClientUri uri,
+                                SocketAddress address,
+                                SniConfig sni,
                                 Tls tls,
                                 Proxy proxy,
-                                HttpClientConfig clientConfig) {
+                                HttpClientConfig clientConfig,
+                                ClientRequestHeaders headers) {
         Tls effectiveTls = "https".equals(uri.scheme()) ? tls : NO_TLS;
-        return address
-                .filter(UnixDomainSocketAddress.class::isInstance)
-                .map(UnixDomainSocketAddress.class::cast)
-                .map(udsAddress -> ConnectionKey.createUnixDomainSocket(uri.scheme(),
-                                                                         uri.host(),
-                                                                         uri.port(),
-                                                                         effectiveTls,
-                                                                         clientConfig.dnsResolver(),
-                                                                         clientConfig.dnsAddressLookup(),
-                                                                         udsAddress))
-                .orElseGet(() -> ConnectionKey.create(uri.scheme(),
-                                                      uri.host(),
-                                                      uri.port(),
-                                                      effectiveTls,
-                                                      clientConfig.dnsResolver(),
-                                                      clientConfig.dnsAddressLookup(),
-                                                      proxy));
+        if (address instanceof UnixDomainSocketAddress udsAddress) {
+            if (sni == null) {
+                return ConnectionKey.createUnixDomainSocket(uri,
+                                                            effectiveTls,
+                                                            clientConfig.dnsResolver(),
+                                                            clientConfig.dnsAddressLookup(),
+                                                            udsAddress);
+            }
+            return ConnectionKey.createUnixDomainSocket(uri,
+                                                        sni,
+                                                        effectiveTls,
+                                                        clientConfig.dnsResolver(),
+                                                        clientConfig.dnsAddressLookup(),
+                                                        udsAddress,
+                                                        headers);
+        }
+        if (sni == null) {
+            return ConnectionKey.create(uri,
+                                        effectiveTls,
+                                        clientConfig.dnsResolver(),
+                                        clientConfig.dnsAddressLookup(),
+                                        proxy);
+        }
+        return ConnectionKey.create(uri,
+                                    sni,
+                                    effectiveTls,
+                                    clientConfig.dnsResolver(),
+                                    clientConfig.dnsAddressLookup(),
+                                    proxy,
+                                    headers);
     }
 }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2CallChainBaseTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2CallChainBaseTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.net.URI;
+
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.webclient.api.ClientUri;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class Http2CallChainBaseTest {
+    @Test
+    void authorityOverridesHostBeforeKeying() {
+        ClientRequestHeaders headers = emptyHeaders();
+        headers.set(HeaderValues.create(HeaderNames.HOST, "host.example:443"));
+        headers.set(HeaderValues.create(Http2Headers.AUTHORITY_NAME, "authority.example:9443"));
+
+        Http2CallChainBase.alignHostHeader(uri(), headers);
+
+        assertThat(headers.first(HeaderNames.HOST).orElseThrow(), is("authority.example:9443"));
+    }
+
+    @Test
+    void hostIsPreservedWhenAuthorityIsAbsent() {
+        ClientRequestHeaders headers = emptyHeaders();
+        headers.set(HeaderValues.create(HeaderNames.HOST, "host.example:443"));
+
+        Http2CallChainBase.alignHostHeader(uri(), headers);
+
+        assertThat(headers.first(HeaderNames.HOST).orElseThrow(), is("host.example:443"));
+    }
+
+    @Test
+    void uriAuthorityIsUsedWhenHeadersAreAbsent() {
+        ClientRequestHeaders headers = emptyHeaders();
+
+        Http2CallChainBase.alignHostHeader(uri(), headers);
+
+        assertThat(headers.first(HeaderNames.HOST).orElseThrow(), is("service.example:8443"));
+    }
+
+    private static ClientRequestHeaders emptyHeaders() {
+        return ClientRequestHeaders.create(WritableHeaders.create());
+    }
+
+    private static ClientUri uri() {
+        return ClientUri.create(URI.create("https://service.example:8443/path"));
+    }
+}

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientRequestImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientRequestImpl.java
@@ -44,6 +44,7 @@ import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.SniConfig;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
 
@@ -164,6 +165,12 @@ class JsonRpcClientRequestImpl implements JsonRpcClientRequest {
     @Override
     public JsonRpcClientRequest tls(Tls tls) {
         delegate.tls(tls);
+        return this;
+    }
+
+    @Override
+    public JsonRpcClientRequest sni(SniConfig sni) {
+        delegate.sni(sni);
         return this;
     }
 

--- a/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientTest.java
+++ b/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientTest.java
@@ -15,16 +15,22 @@
  */
 package io.helidon.webclient.jsonrpc;
 
+import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
 import io.helidon.json.JsonException;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonString;
+import io.helidon.webclient.api.SniConfig;
+import io.helidon.webclient.api.SniMode;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientRequest;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
@@ -34,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
@@ -105,6 +112,21 @@ class JsonRpcClientTest {
     }
 
     @Test
+    void testRequestLevelSniDelegatesToHttp1Request() {
+        AtomicReference<SniConfig> configuredSni = new AtomicReference<>();
+        Http1ClientRequest http1Request = http1Request(configuredSni);
+        Http1Client http1Client = http1Client(http1Request);
+        JsonRpcClientRequest request = new JsonRpcClientRequestImpl(http1Client, "start");
+        SniConfig sni = SniConfig.builder()
+                .mode(SniMode.EXPLICIT)
+                .host("service.example")
+                .build();
+
+        assertThat(request.sni(sni), sameInstance(request));
+        assertThat(configuredSni.get(), sameInstance(sni));
+    }
+
+    @Test
     void testSubmitWithHelidonJsonMedia() {
         JsonRpcClient jsonRpcClient = JsonRpcClient.builder()
                 .baseUri(serverUri)
@@ -134,5 +156,41 @@ class JsonRpcClientTest {
             assertThat(res.status(), is(Status.OK_200));
             assertThrows(JsonException.class, res::error);
         }
+    }
+
+    private static Http1Client http1Client(Http1ClientRequest request) {
+        return (Http1Client) Proxy.newProxyInstance(JsonRpcClientTest.class.getClassLoader(),
+                                                    new Class<?>[] {Http1Client.class},
+                                                    (proxy, method, args) -> {
+                                                        if (method.getName().equals("post")) {
+                                                            return request;
+                                                        }
+                                                        return defaultValue(method.getReturnType());
+                                                    });
+    }
+
+    private static Http1ClientRequest http1Request(AtomicReference<SniConfig> configuredSni) {
+        return (Http1ClientRequest) Proxy.newProxyInstance(JsonRpcClientTest.class.getClassLoader(),
+                                                           new Class<?>[] {Http1ClientRequest.class},
+                                                           (proxy, method, args) -> {
+                                                               if (method.getName().equals("sni")) {
+                                                                   configuredSni.set((SniConfig) args[0]);
+                                                                   return proxy;
+                                                               }
+                                                               return defaultValue(method.getReturnType());
+                                                           });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == void.class) {
+            return null;
+        }
+        return 0;
     }
 }

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcProxyProtocolTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcProxyProtocolTest.java
@@ -40,6 +40,7 @@ import io.helidon.common.tls.Tls;
 import io.helidon.config.Config;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionListener;
+import io.helidon.webclient.api.SniMode;
 import io.helidon.webclient.grpc.ClientUriSuppliers;
 import io.helidon.webclient.grpc.GrpcClient;
 import io.helidon.webserver.ProxyProtocolData;
@@ -286,6 +287,34 @@ public class GrpcProxyProtocolTest {
         assertThat(response.getText(), is("HELLO"));
 
         server.stop();
+    }
+
+    @Test
+    public void testTlsOverTcpUsesConfiguredSni() {
+        var server = WebServer.builder()
+            .tls(serverTls())
+            .bindAddress(new InetSocketAddress(Inet4Address.getLoopbackAddress(), 0))
+            .addRouting(GrpcRouting.builder()
+                .unary(Strings.getDescriptor(), "StringService", "Upper", GrpcProxyProtocolTest::upper))
+            .build();
+        server.start();
+
+        try {
+            GrpcClient grpcClient = GrpcClient.create(b -> b
+                .config(Config.create().get("grpc-client"))
+                .tls(clientTls())
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(LOGICAL_HOST))
+                .baseUri(URI.create("https://127.0.0.1:" + server.port())));
+            var service = StringServiceGrpc.newBlockingStub(grpcClient.channel());
+            var response = service.upper(Strings.StringMessage.newBuilder()
+                                                 .setText("hello")
+                                                 .build());
+
+            assertThat(response.getText(), is("HELLO"));
+        } finally {
+            server.stop();
+        }
     }
 
     private ConnectionListener v1Listener(String proxyHeader) {

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcProxyProtocolTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcProxyProtocolTest.java
@@ -33,6 +33,8 @@ import javax.net.ssl.SSLParameters;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import io.grpc.CallOptions;
+import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
 
 import io.helidon.common.configurable.Resource;
@@ -310,6 +312,35 @@ public class GrpcProxyProtocolTest {
             var response = service.upper(Strings.StringMessage.newBuilder()
                                                  .setText("hello")
                                                  .build());
+
+            assertThat(response.getText(), is("HELLO"));
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testTlsOverTcpHostHeaderSniUsesGrpcAuthority() {
+        var server = WebServer.builder()
+            .tls(serverTls())
+            .bindAddress(new InetSocketAddress(Inet4Address.getLoopbackAddress(), 0))
+            .addRouting(GrpcRouting.builder()
+                .unary(Strings.getDescriptor(), "StringService", "Upper", GrpcProxyProtocolTest::upper))
+            .build();
+        server.start();
+
+        try {
+            GrpcClient grpcClient = GrpcClient.create(b -> b
+                .config(Config.create().get("grpc-client"))
+                .tls(clientTls())
+                .sni(sni -> sni.mode(SniMode.HOST_HEADER))
+                .baseUri(URI.create("https://127.0.0.1:" + server.port())));
+            var response = ClientCalls.blockingUnaryCall(grpcClient.channel(),
+                                                         StringServiceGrpc.getUpperMethod(),
+                                                         CallOptions.DEFAULT.withAuthority(LOGICAL_AUTHORITY),
+                                                         Strings.StringMessage.newBuilder()
+                                                                 .setText("hello")
+                                                                 .build());
 
             assertThat(response.getText(), is("HELLO"));
         } finally {

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.api.HttpClientRequest;
 import io.helidon.webclient.api.HttpClientResponse;
-import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRules;
@@ -255,8 +254,7 @@ class Http1ClientTest {
             connectionNow = http1Client
                     .connectionCache()
                     .connection(http1Client,
-                                injectedHttp1client.prototype().tls(),
-                                Proxy.noProxy(),
+                                request,
                                 request.resolvedUri(),
                                 request.headers(),
                                 true);
@@ -284,8 +282,7 @@ class Http1ClientTest {
             connectionNow = http1Client
                     .connectionCache()
                     .connection(http1Client,
-                                injectedHttp1client.prototype().tls(),
-                                Proxy.noProxy(),
+                                request,
                                 request.resolvedUri(),
                                 request.headers(),
                                 true);
@@ -318,8 +315,7 @@ class Http1ClientTest {
             connectionList.add(http1Client
                                        .connectionCache()
                                        .connection(http1Client,
-                                                   clientConfig.tls(),
-                                                   Proxy.noProxy(),
+                                                   request,
                                                    request.resolvedUri(),
                                                    request.headers(),
                                                    true));
@@ -345,8 +341,7 @@ class Http1ClientTest {
             connection = http1Client
                     .connectionCache()
                     .connection(http1Client,
-                                clientConfig.tls(),
-                                Proxy.noProxy(),
+                                request,
                                 request.resolvedUri(),
                                 request.headers(),
                                 true);
@@ -373,8 +368,7 @@ class Http1ClientTest {
         ClientConnection connectionNow = http1Client
                 .connectionCache()
                 .connection(http1Client,
-                            clientConfig.tls(),
-                            Proxy.noProxy(),
+                            request,
                             request.resolvedUri(),
                             request.headers(),
                             true);

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2ClientTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2ClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,28 @@
 
 package io.helidon.webclient.tests.http2;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 
 import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.Keys;
@@ -27,7 +47,9 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
+import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.HttpClientRequest;
+import io.helidon.webclient.api.SniMode;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
@@ -47,6 +69,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ServerTest
@@ -58,20 +81,17 @@ class Http2ClientTest {
     private final Http1Client http1Client;
     private final Supplier<Http2Client> tlsClient;
     private final Supplier<Http2Client> plainClient;
+    private final Tls clientTls;
     private final int tlsPort;
+    private final int sniTlsPort;
     private final int plainPort;
 
     Http2ClientTest(WebServer server, Http1Client http1Client) {
         plainPort = server.port();
         tlsPort = server.port("https");
+        sniTlsPort = server.port("https-sni");
         this.http1Client = http1Client;
-        Tls clientTls = Tls.builder()
-                .trust(trust -> trust
-                        .keystore(store -> store
-                                .passphrase("password")
-                                .trustStore(true)
-                                .keystore(Resource.create("client.p12"))))
-                .build();
+        this.clientTls = clientTls();
         this.tlsClient = () -> Http2Client.builder()
                 .baseUri("https://localhost:" + tlsPort + "/")
                 .shareConnectionCache(false)
@@ -96,8 +116,18 @@ class Http2ClientTest {
                 .privateKeyCertChain(privateKeyConfig)
                 .build();
 
+        SSLParameters sniParameters = new SSLParameters();
+        sniParameters.setSNIMatchers(List.of(SNIHostName.createSNIMatcher("(first|second|host-header)\\.example")));
+        Tls sniTls = Tls.builder()
+                .privateKey(privateKeyConfig)
+                .privateKeyCertChain(privateKeyConfig)
+                .sslParameters(sniParameters)
+                .build();
+
         serverBuilder.putSocket("https",
                                 socketBuilder -> socketBuilder.tls(tls));
+        serverBuilder.putSocket("https-sni",
+                                socketBuilder -> socketBuilder.tls(sniTls));
     }
 
     @SetUpRoute
@@ -113,6 +143,15 @@ class Http2ClientTest {
         router.route(Http2Route.route(Method.GET, "/", (req, res) -> res.header(TEST_HEADER)
                 .send(MESSAGE)));
     }
+
+    @SetUpRoute("https-sni")
+    static void routerHttpsSni(HttpRouting.Builder router) {
+        // explicitly on HTTP/2 only, to make sure we do upgrade
+        router.route(Http2Route.route(Method.GET, "/", (req, res) -> res.header(TEST_HEADER)
+                        .send(MESSAGE)))
+                .route(Http2Route.route(Method.GET, "/socket-id", (req, res) -> res.send(req.socketId())));
+    }
+
     @Test
     void testHttp1() {
         // make sure the HTTP/1 route is not working
@@ -186,6 +225,137 @@ class Http2ClientTest {
     }
 
     @Test
+    void testGenericHostHeaderSniNegotiatesHttp2OverTls() {
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + tlsPort + "/")
+                .tls(clientTls)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .build();
+        try (HttpClientResponse response = client.get()
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is(MESSAGE));
+            assertThat(TEST_HEADER + " header must be present in response",
+                       response.headers().contains(TEST_HEADER), is(true));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniUsesHostHeaderForTlsHandshake() {
+        Tls tlsWithoutEndpointIdentification = clientTlsWithoutEndpointIdentification();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + sniTlsPort + "/")
+                .tls(tlsWithoutEndpointIdentification)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .build();
+        try (HttpClientResponse response = client.get()
+                .header(HeaderValues.create(HeaderNames.HOST, "host-header.example:" + sniTlsPort))
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is(MESSAGE));
+            assertThat(TEST_HEADER + " header must be present in response",
+                       response.headers().contains(TEST_HEADER), is(true));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniUsesServiceHostHeaderForTlsHandshake() {
+        Tls tlsWithoutEndpointIdentification = clientTlsWithoutEndpointIdentification();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + sniTlsPort + "/")
+                .tls(tlsWithoutEndpointIdentification)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .addService((chain, request) -> {
+                    request.headers().set(HeaderValues.create(HeaderNames.HOST, "host-header.example:" + sniTlsPort));
+                    return chain.proceed(request);
+                })
+                .build();
+        try (HttpClientResponse response = client.get()
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is(MESSAGE));
+            assertThat(TEST_HEADER + " header must be present in response",
+                       response.headers().contains(TEST_HEADER), is(true));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniSeparatesHttp2ConnectionCache() {
+        Tls tlsWithoutEndpointIdentification = clientTlsWithoutEndpointIdentification();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + sniTlsPort + "/")
+                .tls(tlsWithoutEndpointIdentification)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .build();
+        try {
+            String firstSocketId = client.get()
+                    .path("/socket-id")
+                    .header(HeaderValues.create(HeaderNames.HOST, "first.example:" + sniTlsPort))
+                    .requestEntity(String.class);
+            String secondSocketId = client.get()
+                    .path("/socket-id")
+                    .header(HeaderValues.create(HeaderNames.HOST, "second.example:" + sniTlsPort))
+                    .requestEntity(String.class);
+
+            assertThat(secondSocketId.equals(firstSocketId), is(false));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniFallsBackToHttp1WhenTlsDoesNotNegotiateAlpn() throws Exception {
+        NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.start();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .tls(clientTls)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .build();
+        try (HttpClientResponse response = client.get()
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("http1"));
+
+            List<String> requestLines = server.requestLines();
+            assertThat(requestLines.getFirst(), is("GET / HTTP/1.1"));
+            assertThat(hasHeader(requestLines, HeaderNames.UPGRADE.defaultCase()), is(false));
+            assertThat(hasHeader(requestLines, "HTTP2-Settings"), is(false));
+        } finally {
+            client.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniHonorsH2OnlyProtocolPreferenceWhenTlsDoesNotNegotiateAlpn() throws Exception {
+        NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.start();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID))
+                .tls(clientTls)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .build();
+        try {
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> client.get().request());
+
+            assertThat(e.getMessage(), startsWith("Cannot handle request"));
+        } finally {
+            client.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
     void testPriorKnowledge() {
         try (Http2ClientResponse response = tlsClient.get()
                 .get("/")
@@ -196,6 +366,104 @@ class Http2ClientTest {
             assertThat(response.as(String.class), is(MESSAGE));
             assertThat(TEST_HEADER + " header must be present in response",
                        response.headers().contains(TEST_HEADER), is(true));
+        }
+    }
+
+    private static boolean hasHeader(List<String> requestLines, String headerName) {
+        String prefix = headerName.toLowerCase(Locale.ROOT) + ":";
+        return requestLines.stream()
+                .map(it -> it.toLowerCase(Locale.ROOT))
+                .anyMatch(it -> it.startsWith(prefix));
+    }
+
+    private static Tls clientTls() {
+        return Tls.builder()
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+    }
+
+    private static Tls clientTlsWithoutEndpointIdentification() {
+        return Tls.builder()
+                .endpointIdentificationAlgorithm(Tls.ENDPOINT_IDENTIFICATION_NONE)
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+    }
+
+    private static final class NoAlpnHttp1TlsServer implements AutoCloseable {
+        private static final char[] PASSWORD = "password".toCharArray();
+
+        private final SSLServerSocket serverSocket;
+        private final CompletableFuture<List<String>> requestLines = new CompletableFuture<>();
+
+        private NoAlpnHttp1TlsServer(SSLServerSocket serverSocket) {
+            this.serverSocket = serverSocket;
+            Thread.ofVirtual().start(this::serve);
+        }
+
+        static NoAlpnHttp1TlsServer start() throws Exception {
+            KeyStore store = KeyStore.getInstance("PKCS12");
+            try (InputStream input = Http2ClientTest.class.getClassLoader().getResourceAsStream("server.p12")) {
+                store.load(Objects.requireNonNull(input, "server.p12"), PASSWORD);
+            }
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(store, PASSWORD);
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(keyManagerFactory.getKeyManagers(), null, null);
+            SSLServerSocket socket = (SSLServerSocket) context.getServerSocketFactory().createServerSocket(0);
+            return new NoAlpnHttp1TlsServer(socket);
+        }
+
+        int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        List<String> requestLines() throws Exception {
+            return requestLines.get(10, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() throws Exception {
+            serverSocket.close();
+        }
+
+        private void serve() {
+            try {
+                while (!serverSocket.isClosed()) {
+                    try (SSLSocket socket = (SSLSocket) serverSocket.accept();
+                            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                                                                                             StandardCharsets.US_ASCII));
+                            Writer writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.US_ASCII)) {
+
+                        socket.startHandshake();
+                        List<String> lines = new ArrayList<>();
+                        String line;
+                        while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                            lines.add(line);
+                        }
+                        if (lines.isEmpty()) {
+                            continue;
+                        }
+                        requestLines.complete(List.copyOf(lines));
+                        writer.write("HTTP/1.1 200 OK\r\n"
+                                             + "Content-Length: 5\r\n"
+                                             + "Connection: close\r\n"
+                                             + "\r\n"
+                                             + "http1");
+                        writer.flush();
+                        return;
+                    }
+                }
+            } catch (Throwable t) {
+                requestLines.completeExceptionally(t);
+            }
         }
     }
 }

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2ClientTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2ClientTest.java
@@ -20,7 +20,10 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
 import java.io.Writer;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.util.ArrayList;
@@ -29,12 +32,16 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
@@ -51,6 +58,7 @@ import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.HttpClientRequest;
 import io.helidon.webclient.api.SniMode;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.http2.Http2Client;
@@ -134,7 +142,11 @@ class Http2ClientTest {
     static void router(HttpRouting.Builder router) {
         // explicitly on HTTP/2 only, to make sure we do upgrade
         router.route(Http2Route.route(Method.GET, "/", (req, res) -> res.header(TEST_HEADER)
-                .send(MESSAGE)));
+                .send(MESSAGE)))
+                .route(Http2Route.route(Method.POST, "/stream", (req, res) -> {
+                    String entity = req.content().as(String.class);
+                    res.send("stream:" + entity);
+                }));
     }
 
     @SetUpRoute("https")
@@ -208,6 +220,98 @@ class Http2ClientTest {
             assertThat(response.as(String.class), is(MESSAGE));
             assertThat(TEST_HEADER + " header must be present in response",
                        response.headers().contains(TEST_HEADER), is(true));
+        }
+    }
+
+    @Test
+    void testUpgradeOutputStreamCompletesWhenSentAfterHandlerStarts() throws Exception {
+        AtomicInteger outputHandlerStarted = new AtomicInteger();
+        CompletableFuture<Boolean> completedBeforeHandler = new CompletableFuture<>();
+        WebClient client = WebClient.builder()
+                .baseUri("http://localhost:" + plainPort + "/")
+                .addService((chain, request) -> {
+                    request.whenSent()
+                            .thenRun(() -> completedBeforeHandler.complete(outputHandlerStarted.get() == 0));
+                    return chain.proceed(request);
+                })
+                .build();
+        byte[] entity = "hello".getBytes(StandardCharsets.US_ASCII);
+        try (HttpClientResponse response = client.post()
+                .path("/stream")
+                .header(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length))
+                .outputStream(it -> {
+                    outputHandlerStarted.incrementAndGet();
+                    assertThat(completedBeforeHandler.getNow(false), is(false));
+                    it.write(entity);
+                    it.close();
+                })) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("stream:hello"));
+            assertThat(completedBeforeHandler.get(10, TimeUnit.SECONDS), is(false));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void testFailedH2cUpgradeWithoutEntityCompletesWhenSent() throws Exception {
+        PlainHttp1Server server = PlainHttp1Server.start();
+        AtomicReference<CompletableFuture<WebClientServiceRequest>> whenSent = new AtomicReference<>();
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://localhost:" + server.port() + "/")
+                .shareConnectionCache(false)
+                .addService((chain, request) -> {
+                    whenSent.set(request.whenSent().toCompletableFuture());
+                    return chain.proceed(request);
+                })
+                .build();
+        try (Http2ClientResponse response = client.get()
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("http1"));
+            assertThat(whenSent.get().get(10, TimeUnit.SECONDS).method(), is(Method.GET));
+
+            List<String> requestLines = server.requestLines();
+            assertThat(requestLines.getFirst(), is("GET / HTTP/1.1"));
+            assertThat(hasHeader(requestLines, HeaderNames.UPGRADE.defaultCase(), "h2c"), is(true));
+            assertThat(hasHeader(requestLines, "HTTP2-Settings"), is(true));
+        } finally {
+            client.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
+    void testFailedH2cUpgradeWithEntityCompletesWhenSentExceptionally() throws Exception {
+        PlainHttp1Server server = PlainHttp1Server.start();
+        AtomicReference<CompletableFuture<WebClientServiceRequest>> whenSent = new AtomicReference<>();
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://localhost:" + server.port() + "/")
+                .shareConnectionCache(false)
+                .addService((chain, request) -> {
+                    whenSent.set(request.whenSent().toCompletableFuture());
+                    return chain.proceed(request);
+                })
+                .build();
+        try {
+            IllegalStateException e = assertThrows(IllegalStateException.class,
+                                                   () -> client.post()
+                                                           .path("/entity")
+                                                           .submit("payload"));
+            assertThat(e.getMessage(), startsWith("Cannot use failed h2c upgrade response"));
+
+            ExecutionException sentFailure = assertThrows(ExecutionException.class,
+                                                          () -> whenSent.get().get(10, TimeUnit.SECONDS));
+            assertThat(sentFailure.getCause(), is(e));
+
+            List<String> requestLines = server.requestLines();
+            assertThat(requestLines.getFirst(), is("POST /entity HTTP/1.1"));
+            assertThat(server.requestBody(), is(""));
+        } finally {
+            client.closeResource();
+            server.close();
         }
     }
 
@@ -337,21 +441,244 @@ class Http2ClientTest {
     }
 
     @Test
-    void testGenericHostHeaderSniHonorsH2OnlyProtocolPreferenceWhenTlsDoesNotNegotiateAlpn() throws Exception {
+    void testGenericHostHeaderSniHttp1FallbackInvokesServicesOnce() throws Exception {
         NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.start();
+        AtomicInteger serviceInvocations = new AtomicInteger();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .tls(clientTlsWithoutEndpointIdentification())
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .addService((chain, request) -> {
+                    serviceInvocations.incrementAndGet();
+                    request.headers().set(HeaderValues.create(HeaderNames.HOST, "host-header.example:" + server.port()));
+                    return chain.proceed(request);
+                })
+                .build();
+        try (HttpClientResponse response = client.get()
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("http1"));
+            assertThat(serviceInvocations.get(), is(1));
+
+            List<String> requestLines = server.requestLines();
+            assertThat(hasHeader(requestLines,
+                                 HeaderNames.HOST.defaultCase(),
+                                 "host-header.example:" + server.port()), is(true));
+        } finally {
+            client.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniHttp1FallbackDoesNotRestoreRemovedDefaultHeader() throws Exception {
+        NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.start();
+        String removedHeader = "X-Removed-Default";
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .tls(clientTlsWithoutEndpointIdentification())
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .addHeader(HeaderNames.create(removedHeader), "remove-me")
+                .addService((chain, request) -> {
+                    request.headers().set(HeaderValues.create(HeaderNames.HOST, "host-header.example:" + server.port()));
+                    request.headers().remove(HeaderNames.create(removedHeader));
+                    return chain.proceed(request);
+                })
+                .build();
+        try (HttpClientResponse response = client.get()
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("http1"));
+
+            List<String> requestLines = server.requestLines();
+            assertThat(hasHeader(requestLines, removedHeader), is(false));
+        } finally {
+            client.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniHttp1FallbackClientClosedWithHttp2Client() throws Exception {
+        NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.startKeepAlive();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .tls(clientTlsWithoutEndpointIdentification())
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .addService((chain, request) -> {
+                    request.headers().set(HeaderValues.create(HeaderNames.HOST, "host-header.example:" + server.port()));
+                    return chain.proceed(request);
+                })
+                .build();
+        try {
+            try (HttpClientResponse response = client.get()
+                    .request()) {
+
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class), is("http1"));
+            }
+
+            client.closeResource();
+            server.awaitClientSocketClosed();
+        } finally {
+            client.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniHttp1FallbackOutputStreamInvokesServicesOnce() throws Exception {
+        NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.start();
+        AtomicInteger serviceInvocations = new AtomicInteger();
+        byte[] entity = "fallback-output-stream".getBytes(StandardCharsets.US_ASCII);
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .tls(clientTlsWithoutEndpointIdentification())
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .addService((chain, request) -> {
+                    serviceInvocations.incrementAndGet();
+                    request.headers().set(HeaderValues.create(HeaderNames.HOST, "host-header.example:" + server.port()));
+                    return chain.proceed(request);
+                })
+                .build();
+        try (HttpClientResponse response = client.post()
+                .path("/stream")
+                .header(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length))
+                .outputStream(it -> {
+                    it.write(entity);
+                    it.close();
+                })) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("http1"));
+            assertThat(serviceInvocations.get(), is(1));
+
+            List<String> requestLines = server.requestLines();
+            assertThat(requestLines.getFirst(), is("POST /stream HTTP/1.1"));
+            assertThat(hasHeader(requestLines,
+                                 HeaderNames.HOST.defaultCase(),
+                                 "host-header.example:" + server.port()), is(true));
+            assertThat(server.requestBody(), is(new String(entity, StandardCharsets.US_ASCII)));
+        } finally {
+            client.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniHonorsH2OnlyProtocolPreferenceWhenTlsDoesNotNegotiateAlpn() throws Exception {
+        NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.start(Http1Client.PROTOCOL_ID);
+        AtomicReference<CompletableFuture<WebClientServiceRequest>> whenSent = new AtomicReference<>();
         WebClient client = WebClient.builder()
                 .baseUri("https://localhost:" + server.port() + "/")
                 .protocolPreference(List.of(Http2Client.PROTOCOL_ID))
                 .tls(clientTls)
                 .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .addService((chain, request) -> {
+                    whenSent.set(request.whenSent().toCompletableFuture());
+                    return chain.proceed(request);
+                })
                 .build();
         try {
-            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> client.get().request());
+            UncheckedIOException e = assertThrows(UncheckedIOException.class, () -> client.get().request());
 
-            assertThat(e.getMessage(), startsWith("Cannot handle request"));
+            assertThat(e.getCause() instanceof SSLHandshakeException, is(true));
+            ExecutionException sentFailure = assertThrows(ExecutionException.class,
+                                                          () -> whenSent.get().get(10, TimeUnit.SECONDS));
+            assertThat(sentFailure.getCause(), is(e));
         } finally {
             client.closeResource();
             server.close();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniHonorsH2OnlyProtocolPreferenceWithCachedHttp1Fallback() throws Exception {
+        NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.startRequests(2);
+        AtomicReference<CompletableFuture<WebClientServiceRequest>> whenSent = new AtomicReference<>();
+        WebClient fallbackClient = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                .tls(clientTls)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .build();
+        WebClient h2OnlyClient = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID))
+                .tls(clientTls)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .addService((chain, request) -> {
+                    whenSent.set(request.whenSent().toCompletableFuture());
+                    return chain.proceed(request);
+                })
+                .build();
+        try {
+            try (HttpClientResponse response = fallbackClient.get()
+                    .request()) {
+
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class), is("http1"));
+            }
+
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> h2OnlyClient.get().request());
+            assertThat(e.getMessage(), startsWith("Cannot handle request"));
+
+            ExecutionException sentFailure = assertThrows(ExecutionException.class,
+                                                          () -> whenSent.get().get(10, TimeUnit.SECONDS));
+            assertThat(sentFailure.getCause(), is(e));
+        } finally {
+            fallbackClient.closeResource();
+            h2OnlyClient.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
+    void testGenericHostHeaderSniCompletesWhenSentWhenHttp2StartupFails() throws Exception {
+        NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.startCloseAfterHandshake(Http2Client.PROTOCOL_ID);
+        AtomicReference<CompletableFuture<WebClientServiceRequest>> whenSent = new AtomicReference<>();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + server.port() + "/")
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID))
+                .tls(clientTls)
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .addService((chain, request) -> {
+                    whenSent.set(request.whenSent().toCompletableFuture());
+                    return chain.proceed(request);
+                })
+                .build();
+        try {
+            RuntimeException e = assertThrows(RuntimeException.class, () -> client.get().request());
+
+            ExecutionException sentFailure = assertThrows(ExecutionException.class,
+                                                          () -> whenSent.get().get(10, TimeUnit.SECONDS));
+            assertThat(sentFailure.getCause(), is(e));
+        } finally {
+            client.closeResource();
+            server.close();
+        }
+    }
+
+    @Test
+    void testDirectHttp2ClientKeepsH2AlpnWithHttp1OnlyOuterPreference() {
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + tlsPort + "/")
+                .protocolPreference(List.of(Http1Client.PROTOCOL_ID))
+                .tls(clientTls)
+                .build();
+        Http2Client http2Client = client.client(Http2Client.PROTOCOL);
+        try (Http2ClientResponse response = http2Client.get()
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is(MESSAGE));
+            assertThat(TEST_HEADER + " header must be present in response",
+                       response.headers().contains(TEST_HEADER), is(true));
+        } finally {
+            http2Client.closeResource();
+            client.closeResource();
         }
     }
 
@@ -376,6 +703,15 @@ class Http2ClientTest {
                 .anyMatch(it -> it.startsWith(prefix));
     }
 
+    private static boolean hasHeader(List<String> requestLines, String headerName, String value) {
+        String prefix = headerName.toLowerCase(Locale.ROOT) + ":";
+        return requestLines.stream()
+                .map(it -> it.toLowerCase(Locale.ROOT))
+                .filter(it -> it.startsWith(prefix))
+                .map(it -> it.substring(prefix.length()).trim())
+                .anyMatch(it -> it.equals(value.toLowerCase(Locale.ROOT)));
+    }
+
     private static Tls clientTls() {
         return Tls.builder()
                 .trust(trust -> trust
@@ -397,28 +733,19 @@ class Http2ClientTest {
                 .build();
     }
 
-    private static final class NoAlpnHttp1TlsServer implements AutoCloseable {
-        private static final char[] PASSWORD = "password".toCharArray();
-
-        private final SSLServerSocket serverSocket;
+    private static final class PlainHttp1Server implements AutoCloseable {
+        private final ServerSocket serverSocket;
         private final CompletableFuture<List<String>> requestLines = new CompletableFuture<>();
+        private final CompletableFuture<String> requestBody = new CompletableFuture<>();
+        private final AtomicReference<Socket> activeSocket = new AtomicReference<>();
 
-        private NoAlpnHttp1TlsServer(SSLServerSocket serverSocket) {
+        private PlainHttp1Server(ServerSocket serverSocket) {
             this.serverSocket = serverSocket;
             Thread.ofVirtual().start(this::serve);
         }
 
-        static NoAlpnHttp1TlsServer start() throws Exception {
-            KeyStore store = KeyStore.getInstance("PKCS12");
-            try (InputStream input = Http2ClientTest.class.getClassLoader().getResourceAsStream("server.p12")) {
-                store.load(Objects.requireNonNull(input, "server.p12"), PASSWORD);
-            }
-            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            keyManagerFactory.init(store, PASSWORD);
-            SSLContext context = SSLContext.getInstance("TLS");
-            context.init(keyManagerFactory.getKeyManagers(), null, null);
-            SSLServerSocket socket = (SSLServerSocket) context.getServerSocketFactory().createServerSocket(0);
-            return new NoAlpnHttp1TlsServer(socket);
+        static PlainHttp1Server start() throws Exception {
+            return new PlainHttp1Server(new ServerSocket(0));
         }
 
         int port() {
@@ -429,20 +756,193 @@ class Http2ClientTest {
             return requestLines.get(10, TimeUnit.SECONDS);
         }
 
+        String requestBody() throws Exception {
+            return requestBody.get(10, TimeUnit.SECONDS);
+        }
+
         @Override
         public void close() throws Exception {
+            Socket socket = activeSocket.getAndSet(null);
+            if (socket != null) {
+                socket.close();
+            }
             serverSocket.close();
         }
 
         private void serve() {
             try {
-                while (!serverSocket.isClosed()) {
-                    try (SSLSocket socket = (SSLSocket) serverSocket.accept();
+                Socket socket = serverSocket.accept();
+                activeSocket.set(socket);
+                try (socket;
+                        BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                                                                                         StandardCharsets.US_ASCII));
+                        Writer writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.US_ASCII)) {
+
+                    List<String> lines = new ArrayList<>();
+                    String line;
+                    while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                        lines.add(line);
+                    }
+                    String body = readBody(reader, lines);
+                    requestLines.complete(List.copyOf(lines));
+                    requestBody.complete(body);
+                    writer.write("HTTP/1.1 200 OK\r\n"
+                                         + "Content-Length: 5\r\n"
+                                         + "Connection: close\r\n"
+                                         + "\r\n"
+                                         + "http1");
+                    writer.flush();
+                } finally {
+                    activeSocket.compareAndSet(socket, null);
+                }
+            } catch (Throwable t) {
+                requestLines.completeExceptionally(t);
+                requestBody.completeExceptionally(t);
+            }
+        }
+
+        private static String readBody(BufferedReader reader, List<String> lines) throws Exception {
+            OptionalLong maybeContentLength = contentLength(lines);
+            if (maybeContentLength.isEmpty()) {
+                return "";
+            }
+            int length = Math.toIntExact(maybeContentLength.getAsLong());
+            char[] body = new char[length];
+            int offset = 0;
+            while (offset < length) {
+                int read = reader.read(body, offset, length - offset);
+                if (read == -1) {
+                    break;
+                }
+                offset += read;
+            }
+            return new String(body, 0, offset);
+        }
+
+        private static OptionalLong contentLength(List<String> lines) {
+            String prefix = HeaderNames.CONTENT_LENGTH.defaultCase().toLowerCase(Locale.ROOT) + ":";
+            for (String line : lines) {
+                String lowerCaseLine = line.toLowerCase(Locale.ROOT);
+                if (lowerCaseLine.startsWith(prefix)) {
+                    return OptionalLong.of(Long.parseLong(line.substring(prefix.length()).trim()));
+                }
+            }
+            return OptionalLong.empty();
+        }
+    }
+
+    private static final class NoAlpnHttp1TlsServer implements AutoCloseable {
+        private static final char[] PASSWORD = "password".toCharArray();
+
+        private final SSLServerSocket serverSocket;
+        private final CompletableFuture<List<String>> requestLines = new CompletableFuture<>();
+        private final CompletableFuture<String> requestBody = new CompletableFuture<>();
+        private final CompletableFuture<Void> clientSocketClosed = new CompletableFuture<>();
+        private final AtomicReference<SSLSocket> activeSocket = new AtomicReference<>();
+        private final int requestCount;
+        private final boolean closeConnection;
+        private final boolean closeAfterHandshake;
+
+        private NoAlpnHttp1TlsServer(SSLServerSocket serverSocket,
+                                     int requestCount,
+                                     boolean closeConnection,
+                                     boolean closeAfterHandshake) {
+            this.serverSocket = serverSocket;
+            this.requestCount = requestCount;
+            this.closeConnection = closeConnection;
+            this.closeAfterHandshake = closeAfterHandshake;
+            Thread.ofVirtual().start(this::serve);
+        }
+
+        static NoAlpnHttp1TlsServer start() throws Exception {
+            return start(new String[0]);
+        }
+
+        static NoAlpnHttp1TlsServer start(String... applicationProtocols) throws Exception {
+            return startRequests(1, applicationProtocols);
+        }
+
+        static NoAlpnHttp1TlsServer startRequests(int requestCount) throws Exception {
+            return startRequests(requestCount, new String[0]);
+        }
+
+        static NoAlpnHttp1TlsServer startRequests(int requestCount, String... applicationProtocols) throws Exception {
+            return startRequests(requestCount, true, applicationProtocols);
+        }
+
+        static NoAlpnHttp1TlsServer startKeepAlive() throws Exception {
+            return startRequests(1, false);
+        }
+
+        static NoAlpnHttp1TlsServer startCloseAfterHandshake(String... applicationProtocols) throws Exception {
+            return startRequests(1, true, true, applicationProtocols);
+        }
+
+        static NoAlpnHttp1TlsServer startRequests(int requestCount,
+                                                  boolean closeConnection,
+                                                  String... applicationProtocols) throws Exception {
+            return startRequests(requestCount, closeConnection, false, applicationProtocols);
+        }
+
+        static NoAlpnHttp1TlsServer startRequests(int requestCount,
+                                                  boolean closeConnection,
+                                                  boolean closeAfterHandshake,
+                                                  String... applicationProtocols) throws Exception {
+            KeyStore store = KeyStore.getInstance("PKCS12");
+            try (InputStream input = Http2ClientTest.class.getClassLoader().getResourceAsStream("server.p12")) {
+                store.load(Objects.requireNonNull(input, "server.p12"), PASSWORD);
+            }
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(store, PASSWORD);
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(keyManagerFactory.getKeyManagers(), null, null);
+            SSLServerSocket socket = (SSLServerSocket) context.getServerSocketFactory().createServerSocket(0);
+            SSLParameters sslParameters = socket.getSSLParameters();
+            sslParameters.setApplicationProtocols(applicationProtocols);
+            socket.setSSLParameters(sslParameters);
+            return new NoAlpnHttp1TlsServer(socket, requestCount, closeConnection, closeAfterHandshake);
+        }
+
+        int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        List<String> requestLines() throws Exception {
+            return requestLines.get(10, TimeUnit.SECONDS);
+        }
+
+        String requestBody() throws Exception {
+            return requestBody.get(10, TimeUnit.SECONDS);
+        }
+
+        void awaitClientSocketClosed() throws Exception {
+            clientSocketClosed.get(10, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() throws Exception {
+            SSLSocket socket = activeSocket.getAndSet(null);
+            if (socket != null) {
+                socket.close();
+            }
+            serverSocket.close();
+        }
+
+        private void serve() {
+            try {
+                int served = 0;
+                while (!serverSocket.isClosed() && served < requestCount) {
+                    SSLSocket socket = (SSLSocket) serverSocket.accept();
+                    activeSocket.set(socket);
+                    try (socket;
                             BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
                                                                                              StandardCharsets.US_ASCII));
                             Writer writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.US_ASCII)) {
 
                         socket.startHandshake();
+                        if (closeAfterHandshake) {
+                            return;
+                        }
                         List<String> lines = new ArrayList<>();
                         String line;
                         while ((line = reader.readLine()) != null && !line.isEmpty()) {
@@ -451,19 +951,67 @@ class Http2ClientTest {
                         if (lines.isEmpty()) {
                             continue;
                         }
+                        String body = readBody(reader, lines);
                         requestLines.complete(List.copyOf(lines));
+                        requestBody.complete(body);
+                        served++;
                         writer.write("HTTP/1.1 200 OK\r\n"
                                              + "Content-Length: 5\r\n"
-                                             + "Connection: close\r\n"
+                                             + (closeConnection ? "Connection: close\r\n" : "")
                                              + "\r\n"
                                              + "http1");
                         writer.flush();
-                        return;
+                        if (!closeConnection) {
+                            waitForClientClose(reader);
+                        }
+                    } finally {
+                        activeSocket.compareAndSet(socket, null);
                     }
                 }
             } catch (Throwable t) {
                 requestLines.completeExceptionally(t);
+                requestBody.completeExceptionally(t);
             }
+        }
+
+        private void waitForClientClose(BufferedReader reader) {
+            try {
+                while (reader.read() != -1) {
+                    // wait for EOF
+                }
+                clientSocketClosed.complete(null);
+            } catch (Exception e) {
+                clientSocketClosed.complete(null);
+            }
+        }
+
+        private static String readBody(BufferedReader reader, List<String> lines) throws Exception {
+            OptionalLong maybeContentLength = contentLength(lines);
+            if (maybeContentLength.isEmpty()) {
+                return "";
+            }
+            int length = Math.toIntExact(maybeContentLength.getAsLong());
+            char[] body = new char[length];
+            int offset = 0;
+            while (offset < length) {
+                int read = reader.read(body, offset, length - offset);
+                if (read == -1) {
+                    break;
+                }
+                offset += read;
+            }
+            return new String(body, 0, offset);
+        }
+
+        private static OptionalLong contentLength(List<String> lines) {
+            String prefix = HeaderNames.CONTENT_LENGTH.defaultCase().toLowerCase(Locale.ROOT) + ":";
+            for (String line : lines) {
+                String lowerCaseLine = line.toLowerCase(Locale.ROOT);
+                if (lowerCaseLine.startsWith(prefix)) {
+                    return OptionalLong.of(Long.parseLong(line.substring(prefix.length()).trim()));
+                }
+            }
+            return OptionalLong.empty();
         }
     }
 }

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2ClientTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2ClientTest.java
@@ -257,11 +257,13 @@ class Http2ClientTest {
     @Test
     void testFailedH2cUpgradeWithoutEntityCompletesWhenSent() throws Exception {
         PlainHttp1Server server = PlainHttp1Server.start();
+        AtomicInteger serviceInvocations = new AtomicInteger();
         AtomicReference<CompletableFuture<WebClientServiceRequest>> whenSent = new AtomicReference<>();
         Http2Client client = Http2Client.builder()
                 .baseUri("http://localhost:" + server.port() + "/")
                 .shareConnectionCache(false)
                 .addService((chain, request) -> {
+                    serviceInvocations.incrementAndGet();
                     whenSent.set(request.whenSent().toCompletableFuture());
                     return chain.proceed(request);
                 })
@@ -272,6 +274,7 @@ class Http2ClientTest {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.as(String.class), is("http1"));
             assertThat(whenSent.get().get(10, TimeUnit.SECONDS).method(), is(Method.GET));
+            assertThat(serviceInvocations.get(), is(1));
 
             List<String> requestLines = server.requestLines();
             assertThat(requestLines.getFirst(), is("GET / HTTP/1.1"));

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/SniTlsTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/SniTlsTest.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.tests;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.webclient.api.SniMode;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class SniTlsTest {
+    private static final String MESSAGE = "SNI works";
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    @Test
+    void explicitSniReachesTlsServer() throws Exception {
+        CapturedExchange exchange = exchange(clientTls(), client -> client.get()
+                .keepAlive(false)
+                .sni(it -> it.mode(SniMode.EXPLICIT).host("explicit.example"))
+                .requestEntity(String.class));
+
+        assertThat(exchange.response(), is(MESSAGE));
+        assertThat(exchange.serverNames(), is(List.of("explicit.example")));
+    }
+
+    @Test
+    void requestSniOverridesClientSni() throws Exception {
+        CapturedExchange exchange = exchange(clientTls(),
+                                             builder -> builder.sni(it -> it.mode(SniMode.EXPLICIT).host("client.example")),
+                                             client -> client.get()
+                                                     .keepAlive(false)
+                                                     .sni(it -> it.mode(SniMode.EXPLICIT).host("request.example"))
+                                                     .requestEntity(String.class));
+
+        assertThat(exchange.response(), is(MESSAGE));
+        assertThat(exchange.serverNames(), is(List.of("request.example")));
+    }
+
+    @Test
+    void noFirstClassSniPreservesRawTlsServerNames() throws Exception {
+        CapturedExchange exchange = exchange(clientTlsWithRawSni(), client -> client.get()
+                .keepAlive(false)
+                .requestEntity(String.class));
+
+        assertThat(exchange.response(), is(MESSAGE));
+        assertThat(exchange.serverNames(), is(List.of("explicit.example")));
+    }
+
+    @Test
+    void disabledSniClearsRawTlsServerNames() throws Exception {
+        CapturedExchange exchange = exchange(clientTlsWithRawSni(), client -> client.get()
+                .keepAlive(false)
+                .sni(it -> it.mode(SniMode.DISABLED))
+                .requestEntity(String.class));
+
+        assertThat(exchange.response(), is(MESSAGE));
+        assertThat(exchange.serverNames(), is(List.of()));
+    }
+
+    @Test
+    void hostHeaderSniReachesHttp1TlsServer() throws Exception {
+        CapturedExchange exchange = exchange(clientTls(), client -> client.get()
+                .keepAlive(false)
+                .header(HeaderValues.create(HeaderNames.HOST, "host-header.example"))
+                .sni(it -> it.mode(SniMode.HOST_HEADER))
+                .requestEntity(String.class));
+
+        assertThat(exchange.response(), is(MESSAGE));
+        assertThat(exchange.serverNames(), is(List.of("host-header.example")));
+    }
+
+    @Test
+    void hostHeaderSniSeparatesHttp1ConnectionCache() throws Exception {
+        try (KeepAliveTlsServer server = KeepAliveTlsServer.start(2)) {
+            Http1Client client = Http1Client.builder()
+                    .baseUri("https://localhost:" + server.port())
+                    .tls(clientTls())
+                    .build();
+            try {
+                String firstResponse = client.get()
+                        .header(HeaderValues.create(HeaderNames.HOST, "first.example"))
+                        .sni(it -> it.mode(SniMode.HOST_HEADER))
+                        .requestEntity(String.class);
+                String secondResponse = client.get()
+                        .header(HeaderValues.create(HeaderNames.HOST, "second.example"))
+                        .sni(it -> it.mode(SniMode.HOST_HEADER))
+                        .requestEntity(String.class);
+
+                CapturedConnections connections = server.awaitConnections();
+                assertThat(firstResponse, is(MESSAGE));
+                assertThat(secondResponse, is(MESSAGE));
+                assertThat(connections.serverNames(), is(List.of(List.of("first.example"), List.of("second.example"))));
+            } finally {
+                client.closeResource();
+            }
+        }
+    }
+
+    private static CapturedExchange exchange(Tls clientTls, RequestInvoker requestInvoker) throws Exception {
+        return exchange(clientTls, builder -> { }, requestInvoker);
+    }
+
+    private static CapturedExchange exchange(Tls clientTls,
+                                             Consumer<Http1ClientConfig.Builder> clientCustomizer,
+                                             RequestInvoker requestInvoker) throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (SSLServerSocket server = serverSocket()) {
+            server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            CompletableFuture<List<String>> serverNames = CompletableFuture.supplyAsync(() -> handleRequest(server), executor);
+            Http1ClientConfig.Builder builder = Http1Client.builder()
+                    .baseUri("https://localhost:" + server.getLocalPort())
+                    .tls(clientTls);
+            clientCustomizer.accept(builder);
+            Http1Client client = builder.build();
+            try {
+                String response = requestInvoker.invoke(client);
+                return new CapturedExchange(response, serverNames.get(TIMEOUT.toSeconds(), TimeUnit.SECONDS));
+            } finally {
+                client.closeResource();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static SSLServerSocket serverSocket() {
+        return serverTls().createServerSocket();
+    }
+
+    private static List<String> handleRequest(SSLServerSocket server) {
+        try (SSLSocket socket = (SSLSocket) server.accept()) {
+            socket.startHandshake();
+            List<String> serverNames = requestedServerNames(socket);
+
+            readHeaders(socket);
+            byte[] entity = MESSAGE.getBytes(StandardCharsets.UTF_8);
+            socket.getOutputStream()
+                    .write(("HTTP/1.1 200 OK\r\n"
+                            + "Content-Length: " + entity.length + "\r\n"
+                            + "Connection: close\r\n\r\n")
+                                   .getBytes(StandardCharsets.US_ASCII));
+            socket.getOutputStream().write(entity);
+            socket.getOutputStream().flush();
+            return serverNames;
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void readHeaders(SSLSocket socket) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+        readHeaders(reader);
+    }
+
+    private static boolean readHeaders(BufferedReader reader) throws IOException {
+        String line;
+        boolean foundRequest = false;
+        while ((line = reader.readLine()) != null && !line.isEmpty()) {
+            // consume request headers
+            foundRequest = true;
+        }
+        return foundRequest;
+    }
+
+    private static List<String> requestedServerNames(SSLSocket socket) {
+        SSLSession session = socket.getSession();
+        if (session instanceof ExtendedSSLSession extended) {
+            return extended.getRequestedServerNames()
+                    .stream()
+                    .map(SniTlsTest::serverName)
+                    .toList();
+        }
+        return List.of();
+    }
+
+    private static String serverName(SNIServerName serverName) {
+        if (serverName instanceof SNIHostName hostName) {
+            return hostName.getAsciiName();
+        }
+        return serverName.toString();
+    }
+
+    private static Tls serverTls() {
+        return Tls.builder()
+                .privateKey(key -> key
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .keystore(Resource.create("server.p12"))))
+                .privateKeyCertChain(key -> key
+                        .keystore(store -> store
+                                .trustStore(true)
+                                .passphrase("password")
+                                .keystore(Resource.create("server.p12"))))
+                .build();
+    }
+
+    private static Tls clientTls() {
+        return Tls.builder()
+                .endpointIdentificationAlgorithm(Tls.ENDPOINT_IDENTIFICATION_NONE)
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+    }
+
+    private static Tls clientTlsWithRawSni() {
+        SSLParameters parameters = new SSLParameters();
+        parameters.setEndpointIdentificationAlgorithm("");
+        parameters.setServerNames(List.of(new SNIHostName("explicit.example")));
+
+        return Tls.builder()
+                .sslParameters(parameters)
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+    }
+
+    private interface RequestInvoker {
+        String invoke(Http1Client client);
+    }
+
+    private record CapturedExchange(String response, List<String> serverNames) {
+    }
+
+    private record CapturedConnections(List<List<String>> serverNames) {
+    }
+
+    private static final class KeepAliveTlsServer implements AutoCloseable {
+        private final SSLServerSocket server;
+        private final int expectedRequestCount;
+        private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        private final AtomicInteger requestCount = new AtomicInteger();
+        private final List<List<String>> serverNames = new CopyOnWriteArrayList<>();
+        private final List<SSLSocket> sockets = new CopyOnWriteArrayList<>();
+        private final CompletableFuture<CapturedConnections> captured = new CompletableFuture<>();
+
+        private KeepAliveTlsServer(SSLServerSocket server, int expectedRequestCount) {
+            this.server = server;
+            this.expectedRequestCount = expectedRequestCount;
+            executor.submit(this::accept);
+        }
+
+        static KeepAliveTlsServer start(int expectedRequestCount) throws IOException {
+            SSLServerSocket server = serverSocket();
+            server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            return new KeepAliveTlsServer(server, expectedRequestCount);
+        }
+
+        int port() {
+            return server.getLocalPort();
+        }
+
+        CapturedConnections awaitConnections() throws Exception {
+            return captured.get(TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() throws Exception {
+            server.close();
+            for (SSLSocket socket : sockets) {
+                socket.close();
+            }
+            executor.shutdownNow();
+        }
+
+        private void accept() {
+            try {
+                while (!captured.isDone()) {
+                    SSLSocket socket = (SSLSocket) server.accept();
+                    sockets.add(socket);
+                    executor.submit(() -> handle(socket));
+                }
+            } catch (SocketException e) {
+                if (!captured.isDone()) {
+                    captured.completeExceptionally(e);
+                }
+            } catch (IOException e) {
+                captured.completeExceptionally(e);
+            }
+        }
+
+        private void handle(SSLSocket socket) {
+            try (SSLSocket accepted = socket;
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(accepted.getInputStream(),
+                                                                                     StandardCharsets.US_ASCII));
+                    OutputStream output = accepted.getOutputStream()) {
+
+                accepted.startHandshake();
+                serverNames.add(requestedServerNames(accepted));
+                while (!captured.isDone() && readHeaders(reader)) {
+                    int currentCount = requestCount.incrementAndGet();
+                    boolean lastResponse = currentCount >= expectedRequestCount;
+                    writeResponse(output, lastResponse);
+                    if (lastResponse) {
+                        captured.complete(new CapturedConnections(List.copyOf(serverNames)));
+                    }
+                }
+            } catch (Throwable t) {
+                captured.completeExceptionally(t);
+            }
+        }
+
+        private void writeResponse(OutputStream output, boolean close) throws IOException {
+            byte[] entity = MESSAGE.getBytes(StandardCharsets.UTF_8);
+            output.write(("HTTP/1.1 200 OK\r\n"
+                    + "Content-Length: " + entity.length + "\r\n"
+                    + "Connection: " + (close ? "close" : "keep-alive") + "\r\n\r\n")
+                                 .getBytes(StandardCharsets.US_ASCII));
+            output.write(entity);
+            output.flush();
+        }
+    }
+}


### PR DESCRIPTION
Part of #6183
Resolves #12055
Resolves #4294

Adds WebClient SNI configuration and routes effective TLS peer host selection through WebClient, HTTP/1, HTTP/2, gRPC, and JSON-RPC clients. The change also isolates connection caches by effective TLS identity, preserves HTTP/2 fallback lifecycle behavior, documents the shared configuration, and adds focused regression and benchmark coverage.
