### PR TITLE
Guard null context classloaders (4.x)

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/ResourceUtil.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ResourceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ final class ResourceUtil {
      */
     static InputStream toIs(String resPath) {
         Objects.requireNonNull(resPath, "Resource path must not be null");
-        InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(resPath);
+        InputStream is = contextClassLoader().getResourceAsStream(resPath);
         Objects.requireNonNull(is, "Resource path does not exist: " + resPath);
         return is;
     }
@@ -104,5 +104,10 @@ final class ResourceUtil {
         } catch (IOException e) {
             throw new ResourceException("Failed to open stream to uri: " + uri, e);
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ResourceUtil.class.getClassLoader() : classLoader;
     }
 }

--- a/common/features/features/src/main/java/io/helidon/common/features/HelidonFeatures.java
+++ b/common/features/features/src/main/java/io/helidon/common/features/HelidonFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ public final class HelidonFeatures {
             return;
         }
 
-        scan(Thread.currentThread().getContextClassLoader());
+        scan(contextClassLoader());
 
         Set<FeatureMetadata> features = FEATURES.get(currentFlavor);
         if (null == features) {
@@ -407,6 +407,11 @@ public final class HelidonFeatures {
             }
             printDetails(actualName, childNode, level + 1);
         });
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? HelidonFeatures.class.getClassLoader() : classLoader;
     }
 
     static final class Node {

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
@@ -84,7 +84,7 @@ class MpConfigBuilder implements Builder<MpConfigBuilder, Config>, ConfigBuilder
     private final List<OrdinalSource> sources = new LinkedList<>();
     private final List<OrdinalConverter> converters = new LinkedList<>();
 
-    private ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    private ClassLoader classLoader = contextClassLoader();
 
     private boolean useDefaultSources = false;
     private boolean useDiscoveredSources = false;
@@ -171,7 +171,7 @@ class MpConfigBuilder implements Builder<MpConfigBuilder, Config>, ConfigBuilder
 
     @Override
     public ConfigBuilder forClassLoader(ClassLoader loader) {
-        this.classLoader = loader;
+        this.classLoader = fallbackClassLoader(loader);
         return this;
     }
 
@@ -464,6 +464,14 @@ class MpConfigBuilder implements Builder<MpConfigBuilder, Config>, ConfigBuilder
                 .build();
         this.sources.add(new OrdinalSource(MpConfigSources.create(helidonConfig)));
         return this;
+    }
+
+    private static ClassLoader contextClassLoader() {
+        return fallbackClassLoader(Thread.currentThread().getContextClassLoader());
+    }
+
+    private static ClassLoader fallbackClassLoader(ClassLoader classLoader) {
+        return classLoader == null ? MpConfigBuilder.class.getClassLoader() : classLoader;
     }
 
     private static class OrdinalSource {

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
@@ -55,14 +55,14 @@ public class MpConfigProviderResolver extends ConfigProviderResolver {
 
     @Override
     public Config getConfig() {
-        return getConfig(Thread.currentThread().getContextClassLoader());
+        return getConfig(contextClassLoader());
     }
 
     @Override
     public Config getConfig(ClassLoader classLoader) {
         ClassLoader loader;
         if (classLoader == null) {
-            loader = Thread.currentThread().getContextClassLoader();
+            loader = contextClassLoader();
         } else {
             loader = classLoader;
         }
@@ -123,7 +123,7 @@ public class MpConfigProviderResolver extends ConfigProviderResolver {
     public void registerConfig(Config config, ClassLoader classLoader) {
         ClassLoader usedClassloader;
         if (null == classLoader) {
-            usedClassloader = Thread.currentThread().getContextClassLoader();
+            usedClassloader = contextClassLoader();
         } else {
             usedClassloader = classLoader;
         }
@@ -182,7 +182,7 @@ public class MpConfigProviderResolver extends ConfigProviderResolver {
 
         CONFIGS.put(classLoader, newConfig);
 
-        if (classLoader == Thread.currentThread().getContextClassLoader()) {
+        if (classLoader == contextClassLoader()) {
             // this should be the default class loader (we do not support classloader magic in Helidon)
             GlobalConfig.config(() -> newConfig, true);
         }
@@ -229,6 +229,11 @@ public class MpConfigProviderResolver extends ConfigProviderResolver {
                 lock.unlock();
             }
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? MpConfigProviderResolver.class.getClassLoader() : classLoader;
     }
 
     /**

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigSources.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,7 +268,7 @@ public final class MpConfigSources {
      * @return a config source for each resource on classpath, empty if none found
      */
     public static List<ConfigSource> classPath(String resource) {
-        return classPath(Thread.currentThread().getContextClassLoader(), resource);
+        return classPath(contextClassLoader(), resource);
     }
 
     /**
@@ -283,7 +283,7 @@ public final class MpConfigSources {
      * @return a config source for each resource on classpath, empty if none found
      */
     public static List<ConfigSource> classPath(String resource, String profile) {
-        return classPath(Thread.currentThread().getContextClassLoader(), resource, profile);
+        return classPath(contextClassLoader(), resource, profile);
     }
 
     /**
@@ -295,6 +295,7 @@ public final class MpConfigSources {
      * @return a config source for each resource on classpath, empty if none found
      */
     public static List<ConfigSource> classPath(ClassLoader classLoader, String resource) {
+        classLoader = fallbackClassLoader(classLoader);
         List<ConfigSource> sources = new LinkedList<>();
         try {
             classLoader.getResources(resource)
@@ -321,6 +322,7 @@ public final class MpConfigSources {
      */
     public static List<ConfigSource> classPath(ClassLoader classLoader, String resource, String profile) {
         Objects.requireNonNull(profile, "Profile must be defined");
+        classLoader = fallbackClassLoader(classLoader);
 
         List<ConfigSource> sources = new LinkedList<>();
 
@@ -511,5 +513,13 @@ public final class MpConfigSources {
 
         originalProperties.keySet().removeIf(it -> !props.containsKey(it));
         originalProperties.putAll(props);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        return fallbackClassLoader(Thread.currentThread().getContextClassLoader());
+    }
+
+    private static ClassLoader fallbackClassLoader(ClassLoader classLoader) {
+        return classLoader == null ? MpConfigSources.class.getClassLoader() : classLoader;
     }
 }

--- a/config/config/src/main/java/io/helidon/config/ClasspathConfigSource.java
+++ b/config/config/src/main/java/io/helidon/config/ClasspathConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,12 +223,15 @@ public class ClasspathConfigSource extends AbstractConfigSource implements Confi
     private static Enumeration<URL> findAllResources(String resource) {
         String cleaned = resource.startsWith("/") ? resource.substring(1) : resource;
         try {
-            return Thread.currentThread()
-                    .getContextClassLoader()
-                    .getResources(cleaned);
+            return contextClassLoader().getResources(cleaned);
         } catch (IOException e) {
             throw new ConfigException("Could not access config resource " + resource, e);
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ClasspathConfigSource.class.getClassLoader() : classLoader;
     }
 
     /**
@@ -308,9 +311,7 @@ public class ClasspathConfigSource extends AbstractConfigSource implements Confi
             this.resource = resource;
 
             // the URL may not exist, and that is fine - maybe we are an optional config source
-            this.url = Thread.currentThread()
-                    .getContextClassLoader()
-                    .getResource(cleaned);
+            this.url = contextClassLoader().getResource(cleaned);
 
             return this;
         }

--- a/config/config/src/main/java/io/helidon/config/ClasspathOverrideSource.java
+++ b/config/config/src/main/java/io/helidon/config/ClasspathOverrideSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,11 @@ public class ClasspathOverrideSource extends AbstractSource implements OverrideS
         return new Builder();
     }
 
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ClasspathOverrideSource.class.getClassLoader() : classLoader;
+    }
+
     /**
      * Classpath OverrideSource Builder.
      * <p>
@@ -141,9 +146,7 @@ public class ClasspathOverrideSource extends AbstractSource implements OverrideS
             this.resource = resource;
 
             // the URL may not exist, and that is fine - maybe we are an optional config source
-            this.url = Thread.currentThread()
-                    .getContextClassLoader()
-                    .getResource(cleaned);
+            this.url = contextClassLoader().getResource(cleaned);
 
             return this;
         }

--- a/config/config/src/main/java/io/helidon/config/ClasspathSourceHelper.java
+++ b/config/config/src/main/java/io/helidon/config/ClasspathSourceHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ class ClasspathSourceHelper {
     }
 
     static Path resourcePath(String resourceName) throws URISyntaxException {
-        URL resourceUrl = Thread.currentThread().getContextClassLoader().getResource(resourceName);
+        URL resourceUrl = contextClassLoader().getResource(resourceName);
         if (resourceUrl != null) {
             // this can only work if we are using a file based classloader (which may not be always the case)
             // we may load classes from http, or from specific loaders, such as in Graal native image
@@ -68,6 +68,11 @@ class ClasspathSourceHelper {
         } else {
             return null;
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ClasspathSourceHelper.class.getClassLoader() : classLoader;
     }
 
 }

--- a/config/config/src/main/java/io/helidon/config/ConfigSources.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSources.java
@@ -238,7 +238,7 @@ public final class ConfigSources {
 
         List<UrlConfigSource.Builder> result = new LinkedList<>();
         try {
-            Enumeration<URL> resources = Thread.currentThread().getContextClassLoader().getResources(resource);
+            Enumeration<URL> resources = contextClassLoader().getResources(resource);
             while (resources.hasMoreElements()) {
                 URL url = resources.nextElement();
                 result.add(url(url));
@@ -293,6 +293,11 @@ public final class ConfigSources {
      */
     public static UrlConfigSource.Builder url(URL url) {
         return UrlConfigSource.builder().url(url);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ConfigSources.class.getClassLoader() : classLoader;
     }
 
     /**

--- a/config/config/src/main/java/io/helidon/config/MetaConfigFinder.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfigFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ final class MetaConfigFinder {
 
     static Optional<ConfigSource> findConfigSource(Function<MediaType, Boolean> supportedMediaType,
                                                    List<String> supportedSuffixes) {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = contextClassLoader();
         return findSource(supportedMediaType, cl, CONFIG_PREFIX, "config source", supportedSuffixes);
     }
 
@@ -139,7 +139,7 @@ final class MetaConfigFinder {
 
     private static Optional<ConfigSource> findMetaConfigSource(Function<MediaType, Boolean> supportedMediaType,
                                                                List<String> supportedSuffixes) {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = contextClassLoader();
         Optional<ConfigSource> source;
 
         // check if meta configuration is configured using system property
@@ -378,5 +378,10 @@ final class MetaConfigFinder {
             return Optional.of(ConfigSources.classpath(name).build());
         }
         return Optional.empty();
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? MetaConfigFinder.class.getClassLoader() : classLoader;
     }
 }

--- a/config/config/src/test/java/io/helidon/config/ClasspathConfigSourceTest.java
+++ b/config/config/src/test/java/io/helidon/config/ClasspathConfigSourceTest.java
@@ -109,4 +109,22 @@ public class ClasspathConfigSourceTest {
 
         assertThat(configSource, notNullValue());
     }
+
+    @Test
+    public void testLoadWithNullContextClassLoader() {
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+
+        try {
+            Thread.currentThread().setContextClassLoader(null);
+
+            ClasspathConfigSource configSource = ConfigSources.classpath("logging.properties")
+                    .optional()
+                    .build();
+
+            assertThat(configSource.load().get().mediaType(),
+                       optionalValue(is(MediaTypes.TEXT_PROPERTIES)));
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
 }

--- a/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/HoconMpConfigSource.java
+++ b/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/HoconMpConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,7 +188,7 @@ public class HoconMpConfigSource implements ConfigSource {
     public static List<ConfigSource> classPath(String resource) {
         List<ConfigSource> sources = new LinkedList<>();
         try {
-            Thread.currentThread().getContextClassLoader().getResources(resource)
+            contextClassLoader().getResources(resource)
                     .asIterator()
                     .forEachRemaining(it -> sources.add(create(it)));
         } catch (IOException e) {
@@ -209,7 +209,7 @@ public class HoconMpConfigSource implements ConfigSource {
         Objects.requireNonNull(profile, "Profile must be defined");
 
         List<ConfigSource> sources = new LinkedList<>();
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader classLoader = contextClassLoader();
 
         try {
             Enumeration<URL> baseResources = classLoader.getResources(resource);
@@ -381,5 +381,10 @@ public class HoconMpConfigSource implements ConfigSource {
     @Override
     public String getName() {
         return name;
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? HoconMpConfigSource.class.getClassLoader() : classLoader;
     }
 }

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ public class YamlMpConfigSource implements ConfigSource {
     public static List<ConfigSource> classPath(String resource) {
         List<ConfigSource> sources = new LinkedList<>();
         try {
-            Thread.currentThread().getContextClassLoader().getResources(resource)
+            contextClassLoader().getResources(resource)
                     .asIterator()
                     .forEachRemaining(it -> sources.add(create(it)));
         } catch (IOException e) {
@@ -197,7 +197,7 @@ public class YamlMpConfigSource implements ConfigSource {
      * @return list of config sources discovered (may be zero length)
      */
     public static List<ConfigSource> classPath(String resource, String profile) {
-        return classPathConfigSources(resource, profile, Thread.currentThread().getContextClassLoader());
+        return classPathConfigSources(resource, profile, contextClassLoader());
     }
 
     /**
@@ -383,5 +383,10 @@ public class YamlMpConfigSource implements ConfigSource {
         // harmful
         Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         return (Map) yaml.loadAs(reader, Object.class);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? YamlMpConfigSource.class.getClassLoader() : classLoader;
     }
 }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/EntityManagerFactories.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/EntityManagerFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -229,7 +229,7 @@ final class EntityManagerFactories {
             returnValue =
                 (PersistenceProvider) instance.select(Class.forName(providerClassName,
                                                                     true,
-                                                                    Thread.currentThread().getContextClassLoader()),
+                                                                    contextClassLoader()),
                                                       selectionQualifiersArray).get();
         }
 
@@ -292,6 +292,11 @@ final class EntityManagerFactories {
             LOGGER.exiting(cn, mn, returnValue);
         }
         return returnValue;
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? EntityManagerFactories.class.getClassLoader() : classLoader;
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -859,7 +859,7 @@ public class JpaExtension implements Extension {
         // Next, and most commonly, load all META-INF/persistence.xml resources with JAXB, and turn them into
         // PersistenceUnitInfo instances, and add beans for all of them as well as their associated PersistenceProviders
         // (if applicable).
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader classLoader = contextClassLoader();
         Enumeration<URL> urls = classLoader.getResources("META-INF/persistence.xml");
         if (urls != null && urls.hasMoreElements()) {
             processImplicits = false;
@@ -1106,7 +1106,7 @@ public class JpaExtension implements Extension {
                 Class<? extends Annotation> transactionScopedAnnotationClass =
                     (Class<? extends Annotation>) Class.forName("jakarta.transaction.TransactionScoped",
                                                                 true,
-                                                                Thread.currentThread().getContextClassLoader());
+                                                                contextClassLoader());
                 temp = transactionScopedAnnotationClass;
             } catch (ClassNotFoundException classNotFoundException) {
                 // This will not happen if this.transactionsSupported is true, or else CDI's exclusion mechanisms are
@@ -2030,7 +2030,7 @@ public class JpaExtension implements Extension {
                         try {
                             ClassLoader classLoader = persistenceUnitInfo.getClassLoader();
                             if (classLoader == null) {
-                                classLoader = Thread.currentThread().getContextClassLoader();
+                                classLoader = contextClassLoader();
                             }
                             assert classLoader != null;
                             @SuppressWarnings("unchecked")
@@ -2065,6 +2065,11 @@ public class JpaExtension implements Extension {
                 emfProxy.isOpen();
             }
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? JpaExtension.class.getClassLoader() : classLoader;
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
@@ -293,7 +293,7 @@ public final class PersistenceExtension implements Extension {
         try {
             Class.forName("jakarta.transaction.TransactionSynchronizationRegistry",
                           false,
-                          Thread.currentThread().getContextClassLoader());
+                          contextClassLoader());
             event.addAnnotatedType(JtaTransactionRegistry.class, JtaTransactionRegistry.class.getName());
             event.addAnnotatedType(JtaAdaptingDataSourceProvider.class, JtaAdaptingDataSourceProvider.class.getName());
             this.transactionsSupported = true;
@@ -590,7 +590,7 @@ public final class PersistenceExtension implements Extension {
         String persistenceXmlResourceName = getConfig()
             .getOptionalValue("jakarta.persistence.descriptor.resource.name", String.class)
             .orElse("META-INF/persistence.xml");
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader classLoader = contextClassLoader();
         Enumeration<URL> urls;
         try {
             urls = classLoader.getResources(persistenceXmlResourceName);
@@ -1049,7 +1049,7 @@ public final class PersistenceExtension implements Extension {
                     try {
                         ClassLoader classLoader = pui.getClassLoader();
                         if (classLoader == null) {
-                            classLoader = Thread.currentThread().getContextClassLoader();
+                            classLoader = contextClassLoader();
                         }
                         return Class.forName(providerClassName, true, classLoader).getDeclaredConstructor().newInstance();
                     } catch (final ReflectiveOperationException e) {
@@ -1447,7 +1447,7 @@ public final class PersistenceExtension implements Extension {
             Instance<?> vf =
                 instance.select(Class.forName("jakarta.validation.ValidatorFactory",
                                               false,
-                                              Thread.currentThread().getContextClassLoader()));
+                                              contextClassLoader()));
             if (!vf.isUnsatisfied()) {
                 properties.put("jakarta.persistence.validation.factory", vf.get());
             }
@@ -1624,6 +1624,11 @@ public final class PersistenceExtension implements Extension {
 
     private static void sink(Object o1, Object o2) {
 
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? PersistenceExtension.class.getClassLoader() : classLoader;
     }
 
     private static final class SyntheticJpaQualifiers {

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceUnitInfoBean.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceUnitInfoBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
              persistenceUnitRootUrl,
              null,
              null,
-             Thread.currentThread().getContextClassLoader(),
+             contextClassLoader(),
              null,
              null,
              managedClassNames != null && !managedClassNames.isEmpty(),
@@ -217,7 +217,7 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
              persistenceUnitRootUrl,
              null,
              null,
-             Thread.currentThread().getContextClassLoader(),
+             contextClassLoader(),
              null,
              null,
              managedClassNames != null && !managedClassNames.isEmpty(),
@@ -757,7 +757,8 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
      * #fromPersistenceUnit(Persistence.PersistenceUnit, ClassLoader,
      * Supplier, URL, Map, DataSourceProvider)} method using the
      * return value of the {@link Thread#getContextClassLoader()}
-     * method as the {@link ClassLoader}.</p>
+     * method as the {@link ClassLoader}, falling back to this class'
+     * {@link ClassLoader} when the thread context class loader is {@code null}.</p>
      *
      * @param persistenceUnit a {@link PersistenceUnit}; must not be
      * {@code null}
@@ -794,7 +795,7 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
                             final Map<? extends String, ? extends Set<? extends Class<?>>> unlistedClasses,
                             final DataSourceProvider dataSourceProvider)
         throws MalformedURLException {
-        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final ClassLoader classLoader = contextClassLoader();
         return fromPersistenceUnit(persistenceUnit,
                                    classLoader,
                                    () -> classLoader,
@@ -846,7 +847,7 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
                             final Map<? extends String, ? extends Set<? extends Class<?>>> unlistedClasses,
                             final Supplier<? extends DataSourceProvider> dataSourceProviderSupplier)
         throws MalformedURLException {
-        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final ClassLoader classLoader = contextClassLoader();
         return fromPersistenceUnit(persistenceUnit,
                                    classLoader,
                                    () -> classLoader,
@@ -1100,6 +1101,11 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
         throws MalformedURLException, URISyntaxException {
         // Revisit: probably won't work if persistenceUnitRootUrl is, say, a jar URL
         return persistenceUnitRootUrl.toURI().resolve(jarFileUrlString).toURL();
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? PersistenceUnitInfoBean.class.getClassLoader() : classLoader;
     }
 
 

--- a/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/RestClientSubstitution.java
+++ b/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/RestClientSubstitution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,10 +33,15 @@ public class RestClientSubstitution {
         @SuppressWarnings("unchecked")
         @Substitute
         static <T> T createProxyInstance(Class<T> restClientClass) {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            ClassLoader cl = contextClassLoader();
             return (T) Proxy.newProxyInstance(cl,
                     new Class[] {restClientClass},
                     new DefaultMethodProxyHandler());
+        }
+
+        private static ClassLoader contextClassLoader() {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            return classLoader == null ? RestClientSubstitution.class.getClassLoader() : classLoader;
         }
     }
 
@@ -65,4 +70,3 @@ public class RestClientSubstitution {
         }
     }
 }
-

--- a/logging/jul/src/main/java/io/helidon/logging/jul/JulProvider.java
+++ b/logging/jul/src/main/java/io/helidon/logging/jul/JulProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ public class JulProvider implements LoggingProvider {
             logConfigStream = new BufferedInputStream(Files.newInputStream(path));
             source = "file: " + path.toAbsolutePath();
         } else {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            ClassLoader cl = contextClassLoader();
 
             // check if there is a logging-test.properties first (we are running within a unit test)
             InputStream resourceStream = classPath(TEST_LOGGING_FILE);
@@ -165,5 +165,10 @@ public class JulProvider implements LoggingProvider {
 
     private static InputStream classPath(String loggingFile) {
         return JulProvider.class.getResourceAsStream("/" + loggingFile);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        return cl == null ? JulProvider.class.getClassLoader() : cl;
     }
 }

--- a/messaging/connectors/wls-jms/src/main/java/io/helidon/messaging/connectors/wls/ThinClientClassLoader.java
+++ b/messaging/connectors/wls-jms/src/main/java/io/helidon/messaging/connectors/wls/ThinClientClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ class ThinClientClassLoader extends URLClassLoader {
 
     ThinClientClassLoader() {
         super("thinClientClassLoader", new URL[0], null);
-        contextClassLoader = Thread.currentThread().getContextClassLoader();
+        contextClassLoader = contextClassLoader();
         try {
 
             File currDirFile = Path.of("", thinJarLocation).toFile();
@@ -106,6 +106,11 @@ class ThinClientClassLoader extends URLClassLoader {
         return !name.startsWith("javax.jms")
                 && !name.startsWith("jakarta.jms")
                 && !name.equals(IsolatedContextFactory.class.getName());
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ThinClientClassLoader.class.getClassLoader() : classLoader;
     }
 
     @FunctionalInterface

--- a/metadata/reflection/src/main/java/io/helidon/metadata/reflection/AnnotationFactory.java
+++ b/metadata/reflection/src/main/java/io/helidon/metadata/reflection/AnnotationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,14 +101,6 @@ public final class AnnotationFactory {
         return Optional.of((T) Proxy.newProxyInstance(classLoader(),
                                                       new Class[] {annotationType},
                                                       new AnnotationInvocationHandler(annotationType, annotation)));
-    }
-
-    private static ClassLoader classLoader() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        if (loader == null) {
-            return loader;
-        }
-        return AnnotationFactory.class.getClassLoader();
     }
 
     // basically the same semantics as in `AptAnnotationFactory` (and scan based annotation factory)
@@ -228,6 +220,14 @@ public final class AnnotationFactory {
             return result;
         }
         throw new IllegalArgumentException("Unknown primitive type: " + componentType.getName());
+    }
+
+    private static ClassLoader classLoader() {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            return AnnotationFactory.class.getClassLoader();
+        }
+        return loader;
     }
 
     private static class AnnotationInvocationHandler implements InvocationHandler {

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceParameter.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,12 +53,17 @@ class FaultToleranceParameter {
      */
     private static String getProperty(String name) {
         try {
-            ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+            ClassLoader ccl = contextClassLoader();
             String value = ConfigProvider.getConfig(ccl).getValue(name, String.class);
             LOGGER.log(Level.DEBUG, () -> "Found config property '" + name + "' value '" + value + "'");
             return value;
         } catch (NoSuchElementException e) {
             return null;
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? FaultToleranceParameter.class.getClassLoader() : classLoader;
     }
 }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,8 +156,7 @@ class MethodInvoker implements FtSupplier<Object> {
         this.helidonContext = Contexts.context().orElseGet(Context::create);
 
         // Create method state using CCL to support multiples apps (like in TCKs)
-        ClassLoader ccl = Thread.currentThread().getContextClassLoader();
-        Objects.requireNonNull(ccl);
+        ClassLoader ccl = contextClassLoader();
         MethodStateKey methodStateKey = new MethodStateKey(ccl, context.getTarget().getClass(), method);
         this.methodState = METHOD_STATES.computeIfAbsent(methodStateKey, key -> {
             MethodState methodState = new MethodState();
@@ -675,6 +674,11 @@ class MethodInvoker implements FtSupplier<Object> {
         } finally {
             methodState.lock.unlock();
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? MethodInvoker.class.getClassLoader() : classLoader;
     }
 
     /**

--- a/microprofile/graphql/server/src/main/java/io/helidon/microprofile/graphql/server/JandexUtils.java
+++ b/microprofile/graphql/server/src/main/java/io/helidon/microprofile/graphql/server/JandexUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ class JandexUtils {
      */
     private List<URL> findIndexFiles(String indexFileName) throws IOException {
         List<URL> result = new ArrayList<>();
-        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader contextClassLoader = contextClassLoader();
         File file = new File(indexFile);
         if (file.isAbsolute()) {
             result.add(file.toPath().toUri().toURL());
@@ -123,7 +123,6 @@ class JandexUtils {
 
         return result;
     }
-
 
     /**
      * Return a {@link Collection} of {@link Class}es which are implementors of a given class/interface.
@@ -191,5 +190,10 @@ class JandexUtils {
      */
     public String getIndexFile() {
         return indexFile;
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? JandexUtils.class.getClassLoader() : classLoader;
     }
 }

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -933,11 +933,12 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
         private InputStream locateStream(String uri) throws IOException {
             InputStream is;
 
-            URL url = Thread.currentThread().getContextClassLoader().getResource(uri);
+            ClassLoader classLoader = contextClassLoader();
+            URL url = classLoader.getResource(uri);
             if (url == null) {
                 // if uri starts with "/", remove it
                 if (uri.startsWith("/")) {
-                    url = Thread.currentThread().getContextClassLoader().getResource(uri.substring(1));
+                    url = classLoader.getResource(uri.substring(1));
                 }
             }
 
@@ -1434,6 +1435,11 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
 
             // jwk is optional, we may be propagating existing token
             config.get("jwk.resource").as(Resource::create).ifPresent(this::signJwk);
+        }
+
+        private static ClassLoader contextClassLoader() {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            return classLoader == null ? JwtAuthProvider.class.getClassLoader() : classLoader;
         }
     }
 

--- a/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/LraCdiExtension.java
+++ b/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/LraCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class LraCdiExtension implements Extension {
     public LraCdiExtension() {
         config = MpConfig.toHelidonConfig(ConfigProvider.getConfig()).get(CONFIG_PREFIX);
         indexer = new Indexer();
-        classLoader = Thread.currentThread().getContextClassLoader();
+        classLoader = contextClassLoader();
         // Needs to be always indexed
         Set.of(LRA.class,
                 AfterLRA.class,
@@ -336,5 +336,10 @@ public class LraCdiExtension implements Extension {
             throw new DeploymentException("Instance of bean " + bean.getName() + " not found");
         }
         return (T) instance;
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? LraCdiExtension.class.getClassLoader() : classLoader;
     }
 }

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/FilteredIndexViewsBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/FilteredIndexViewsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -304,7 +304,7 @@ class FilteredIndexViewsBuilder {
         for (String path : paths) {
             Enumeration<URL> urls;
             try {
-                urls = Thread.currentThread().getContextClassLoader().getResources(path);
+                urls = contextClassLoader().getResources(path);
                 while (urls.hasMoreElements()) {
                     result.add(urls.nextElement());
                 }
@@ -313,6 +313,11 @@ class FilteredIndexViewsBuilder {
             }
         }
         return result;
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? FilteredIndexViewsBuilder.class.getClassLoader() : classLoader;
     }
 
     private static class FilteringOpenApiConfigImpl extends OpenApiConfigImpl {

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MpOpenApiManager.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MpOpenApiManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ final class MpOpenApiManager implements OpenApiManager<OpenAPI> {
 
     @Override
     public OpenAPI load(String content) {
-        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader contextClassLoader = contextClassLoader();
         OpenApiDocument.INSTANCE.reset();
         OpenApiDocument.INSTANCE.config(openApiConfig);
         OpenApiDocument.INSTANCE.modelFromReader(OpenApiProcessor.modelFromReader(openApiConfig, contextClassLoader));
@@ -151,5 +151,10 @@ final class MpOpenApiManager implements OpenApiManager<OpenAPI> {
                                              annotatedTypes,
                                              managerConfig.indexPaths(),
                                              managerConfig.useJaxRsSemantics()).buildViews();
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? MpOpenApiManager.class.getClassLoader() : classLoader;
     }
 }

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -164,7 +164,7 @@ public interface Server {
             STARTUP_LOGGER.log(Level.TRACE, Builder.class.getName() + " build ENTRY");
 
             // configuration must be initialized before we start the container
-            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            ClassLoader classLoader = contextClassLoader();
 
             if (null == config) {
                 this.config = ConfigProviderResolver.instance().getConfig(classLoader);
@@ -486,6 +486,11 @@ public interface Server {
 
         int port() {
             return port;
+        }
+
+        private static ClassLoader contextClassLoader() {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            return classLoader == null ? Server.class.getClassLoader() : classLoader;
         }
     }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/OpenTelemetryProducer.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/OpenTelemetryProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ class OpenTelemetryProducer {
                 openTelemetry = AutoConfiguredOpenTelemetrySdk.builder()
                         .addPropertiesCustomizer(x -> telemetryProperties)
                         .addResourceCustomizer(this::customizeResource)
-                        .setServiceClassLoader(Thread.currentThread().getContextClassLoader())
+                        .setServiceClassLoader(contextClassLoader())
                         .disableShutdownHook()
                         .build()
                         .getOpenTelemetrySdk();
@@ -316,6 +316,11 @@ class OpenTelemetryProducer {
 
     private String getServiceName(ConfigProperties c) {
         return c.getString(SERVICE_NAME_PROPERTY, HELIDON_SERVICE_NAME);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? OpenTelemetryProducer.class.getClassLoader() : classLoader;
     }
 
 }

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestConfig.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class HelidonTestConfig extends HelidonTestConfigDelegate {
     private volatile Config delegate;
 
     HelidonTestConfig(HelidonTestInfo<?> testInfo) {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = contextClassLoader();
         ConfigProviderResolver resolver = ConfigProviderResolver.instance();
 
         originalConfig = resolver.getConfig(cl);
@@ -93,8 +93,13 @@ class HelidonTestConfig extends HelidonTestConfigDelegate {
      * Restore the original config.
      */
     void restore() {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = contextClassLoader();
         ConfigProviderResolver resolver = ConfigProviderResolver.instance();
         resolver.registerConfig(originalConfig, cl);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? HelidonTestConfig.class.getClassLoader() : classLoader;
     }
 }

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestConfigSynthetic.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestConfigSynthetic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +190,7 @@ class HelidonTestConfigSynthetic extends HelidonTestConfigDelegate {
 
     private static Collection<URL> resources(String name) {
         try {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            ClassLoader cl = contextClassLoader();
             Map<String, URL> urls = new HashMap<>();
             cl.getResources(name).asIterator()
                     .forEachRemaining(u -> urls.put(u.toString(), u));
@@ -199,6 +199,11 @@ class HelidonTestConfigSynthetic extends HelidonTestConfigDelegate {
             throw new UncheckedIOException(String.format(
                     "Failed to read '%s' from classpath", name), e);
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? HelidonTestConfigSynthetic.class.getClassLoader() : classLoader;
     }
 
     private record ConfigSourceWrapper(ConfigSource delegate) implements ConfigSource {

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/Proxies.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/Proxies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class Proxies {
      * @return mirror
      */
     public static <T extends Annotation> T mirror(Class<T> type, Annotation annotation) {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = contextClassLoader();
         Object o = Proxy.newProxyInstance(cl, new Class[] {type}, (proxy, method, args) -> {
             Method sourceMethod = annotation.getClass().getMethod(method.getName());
             return invoke(Object.class, sourceMethod, annotation);
@@ -58,7 +58,7 @@ public class Proxies {
      * @return annotation
      */
     public static <T extends Annotation> T annotation(Class<T> type, Function<String, Object> function) {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = contextClassLoader();
         Object o = Proxy.newProxyInstance(cl, List.of(type).toArray(Class[]::new),
                 (proxy, method, args) -> {
                     String methodName = method.getName();
@@ -69,5 +69,10 @@ public class Proxies {
                     return value != null ? value : method.getDefaultValue();
                 });
         return type.cast(o);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? Proxies.class.getClassLoader() : classLoader;
     }
 }

--- a/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/HelidonDeployableContainer.java
+++ b/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/HelidonDeployableContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -385,7 +385,7 @@ public class HelidonDeployableContainer implements DeployableContainer<HelidonCo
             parent = urlClassloader;
         } else {
             urlClassloader = new URLClassLoader(toUrls(classPath), null);
-            parent = Thread.currentThread().getContextClassLoader();
+            parent = contextClassLoader();
         }
 
         context.classLoader = new HelidonContainerClassloader(parent,
@@ -485,7 +485,7 @@ public class HelidonDeployableContainer implements DeployableContainer<HelidonCo
                 // this must be a jar file (classpath is either jar file or a directory)
                 FileSystem fs;
                 try {
-                    fs = FileSystems.newFileSystem(path, Thread.currentThread().getContextClassLoader());
+                    fs = FileSystems.newFileSystem(path, contextClassLoader());
                     Path mpConfig = fs.getPath(location);
                     if (Files.exists(mpConfig)) {
                         sources.add(MpConfigSources.create(path + "!" + mpConfig, mpConfig));
@@ -670,6 +670,11 @@ public class HelidonDeployableContainer implements DeployableContainer<HelidonCo
             return directory.resolve(path.substring(1));
         }
         return directory.resolve(path);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? HelidonDeployableContainer.class.getClassLoader() : classLoader;
     }
 
     private static class RunContext {

--- a/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/ServerRunner.java
+++ b/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/ServerRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class ServerRunner {
         stop();
 
         ConfigProviderResolver.instance()
-                .registerConfig(config, Thread.currentThread().getContextClassLoader());
+                .registerConfig(config, contextClassLoader());
 
         Server.Builder builder = Server.builder()
                 .port(port)
@@ -102,5 +102,10 @@ public class ServerRunner {
         } catch (Throwable t) {
             t.printStackTrace();
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ServerRunner.class.getClassLoader() : classLoader;
     }
 }

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
@@ -204,12 +204,17 @@ public final class OpenApiFeature implements Weighted, ServerFeature, RuntimeTyp
             if (Files.exists(file)) {
                 return Files.readString(file);
             } else {
-                try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)) {
+                try (InputStream is = contextClassLoader().getResourceAsStream(path)) {
                     return is != null ? new String(is.readAllBytes(), StandardCharsets.UTF_8) : null;
                 }
             }
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? OpenApiFeature.class.getClassLoader() : classLoader;
     }
 }

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentFeature.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ public class StaticContentFeature implements Weighted, ServerFeature, RuntimeTyp
             defaultSockets = new HashSet<>(this.sockets);
         }
 
-        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader contextClassLoader = contextClassLoader();
 
         for (ClasspathHandlerConfig handlerConfig : config.classpath()) {
             if (!handlerConfig.enabled()) {
@@ -245,5 +245,10 @@ public class StaticContentFeature implements Weighted, ServerFeature, RuntimeTyp
                         .register(handlerConfig.context(), service);
             }
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? StaticContentFeature.class.getClassLoader() : classLoader;
     }
 }

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentService.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public interface StaticContentService extends HttpService {
     @Deprecated(forRemoval = true, since = "4.1.5")
     static ClassPathBuilder builder(String resourceRoot) {
         Objects.requireNonNull(resourceRoot, "Attribute resourceRoot is null!");
-        return builder(resourceRoot, Thread.currentThread().getContextClassLoader());
+        return builder(resourceRoot, contextClassLoader());
     }
 
     /**
@@ -114,7 +114,7 @@ public interface StaticContentService extends HttpService {
      */
     @Deprecated(forRemoval = true, since = "4.1.5")
     static StaticContentService create(String resourceRoot) {
-        return create(resourceRoot, Thread.currentThread().getContextClassLoader());
+        return create(resourceRoot, contextClassLoader());
     }
 
     /**
@@ -144,6 +144,11 @@ public interface StaticContentService extends HttpService {
     @Deprecated(forRemoval = true, since = "4.1.5")
     static StaticContentService create(Path root) {
         return builder(root).build();
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? StaticContentService.class.getClassLoader() : classLoader;
     }
 
     /**

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static io.helidon.webserver.staticcontent.StaticContentFeature.createService;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @RoutingTest
@@ -131,6 +132,22 @@ class StaticContentTest {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_TYPE, "text/plain"));
             assertThat(response.as(String.class), is("Content"));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void testClasspathBuilderWithNullContextClassLoader() {
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+
+        try {
+            Thread.currentThread().setContextClassLoader(null);
+
+            StaticContentService service = StaticContentService.builder("web").build();
+
+            assertThat(service, notNullValue());
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
         }
     }
 


### PR DESCRIPTION
Resolves #12077

Guards current thread context class loader lookups that require a non-null class loader and falls back to the owning class loader when the TCCL is null. Existing non-null TCCL behavior is preserved, and nullable propagation-only paths continue to propagate null.

Adds regression coverage for classpath config and static content fallback behavior.

The issue has a reproducer that is not valid for this case, but based on discussion with the submitter, the problem fixed in this PR seemed to be the most probable cause, as they reported the following log message:

```
Cannot invoke "java.lang.ClassLoader.getResource(String)" because "cl" is null
```


This PR adds a guard for all usages of TCCL to make sure we never de-reference the returned class loader, and we use the current class' classloader if TCCL is `null`.