### PR TITLE
Add WebServer SNI support

### DIFF
--- a/common/socket/src/main/java/io/helidon/common/socket/TlsNioSocket.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/TlsNioSocket.java
@@ -24,6 +24,7 @@ import java.security.Principal;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -34,6 +35,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 
+import io.helidon.common.Api;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 
@@ -51,6 +53,7 @@ public final class TlsNioSocket extends NioSocket {
     private ByteBuffer peerAppData;
     private ByteBuffer myNetData;
     private ByteBuffer peerNetData;
+    private ByteBuffer replayNetData;
     private boolean closed;
 
     private volatile PeerInfo localPeer;
@@ -60,10 +63,15 @@ public final class TlsNioSocket extends NioSocket {
     private volatile boolean idle;
     private boolean peerAppDataReady;
 
-    private TlsNioSocket(SocketChannel delegate, SSLEngine sslEngine, String channelId, String serverChannelId) {
+    private TlsNioSocket(SocketChannel delegate,
+                         SSLEngine sslEngine,
+                         String channelId,
+                         String serverChannelId,
+                         ByteBuffer replayNetData) {
         super(delegate, channelId, serverChannelId);
 
         this.engine = sslEngine;
+        this.replayNetData = replayNetData;
 
         SSLSession dummySession = engine.getSession();
         this.peerNetData = ByteBuffer.allocate(dummySession.getPacketBufferSize());
@@ -78,8 +86,8 @@ public final class TlsNioSocket extends NioSocket {
      *
      * @param delegate        underlying socket
      * @param sslEngine       SSL engine
-     * @param channelId       listener channel id
-     * @param serverChannelId connection channel id
+     * @param channelId       connection channel id
+     * @param serverChannelId listener channel id
      * @return a new TLS socket
      */
     public static TlsNioSocket server(SocketChannel delegate,
@@ -87,7 +95,32 @@ public final class TlsNioSocket extends NioSocket {
                                       String channelId,
                                       String serverChannelId) {
         sslEngine.setUseClientMode(false);
-        return new TlsNioSocket(delegate, sslEngine, channelId, serverChannelId);
+        return new TlsNioSocket(delegate, sslEngine, channelId, serverChannelId, null);
+    }
+
+    /**
+     * Create a server TLS NIO socket with already-read TLS network data to replay into the first unwrap.
+     * This is intended for server implementations that need to inspect TLS records before creating the engine.
+     *
+     * @param delegate        underlying socket
+     * @param sslEngine       SSL engine
+     * @param channelId       connection channel id
+     * @param serverChannelId listener channel id
+     * @param replayNetData   already-read TLS network data
+     * @return a new TLS socket
+     */
+    @Api.Internal
+    public static TlsNioSocket server(SocketChannel delegate,
+                                      SSLEngine sslEngine,
+                                      String channelId,
+                                      String serverChannelId,
+                                      ByteBuffer replayNetData) {
+        sslEngine.setUseClientMode(false);
+        return new TlsNioSocket(delegate,
+                                sslEngine,
+                                channelId,
+                                serverChannelId,
+                                Objects.requireNonNull(replayNetData));
     }
 
     /**
@@ -102,7 +135,7 @@ public final class TlsNioSocket extends NioSocket {
                                       SSLEngine sslEngine,
                                       String channelId) {
         sslEngine.setUseClientMode(true);
-        return new TlsNioSocket(delegate, sslEngine, channelId, "client");
+        return new TlsNioSocket(delegate, sslEngine, channelId, "client", null);
     }
 
     @Override
@@ -366,6 +399,9 @@ public final class TlsNioSocket extends NioSocket {
             peerNetData.compact();
             peerNetData.flip();
             needData = false;
+        } else if (replayNetData != null) {
+            prepareReplayNetData(false);
+            needData = false;
         } else {
             peerNetData.clear();
             needData = true;
@@ -385,13 +421,17 @@ public final class TlsNioSocket extends NioSocket {
             result = engine.unwrap(peerNetData, peerAppData);
             status = result.getStatus();
             if (status == SSLEngineResult.Status.BUFFER_UNDERFLOW) {
-                if (peerNetData.limit() == peerNetData.capacity()) {
+                if (replayNetData != null) {
+                    prepareReplayNetData(true);
+                    needData = false;
+                } else if (peerNetData.limit() == peerNetData.capacity()) {
                     peerNetData = reallocate(peerNetData, engine.getSession().getPacketBufferSize(), false);
+                    needData = true;
                 } else {
                     peerNetData.position(peerNetData.limit());
                     peerNetData.limit(peerNetData.capacity());
+                    needData = true;
                 }
-                needData = true;
             } else if (status == SSLEngineResult.Status.BUFFER_OVERFLOW) {
                 peerAppData = reallocate(peerAppData, engine.getSession().getApplicationBufferSize(), true);
                 needData = false;
@@ -404,6 +444,28 @@ public final class TlsNioSocket extends NioSocket {
 
         unwrapRemaining = peerNetData.remaining();
         return result;
+    }
+
+    private void prepareReplayNetData(boolean append) {
+        ByteBuffer replay = replayNetData;
+        if (append) {
+            if (peerNetData.remaining() == peerNetData.capacity()) {
+                peerNetData = reallocate(peerNetData, engine.getSession().getPacketBufferSize(), false);
+            } else {
+                peerNetData.compact();
+            }
+        } else {
+            peerNetData.clear();
+        }
+        int chunk = Math.min(peerNetData.remaining(), replay.remaining());
+        int replayLimit = replay.limit();
+        replay.limit(replay.position() + chunk);
+        peerNetData.put(replay);
+        replay.limit(replayLimit);
+        peerNetData.flip();
+        if (!replay.hasRemaining()) {
+            replayNetData = null;
+        }
     }
 
     private byte[] appBytes() {

--- a/common/socket/src/test/java/io/helidon/common/socket/TlsNioSocketTest.java
+++ b/common/socket/src/test/java/io/helidon/common/socket/TlsNioSocketTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLEngine;
@@ -39,6 +40,7 @@ import io.helidon.common.buffers.BufferData;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -169,6 +171,46 @@ class TlsNioSocketTest {
         socket.handshake();
 
         assertArrayEquals(new byte[] {'S'}, socket.get());
+    }
+
+    @Test
+    void replayedNetworkDataUsesPacketSizedChunks() throws Exception {
+        BlockingSocketChannel channel = new BlockingSocketChannel();
+        SSLEngine engine = mock(SSLEngine.class);
+        SSLSession session = mock(SSLSession.class);
+        ByteBuffer replay = ByteBuffer.wrap(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        AtomicInteger consumed = new AtomicInteger();
+
+        when(engine.getSession()).thenReturn(session);
+        when(engine.getHandshakeStatus()).thenReturn(SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING);
+        when(session.getPacketBufferSize()).thenReturn(4);
+        when(session.getApplicationBufferSize()).thenReturn(8);
+        when(engine.unwrap(any(ByteBuffer.class), any(ByteBuffer.class))).thenAnswer(invocation -> {
+            ByteBuffer src = invocation.getArgument(0);
+            ByteBuffer dst = invocation.getArgument(1);
+            int available = src.remaining();
+            assertTrue(available <= 4, "Replay should not expand the retained peer network buffer");
+
+            src.position(src.limit());
+            int totalConsumed = consumed.addAndGet(available);
+            if (totalConsumed < 10) {
+                return new SSLEngineResult(SSLEngineResult.Status.BUFFER_UNDERFLOW,
+                                           SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING,
+                                           available,
+                                           0);
+            }
+
+            dst.put((byte) 'R');
+            return new SSLEngineResult(SSLEngineResult.Status.OK,
+                                       SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING,
+                                       available,
+                                       1);
+        });
+
+        TlsNioSocket socket = TlsNioSocket.server(channel, engine, "listener", "server", replay);
+
+        assertArrayEquals(new byte[] {'R'}, socket.get());
+        assertEquals(10, consumed.get());
     }
 
     @Test

--- a/docs/src/main/asciidoc/se/grpc/server.adoc
+++ b/docs/src/main/asciidoc/se/grpc/server.adoc
@@ -31,6 +31,7 @@ include::{rootdir}/includes/se.adoc[]
 - <<Usage, Usage>>
 ** <<gRPC Server Routing, gRPC Server Routing>>
 ** <<Service Implementation, Service Implementation>>
+** <<Connection Metadata, Connection Metadata>>
 ** <<Server Interceptors, Server Interceptors>>
 ** <<Metrics, Metrics>>
 - <<Configuration, Configuration>>
@@ -163,6 +164,19 @@ enable Protobuf marshalling.
 NOTE: The `complete` method shown in the example above is just one of many helper
 methods available in the `ResponseHelper` class. See the full list
 link:{javadoc-base-url}/io.helidon.grpc.core/io/helidon/grpc/core/ResponseHelper.html[here].
+
+=== Connection Metadata
+
+Helidon stores connection-level metadata in the gRPC context. Handlers and interceptors can obtain
+`GrpcConnectionContext` using `ServerContextKeys.CONNECTION_CONTEXT`.
+
+[source,java]
+----
+include::{sourcedir}/se/grpc/ServerSnippets.java[tag=snippet_5, indent=0]
+----
+
+The requested SNI host is normalized client request data. The matched SNI host is the configured
+virtual-host host or wildcard pattern selected by SNI.
 
 === Server Interceptors
 

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -114,6 +114,68 @@ To configure TLS in WebServer programmatically create your keystore configuratio
 include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_30, indent=0]
 ----
 
+==== Configuring TLS Virtual Hosts with SNI
+
+You can configure listener TLS virtual hosts selected by the TLS Server Name Indication (SNI) host.
+Virtual hosts select TLS material only. All requests still use the listener routing.
+
+[source,java]
+----
+include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_39, indent=0]
+----
+
+The listener default `tls` configuration is the fallback when the client omits SNI or presents an
+unmatched SNI host. Exact DNS names and narrow wildcard patterns such as `*.example.com` are supported.
+Wildcard patterns match one left-most label only. If `sni.missing` is set to `REJECT`, the server
+rejects connections without SNI. If `sni.unmatched` is set to `REJECT`, the server aborts an unmatched
+SNI handshake with a TLS `unrecognized_name` alert.
+
+By default, the server rejects HTTP requests with status `421 Misdirected Request` when the request
+authority differs from the client-presented SNI host, or when fallback TLS is used for an authority configured
+as a virtual host.
+
+Handlers can inspect both the normalized SNI host requested by the client and the configured virtual-host
+host that matched it. The requested host is client supplied, so treat it as request data; the matched host
+comes from configuration and is suitable for configuration-driven choices.
+
+[source,java]
+----
+include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_40, indent=0]
+----
+
+[source,yaml]
+.WebServer SNI virtual-host configuration in `application.yaml`
+----
+server:
+  tls:
+    private-key:
+      keystore:
+        passphrase: "password"
+        resource:
+          resource-path: "default-server.p12"
+  virtual-hosts:
+    - host: "api.example.com"
+      tls:
+        private-key:
+          keystore:
+            passphrase: "password"
+            resource:
+              resource-path: "api-server.p12"
+    - host: "*.example.org"
+      tls:
+        private-key:
+          keystore:
+            passphrase: "password"
+            resource:
+              resource-path: "wildcard-server.p12"
+  sni:
+    missing: "FALLBACK"
+    unmatched: "FALLBACK"
+    authority-mismatch: "REJECT"
+    fallback-authority: "REJECT"
+----
+
+SNI virtual hosts require listener TLS and the NIO socket-channel transport, which is the default.
 
 ==== Configuring TLS in the Config File
 

--- a/docs/src/main/java/io/helidon/docs/se/WebServerSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/WebServerSnippets.java
@@ -30,10 +30,12 @@ import io.helidon.common.tls.Tls;
 import io.helidon.common.uri.UriInfo;
 // end::snippet_16[]
 import io.helidon.config.Config;
+import io.helidon.http.DirectHandler;
+import io.helidon.http.DirectHandler.EventType;
 import io.helidon.http.HttpException;
 import io.helidon.http.Method;
-import io.helidon.http.Status;
 import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.Status;
 import io.helidon.http.encoding.gzip.GzipEncoding;
 import io.helidon.http.media.jsonp.JsonpSupport;
 import io.helidon.webserver.ProxyProtocolData;
@@ -42,6 +44,7 @@ import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.accesslog.AccessLogFeature;
 import io.helidon.webserver.hsts.HstsFeature;
+import io.helidon.webserver.http.DirectHandlers;
 import io.helidon.webserver.http.HttpRoute;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.HttpRules;
@@ -49,10 +52,6 @@ import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http1.Http1Route;
 import io.helidon.webserver.http2.Http2Route;
 import io.helidon.webserver.staticcontent.StaticContentFeature;
-import io.helidon.webserver.http.DirectHandlers;
-import io.helidon.webserver.http.HttpRouting;
-import io.helidon.http.DirectHandler;
-import io.helidon.http.DirectHandler.EventType;
 
 // tag::snippet_14[]
 import jakarta.json.Json;
@@ -357,12 +356,44 @@ class WebServerSnippets {
         // end::snippet_31[]
     }
 
+    void snippet_39() {
+        // tag::snippet_39[]
+        Tls defaultTls = Tls.builder()
+                .privateKey(pk -> pk
+                        .keystore(keys -> keys.keystore(it -> it.resourcePath("default-server.p12"))
+                                .passphrase("password".toCharArray())))
+                .build();
+        Tls apiTls = Tls.builder()
+                .privateKey(pk -> pk
+                        .keystore(keys -> keys.keystore(it -> it.resourcePath("api-server.p12"))
+                                .passphrase("password".toCharArray())))
+                .build();
+
+        WebServer.builder()
+                .tls(defaultTls)
+                .addVirtualHost(virtualHost -> virtualHost
+                        .host("api.example.com")
+                        .tls(apiTls));
+        // end::snippet_39[]
+    }
+
+    void snippet_40(HttpRules rules) {
+        // tag::snippet_40[]
+        rules.get("/template", (req, res) -> {
+            String requestedHost = req.sniRequestedHost().orElse("default.example.com");
+            String matchedHost = req.sniMatchedHost().orElse("default");
+
+            res.send(templateFor(matchedHost, requestedHost));
+        });
+        // end::snippet_40[]
+    }
+
     void snippet_32() {
         // tag::snippet_32[]
         WebServer.builder()
                 .contentEncoding(it -> it
-                .contentEncodingsDiscoverServices(false)
-                .addContentEncoding(GzipEncoding.create()));
+                        .contentEncodingsDiscoverServices(false)
+                        .addContentEncoding(GzipEncoding.create()));
         // end::snippet_32[]
     }
 
@@ -456,9 +487,13 @@ class WebServerSnippets {
         // tag::snippet_38[]
         WebServer.builder()
                 .addFeature(HstsFeature.builder()
-                                    .maxAge(Duration.ofDays(365))
-                                    .includeSubDomains(true)
-                                    .build());
+                        .maxAge(Duration.ofDays(365))
+                        .includeSubDomains(true)
+                        .build());
         // end::snippet_38[]
+    }
+
+    private String templateFor(String matchedHost, String requestedHost) {
+        return matchedHost + ":" + requestedHost;
     }
 }

--- a/docs/src/main/java/io/helidon/docs/se/grpc/ServerSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/grpc/ServerSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,20 @@
 package io.helidon.docs.se.grpc;
 
 import io.helidon.config.Config;
+import io.helidon.grpc.core.InterceptorWeights;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.grpc.GrpcConnectionContext;
 import io.helidon.webserver.grpc.GrpcRouting;
 import io.helidon.webserver.grpc.GrpcService;
-import io.helidon.grpc.core.InterceptorWeights;
+import io.helidon.webserver.grpc.ServerContextKeys;
 
 import com.google.protobuf.Descriptors;
-import io.grpc.stub.StreamObserver;
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import io.grpc.ServerCall;
-import io.grpc.Metadata;
+import io.grpc.stub.StreamObserver;
 
 import static io.helidon.grpc.core.ResponseHelper.complete;
 
@@ -207,5 +210,17 @@ class ServerSnippets {
                 .service(new MathService())
                 .build();
         // end::snippet_4[]
+    }
+
+    void snippet_5() {
+        // tag::snippet_5[]
+        GrpcConnectionContext connectionContext =
+                ServerContextKeys.CONNECTION_CONTEXT.get(Context.current());
+
+        String requestedHost = connectionContext.sniRequestedHost()
+                .orElse("default.example.com");
+        String matchedHost = connectionContext.sniMatchedHost()
+                .orElse("default");
+        // end::snippet_5[]
     }
 }

--- a/http/http2/pom.xml
+++ b/http/http2/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>helidon-common-buffers</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-uri</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http</groupId>
             <artifactId>helidon-http</artifactId>
         </dependency>

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.uri.UriAuthority;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -348,6 +349,26 @@ public class Http2Headers {
         }
         if (!pseudoHeaders.hasMethod()) {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :method pseudo header");
+        }
+        if (pseudoHeaders.hasAuthority()) {
+            validateHostAuthority();
+        }
+    }
+
+    private void validateHostAuthority() {
+        List<String> hostHeaders = headers.all(HeaderNames.HOST, List::of);
+        if (hostHeaders.isEmpty()) {
+            return;
+        }
+        if (hostHeaders.size() > 1) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Only a single Host header is allowed");
+        }
+        try {
+            if (!UriAuthority.create(pseudoHeaders.authority()).equals(UriAuthority.create(hostHeaders.getFirst()))) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Host header must match :authority");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Invalid Host or :authority header", e);
         }
     }
 

--- a/http/http2/src/main/java/module-info.java
+++ b/http/http2/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 module io.helidon.http.http2 {
 
     requires io.helidon.common;
+    requires io.helidon.common.uri;
     
     requires transitive io.helidon.common.socket;
     requires transitive io.helidon.http;

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.http.http2;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
 
 import io.helidon.common.buffers.BufferData;
@@ -33,6 +35,8 @@ import org.mockito.Mockito;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class Http2HeadersTest {
     private static final HeaderName CUSTOM_HEADER_NAME = HeaderNames.create("custom-key");
@@ -260,6 +264,22 @@ class Http2HeadersTest {
         assertThat(requestHeaders.contains(HeaderNames.CONTENT_LOCATION), is(false));
     }
 
+    @Test
+    void validatesRegularHostMatchesAuthority() {
+        Http2Headers http2Headers = parsedHeadersWithAuthorityAndHost("api.example.com", "Api.Example.COM");
+
+        assertDoesNotThrow(http2Headers::validateRequest);
+    }
+
+    @Test
+    void rejectsRegularHostDifferentFromAuthority() {
+        Http2Headers http2Headers = parsedHeadersWithAuthorityAndHost("api.example.com", "admin.example.com");
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
     private Http2Headers headers(String hexEncoded, DynamicTable dynamicTable) {
         BufferData data = data(hexEncoded);
         Http2FrameHeader header = Http2FrameHeader.create(data.available(),
@@ -273,5 +293,48 @@ class Http2HeadersTest {
                                    dynamicTable,
                                    Http2HuffmanDecoder.create(),
                                    new Http2FrameData(header, data));
+    }
+
+    private Http2Headers parsedHeadersWithAuthorityAndHost(String authority, String host) {
+        ByteArrayOutputStream headerBlock = new ByteArrayOutputStream();
+        headerBlock.write(0x82); // :method: GET
+        headerBlock.write(0x87); // :scheme: https
+        headerBlock.write(0x84); // :path: /
+        writeLiteralWithoutIndex(headerBlock, 1, authority); // :authority
+        writeLiteralWithoutIndex(headerBlock, 38, host); // host
+
+        BufferData data = BufferData.create(headerBlock.toByteArray());
+        Http2FrameHeader header = Http2FrameHeader.create(data.available(),
+                                                          Http2FrameTypes.HEADERS,
+                                                          Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                                          1);
+        Http2Stream stream = Mockito.mock(Http2Stream.class);
+        return Http2Headers.create(stream,
+                                   DynamicTable.create(Http2Settings.create()),
+                                   Http2HuffmanDecoder.create(),
+                                   new Http2FrameData(header, data));
+    }
+
+    private static void writeLiteralWithoutIndex(ByteArrayOutputStream headerBlock, int nameIndex, String value) {
+        writeHpackInt(headerBlock, 0, 4, nameIndex);
+        byte[] bytes = value.getBytes(StandardCharsets.US_ASCII);
+        writeHpackInt(headerBlock, 0, 7, bytes.length);
+        headerBlock.writeBytes(bytes);
+    }
+
+    private static void writeHpackInt(ByteArrayOutputStream headerBlock, int firstByteBits, int prefixBits, int value) {
+        int maxPrefixValue = (1 << prefixBits) - 1;
+        if (value < maxPrefixValue) {
+            headerBlock.write(firstByteBits | value);
+            return;
+        }
+
+        headerBlock.write(firstByteBits | maxPrefixValue);
+        value -= maxPrefixValue;
+        while (value >= 128) {
+            headerBlock.write((value & 0x7F) | 0x80);
+            value >>>= 7;
+        }
+        headerBlock.write(value);
     }
 }

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ServerSniJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ServerSniJmhTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.http.Headers;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.http.ServerRequestHeaders;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.SniContext;
+import io.helidon.webserver.SniRequestSupport;
+import io.helidon.webserver.VirtualHostConfig;
+import io.helidon.webserver.internal.SniBenchmarkSupport;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class ServerSniJmhTest {
+    private static final String SOCKET_NAME = "jmh";
+    private static final String EXACT_HOST = "api.example.com";
+    private static final String WILDCARD_HOST = "admin.wild.example.com";
+    private static final String FALLBACK_HOST = "other.example.com";
+    private static final Headers HEADERS = ServerRequestHeaders.create();
+    private static final HttpPrologue PROLOGUE = HttpPrologue.create("HTTP/1.1",
+                                                                     "HTTP",
+                                                                     "1.1",
+                                                                     Method.GET,
+                                                                     "/plaintext",
+                                                                     true);
+    private static final Tls TLS = Tls.builder()
+            .trustAll(true)
+            .build();
+
+    private byte[] noSniClientHello;
+    private byte[] exactClientHello;
+    private byte[] wildcardClientHello;
+    private byte[] fragmentedExactClientHello;
+    private SniBenchmarkSupport.Registry exactRegistry;
+    private SniBenchmarkSupport.Registry wildcardRegistry;
+    private SniBenchmarkSupport.Registry manyVirtualHostsRegistry;
+    private SniContext exactSniContext;
+    private SniContext fallbackSniContext;
+    private SniContext manyFallbackSniContext;
+
+    @Setup
+    public void setup() {
+        byte[] exactHandshake = clientHello(EXACT_HOST);
+        noSniClientHello = record(clientHelloWithoutSni());
+        exactClientHello = record(exactHandshake);
+        wildcardClientHello = record(clientHello(WILDCARD_HOST));
+        fragmentedExactClientHello = concat(record(exactHandshake, 0, 11),
+                                            record(exactHandshake, 11, exactHandshake.length - 11));
+
+        exactRegistry = registry(EXACT_HOST);
+        wildcardRegistry = registry("*.wild.example.com");
+        manyVirtualHostsRegistry = manyVirtualHostsRegistry();
+
+        exactSniContext = SniBenchmarkSupport.select(exactRegistry, EXACT_HOST);
+        fallbackSniContext = SniBenchmarkSupport.selectWithoutSni(exactRegistry);
+        manyFallbackSniContext = SniBenchmarkSupport.selectWithoutSni(manyVirtualHostsRegistry);
+    }
+
+    @Benchmark
+    public SniContext clientHelloParserNoSniFallback() throws IOException {
+        return SniBenchmarkSupport.readParserAndSelect(noSniClientHello, exactRegistry);
+    }
+
+    @Benchmark
+    public SniContext clientHelloParserExactSni() throws IOException {
+        return SniBenchmarkSupport.readParserAndSelect(exactClientHello, exactRegistry);
+    }
+
+    @Benchmark
+    public SniContext clientHelloParserWildcardSni() throws IOException {
+        return SniBenchmarkSupport.readParserAndSelect(wildcardClientHello, wildcardRegistry);
+    }
+
+    @Benchmark
+    public SniContext clientHelloParserFragmentedExactSni() throws IOException {
+        return SniBenchmarkSupport.readParserAndSelect(fragmentedExactClientHello, exactRegistry);
+    }
+
+    @Benchmark
+    public SniContext clientHelloParserExactSniManyVirtualHosts() throws IOException {
+        return SniBenchmarkSupport.readParserAndSelect(exactClientHello, manyVirtualHostsRegistry);
+    }
+
+    @Benchmark
+    public SniContext authorityFallbackAllowed() {
+        SniRequestSupport.validateAuthority(fallbackSniContext, PROLOGUE, HEADERS, FALLBACK_HOST);
+        return fallbackSniContext;
+    }
+
+    @Benchmark
+    public SniContext authorityExactAllowed() {
+        SniRequestSupport.validateAuthority(exactSniContext, PROLOGUE, HEADERS, EXACT_HOST);
+        return exactSniContext;
+    }
+
+    @Benchmark
+    public SniContext.AuthorityCheck authorityMismatchCheck() {
+        return exactSniContext.checkAuthority("admin.example.com");
+    }
+
+    @Benchmark
+    public SniContext.AuthorityCheck fallbackAuthorityExactConfiguredCheck() {
+        return fallbackSniContext.checkAuthority(EXACT_HOST);
+    }
+
+    @Benchmark
+    public SniContext.AuthorityCheck fallbackAuthorityWildcardConfiguredCheck() {
+        return fallbackSniContext.checkAuthority(WILDCARD_HOST);
+    }
+
+    @Benchmark
+    public SniContext.AuthorityCheck fallbackAuthorityManyVirtualHostsCheck() {
+        return manyFallbackSniContext.checkAuthority("host127.example.com");
+    }
+
+    private static SniBenchmarkSupport.Registry registry(String... hosts) {
+        ListenerConfig.Builder builder = ListenerConfig.builder()
+                .tls(TLS);
+        for (String host : hosts) {
+            builder.addVirtualHost(virtualHost(host));
+        }
+        return SniBenchmarkSupport.registry(SOCKET_NAME, builder.build(), TLS);
+    }
+
+    private static SniBenchmarkSupport.Registry manyVirtualHostsRegistry() {
+        ListenerConfig.Builder builder = ListenerConfig.builder()
+                .tls(TLS)
+                .addVirtualHost(virtualHost(EXACT_HOST));
+        for (int i = 0; i < 128; i++) {
+            builder.addVirtualHost(virtualHost("host" + i + ".example.com"));
+        }
+        return SniBenchmarkSupport.registry(SOCKET_NAME, builder.build(), TLS);
+    }
+
+    private static VirtualHostConfig virtualHost(String host) {
+        return VirtualHostConfig.builder()
+                .host(host)
+                .tls(TLS)
+                .build();
+    }
+
+    private static byte[] clientHello(String host) {
+        byte[] hostBytes = host.getBytes(StandardCharsets.US_ASCII);
+        ByteArrayOutputStream sni = new ByteArrayOutputStream();
+        writeShort(sni, 3 + hostBytes.length);
+        sni.write(0);
+        writeShort(sni, hostBytes.length);
+        sni.writeBytes(hostBytes);
+
+        ByteArrayOutputStream extension = new ByteArrayOutputStream();
+        writeShort(extension, 0);
+        writeShort(extension, sni.size());
+        extension.writeBytes(sni.toByteArray());
+
+        ByteArrayOutputStream body = baseClientHelloBody();
+        writeShort(body, extension.size());
+        body.writeBytes(extension.toByteArray());
+
+        return handshake(body.toByteArray());
+    }
+
+    private static byte[] clientHelloWithoutSni() {
+        ByteArrayOutputStream body = baseClientHelloBody();
+        writeShort(body, 0);
+        return handshake(body.toByteArray());
+    }
+
+    private static ByteArrayOutputStream baseClientHelloBody() {
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        body.write(0x03);
+        body.write(0x03);
+        body.writeBytes(new byte[32]);
+        body.write(0);
+        writeShort(body, 2);
+        body.write(0x13);
+        body.write(0x01);
+        body.write(1);
+        body.write(0);
+        return body;
+    }
+
+    private static byte[] handshake(byte[] body) {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        result.write(1);
+        writeMedium(result, body.length);
+        result.writeBytes(body);
+        return result.toByteArray();
+    }
+
+    private static byte[] record(byte[] handshake) {
+        return record(handshake, 0, handshake.length);
+    }
+
+    private static byte[] record(byte[] handshake, int offset, int length) {
+        byte[] fragment = new byte[length];
+        System.arraycopy(handshake, offset, fragment, 0, length);
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        result.write(22);
+        result.write(0x03);
+        result.write(0x03);
+        writeShort(result, fragment.length);
+        result.writeBytes(fragment);
+        return result.toByteArray();
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        result.writeBytes(first);
+        result.writeBytes(second);
+        return result.toByteArray();
+    }
+
+    private static void writeShort(ByteArrayOutputStream stream, int value) {
+        stream.write((value >>> 8) & 0xFF);
+        stream.write(value & 0xFF);
+    }
+
+    private static void writeMedium(ByteArrayOutputStream stream, int value) {
+        stream.write((value >>> 16) & 0xFF);
+        stream.write((value >>> 8) & 0xFF);
+        stream.write(value & 0xFF);
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/TlsNioSocketJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/TlsNioSocketJmhTest.java
@@ -33,6 +33,7 @@ import javax.net.ssl.SSLSessionContext;
 import io.helidon.common.socket.TlsNioSocket;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -67,7 +68,42 @@ public class TlsNioSocketJmhTest {
         return socket.isConnected();
     }
 
-    private static final class IdleSslEngine extends SSLEngine {
+    @Benchmark
+    public byte[] tlsReplayFirstUnwrap(ReplayState state) {
+        return state.socket.get();
+    }
+
+    @State(Scope.Thread)
+    public static class ReplayState {
+        private static final byte[] REPLAY = new byte[32];
+
+        private ServerSocketChannel server;
+        private SocketChannel clientChannel;
+        private SocketChannel serverChannel;
+        private TlsNioSocket socket;
+
+        @Setup(Level.Invocation)
+        public void setup() throws IOException {
+            server = ServerSocketChannel.open();
+            server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            clientChannel = SocketChannel.open(server.getLocalAddress());
+            serverChannel = server.accept();
+            socket = TlsNioSocket.server(serverChannel,
+                                         new ReplaySslEngine(REPLAY.length),
+                                         "listener",
+                                         "server",
+                                         ByteBuffer.wrap(REPLAY));
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown() throws IOException {
+            clientChannel.close();
+            serverChannel.close();
+            server.close();
+        }
+    }
+
+    private static class IdleSslEngine extends SSLEngine {
         private static final SSLSession SESSION = new IdleSslSession();
 
         @Override
@@ -185,6 +221,34 @@ public class TlsNioSocketJmhTest {
         @Override
         public boolean getEnableSessionCreation() {
             return false;
+        }
+    }
+
+    private static final class ReplaySslEngine extends IdleSslEngine {
+        private final int replayLength;
+        private int consumed;
+
+        private ReplaySslEngine(int replayLength) {
+            this.replayLength = replayLength;
+        }
+
+        @Override
+        public SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts, int offset, int length) {
+            int available = src.remaining();
+            src.position(src.limit());
+            consumed += available;
+            if (consumed < replayLength) {
+                return new SSLEngineResult(SSLEngineResult.Status.BUFFER_UNDERFLOW,
+                                           SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING,
+                                           available,
+                                           0);
+            }
+
+            dsts[offset].put((byte) 'R');
+            return new SSLEngineResult(SSLEngineResult.Status.OK,
+                                       SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING,
+                                       available,
+                                       1);
         }
     }
 

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConnectionContext.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConnectionContext.java
@@ -25,7 +25,7 @@ import io.helidon.webserver.ProxyProtocolData;
 
 /**
  * Exposes connection-level information to gRPC request handlers. An instance of this interface is
- * available from the {@link io.helidon.common.context.Context#get(Class)} by passing {@code GrpcConnectionContext.class}.
+ * available from {@link ServerContextKeys#CONNECTION_CONTEXT} in the current gRPC context.
  */
 public interface GrpcConnectionContext {
     /**
@@ -68,4 +68,27 @@ public interface GrpcConnectionContext {
      * @see ListenerConfig#enableProxyProtocol()
      */
     Optional<ProxyProtocolData> proxyProtocolData();
+
+    /**
+     * Normalized DNS host name requested by the client using TLS Server Name Indication (SNI).
+     * <p>
+     * This value comes from the client TLS handshake, so it is suitable for diagnostics and application choices that
+     * are expected to use client-requested host names, but it should not be treated as a trusted identity by itself.
+     *
+     * @return normalized SNI requested host, if available
+     */
+    default Optional<String> sniRequestedHost() {
+        return Optional.empty();
+    }
+
+    /**
+     * Configured virtual-host host that matched the TLS Server Name Indication (SNI) requested host.
+     * <p>
+     * For wildcard virtual hosts, this method returns the configured wildcard host such as {@code *.example.com}.
+     *
+     * @return configured SNI matched host, if a virtual host matched
+     */
+    default Optional<String> sniMatchedHost() {
+        return Optional.empty();
+    }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConnectionContextImpl.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConnectionContextImpl.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ProxyProtocolData;
+import io.helidon.webserver.SniContext;
 
 
 /**
@@ -79,5 +80,21 @@ final class GrpcConnectionContextImpl implements GrpcConnectionContext {
     @Override
     public Optional<ProxyProtocolData> proxyProtocolData() {
         return connectionContext.proxyProtocolData();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<String> sniRequestedHost() {
+        return connectionContext.sniContext().flatMap(SniContext::presentedHost);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<String> sniMatchedHost() {
+        return connectionContext.sniContext().flatMap(SniContext::matchedHost);
     }
 }

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcConnectionContextImplTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcConnectionContextImplTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.grpc;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.PeerInfo;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.SniContext;
+import io.helidon.webserver.SniMatchType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class GrpcConnectionContextImplTest {
+    @Test
+    void exposesSniHosts() {
+        GrpcConnectionContext context = new GrpcConnectionContextImpl(
+                new TestConnectionContext(sniContext("api.example.com", "*.example.com")));
+
+        assertThat(context.sniRequestedHost(), is(Optional.of("api.example.com")));
+        assertThat(context.sniMatchedHost(), is(Optional.of("*.example.com")));
+    }
+
+    @Test
+    void returnsEmptySniHostsWithoutSniContext() {
+        GrpcConnectionContext context = new GrpcConnectionContextImpl(new TestConnectionContext(null));
+
+        assertThat(context.sniRequestedHost(), is(Optional.empty()));
+        assertThat(context.sniMatchedHost(), is(Optional.empty()));
+    }
+
+    private static SniContext sniContext(String presentedHost, String matchedHost) {
+        return new SniContext() {
+            @Override
+            public Optional<String> presentedHost() {
+                return Optional.of(presentedHost);
+            }
+
+            @Override
+            public Optional<String> matchedHost() {
+                return Optional.of(matchedHost);
+            }
+
+            @Override
+            public SniMatchType matchType() {
+                return SniMatchType.WILDCARD;
+            }
+
+            @Override
+            public AuthorityCheck checkAuthority(String authority) {
+                return AuthorityCheck.ALLOWED;
+            }
+        };
+    }
+
+    private static final class TestConnectionContext implements ConnectionContext {
+        private final SniContext sniContext;
+
+        private TestConnectionContext(SniContext sniContext) {
+            this.sniContext = sniContext;
+        }
+
+        @Override
+        public Optional<SniContext> sniContext() {
+            return Optional.ofNullable(sniContext);
+        }
+
+        @Override
+        public ListenerContext listenerContext() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ExecutorService executor() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public DataWriter dataWriter() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public DataReader dataReader() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public Router router() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public PeerInfo remotePeer() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public PeerInfo localPeer() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public boolean isSecure() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public String socketId() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public String childSocketId() {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+    }
+}

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -23,8 +23,10 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -47,6 +49,8 @@ import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.ServerConnectionException;
+import io.helidon.webserver.SniContext;
+import io.helidon.webserver.SniMatchType;
 
 import io.grpc.Drainable;
 import io.grpc.Metadata;
@@ -231,6 +235,33 @@ class GrpcProtocolHandlerTest {
         assertThat(serverCall.isCancelled(), is(true));
     }
 
+    @Test
+    void exposesSniHostsInGrpcContext() {
+        AtomicReference<GrpcConnectionContext> grpcConnectionContext = new AtomicReference<>();
+        ServerCallHandler<String, String> callHandler = new ServerCallHandler<>() {
+            @Override
+            public ServerCall.Listener<String> startCall(ServerCall<String, String> call, Metadata headers) {
+                grpcConnectionContext.set(ServerContextKeys.CONNECTION_CONTEXT.get(io.grpc.Context.current()));
+                return new ServerCall.Listener<>() {
+                };
+            }
+        };
+        GrpcProtocolHandler<String, String> handler = new GrpcProtocolHandler<>(
+                new UnimplementedGrpcConnectionContext(sniContext("api.example.com", "*.example.com")),
+                Http2Headers.create(WritableHeaders.create()),
+                noOpWriter(),
+                1,
+                null,
+                Http2StreamState.OPEN,
+                route(callHandler),
+                GrpcConfig.create());
+
+        handler.init();
+
+        assertThat(grpcConnectionContext.get().sniRequestedHost(), is(Optional.of("api.example.com")));
+        assertThat(grpcConnectionContext.get().sniMatchedHost(), is(Optional.of("*.example.com")));
+    }
+
     private static ServerCall<String, String> createServerCall(Http2StreamWriter streamWriter) {
         GrpcProtocolHandler<String, String> handler = new GrpcProtocolHandler<>(new UnimplementedGrpcConnectionContext(),
                                                                                 Http2Headers.create(WritableHeaders.create()),
@@ -248,14 +279,42 @@ class GrpcProtocolHandlerTest {
     }
 
     private static GrpcRouteHandler<String, String> route(ServerCall.Listener<String> listener) {
+        return route(new ServerCallHandler<>() {
+            @Override
+            public ServerCall.Listener<String> startCall(ServerCall<String, String> call, Metadata headers) {
+                return listener;
+            }
+        });
+    }
+
+    private static GrpcRouteHandler<String, String> route(ServerCallHandler<String, String> callHandler) {
         ServerMethodDefinition<String, String> definition =
-                ServerMethodDefinition.create(stringMethodDescriptor(), new ServerCallHandler<>() {
-                    @Override
-                    public ServerCall.Listener<String> startCall(ServerCall<String, String> call, Metadata headers) {
-                        return listener;
-                    }
-                });
+                ServerMethodDefinition.create(stringMethodDescriptor(), callHandler);
         return GrpcRouteHandler.methodDefinition(definition, null, WeightedBag.create());
+    }
+
+    private static SniContext sniContext(String presentedHost, String matchedHost) {
+        return new SniContext() {
+            @Override
+            public Optional<String> presentedHost() {
+                return Optional.of(presentedHost);
+            }
+
+            @Override
+            public Optional<String> matchedHost() {
+                return Optional.of(matchedHost);
+            }
+
+            @Override
+            public SniMatchType matchType() {
+                return SniMatchType.WILDCARD;
+            }
+
+            @Override
+            public AuthorityCheck checkAuthority(String authority) {
+                return AuthorityCheck.ALLOWED;
+            }
+        };
     }
 
     private static MethodDescriptor<String, String> stringMethodDescriptor() {
@@ -497,6 +556,21 @@ class GrpcProtocolHandlerTest {
     }
 
     private static class UnimplementedGrpcConnectionContext implements ConnectionContext {
+        private final SniContext sniContext;
+
+        private UnimplementedGrpcConnectionContext() {
+            this(null);
+        }
+
+        private UnimplementedGrpcConnectionContext(SniContext sniContext) {
+            this.sniContext = sniContext;
+        }
+
+        @Override
+        public Optional<SniContext> sniContext() {
+            return Optional.ofNullable(sniContext);
+        }
+
         @Override
         public ListenerContext listenerContext() {
             throw new UnsupportedOperationException("Should not be called");

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
@@ -43,6 +43,7 @@ import io.helidon.http.media.ReadableEntityBase;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.ProxyProtocolData;
+import io.helidon.webserver.SniContext;
 import io.helidon.webserver.http.HttpSecurity;
 import io.helidon.webserver.http.RoutingRequest;
 
@@ -271,6 +272,16 @@ class Http2ServerRequest implements RoutingRequest {
     @Override
     public Optional<ProxyProtocolData> proxyProtocolData() {
         return ctx.proxyProtocolData();
+    }
+
+    @Override
+    public Optional<String> sniRequestedHost() {
+        return ctx.sniContext().flatMap(SniContext::presentedHost);
+    }
+
+    @Override
+    public Optional<String> sniMatchedHost() {
+        return ctx.sniContext().flatMap(SniContext::matchedHost);
     }
 
     private UriInfo createUriInfo() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -63,6 +63,8 @@ import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ErrorHandling;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.ServerConnectionException;
+import io.helidon.webserver.SniContext;
+import io.helidon.webserver.SniRequestSupport;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 import io.helidon.webserver.http2.spi.SubProtocolResult;
@@ -101,6 +103,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private boolean hasEntity = true;
     private volatile Http2Headers headers;
     private volatile Http2Priority priority;
+    private volatile boolean ignoreInboundDataAfterReset;
     // used from this instance and from connection
     private volatile Http2StreamState state = Http2StreamState.IDLE;
     private Http2SubProtocolSelector.SubProtocolHandler subProtocolHandler;
@@ -160,6 +163,9 @@ class Http2ServerStream implements Runnable, Http2Stream {
      * @throws Http2Exception in case data cannot be received
      */
     public void checkDataReceivable() throws Http2Exception {
+        if (ignoreInboundDataAfterReset) {
+            return;
+        }
         if (!DATA_RECEIVABLE_STATES.contains(state)) {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received data for stream "
                     + streamId + " in state " + state);
@@ -257,6 +263,10 @@ class Http2ServerStream implements Runnable, Http2Stream {
 
     @Override
     public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
+        if (!DATA_RECEIVABLE_STATES.contains(state)) {
+            flowControl.inbound().incrementWindowSize(header.length());
+            return;
+        }
         if (expectedLength != -1 && expectedLength < header.length()) {
             state = Http2StreamState.CLOSED;
             writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
@@ -282,10 +292,14 @@ class Http2ServerStream implements Runnable, Http2Stream {
         if (expectedLength != -1) {
             expectedLength -= header.length();
         }
+        DataFrame frame = new DataFrame(header, data);
         try {
-            inboundData.put(new DataFrame(header, data));
+            inboundData.put(frame);
         } catch (InterruptedException e) {
             throw new Http2Exception(Http2ErrorCode.INTERNAL, "Interrupted", e);
+        }
+        if (!DATA_RECEIVABLE_STATES.contains(state) && inboundData.remove(frame)) {
+            flowControl.inbound().incrementWindowSize(header.length());
         }
     }
 
@@ -357,7 +371,8 @@ class Http2ServerStream implements Runnable, Http2Stream {
             if (entity.length != 0) {
                 headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
             }
-            Http2Headers http2Headers = Http2Headers.create(headers);
+            Http2Headers http2Headers = Http2Headers.create(headers)
+                    .status(e.status());
             if (entity.length == 0) {
                 writer.writeHeaders(http2Headers,
                                     streamId,
@@ -374,6 +389,12 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                     new Http2FrameData(dataHeader, BufferData.create(message)),
                                     flowControl.outbound());
             }
+            closeRejectedStream();
+        } catch (Http2Exception e) {
+            ctx.log(LOGGER, DEBUG, "Intentional HTTP/2 stream exception, code: %s, message: %s",
+                    e.code(),
+                    e.getMessage());
+            closeRejectedStream(e.code(), true);
         } finally {
             headers = null;
             subProtocolHandler = null;
@@ -539,11 +560,56 @@ class Http2ServerStream implements Runnable, Http2Stream {
         return frame.data();
     }
 
+    private void closeRejectedStream() {
+        closeRejectedStream(Http2ErrorCode.CANCEL, false);
+    }
+
+    private void closeRejectedStream(Http2ErrorCode resetCode, boolean forceReset) {
+        boolean resetRequestBody = forceReset || hasEntity && state != Http2StreamState.HALF_CLOSED_REMOTE;
+        ignoreInboundDataAfterReset = resetRequestBody;
+        this.state = Http2StreamState.CLOSED;
+        writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
+        streams.remove(this.streamId);
+        restoreInboundFlowControl();
+        if (!inboundData.offer(TERMINATING_FRAME)) {
+            throw new Http2Exception(Http2ErrorCode.INTERNAL, "Failed to close stream data queue.");
+        }
+        if (resetRequestBody) {
+            Http2RstStream rst = new Http2RstStream(resetCode);
+            try {
+                writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+            } catch (SocketWriterException | UncheckedIOException e) {
+                throw new ServerConnectionException("Failed to write reset stream", e);
+            }
+            connectionAttackVectorMetrics.madeYouResetCheck(streamId);
+        }
+    }
+
+    private void restoreInboundFlowControl() {
+        DataFrame frame;
+        while ((frame = inboundData.poll()) != null) {
+            flowControl.inbound().incrementWindowSize(frame.header().length());
+        }
+    }
+
     private void handle() {
         Headers httpHeaders = headers.httpHeaders();
         if (httpHeaders.containsToken(HeaderValues.EXPECT_100)) {
             writeState.updateAndGet(s -> s.checkAndMove(WriteState.EXPECTED_100));
         }
+        ctx.sniContext().ifPresent(sniContext -> {
+            String authority = headers.authority();
+            if (authority == null) {
+                throw SniRequestSupport.missingAuthority(prologue, httpHeaders);
+            }
+            SniContext.AuthorityCheck check;
+            try {
+                check = SniRequestSupport.checkAuthority(sniContext, authority);
+            } catch (IllegalArgumentException e) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, e.getMessage(), e);
+            }
+            SniRequestSupport.validateAuthorityCheck(check, prologue, httpHeaders);
+        });
 
         subProtocolHandler = null;
 
@@ -601,7 +667,6 @@ class Http2ServerStream implements Runnable, Http2Stream {
             Http2ServerResponse response = new Http2ServerResponse(this, request);
 
             try {
-
                 if (outcome.disposition() == LimitAlgorithm.Outcome.Disposition.ACCEPTED) {
                     LimitAlgorithm.Outcome.Accepted accepted = (LimitAlgorithm.Outcome.Accepted) outcome;
                     LimitAlgorithm.Token permit = accepted.token();

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.ConnectionFlowControl;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Exception;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameTypes;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2RstStream;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2StreamState;
+import io.helidon.http.http2.Http2StreamWriter;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.SniContext;
+import io.helidon.webserver.SniMatchType;
+import io.helidon.webserver.http.DirectHandlers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Http2ServerStreamSniTest {
+    private static final int STREAM_ID = 1;
+    private static final HttpPrologue PROLOGUE = HttpPrologue.create(Http2Connection.FULL_PROTOCOL,
+                                                                     Http2Connection.PROTOCOL,
+                                                                     Http2Connection.PROTOCOL_VERSION,
+                                                                     Method.GET,
+                                                                     "/",
+                                                                     true);
+
+    @Test
+    void missingAuthorityClosesStream() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(), false);
+
+        stream.run();
+        streams.doMaintenance(0);
+
+        assertThat(writer.status, is(Status.BAD_REQUEST_400));
+        assertThat(writer.rstStreamCount, is(1));
+        assertThat(stream.streamState(), is(Http2StreamState.CLOSED));
+        assertThat(streams.get(STREAM_ID), is(nullValue()));
+        assertDoesNotThrow(stream::checkDataReceivable);
+    }
+
+    @Test
+    void rejectedStreamRestoresQueuedDataFlowControl() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        List<WindowUpdate> windowUpdates = new ArrayList<>();
+        Http2ServerStream stream = stream(streams, writer, windowUpdates);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        byte[] entity = "hello".getBytes();
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(String.valueOf(entity.length)), false);
+        stream.flowControl().inbound().decrementWindowSize(entity.length);
+        stream.data(Http2FrameHeader.create(entity.length,
+                                            Http2FrameTypes.DATA,
+                                            Http2Flag.DataFlags.create(0),
+                                            STREAM_ID),
+                    BufferData.create(entity),
+                    false);
+
+        stream.run();
+
+        assertThat(windowUpdates, hasItems(new WindowUpdate(STREAM_ID, entity.length),
+                                           new WindowUpdate(0, entity.length)));
+    }
+
+    @Test
+    void rejectedStreamRestoresRacingDataFlowControl() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        List<WindowUpdate> windowUpdates = new ArrayList<>();
+        Http2ServerStream stream = stream(streams, writer, windowUpdates);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        byte[] entity = "hello".getBytes();
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(String.valueOf(entity.length)), false);
+        stream.checkDataReceivable();
+        stream.flowControl().inbound().decrementWindowSize(entity.length);
+
+        stream.run();
+
+        stream.data(Http2FrameHeader.create(entity.length,
+                                            Http2FrameTypes.DATA,
+                                            Http2Flag.DataFlags.create(0),
+                                            STREAM_ID),
+                    BufferData.create(entity),
+                    false);
+
+        assertThat(windowUpdates, hasItems(new WindowUpdate(STREAM_ID, entity.length),
+                                           new WindowUpdate(0, entity.length)));
+    }
+
+    @Test
+    void rejectedStreamAllowsRacingDataAfterConnectionPrecheck() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        List<WindowUpdate> windowUpdates = new ArrayList<>();
+        Http2ServerStream stream = stream(streams, writer, windowUpdates);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        byte[] entity = "hello".getBytes();
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(String.valueOf(entity.length)), false);
+
+        stream.run();
+
+        assertDoesNotThrow(stream::checkDataReceivable);
+        stream.flowControl().inbound().decrementWindowSize(entity.length);
+        stream.data(Http2FrameHeader.create(entity.length,
+                                            Http2FrameTypes.DATA,
+                                            Http2Flag.DataFlags.create(0),
+                                            STREAM_ID),
+                    BufferData.create(entity),
+                    false);
+
+        assertThat(windowUpdates, hasItems(new WindowUpdate(STREAM_ID, entity.length),
+                                           new WindowUpdate(0, entity.length)));
+    }
+
+    @Test
+    void invalidAuthoritySyntaxResetsStreamWithProtocolError() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        Http2ServerStream stream = stream(streams, writer, parsingSniContext());
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithAuthority("bad authority"), true);
+
+        stream.run();
+        streams.doMaintenance(0);
+
+        assertThat(writer.status, is(nullValue()));
+        assertThat(writer.rstStreamCodes, hasItems(Http2ErrorCode.PROTOCOL));
+        assertThat(stream.streamState(), is(Http2StreamState.CLOSED));
+        assertThat(streams.get(STREAM_ID), is(nullValue()));
+    }
+
+    private static Http2ServerStream stream(Http2ConnectionStreams streams, Http2StreamWriter writer) {
+        return stream(streams, writer, new ArrayList<>());
+    }
+
+    private static Http2ServerStream stream(Http2ConnectionStreams streams,
+                                            Http2StreamWriter writer,
+                                            SniContext sniContext) {
+        return stream(streams, writer, new ArrayList<>(), sniContext);
+    }
+
+    private static Http2ServerStream stream(Http2ConnectionStreams streams,
+                                            Http2StreamWriter writer,
+                                            List<WindowUpdate> windowUpdates) {
+        return stream(streams, writer, windowUpdates, sniContext());
+    }
+
+    private static Http2ServerStream stream(Http2ConnectionStreams streams,
+                                            Http2StreamWriter writer,
+                                            List<WindowUpdate> windowUpdates,
+                                            SniContext sniContext) {
+        Http2Config config = Http2Config.builder()
+                .initialWindowSize(8192)
+                .maxFrameSize(16384)
+                .build();
+        ConnectionFlowControl flowControl = ConnectionFlowControl.serverBuilder((streamId, windowUpdate) ->
+                        windowUpdates.add(new WindowUpdate(streamId, windowUpdate.windowSizeIncrement())))
+                .initialWindowSize(config.initialWindowSize())
+                .maxFrameSize(config.maxFrameSize())
+                .build();
+        return new Http2ServerStream(connectionContext(sniContext),
+                                     streams,
+                                     null,
+                                     config,
+                                     List.of(),
+                                     STREAM_ID,
+                                     Http2Settings.builder().build(),
+                                     Http2Settings.builder().build(),
+                                     writer,
+                                     flowControl,
+                                     new Http2ConnectionChecks(config, mock(Http2Connection.class)));
+    }
+
+    private static ConnectionContext connectionContext() {
+        return connectionContext(sniContext());
+    }
+
+    private static ConnectionContext connectionContext(SniContext sniContext) {
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.config()).thenReturn(ListenerConfig.create());
+        when(listenerContext.directHandlers()).thenReturn(DirectHandlers.create());
+
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.listenerContext()).thenReturn(listenerContext);
+        when(ctx.sniContext()).thenReturn(Optional.of(sniContext));
+        return ctx;
+    }
+
+    private static SniContext sniContext() {
+        return new SniContext() {
+            @Override
+            public Optional<String> presentedHost() {
+                return Optional.of("api.example.com");
+            }
+
+            @Override
+            public Optional<String> matchedHost() {
+                return Optional.of("api.example.com");
+            }
+
+            @Override
+            public SniMatchType matchType() {
+                return SniMatchType.EXACT;
+            }
+
+            @Override
+            public AuthorityCheck checkAuthority(String authority) {
+                return AuthorityCheck.ALLOWED;
+            }
+        };
+    }
+
+    private static SniContext parsingSniContext() {
+        return new SniContext() {
+            @Override
+            public Optional<String> presentedHost() {
+                return Optional.of("api.example.com");
+            }
+
+            @Override
+            public Optional<String> matchedHost() {
+                return Optional.of("api.example.com");
+            }
+
+            @Override
+            public SniMatchType matchType() {
+                return SniMatchType.EXACT;
+            }
+
+            @Override
+            public AuthorityCheck checkAuthority(String authority) {
+                UriAuthority.create(authority).host();
+                return AuthorityCheck.ALLOWED;
+            }
+        };
+    }
+
+    private static Http2Headers headersWithoutAuthority() {
+        return headersWithoutAuthority("1");
+    }
+
+    private static Http2Headers headersWithoutAuthority(String contentLength) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(Http2Headers.METHOD_NAME, Method.GET.text());
+        headers.add(Http2Headers.PATH_NAME, "/");
+        headers.add(Http2Headers.SCHEME_NAME, "https");
+        headers.add(HeaderNames.CONTENT_LENGTH, contentLength);
+        return Http2Headers.create(headers);
+    }
+
+    private static Http2Headers headersWithAuthority(String authority) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(Http2Headers.METHOD_NAME, Method.GET.text());
+        headers.add(Http2Headers.PATH_NAME, "/");
+        headers.add(Http2Headers.SCHEME_NAME, "https");
+        headers.add(Http2Headers.AUTHORITY_NAME, authority);
+        return Http2Headers.create(headers);
+    }
+
+    private record WindowUpdate(int streamId, int increment) {
+    }
+
+    private static final class RecordingStreamWriter implements Http2StreamWriter {
+        private Status status;
+        private int rstStreamCount;
+        private final List<Http2ErrorCode> rstStreamCodes = new ArrayList<>();
+
+        @Override
+        public void write(Http2FrameData frame) {
+            if (frame.header().type() == Http2FrameTypes.RST_STREAM.type()) {
+                rstStreamCount++;
+                rstStreamCodes.add(Http2RstStream.create(frame.data()).errorCode());
+            }
+        }
+
+        @Override
+        public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                FlowControl.Outbound flowControl) {
+            this.status = headers.status();
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                Http2FrameData dataFrame,
+                                FlowControl.Outbound flowControl) {
+            this.status = headers.status();
+            return 0;
+        }
+    }
+}

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRequestImpl.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRequestImpl.java
@@ -108,6 +108,16 @@ class JsonRpcRequestImpl implements JsonRpcRequest {
     }
 
     @Override
