### PR TITLE
Fix FT config bootstrap metrics lookup

### DIFF
--- a/docs/src/main/asciidoc/se/injection/injection.adoc
+++ b/docs/src/main/asciidoc/se/injection/injection.adoc
@@ -787,6 +787,7 @@ Registry methods:
 - `T get(...)` - immediately get an instance of a contract from the registry; throws if implementation not available
 - `Optional<T> first(...)` - immediately get an instance of a contract from the registry; there may not be an implementation
 available
+- `Optional<T> firstActive(...)` - get an already active instance of a contract from the registry, if one is available
 - `List<T> all(...)` - immediately get all instances of a contract from the registry; result may be empty
 - `Supplier<T> supply(...)` - get a supplier of an instance; the service may be instantiated only when `get` is called
 - `Supplier<Optional<T>> supplyFirst(...)` - get a supplier of an optional instance

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -16,6 +16,7 @@
 package io.helidon.faulttolerance;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
@@ -27,7 +28,8 @@ import io.helidon.metrics.api.Metrics;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
-import io.helidon.service.registry.Services;
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.ServiceRegistry;
 
 import static io.helidon.faulttolerance.FaultTolerance.FT_METRICS_DEFAULT_ENABLED;
 import static io.helidon.metrics.api.Meter.Scope.VENDOR;
