### PR TITLE
Deprecate BufferData#asInputStream() (27.x)

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
@@ -684,7 +684,9 @@ public interface BufferData {
      * or rewinds the buffer.
      *
      * @return an input stream backed by this buffer
+     * @deprecated this method will be removed without replacement
      */
+    @Deprecated(forRemoval = true, since = "27.0.0")
     default InputStream asInputStream() {
         return new InputStream() {
             @Override


### PR DESCRIPTION
Resolves #11788

Deprecates `BufferData#asInputStream()` for removal in 27.0.0 and documents that the method will be removed without replacement.