+    public Optional<String> sniRequestedHost() {
+        return delegate.sniRequestedHost();
+    }
+
+    @Override
+    public Optional<String> sniMatchedHost() {
+        return delegate.sniMatchedHost();
+    }
+
+    @Override
     public HttpPrologue prologue() {
         return delegate.prologue();
     }

--- a/webserver/jsonrpc/src/test/java/io/helidon/webserver/jsonrpc/JsonRpcRequestImplTest.java
+++ b/webserver/jsonrpc/src/test/java/io/helidon/webserver/jsonrpc/JsonRpcRequestImplTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.jsonrpc;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+
+import io.helidon.json.JsonObject;
+import io.helidon.webserver.http.ServerRequest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JsonRpcRequestImplTest {
+    @Test
+    void delegatesSniHosts() {
+        JsonRpcRequestImpl request = new JsonRpcRequestImpl(delegate(),
+                                                            JsonObject.builder()
+                                                                    .set("jsonrpc", "2.0")
+                                                                    .set("method", "test")
+                                                                    .build());
+
+        assertThat(request.sniRequestedHost(), is(Optional.of("api.example.com")));
+        assertThat(request.sniMatchedHost(), is(Optional.of("*.example.com")));
+    }
+
+    private static ServerRequest delegate() {
+        return (ServerRequest) Proxy.newProxyInstance(JsonRpcRequestImplTest.class.getClassLoader(),
+                                                      new Class<?>[] {ServerRequest.class},
+                                                      (proxy, method, args) -> switch (method.getName()) {
+                                                          case "sniRequestedHost" -> Optional.of("api.example.com");
+                                                          case "sniMatchedHost" -> Optional.of("*.example.com");
+                                                          case "toString" -> "test-server-request";
+                                                          default -> throw new AssertionError(method.getName());
+                                                      });
+    }
+}

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SniTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SniTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.net.URI;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.Keys;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.SniMode;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webclient.http2.Http2ClientResponse;
+import io.helidon.webserver.SniSelectionPolicy;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2Route;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SniTest {
+    private static final String SNI_HOST = "api.example.com";
+    private static final String OTHER_HOST = "admin.example.com";
+    private static final String DIFFERENT_HOST = "other.example.com";
+
+    private static WebServer server;
+    private static Http2Client client;
+
+    @BeforeAll
+    static void startServer() {
+        Tls tls = tls();
+
+        server = WebServerConfig.builder()
+                .host("localhost")
+                .port(0)
+                .shutdownHook(false)
+                .tls(tls)
+                .addVirtualHost(virtualHost -> virtualHost
+                        .host(SNI_HOST)
+                        .tls(tls))
+                .addProtocol(Http2Config.builder().build())
+                .routing(routing -> routing
+                        .route(Http2Route.route(Method.GET, "/", (req, res) -> res.send("ok")))
+                        .route(Http2Route.route(Method.GET, "/sni", (req, res) -> res.send(sniHosts(req)))))
+                .build()
+                .start();
+
+        client = Http2Client.builder()
+                .baseUri(URI.create("https://localhost:" + server.port() + "/"))
+                .shareConnectionCache(false)
+                .tls(clientTls -> clientTls
+                        .trustAll(true)
+                        .endpointIdentificationAlgorithm("NONE"))
+                .build();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (client != null) {
+            client.closeResource();
+        }
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void acceptsMatchingAuthority() {
+        try (Http2ClientResponse response = client.get()
+                .header(HeaderValues.create(HeaderNames.HOST, SNI_HOST))
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(SNI_HOST))
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("ok"));
+        }
+    }
+
+    @Test
+    void exposesSniHosts() {
+        try (Http2ClientResponse response = client.get("/sni")
+                .header(HeaderValues.create(HeaderNames.HOST, SNI_HOST))
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(SNI_HOST))
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is(SNI_HOST + "|" + SNI_HOST));
+        }
+    }
+
+    @Test
+    void rejectsAuthorityMismatch() {
+        try (Http2ClientResponse response = client.get()
+                .header(HeaderValues.create(HeaderNames.HOST, OTHER_HOST))
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(SNI_HOST))
+                .request()) {
+
+            assertThat(response.status(), is(Status.MISDIRECTED_REQUEST_421));
+        }
+    }
+
+    @Test
+    void rejectsUnmatchedSniAuthorityMismatch() {
+        try (Http2ClientResponse response = client.get()
+                .header(HeaderValues.create(HeaderNames.HOST, DIFFERENT_HOST))
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(OTHER_HOST))
+                .request()) {
+
+            assertThat(response.status(), is(Status.MISDIRECTED_REQUEST_421));
+        }
+    }
+
+    @Test
+    void rejectsFallbackAuthorityForConfiguredVirtualHost() {
+        try (Http2ClientResponse response = client.get()
+                .header(HeaderValues.create(HeaderNames.HOST, SNI_HOST))
+                .sni(sni -> sni.mode(SniMode.DISABLED))
+                .request()) {
+
+            assertThat(response.status(), is(Status.MISDIRECTED_REQUEST_421));
+        }
+    }
+
+    @Test
+    void rejectsUnmatchedSniDuringTlsHandshake() {
+        WebServer rejectingServer = rejectingServer(SniSelectionPolicy.FALLBACK, SniSelectionPolicy.REJECT);
+        Http2Client rejectingClient = client(rejectingServer.port());
+        try {
+            assertThrows(RuntimeException.class, () -> {
+                try (Http2ClientResponse response = rejectingClient.get()
+                        .header(HeaderValues.create(HeaderNames.HOST, SNI_HOST))
+                        .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                                .host(OTHER_HOST))
+                        .request()) {
+                    response.status();
+                }
+            });
+        } finally {
+            rejectingClient.closeResource();
+            rejectingServer.stop();
+        }
+    }
+
+    @Test
+    void rejectsMissingSniDuringTlsHandshake() {
+        WebServer rejectingServer = rejectingServer(SniSelectionPolicy.REJECT, SniSelectionPolicy.FALLBACK);
+        Http2Client rejectingClient = client(rejectingServer.port());
+        try {
+            assertThrows(RuntimeException.class, () -> {
+                try (Http2ClientResponse response = rejectingClient.get()
+                        .header(HeaderValues.create(HeaderNames.HOST, SNI_HOST))
+                        .sni(sni -> sni.mode(SniMode.DISABLED))
+                        .request()) {
+                    response.status();
+                }
+            });
+        } finally {
+            rejectingClient.closeResource();
+            rejectingServer.stop();
+        }
+    }
+
+    private static Tls tls() {
+        Keys keys = Keys.builder()
+                .keystore(store -> store
+                        .passphrase("password")
+                        .keystore(Resource.create("server.p12")))
+                .build();
+        return Tls.builder()
+                .privateKey(keys)
+                .privateKeyCertChain(keys)
+                .build();
+    }
+
+    private static WebServer rejectingServer(SniSelectionPolicy missing, SniSelectionPolicy unmatched) {
+        Tls tls = tls();
+        return WebServerConfig.builder()
+                .host("localhost")
+                .port(0)
+                .shutdownHook(false)
+                .tls(tls)
+                .sni(sni -> sni.missing(missing)
+                        .unmatched(unmatched))
+                .addVirtualHost(virtualHost -> virtualHost
+                        .host(SNI_HOST)
+                        .tls(tls))
+                .addProtocol(Http2Config.builder().build())
+                .routing(routing -> routing.route(Http2Route.route(Method.GET, "/", (req, res) -> res.send("ok"))))
+                .build()
+                .start();
+    }
+
+    private static Http2Client client(int port) {
+        return Http2Client.builder()
+                .baseUri(URI.create("https://localhost:" + port + "/"))
+                .shareConnectionCache(false)
+                .tls(clientTls -> clientTls
+                        .trustAll(true)
+                        .endpointIdentificationAlgorithm("NONE"))
+                .build();
+    }
+
+    private static String sniHosts(ServerRequest request) {
+        return request.sniRequestedHost().orElse("") + "|" + request.sniMatchedHost().orElse("");
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/SniTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/SniTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.Keys;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.SniMode;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.SniSelectionPolicy;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http1.Http1Config;
+import io.helidon.webserver.http1.Http1ConnectionSelector;
+import io.helidon.webserver.spi.ServerConnectionSelector;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SniTest {
+    private static final String SNI_HOST = "api.example.com";
+    private static final String OTHER_HOST = "admin.example.com";
+    private static final String DIFFERENT_HOST = "other.example.com";
+    private static final String DEFAULT_CIPHER = "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384";
+    private static final String VIRTUAL_HOST_CIPHER = "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256";
+
+    private static WebServer server;
+    private static Http1Client defaultTlsClient;
+    private static Http1Client virtualHostTlsClient;
+
+    @BeforeAll
+    static void startServer() {
+        Tls defaultTls = tls(DEFAULT_CIPHER);
+        Tls virtualHostTls = tls(VIRTUAL_HOST_CIPHER);
+
+        server = WebServerConfig.builder()
+                .host("localhost")
+                .port(0)
+                .shutdownHook(false)
+                .tls(defaultTls)
+                .addConnectionSelector(http1WithoutHeaderValidation())
+                .addVirtualHost(virtualHost -> virtualHost
+                        .host(SNI_HOST)
+                        .tls(virtualHostTls))
+                .routing(routing -> routing
+                        .get("/", (req, res) -> res.send("ok"))
+                        .get("/sni", (req, res) -> res.send(sniHosts(req))))
+                .build()
+                .start();
+
+        URI defaultUri = URI.create("https://localhost:" + server.port() + "/");
+        defaultTlsClient = client(defaultUri, DEFAULT_CIPHER);
+        virtualHostTlsClient = client(defaultUri, VIRTUAL_HOST_CIPHER);
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void rejectsMissingHostHeader() throws Exception {
+        try (SSLSocket socket = tlsSocket(SNI_HOST, VIRTUAL_HOST_CIPHER)) {
+            socket.setSoTimeout(5000);
+            socket.startHandshake();
+
+            OutputStream output = socket.getOutputStream();
+            output.write("GET / HTTP/1.1\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+            output.flush();
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+            assertThat(reader.readLine(), startsWith("HTTP/1.1 400 "));
+        }
+    }
+
+    @Test
+    void rejectsInvalidHostHeader() throws Exception {
+        try (SSLSocket socket = tlsSocket(SNI_HOST, VIRTUAL_HOST_CIPHER)) {
+            socket.setSoTimeout(5000);
+            socket.startHandshake();
+
+            OutputStream output = socket.getOutputStream();
+            output.write("GET / HTTP/1.1\r\nHost: example.com:abc\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+            output.flush();
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+            assertThat(reader.readLine(), startsWith("HTTP/1.1 400 "));
+        }
+    }
+
+    @Test
+    void rejectsMultipleHostHeaders() throws Exception {
+        try (SSLSocket socket = tlsSocket(SNI_HOST, VIRTUAL_HOST_CIPHER)) {
+            socket.setSoTimeout(5000);
+            socket.startHandshake();
+
+            OutputStream output = socket.getOutputStream();
+            output.write(("GET / HTTP/1.1\r\n"
+                                  + "Host: " + SNI_HOST + "\r\n"
+                                  + "Host: " + OTHER_HOST + "\r\n"
+                                  + "\r\n").getBytes(StandardCharsets.US_ASCII));
+            output.flush();
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+            assertThat(reader.readLine(), startsWith("HTTP/1.1 400 "));
+        }
+    }
+
+    @Test
+    void selectsVirtualHostTlsFromSni() {
+        String entity = virtualHostTlsClient.get()
+                .header(HeaderValues.create(HeaderNames.HOST, SNI_HOST))
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(SNI_HOST))
+                .requestEntity(String.class);
+
+        assertThat(entity, is("ok"));
+    }
+
+    @Test
+    void exposesSniHosts() {
+        String entity = virtualHostTlsClient.get("/sni")
+                .header(HeaderValues.create(HeaderNames.HOST, SNI_HOST))
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(SNI_HOST))
+                .requestEntity(String.class);
+
+        assertThat(entity, is(SNI_HOST + "|" + SNI_HOST));
+    }
+
+    @Test
+    void rejectsAuthorityMismatch() {
+        try (Http1ClientResponse response = virtualHostTlsClient.get()
+                .header(HeaderValues.create(HeaderNames.HOST, OTHER_HOST))
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(SNI_HOST))
+                .request()) {
+
+            assertThat(response.status(), is(Status.MISDIRECTED_REQUEST_421));
+        }
+    }
+
+    @Test
+    void rejectsUnmatchedSniAuthorityMismatch() {
+        try (Http1ClientResponse response = defaultTlsClient.get()
+                .header(HeaderValues.create(HeaderNames.HOST, DIFFERENT_HOST))
+                .sni(sni -> sni.mode(SniMode.EXPLICIT)
+                        .host(OTHER_HOST))
+                .request()) {
+
+            assertThat(response.status(), is(Status.MISDIRECTED_REQUEST_421));
+        }
+    }
+
+    @Test
+    void rejectsFallbackAuthorityForConfiguredVirtualHost() {
+        try (Http1ClientResponse response = defaultTlsClient.get()
+                .header(HeaderValues.create(HeaderNames.HOST, SNI_HOST))
+                .sni(sni -> sni.mode(SniMode.DISABLED))
+                .request()) {
+
+            assertThat(response.status(), is(Status.MISDIRECTED_REQUEST_421));
+        }
+    }
+
+    @Test
+    void rejectsUnmatchedSniDuringTlsHandshake() throws Exception {
+        WebServer rejectingServer = rejectingServer(SniSelectionPolicy.FALLBACK, SniSelectionPolicy.REJECT);
+        try {
+            try (SSLSocket socket = tlsSocket(rejectingServer.port(), OTHER_HOST, DEFAULT_CIPHER)) {
+                socket.setSoTimeout(5000);
+
+                assertThrows(IOException.class, socket::startHandshake);
+            }
+        } finally {
+            rejectingServer.stop();
+        }
+    }
+
+    @Test
+    void rejectsMissingSniDuringTlsHandshake() throws Exception {
+        WebServer rejectingServer = rejectingServer(SniSelectionPolicy.REJECT, SniSelectionPolicy.FALLBACK);
+        try {
+            try (SSLSocket socket = tlsSocketWithoutSni(rejectingServer.port(), DEFAULT_CIPHER)) {
+                socket.setSoTimeout(5000);
+
+                assertThrows(IOException.class, socket::startHandshake);
+            }
+        } finally {
+            rejectingServer.stop();
+        }
+    }
+
+    private static WebServer rejectingServer(SniSelectionPolicy missing, SniSelectionPolicy unmatched) {
+        Tls tls = tls(DEFAULT_CIPHER);
+        return WebServerConfig.builder()
+                .host("localhost")
+                .port(0)
+                .shutdownHook(false)
+                .tls(tls)
+                .sni(sni -> sni.missing(missing)
+                        .unmatched(unmatched))
+                .addConnectionSelector(http1WithoutHeaderValidation())
+                .addVirtualHost(virtualHost -> virtualHost
+                        .host(SNI_HOST)
+                        .tls(tls))
+                .routing(routing -> routing.get("/", (req, res) -> res.send("ok")))
+                .build()
+                .start();
+    }
+
+    private static Http1Client client(URI defaultUri, String cipher) {
+        return Http1Client.builder()
+                .baseUri(defaultUri)
+                .tls(tls -> tls.enabledCipherSuites(List.of(cipher))
+                        .trustAll(true)
+                        .endpointIdentificationAlgorithm("NONE"))
+                .build();
+    }
+
+    private static ServerConnectionSelector http1WithoutHeaderValidation() {
+        return Http1ConnectionSelector.builder()
+                .config(Http1Config.builder()
+                                .validateRequestHeaders(false)
+                                .build())
+                .build();
+    }
+
+    private static SSLSocket tlsSocket(String sniHost, String cipher) throws Exception {
+        return tlsSocket(server.port(), sniHost, cipher);
+    }
+
+    private static SSLSocket tlsSocket(int port, String sniHost, String cipher) throws Exception {
+        SSLSocket socket = (SSLSocket) trustAllContext().getSocketFactory().createSocket("localhost", port);
+        socket.setEnabledCipherSuites(new String[] {cipher});
+        SSLParameters parameters = socket.getSSLParameters();
+        parameters.setServerNames(List.of(new SNIHostName(sniHost)));
+        socket.setSSLParameters(parameters);
+        return socket;
+    }
+
+    private static SSLSocket tlsSocketWithoutSni(int port, String cipher) throws Exception {
+        SSLSocket socket = (SSLSocket) trustAllContext().getSocketFactory().createSocket("localhost", port);
+        socket.setEnabledCipherSuites(new String[] {cipher});
+        SSLParameters parameters = socket.getSSLParameters();
+        parameters.setServerNames(List.of());
+        socket.setSSLParameters(parameters);
+        return socket;
+    }
+
+    private static SSLContext trustAllContext() throws Exception {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, new TrustManager[] {TRUST_ALL}, new SecureRandom());
+        return sslContext;
+    }
+
+    private static String sniHosts(ServerRequest request) {
+        return request.sniRequestedHost().orElse("") + "|" + request.sniMatchedHost().orElse("");
+    }
+
+    private static Tls tls(String cipher) {
+        Keys keys = Keys.builder()
+                .keystore(store -> store
+                        .passphrase("helidon")
+                        .keystore(Resource.create("certificate.p12")))
+                .build();
+        return Tls.builder()
+                .privateKey(keys)
+                .privateKeyCertChain(keys)
+                .enabledCipherSuites(List.of(cipher))
+                .build();
+    }
+
+    private static final X509TrustManager TRUST_ALL = new X509TrustManager() {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    };
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ClientHelloPrefaceReader.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ClientHelloPrefaceReader.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.uri.UriHost;
+
+/**
+ * Reads the TLS ClientHello bytes that appear before the selected TLS engine owns the connection.
+ * <p>
+ * WebServer uses this only for listener SNI virtual hosts: it captures the bytes that must be replayed into the TLS
+ * engine after host selection, and extracts a normalized DNS SNI host without completing or otherwise interpreting TLS.
+ */
+final class ClientHelloPrefaceReader {
+    private static final int MAX_PREFACE_BYTES = 64 * 1024;
+    private static final int MAX_TLS_PLAINTEXT_RECORD_BYTES = 16 * 1024;
+    private static final int TLS_HANDSHAKE_CONTENT_TYPE = 22;
+    private static final int CLIENT_HELLO_HANDSHAKE_TYPE = 1;
+    private static final int SNI_EXTENSION_TYPE = 0;
+    private static final int SNI_HOST_NAME_TYPE = 0;
+    private static final ReadWaiter BLOCKING_READ_WAITER = () -> { };
+
+    private ClientHelloPrefaceReader() {
+    }
+
+    static ClientHelloPreface read(ReadableByteChannel channel) throws IOException {
+        return read(channel, BLOCKING_READ_WAITER);
+    }
+
+    static ClientHelloPreface read(SocketChannel channel, Duration timeout) throws IOException {
+        Objects.requireNonNull(channel);
+        Objects.requireNonNull(timeout);
+
+        boolean blocking = channel.isBlocking();
+        try (Selector selector = Selector.open()) {
+            channel.configureBlocking(false);
+            channel.register(selector, SelectionKey.OP_READ);
+            return read(channel, new DeadlineWaiter(selector, timeout));
+        } finally {
+            if (channel.isOpen()) {
+                channel.configureBlocking(blocking);
+            }
+        }
+    }
+
+    private static ClientHelloPreface read(ReadableByteChannel channel, ReadWaiter readWaiter) throws IOException {
+        ByteBuffer replay = ByteBuffer.allocate(512);
+        ByteBuffer handshake = ByteBuffer.allocate(512);
+        int requiredHandshakeBytes = -1;
+
+        while (requiredHandshakeBytes == -1 || handshake.position() < requiredHandshakeBytes) {
+            int recordStart = replay.position();
+            replay = readFully(channel, replay, 5, readWaiter);
+
+            int contentType = unsigned(replay.get(recordStart));
+            if (contentType != TLS_HANDSHAKE_CONTENT_TYPE) {
+                throw new IllegalArgumentException("TLS ClientHello expected a handshake record");
+            }
+
+            int recordLength = unsignedShort(replay, recordStart + 3);
+            if (recordLength == 0) {
+                throw new IllegalArgumentException("TLS ClientHello record cannot be empty");
+            }
+            if (recordLength > MAX_TLS_PLAINTEXT_RECORD_BYTES) {
+                throw new IllegalArgumentException("TLS ClientHello record is too large");
+            }
+            replay = readFully(channel, replay, recordLength, readWaiter);
+
+            ByteBuffer recordBody = replay.duplicate();
+            recordBody.position(recordStart + 5);
+            recordBody.limit(recordStart + 5 + recordLength);
+            handshake = ensureRemaining(handshake, recordLength);
+            handshake.put(recordBody);
+
+            if (handshake.position() >= 4 && requiredHandshakeBytes == -1) {
+                if (unsigned(handshake.get(0)) != CLIENT_HELLO_HANDSHAKE_TYPE) {
+                    throw new IllegalArgumentException("TLS ClientHello expected a client_hello handshake message");
+                }
+                requiredHandshakeBytes = 4 + unsignedMedium(handshake, 1);
+                if (requiredHandshakeBytes > MAX_PREFACE_BYTES) {
+                    throw new IllegalArgumentException("TLS ClientHello is too large");
+                }
+            }
+        }
+
+        replay.flip();
+        handshake.flip();
+        ByteBuffer clientHello = handshake.slice();
+        clientHello.limit(requiredHandshakeBytes);
+        return new ClientHelloPreface(replay.slice(), sniHost(clientHello));
+    }
+
+    private static ByteBuffer readFully(ReadableByteChannel channel,
+                                        ByteBuffer buffer,
+                                        int bytes,
+                                        ReadWaiter readWaiter) throws IOException {
+        buffer = ensureRemaining(buffer, bytes);
+        int target = buffer.position() + bytes;
+        int oldLimit = buffer.limit();
+        try {
+            buffer.limit(target);
+            while (buffer.position() < target) {
+                int read = channel.read(buffer);
+                if (read == -1) {
+                    throw new IllegalArgumentException("TLS ClientHello input ended before the preface was complete");
+                }
+                if (read == 0) {
+                    readWaiter.awaitReadable();
+                }
+            }
+        } finally {
+            buffer.limit(oldLimit);
+        }
+        return buffer;
+    }
+
+    private static Optional<String> sniHost(ByteBuffer clientHello) {
+        int end = 4 + unsignedMedium(clientHello, 1);
+        require(clientHello, end);
+
+        int position = 4;
+        position += 2; // legacy_version
+        position += 32; // random
+        require(clientHello, position + 1);
+        position += 1 + unsigned(clientHello.get(position)); // session_id
+        require(clientHello, position + 2);
+        position += 2 + unsignedShort(clientHello, position); // cipher_suites
+        require(clientHello, position + 1);
+        position += 1 + unsigned(clientHello.get(position)); // compression_methods
+
+        if (position == end) {
+            return Optional.empty();
+        }
+
+        require(clientHello, position + 2);
+        int extensionsLength = unsignedShort(clientHello, position);
+        position += 2;
+        int extensionsEnd = position + extensionsLength;
+        require(clientHello, extensionsEnd);
+        if (extensionsEnd > end) {
+            throw new IllegalArgumentException("TLS ClientHello extensions exceed the handshake message");
+        }
+
+        Optional<String> sniHost = Optional.empty();
+        boolean sniExtensionSeen = false;
+        while (position < extensionsEnd) {
+            require(clientHello, position + 4);
+            int type = unsignedShort(clientHello, position);
+            int length = unsignedShort(clientHello, position + 2);
+            position += 4;
+            int extensionEnd = position + length;
+            require(clientHello, extensionEnd);
+            if (extensionEnd > extensionsEnd) {
+                throw new IllegalArgumentException("TLS ClientHello extension exceeds the extensions block");
+            }
+            if (type == SNI_EXTENSION_TYPE) {
+                if (sniExtensionSeen) {
+                    throw new IllegalArgumentException("TLS ClientHello SNI extension cannot be duplicated");
+                }
+                sniExtensionSeen = true;
+                sniHost = sniExtension(clientHello, position, extensionEnd);
+            }
+            position = extensionEnd;
+        }
+        if (position != extensionsEnd) {
+            throw new IllegalArgumentException("TLS ClientHello extensions length is invalid");
+        }
+        return sniHost;
+    }
+
+    private static Optional<String> sniExtension(ByteBuffer clientHello, int position, int extensionEnd) {
+        require(clientHello, position + 2);
+        int listLength = unsignedShort(clientHello, position);
+        position += 2;
+        if (listLength == 0) {
+            throw new IllegalArgumentException("TLS ClientHello SNI server name list cannot be empty");
+        }
+        int listEnd = position + listLength;
+        require(clientHello, listEnd);
+        if (listEnd != extensionEnd) {
+            throw new IllegalArgumentException("TLS ClientHello SNI extension length is invalid");
+        }
+
+        String host = null;
+        while (position < listEnd) {
+            require(clientHello, position + 3);
+            int nameType = unsigned(clientHello.get(position));
+            int nameLength = unsignedShort(clientHello, position + 1);
+            position += 3;
+            int nameEnd = position + nameLength;
+            require(clientHello, nameEnd);
+            if (nameEnd > listEnd) {
+                throw new IllegalArgumentException("TLS ClientHello SNI server name exceeds the server name list");
+            }
+            if (nameType == SNI_HOST_NAME_TYPE) {
+                if (host != null) {
+                    throw new IllegalArgumentException("TLS ClientHello SNI host name cannot be duplicated");
+                }
+                if (nameLength == 0) {
+                    throw new IllegalArgumentException("TLS ClientHello SNI host name cannot be empty");
+                }
+                byte[] bytes = new byte[nameLength];
+                ByteBuffer duplicate = clientHello.duplicate();
+                duplicate.position(position);
+                duplicate.get(bytes);
+                String asciiHost = asciiString(bytes);
+                if (asciiHost.endsWith(".")) {
+                    throw new IllegalArgumentException("TLS ClientHello SNI host name must not end with a dot");
+                }
+                UriHost uriHost = UriHost.create(asciiHost);
+                if (uriHost.kind() != UriHost.Kind.DNS) {
+                    throw new IllegalArgumentException("TLS ClientHello SNI host name must be a DNS name");
+                }
+                host = uriHost.value();
+            }
+            position = nameEnd;
+        }
+        return Optional.ofNullable(host);
+    }
+
+    private static String asciiString(byte[] bytes) {
+        try {
+            return StandardCharsets.US_ASCII.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes))
+                    .toString();
+        } catch (CharacterCodingException e) {
+            throw new IllegalArgumentException("TLS ClientHello SNI host name must be ASCII", e);
+        }
+    }
+
+    private static ByteBuffer ensureRemaining(ByteBuffer buffer, int additional) {
+        if (additional > MAX_PREFACE_BYTES || buffer.position() > MAX_PREFACE_BYTES - additional) {
+            throw new IllegalArgumentException("TLS ClientHello is too large");
+        }
+        if (buffer.remaining() >= additional) {
+            return buffer;
+        }
+        int needed = buffer.position() + additional;
+        int capacity = buffer.capacity();
+        while (capacity < needed) {
+            capacity = Math.min(MAX_PREFACE_BYTES, capacity * 2);
+            if (capacity < needed && capacity == MAX_PREFACE_BYTES) {
+                throw new IllegalArgumentException("TLS ClientHello is too large");
+            }
+        }
+        ByteBuffer expanded = ByteBuffer.allocate(capacity);
+        buffer.flip();
+        expanded.put(buffer);
+        return expanded;
+    }
+
+    private static void require(ByteBuffer buffer, int needed) {
+        if (needed > buffer.limit()) {
+            throw new IllegalArgumentException("TLS ClientHello is malformed");
+        }
+    }
+
+    private static int unsigned(ByteBuffer buffer, int index) {
+        return unsigned(buffer.get(index));
+    }
+
+    private static int unsigned(byte value) {
+        return value & 0xFF;
+    }
+
+    private static int unsignedShort(ByteBuffer buffer, int index) {
+        return (unsigned(buffer, index) << 8) | unsigned(buffer, index + 1);
+    }
+
+    private static int unsignedMedium(ByteBuffer buffer, int index) {
+        return (unsigned(buffer, index) << 16) | (unsigned(buffer, index + 1) << 8) | unsigned(buffer, index + 2);
+    }
+
+    /**
+     * ClientHello bytes consumed before TLS engine selection.
+     *
+     * @param replayBuffer bytes to replay into the selected TLS engine
+     * @param sniHost normalized DNS SNI host from the ClientHello, if one was present
+     */
+    record ClientHelloPreface(ByteBuffer replayBuffer, Optional<String> sniHost) {
+    }
+
+    @FunctionalInterface
+    private interface ReadWaiter {
+        void awaitReadable() throws IOException;
+    }
+
+    private static final class DeadlineWaiter implements ReadWaiter {
+        private static final long NANOS_PER_MILLI = 1_000_000;
+
+        private final Selector selector;
+        private final long deadlineNanos;
+
+        private DeadlineWaiter(Selector selector, Duration timeout) {
+            this.selector = selector;
+            this.deadlineNanos = System.nanoTime() + timeout.toNanos();
+        }
+
+        @Override
+        public void awaitReadable() throws IOException {
+            while (true) {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    throw new IllegalArgumentException("TLS ClientHello input timed out before the preface was complete");
+                }
+                long timeoutMillis = Math.max(1, (remainingNanos + NANOS_PER_MILLI - 1) / NANOS_PER_MILLI);
+                int selected = selector.select(timeoutMillis);
+                selector.selectedKeys().clear();
+                if (selected != 0) {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ClientHelloPrefaceReader.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ClientHelloPrefaceReader.java
@@ -317,16 +317,26 @@ final class ClientHelloPrefaceReader {
         private static final long NANOS_PER_MILLI = 1_000_000;
 
         private final Selector selector;
+        private final boolean indefinite;
         private final long deadlineNanos;
 
         private DeadlineWaiter(Selector selector, Duration timeout) {
             this.selector = selector;
-            this.deadlineNanos = System.nanoTime() + timeout.toNanos();
+            this.indefinite = timeout.isZero();
+            this.deadlineNanos = indefinite ? 0 : System.nanoTime() + timeout.toNanos();
         }
 
         @Override
         public void awaitReadable() throws IOException {
             while (true) {
+                if (indefinite) {
+                    int selected = selector.select();
+                    selector.selectedKeys().clear();
+                    if (selected != 0) {
+                        return;
+                    }
+                    continue;
+                }
                 long remainingNanos = deadlineNanos - System.nanoTime();
                 if (remainingNanos <= 0) {
                     throw new IllegalArgumentException("TLS ClientHello input timed out before the preface was complete");

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.webserver;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
+import io.helidon.common.Api;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
@@ -70,6 +71,16 @@ public interface ConnectionContext extends SocketContext {
      * @see ListenerConfig#enableProxyProtocol()
      */
     default Optional<ProxyProtocolData> proxyProtocolData() {
+        return Optional.empty();
+    }
+
+    /**
+     * Listener SNI context for this connection.
+     *
+     * @return SNI context, if listener virtual hosts are configured
+     */
+    @Api.Internal
+    default Optional<SniContext> sniContext() {
         return Optional.empty();
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
+import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.time.Duration;
 import java.util.HexFormat;
@@ -67,6 +68,9 @@ import static java.lang.System.Logger.Level.WARNING;
 class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     private static final System.Logger LOGGER = System.getLogger(ConnectionHandler.class.getName());
     private static final String HTTP_1_0 = "HTTP/1.0\r";
+    private static final byte TLS_ALERT_CONTENT_TYPE = 21;
+    private static final byte TLS_ALERT_LEVEL_FATAL = 2;
+    private static final byte TLS_ALERT_UNRECOGNIZED_NAME = 112;
 
     private final ListenerContext listenerContext;
     // we must safely release the token whenever this connection is finished, so other connections can be created!
@@ -78,6 +82,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     private final String serverChannelId;
     private final Router router;
     private final Tls tls;
+    private final VirtualHostRegistry virtualHosts;
     private final ListenerConfig listenerConfig;
     private final String channelId;
     private final Consumer<ConnectionHandler> connectionHandlerRemoveListener;
@@ -90,6 +95,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     private DataReader reader;
     private SocketWriter writer;
     private ProxyProtocolData proxyProtocolData;
+    private SniContext sniContext;
 
     // Published before handling starts so lifecycle close/interrupt paths do not miss the delegate.
     private volatile ServerConnection connection;
@@ -104,6 +110,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
                       String serverChannelId,
                       Router router,
                       Tls tls,
+                      VirtualHostRegistry virtualHosts,
                       Consumer<ConnectionHandler> connectionHandlerRemoveListener) {
         this.listenerContext = listenerContext;
         this.limitToken = limitToken;
@@ -114,6 +121,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         this.serverChannelId = serverChannelId;
         this.router = router;
         this.tls = tls;
+        this.virtualHosts = virtualHosts;
         this.listenerConfig = listenerContext.config();
         this.connectionHandlerRemoveListener = connectionHandlerRemoveListener;
         this.channelId = "0x" + HexFormat.of().toHexDigits(System.identityHashCode(socket));
@@ -198,6 +206,11 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
     @Override
     public Optional<ProxyProtocolData> proxyProtocolData() {
         return Optional.ofNullable(proxyProtocolData);
+    }
+
+    @Override
+    public Optional<SniContext> sniContext() {
+        return Optional.ofNullable(sniContext);
     }
 
     @Override
@@ -382,16 +395,36 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
 
     private HelidonSocket createNioSocket(Tls tls, SocketChannel channel, String channelId) throws IOException {
         if (tls.enabled()) {
+            ByteBuffer replayBuffer = null;
+            Tls selectedTls = tls;
+            if (virtualHosts.enabled()) {
+                ClientHelloPrefaceReader.ClientHelloPreface preface =
+                        ClientHelloPrefaceReader.read(channel, listenerConfig.connectionOptions().readTimeout());
+                VirtualHostRegistry.Selection selection;
+                try {
+                    selection = preface.sniHost()
+                            .map(virtualHosts::select)
+                            .orElseGet(virtualHosts::selectWithoutSni);
+                } catch (VirtualHostRegistry.RejectedSniException e) {
+                    if (e.sendUnrecognizedNameAlert()) {
+                        sendUnrecognizedNameAlert(channel, preface.replayBuffer());
+                    }
+                    throw e;
+                }
+                selectedTls = selection.tls();
+                sniContext = selection.sniContext();
+                replayBuffer = preface.replayBuffer();
+            }
             var address = channel.getRemoteAddress();
 
             SSLEngine engine;
             if (address instanceof InetSocketAddress isa) {
-                engine = tls.sslContext().createSSLEngine(isa.getHostString(), isa.getPort());
+                engine = selectedTls.sslContext().createSSLEngine(isa.getHostString(), isa.getPort());
             } else {
-                engine = tls.sslContext().createSSLEngine();
+                engine = selectedTls.sslContext().createSSLEngine();
             }
 
-            SSLParameters parameters = tls.sslParameters();
+            SSLParameters parameters = selectedTls.sslParameters();
             parameters.setEndpointIdentificationAlgorithm("");
             engine.setSSLParameters(parameters);
 
@@ -405,14 +438,42 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
                 return null;
             });
 
-            return TlsNioSocket
-                    .server(channel, engine, channelId, serverChannelId);
+            if (replayBuffer == null) {
+                return TlsNioSocket.server(channel, engine, channelId, serverChannelId);
+            }
+            return TlsNioSocket.server(channel, engine, channelId, serverChannelId, replayBuffer);
         }
         return NioSocket.server(channel, channelId, serverChannelId);
     }
 
+    private void sendUnrecognizedNameAlert(SocketChannel channel, ByteBuffer replayBuffer) throws IOException {
+        ByteBuffer replay = replayBuffer.duplicate();
+        byte recordMajor = 3;
+        byte recordMinor = 3;
+        if (replay.remaining() >= 3) {
+            int position = replay.position();
+            recordMajor = replay.get(position + 1);
+            recordMinor = replay.get(position + 2);
+        }
+        ByteBuffer alert = ByteBuffer.wrap(new byte[] {
+                TLS_ALERT_CONTENT_TYPE,
+                recordMajor,
+                recordMinor,
+                0,
+                2,
+                TLS_ALERT_LEVEL_FATAL,
+                TLS_ALERT_UNRECOGNIZED_NAME
+        });
+        while (alert.hasRemaining()) {
+            channel.write(alert);
+        }
+    }
+
     private HelidonSocket createByteSocket(Tls tls, SocketChannel channel, String channelId) throws IOException {
         if (tls.enabled()) {
+            if (virtualHosts.enabled()) {
+                throw new IllegalStateException("Listener virtual hosts require NIO TLS");
+            }
             SSLSocket sslSocket = (SSLSocket) tls.sslContext()
                     .getSocketFactory()
                     .createSocket(channel.socket(), null, false);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -210,6 +210,28 @@ interface ListenerConfigBlueprint {
     Optional<Tls> tls();
 
     /**
+     * Listener TLS virtual hosts selected by SNI; requires listener TLS and NIO socket-channel transport
+     * ({@code use-nio=true}).
+     * <p>
+     * Virtual hosts select TLS material only. The listener routing is used for all requests.
+     * Server startup fails if virtual hosts are configured without listener TLS or with {@code use-nio} disabled.
+     *
+     * @return configured listener virtual hosts
+     */
+    @Option.Configured
+    @Option.Singular
+    List<VirtualHostConfig> virtualHosts();
+
+    /**
+     * Listener-scoped server TLS SNI policy.
+     *
+     * @return SNI policy
+     */
+    @Option.Configured
+    @Option.DefaultMethod("create")
+    SniConfig sni();
+
+    /**
      * Configure the listener specific {@link io.helidon.http.encoding.ContentEncodingContext}.
      * This method discards all previously registered ContentEncodingContext.
      * If no content encoding context is registered, content encoding context of the webserver would be used.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -85,6 +85,7 @@ class ServerListener implements ListenerContext {
     private final ExecutorService sharedExecutor;
     private final DirectHandlers directHandlers;
     private final Tls tls;
+    private final VirtualHostRegistry virtualHosts;
     private final SocketOptions connectionOptions;
     private final SocketAddress configuredAddress;
     private final Duration gracePeriod;
@@ -159,6 +160,7 @@ class ServerListener implements ListenerContext {
         this.socketName = socketName;
         this.listenerConfig = listenerConfig;
         this.tls = listenerConfig.tls().orElseGet(() -> Tls.builder().enabled(false).build());
+        this.virtualHosts = VirtualHostRegistry.create(socketName, listenerConfig, tls);
         this.connectionOptions = listenerConfig.connectionOptions();
         this.directHandlers = listenerConfig.directHandlers().orElse(defaultDirectHandlers);
         this.mediaContext = listenerConfig.mediaContext().orElse(defaultMediaContext);
@@ -453,6 +455,7 @@ class ServerListener implements ListenerContext {
             if (tls.enabled()) {
                 // basic validation of the configuration
                 tls.newEngine();
+                virtualHosts.validateTls();
             }
             listenerConfig.configureSocket(serverSocket);
 
@@ -731,6 +734,7 @@ class ServerListener implements ListenerContext {
                                                                       serverChannelId,
                                                                       router,
                                                                       tls,
+                                                                      virtualHosts,
                                                                       connectionHandlers::remove);
                     connectionHandlers.add(handler);
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SniAuthorityPolicy.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SniAuthorityPolicy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+/**
+ * HTTP request authority policy used after SNI TLS selection.
+ * <p>
+ * The policy decides whether HTTP authority values that disagree with the TLS SNI selection are allowed or rejected as
+ * misdirected requests.
+ */
+public enum SniAuthorityPolicy {
+    /**
+     * Allow the request authority.
+     */
+    ALLOW,
+    /**
+     * Reject the request with HTTP 421.
+     */
+    REJECT
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SniConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SniConfigBlueprint.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Listener-scoped server TLS SNI policy configuration.
+ * <p>
+ * These options define how listener TLS virtual-host selection handles missing or unmatched ClientHello SNI hosts, and
+ * how the HTTP request authority is checked after TLS selects certificate material.
+ */
+@Prototype.Configured
+@Prototype.Blueprint
+interface SniConfigBlueprint {
+    /**
+     * Policy for TLS connections without an SNI host; {@link SniSelectionPolicy#REJECT} requires at least one listener
+     * virtual host.
+     *
+     * @return missing SNI policy
+     */
+    @Option.Configured
+    @Option.Default("FALLBACK")
+    SniSelectionPolicy missing();
+
+    /**
+     * Policy for TLS connections with an SNI host that does not match any configured virtual host;
+     * {@link SniSelectionPolicy#REJECT} requires at least one listener virtual host.
+     *
+     * @return unmatched SNI policy
+     */
+    @Option.Configured
+    @Option.Default("FALLBACK")
+    SniSelectionPolicy unmatched();
+
+    /**
+     * Policy for HTTP requests whose authority differs from the client-presented SNI host.
+     *
+     * @return authority mismatch policy
+     */
+    @Option.Configured("authority-mismatch")
+    @Option.Default("REJECT")
+    SniAuthorityPolicy authorityMismatch();
+
+    /**
+     * Policy for HTTP requests that use default listener TLS but claim a configured virtual-host authority.
+     *
+     * @return fallback authority policy
+     */
+    @Option.Configured("fallback-authority")
+    @Option.Default("REJECT")
+    SniAuthorityPolicy fallbackAuthority();
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SniContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SniContext.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.Optional;
+
+import io.helidon.common.Api;
+
+/**
+ * Listener SNI decision attached to a connection after TLS virtual-host selection.
+ * <p>
+ * Protocol handlers use this context to expose selected host information and to validate the parsed HTTP authority
+ * against the TLS SNI selection policy.
+ */
+@Api.Internal
+public interface SniContext {
+    /**
+     * Normalized SNI host presented by the client.
+     *
+     * @return presented SNI host, when present
+     */
+    Optional<String> presentedHost();
+
+    /**
+     * Configured virtual-host pattern that matched the presented SNI host.
+     *
+     * @return matched configured host, when a virtual host matched
+     */
+    Optional<String> matchedHost();
+
+    /**
+     * SNI match type.
+     *
+     * @return match type
+     */
+    SniMatchType matchType();
+
+    /**
+     * Check whether an HTTP authority is allowed by the listener SNI policy.
+     *
+     * @param authority HTTP authority
+     * @return authority check result
+     */
+    AuthorityCheck checkAuthority(String authority);
+
+    /**
+     * Authority check result.
+     */
+    enum AuthorityCheck {
+        /**
+         * Authority is allowed.
+         */
+        ALLOWED,
+        /**
+         * Authority differs from the matched SNI virtual-host host.
+         */
+        AUTHORITY_MISMATCH,
+        /**
+         * Fallback TLS was used but authority matches a configured virtual host.
+         */
+        FALLBACK_AUTHORITY
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SniMatchType.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SniMatchType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import io.helidon.common.Api;
+
+/**
+ * Internal classification of the TLS material selected for a connection from SNI.
+ * <p>
+ * The match type distinguishes exact and wildcard virtual-host matches from fallback to listener default TLS, so later
+ * HTTP protocol handling can expose and enforce the correct request-time policy.
+ */
+@Api.Internal
+public enum SniMatchType {
+    /**
+     * SNI matched an exact configured virtual host.
+     */
+    EXACT,
+    /**
+     * SNI matched a configured wildcard virtual host.
+     */
+    WILDCARD,
+    /**
+     * ClientHello had no SNI host and listener default TLS was selected.
+     */
+    FALLBACK_MISSING,
+    /**
+     * ClientHello had unmatched SNI and listener default TLS was selected.
+     */
+    FALLBACK_UNMATCHED
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SniRequestSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SniRequestSupport.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.helidon.common.Api;
+import io.helidon.http.DirectHandler;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Headers;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.RequestException;
+import io.helidon.http.Status;
+import io.helidon.webserver.http.DirectTransportRequest;
+
+/**
+ * Request-time SNI policy support.
+ * <p>
+ * TLS selection happens before HTTP parsing. This helper is the shared protocol hook that checks the parsed HTTP
+ * authority against the SNI context selected for the connection.
+ */
+@Api.Internal
+public final class SniRequestSupport {
+    private SniRequestSupport() {
+    }
+
+    /**
+     * Validate an HTTP authority against the connection SNI context.
+     *
+     * @param sniContext SNI context
+     * @param prologue   HTTP prologue
+     * @param headers    request headers
+     * @param authority  request authority
+     */
+    public static void validateAuthority(SniContext sniContext,
+                                         HttpPrologue prologue,
+                                         Headers headers,
+                                         String authority) {
+        Objects.requireNonNull(prologue);
+        Objects.requireNonNull(headers);
+        try {
+            validateAuthorityCheck(checkAuthority(sniContext, authority), prologue, headers);
+        } catch (IllegalArgumentException e) {
+            throw invalidAuthority(prologue, headers, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Validate an already parsed SNI authority check result.
+     *
+     * @param check    authority check result
+     * @param prologue HTTP prologue
+     * @param headers  request headers
+     */
+    public static void validateAuthorityCheck(SniContext.AuthorityCheck check, HttpPrologue prologue, Headers headers) {
+        Objects.requireNonNull(check);
+        Objects.requireNonNull(prologue);
+        Objects.requireNonNull(headers);
+        switch (check) {
+        case ALLOWED -> {
+        }
+        case AUTHORITY_MISMATCH -> throw misdirected(prologue,
+                                                     headers,
+                                                     "HTTP authority does not match the selected SNI host");
+        case FALLBACK_AUTHORITY -> throw misdirected(prologue,
+                                                     headers,
+                                                     "HTTP authority requires a configured SNI virtual host");
+        default -> throw new IllegalStateException("Unknown SNI authority check: " + check);
+        }
+    }
+
+    /**
+     * Check an HTTP authority against the connection SNI context.
+     *
+     * @param sniContext SNI context
+     * @param authority  request authority
+     * @return authority check result
+     */
+    public static SniContext.AuthorityCheck checkAuthority(SniContext sniContext, String authority) {
+        Objects.requireNonNull(sniContext);
+        Objects.requireNonNull(authority);
+        if (authority.isBlank()) {
+            throw new IllegalArgumentException("HTTP authority is required by SNI policy");
+        }
+        try {
+            return sniContext.checkAuthority(authority);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid HTTP authority: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Return the single HTTP/1 Host header authority required by SNI policy.
+     *
+     * @param prologue HTTP prologue
+     * @param headers  request headers
+     * @return Host header authority
+     */
+    public static String singleHostAuthority(HttpPrologue prologue, Headers headers) {
+        Objects.requireNonNull(prologue);
+        Objects.requireNonNull(headers);
+        List<String> hostHeaders = headers.all(HeaderNames.HOST, List::of);
+        if (hostHeaders.isEmpty()) {
+            throw missingAuthority(prologue, headers);
+        }
+        if (hostHeaders.size() > 1) {
+            throw invalidAuthority(prologue,
+                                   headers,
+                                   "Only a single Host header is allowed by SNI policy",
+                                   null);
+        }
+        return hostHeaders.getFirst();
+    }
+
+    /**
+     * Create the request exception for a missing authority.
+     *
+     * @param prologue HTTP prologue
+     * @param headers  request headers
+     * @return request exception
+     */
+    public static RequestException missingAuthority(HttpPrologue prologue, Headers headers) {
+        Objects.requireNonNull(prologue);
+        Objects.requireNonNull(headers);
+        return invalidAuthority(prologue, headers, "HTTP authority is required by SNI policy", null);
+    }
+
+    private static RequestException invalidAuthority(HttpPrologue prologue,
+                                                     Headers headers,
+                                                     String message,
+                                                     Throwable cause) {
+        return RequestException.builder()
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .status(Status.BAD_REQUEST_400)
+                .request(DirectTransportRequest.create(prologue, headers))
+                .setKeepAlive(false)
+                .message(message)
+                .cause(cause)
+                .build();
+    }
+
+    private static RequestException misdirected(HttpPrologue prologue, Headers headers, String message) {
+        return RequestException.builder()
+                .type(DirectHandler.EventType.OTHER)
+                .status(Status.MISDIRECTED_REQUEST_421)
+                .request(DirectTransportRequest.create(prologue, headers))
+                .setKeepAlive(true)
+                .message(message)
+                .build();
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SniSelectionPolicy.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SniSelectionPolicy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+/**
+ * TLS handshake policy for ClientHello messages that cannot select a configured SNI virtual host.
+ * <p>
+ * The policy decides whether the listener falls back to its default TLS configuration or rejects the handshake.
+ */
+public enum SniSelectionPolicy {
+    /**
+     * Use listener default TLS.
+     */
+    FALLBACK,
+    /**
+     * Reject the TLS connection.
+     */
+    REJECT
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostConfigBlueprint.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.tls.Tls;
+
+/**
+ * TLS material for one listener virtual host selected by SNI.
+ * <p>
+ * A virtual host contributes certificate and key material only. Request routing still comes from the listener that owns
+ * the virtual host.
+ */
+@Prototype.Configured
+@Prototype.Blueprint
+interface VirtualHostConfigBlueprint {
+    /**
+     * Exact DNS host name or narrow wildcard pattern such as {@code *.example.com}.
+     *
+     * @return virtual-host pattern
+     */
+    @Option.Configured
+    String host();
+
+    /**
+     * Required enabled TLS configuration for this virtual host; virtual hosts do not inherit the listener TLS configuration.
+     *
+     * @return virtual-host TLS
+     */
+    @Option.Configured
+    @Option.Required
+    Tls tls();
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostRegistry.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostRegistry.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
+
+/**
+ * Listener-local registry that maps normalized SNI host names to virtual-host TLS configuration.
+ * <p>
+ * The registry is deliberately about TLS selection only. It validates virtual-host TLS configuration at startup, chooses
+ * the TLS material for a connection before request routing, and creates the SNI context later used to enforce HTTP
+ * authority policy.
+ */
+final class VirtualHostRegistry {
+    private final String socketName;
+    private final Tls defaultTls;
+    private final SniConfig sniConfig;
+    private final Map<String, HostEntry> exactHosts;
+    private final Map<String, HostEntry> wildcardHosts;
+    private final boolean enabled;
+
+    private VirtualHostRegistry(String socketName,
+                                Tls defaultTls,
+                                SniConfig sniConfig,
+                                Map<String, HostEntry> exactHosts,
+                                Map<String, HostEntry> wildcardHosts) {
+        this.socketName = socketName;
+        this.defaultTls = defaultTls;
+        this.sniConfig = sniConfig;
+        this.exactHosts = Map.copyOf(exactHosts);
+        this.wildcardHosts = Map.copyOf(wildcardHosts);
+        this.enabled = !exactHosts.isEmpty() || !wildcardHosts.isEmpty();
+    }
+
+    static VirtualHostRegistry create(String socketName, ListenerConfig listenerConfig, Tls defaultTls) {
+        SniConfig sniConfig = listenerConfig.sni();
+        List<VirtualHostConfig> virtualHosts = listenerConfig.virtualHosts();
+
+        if (virtualHosts.isEmpty()) {
+            if (sniConfig.missing() != SniSelectionPolicy.FALLBACK
+                    || sniConfig.unmatched() != SniSelectionPolicy.FALLBACK) {
+                throw new IllegalArgumentException("Listener " + socketName
+                                                           + " cannot reject missing or unmatched SNI without virtual hosts");
+            }
+            return new VirtualHostRegistry(socketName, defaultTls, sniConfig, Map.of(), Map.of());
+        }
+
+        if (!defaultTls.enabled()) {
+            throw new IllegalArgumentException("Listener " + socketName + " virtual hosts require listener TLS");
+        }
+        if (!listenerConfig.useNio()) {
+            throw new IllegalArgumentException("Listener " + socketName
+                                                       + " virtual hosts require NIO TLS; use-nio must be true");
+        }
+
+        Map<String, HostEntry> exact = new HashMap<>();
+        Map<String, HostEntry> wildcard = new HashMap<>();
+        for (VirtualHostConfig virtualHost : virtualHosts) {
+            Tls tls = virtualHost.tls();
+            if (!tls.enabled()) {
+                throw new IllegalArgumentException("Virtual host " + virtualHost.host()
+                                                           + " on listener " + socketName + " requires enabled TLS");
+            }
+            HostEntry entry = HostEntry.create(virtualHost.host(), tls);
+            Map<String, HostEntry> target = entry.wildcard() ? wildcard : exact;
+            HostEntry previous = target.putIfAbsent(entry.indexKey(), entry);
+            if (previous != null) {
+                throw new IllegalArgumentException("Duplicate virtual host " + entry.configuredHost()
+                                                           + " on listener " + socketName);
+            }
+        }
+        return new VirtualHostRegistry(socketName, defaultTls, sniConfig, exact, wildcard);
+    }
+
+    boolean enabled() {
+        return enabled;
+    }
+
+    void validateTls() {
+        for (HostEntry entry : exactHosts.values()) {
+            entry.tls().newEngine();
+        }
+        for (HostEntry entry : wildcardHosts.values()) {
+            entry.tls().newEngine();
+        }
+    }
+
+    Selection select(String presentedHost) {
+        String host = Objects.requireNonNull(presentedHost);
+        HostEntry entry = match(host);
+        if (entry != null) {
+            SniMatchType matchType = entry.wildcard() ? SniMatchType.WILDCARD : SniMatchType.EXACT;
+            return new Selection(entry.tls(),
+                                 new Context(Optional.of(host), Optional.of(entry.configuredHost()), matchType));
+        }
+
+        if (sniConfig.unmatched() == SniSelectionPolicy.REJECT) {
+            throw new RejectedSniException("Unmatched SNI " + host + " rejected by listener " + socketName, true);
+        }
+        return fallback(Optional.of(host), SniMatchType.FALLBACK_UNMATCHED);
+    }
+
+    Selection selectWithoutSni() {
+        if (sniConfig.missing() == SniSelectionPolicy.REJECT) {
+            throw new RejectedSniException("Missing SNI rejected by listener " + socketName, false);
+        }
+        return fallback(Optional.empty(), SniMatchType.FALLBACK_MISSING);
+    }
+
+    private Selection fallback(Optional<String> presentedHost, SniMatchType matchType) {
+        return new Selection(defaultTls, new Context(presentedHost, Optional.empty(), matchType));
+    }
+
+    private HostEntry match(String host) {
+        HostEntry exact = exactHosts.get(host);
+        if (exact != null) {
+            return exact;
+        }
+
+        int dot = host.indexOf('.');
+        if (dot == -1 || dot == host.length() - 1) {
+            return null;
+        }
+        String suffix = host.substring(dot + 1);
+        return wildcardHosts.get(suffix);
+    }
+
+    private boolean matchesConfiguredHost(String host) {
+        return match(host) != null;
+    }
+
+    record Selection(Tls tls, SniContext sniContext) {
+    }
+
+    static final class RejectedSniException extends IllegalArgumentException {
+        private final boolean sendUnrecognizedNameAlert;
+
+        private RejectedSniException(String message, boolean sendUnrecognizedNameAlert) {
+            super(message);
+            this.sendUnrecognizedNameAlert = sendUnrecognizedNameAlert;
+        }
+
+        boolean sendUnrecognizedNameAlert() {
+            return sendUnrecognizedNameAlert;
+        }
+    }
+
+    private record HostEntry(String configuredHost, String indexKey, boolean wildcard, Tls tls) {
+        private static HostEntry create(String configuredHost, Tls tls) {
+            if (configuredHost.startsWith("*.")) {
+                return wildcard(configuredHost, tls);
+            }
+            if (configuredHost.indexOf('*') >= 0) {
+                throw new IllegalArgumentException("Virtual host wildcard must be the complete left-most label: "
+                                                           + configuredHost);
+            }
+
+            UriHost host = UriHost.create(configuredHost);
+            if (host.kind() != UriHost.Kind.DNS) {
+                throw new IllegalArgumentException("Virtual host must be a DNS name: " + configuredHost);
+            }
+            return new HostEntry(host.value(), host.value(), false, tls);
+        }
+
+        private static HostEntry wildcard(String configuredHost, Tls tls) {
+            if (configuredHost.indexOf('*', 1) != -1) {
+                throw new IllegalArgumentException("Virtual host wildcard must be the complete left-most label: "
+                                                           + configuredHost);
+            }
+            String suffix = configuredHost.substring(2);
+            UriHost host = UriHost.create(suffix);
+            if (host.kind() != UriHost.Kind.DNS) {
+                throw new IllegalArgumentException("Virtual host wildcard suffix must be a DNS name: " + configuredHost);
+            }
+            return new HostEntry("*." + host.value(), host.value(), true, tls);
+        }
+    }
+
+    private final class Context implements SniContext {
+        private final Optional<String> presentedHost;
+        private final Optional<String> matchedHost;
+        private final SniMatchType matchType;
+
+        private Context(Optional<String> presentedHost, Optional<String> matchedHost, SniMatchType matchType) {
+            this.presentedHost = Objects.requireNonNull(presentedHost);
+            this.matchedHost = Objects.requireNonNull(matchedHost);
+            this.matchType = Objects.requireNonNull(matchType);
+        }
+
+        @Override
+        public Optional<String> presentedHost() {
+            return presentedHost;
+        }
+
+        @Override
+        public Optional<String> matchedHost() {
+            return matchedHost;
+        }
+
+        @Override
+        public SniMatchType matchType() {
+            return matchType;
+        }
+
+        @Override
+        public AuthorityCheck checkAuthority(String authority) {
+            UriHost authorityHost = UriAuthority.create(authority).host();
+            String normalizedAuthority = authorityHost.value();
+
+            if (sniConfig.authorityMismatch() == SniAuthorityPolicy.REJECT
+                    && presentedHost.isPresent()
+                    && !normalizedAuthority.equals(presentedHost.get())) {
+                return AuthorityCheck.AUTHORITY_MISMATCH;
+            }
+
+            if (matchedHost.isPresent()) {
+                return AuthorityCheck.ALLOWED;
+            }
+
+            if (sniConfig.fallbackAuthority() == SniAuthorityPolicy.REJECT
+                    && authorityHost.kind() == UriHost.Kind.DNS
+                    && matchesConfiguredHost(normalizedAuthority)) {
+                return AuthorityCheck.FALLBACK_AUTHORITY;
+            }
+            return AuthorityCheck.ALLOWED;
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,6 +122,29 @@ public interface ServerRequest extends HttpRequest {
      * @see io.helidon.webserver.ListenerConfig#enableProxyProtocol()
      */
     Optional<ProxyProtocolData> proxyProtocolData();
+
+    /**
+     * Normalized DNS host name requested by the client using TLS Server Name Indication (SNI).
+     * <p>
+     * This value comes from the client TLS handshake, so it is suitable for diagnostics and application choices that
+     * are expected to use client-requested host names, but it should not be treated as a trusted identity by itself.
+     *
+     * @return normalized SNI requested host, if available
+     */
+    default Optional<String> sniRequestedHost() {
+        return Optional.empty();
+    }
+
+    /**
+     * Configured virtual-host host that matched the TLS Server Name Indication (SNI) requested host.
+     * <p>
+     * For wildcard virtual hosts, this method returns the configured wildcard host such as {@code *.example.com}.
+     *
+     * @return configured SNI matched host, if a virtual host matched
+     */
+    default Optional<String> sniMatchedHost() {
+        return Optional.empty();
+    }
 
     /**
      * The pattern used to match this request. Such as "/foo/{bar}".

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -59,6 +59,7 @@ import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ErrorHandling;
 import io.helidon.webserver.ProxyProtocolData;
 import io.helidon.webserver.ServerConnectionException;
+import io.helidon.webserver.SniRequestSupport;
 import io.helidon.webserver.http.DirectTransportRequest;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http1.spi.Http1Upgrader;
@@ -168,6 +169,10 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                 if (http1Config.validateRequestHeaders()) {
                     validateHostHeader(prologue, headers, true);
                 }
+                ctx.sniContext().ifPresent(sniContext -> {
+                    String authority = SniRequestSupport.singleHostAuthority(prologue, headers);
+                    SniRequestSupport.validateAuthority(sniContext, prologue, headers, authority);
+                });
                 ctx.remotePeer().tlsCertificates()
                         .flatMap(TlsUtils::parseCn)
                         .ifPresent(name -> headers.set(X_HELIDON_CN, name));

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import io.helidon.http.encoding.ContentDecoder;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.ProxyProtocolData;
+import io.helidon.webserver.SniContext;
 import io.helidon.webserver.http.HttpSecurity;
 import io.helidon.webserver.http.RoutingRequest;
 
@@ -238,6 +239,16 @@ abstract class Http1ServerRequest implements RoutingRequest {
     @Override
     public Optional<ProxyProtocolData> proxyProtocolData() {
         return ctx.proxyProtocolData();
+    }
+
+    @Override
+    public Optional<String> sniRequestedHost() {
+        return ctx.sniContext().flatMap(SniContext::presentedHost);
+    }
+
+    @Override
+    public Optional<String> sniMatchedHost() {
+        return ctx.sniContext().flatMap(SniContext::matchedHost);
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/internal/SniBenchmarkSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/internal/SniBenchmarkSupport.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.nio.channels.Channels;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.Api;
+import io.helidon.common.tls.Tls;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.SniContext;
+
+/**
+ * Internal access used by in-repository SNI benchmarks.
+ * <p>
+ * The production SNI registry and ClientHello reader are package-private implementation details. This class keeps the
+ * benchmark module out of the {@code io.helidon.webserver} package while still allowing it to measure those hot paths.
+ */
+@Api.Internal
+public final class SniBenchmarkSupport {
+    private static final MethodHandle REGISTRY_CREATE;
+    private static final MethodHandle REGISTRY_SELECT;
+    private static final MethodHandle REGISTRY_SELECT_WITHOUT_SNI;
+    private static final MethodHandle SELECTION_SNI_CONTEXT;
+    private static final MethodHandle CLIENT_HELLO_READ;
+    private static final MethodHandle CLIENT_HELLO_SNI_HOST;
+
+    static {
+        try {
+            Class<?> registryType = Class.forName("io.helidon.webserver.VirtualHostRegistry");
+            Class<?> selectionType = Class.forName("io.helidon.webserver.VirtualHostRegistry$Selection");
+            Class<?> readerType = Class.forName("io.helidon.webserver.ClientHelloPrefaceReader");
+            Class<?> prefaceType = Class.forName("io.helidon.webserver.ClientHelloPrefaceReader$ClientHelloPreface");
+
+            REGISTRY_CREATE = unreflect(registryType, "create", String.class, ListenerConfig.class, Tls.class);
+            REGISTRY_SELECT = unreflect(registryType, "select", String.class);
+            REGISTRY_SELECT_WITHOUT_SNI = unreflect(registryType, "selectWithoutSni");
+            SELECTION_SNI_CONTEXT = unreflect(selectionType, "sniContext");
+            CLIENT_HELLO_READ = unreflect(readerType, "read", java.nio.channels.ReadableByteChannel.class);
+            CLIENT_HELLO_SNI_HOST = unreflect(prefaceType, "sniHost");
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private SniBenchmarkSupport() {
+    }
+
+    /**
+     * Create an internal SNI virtual-host registry.
+     *
+     * @param socketName     socket name
+     * @param listenerConfig listener configuration
+     * @param defaultTls     fallback listener TLS
+     * @return registry handle
+     */
+    public static Registry registry(String socketName, ListenerConfig listenerConfig, Tls defaultTls) {
+        try {
+            Object delegate = REGISTRY_CREATE.invoke(Objects.requireNonNull(socketName),
+                                                    Objects.requireNonNull(listenerConfig),
+                                                    Objects.requireNonNull(defaultTls));
+            return new Registry(delegate);
+        } catch (Throwable e) {
+            throw rethrow(e);
+        }
+    }
+
+    /**
+     * Select SNI context for a presented host.
+     *
+     * @param registry registry handle
+     * @param sniHost  normalized SNI host
+     * @return selected SNI context
+     */
+    public static SniContext select(Registry registry, String sniHost) {
+        try {
+            Object selection = REGISTRY_SELECT.invoke(Objects.requireNonNull(registry).delegate,
+                                                      Objects.requireNonNull(sniHost));
+            return (SniContext) SELECTION_SNI_CONTEXT.invoke(selection);
+        } catch (Throwable e) {
+            throw rethrow(e);
+        }
+    }
+
+    /**
+     * Select SNI context for a connection without a presented SNI host.
+     *
+     * @param registry registry handle
+     * @return selected SNI context
+     */
+    public static SniContext selectWithoutSni(Registry registry) {
+        try {
+            Object selection = REGISTRY_SELECT_WITHOUT_SNI.invoke(Objects.requireNonNull(registry).delegate);
+            return (SniContext) SELECTION_SNI_CONTEXT.invoke(selection);
+        } catch (Throwable e) {
+            throw rethrow(e);
+        }
+    }
+
+    /**
+     * Read in-memory ClientHello bytes and select the corresponding SNI context.
+     * <p>
+     * This helper intentionally measures ClientHello parser and virtual-host registry costs only. It does not exercise
+     * the production {@code SocketChannel} pre-read timeout, selector registration, or blocking-mode restore path.
+     *
+     * @param clientHello TLS ClientHello record bytes
+     * @param registry    registry handle
+     * @return selected SNI context
+     * @throws IOException if the ClientHello bytes cannot be read
+     */
+    public static SniContext readParserAndSelect(byte[] clientHello, Registry registry) throws IOException {
+        var channel = Channels.newChannel(new ByteArrayInputStream(Objects.requireNonNull(clientHello)));
+        try {
+            Object preface = CLIENT_HELLO_READ.invoke(channel);
+            Optional<?> sniHost = (Optional<?>) CLIENT_HELLO_SNI_HOST.invoke(preface);
+            Object selection = sniHost.isPresent()
+                    ? REGISTRY_SELECT.invoke(Objects.requireNonNull(registry).delegate, sniHost.get())
+                    : REGISTRY_SELECT_WITHOUT_SNI.invoke(Objects.requireNonNull(registry).delegate);
+            return (SniContext) SELECTION_SNI_CONTEXT.invoke(selection);
+        } catch (Throwable e) {
+            Throwable cause = unwrap(e);
+            if (cause instanceof IOException ioe) {
+                throw ioe;
+            }
+            throw rethrow(cause);
+        }
+    }
+
+    private static MethodHandle unreflect(Class<?> type, String name, Class<?>... parameters)
+            throws ReflectiveOperationException {
+        Method method = type.getDeclaredMethod(name, parameters);
+        method.setAccessible(true);
+        return MethodHandles.lookup().unreflect(method);
+    }
+
+    private static RuntimeException rethrow(Throwable throwable) {
+        Throwable cause = unwrap(throwable);
+        if (cause instanceof RuntimeException re) {
+            return re;
+        }
+        if (cause instanceof Error error) {
+            throw error;
+        }
+        return new IllegalStateException(cause);
+    }
+
+    private static Throwable unwrap(Throwable throwable) {
+        return throwable instanceof java.lang.reflect.InvocationTargetException invocation
+                ? invocation.getCause()
+                : throwable;
+    }
+
+    /**
+     * Handle to an internal virtual-host registry.
+     */
+    @Api.Internal
+    public static final class Registry {
+        private final Object delegate;
+
+        private Registry(Object delegate) {
+            this.delegate = delegate;
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/internal/package-info.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WebServer implementation helpers that are not exported from the module.
+ */
+package io.helidon.webserver.internal;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ClientHelloPrefaceReaderTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ClientHelloPrefaceReaderTest.java
@@ -28,6 +28,8 @@ import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -124,6 +126,30 @@ class ClientHelloPrefaceReaderTest {
 
                 assertThat(exception.getMessage(), containsString("timed out"));
                 assertThat(accepted.isBlocking(), is(true));
+            }
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void zeroSocketChannelTimeoutWaitsForClientHello() throws Exception {
+        byte[] record = record(clientHello("api.example.com"));
+        try (ServerSocketChannel server = ServerSocketChannel.open()) {
+            server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            InetSocketAddress address = (InetSocketAddress) server.getLocalAddress();
+            try (SocketChannel client = SocketChannel.open(address);
+                    SocketChannel accepted = server.accept()) {
+                FutureTask<ClientHelloPrefaceReader.ClientHelloPreface> read =
+                        new FutureTask<>(() -> ClientHelloPrefaceReader.read(accepted, Duration.ZERO));
+                Thread reader = Thread.ofPlatform().start(read);
+
+                Thread.sleep(100);
+                client.write(ByteBuffer.wrap(record));
+
+                ClientHelloPrefaceReader.ClientHelloPreface preface = read.get(5, TimeUnit.SECONDS);
+                assertThat(preface.sniHost(), is(Optional.of("api.example.com")));
+                assertThat(preface.replayBuffer().remaining(), is(record.length));
+                reader.join(5_000);
             }
         }
     }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ClientHelloPrefaceReaderTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ClientHelloPrefaceReaderTest.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClientHelloPrefaceReaderTest {
+    private static final String DNS_LABEL_63 = "a".repeat(63);
+    private static final String DNS_LABEL_64 = "a".repeat(64);
+    private static final String LONGEST_DNS_NAME = DNS_LABEL_63 + "."
+            + DNS_LABEL_63 + "."
+            + DNS_LABEL_63 + "."
+            + "a".repeat(61);
+    private static final String TOO_LONG_DNS_NAME = DNS_LABEL_63 + "."
+            + DNS_LABEL_63 + "."
+            + DNS_LABEL_63 + "."
+            + "a".repeat(62);
+
+    @Test
+    void readsSniFromSingleRecordClientHello() throws IOException {
+        byte[] clientHello = clientHello("Api.Example.COM");
+
+        ClientHelloPrefaceReader.ClientHelloPreface preface = read(record(clientHello));
+
+        assertThat(preface.sniHost(), is(Optional.of("api.example.com")));
+        assertThat(preface.replayBuffer().remaining(), is(record(clientHello).length));
+    }
+
+    @Test
+    void readsShortestSniHostName() throws IOException {
+        byte[] clientHello = clientHello("a");
+
+        ClientHelloPrefaceReader.ClientHelloPreface preface = read(record(clientHello));
+
+        assertThat(preface.sniHost(), is(Optional.of("a")));
+    }
+
+    @Test
+    void readsLongestSniHostName() throws IOException {
+        byte[] clientHello = clientHello(LONGEST_DNS_NAME);
+
+        ClientHelloPrefaceReader.ClientHelloPreface preface = read(record(clientHello));
+
+        assertThat(preface.sniHost(), is(Optional.of(LONGEST_DNS_NAME)));
+    }
+
+    @Test
+    void readsSniFromFragmentedClientHello() throws IOException {
+        byte[] clientHello = clientHello("api.example.com");
+        byte[] records = concat(record(clientHello, 0, 11), record(clientHello, 11, clientHello.length - 11));
+
+        ClientHelloPrefaceReader.ClientHelloPreface preface = read(records);
+
+        assertThat(preface.sniHost(), is(Optional.of("api.example.com")));
+        assertThat(preface.replayBuffer().remaining(), is(records.length));
+    }
+
+    @Test
+    void returnsEmptyWhenClientHelloHasNoSniExtension() throws IOException {
+        ClientHelloPrefaceReader.ClientHelloPreface preface = read(record(clientHelloWithoutSni()));
+
+        assertThat(preface.sniHost(), is(Optional.empty()));
+    }
+
+    @Test
+    void rejectsNonHandshakeRecord() {
+        byte[] record = record(23, new byte[] {1, 2, 3});
+
+        assertThrows(IllegalArgumentException.class, () -> read(record));
+    }
+
+    @Test
+    void rejectsTruncatedRecord() {
+        byte[] record = new byte[] {22, 3, 3, 0, 4, 1, 0};
+
+        assertThrows(IllegalArgumentException.class, () -> read(record));
+    }
+
+    @Test
+    @Timeout(10)
+    void timesOutPartialSocketChannelPreface() throws Exception {
+        try (ServerSocketChannel server = ServerSocketChannel.open()) {
+            server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            InetSocketAddress address = (InetSocketAddress) server.getLocalAddress();
+            try (SocketChannel client = SocketChannel.open(address);
+                    SocketChannel accepted = server.accept()) {
+                client.write(ByteBuffer.wrap(new byte[] {22, 3, 3, 0, 4, 1, 0}));
+
+                IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                        () -> ClientHelloPrefaceReader.read(accepted, Duration.ofMillis(100)));
+
+                assertThat(exception.getMessage(), containsString("timed out"));
+                assertThat(accepted.isBlocking(), is(true));
+            }
+        }
+    }
+
+    @Test
+    void rejectsTooLargeClientHello() {
+        byte[] handshake = handshakeHeaderOnly(64 * 1024);
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(handshake)));
+    }
+
+    @Test
+    void rejectsTooLargeTlsRecord() {
+        byte[] record = record(22, new byte[16 * 1024 + 1]);
+
+        assertThrows(IllegalArgumentException.class, () -> read(record));
+    }
+
+    @Test
+    void rejectsMalformedExtensionsLength() {
+        ByteArrayOutputStream body = baseClientHelloBody();
+        writeShort(body, 8);
+        writeShort(body, 0);
+        writeShort(body, 0);
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(handshake(body.toByteArray()))));
+    }
+
+    @Test
+    void rejectsInvalidSniServerNameListLength() {
+        byte[] extension = sniExtensionWithListLength(1, new byte[] {0});
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHelloWithExtension(extension))));
+    }
+
+    @Test
+    void rejectsEmptySniServerNameList() {
+        byte[] extension = sniExtensionWithListLength(0, new byte[0]);
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHelloWithExtension(extension))));
+    }
+
+    @Test
+    void rejectsEmptySniHostName() {
+        byte[] extension = sniExtensionWithListLength(3, new byte[] {0, 0, 0});
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHelloWithExtension(extension))));
+    }
+
+    @Test
+    void rejectsDuplicateSniHostName() {
+        ByteArrayOutputStream serverNameList = new ByteArrayOutputStream();
+        writeServerName(serverNameList, "api.example.com");
+        writeServerName(serverNameList, "admin.example.com");
+        byte[] extension = sniExtensionWithListLength(serverNameList.size(), serverNameList.toByteArray());
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHelloWithExtension(extension))));
+    }
+
+    @Test
+    void rejectsMalformedTrailingSniServerName() {
+        ByteArrayOutputStream serverNameList = new ByteArrayOutputStream();
+        writeServerName(serverNameList, "api.example.com");
+        serverNameList.write(0);
+        byte[] extension = sniExtensionWithListLength(serverNameList.size(), serverNameList.toByteArray());
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHelloWithExtension(extension))));
+    }
+
+    @Test
+    void rejectsDuplicateSniExtension() {
+        byte[] extension = sniExtension("api.example.com");
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> read(record(clientHelloWithExtensions(extension, extension))));
+    }
+
+    @Test
+    void rejectsMalformedExtensionAfterSni() {
+        byte[] extension = sniExtension("api.example.com");
+        byte[] malformedExtensionHeader = new byte[] {0, 1, 0};
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> read(record(clientHelloWithExtensions(extension, malformedExtensionHeader))));
+    }
+
+    @Test
+    void rejectsTrailingDotSniHostName() {
+        byte[] clientHello = clientHello("api.example.com.");
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHello)));
+    }
+
+    @Test
+    void rejectsTooLongSniHostName() {
+        byte[] clientHello = clientHello(TOO_LONG_DNS_NAME);
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHello)));
+    }
+
+    @Test
+    void rejectsTooLongSniHostNameLabel() {
+        byte[] clientHello = clientHello(DNS_LABEL_64);
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHello)));
+    }
+
+    @Test
+    void rejectsIpLiteralSniHostName() {
+        byte[] clientHello = clientHello("127.0.0.1");
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHello)));
+    }
+
+    @Test
+    void rejectsNonAsciiSniHostName() {
+        byte[] clientHello = clientHello(new byte[] {'a', (byte) 0xFF});
+
+        assertThrows(IllegalArgumentException.class, () -> read(record(clientHello)));
+    }
+
+    private static ClientHelloPrefaceReader.ClientHelloPreface read(byte[] bytes) throws IOException {
+        return ClientHelloPrefaceReader.read(Channels.newChannel(new ByteArrayInputStream(bytes)));
+    }
+
+    private static byte[] clientHello(String host) {
+        return clientHello(host.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    private static byte[] clientHello(byte[] hostBytes) {
+        return clientHelloWithExtensions(sniExtension(hostBytes));
+    }
+
+    private static byte[] sniExtension(String host) {
+        return sniExtension(host.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    private static byte[] sniExtension(byte[] hostBytes) {
+        ByteArrayOutputStream sni = new ByteArrayOutputStream();
+        writeShort(sni, 3 + hostBytes.length);
+        writeServerName(sni, hostBytes);
+
+        ByteArrayOutputStream extension = new ByteArrayOutputStream();
+        writeShort(extension, 0);
+        writeShort(extension, sni.size());
+        extension.writeBytes(sni.toByteArray());
+        return extension.toByteArray();
+    }
+
+    private static void writeServerName(ByteArrayOutputStream stream, String host) {
+        writeServerName(stream, host.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    private static void writeServerName(ByteArrayOutputStream stream, byte[] hostBytes) {
+        stream.write(0);
+        writeShort(stream, hostBytes.length);
+        stream.writeBytes(hostBytes);
+    }
+
+    private static byte[] clientHelloWithoutSni() {
+        ByteArrayOutputStream body = baseClientHelloBody();
+        writeShort(body, 0);
+        return handshake(body.toByteArray());
+    }
+
+    private static byte[] clientHelloWithExtension(byte[] extension) {
+        return clientHelloWithExtensions(extension);
+    }
+
+    private static byte[] clientHelloWithExtensions(byte[]... extensions) {
+        ByteArrayOutputStream body = baseClientHelloBody();
+        int extensionsLength = 0;
+        for (byte[] extension : extensions) {
+            extensionsLength += extension.length;
+        }
+        writeShort(body, extensionsLength);
+        for (byte[] extension : extensions) {
+            body.writeBytes(extension);
+        }
+        return handshake(body.toByteArray());
+    }
+
+    private static byte[] sniExtensionWithListLength(int listLength, byte[] serverNameList) {
+        ByteArrayOutputStream sni = new ByteArrayOutputStream();
+        writeShort(sni, listLength);
+        sni.writeBytes(serverNameList);
+
+        ByteArrayOutputStream extension = new ByteArrayOutputStream();
+        writeShort(extension, 0);
+        writeShort(extension, sni.size());
+        extension.writeBytes(sni.toByteArray());
+        return extension.toByteArray();
+    }
+
+    private static ByteArrayOutputStream baseClientHelloBody() {
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        body.write(0x03);
+        body.write(0x03);
+        body.writeBytes(new byte[32]);
+        body.write(0);
+        writeShort(body, 2);
+        body.write(0x13);
+        body.write(0x01);
+        body.write(1);
+        body.write(0);
+        return body;
+    }
+
+    private static byte[] handshake(byte[] body) {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        result.write(1);
+        writeMedium(result, body.length);
+        result.writeBytes(body);
+        return result.toByteArray();
+    }
+
+    private static byte[] handshakeHeaderOnly(int bodyLength) {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        result.write(1);
+        writeMedium(result, bodyLength);
+        return result.toByteArray();
+    }
+
+    private static byte[] record(byte[] handshake) {
+        return record(handshake, 0, handshake.length);
+    }
+
+    private static byte[] record(byte[] handshake, int offset, int length) {
+        byte[] fragment = new byte[length];
+        System.arraycopy(handshake, offset, fragment, 0, length);
+        return record(22, fragment);
+    }
+
+    private static byte[] record(int type, byte[] data) {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        result.write(type);
+        result.write(0x03);
+        result.write(0x03);
+        writeShort(result, data.length);
+        result.writeBytes(data);
+        return result.toByteArray();
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        result.writeBytes(first);
+        result.writeBytes(second);
+        return result.toByteArray();
+    }
+
+    private static void writeShort(ByteArrayOutputStream stream, int value) {
+        stream.write((value >>> 8) & 0xFF);
+        stream.write(value & 0xFF);
+    }
+
+    private static void writeMedium(ByteArrayOutputStream stream, int value) {
+        stream.write((value >>> 16) & 0xFF);
+        stream.write((value >>> 8) & 0xFF);
+        stream.write(value & 0xFF);
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
@@ -56,6 +56,10 @@ class ConnectionHandlerTest {
         when(listenerConfig.enableProxyProtocol()).thenThrow(failure);
         ListenerContext listenerContext = mock(ListenerContext.class);
         when(listenerContext.config()).thenReturn(listenerConfig);
+        ListenerConfig virtualHostConfig = mock(ListenerConfig.class);
+        when(virtualHostConfig.sni()).thenReturn(SniConfig.create());
+        when(virtualHostConfig.virtualHosts()).thenReturn(List.of());
+        VirtualHostRegistry virtualHosts = VirtualHostRegistry.create("server", virtualHostConfig, mock(Tls.class));
         LimitAlgorithm.Token token = mock(LimitAlgorithm.Token.class);
         ConnectionHandler handler = new ConnectionHandler(listenerContext,
                                                           token,
@@ -65,6 +69,7 @@ class ConnectionHandlerTest {
                                                           "server",
                                                           Router.empty(),
                                                           mock(Tls.class),
+                                                          virtualHosts,
                                                           it -> { });
 
         try (TestLogHandler logHandler = TestLogHandler.install()) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
@@ -18,6 +18,7 @@ package io.helidon.webserver;
 
 import java.net.UnixDomainSocketAddress;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import io.helidon.config.Config;
@@ -92,5 +93,23 @@ public class ListenerConfigTest {
         assertThat(webServerConfig3.enableProxyProtocol(), is(false));
         ListenerConfig graceConfig = webServerConfig3.sockets().get("grace");
         assertThat(graceConfig.enableProxyProtocol(), is(true));
+    }
+
+    @Test
+    void testSniVirtualHostConfig() {
+        Config config = Config.create();
+        var webServerConfig = WebServer.builder().config(config.get("server4")).buildPrototype();
+
+        assertThat(webServerConfig.sni().missing(), is(SniSelectionPolicy.REJECT));
+        assertThat(webServerConfig.sni().unmatched(), is(SniSelectionPolicy.REJECT));
+        assertThat(webServerConfig.sni().authorityMismatch(), is(SniAuthorityPolicy.ALLOW));
+        assertThat(webServerConfig.sni().fallbackAuthority(), is(SniAuthorityPolicy.ALLOW));
+        assertThat(webServerConfig.virtualHosts().size(), is(1));
+
+        VirtualHostConfig virtualHost = webServerConfig.virtualHosts().getFirst();
+        assertThat(virtualHost.host(), is("Api.Example.COM."));
+        assertThat(virtualHost.tls().enabled(), is(true));
+        assertThat(virtualHost.tls().prototype().enabledCipherSuites(),
+                   is(List.of("TLS_AES_128_GCM_SHA256")));
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/VirtualHostRegistryTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/VirtualHostRegistryTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.Optional;
+
+import io.helidon.common.tls.Tls;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class VirtualHostRegistryTest {
+    private static final String SOCKET_NAME = "test";
+    private static final Tls TLS = Tls.builder()
+            .trustAll(true)
+            .build();
+    private static final Tls DISABLED_TLS = Tls.builder()
+            .enabled(false)
+            .build();
+
+    @Test
+    void rejectsNonDefaultSelectionPolicyWithoutVirtualHosts() {
+        ListenerConfig listener = ListenerConfig.builder()
+                .sni(it -> it.missing(SniSelectionPolicy.REJECT))
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> VirtualHostRegistry.create(SOCKET_NAME, listener, DISABLED_TLS));
+    }
+
+    @Test
+    void virtualHostsRequireListenerTls() {
+        ListenerConfig listener = ListenerConfig.builder()
+                .addVirtualHost(virtualHost("api.example.com"))
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> VirtualHostRegistry.create(SOCKET_NAME, listener, DISABLED_TLS));
+    }
+
+    @Test
+    void virtualHostsRequireNioTls() {
+        ListenerConfig listener = ListenerConfig.builder()
+                .tls(TLS)
+                .useNio(false)
+                .addVirtualHost(virtualHost("api.example.com"))
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> VirtualHostRegistry.create(SOCKET_NAME, listener, TLS));
+    }
+
+    @Test
+    void duplicateNormalizedHostsFail() {
+        ListenerConfig listener = ListenerConfig.builder()
+                .tls(TLS)
+                .addVirtualHost(virtualHost("Api.Example.COM."))
+                .addVirtualHost(virtualHost("api.example.com"))
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> VirtualHostRegistry.create(SOCKET_NAME, listener, TLS));
+    }
+
+    @Test
+    void exactHostWinsOverWildcardAndAuthorityMustMatchPresentedSni() {
+        VirtualHostRegistry registry = registry("api.example.com", "*.example.com");
+
+        VirtualHostRegistry.Selection selection = registry.select("api.example.com");
+
+        assertThat(selection.tls(), is(TLS));
+        assertThat(selection.sniContext().matchType(), is(SniMatchType.EXACT));
+        assertThat(selection.sniContext().matchedHost(), is(Optional.of("api.example.com")));
+        assertThat(selection.sniContext().checkAuthority("api.example.com"), is(SniContext.AuthorityCheck.ALLOWED));
+        assertThat(selection.sniContext().checkAuthority("admin.example.com"),
+                   is(SniContext.AuthorityCheck.AUTHORITY_MISMATCH));
+    }
+
+    @Test
+    void wildcardMatchesOneLabelOnly() {
+        VirtualHostRegistry registry = registry("*.example.com");
+
+        SniContext context = registry.select("api.example.com").sniContext();
+
+        assertThat(context.presentedHost(), is(Optional.of("api.example.com")));
+        assertThat(context.matchedHost(), is(Optional.of("*.example.com")));
+        assertThat(context.matchType(), is(SniMatchType.WILDCARD));
+        assertThat(registry.select("a.b.example.com").sniContext().matchType(),
+                   is(SniMatchType.FALLBACK_UNMATCHED));
+    }
+
+    @Test
+    void fallbackAuthorityRejectsConfiguredHostNames() {
+        VirtualHostRegistry registry = registry("api.example.com", "*.example.org");
+
+        SniContext context = registry.selectWithoutSni().sniContext();
+
+        assertThat(context.matchType(), is(SniMatchType.FALLBACK_MISSING));
+        assertThat(context.checkAuthority("api.example.com"), is(SniContext.AuthorityCheck.FALLBACK_AUTHORITY));
+        assertThat(context.checkAuthority("admin.example.org"), is(SniContext.AuthorityCheck.FALLBACK_AUTHORITY));
+        assertThat(context.checkAuthority("other.example.net"), is(SniContext.AuthorityCheck.ALLOWED));
+    }
+
+    @Test
+    void unmatchedPresentedSniRejectsDifferentAuthority() {
+        VirtualHostRegistry registry = registry("api.example.com");
+        SniContext context = registry.select("unmatched.example.com").sniContext();
+
+        assertThat(context.checkAuthority("unmatched.example.com"), is(SniContext.AuthorityCheck.ALLOWED));
+        assertThat(context.checkAuthority("other.example.com"), is(SniContext.AuthorityCheck.AUTHORITY_MISMATCH));
+    }
+
+    @Test
+    void checkAuthorityUsesRealAuthorityParser() {
+        VirtualHostRegistry registry = registry("api.example.com");
+        SniContext context = registry.select("api.example.com").sniContext();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> SniRequestSupport.checkAuthority(context, "bad authority"));
+
+        assertThat(exception.getMessage(), containsString("Invalid HTTP authority"));
+    }
+
+    @Test
+    void missingAndUnmatchedRejectPoliciesRejectTlsSelection() {
+        ListenerConfig listener = ListenerConfig.builder()
+                .tls(TLS)
+                .addVirtualHost(virtualHost("api.example.com"))
+                .sni(it -> it.missing(SniSelectionPolicy.REJECT)
+                        .unmatched(SniSelectionPolicy.REJECT))
+                .build();
+        VirtualHostRegistry registry = VirtualHostRegistry.create(SOCKET_NAME, listener, TLS);
+
+        VirtualHostRegistry.RejectedSniException missing =
+                assertThrows(VirtualHostRegistry.RejectedSniException.class, registry::selectWithoutSni);
+        VirtualHostRegistry.RejectedSniException unmatched =
+                assertThrows(VirtualHostRegistry.RejectedSniException.class,
+                             () -> registry.select("other.example.com"));
+
+        assertThat(missing.sendUnrecognizedNameAlert(), is(false));
+        assertThat(unmatched.sendUnrecognizedNameAlert(), is(true));
+    }
+
+    private static VirtualHostRegistry registry(String... hosts) {
+        ListenerConfig.Builder builder = ListenerConfig.builder()
+                .tls(TLS);
+        for (String host : hosts) {
+            builder.addVirtualHost(virtualHost(host));
+        }
+        return VirtualHostRegistry.create(SOCKET_NAME, builder.build(), TLS);
+    }
+
+    private static VirtualHostConfig virtualHost(String host) {
+        return VirtualHostConfig.builder()
+                .host(host)
+                .tls(TLS)
+                .build();
+    }
+}

--- a/webserver/webserver/src/test/resources/application.yaml
+++ b/webserver/webserver/src/test/resources/application.yaml
@@ -61,5 +61,22 @@ server3:
       shutdown-grace-period: PT2S
       enable-proxy-protocol: true
 
+server4:
+  port: 8079
+  host: 127.0.0.1
+  tls:
+    enabled: true
+  sni:
+    missing: REJECT
+    unmatched: REJECT
+    authority-mismatch: ALLOW
+    fallback-authority: ALLOW
+  virtual-hosts:
+    - host: "Api.Example.COM."
+      tls:
+        enabled: true
+        cipher-suite:
+          - "TLS_AES_128_GCM_SHA256"
+
 inject:
   permits-dynamic: true


### PR DESCRIPTION
Resolves #12056

Adds WebServer listener virtual-host SNI TLS selection for NIO TLS, request authority policy enforcement for HTTP/1 and HTTP/2, and exposes SNI host metadata on ServerRequest and gRPC/JSON-RPC request contexts. Updates docs, snippets, regression tests, and SNI-related JMH parser/replay benchmarks.


SNI virtual hosts require listener TLS and the NIO socket-channel transport, which is the default.

Config example:

```yaml
server:
  tls:
    private-key:
      keystore:
        passphrase: "password"
        resource:
          resource-path: "default-server.p12"
  virtual-hosts:
    - host: "api.example.com"
      tls:
        private-key:
          keystore:
            passphrase: "password"
            resource:
              resource-path: "api-server.p12"
    - host: "*.example.org"
      tls:
        private-key:
          keystore:
            passphrase: "password"
            resource:
              resource-path: "wildcard-server.p12"
  sni:
    missing: "FALLBACK"
    unmatched: "FALLBACK"
    authority-mismatch: "REJECT"
    fallback-authority: "REJECT"
```