@@ -48,9 +50,10 @@ class MetricsUtils {
      * @return value of metrics flag
      */
     static boolean defaultEnabled() {
-        return Services.get(Config.class)
-                .get(FT_METRICS_DEFAULT_ENABLED)
-                .asBoolean()
+        return maybeExistingConfig()
+                .map(config -> config.get(FT_METRICS_DEFAULT_ENABLED)
+                        .asBoolean()
+                        .orElse(false))
                 .orElse(false);
     }
 
@@ -88,5 +91,14 @@ class MetricsUtils {
 
     static Timer timer(String name, Tag... tags) {
         return METRICS_REGISTRY.get().timer(name, List.of(tags)).orElseThrow();
+    }
+
+    private static Optional<Config> maybeExistingConfig() {
+        if (!GlobalServiceRegistry.configured()) {
+            return Optional.empty();
+        }
+
+        ServiceRegistry registry = GlobalServiceRegistry.registry();
+        return registry.firstActive(Config.class);
     }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -16,7 +16,6 @@
 package io.helidon.faulttolerance;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
@@ -50,10 +49,13 @@ class MetricsUtils {
      * @return value of metrics flag
      */
     static boolean defaultEnabled() {
-        return maybeExistingConfig()
-                .map(config -> config.get(FT_METRICS_DEFAULT_ENABLED)
-                        .asBoolean()
-                        .orElse(false))
+        ServiceRegistry registry = GlobalServiceRegistry.registry();
+        if (registry.isResolvingOnCurrentThread(Config.class)) {
+            return false;
+        }
+        return registry.get(Config.class)
+                .get(FT_METRICS_DEFAULT_ENABLED)
+                .asBoolean()
                 .orElse(false);
     }
 
@@ -93,12 +95,4 @@ class MetricsUtils {
         return METRICS_REGISTRY.get().timer(name, List.of(tags)).orElseThrow();
     }
 
-    private static Optional<Config> maybeExistingConfig() {
-        if (!GlobalServiceRegistry.configured()) {
-            return Optional.empty();
-        }
-
-        ServiceRegistry registry = GlobalServiceRegistry.registry();
-        return registry.firstActive(Config.class);
-    }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -16,6 +16,7 @@
 package io.helidon.faulttolerance;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
@@ -49,13 +50,10 @@ class MetricsUtils {
      * @return value of metrics flag
      */
     static boolean defaultEnabled() {
-        ServiceRegistry registry = GlobalServiceRegistry.registry();
-        if (registry.isResolvingOnCurrentThread(Config.class)) {
-            return false;
-        }
-        return registry.get(Config.class)
-                .get(FT_METRICS_DEFAULT_ENABLED)
-                .asBoolean()
+        return maybeExistingConfig()
+                .map(config -> config.get(FT_METRICS_DEFAULT_ENABLED)
+                        .asBoolean()
+                        .orElse(false))
                 .orElse(false);
     }
 
@@ -95,4 +93,12 @@ class MetricsUtils {
         return METRICS_REGISTRY.get().timer(name, List.of(tags)).orElseThrow();
     }
 
+    private static Optional<Config> maybeExistingConfig() {
+        if (!GlobalServiceRegistry.configured()) {
+            return Optional.empty();
+        }
+
+        ServiceRegistry registry = GlobalServiceRegistry.registry();
+        return registry.firstActive(Config.class);
+    }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -16,7 +16,6 @@
 package io.helidon.faulttolerance;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
@@ -29,7 +28,6 @@ import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.GlobalServiceRegistry;
-import io.helidon.service.registry.ServiceRegistry;
 
 import static io.helidon.faulttolerance.FaultTolerance.FT_METRICS_DEFAULT_ENABLED;
 import static io.helidon.metrics.api.Meter.Scope.VENDOR;
@@ -50,7 +48,12 @@ class MetricsUtils {
      * @return value of metrics flag
      */
     static boolean defaultEnabled() {
-        return maybeExistingConfig()
+        if (!GlobalServiceRegistry.configured()) {
+            return false;
+        }
+
+        return GlobalServiceRegistry.registry()
+                .firstActive(Config.class)
                 .map(config -> config.get(FT_METRICS_DEFAULT_ENABLED)
                         .asBoolean()
                         .orElse(false))
@@ -93,12 +96,4 @@ class MetricsUtils {
         return METRICS_REGISTRY.get().timer(name, List.of(tags)).orElseThrow();
     }
 
-    private static Optional<Config> maybeExistingConfig() {
-        if (!GlobalServiceRegistry.configured()) {
-            return Optional.empty();
-        }
-
-        ServiceRegistry registry = GlobalServiceRegistry.registry();
-        return registry.firstActive(Config.class);
-    }
 }

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/BulkheadMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/BulkheadMetricsTest.java
@@ -29,6 +29,7 @@ import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 import io.helidon.testing.junit5.Testing;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.faulttolerance.Bulkhead.FT_BULKHEAD_CALLS_TOTAL;
@@ -45,6 +46,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Testing.Test
 class BulkheadMetricsTest extends BulkheadBaseTest {
+    @BeforeAll
+    static void activateConfig() {
+        MetricsTestSupport.activateConfig();
+    }
 
     @Test
     void testBulkhead() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Tag;
 import io.helidon.testing.junit5.Testing;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.faulttolerance.CircuitBreaker.FT_CIRCUITBREAKER_CALLS_TOTAL;
@@ -31,6 +32,10 @@ import static org.hamcrest.Matchers.is;
 
 @Testing.Test
 class CircuitBreakerMetricsTest extends CircuitBreakerBaseTest {
+    @BeforeAll
+    static void activateConfig() {
+        MetricsTestSupport.activateConfig();
+    }
 
     @Test
     void testCircuitBreaker() {

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsExplicitConfigTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsExplicitConfigTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Tag;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.faulttolerance.FaultTolerance.FT_METRICS_DEFAULT_ENABLED;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Testing.Test
+class MetricsExplicitConfigTest {
+    @BeforeAll
+    static void setupTest() {
+        Services.set(Config.class,
+                     Config.just(ConfigSources.create(Map.of(FT_METRICS_DEFAULT_ENABLED, "true"))));
+    }
+
+    @Test
+    void testGlobalMetricsEnabledFromSetConfig() {
+        Retry retry = Retry.builder()
+                .name("explicit-config")
+                .build();
+
+        retry.invoke(() -> 0);
+
+        Counter callsCounter = MetricsUtils.counter(Retry.FT_RETRY_CALLS_TOTAL, Tag.create("name", retry.name()));
+        assertThat(callsCounter.count(), is(1L));
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsLazyConfigTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsLazyConfigTest.java
@@ -16,8 +16,9 @@
 
 package io.helidon.faulttolerance;
 
-import io.helidon.metrics.api.Counter;
-import io.helidon.metrics.api.Tag;
+import io.helidon.config.Config;
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.testing.junit5.Testing;
 
 import org.junit.jupiter.api.Test;
@@ -28,14 +29,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Testing.Test
 class MetricsLazyConfigTest {
     @Test
-    void testGlobalMetricsEnabledBeforeConfigActivation() {
+    void testGlobalMetricsDoNotActivateConfig() {
+        ServiceRegistry registry = GlobalServiceRegistry.registry();
+        assertThat(registry.firstActive(Config.class).isEmpty(), is(true));
+
         Retry retry = Retry.builder()
-                .name("lazy-config")
+                .name("inactive-config")
                 .build();
 
         retry.invoke(() -> 0);
 
-        Counter callsCounter = MetricsUtils.counter(Retry.FT_RETRY_CALLS_TOTAL, Tag.create("name", retry.name()));
-        assertThat(callsCounter.count(), is(1L));
+        assertThat(registry.firstActive(Config.class).isEmpty(), is(true));
     }
 }

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsLazyConfigTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsLazyConfigTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Tag;
+import io.helidon.testing.junit5.Testing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Testing.Test
+class MetricsLazyConfigTest {
+    @Test
+    void testGlobalMetricsEnabledBeforeConfigActivation() {
+        Retry retry = Retry.builder()
+                .name("lazy-config")
+                .build();
+
+        retry.invoke(() -> 0);
+
+        Counter callsCounter = MetricsUtils.counter(Retry.FT_RETRY_CALLS_TOTAL, Tag.create("name", retry.name()));
+        assertThat(callsCounter.count(), is(1L));
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsTestSupport.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsTestSupport.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import io.helidon.config.Config;
+import io.helidon.service.registry.Services;
+
+final class MetricsTestSupport {
+    private MetricsTestSupport() {
+    }
+
+    static void activateConfig() {
+        Services.get(Config.class);
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryMetricsTest.java
@@ -24,6 +24,7 @@ import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Tag;
 import io.helidon.testing.junit5.Testing;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -31,6 +32,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Testing.Test
 class RetryMetricsTest {
+    @BeforeAll
+    static void activateConfig() {
+        MetricsTestSupport.activateConfig();
+    }
 
     @Test
     void testRetry() {

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 import io.helidon.testing.junit5.Testing;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -30,6 +31,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Testing.Test
 class TimeoutMetricsTest {
+    @BeforeAll
+    static void activateConfig() {
+        MetricsTestSupport.activateConfig();
+    }
+
     @Test
     void testTimeout() {
         Timeout timeout;

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -53,6 +53,10 @@ import static java.util.function.Predicate.not;
  */
 @SuppressWarnings("checkstyle:VisibilityModifier") // as long as all are inner classes, this is OK
 final class Activators {
+    private static final ActivationRequest ACTIVE_REQUEST = ActivationRequest.builder()
+            .targetPhase(ActivationPhase.ACTIVE)
+            .build();
+
     private Activators() {
     }
 
@@ -70,6 +74,12 @@ final class Activators {
             case INJECTION_POINT -> new Activators.FixedIpFactoryActivator<>(provider, (InjectionPointFactory<T>) instance);
             case QUALIFIED -> new Activators.FixedQualifiedFactoryActivator<>(provider, (QualifiedFactory<T, ?>) instance);
         };
+    }
+
+    static <T> Activator<T> createActive(ServiceProvider<T> provider, T instance) {
+        Activator<T> activator = create(provider, instance);
+        activator.activate(ACTIVE_REQUEST);
+        return activator;
     }
 
     static <T> Supplier<Activator<T>> create(CoreServiceRegistry registry, ServiceProvider<T> provider) {

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
@@ -55,8 +56,84 @@ final class Activators {
     private static final ActivationRequest ACTIVE_REQUEST = ActivationRequest.builder()
             .targetPhase(ActivationPhase.ACTIVE)
             .build();
+    private static final ThreadLocal<Object> RESOLVING_SERVICE = new ThreadLocal<>();
 
     private Activators() {
+    }
+
+    static boolean isResolvingOnCurrentThread(ActivationRequest activationRequest, TypeName contract) {
+        Object resolvingService = RESOLVING_SERVICE.get();
+        if (resolvingService == null) {
+            return false;
+        }
+
+        Lookup lookup = Lookup.create(contract);
+        if (resolvingService instanceof BaseActivator<?> activator) {
+            return matches(activator, activationRequest, lookup);
+        }
+
+        @SuppressWarnings("unchecked")
+        List<BaseActivator<?>> nestedActivators = (List<BaseActivator<?>>) resolvingService;
+        for (BaseActivator<?> activator : nestedActivators) {
+            if (matches(activator, activationRequest, lookup)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matches(BaseActivator<?> activator,
+                                   ActivationRequest activationRequest,
+                                   Lookup lookup) {
+        ServiceProvider<?> provider = activator.provider;
+        return provider.activationRequest() == activationRequest && lookup.matches(provider.descriptor());
+    }
+
+    private static boolean startResolving(BaseActivator<?> activator) {
+        Object resolvingService = RESOLVING_SERVICE.get();
+        if (resolvingService == null) {
+            RESOLVING_SERVICE.set(activator);
+            return true;
+        }
+
+        if (resolvingService == activator) {
+            return false;
+        }
+
+        if (resolvingService instanceof BaseActivator<?> currentActivator) {
+            List<BaseActivator<?>> nestedActivators = new ArrayList<>();
+            nestedActivators.add(currentActivator);
+            nestedActivators.add(activator);
+            RESOLVING_SERVICE.set(nestedActivators);
+            return true;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<BaseActivator<?>> nestedActivators = (List<BaseActivator<?>>) resolvingService;
+        if (nestedActivators.contains(activator)) {
+            return false;
+        }
+        nestedActivators.add(activator);
+        return true;
+    }
+
+    private static void finishResolving(boolean startedResolving) {
+        if (!startedResolving) {
+            return;
+        }
+
+        Object resolvingService = RESOLVING_SERVICE.get();
+        if (resolvingService instanceof BaseActivator<?>) {
+            RESOLVING_SERVICE.remove();
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<BaseActivator<?>> nestedActivators = (List<BaseActivator<?>>) resolvingService;
+        nestedActivators.removeLast();
+        if (nestedActivators.size() == 1) {
+            RESOLVING_SERVICE.set(nestedActivators.getFirst());
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -162,7 +239,7 @@ final class Activators {
         final ServiceProvider<T> provider;
         final DependencyContext dependencyContext;
 
-        private final ReentrantReadWriteLock instanceLock = new ReentrantReadWriteLock();
+        private final ReadWriteLock instanceLock = new ReentrantReadWriteLock();
 
         volatile ActivationPhase currentPhase = ActivationPhase.INIT;
 
@@ -182,26 +259,31 @@ final class Activators {
             As this type represents a value within a scope, and not "instance per call", we can safely
             store the result, unless it is lookup bound
              */
-            instanceLock.readLock().lock();
+            boolean startedResolving = startResolving(this);
             try {
-                if (currentPhase == ActivationPhase.ACTIVE) {
-                    return targetInstances(lookup);
-                }
-            } finally {
-                instanceLock.readLock().unlock();
-            }
-
-            instanceLock.writeLock().lock();
-            try {
-                if (currentPhase != ActivationPhase.ACTIVE) {
-                    ActivationResult res = activate(provider.activationRequest());
-                    if (res.failure()) {
-                        return Optional.empty();
+                instanceLock.readLock().lock();
+                try {
+                    if (currentPhase == ActivationPhase.ACTIVE) {
+                        return targetInstances(lookup);
                     }
+                } finally {
+                    instanceLock.readLock().unlock();
                 }
-                return targetInstances(lookup);
+
+                instanceLock.writeLock().lock();
+                try {
+                    if (currentPhase != ActivationPhase.ACTIVE) {
+                        ActivationResult res = activate(provider.activationRequest());
+                        if (res.failure()) {
+                            return Optional.empty();
+                        }
+                    }
+                    return targetInstances(lookup);
+                } finally {
+                    instanceLock.writeLock().unlock();
+                }
             } finally {
-                instanceLock.writeLock().unlock();
+                finishResolving(startedResolving);
             }
         }
 
@@ -218,30 +300,35 @@ final class Activators {
 
         @Override
         public ActivationResult activate(ActivationRequest request) {
-            // probably re-entering the same lock
-            instanceLock.writeLock().lock();
+            boolean startedResolving = startResolving(this);
             try {
-                if (currentPhase == request.targetPhase()) {
-                    // we are already there, just return success
-                    return ActivationResult.builder()
-                            .startingActivationPhase(currentPhase)
-                            .finishingActivationPhase(currentPhase)
-                            .targetActivationPhase(currentPhase)
-                            .success(true)
-                            .build();
+                // probably re-entering the same lock
+                instanceLock.writeLock().lock();
+                try {
+                    if (currentPhase == request.targetPhase()) {
+                        // we are already there, just return success
+                        return ActivationResult.builder()
+                                .startingActivationPhase(currentPhase)
+                                .finishingActivationPhase(currentPhase)
+                                .targetActivationPhase(currentPhase)
+                                .success(true)
+                                .build();
+                    }
+                    if (currentPhase.ordinal() > request.targetPhase().ordinal()) {
+                        // we are already ahead, this is a problem
+                        return ActivationResult.builder()
+                                .startingActivationPhase(currentPhase)
+                                .finishingActivationPhase(currentPhase)
+                                .targetActivationPhase(request.targetPhase())
+                                .success(false)
+                                .build();
+                    }
+                    return doActivate(request);
+                } finally {
+                    instanceLock.writeLock().unlock();
                 }
-                if (currentPhase.ordinal() > request.targetPhase().ordinal()) {
-                    // we are already ahead, this is a problem
-                    return ActivationResult.builder()
-                            .startingActivationPhase(currentPhase)
-                            .finishingActivationPhase(currentPhase)
-                            .targetActivationPhase(request.targetPhase())
-                            .success(false)
-                            .build();
-                }
-                return doActivate(request);
             } finally {
-                instanceLock.writeLock().unlock();
+                finishResolving(startedResolving);
             }
         }
 
@@ -294,10 +381,6 @@ final class Activators {
         @Override
         public ActivationPhase phase() {
             return currentPhase;
-        }
-
-        boolean isResolvingOnCurrentThread() {
-            return instanceLock.isWriteLockedByCurrentThread() || instanceLock.getReadHoldCount() > 0;
         }
 
         @Override

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -734,6 +734,11 @@ final class Activators {
         }
 
         @Override
+        boolean activeInstancesAvailable(Lookup lookup) {
+            return requestedProvider(lookup, FactoryType.QUALIFIED);
+        }
+
+        @Override
         void setTargetInstances() {
             // target instances cannot be created, they are resolved on each lookup
         }
@@ -786,6 +791,11 @@ final class Activators {
     static class IpFactoryActivator<T> extends SingleServiceActivator<T> {
         IpFactoryActivator(ServiceProvider<T> provider, DependencyContext dependencyContext) {
             super(provider, dependencyContext);
+        }
+
+        @Override
+        boolean activeInstancesAvailable(Lookup lookup) {
+            return requestedProvider(lookup, FactoryType.INJECTION_POINT);
         }
 
         @Override

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -383,6 +383,10 @@ final class Activators {
             return currentPhase;
         }
 
+        boolean activeInstancesAvailable(Lookup lookup) {
+            return true;
+        }
+
         @Override
         public String toString() {
             return getClass().getSimpleName() + " for " + provider;
@@ -529,6 +533,7 @@ final class Activators {
             });
         }
 
+        @Override
         boolean activeInstancesAvailable(Lookup lookup) {
             return requestedProvider(lookup, FactoryType.SUPPLIER) || instances.isLoaded();
         }
@@ -560,10 +565,30 @@ final class Activators {
     }
 
     static class FixedServicesFactoryActivator<T> extends ServicesFactoryActivator<T> {
+        private final LazyValue<Optional<List<QualifiedInstance<T>>>> instances;
+
         FixedServicesFactoryActivator(ServiceProvider<T> provider,
                                       Service.ServicesFactory<T> factory) {
             super(provider, null);
             serviceInstance = InstanceHolder.create(factory);
+            instances = LazyValue.create(() -> Optional.ofNullable(factory.services()));
+        }
+
+        @Override
+        boolean activeInstancesAvailable(Lookup lookup) {
+            return requestedProvider(lookup, FactoryType.SERVICES) || instances.isLoaded();
+        }
+
+        @Override
+        void setTargetInstances() {
+        }
+
+        @Override
+        Optional<List<QualifiedInstance<T>>> targetInstances(Lookup lookup) {
+            if (requestedProvider(lookup, FactoryType.SERVICES)) {
+                return super.targetInstances(lookup);
+            }
+            return instances.get().flatMap(it -> matchingInstances(lookup, it));
         }
     }
 
@@ -821,12 +846,17 @@ final class Activators {
                 return Optional.of(List.of(QualifiedInstance.create(serviceInstance.get(), descriptor().qualifiers())));
             }
 
-            if (targetInstances == null) {
+            return matchingInstances(lookup, targetInstances);
+        }
+
+        Optional<List<QualifiedInstance<T>>> matchingInstances(Lookup lookup,
+                                                                List<QualifiedInstance<T>> instances) {
+            if (instances == null) {
                 return Optional.empty();
             }
 
             List<QualifiedInstance<T>> response = new ArrayList<>();
-            for (QualifiedInstance<T> instance : targetInstances) {
+            for (QualifiedInstance<T> instance : instances) {
                 if (lookup.matchesQualifiers(instance.qualifiers())) {
                     response.add(instance);
                 }

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -56,84 +56,8 @@ final class Activators {
     private static final ActivationRequest ACTIVE_REQUEST = ActivationRequest.builder()
             .targetPhase(ActivationPhase.ACTIVE)
             .build();
-    private static final ThreadLocal<Object> RESOLVING_SERVICE = new ThreadLocal<>();
 
     private Activators() {
-    }
-
-    static boolean isResolvingOnCurrentThread(ActivationRequest activationRequest, TypeName contract) {
-        Object resolvingService = RESOLVING_SERVICE.get();
-        if (resolvingService == null) {
-            return false;
-        }
-
-        Lookup lookup = Lookup.create(contract);
-        if (resolvingService instanceof BaseActivator<?> activator) {
-            return matches(activator, activationRequest, lookup);
-        }
-
-        @SuppressWarnings("unchecked")
-        List<BaseActivator<?>> nestedActivators = (List<BaseActivator<?>>) resolvingService;
-        for (BaseActivator<?> activator : nestedActivators) {
-            if (matches(activator, activationRequest, lookup)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean matches(BaseActivator<?> activator,
-                                   ActivationRequest activationRequest,
-                                   Lookup lookup) {
-        ServiceProvider<?> provider = activator.provider;
-        return provider.activationRequest() == activationRequest && lookup.matches(provider.descriptor());
-    }
-
-    private static boolean startResolving(BaseActivator<?> activator) {
-        Object resolvingService = RESOLVING_SERVICE.get();
-        if (resolvingService == null) {
-            RESOLVING_SERVICE.set(activator);
-            return true;
-        }
-
-        if (resolvingService == activator) {
-            return false;
-        }
-
-        if (resolvingService instanceof BaseActivator<?> currentActivator) {
-            List<BaseActivator<?>> nestedActivators = new ArrayList<>();
-            nestedActivators.add(currentActivator);
-            nestedActivators.add(activator);
-            RESOLVING_SERVICE.set(nestedActivators);
-            return true;
-        }
-
-        @SuppressWarnings("unchecked")
-        List<BaseActivator<?>> nestedActivators = (List<BaseActivator<?>>) resolvingService;
-        if (nestedActivators.contains(activator)) {
-            return false;
-        }
-        nestedActivators.add(activator);
-        return true;
-    }
-
-    private static void finishResolving(boolean startedResolving) {
-        if (!startedResolving) {
-            return;
-        }
-
-        Object resolvingService = RESOLVING_SERVICE.get();
-        if (resolvingService instanceof BaseActivator<?>) {
-            RESOLVING_SERVICE.remove();
-            return;
-        }
-
-        @SuppressWarnings("unchecked")
-        List<BaseActivator<?>> nestedActivators = (List<BaseActivator<?>>) resolvingService;
-        nestedActivators.removeLast();
-        if (nestedActivators.size() == 1) {
-            RESOLVING_SERVICE.set(nestedActivators.getFirst());
-        }
     }
 
     @SuppressWarnings("unchecked")
@@ -259,31 +183,26 @@ final class Activators {
             As this type represents a value within a scope, and not "instance per call", we can safely
             store the result, unless it is lookup bound
              */
-            boolean startedResolving = startResolving(this);
+            instanceLock.readLock().lock();
             try {
-                instanceLock.readLock().lock();
-                try {
-                    if (currentPhase == ActivationPhase.ACTIVE) {
-                        return targetInstances(lookup);
-                    }
-                } finally {
-                    instanceLock.readLock().unlock();
-                }
-
-                instanceLock.writeLock().lock();
-                try {
-                    if (currentPhase != ActivationPhase.ACTIVE) {
-                        ActivationResult res = activate(provider.activationRequest());
-                        if (res.failure()) {
-                            return Optional.empty();
-                        }
-                    }
+                if (currentPhase == ActivationPhase.ACTIVE) {
                     return targetInstances(lookup);
-                } finally {
-                    instanceLock.writeLock().unlock();
                 }
             } finally {
-                finishResolving(startedResolving);
+                instanceLock.readLock().unlock();
+            }
+
+            instanceLock.writeLock().lock();
+            try {
+                if (currentPhase != ActivationPhase.ACTIVE) {
+                    ActivationResult res = activate(provider.activationRequest());
+                    if (res.failure()) {
+                        return Optional.empty();
+                    }
+                }
+                return targetInstances(lookup);
+            } finally {
+                instanceLock.writeLock().unlock();
             }
         }
 
@@ -300,35 +219,30 @@ final class Activators {
 
         @Override
         public ActivationResult activate(ActivationRequest request) {
-            boolean startedResolving = startResolving(this);
+            // probably re-entering the same lock
+            instanceLock.writeLock().lock();
             try {
-                // probably re-entering the same lock
-                instanceLock.writeLock().lock();
-                try {
-                    if (currentPhase == request.targetPhase()) {
-                        // we are already there, just return success
-                        return ActivationResult.builder()
-                                .startingActivationPhase(currentPhase)
-                                .finishingActivationPhase(currentPhase)
-                                .targetActivationPhase(currentPhase)
-                                .success(true)
-                                .build();
-                    }
-                    if (currentPhase.ordinal() > request.targetPhase().ordinal()) {
-                        // we are already ahead, this is a problem
-                        return ActivationResult.builder()
-                                .startingActivationPhase(currentPhase)
-                                .finishingActivationPhase(currentPhase)
-                                .targetActivationPhase(request.targetPhase())
-                                .success(false)
-                                .build();
-                    }
-                    return doActivate(request);
-                } finally {
-                    instanceLock.writeLock().unlock();
+                if (currentPhase == request.targetPhase()) {
+                    // we are already there, just return success
+                    return ActivationResult.builder()
+                            .startingActivationPhase(currentPhase)
+                            .finishingActivationPhase(currentPhase)
+                            .targetActivationPhase(currentPhase)
+                            .success(true)
+                            .build();
                 }
+                if (currentPhase.ordinal() > request.targetPhase().ordinal()) {
+                    // we are already ahead, this is a problem
+                    return ActivationResult.builder()
+                            .startingActivationPhase(currentPhase)
+                            .finishingActivationPhase(currentPhase)
+                            .targetActivationPhase(request.targetPhase())
+                            .success(false)
+                            .build();
+                }
+                return doActivate(request);
             } finally {
-                finishResolving(startedResolving);
+                instanceLock.writeLock().unlock();
             }
         }
 

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -430,7 +430,7 @@ final class Activators {
 
     static class FixedSupplierActivator<T> extends BaseActivator<T> {
         private final Supplier<T> instanceSupplier;
-        private final Supplier<Optional<List<QualifiedInstance<T>>>> instances;
+        private final LazyValue<Optional<List<QualifiedInstance<T>>>> instances;
 
         FixedSupplierActivator(ServiceProvider<T> provider, Supplier<T> instanceSupplier) {
             super(provider, null);
@@ -441,6 +441,10 @@ final class Activators {
                                                                                      provider.descriptor().qualifiers()));
                 return Optional.of(values);
             });
+        }
+
+        boolean activeInstancesAvailable(Lookup lookup) {
+            return requestedProvider(lookup, FactoryType.SUPPLIER) || instances.isLoaded();
         }
 
         @SuppressWarnings("unchecked")

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -429,16 +429,28 @@ final class Activators {
     }
 
     static class FixedSupplierActivator<T> extends BaseActivator<T> {
+        private final Supplier<T> instanceSupplier;
         private final Supplier<Optional<List<QualifiedInstance<T>>>> instances;
 
         FixedSupplierActivator(ServiceProvider<T> provider, Supplier<T> instanceSupplier) {
             super(provider, null);
 
+            this.instanceSupplier = instanceSupplier;
             instances = LazyValue.create(() -> {
                 List<QualifiedInstance<T>> values = List.of(QualifiedInstance.create(instanceSupplier.get(),
                                                                                      provider.descriptor().qualifiers()));
                 return Optional.of(values);
             });
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        Optional<List<QualifiedInstance<T>>> targetInstances(Lookup lookup) {
+            if (requestedProvider(lookup, FactoryType.SUPPLIER)) {
+                return Optional.of(List.of(QualifiedInstance.create((T) instanceSupplier,
+                                                                    provider.descriptor().qualifiers())));
+            }
+            return targetInstances();
         }
 
         @Override

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -479,7 +479,7 @@ final class Activators {
     }
 
     static class FixedServicesFactoryActivator<T> extends ServicesFactoryActivator<T> {
-        private final LazyValue<Optional<List<QualifiedInstance<T>>>> instances;
+        private volatile LazyValue<Optional<List<QualifiedInstance<T>>>> instances;
 
         FixedServicesFactoryActivator(ServiceProvider<T> provider,
                                       Service.ServicesFactory<T> factory) {
@@ -503,6 +503,12 @@ final class Activators {
                 return super.targetInstances(lookup);
             }
             return instances.get().flatMap(it -> matchingInstances(lookup, it));
+        }
+
+        @Override
+        void preDestroy(ActivationResult.Builder response) {
+            super.preDestroy(response);
+            instances = LazyValue.create(Optional.empty());
         }
     }
 

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
@@ -163,7 +162,7 @@ final class Activators {
         final ServiceProvider<T> provider;
         final DependencyContext dependencyContext;
 
-        private final ReadWriteLock instanceLock = new ReentrantReadWriteLock();
+        private final ReentrantReadWriteLock instanceLock = new ReentrantReadWriteLock();
 
         volatile ActivationPhase currentPhase = ActivationPhase.INIT;
 
@@ -295,6 +294,10 @@ final class Activators {
         @Override
         public ActivationPhase phase() {
             return currentPhase;
+        }
+
+        boolean isResolvingOnCurrentThread() {
+            return instanceLock.isWriteLockedByCurrentThread() || instanceLock.getReadHoldCount() > 0;
         }
 
         @Override

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -495,6 +495,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
                                                                       scopeSupplier(descriptor),
                                                                       provider,
                                                                       true,
+                                                                      false,
                                                                       activator));
 
             for (ResolvedType contract : contracts) {

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -44,6 +44,7 @@ import io.helidon.common.types.TypeNames;
 import io.helidon.service.registry.ServiceSupplies.ServiceSupplyList;
 
 import static io.helidon.service.registry.LookupTrace.traceLookup;
+import static io.helidon.service.registry.LookupTrace.traceLookupInstance;
 import static io.helidon.service.registry.ServiceRegistryManager.SERVICE_INFO_COMPARATOR;
 
 /**
@@ -266,6 +267,36 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
     }
 
     @Override
+    public <T> Optional<T> firstActive(TypeName contract) {
+        return firstActive(Lookup.create(contract));
+    }
+
+    @Override
+    public <T> Optional<T> firstActive(Lookup lookup) {
+        List<ServiceManager<T>> managers = lookupManagers(lookup, false, false);
+
+        if (managers.isEmpty()) {
+            return Optional.empty();
+        }
+
+        traceLookup(lookup, "first active");
+
+        for (ServiceManager<T> serviceManager : managers) {
+            List<ServiceInstance<T>> thisManager = serviceManager.activeInstances(lookup)
+                    .orElseGet(List::of);
+
+            traceLookupInstance(lookup, serviceManager, thisManager);
+
+            if (!thisManager.isEmpty()) {
+                accessed(serviceManager.descriptor());
+                return Optional.of(thisManager.getFirst().get());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
     public <T> Supplier<Optional<T>> supplyFirst(TypeName contract) {
         return supplyFirst(Lookup.create(contract));
     }
@@ -312,6 +343,10 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
 
     @Override
     public List<ServiceInfo> lookupServices(Lookup lookup) {
+        return lookupServices(lookup, true);
+    }
+
+    private List<ServiceInfo> lookupServices(Lookup lookup, boolean useCache) {
         try {
             stateReadLock.lock();
             // a very special lookup
@@ -323,7 +358,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
             metrics.lookup();
             traceLookup(lookup, "start: {0}", lookup);
 
-            if (cacheEnabled) {
+            if (useCache && cacheEnabled) {
                 List<ServiceInfo> cacheResult = cache.get(lookup)
                         .orElse(null);
                 metrics.cacheAccess();
@@ -357,7 +392,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
                             .forEach(result::add);
                     if (!result.isEmpty()) {
                         traceLookup(lookup, "by single contract", result);
-                        if (cacheEnabled) {
+                        if (useCache && cacheEnabled) {
                             return cacheLookupResult(lookup, result);
                         }
 
@@ -398,7 +433,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
                 }
             }
 
-            if (cacheEnabled) {
+            if (useCache && cacheEnabled) {
                 result = cacheLookupResult(lookup, result);
             }
 
@@ -726,11 +761,21 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
     }
 
     <T> List<ServiceManager<T>> lookupManagers(Lookup lookup) {
+        return lookupManagers(lookup, true);
+    }
+
+    private <T> List<ServiceManager<T>> lookupManagers(Lookup lookup, boolean markAccessed) {
+        return lookupManagers(lookup, markAccessed, true);
+    }
+
+    private <T> List<ServiceManager<T>> lookupManagers(Lookup lookup, boolean markAccessed, boolean useCache) {
         List<ServiceManager<T>> result = new ArrayList<>();
 
-        for (ServiceInfo service : lookupServices(lookup)) {
+        for (ServiceInfo service : lookupServices(lookup, useCache)) {
             result.add(serviceManager(service));
-            accessed(service);
+            if (markAccessed) {
+                accessed(service);
+            }
         }
 
         return result;

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -154,7 +154,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
                     (ServiceDescriptor<Object>) descriptor);
 
             if (instance != null) {
-                Activator<Object> activator = Activators.create(provider, instance);
+                Activator<Object> activator = Activators.createActive(provider, instance);
                 servicesByDescriptor.put(descriptor,
                                          new ServiceManager<>(this,
                                                               scopeSupplier(descriptor),
@@ -639,7 +639,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
             VirtualDescriptor vt = new VirtualDescriptor(contract.type(), Weighted.DEFAULT_WEIGHT, instance, qualifiers);
 
             ServiceProvider<Object> provider = new ServiceProvider<>(this, vt);
-            Activator<Object> activator = Activators.create(provider, instance);
+            Activator<Object> activator = Activators.createActive(provider, instance);
 
             servicesByDescriptor.put(vt, new ServiceManager<>(this,
                                                               scopeSupplier(vt),
@@ -655,7 +655,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
             ServiceProvider<Object> provider = new ServiceProvider<>(this,
                                                                      (ServiceDescriptor<Object>) serviceInfo);
 
-            Activator<Object> activator = Activators.create(provider, instance);
+            Activator<Object> activator = Activators.createActive(provider, instance);
             servicesByDescriptor.put(serviceInfo, new ServiceManager<>(this,
                                                                        scopeSupplier(serviceInfo),
                                                                        provider,
@@ -691,7 +691,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
                 throw new ServiceRegistryException("Attempting to set a service provider with wrong number of instances. "
                                                            + "A service provider must have exactly one instance.");
             }
-            Activator<Object> activator = Activators.create(provider, instances[0]);
+            Activator<Object> activator = Activators.createActive(provider, instances[0]);
             servicesByDescriptor.put(serviceInfo, new ServiceManager<>(this,
                                                                        scopeSupplier(serviceInfo),
                                                                        provider,
@@ -824,7 +824,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
         VirtualDescriptor vt = new VirtualDescriptor(contractType.type(), currentWeight, instance, qualifiers);
         ServiceProvider<Object> provider = new ServiceProvider<>(this,
                                                                  vt);
-        Activator<Object> activator = Activators.create(provider, instance);
+        Activator<Object> activator = Activators.createActive(provider, instance);
 
         servicesByDescriptor.put(vt, new ServiceManager<>(this,
                                                           scopeSupplier(vt),

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -297,11 +297,6 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
     }
 
     @Override
-    public boolean isResolvingOnCurrentThread(TypeName contract) {
-        return Activators.isResolvingOnCurrentThread(activationRequest, contract);
-    }
-
-    @Override
     public <T> Supplier<Optional<T>> supplyFirst(TypeName contract) {
         return supplyFirst(Lookup.create(contract));
     }

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -298,16 +298,7 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
 
     @Override
     public boolean isResolvingOnCurrentThread(TypeName contract) {
-        List<ServiceManager<Object>> managers = lookupManagers(Lookup.create(contract), false, false);
-        for (ServiceManager<Object> manager : managers) {
-            Optional<Activator<Object>> activator = manager.existingActivator();
-            if (activator.isPresent()
-                    && activator.get() instanceof Activators.BaseActivator<?> baseActivator
-                    && baseActivator.isResolvingOnCurrentThread()) {
-                return true;
-            }
-        }
-        return false;
+        return Activators.isResolvingOnCurrentThread(activationRequest, contract);
     }
 
     @Override

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -923,6 +923,19 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
         return scope;
     }
 
+    boolean scopeHandlerInitialized(TypeName scope) {
+        if (Service.Singleton.TYPE.equals(scope) || Service.PerLookup.TYPE.equals(scope)) {
+            return true;
+        }
+
+        scopeHandlerInstancesLock.lock();
+        try {
+            return scopeHandlerInstances.containsKey(scope);
+        } finally {
+            scopeHandlerInstancesLock.unlock();
+        }
+    }
+
     private Service.ScopeHandler scopeHandler(TypeName scope) {
         scopeHandlerInstancesLock.lock();
         try {

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -297,6 +297,20 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
     }
 
     @Override
+    public boolean isResolvingOnCurrentThread(TypeName contract) {
+        List<ServiceManager<Object>> managers = lookupManagers(Lookup.create(contract), false, false);
+        for (ServiceManager<Object> manager : managers) {
+            Optional<Activator<Object>> activator = manager.existingActivator();
+            if (activator.isPresent()
+                    && activator.get() instanceof Activators.BaseActivator<?> baseActivator
+                    && baseActivator.isResolvingOnCurrentThread()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public <T> Supplier<Optional<T>> supplyFirst(TypeName contract) {
         return supplyFirst(Lookup.create(contract));
     }

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -62,7 +62,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
             Object value = entry.getValue();
             Activator<?> fixedService;
 
-            fixedService = Activators.create(provider, value);
+            fixedService = Activators.createActive(provider, value);
 
             activators.put(key, fixedService);
         }

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
@@ -150,6 +151,17 @@ class ScopedRegistryImpl implements ScopedRegistry {
                                                              desc -> activatorSupplier.get());
         } finally {
             serviceProvidersLock.writeLock().unlock();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> Optional<Activator<T>> existingActivator(ServiceInfo descriptor) {
+        try {
+            serviceProvidersLock.readLock().lock();
+            checkActive();
+            return Optional.ofNullable((Activator<T>) activators.get(descriptor));
+        } finally {
+            serviceProvidersLock.readLock().unlock();
         }
     }
 

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -23,7 +23,6 @@ import java.util.function.Supplier;
 
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeName;
-import io.helidon.service.registry.Activators.BaseActivator;
 import io.helidon.service.registry.Service.QualifiedInstance;
 
 /*
@@ -81,6 +80,10 @@ class ServiceManager<T> {
     }
 
     Optional<List<ServiceInstance<T>>> activeInstances(Lookup lookup) {
+        if (!fixedInstance && Service.PerLookup.TYPE.equals(provider.descriptor().scope())) {
+            return Optional.empty();
+        }
+
         Activator<T> serviceActivator;
         if (fixedInstance) {
             serviceActivator = activatorSupplier.get();
@@ -93,27 +96,7 @@ class ServiceManager<T> {
         }
 
         if (serviceActivator.phase() != ActivationPhase.ACTIVE) {
-            if (fixedInstance) {
-                return explicitInstances(serviceActivator, lookup);
-            }
             return Optional.empty();
-        }
-
-        return serviceActivator
-                .instances(lookup)
-                .map(it -> it.stream()
-                        .map(instance -> registryInstance(lookup, instance))
-                        .toList());
-    }
-
-    @SuppressWarnings("unchecked")
-    private Optional<List<ServiceInstance<T>>> explicitInstances(Activator<T> serviceActivator, Lookup lookup) {
-        if (serviceActivator instanceof BaseActivator<?> baseActivator) {
-            return ((BaseActivator<T>) baseActivator)
-                    .targetInstances(lookup)
-                    .map(it -> it.stream()
-                            .map(instance -> registryInstance(lookup, instance))
-                            .toList());
         }
 
         return serviceActivator

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.service.registry;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -64,6 +66,37 @@ class ServiceManager<T> {
         return new ServiceInstanceImpl<>(provider.descriptor(),
                                          provider.contracts(lookup),
                                          instance);
+    }
+
+    Optional<List<ServiceInstance<T>>> activeInstances(Lookup lookup) {
+        Optional<Activator<T>> existingActivator = existingActivator();
+        if (existingActivator.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Activator<T> serviceActivator = existingActivator.get();
+        if (serviceActivator.phase() != ActivationPhase.ACTIVE) {
+            return Optional.empty();
+        }
+
+        return serviceActivator
+                .instances(lookup)
+                .map(it -> it.stream()
+                        .map(instance -> registryInstance(lookup, instance))
+                        .toList());
+    }
+
+    private Optional<Activator<T>> existingActivator() {
+        try {
+            ScopedRegistry scopedRegistry = scopeSupplier.get().registry();
+            if (scopedRegistry instanceof ScopedRegistryImpl scopedRegistryImpl) {
+                return scopedRegistryImpl.existingActivator(provider.descriptor());
+            }
+
+            return Optional.empty();
+        } catch (ScopeNotActiveException e) {
+            return Optional.empty();
+        }
     }
 
     ServiceInfo descriptor() {

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.Activators.BaseActivator;
 import io.helidon.service.registry.Service.QualifiedInstance;
 
 /*
@@ -30,7 +31,8 @@ Manager of a single service. There is one instance per service provider (and per
  */
 class ServiceManager<T> {
     private final ServiceProvider<T> provider;
-    private final boolean explicitInstance;
+    private final boolean skipBindingPlan;
+    private final boolean fixedInstance;
     private final Supplier<Activator<T>> activatorSupplier;
     private final CoreServiceRegistry registry;
     private final Supplier<Scope> scopeSupplier;
@@ -38,12 +40,22 @@ class ServiceManager<T> {
     ServiceManager(CoreServiceRegistry registry,
                    Supplier<Scope> scopeSupplier,
                    ServiceProvider<T> provider,
-                   boolean explicitInstance,
+                   boolean skipBindingPlan,
+                   Supplier<Activator<T>> activatorSupplier) {
+        this(registry, scopeSupplier, provider, skipBindingPlan, skipBindingPlan, activatorSupplier);
+    }
+
+    ServiceManager(CoreServiceRegistry registry,
+                   Supplier<Scope> scopeSupplier,
+                   ServiceProvider<T> provider,
+                   boolean skipBindingPlan,
+                   boolean fixedInstance,
                    Supplier<Activator<T>> activatorSupplier) {
         this.registry = registry;
         this.scopeSupplier = scopeSupplier;
         this.provider = provider;
-        this.explicitInstance = explicitInstance;
+        this.skipBindingPlan = skipBindingPlan;
+        this.fixedInstance = fixedInstance;
         this.activatorSupplier = activatorSupplier;
     }
 
@@ -53,8 +65,8 @@ class ServiceManager<T> {
     }
 
     void ensureBindingPlan() {
-        if (explicitInstance) {
-            // we do not need injection plan, if service was provided as an instance
+        if (skipBindingPlan) {
+            // late-bound instances and descriptors are not part of the build-time binding plan
             return;
         }
         registry.bindings()
@@ -69,14 +81,39 @@ class ServiceManager<T> {
     }
 
     Optional<List<ServiceInstance<T>>> activeInstances(Lookup lookup) {
-        Optional<Activator<T>> existingActivator = existingActivator();
-        if (existingActivator.isEmpty()) {
+        Activator<T> serviceActivator;
+        if (fixedInstance) {
+            serviceActivator = activatorSupplier.get();
+        } else {
+            Optional<Activator<T>> existingActivator = existingActivator();
+            if (existingActivator.isEmpty()) {
+                return Optional.empty();
+            }
+            serviceActivator = existingActivator.get();
+        }
+
+        if (serviceActivator.phase() != ActivationPhase.ACTIVE) {
+            if (fixedInstance) {
+                return explicitInstances(serviceActivator, lookup);
+            }
             return Optional.empty();
         }
 
-        Activator<T> serviceActivator = existingActivator.get();
-        if (serviceActivator.phase() != ActivationPhase.ACTIVE) {
-            return Optional.empty();
+        return serviceActivator
+                .instances(lookup)
+                .map(it -> it.stream()
+                        .map(instance -> registryInstance(lookup, instance))
+                        .toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<List<ServiceInstance<T>>> explicitInstances(Activator<T> serviceActivator, Lookup lookup) {
+        if (serviceActivator instanceof BaseActivator<?> baseActivator) {
+            return ((BaseActivator<T>) baseActivator)
+                    .targetInstances(lookup)
+                    .map(it -> it.stream()
+                            .map(instance -> registryInstance(lookup, instance))
+                            .toList());
         }
 
         return serviceActivator

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -86,7 +86,11 @@ class ServiceManager<T> {
 
         Activator<T> serviceActivator;
         if (fixedInstance) {
-            serviceActivator = activatorSupplier.get();
+            try {
+                serviceActivator = activator();
+            } catch (ScopeNotActiveException e) {
+                return Optional.empty();
+            }
         } else {
             Optional<Activator<T>> existingActivator = existingActivator();
             if (existingActivator.isEmpty()) {

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -142,7 +142,7 @@ class ServiceManager<T> {
         return result;
     }
 
-    Optional<Activator<T>> existingActivator() {
+    private Optional<Activator<T>> existingActivator() {
         try {
             ScopedRegistry scopedRegistry = scopeSupplier.get().registry();
             if (scopedRegistry instanceof ScopedRegistryImpl scopedRegistryImpl) {

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -97,7 +97,13 @@ class ServiceManager<T> {
         Activator<T> serviceActivator;
         if (fixedInstance) {
             try {
-                serviceActivator = activator();
+                ScopedRegistry scopedRegistry = scopeSupplier.get().registry();
+                if (scopedRegistry instanceof ScopedRegistryImpl scopedRegistryImpl) {
+                    serviceActivator = scopedRegistryImpl.<T>existingActivator(provider.descriptor())
+                            .orElseGet(activatorSupplier);
+                } else {
+                    serviceActivator = activator();
+                }
             } catch (ScopeNotActiveException e) {
                 return Optional.empty();
             }
@@ -117,11 +123,20 @@ class ServiceManager<T> {
             return Optional.empty();
         }
 
-        return serviceActivator
+        Optional<List<ServiceInstance<T>>> result = serviceActivator
                 .instances(lookup)
                 .map(it -> it.stream()
                         .map(instance -> registryInstance(lookup, instance))
                         .toList());
+        // Only retain a fixed activator when the active lookup actually uses it.
+        if (fixedInstance && result.map(it -> !it.isEmpty()).orElse(false)) {
+            try {
+                activator();
+            } catch (ScopeNotActiveException e) {
+                return Optional.empty();
+            }
+        }
+        return result;
     }
 
     private Optional<Activator<T>> existingActivator() {

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -93,6 +93,9 @@ class ServiceManager<T> {
                 return Optional.empty();
             }
         }
+        if (!registry.scopeHandlerInitialized(descriptor.scope())) {
+            return Optional.empty();
+        }
 
         Activator<T> serviceActivator;
         if (fixedInstance) {

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -118,8 +118,8 @@ class ServiceManager<T> {
         if (serviceActivator.phase() != ActivationPhase.ACTIVE) {
             return Optional.empty();
         }
-        if (serviceActivator instanceof Activators.FixedSupplierActivator<?> fixedSupplier
-                && !fixedSupplier.activeInstancesAvailable(lookup)) {
+        if (serviceActivator instanceof Activators.BaseActivator<?> baseActivator
+                && !baseActivator.activeInstancesAvailable(lookup)) {
             return Optional.empty();
         }
 

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -112,6 +112,10 @@ class ServiceManager<T> {
         if (serviceActivator.phase() != ActivationPhase.ACTIVE) {
             return Optional.empty();
         }
+        if (serviceActivator instanceof Activators.FixedSupplierActivator<?> fixedSupplier
+                && !fixedSupplier.activeInstancesAvailable(lookup)) {
+            return Optional.empty();
+        }
 
         return serviceActivator
                 .instances(lookup)

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -139,7 +139,7 @@ class ServiceManager<T> {
         return result;
     }
 
-    private Optional<Activator<T>> existingActivator() {
+    Optional<Activator<T>> existingActivator() {
         try {
             ScopedRegistry scopedRegistry = scopeSupplier.get().registry();
             if (scopedRegistry instanceof ScopedRegistryImpl scopedRegistryImpl) {

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceManager.java
@@ -80,8 +80,18 @@ class ServiceManager<T> {
     }
 
     Optional<List<ServiceInstance<T>>> activeInstances(Lookup lookup) {
-        if (!fixedInstance && Service.PerLookup.TYPE.equals(provider.descriptor().scope())) {
-            return Optional.empty();
+        ServiceDescriptor<T> descriptor = provider.descriptor();
+        if (Service.PerLookup.TYPE.equals(descriptor.scope())) {
+            if (!fixedInstance) {
+                return Optional.empty();
+            }
+
+            FactoryType factoryType = descriptor.factoryType();
+            if (factoryType != FactoryType.NONE
+                    && factoryType != FactoryType.SERVICE
+                    && !Contracts.requestedProvider(lookup, descriptor, factoryType)) {
+                return Optional.empty();
+            }
         }
 
         Activator<T> serviceActivator;

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,6 +186,68 @@ public interface ServiceRegistry {
      *                                                              resolution to instance failed
      */
     <T> Optional<T> first(TypeName contract);
+
+    /**
+     * Get the first active service instance matching the contract.
+     * <p>
+     * The default implementation may trigger activation.
+     *
+     * @param contract contract to find
+     * @param <T>      type of the contract
+     * @return first active instance, or an empty optional
+     */
+    default <T> Optional<T> firstActive(Class<T> contract) {
+        return firstActive(TypeName.create(contract));
+    }
+
+    /**
+     * Get the first active service instance matching the contract with the expectation that there may not be a match
+     * available.
+     * <p>
+     * The default implementation may trigger activation.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best active service instance matching the contract, or an empty {@link java.util.Optional} if none match
+     */
+    default <T> Optional<T> firstActive(Class<T> contract, Qualifier... qualifiers) {
+        return firstActive(Lookup.builder()
+                                   .addContract(contract)
+                                   .qualifiers(Set.of(qualifiers))
+                                   .build());
+    }
+
+    /**
+     * Get the first active service instance matching the contract.
+     * <p>
+     * The default implementation delegates to {@link #firstActive(Lookup)} and may trigger activation.
+     *
+     * @param contract contract to find
+     * @param <T>      type of the contract
+     * @return first active instance, or an empty optional
+     */
+    default <T> Optional<T> firstActive(TypeName contract) {
+        return firstActive(Lookup.create(contract));
+    }
+
+    /**
+     * Get the first active service instance matching the contract with the expectation that there may not be a match
+     * available.
+     * <p>
+     * The default implementation may trigger activation.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best active service instance matching the contract, or an empty {@link java.util.Optional} if none match
+     */
+    default <T> Optional<T> firstActive(TypeName contract, Qualifier... qualifiers) {
+        return firstActive(Lookup.builder()
+                                   .addContract(contract)
+                                   .qualifiers(Set.of(qualifiers))
+                                   .build());
+    }
 
     /**
      * Get the first named service instance matching the contract with the expectation that there may not be a match available.
@@ -496,6 +558,20 @@ public interface ServiceRegistry {
      *         if the result may contain an unknown instance
      */
     <T> Optional<T> first(Lookup lookup);
+
+    /**
+     * Get the first active service instance matching the lookup with the expectation that there may not be a match available.
+     * <p>
+     * The default implementation delegates to {@link #first(Lookup)} and may trigger activation.
+     *
+     * @param lookup lookup criteria to find matching services
+     * @param <T>    type of the service, if you use any other than {@link java.lang.Object}, make sure
+     *               you have configured appropriate contracts in the lookup, as we cannot infer this
+     * @return the best active service instance matching the lookup, or an empty {@link java.util.Optional} if none match
+     */
+    default <T> Optional<T> firstActive(Lookup lookup) {
+        return first(lookup);
+    }
 
     /**
      * Get all service instances matching the lookup with the expectation that there may not be a match available.

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
@@ -190,7 +190,9 @@ public interface ServiceRegistry {
     /**
      * Get the first active service instance matching the contract.
      * <p>
-     * The default implementation may trigger activation.
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
+     * instance. The default implementation may trigger activation.
      *
      * @param contract contract to find
      * @param <T>      type of the contract
@@ -204,7 +206,9 @@ public interface ServiceRegistry {
      * Get the first active service instance matching the contract with the expectation that there may not be a match
      * available.
      * <p>
-     * The default implementation may trigger activation.
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
+     * instance. The default implementation may trigger activation.
      *
      * @param contract   contract to look-up
      * @param qualifiers qualifiers to find
@@ -221,7 +225,9 @@ public interface ServiceRegistry {
     /**
      * Get the first active service instance matching the contract.
      * <p>
-     * The default implementation delegates to {@link #firstActive(Lookup)} and may trigger activation.
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
+     * instance. The default implementation delegates to {@link #firstActive(Lookup)} and may trigger activation.
      *
      * @param contract contract to find
      * @param <T>      type of the contract
@@ -235,7 +241,9 @@ public interface ServiceRegistry {
      * Get the first active service instance matching the contract with the expectation that there may not be a match
      * available.
      * <p>
-     * The default implementation may trigger activation.
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
+     * instance. The default implementation may trigger activation.
      *
      * @param contract   contract to look-up
      * @param qualifiers qualifiers to find
@@ -562,7 +570,9 @@ public interface ServiceRegistry {
     /**
      * Get the first active service instance matching the lookup with the expectation that there may not be a match available.
      * <p>
-     * The default implementation delegates to {@link #first(Lookup)} and may trigger activation.
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
+     * instance. The default implementation delegates to {@link #first(Lookup)} and may trigger activation.
      *
      * @param lookup lookup criteria to find matching services
      * @param <T>    type of the service, if you use any other than {@link java.lang.Object}, make sure

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
@@ -191,8 +191,9 @@ public interface ServiceRegistry {
      * Get the first active service instance matching the contract.
      * <p>
      * Implementations that support active lookup should return only instances that are already active and should not
-     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
-     * instance. The default implementation may trigger activation.
+     * create new products for {@link Service.PerLookup} services. An explicitly registered fixed provider or service
+     * instance may be returned when the lookup requests that provider or service instance. The default implementation
+     * delegates to {@link #firstActive(TypeName)}.
      *
      * @param contract contract to find
      * @param <T>      type of the contract
@@ -207,8 +208,9 @@ public interface ServiceRegistry {
      * available.
      * <p>
      * Implementations that support active lookup should return only instances that are already active and should not
-     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
-     * instance. The default implementation may trigger activation.
+     * create new products for {@link Service.PerLookup} services. An explicitly registered fixed provider or service
+     * instance may be returned when the lookup requests that provider or service instance. The default implementation
+     * delegates to {@link #firstActive(Lookup)}.
      *
      * @param contract   contract to look-up
      * @param qualifiers qualifiers to find
@@ -226,8 +228,9 @@ public interface ServiceRegistry {
      * Get the first active service instance matching the contract.
      * <p>
      * Implementations that support active lookup should return only instances that are already active and should not
-     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
-     * instance. The default implementation delegates to {@link #firstActive(Lookup)} and may trigger activation.
+     * create new products for {@link Service.PerLookup} services. An explicitly registered fixed provider or service
+     * instance may be returned when the lookup requests that provider or service instance. The default implementation
+     * delegates to {@link #firstActive(Lookup)}.
      *
      * @param contract contract to find
      * @param <T>      type of the contract
@@ -242,8 +245,9 @@ public interface ServiceRegistry {
      * available.
      * <p>
      * Implementations that support active lookup should return only instances that are already active and should not
-     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
-     * instance. The default implementation may trigger activation.
+     * create new products for {@link Service.PerLookup} services. An explicitly registered fixed provider or service
+     * instance may be returned when the lookup requests that provider or service instance. The default implementation
+     * delegates to {@link #firstActive(Lookup)}.
      *
      * @param contract   contract to look-up
      * @param qualifiers qualifiers to find
@@ -571,8 +575,9 @@ public interface ServiceRegistry {
      * Get the first active service instance matching the lookup with the expectation that there may not be a match available.
      * <p>
      * Implementations that support active lookup should return only instances that are already active and should not
-     * create new instances for {@link Service.PerLookup} services, as per-lookup services do not have an active reusable
-     * instance. The default implementation delegates to {@link #first(Lookup)} and may trigger activation.
+     * create new products for {@link Service.PerLookup} services. An explicitly registered fixed provider or service
+     * instance may be returned when the lookup requests that provider or service instance. The default implementation
+     * returns an empty optional.
      *
      * @param lookup lookup criteria to find matching services
      * @param <T>    type of the service, if you use any other than {@link java.lang.Object}, make sure
@@ -580,7 +585,8 @@ public interface ServiceRegistry {
      * @return the best active service instance matching the lookup, or an empty {@link java.util.Optional} if none match
      */
     default <T> Optional<T> firstActive(Lookup lookup) {
-        return first(lookup);
+        Objects.requireNonNull(lookup);
+        return Optional.empty();
     }
 
     /**

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -260,31 +259,6 @@ public interface ServiceRegistry {
                                    .addContract(contract)
                                    .qualifiers(Set.of(qualifiers))
                                    .build());
-    }
-
-    /**
-     * Whether the current thread is resolving an instance matching the contract.
-     *
-     * @param contract contract to check
-     * @return whether the current thread is resolving an instance matching the contract
-     */
-    @Api.Internal
-    default boolean isResolvingOnCurrentThread(Class<?> contract) {
-        return isResolvingOnCurrentThread(TypeName.create(contract));
-    }
-
-    /**
-     * Whether the current thread is resolving an instance matching the contract.
-     * <p>
-     * The default implementation returns {@code false}.
-     *
-     * @param contract contract to check
-     * @return whether the current thread is resolving an instance matching the contract
-     */
-    @Api.Internal
-    default boolean isResolvingOnCurrentThread(TypeName contract) {
-        Objects.requireNonNull(contract);
-        return false;
     }
 
     /**

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -259,6 +260,31 @@ public interface ServiceRegistry {
                                    .addContract(contract)
                                    .qualifiers(Set.of(qualifiers))
                                    .build());
+    }
+
+    /**
+     * Whether the current thread is resolving an instance matching the contract.
+     *
+     * @param contract contract to check
+     * @return whether the current thread is resolving an instance matching the contract
+     */
+    @Api.Internal
+    default boolean isResolvingOnCurrentThread(Class<?> contract) {
+        return isResolvingOnCurrentThread(TypeName.create(contract));
+    }
+
+    /**
+     * Whether the current thread is resolving an instance matching the contract.
+     * <p>
+     * The default implementation returns {@code false}.
+     *
+     * @param contract contract to check
+     * @return whether the current thread is resolving an instance matching the contract
+     */
+    @Api.Internal
+    default boolean isResolvingOnCurrentThread(TypeName contract) {
+        Objects.requireNonNull(contract);
+        return false;
     }
 
     /**

--- a/service/tests/lookup/src/main/java/io/helidon/service/tests/lookup/SingletonInjectionPointProviderExample.java
+++ b/service/tests/lookup/src/main/java/io/helidon/service/tests/lookup/SingletonInjectionPointProviderExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,11 @@ class SingletonInjectionPointProviderExample implements InjectionPointFactory<Co
     static final QualifiedInstance<ContractSingleton> FIRST = QualifiedInstance.create(new FirstClass(), FIRST_QUALI);
     static final QualifiedInstance<ContractSingleton> SECOND = QualifiedInstance.create(new SecondClass(), SECOND_QUALI);
 
+    private int calls;
+
     @Override
     public Optional<QualifiedInstance<ContractSingleton>> first(Lookup lookup) {
+        calls++;
         if (lookup.qualifiers().contains(FIRST_QUALI)) {
             return Optional.of(FIRST);
         }
@@ -42,6 +45,10 @@ class SingletonInjectionPointProviderExample implements InjectionPointFactory<Co
             return Optional.of(SECOND);
         }
         return Optional.empty();
+    }
+
+    int calls() {
+        return calls;
     }
 
     @Service.Qualifier

--- a/service/tests/lookup/src/test/java/io/helidon/service/tests/lookup/SingletonLookupTest.java
+++ b/service/tests/lookup/src/test/java/io/helidon/service/tests/lookup/SingletonLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Service.InjectionPointFactory;
 import io.helidon.service.registry.ServiceInfo;
 import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 
 import org.junit.jupiter.api.AfterAll;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.common.testing.junit5.OptionalMatcher.optionalPresent;
 import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -79,6 +81,38 @@ class SingletonLookupTest {
         assertThat(first, instanceOf(SingletonSupplierExample.First.class));
         ContractSingleton second = registry.get(CONTRACT);
         assertThat(first, sameInstance(second));
+    }
+
+    @Test
+    void firstActiveDoesNotInvokeInjectionPointFactory() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                               .discoverServices(false)
+                                                                               .addServiceDescriptor(
+                                                                                       SingletonInjectionPointProviderExample__ServiceDescriptor.INSTANCE)
+                                                                               .build());
+        ServiceRegistry serviceRegistry = manager.registry();
+
+        try {
+            SingletonInjectionPointProviderExample provider =
+                    serviceRegistry.get(SingletonInjectionPointProviderExample.class);
+            Lookup productLookup = Lookup.builder()
+                    .addContract(ContractSingleton.class)
+                    .addQualifier(SingletonInjectionPointProviderExample.FIRST_QUALI)
+                    .build();
+
+            assertThat(serviceRegistry.firstActive(SingletonInjectionPointProviderExample.class).orElseThrow(),
+                       sameInstance(provider));
+            assertThat(serviceRegistry.firstActive(productLookup).isEmpty(), is(true));
+            assertThat(provider.calls(), is(0));
+
+            assertThat(serviceRegistry.get(productLookup),
+                       sameInstance(SingletonInjectionPointProviderExample.FIRST.get()));
+            assertThat(provider.calls(), is(1));
+            assertThat(serviceRegistry.firstActive(productLookup).isEmpty(), is(true));
+            assertThat(provider.calls(), is(1));
+        } finally {
+            manager.shutdown();
+        }
     }
 
     @Test

--- a/service/tests/qualified-providers/src/main/java/io/helidon/service/tests/qualified/providers/FirstQualifiedProvider.java
+++ b/service/tests/qualified-providers/src/main/java/io/helidon/service/tests/qualified/providers/FirstQualifiedProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,18 @@ import io.helidon.service.registry.Service.QualifiedInstance;
 class FirstQualifiedProvider implements Service.QualifiedFactory<Object, FirstQualifier> {
     private final Map<String, String> values = Map.of("first", "first",
                                                       "second", "49");
+    private int calls;
 
     @Override
     public Optional<QualifiedInstance<Object>> first(Qualifier qualifier, Lookup lookup, GenericType<Object> type) {
+        calls++;
         Optional<String> stringValue = Optional.of(values.get(qualifier.value().orElse("not-defined")));
 
         return stringValue.map(str -> QualifiedInstance.create(mapType(str, type), qualifier));
+    }
+
+    int calls() {
+        return calls;
     }
 
     private Object mapType(String str, GenericType<Object> type) {

--- a/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
+++ b/service/tests/qualified-providers/src/test/java/io/helidon/service/tests/qualified/providers/QualifiedProvidersTest.java
@@ -63,6 +63,39 @@ public class QualifiedProvidersTest {
         }
     }
 
+    @Test
+    public void testFirstActiveDoesNotInvokeQualifiedFactory() {
+        ServiceRegistryManager registryManager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                     .discoverServices(false)
+                                                                                     .addServiceDescriptor(
+                                                                                             FirstQualifiedProvider__ServiceDescriptor.INSTANCE)
+                                                                                     .build());
+
+        try {
+            ServiceRegistry registry = registryManager.registry();
+            Lookup providerLookup = Lookup.builder()
+                    .serviceType(FirstQualifiedProvider.class)
+                    .addFactoryType(FactoryType.QUALIFIED)
+                    .build();
+            FirstQualifiedProvider provider = registry.get(providerLookup);
+            Lookup productLookup = Lookup.builder()
+                    .addContract(String.class)
+                    .addQualifier(Qualifier.create(FirstQualifier.class, "first"))
+                    .build();
+
+            assertThat(registry.firstActive(providerLookup).orElseThrow(), sameInstance(provider));
+            assertThat(registry.firstActive(productLookup).isEmpty(), is(true));
+            assertThat(provider.calls(), is(0));
+
+            assertThat(registry.get(productLookup), is("first"));
+            assertThat(provider.calls(), is(1));
+            assertThat(registry.firstActive(productLookup).isEmpty(), is(true));
+            assertThat(provider.calls(), is(1));
+        } finally {
+            registryManager.shutdown();
+        }
+    }
+
     private void testServices(ServiceRegistry registry) {
         TheService theService = registry.get(TheService.class);
 

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/FirstActiveContract.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/FirstActiveContract.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import io.helidon.service.registry.Service;
+
+@Service.Contract
+interface FirstActiveContract {
+}

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/FirstActiveService.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/FirstActiveService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class FirstActiveService implements FirstActiveContract {
+    static int instances;
+
+    FirstActiveService() {
+        instances++;
+    }
+}

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/ServiceSupplier.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/ServiceSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,14 @@ import io.helidon.service.registry.Service;
 @Service.PerLookup
 class ServiceSupplier implements Supplier<SuppliedContract> {
     private static final AtomicInteger COUNTER = new AtomicInteger();
+
+    static void reset() {
+        COUNTER.set(0);
+    }
+
+    static int instances() {
+        return COUNTER.get();
+    }
 
     @Override
     public SuppliedContract get() {

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServiceSupplier.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServiceSupplier.java
@@ -30,8 +30,11 @@ class SingletonServiceSupplier implements Supplier<SuppliedContract> {
     private final ServiceRegistry registry;
 
     private boolean reenter;
+    private boolean fail;
     private boolean resolvingDuringGet;
+    private boolean otherRegistryResolvingDuringGet;
     private Optional<SuppliedContract> activeDuringGet = Optional.empty();
+    private ServiceRegistry otherRegistry;
 
     @Service.Inject
     SingletonServiceSupplier() {
@@ -50,6 +53,14 @@ class SingletonServiceSupplier implements Supplier<SuppliedContract> {
         reenter = true;
     }
 
+    void failOnGet() {
+        fail = true;
+    }
+
+    void checkOtherRegistry(ServiceRegistry otherRegistry) {
+        this.otherRegistry = otherRegistry;
+    }
+
     Optional<SuppliedContract> activeDuringGet() {
         return activeDuringGet;
     }
@@ -58,13 +69,23 @@ class SingletonServiceSupplier implements Supplier<SuppliedContract> {
         return resolvingDuringGet;
     }
 
+    boolean otherRegistryResolvingDuringGet() {
+        return otherRegistryResolvingDuringGet;
+    }
+
     @Override
     public SuppliedContract get() {
         int i = counter.incrementAndGet();
         ServiceRegistry currentRegistry = registry == null ? GlobalServiceRegistry.registry() : registry;
         resolvingDuringGet = currentRegistry.isResolvingOnCurrentThread(SuppliedContract.class);
+        if (otherRegistry != null) {
+            otherRegistryResolvingDuringGet = otherRegistry.isResolvingOnCurrentThread(SuppliedContract.class);
+        }
         if (reenter) {
             activeDuringGet = currentRegistry.firstActive(SuppliedContract.class);
+        }
+        if (fail) {
+            throw new IllegalStateException("Supplier failure");
         }
         return () -> "Supplied:" + i;
     }

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServiceSupplier.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServiceSupplier.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceRegistry;
 
@@ -30,11 +29,7 @@ class SingletonServiceSupplier implements Supplier<SuppliedContract> {
     private final ServiceRegistry registry;
 
     private boolean reenter;
-    private boolean fail;
-    private boolean resolvingDuringGet;
-    private boolean otherRegistryResolvingDuringGet;
     private Optional<SuppliedContract> activeDuringGet = Optional.empty();
-    private ServiceRegistry otherRegistry;
 
     @Service.Inject
     SingletonServiceSupplier() {
@@ -53,39 +48,15 @@ class SingletonServiceSupplier implements Supplier<SuppliedContract> {
         reenter = true;
     }
 
-    void failOnGet() {
-        fail = true;
-    }
-
-    void checkOtherRegistry(ServiceRegistry otherRegistry) {
-        this.otherRegistry = otherRegistry;
-    }
-
     Optional<SuppliedContract> activeDuringGet() {
         return activeDuringGet;
-    }
-
-    boolean resolvingDuringGet() {
-        return resolvingDuringGet;
-    }
-
-    boolean otherRegistryResolvingDuringGet() {
-        return otherRegistryResolvingDuringGet;
     }
 
     @Override
     public SuppliedContract get() {
         int i = counter.incrementAndGet();
-        ServiceRegistry currentRegistry = registry == null ? GlobalServiceRegistry.registry() : registry;
-        resolvingDuringGet = currentRegistry.isResolvingOnCurrentThread(SuppliedContract.class);
-        if (otherRegistry != null) {
-            otherRegistryResolvingDuringGet = otherRegistry.isResolvingOnCurrentThread(SuppliedContract.class);
-        }
         if (reenter) {
-            activeDuringGet = currentRegistry.firstActive(SuppliedContract.class);
-        }
-        if (fail) {
-            throw new IllegalStateException("Supplier failure");
+            activeDuringGet = registry.firstActive(SuppliedContract.class);
         }
         return () -> "Supplied:" + i;
     }

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServiceSupplier.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServiceSupplier.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceRegistry;
 
@@ -29,6 +30,7 @@ class SingletonServiceSupplier implements Supplier<SuppliedContract> {
     private final ServiceRegistry registry;
 
     private boolean reenter;
+    private boolean resolvingDuringGet;
     private Optional<SuppliedContract> activeDuringGet = Optional.empty();
 
     @Service.Inject
@@ -52,11 +54,17 @@ class SingletonServiceSupplier implements Supplier<SuppliedContract> {
         return activeDuringGet;
     }
 
+    boolean resolvingDuringGet() {
+        return resolvingDuringGet;
+    }
+
     @Override
     public SuppliedContract get() {
         int i = counter.incrementAndGet();
+        ServiceRegistry currentRegistry = registry == null ? GlobalServiceRegistry.registry() : registry;
+        resolvingDuringGet = currentRegistry.isResolvingOnCurrentThread(SuppliedContract.class);
         if (reenter) {
-            activeDuringGet = registry.firstActive(SuppliedContract.class);
+            activeDuringGet = currentRegistry.firstActive(SuppliedContract.class);
         }
         return () -> "Supplied:" + i;
     }

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServiceSupplier.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServiceSupplier.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
+
+@Service.Singleton
+class SingletonServiceSupplier implements Supplier<SuppliedContract> {
+    private final AtomicInteger counter = new AtomicInteger();
+    private final ServiceRegistry registry;
+
+    private boolean reenter;
+    private Optional<SuppliedContract> activeDuringGet = Optional.empty();
+
+    @Service.Inject
+    SingletonServiceSupplier() {
+        registry = null;
+    }
+
+    SingletonServiceSupplier(ServiceRegistry registry) {
+        this.registry = registry;
+    }
+
+    int instances() {
+        return counter.get();
+    }
+
+    void reenterOnGet() {
+        reenter = true;
+    }
+
+    Optional<SuppliedContract> activeDuringGet() {
+        return activeDuringGet;
+    }
+
+    @Override
+    public SuppliedContract get() {
+        int i = counter.incrementAndGet();
+        if (reenter) {
+            activeDuringGet = registry.firstActive(SuppliedContract.class);
+        }
+        return () -> "Supplied:" + i;
+    }
+}

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServicesFactory.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServicesFactory.java
@@ -24,6 +24,7 @@ import io.helidon.service.registry.Service;
 @Service.Singleton
 class SingletonServicesFactory implements Service.ServicesFactory<SuppliedContract> {
     private final List<Service.QualifiedInstance<SuppliedContract>> services;
+    private int servicesCalls;
 
     @Service.Inject
     SingletonServicesFactory() {
@@ -36,6 +37,11 @@ class SingletonServicesFactory implements Service.ServicesFactory<SuppliedContra
 
     @Override
     public List<Service.QualifiedInstance<SuppliedContract>> services() {
+        servicesCalls++;
         return services;
+    }
+
+    int servicesCalls() {
+        return servicesCalls;
     }
 }

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServicesFactory.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/SingletonServicesFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class SingletonServicesFactory implements Service.ServicesFactory<SuppliedContract> {
+    private final List<Service.QualifiedInstance<SuppliedContract>> services;
+
+    @Service.Inject
+    SingletonServicesFactory() {
+        services = List.of();
+    }
+
+    SingletonServicesFactory(SuppliedContract service) {
+        services = List.of(Service.QualifiedInstance.create(service, Set.of()));
+    }
+
+    @Override
+    public List<Service.QualifiedInstance<SuppliedContract>> services() {
+        return services;
+    }
+}

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -69,6 +71,70 @@ public class RegistryTest {
         assertThat(myContract, instanceOf(MyService2.class));
         assertThat(MyService2.instances, is(1));
         assertThat(MyService.instances, is(1));
+    }
+
+    @Test
+    public void testRegistryFirstActive() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        FirstActiveService.instances = 0;
+
+        try {
+            assertThat(serviceRegistry.firstActive(FirstActiveContract.class).isEmpty(), is(true));
+            assertThat(FirstActiveService.instances, is(0));
+
+            FirstActiveContract activated = serviceRegistry.get(FirstActiveContract.class);
+            assertThat(activated, notNullValue());
+            assertThat(FirstActiveService.instances, is(1));
+
+            assertThat(serviceRegistry.firstActive(FirstActiveContract.class).orElseThrow(), sameInstance(activated));
+            assertThat(FirstActiveService.instances, is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegistryFirstActiveDoesNotBlockSet() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        FirstActiveService.instances = 0;
+        FirstActiveContract explicit = new FirstActiveContract() {
+        };
+
+        Services.registry(serviceRegistry);
+        try {
+            assertThat(serviceRegistry.firstActive(FirstActiveContract.class).isEmpty(), is(true));
+            assertThat(FirstActiveService.instances, is(0));
+
+            Services.set(FirstActiveContract.class, explicit);
+
+            assertThat(serviceRegistry.get(FirstActiveContract.class), sameInstance(explicit));
+            assertThat(FirstActiveService.instances, is(0));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegistryFirstActiveDoesNotBlockSetByServiceType() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        FirstActiveService.instances = 0;
+
+        Services.registry(serviceRegistry);
+        try {
+            assertThat(serviceRegistry.firstActive(FirstActiveService.class).isEmpty(), is(true));
+            assertThat(FirstActiveService.instances, is(0));
+
+            FirstActiveService explicit = new FirstActiveService();
+            Services.set(FirstActiveService.class, explicit);
+
+            assertThat(serviceRegistry.get(FirstActiveService.class), sameInstance(explicit));
+            assertThat(FirstActiveService.instances, is(1));
+        } finally {
+            manager.shutdown();
+        }
     }
 
     @Test

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -192,7 +192,6 @@ public class RegistryTest {
             Services.set(FirstActiveContract.class, explicit);
 
             assertThat(serviceRegistry.firstActive(FirstActiveContract.class).orElseThrow(), sameInstance(explicit));
-            assertThat(serviceRegistry.get(FirstActiveContract.class), sameInstance(explicit));
 
             manager.shutdown();
             shutDown = true;

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -19,6 +19,7 @@ package io.helidon.service.test.registry;
 import java.util.List;
 import java.util.function.Supplier;
 
+import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.service.registry.Services;
@@ -130,8 +131,49 @@ public class RegistryTest {
             FirstActiveService explicit = new FirstActiveService();
             Services.set(FirstActiveService.class, explicit);
 
+            assertThat(serviceRegistry.firstActive(FirstActiveService.class).orElseThrow(), sameInstance(explicit));
             assertThat(serviceRegistry.get(FirstActiveService.class), sameInstance(explicit));
             assertThat(FirstActiveService.instances, is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegistryFirstActiveReturnsSetInstance() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        FirstActiveService.instances = 0;
+        FirstActiveContract explicit = new FirstActiveContract() {
+        };
+
+        Services.registry(serviceRegistry);
+        try {
+            Services.set(FirstActiveContract.class, explicit);
+
+            assertThat(serviceRegistry.firstActive(FirstActiveContract.class).orElseThrow(), sameInstance(explicit));
+            assertThat(FirstActiveService.instances, is(0));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegistryFirstActiveReturnsQualifiedSetInstance() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        FirstActiveContract explicit = new FirstActiveContract() {
+        };
+        Qualifier qualifier = Qualifier.createNamed("explicit");
+        Qualifier otherQualifier = Qualifier.createNamed("other");
+
+        Services.registry(serviceRegistry);
+        try {
+            Services.setQualified(FirstActiveContract.class, explicit, qualifier);
+
+            assertThat(serviceRegistry.firstActive(FirstActiveContract.class, otherQualifier).isEmpty(), is(true));
+            assertThat(serviceRegistry.firstActive(FirstActiveContract.class, qualifier).orElseThrow(),
+                       sameInstance(explicit));
         } finally {
             manager.shutdown();
         }

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -180,6 +180,53 @@ public class RegistryTest {
     }
 
     @Test
+    public void testRegistryFirstActiveDoesNotReturnDestroyedSetInstance() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        FirstActiveContract explicit = new FirstActiveContract() {
+        };
+        boolean shutDown = false;
+
+        Services.registry(serviceRegistry);
+        try {
+            Services.set(FirstActiveContract.class, explicit);
+
+            assertThat(serviceRegistry.firstActive(FirstActiveContract.class).orElseThrow(), sameInstance(explicit));
+            assertThat(serviceRegistry.get(FirstActiveContract.class), sameInstance(explicit));
+
+            manager.shutdown();
+            shutDown = true;
+
+            assertThat(serviceRegistry.firstActive(FirstActiveContract.class).isEmpty(), is(true));
+        } finally {
+            if (!shutDown) {
+                manager.shutdown();
+            }
+        }
+    }
+
+    @Test
+    public void testRegistryFirstActiveDoesNotCreatePerLookupInstance() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        ServiceSupplier.reset();
+
+        try {
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).isEmpty(), is(true));
+            assertThat(ServiceSupplier.instances(), is(0));
+
+            Supplier<SuppliedContract> supplier = serviceRegistry.supply(SuppliedContract.class);
+            SuppliedContract first = supplier.get();
+            assertThat(first.message(), is("Supplied:1"));
+
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).isEmpty(), is(true));
+            assertThat(ServiceSupplier.instances(), is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     public void testRegistryAll() {
         List<MyContract> myContracts = registry.all(MyContract.class);
         assertThat(myContracts, hasSize(2));
@@ -193,6 +240,7 @@ public class RegistryTest {
 
     @Test
     public void testSupplier() {
+        ServiceSupplier.reset();
         Supplier<SuppliedContract> supplier = registry.supply(SuppliedContract.class);
 
         SuppliedContract first = supplier.get();

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -280,6 +280,34 @@ public class RegistryTest {
     }
 
     @Test
+    public void testRegistryFirstActiveDoesNotRetainEmptyFixedFactory() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                               .discoverServices(false)
+                                                                               .addServiceDescriptor(
+                                                                                       SingletonServicesFactory__ServiceDescriptor.INSTANCE)
+                                                                               .build());
+        ServiceRegistry serviceRegistry = manager.registry();
+        SingletonServicesFactory emptyFactory = new SingletonServicesFactory();
+        SuppliedContract product = () -> "replacement";
+        SingletonServicesFactory replacementFactory = new SingletonServicesFactory(product);
+
+        Services.registry(serviceRegistry);
+        try {
+            Services.set(SingletonServicesFactory.class, emptyFactory);
+
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).isEmpty(), is(true));
+
+            Services.set(SingletonServicesFactory.class, replacementFactory);
+
+            assertThat(serviceRegistry.firstActive(SingletonServicesFactory.class).orElseThrow(),
+                       sameInstance(replacementFactory));
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).orElseThrow(), sameInstance(product));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     public void testRegistryAll() {
         List<MyContract> myContracts = registry.all(MyContract.class);
         assertThat(myContracts, hasSize(2));

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -226,6 +226,27 @@ public class RegistryTest {
     }
 
     @Test
+    public void testRegistryFirstActiveDoesNotCreateFixedPerLookupInstance() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        ServiceSupplier.reset();
+        ServiceSupplier explicit = new ServiceSupplier();
+
+        Services.registry(serviceRegistry);
+        try {
+            Services.set(ServiceSupplier.class, explicit);
+
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).isEmpty(), is(true));
+            assertThat(ServiceSupplier.instances(), is(0));
+
+            assertThat(serviceRegistry.firstActive(ServiceSupplier.class).orElseThrow(), sameInstance(explicit));
+            assertThat(ServiceSupplier.instances(), is(0));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     public void testRegistryAll() {
         List<MyContract> myContracts = registry.all(MyContract.class);
         assertThat(myContracts, hasSize(2));

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -350,12 +350,46 @@ public class RegistryTest {
             Services.set(SingletonServicesFactory.class, emptyFactory);
 
             assertThat(serviceRegistry.firstActive(SuppliedContract.class).isEmpty(), is(true));
+            assertThat(emptyFactory.servicesCalls(), is(0));
 
             Services.set(SingletonServicesFactory.class, replacementFactory);
 
             assertThat(serviceRegistry.firstActive(SingletonServicesFactory.class).orElseThrow(),
                        sameInstance(replacementFactory));
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).isEmpty(), is(true));
+            assertThat(replacementFactory.servicesCalls(), is(0));
+
+            assertThat(serviceRegistry.get(SuppliedContract.class), sameInstance(product));
+            assertThat(replacementFactory.servicesCalls(), is(1));
             assertThat(serviceRegistry.firstActive(SuppliedContract.class).orElseThrow(), sameInstance(product));
+            assertThat(replacementFactory.servicesCalls(), is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegistryInitialFixedFactoryProductsAreLazy() {
+        SuppliedContract product = () -> "initial";
+        SingletonServicesFactory factory = new SingletonServicesFactory(product);
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                               .discoverServices(false)
+                                                                               .addServiceDescriptor(
+                                                                                       SingletonServicesFactory__ServiceDescriptor.INSTANCE)
+                                                                               .putServiceInstance(
+                                                                                       SingletonServicesFactory__ServiceDescriptor.INSTANCE,
+                                                                                       factory)
+                                                                               .build());
+        ServiceRegistry serviceRegistry = manager.registry();
+
+        try {
+            assertThat(factory.servicesCalls(), is(0));
+            assertThat(serviceRegistry.firstActive(SingletonServicesFactory.class).orElseThrow(), sameInstance(factory));
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).isEmpty(), is(true));
+            assertThat(factory.servicesCalls(), is(0));
+
+            assertThat(serviceRegistry.get(SuppliedContract.class), sameInstance(product));
+            assertThat(factory.servicesCalls(), is(1));
         } finally {
             manager.shutdown();
         }

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.service.registry.Services;
 
@@ -241,6 +242,38 @@ public class RegistryTest {
 
             assertThat(serviceRegistry.firstActive(ServiceSupplier.class).orElseThrow(), sameInstance(explicit));
             assertThat(ServiceSupplier.instances(), is(0));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegistryFirstActiveDoesNotCreateFixedSingletonSupplierProduct() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                               .discoverServices(false)
+                                                                               .addServiceDescriptor(
+                                                                                       SingletonServiceSupplier__ServiceDescriptor.INSTANCE)
+                                                                               .build());
+        ServiceRegistry serviceRegistry = manager.registry();
+        SingletonServiceSupplier explicit = new SingletonServiceSupplier(serviceRegistry);
+
+        Services.registry(serviceRegistry);
+        try {
+            Services.set(SingletonServiceSupplier.class, explicit);
+
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).isEmpty(), is(true));
+            assertThat(explicit.instances(), is(0));
+            assertThat(serviceRegistry.firstActive(SingletonServiceSupplier.class).orElseThrow(), sameInstance(explicit));
+            assertThat(explicit.instances(), is(0));
+
+            explicit.reenterOnGet();
+            SuppliedContract activated = serviceRegistry.get(SuppliedContract.class);
+
+            assertThat(activated.message(), is("Supplied:1"));
+            assertThat(explicit.activeDuringGet().isEmpty(), is(true));
+            assertThat(explicit.instances(), is(1));
+            assertThat(serviceRegistry.firstActive(SuppliedContract.class).orElseThrow(), sameInstance(activated));
+            assertThat(explicit.instances(), is(1));
         } finally {
             manager.shutdown();
         }

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -271,9 +271,31 @@ public class RegistryTest {
 
             assertThat(activated.message(), is("Supplied:1"));
             assertThat(explicit.activeDuringGet().isEmpty(), is(true));
+            assertThat(explicit.resolvingDuringGet(), is(true));
             assertThat(explicit.instances(), is(1));
             assertThat(serviceRegistry.firstActive(SuppliedContract.class).orElseThrow(), sameInstance(activated));
+            assertThat(serviceRegistry.isResolvingOnCurrentThread(SuppliedContract.class), is(false));
             assertThat(explicit.instances(), is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegistryReportsNormalSingletonSupplierResolution() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                               .discoverServices(false)
+                                                                               .addServiceDescriptor(
+                                                                                       SingletonServiceSupplier__ServiceDescriptor.INSTANCE)
+                                                                               .build());
+        ServiceRegistry serviceRegistry = manager.registry();
+
+        Services.registry(serviceRegistry);
+        try {
+            SingletonServiceSupplier supplier = serviceRegistry.get(SingletonServiceSupplier.class);
+
+            assertThat(supplier.resolvingDuringGet(), is(true));
+            assertThat(serviceRegistry.isResolvingOnCurrentThread(SuppliedContract.class), is(false));
         } finally {
             manager.shutdown();
         }

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RegistryTest {
     private static ServiceRegistryManager registryManager;
@@ -272,63 +271,10 @@ public class RegistryTest {
 
             assertThat(activated.message(), is("Supplied:1"));
             assertThat(explicit.activeDuringGet().isEmpty(), is(true));
-            assertThat(explicit.resolvingDuringGet(), is(true));
             assertThat(explicit.instances(), is(1));
             assertThat(serviceRegistry.firstActive(SuppliedContract.class).orElseThrow(), sameInstance(activated));
-            assertThat(serviceRegistry.isResolvingOnCurrentThread(SuppliedContract.class), is(false));
             assertThat(explicit.instances(), is(1));
         } finally {
-            manager.shutdown();
-        }
-    }
-
-    @Test
-    public void testRegistryReportsNormalSingletonSupplierResolution() {
-        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
-                                                                               .discoverServices(false)
-                                                                               .addServiceDescriptor(
-                                                                                       SingletonServiceSupplier__ServiceDescriptor.INSTANCE)
-                                                                               .build());
-        ServiceRegistry serviceRegistry = manager.registry();
-
-        Services.registry(serviceRegistry);
-        try {
-            SingletonServiceSupplier supplier = serviceRegistry.get(SingletonServiceSupplier.class);
-
-            assertThat(supplier.resolvingDuringGet(), is(true));
-            assertThat(serviceRegistry.isResolvingOnCurrentThread(SuppliedContract.class), is(false));
-        } finally {
-            manager.shutdown();
-        }
-    }
-
-    @Test
-    public void testRegistryClearsFixedSupplierResolutionAfterFailure() {
-        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
-                                                                               .discoverServices(false)
-                                                                               .addServiceDescriptor(
-                                                                                       SingletonServiceSupplier__ServiceDescriptor.INSTANCE)
-                                                                               .build());
-        ServiceRegistryManager otherManager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
-                                                                                    .discoverServices(false)
-                                                                                    .addServiceDescriptor(
-                                                                                            SingletonServiceSupplier__ServiceDescriptor.INSTANCE)
-                                                                                    .build());
-        ServiceRegistry serviceRegistry = manager.registry();
-        SingletonServiceSupplier explicit = new SingletonServiceSupplier(serviceRegistry);
-        explicit.failOnGet();
-        explicit.checkOtherRegistry(otherManager.registry());
-
-        Services.registry(serviceRegistry);
-        try {
-            Services.set(SingletonServiceSupplier.class, explicit);
-
-            assertThrows(IllegalStateException.class, () -> serviceRegistry.get(SuppliedContract.class));
-            assertThat(explicit.resolvingDuringGet(), is(true));
-            assertThat(explicit.otherRegistryResolvingDuringGet(), is(false));
-            assertThat(serviceRegistry.isResolvingOnCurrentThread(SuppliedContract.class), is(false));
-        } finally {
-            otherManager.shutdown();
             manager.shutdown();
         }
     }

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RegistryTest {
     private static ServiceRegistryManager registryManager;
@@ -297,6 +298,37 @@ public class RegistryTest {
             assertThat(supplier.resolvingDuringGet(), is(true));
             assertThat(serviceRegistry.isResolvingOnCurrentThread(SuppliedContract.class), is(false));
         } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRegistryClearsFixedSupplierResolutionAfterFailure() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                               .discoverServices(false)
+                                                                               .addServiceDescriptor(
+                                                                                       SingletonServiceSupplier__ServiceDescriptor.INSTANCE)
+                                                                               .build());
+        ServiceRegistryManager otherManager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                    .discoverServices(false)
+                                                                                    .addServiceDescriptor(
+                                                                                            SingletonServiceSupplier__ServiceDescriptor.INSTANCE)
+                                                                                    .build());
+        ServiceRegistry serviceRegistry = manager.registry();
+        SingletonServiceSupplier explicit = new SingletonServiceSupplier(serviceRegistry);
+        explicit.failOnGet();
+        explicit.checkOtherRegistry(otherManager.registry());
+
+        Services.registry(serviceRegistry);
+        try {
+            Services.set(SingletonServiceSupplier.class, explicit);
+
+            assertThrows(IllegalStateException.class, () -> serviceRegistry.get(SuppliedContract.class));
+            assertThat(explicit.resolvingDuringGet(), is(true));
+            assertThat(explicit.otherRegistryResolvingDuringGet(), is(false));
+            assertThat(serviceRegistry.isResolvingOnCurrentThread(SuppliedContract.class), is(false));
+        } finally {
+            otherManager.shutdown();
             manager.shutdown();
         }
     }

--- a/service/tests/scopes/src/test/java/io/helidon/service/tests/scopes/TestScopes.java
+++ b/service/tests/scopes/src/test/java/io/helidon/service/tests/scopes/TestScopes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -112,5 +113,22 @@ class TestScopes {
             int nextId = supply.get().id();
             assertThat("We should get a different custom scope than last time", nextId, not(id));
         }
+    }
+
+    @Test
+    void firstActiveDoesNotActivateCustomScopeHandler() {
+        assertThat(registry.firstActive(CustomScopedContract.class).isEmpty(), is(true));
+        assertThat(registry.firstActive(CustomScopeHandler.class).isEmpty(), is(true));
+
+        Scopes scopes = registry.get(Scopes.class);
+        try (Scope ignored = scopes.createScope(CustomScope.TYPE, "active-lookup", CUSTOM_BINDINGS)) {
+            assertThat(registry.firstActive(CustomScopedContract.class).isEmpty(), is(true));
+            assertThat(registry.firstActive(CustomScopeHandler.class).isPresent(), is(true));
+
+            CustomScopedContract service = registry.get(CustomScopedContract.class);
+            assertThat(registry.firstActive(CustomScopedContract.class).orElseThrow(), sameInstance(service));
+        }
+
+        assertThat(registry.firstActive(CustomScopedContract.class).isEmpty(), is(true));
     }
 }

--- a/tests/integration/config/ft-config-bootstrap/pom.xml
+++ b/tests/integration/config/ft-config-bootstrap/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration-config</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-ft-config-bootstrap</artifactId>
+    <name>Helidon Tests Integration Fault Tolerance Config Bootstrap</name>
+    <description>Validates Fault Tolerance use from an SE meta-configured config source.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.fault-tolerance</groupId>
+            <artifactId>helidon-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/config/ft-config-bootstrap/src/test/java/io/helidon/tests/integration/config/ftbootstrap/FaultToleranceConfigBootstrapTest.java
+++ b/tests/integration/config/ft-config-bootstrap/src/test/java/io/helidon/tests/integration/config/ftbootstrap/FaultToleranceConfigBootstrapTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.config.ftbootstrap;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigValues;
+import io.helidon.service.registry.Services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class FaultToleranceConfigBootstrapTest {
+    @Test
+    void serviceRegistryConfigSourceCanCreateRetryDuringConfigBootstrap() {
+        Config config = Services.get(Config.class);
+
+        assertThat(config.get("repro.config-source.loaded").asBoolean(), is(ConfigValues.simpleValue(true)));
+    }
+}

--- a/tests/integration/config/ft-config-bootstrap/src/test/java/io/helidon/tests/integration/config/ftbootstrap/RetryConfigSource.java
+++ b/tests/integration/config/ft-config-bootstrap/src/test/java/io/helidon/tests/integration/config/ftbootstrap/RetryConfigSource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.config.ftbootstrap;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.helidon.config.ConfigException;
+import io.helidon.config.spi.ConfigContent.NodeContent;
+import io.helidon.config.spi.ConfigNode.ObjectNode;
+import io.helidon.config.spi.NodeConfigSource;
+import io.helidon.faulttolerance.Retry;
+
+class RetryConfigSource implements NodeConfigSource {
+    static final String TYPE = "fault-tolerance-bootstrap";
+
+    RetryConfigSource() {
+        Retry.builder()
+                .retryPolicy(Retry.DelayingRetryPolicy.builder()
+                                     .calls(3)
+                                     .delay(Duration.ofMillis(10))
+                                     .build())
+                .overallTimeout(Duration.ofSeconds(1))
+                .build();
+    }
+
+    @Override
+    public Optional<NodeContent> load() throws ConfigException {
+        return Optional.of(NodeContent.builder()
+                                   .node(ObjectNode.builder()
+                                                 .addValue("repro.config-source.loaded", "true")
+                                                 .build())
+                                   .build());
+    }
+}

--- a/tests/integration/config/ft-config-bootstrap/src/test/java/io/helidon/tests/integration/config/ftbootstrap/RetryConfigSourceProvider.java
+++ b/tests/integration/config/ft-config-bootstrap/src/test/java/io/helidon/tests/integration/config/ftbootstrap/RetryConfigSourceProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.config.ftbootstrap;
+
+import java.util.Set;
+
+import io.helidon.config.Config;
+import io.helidon.config.spi.ConfigSource;
+import io.helidon.config.spi.ConfigSourceProvider;
+
+public class RetryConfigSourceProvider implements ConfigSourceProvider {
+    @Override
+    public boolean supports(String type) {
+        return RetryConfigSource.TYPE.equals(type);
+    }
+
+    @Override
+    public ConfigSource create(String type, Config metaConfig) {
+        return new RetryConfigSource();
+    }
+
+    @Override
+    public Set<String> supported() {
+        return Set.of(RetryConfigSource.TYPE);
+    }
+}

--- a/tests/integration/config/ft-config-bootstrap/src/test/resources/META-INF/services/io.helidon.config.spi.ConfigSourceProvider
+++ b/tests/integration/config/ft-config-bootstrap/src/test/resources/META-INF/services/io.helidon.config.spi.ConfigSourceProvider
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.tests.integration.config.ftbootstrap.RetryConfigSourceProvider

--- a/tests/integration/config/ft-config-bootstrap/src/test/resources/meta-config.yaml
+++ b/tests/integration/config/ft-config-bootstrap/src/test/resources/meta-config.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sources:
+  - type: "fault-tolerance-bootstrap"

--- a/tests/integration/config/pom.xml
+++ b/tests/integration/config/pom.xml
@@ -35,6 +35,7 @@
     </description>
 
     <modules>
+        <module>ft-config-bootstrap</module>
         <module>gh-2171</module>
         <module>gh-2171-yml</module>
     </modules>


### PR DESCRIPTION
Resolves #12071

This fixes FT bootstrap recursion by:
- adding active-only ServiceRegistry lookup support that can observe already active services without creating Config
- marking explicit Services.set instances ACTIVE so firstActive lookup can return them while still rejecting DESTROYED instances
- using active-only config lookup for Fault Tolerance metrics defaults
- adding the SE config bootstrap reproducer and service-registry lifecycle regressions
