### PR TITLE
Reloadable TLS

### DIFF
--- a/common/tls/README.md
+++ b/common/tls/README.md
@@ -1,0 +1,36 @@
+# TLS
+
+This module is used to get an instance of `SSLContext` and `SSLParameters` from configuration, or built using a builder.
+
+In addition, TLS supports reloading of TLS material, either explicitly "form outside", or internally using a
+`TlsManager`.
+
+## 4.x Design
+
+The current design introduces a circular behavior, where we have `Tls`, that owns a `TlsManager`, but to reload existing `Tls`,
+we must provide a new instance of `Tls`, with its own, new `TlsManager`.
+
+## 27.x Design
+
+To separate the concerns of each component:
+
+- `TlsConfig` is the _initial_ information needed to construct a `Tls` instance
+- `TlsMaterial` is the _changeable_ information needed to update a `Tls` instance
+- `Tls` still owns a `TlsManager`
+- `TlsManager` knows how to create `SSLContext`, `K509KeyManager`, and `X509TrustManager`, it may also support an explicit method `reload(TlsMaterial)` that may be delegated from a listener method
+
+Intention (target solution):
+
+There is only one `Tls` instance per use (i.e. listener).
+
+There is only one `TlsManager` instance per instance of `Tls`.
+
+The method `reload(TlsMaterial)` on listener(s) will delegate the call to the currently configured `TlsManager` - this may not be supported by the chosen manager (i.e. OCI based manager may refuse or ignore calls, as it has a scheduler to read rotated information).
+
+`TlsManager` is responsible for reading configuration, and obtaining the initial information to setup an SSLContext - this may be from config, or from external sources (i.e. a cloud service, environment).
+
+Example of `TlsManager`s we provide/expect:
+
+- `ExplicitTlsManager` - used when we have an explicit instance of `SSLContext` configure, reload throws an exception
+- `ConfiguredTlsManager` - uses configuration as the main source of truth
+- `OciCertificatesTlsManager` - uses information that may be rotated by OCI

--- a/common/tls/README.md
+++ b/common/tls/README.md
@@ -29,8 +29,7 @@ The method `reload(TlsMaterial)` on listener(s) will delegate the call to the cu
 
 `TlsManager` is responsible for reading configuration, and obtaining the initial information to setup an SSLContext - this may be from config, or from external sources (i.e. a cloud service, environment).
 
-Example of `TlsManager`s we provide/expect:
+`TlsManager` implementations:
 
 - `ExplicitContextTlsManager` - used when we have an explicit instance of `SSLContext` configured, reload throws an exception
 - `ConfiguredTlsManager` - uses configuration as the main source of truth
-- `OciCertificatesTlsManager` - uses information that may be rotated by OCI

--- a/common/tls/README.md
+++ b/common/tls/README.md
@@ -2,7 +2,7 @@
 
 This module is used to get an instance of `SSLContext` and `SSLParameters` from configuration, or built using a builder.
 
-In addition, TLS supports reloading of TLS material, either explicitly "form outside", or internally using a
+In addition, TLS supports reloading of TLS material, either explicitly "from outside", or internally using a
 `TlsManager`.
 
 ## 4.x Design
@@ -17,7 +17,7 @@ To separate the concerns of each component:
 - `TlsConfig` is the _initial_ information needed to construct a `Tls` instance
 - `TlsMaterial` is the _changeable_ information needed to update a `Tls` instance
 - `Tls` still owns a `TlsManager`
-- `TlsManager` knows how to create `SSLContext`, `K509KeyManager`, and `X509TrustManager`, it may also support an explicit method `reload(TlsMaterial)` that may be delegated from a listener method
+- `TlsManager` knows how to create `SSLContext`, `X509KeyManager`, and `X509TrustManager`, it may also support an explicit method `reload(TlsMaterial)` that may be delegated from a listener method
 
 Intention (target solution):
 
@@ -31,6 +31,6 @@ The method `reload(TlsMaterial)` on listener(s) will delegate the call to the cu
 
 Example of `TlsManager`s we provide/expect:
 
-- `ExplicitTlsManager` - used when we have an explicit instance of `SSLContext` configure, reload throws an exception
+- `ExplicitContextTlsManager` - used when we have an explicit instance of `SSLContext` configured, reload throws an exception
 - `ConfiguredTlsManager` - uses configuration as the main source of truth
 - `OciCertificatesTlsManager` - uses information that may be rotated by OCI

--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -103,6 +103,14 @@ public class ConfiguredTlsManager implements TlsManager {
     }
 
     @Override // TlsManager
+    @Deprecated(forRemoval = true, since = "27.0.0")
+    @SuppressWarnings("removal")
+    public void reload(Tls tls) {
+        Objects.requireNonNull(tls, "tls");
+        reload(tls.keyManager(), tls.trustManager());
+    }
+
+    @Override // TlsManager
     public void reload(TlsMaterial material) {
         Objects.requireNonNull(material, "material");
         validateMaterial(material);

--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -56,6 +56,7 @@ import io.helidon.common.LazyValue;
  * The default configured {@link TlsManager} implementation.
  */
 public class ConfiguredTlsManager implements TlsManager {
+    private static final System.Logger LOGGER = System.getLogger(ConfiguredTlsManager.class.getName());
     // secure random cannot be stored in native image, it must
     // be initialized at runtime
     private static final LazyValue<SecureRandom> RANDOM = LazyValue.create(SecureRandom::new);
@@ -102,8 +103,14 @@ public class ConfiguredTlsManager implements TlsManager {
     }
 
     @Override // TlsManager
-    public void reload(Tls tls) {
-        reload(tls.keyManager(), tls.trustManager());
+    public void reload(TlsMaterial material) {
+        Objects.requireNonNull(material, "material");
+        validateMaterial(material);
+        try {
+            reload(keyManager(material), trustManager(material));
+        } catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException("Failed to create TLS material", e);
+        }
     }
 
     @Override // TlsManager
@@ -186,22 +193,41 @@ public class ConfiguredTlsManager implements TlsManager {
      * @return secure random
      */
     protected SecureRandom secureRandom(TlsConfig tlsConfig) {
-        if (tlsConfig.secureRandom().isPresent()) {
-            return tlsConfig.secureRandom().get();
-        }
+        return secureRandom(tlsConfig.secureRandom(),
+                            tlsConfig.secureRandomAlgorithm(),
+                            tlsConfig.secureRandomProvider());
+    }
 
+    /**
+     * Load secure random.
+     *
+     * @param material TLS material
+     * @return secure random
+     */
+    protected SecureRandom secureRandom(TlsMaterial material) {
+        return secureRandom(material.secureRandom(),
+                            material.secureRandomAlgorithm(),
+                            material.secureRandomProvider());
+    }
+
+    private SecureRandom secureRandom(Optional<SecureRandom> configured,
+                                      Optional<String> algorithm,
+                                      Optional<String> provider) {
+        if (configured.isPresent()) {
+            return configured.get();
+        }
         try {
-            if (tlsConfig.secureRandomAlgorithm().isPresent() && tlsConfig.secureRandomProvider().isEmpty()) {
-                return SecureRandom.getInstance(tlsConfig.secureRandomAlgorithm().get());
+            if (algorithm.isPresent() && provider.isEmpty()) {
+                return SecureRandom.getInstance(algorithm.get());
             }
 
-            if (tlsConfig.secureRandomProvider().isPresent()) {
-                if (tlsConfig.secureRandomAlgorithm().isEmpty()) {
+            if (provider.isPresent()) {
+                if (algorithm.isEmpty()) {
                     throw new IllegalArgumentException("Invalid configuration of secure random. Provider is configured to "
-                                                               + tlsConfig.secureRandomProvider().get()
+                                                               + provider.get()
                                                                + ", but algorithm is not specified");
                 }
-                return SecureRandom.getInstance(tlsConfig.secureRandomAlgorithm().get(), tlsConfig.secureRandomProvider().get());
+                return SecureRandom.getInstance(algorithm.get(), provider.get());
             }
         } catch (GeneralSecurityException e) {
             throw new IllegalArgumentException("invalid configuration for secure random, cannot create it", e);
@@ -223,20 +249,50 @@ public class ConfiguredTlsManager implements TlsManager {
                                          SecureRandom secureRandom,
                                          PrivateKey privateKey,
                                          Certificate[] certificates) {
+        return buildKmf(secureRandom,
+                        privateKey,
+                        certificates,
+                        internalKeystore(target),
+                        kmf(target));
+    }
+
+    /**
+     * Build the key manager factory.
+     *
+     * @param target       the TLS material
+     * @param secureRandom the secure random
+     * @param privateKey   the private key for the key store
+     * @param certificates the certificates for the keystore
+     * @return a key manager factory instance
+     */
+    protected KeyManagerFactory buildKmf(TlsMaterial target,
+                                         SecureRandom secureRandom,
+                                         PrivateKey privateKey,
+                                         Certificate[] certificates) {
+        return buildKmf(secureRandom,
+                        privateKey,
+                        certificates,
+                        internalKeystore(target),
+                        kmf(target));
+    }
+
+    private KeyManagerFactory buildKmf(SecureRandom secureRandom,
+                                       PrivateKey privateKey,
+                                       Certificate[] certificates,
+                                       KeyStore keyStore,
+                                       KeyManagerFactory keyManagerFactory) {
         byte[] passwordBytes = new byte[64];
         secureRandom.nextBytes(passwordBytes);
         char[] password = Base64.getEncoder().encodeToString(passwordBytes).toCharArray();
 
         try {
-            KeyStore ks = internalKeystore(target);
-            ks.setKeyEntry("key",
-                           privateKey,
-                           password,
-                           certificates);
+            keyStore.setKeyEntry("key",
+                                 privateKey,
+                                 password,
+                                 certificates);
 
-            KeyManagerFactory kmf = kmf(target);
-            kmf.init(ks, password);
-            return kmf;
+            keyManagerFactory.init(keyStore, password);
+            return keyManagerFactory;
         } catch (UnrecoverableKeyException | KeyStoreException | NoSuchAlgorithmException e) {
             throw new IllegalArgumentException("Invalid configuration for key management factory, cannot create factory", e);
         }
@@ -249,14 +305,30 @@ public class ConfiguredTlsManager implements TlsManager {
      * @return a new keystore
      */
     protected KeyStore internalKeystore(TlsConfig tlsConfig) {
+        return internalKeystore(tlsConfig.internalKeystoreType(),
+                                tlsConfig.internalKeystoreProvider());
+    }
+
+    /**
+     * Creates an internal keystore and loads it with no password and no data.
+     *
+     * @param material TLS material
+     * @return a new keystore
+     */
+    protected KeyStore internalKeystore(TlsMaterial material) {
+        return internalKeystore(material.internalKeystoreType(),
+                                material.internalKeystoreProvider());
+    }
+
+    private KeyStore internalKeystore(Optional<String> typeOption, Optional<String> providerOption) {
         try {
-            String type = tlsConfig.internalKeystoreType().orElseGet(KeyStore::getDefaultType);
+            String type = typeOption.orElseGet(KeyStore::getDefaultType);
 
             KeyStore ks;
-            if (tlsConfig.internalKeystoreProvider().isEmpty()) {
+            if (providerOption.isEmpty()) {
                 ks = KeyStore.getInstance(type);
             } else {
-                ks = KeyStore.getInstance(type, tlsConfig.internalKeystoreProvider().get());
+                ks = KeyStore.getInstance(type, providerOption.get());
             }
 
             ks.load(null, null);
@@ -267,8 +339,8 @@ public class ConfiguredTlsManager implements TlsManager {
                  | NoSuchAlgorithmException
                  | CertificateException e) {
             throw new IllegalArgumentException("Invalid configuration of internal keystores. Provider: "
-                                                       + tlsConfig.internalKeystoreProvider()
-                                                       + ", type: " + tlsConfig.internalKeystoreType(), e);
+                                                       + providerOption
+                                                       + ", type: " + typeOption, e);
         }
     }
 
@@ -279,17 +351,33 @@ public class ConfiguredTlsManager implements TlsManager {
      * @return a new trust manager factory
      */
     protected TrustManagerFactory createTmf(TlsConfig tlsConfig) {
+        return createTmf(tlsConfig.trustManagerFactoryAlgorithm(),
+                         tlsConfig.trustManagerFactoryProvider());
+    }
+
+    /**
+     * Create a new trust manager factory based on the TLS material (i.e., the algorithm and provider).
+     *
+     * @param material TLS material
+     * @return a new trust manager factory
+     */
+    protected TrustManagerFactory createTmf(TlsMaterial material) {
+        return createTmf(material.trustManagerFactoryAlgorithm(),
+                         material.trustManagerFactoryProvider());
+    }
+
+    private TrustManagerFactory createTmf(Optional<String> algorithmOption, Optional<String> providerOption) {
         try {
-            String algorithm = tlsConfig.trustManagerFactoryAlgorithm().orElseGet(TrustManagerFactory::getDefaultAlgorithm);
-            if (tlsConfig.trustManagerFactoryProvider().isEmpty()) {
+            String algorithm = algorithmOption.orElseGet(TrustManagerFactory::getDefaultAlgorithm);
+            if (providerOption.isEmpty()) {
                 return TrustManagerFactory.getInstance(algorithm);
             } else {
-                return TrustManagerFactory.getInstance(algorithm, tlsConfig.trustManagerFactoryProvider().get());
+                return TrustManagerFactory.getInstance(algorithm, providerOption.get());
             }
         } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
             throw new IllegalArgumentException("Invalid configuration of trust manager factory. Provider: "
-                                                       + tlsConfig.trustManagerFactoryProvider()
-                                                       + ", algorithm: " + tlsConfig.trustManagerFactoryAlgorithm(), e);
+                                                       + providerOption
+                                                       + ", algorithm: " + algorithmOption, e);
         }
     }
 
@@ -301,9 +389,24 @@ public class ConfiguredTlsManager implements TlsManager {
      * @param tlsConfig tls configuration
      */
     protected void initializeTmf(TrustManagerFactory tmf, KeyStore keyStore, TlsConfig tlsConfig) {
+        initializeTmf(tmf, keyStore, tlsConfig.revocation());
+    }
+
+    /**
+     * Perform initialization of the {@link TrustManagerFactory} based on the provided TLS material.
+     *
+     * @param tmf      trust manager factory to be initialized
+     * @param keyStore keystore
+     * @param material TLS material
+     */
+    protected void initializeTmf(TrustManagerFactory tmf, KeyStore keyStore, TlsMaterial material) {
+        initializeTmf(tmf, keyStore, material.revocation());
+    }
+
+    private void initializeTmf(TrustManagerFactory tmf, KeyStore keyStore, Optional<RevocationConfig> revocation) {
         try {
-            if (tlsConfig.revocation().isPresent()) {
-                RevocationConfig revocationConfig = tlsConfig.revocation().get();
+            if (revocation.isPresent()) {
+                RevocationConfig revocationConfig = revocation.get();
                 if (revocationConfig.enabled()) {
                     CertPathBuilder cpb = null;
                     cpb = CertPathBuilder.getInstance("PKIX");
@@ -349,6 +452,51 @@ public class ConfiguredTlsManager implements TlsManager {
         return state.reloadableKeyManager;
     }
 
+    private static void validateMaterial(TlsMaterial material) {
+        boolean hasPrivateKey = material.privateKey().isPresent();
+        boolean hasPrivateKeyCertChain = !material.privateKeyCertChain().isEmpty();
+        boolean hasTrust = !material.trust().isEmpty();
+
+        if (hasPrivateKey && !hasPrivateKeyCertChain) {
+            throw new IllegalArgumentException("TLS material with private key must also define the certificate chain");
+        }
+        if (!hasPrivateKey && hasPrivateKeyCertChain) {
+            throw new IllegalArgumentException("TLS material certificate chain requires a private key");
+        }
+        if (material.trustAll() && hasTrust) {
+            throw new IllegalArgumentException("TLS material cannot combine trustAll and trust certificates");
+        }
+        if (!hasPrivateKey && !hasTrust && !material.trustAll()) {
+            throw new IllegalArgumentException("TLS material must define private key or trust material");
+        }
+    }
+
+    private Optional<X509KeyManager> keyManager(TlsMaterial material) {
+        Optional<PrivateKey> privateKey = material.privateKey();
+        if (privateKey.isEmpty()) {
+            return Optional.empty();
+        }
+
+        SecureRandom secureRandom = secureRandom(material);
+        KeyManagerFactory kmf = buildKmf(material,
+                                         secureRandom,
+                                         privateKey.get(),
+                                         material.privateKeyCertChain().toArray(new Certificate[0]));
+        return Optional.of(x509KeyManager(kmf.getKeyManagers())
+                                   .orElseThrow(() -> new IllegalArgumentException(
+                                           "Configured key manager factory did not provide an X509KeyManager")));
+    }
+
+    private Optional<X509TrustManager> trustManager(TlsMaterial material) throws KeyStoreException {
+        TrustManagerFactory tmf = tmf(material);
+        if (tmf == null) {
+            return Optional.empty();
+        }
+        return Optional.of(x509TrustManager(tmf.getTrustManagers())
+                                   .orElseThrow(() -> new IllegalArgumentException(
+                                           "Configured trust manager factory did not provide an X509TrustManager")));
+    }
+
     private static void validateReload(TlsReloadableX509KeyManager reloadableKeyManager, X509KeyManager keyManager) {
         if (reloadableKeyManager instanceof TlsReloadableX509KeyManager.NotReloadableKeyManager) {
             reloadableKeyManager.reload(keyManager);
@@ -362,6 +510,24 @@ public class ConfiguredTlsManager implements TlsManager {
             reloadableTrustManager.reload(trustManager);
         }
         TlsReloadableX509TrustManager.assertValid(trustManager);
+    }
+
+    private static Optional<X509KeyManager> x509KeyManager(KeyManager[] keyManagers) {
+        for (KeyManager keyManager : keyManagers) {
+            if (keyManager instanceof X509KeyManager x509KeyManager) {
+                return Optional.of(x509KeyManager);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<X509TrustManager> x509TrustManager(TrustManager[] trustManagers) {
+        for (TrustManager trustManager : trustManagers) {
+            if (trustManager instanceof X509TrustManager x509TrustManager) {
+                return Optional.of(x509TrustManager);
+            }
+        }
+        return Optional.empty();
     }
 
     private void initSslContextLocked(TlsConfig tlsConfig,
@@ -426,14 +592,44 @@ public class ConfiguredTlsManager implements TlsManager {
         return tmf;
     }
 
+    // creates an internal keystore and initializes it with certificates discovered from TLS material, then gets the trust
+    // manager factory using tmf(TlsMaterial)
+    private TrustManagerFactory initTmf(TlsMaterial material) throws KeyStoreException {
+        KeyStore ks = internalKeystore(material);
+        int i = 1;
+        for (X509Certificate cert : material.trust()) {
+            ks.setCertificateEntry(String.valueOf(i), cert);
+            i++;
+        }
+        TrustManagerFactory tmf = createTmf(material);
+        initializeTmf(tmf, ks, material);
+        return tmf;
+    }
+
     // used by ConfiguredTlsManager to setup a TrustManagerFactory, that may be "trustAll", or based on configuration
     private TrustManagerFactory tmf(TlsConfig tlsConfig) throws KeyStoreException {
         if (tlsConfig.trustAll()) {
+            LOGGER.log(System.Logger.Level.WARNING,
+                       "Using a trust manager that trusts ANY certificate. Never use this in production. "
+                               + "This is a significant warning, do not ignore.");
             return trustAllTmf();
         }
 
         if (!tlsConfig.trust().isEmpty()) {
             return initTmf(tlsConfig);
+        }
+
+        return null;
+    }
+
+    // used by ConfiguredTlsManager to setup a TrustManagerFactory, that may be "trustAll", or based on TLS material
+    private TrustManagerFactory tmf(TlsMaterial material) throws KeyStoreException {
+        if (material.trustAll()) {
+            return trustAllTmf();
+        }
+
+        if (!material.trust().isEmpty()) {
+            return initTmf(material);
         }
 
         return null;
@@ -476,18 +672,34 @@ public class ConfiguredTlsManager implements TlsManager {
      * @return a new key manager factory
      */
     private KeyManagerFactory kmf(TlsConfig tlsConfig) {
-        try {
-            String algorithm = tlsConfig.keyManagerFactoryAlgorithm().orElseGet(KeyManagerFactory::getDefaultAlgorithm);
+        return kmf(tlsConfig.keyManagerFactoryAlgorithm(),
+                   tlsConfig.keyManagerFactoryProvider());
+    }
 
-            if (tlsConfig.keyManagerFactoryProvider().isPresent()) {
-                return KeyManagerFactory.getInstance(algorithm, tlsConfig.keyManagerFactoryProvider().get());
+    /**
+     * Loads a key manager factory based on TLS material.
+     *
+     * @param material TLS material
+     * @return a new key manager factory
+     */
+    private KeyManagerFactory kmf(TlsMaterial material) {
+        return kmf(material.keyManagerFactoryAlgorithm(),
+                   material.keyManagerFactoryProvider());
+    }
+
+    private KeyManagerFactory kmf(Optional<String> algorithmOption, Optional<String> providerOption) {
+        try {
+            String algorithm = algorithmOption.orElseGet(KeyManagerFactory::getDefaultAlgorithm);
+
+            if (providerOption.isPresent()) {
+                return KeyManagerFactory.getInstance(algorithm, providerOption.get());
             } else {
                 return KeyManagerFactory.getInstance(algorithm);
             }
         } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
             throw new IllegalArgumentException("Invalid configuration of key manager factory. Provider: "
-                                                       + tlsConfig.keyManagerFactoryProvider()
-                                                       + ", algorithm: " + tlsConfig.keyManagerFactoryAlgorithm(), e);
+                                                       + providerOption
+                                                       + ", algorithm: " + algorithmOption, e);
         }
     }
 

--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -106,7 +106,7 @@ public class ConfiguredTlsManager implements TlsManager {
     @Deprecated(forRemoval = true, since = "27.0.0")
     @SuppressWarnings("removal")
     public void reload(Tls tls) {
-        Objects.requireNonNull(tls, "tls");
+        Tls.validateReloadSource(tls);
         reload(tls.keyManager(), tls.trustManager());
     }
 

--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -617,9 +617,7 @@ public class ConfiguredTlsManager implements TlsManager {
     // used by ConfiguredTlsManager to setup a TrustManagerFactory, that may be "trustAll", or based on configuration
     private TrustManagerFactory tmf(TlsConfig tlsConfig) throws KeyStoreException {
         if (tlsConfig.trustAll()) {
-            LOGGER.log(System.Logger.Level.WARNING,
-                       "Using a trust manager that trusts ANY certificate. Never use this in production. "
-                               + "This is a significant warning, do not ignore.");
+            logTrustAllWarning();
             return trustAllTmf();
         }
 
@@ -633,6 +631,7 @@ public class ConfiguredTlsManager implements TlsManager {
     // used by ConfiguredTlsManager to setup a TrustManagerFactory, that may be "trustAll", or based on TLS material
     private TrustManagerFactory tmf(TlsMaterial material) throws KeyStoreException {
         if (material.trustAll()) {
+            logTrustAllWarning();
             return trustAllTmf();
         }
 
@@ -641,6 +640,12 @@ public class ConfiguredTlsManager implements TlsManager {
         }
 
         return null;
+    }
+
+    private static void logTrustAllWarning() {
+        LOGGER.log(System.Logger.Level.WARNING,
+                   "Using a trust manager that trusts ANY certificate. Never use this in production. "
+                           + "This is a significant warning, do not ignore.");
     }
 
     private void sslContext(TlsConfig tlsConfig) {

--- a/common/tls/src/main/java/io/helidon/common/tls/ExplicitContextTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ExplicitContextTlsManager.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.helidon.common.tls;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
@@ -19,7 +36,8 @@ class ExplicitContextTlsManager implements TlsManager {
     }
 
     @Override
-    public void reload(TlsMaterial tls) {
+    public void reload(TlsMaterial material) {
+        Objects.requireNonNull(material);
         throw new UnsupportedOperationException(
                 "TLS cannot be reloaded when an explicit instance of SSL context was used to create it");
     }

--- a/common/tls/src/main/java/io/helidon/common/tls/ExplicitContextTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ExplicitContextTlsManager.java
@@ -24,6 +24,9 @@ import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
 class ExplicitContextTlsManager implements TlsManager {
+    static final String RELOAD_NOT_SUPPORTED_MESSAGE =
+            "TLS cannot be reloaded when an explicit instance of SSL context was used to create it";
+
     private static final String TYPE = "explicit";
     private final SSLContext sslContext;
 
@@ -38,8 +41,7 @@ class ExplicitContextTlsManager implements TlsManager {
     @Override
     public void reload(TlsMaterial material) {
         Objects.requireNonNull(material);
-        throw new UnsupportedOperationException(
-                "TLS cannot be reloaded when an explicit instance of SSL context was used to create it");
+        throw new UnsupportedOperationException(RELOAD_NOT_SUPPORTED_MESSAGE);
     }
 
     @Override

--- a/common/tls/src/main/java/io/helidon/common/tls/ExplicitContextTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ExplicitContextTlsManager.java
@@ -1,0 +1,51 @@
+package io.helidon.common.tls;
+
+import java.util.Optional;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+
+class ExplicitContextTlsManager implements TlsManager {
+    private static final String TYPE = "explicit";
+    private final SSLContext sslContext;
+
+    ExplicitContextTlsManager(SSLContext sslContext) {
+        this.sslContext = sslContext;
+    }
+
+    @Override
+    public void init(TlsConfig tls) {
+    }
+
+    @Override
+    public void reload(TlsMaterial tls) {
+        throw new UnsupportedOperationException(
+                "TLS cannot be reloaded when an explicit instance of SSL context was used to create it");
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return sslContext;
+    }
+
+    @Override
+    public Optional<X509KeyManager> keyManager() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<X509TrustManager> trustManager() {
+        return Optional.empty();
+    }
+
+    @Override
+    public String name() {
+        return TYPE;
+    }
+
+    @Override
+    public String type() {
+        return TYPE;
+    }
+}

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -70,7 +70,8 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
     private Tls(TlsConfig config) {
         // at this time, the TlsConfigDecorator should have created SSL parameters; the SSL context is the responsibility
         // of the manager to provide
-        this.tlsConfig = Objects.requireNonNull(config);
+        config = Objects.requireNonNull(config);
+        TlsConfig configuredTls = config;
         this.sslParameters = copySslParameters(config.sslParameters().orElseThrow());
         this.enabled = config.enabled();
 
@@ -79,8 +80,11 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
                 this.tlsManager = config.manager();
             } else {
                 this.tlsManager = new ExplicitContextTlsManager(config.sslContext().get());
+                configuredTls = TlsConfig.builder(config)
+                        .manager(this.tlsManager)
+                        .buildPrototype();
             }
-            this.tlsManager.init(config);
+            this.tlsManager.init(configuredTls);
             this.sslContext = tlsManager.sslContext();
             this.sslSocketFactory = sslContext.getSocketFactory();
             this.sslServerSocketFactory = sslContext.getServerSocketFactory();
@@ -90,6 +94,7 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
             this.sslServerSocketFactory = null;
             this.tlsManager = null;
         }
+        this.tlsConfig = configuredTls;
     }
 
     /**

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -75,7 +75,11 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
         this.enabled = config.enabled();
 
         if (config.enabled()) {
-            this.tlsManager = config.manager();
+            if (config.sslContext().isEmpty()) {
+                this.tlsManager = config.manager();
+            } else {
+                this.tlsManager = new ExplicitContextTlsManager(config.sslContext().get());
+            }
             this.tlsManager.init(config);
             this.sslContext = tlsManager.sslContext();
             this.sslSocketFactory = sslContext.getSocketFactory();
@@ -268,10 +272,24 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
      * Reload reloadable {@link TlsReloadableComponent}s with the new configuration.
      *
      * @param tls new TLS configuration
+     * @deprecated use {@link #reload(TlsMaterial)}
      */
+    @Deprecated
     public void reload(Tls tls) {
         if (enabled) {
             tlsManager.reload(tls);
+        }
+    }
+
+    /**
+     * Reload reloadable {@link TlsReloadableComponent}s with new key and trust material.
+     *
+     * @param material new TLS material
+     */
+    public void reload(TlsMaterial material) {
+        Objects.requireNonNull(material, "material");
+        if (enabled) {
+            tlsManager.reload(material);
         }
     }
 

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -283,6 +283,7 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
     @SuppressWarnings("removal")
     public void reload(Tls tls) {
         if (enabled) {
+            validateReloadSource(tls);
             tlsManager.reload(tls);
         }
     }
@@ -314,6 +315,13 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
 
     Optional<X509TrustManager> trustManager() {
         return tlsManager.trustManager();
+    }
+
+    static void validateReloadSource(Tls tls) {
+        Objects.requireNonNull(tls, "tls");
+        if (tls.prototype().sslContext().isPresent()) {
+            throw new UnsupportedOperationException(ExplicitContextTlsManager.RELOAD_NOT_SUPPORTED_MESSAGE);
+        }
     }
 
     private static SSLParameters copySslParameters(SSLParameters source) {

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -275,6 +275,7 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
      * @deprecated use {@link #reload(TlsMaterial)}
      */
     @Deprecated
+    @SuppressWarnings("removal")
     public void reload(Tls tls) {
         if (enabled) {
             tlsManager.reload(tls);

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
@@ -16,9 +16,6 @@
 
 package io.helidon.common.tls;
 
-import java.security.PrivateKey;
-import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -30,61 +27,23 @@ import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.common.tls.spi.TlsManagerProvider;
 
+/**
+ * TLS configuration, used by web server listeners, web client and other components that need TLS.
+ */
 @Prototype.Blueprint(decorator = TlsConfigDecorator.class)
 @Prototype.Configured
-@Prototype.CustomMethods(TlsConfigSupport.CustomMethods.class)
-interface TlsConfigBlueprint extends Prototype.Factory<Tls> {
-    /**
-     * The default protocol is set to {@value}.
-     */
-    String DEFAULT_PROTOCOL = "TLS";
-    /**
-     * The default session cache size as defined for unset value in {@link javax.net.ssl.SSLSessionContext#getSessionCacheSize()}.
-     */
-    int DEFAULT_SESSION_CACHE_SIZE = 20480;
-    /**
-     * The default session timeout as defined for unset value in {@link javax.net.ssl.SSLSessionContext#getSessionTimeout()}.
-     */
-    String DEFAULT_SESSION_TIMEOUT = "PT24H";
-
+interface TlsConfigBlueprint extends TlsMaterialBlueprint, Prototype.Factory<Tls> {
     /**
      * Provide a fully configured {@link javax.net.ssl.SSLContext}. If defined, context related configuration
-     * is ignored.
+     * is ignored, and reload of Tls is not supported, and will throw an exception.
      *
      * @return SSL context to use
      */
     Optional<SSLContext> sslContext();
 
     /**
-     * Private key to use. For server side TLS, this is required.
-     * For client side TLS, this is optional (used when mutual TLS is enabled).
-     *
-     * @return private key to use
-     */
-    @Option.Configured
-    Optional<PrivateKey> privateKey();
-
-    /**
-     * Certificate chain of the private key.
-     *
-     * @return private key certificate chain, only used when private key is configured
-     */
-    @Option.Singular
-    @Option.Configured("private-key")
-    // same config node as privateKey
-    List<X509Certificate> privateKeyCertChain();
-
-    /**
-     * List of certificates that form the trust manager.
-     *
-     * @return certificates to be trusted
-     */
-    @Option.Singular
-    @Option.Configured
-    List<X509Certificate> trust();
-
-    /**
      * The Tls manager. If one is not explicitly defined in the config then a default manager will be created.
+     * Default is either a configuration based TLS manager, or an explicit manager when {@link #sslContext()} is provided.
      *
      * @return the tls manager of the tls instance
      * @see ConfiguredTlsManager
@@ -94,67 +53,12 @@ interface TlsConfigBlueprint extends Prototype.Factory<Tls> {
     TlsManager manager();
 
     /**
-     * Explicit secure random to use.
-     *
-     * @return secure random to use
-     */
-    Optional<SecureRandom> secureRandom();
-
-    /**
      * Configure SSL parameters.
      * This will always have a value, as we compute ssl parameters in a builder interceptor from configured options.
      *
      * @return SSL parameters to use
      */
     Optional<SSLParameters> sslParameters();
-
-    /**
-     * Provider to use when creating a new secure random.
-     * When defined, {@link #secureRandomAlgorithm()} must be defined as well.
-     *
-     * @return provider to use, by default no provider is specified
-     */
-    @Option.Configured
-    Optional<String> secureRandomProvider();
-
-    /**
-     * Algorithm to use when creating a new secure random.
-     *
-     * @return algorithm to use, by default uses {@link java.security.SecureRandom} constructor
-     */
-    @Option.Configured
-    Optional<String> secureRandomAlgorithm();
-
-    /**
-     * Algorithm of the key manager factory used when private key is defined.
-     * Defaults to {@link javax.net.ssl.KeyManagerFactory#getDefaultAlgorithm()}.
-     *
-     * @return algorithm to use
-     */
-    @Option.Configured
-    Optional<String> keyManagerFactoryAlgorithm();
-
-    /**
-     * Key manager factory provider.
-     *
-     * @return provider to use
-     */
-    Optional<String> keyManagerFactoryProvider();
-
-    /**
-     * Trust manager factory algorithm.
-     *
-     * @return algorithm to use
-     */
-    @Option.Configured
-    Optional<String> trustManagerFactoryAlgorithm();
-
-    /**
-     * Trust manager factory provider to use.
-     *
-     * @return provider to use
-     */
-    Optional<String> trustManagerFactoryProvider();
 
     /**
      * Configure list of supported application protocols (such as {@code h2}) for application layer protocol negotiation (ALPN).
@@ -177,24 +81,13 @@ interface TlsConfigBlueprint extends Prototype.Factory<Tls> {
 
     /**
      * Flag indicating whether Tls is enabled.
+     * When disabled, all other configuration is ignored.
      *
      * @return enabled flag
      */
     @Option.Configured
     @Option.DefaultBoolean(true)
     boolean enabled();
-
-    /**
-     * Trust any certificate provided by the other side of communication.
-     * <p>
-     * <b>This is a dangerous setting: </b> if set to {@code true}, any certificate will be accepted, throwing away
-     * most of the security advantages of TLS. <b>NEVER</b> do this in production.
-     *
-     * @return whether to trust all certificates, do not use in production
-     */
-    @Option.Configured
-    @Option.DefaultBoolean(false)
-    boolean trustAll();
 
     /**
      * Configure requirement for mutual TLS.
@@ -208,10 +101,10 @@ interface TlsConfigBlueprint extends Prototype.Factory<Tls> {
     /**
      * Configure the protocol used to obtain an instance of {@link javax.net.ssl.SSLContext}.
      *
-     * @return protocol to use, defaults to {@value DEFAULT_PROTOCOL}
+     * @return protocol to use, defaults to {@value TlsConfigSupport.CustomMethods#DEFAULT_PROTOCOL}
      */
     @Option.Configured
-    @Option.Default(DEFAULT_PROTOCOL)
+    @Option.Default(TlsConfigSupport.CustomMethods.DEFAULT_PROTOCOL)
     String protocol();
 
     /**
@@ -245,43 +138,19 @@ interface TlsConfigBlueprint extends Prototype.Factory<Tls> {
     /**
      * SSL session cache size.
      *
-     * @return session cache size, defaults to {@value DEFAULT_SESSION_CACHE_SIZE}.
+     * @return session cache size, defaults to {@value TlsConfigSupport.CustomMethods#DEFAULT_SESSION_CACHE_SIZE}.
      */
     @Option.Configured
-    @Option.DefaultInt(DEFAULT_SESSION_CACHE_SIZE)
+    @Option.DefaultInt(TlsConfigSupport.CustomMethods.DEFAULT_SESSION_CACHE_SIZE)
     int sessionCacheSize();
 
     /**
      * SSL session timeout.
      *
-     * @return session timeout, defaults to {@value DEFAULT_SESSION_TIMEOUT}.
+     * @return session timeout, defaults to {@value TlsConfigSupport.CustomMethods#DEFAULT_SESSION_TIMEOUT}.
      */
     @Option.Configured
-    @Option.Default(DEFAULT_SESSION_TIMEOUT)
+    @Option.Default(TlsConfigSupport.CustomMethods.DEFAULT_SESSION_TIMEOUT)
     Duration sessionTimeout();
-
-    /**
-     * Type of the key stores used internally to create a key and trust manager factories.
-     *
-     * @return keystore type, defaults to {@link java.security.KeyStore#getDefaultType()}
-     */
-    @Option.Configured
-    Optional<String> internalKeystoreType();
-
-    /**
-     * Provider of the key stores used internally to create a key and trust manager factories.
-     *
-     * @return keystore provider, if not defined, provider is not specified
-     */
-    @Option.Configured
-    Optional<String> internalKeystoreProvider();
-
-    /**
-     * Certificate revocation check configuration.
-     *
-     * @return certificate revocation configuration
-     */
-    @Option.Configured
-    Optional<RevocationConfig> revocation();
 
 }

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
@@ -32,6 +32,7 @@ import io.helidon.common.tls.spi.TlsManagerProvider;
  */
 @Prototype.Blueprint(decorator = TlsConfigDecorator.class)
 @Prototype.Configured
+@Prototype.CustomMethods(TlsConfigSupport.CustomMethods.class)
 interface TlsConfigBlueprint extends TlsMaterialBlueprint, Prototype.Factory<Tls> {
     /**
      * Provide a fully configured {@link javax.net.ssl.SSLContext}. If defined, context related configuration

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigSupport.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigSupport.java
@@ -16,13 +16,7 @@
 
 package io.helidon.common.tls;
 
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
-import java.util.List;
-import java.util.Optional;
-
 import io.helidon.builder.api.Prototype;
-import io.helidon.common.pki.Keys;
 
 final class TlsConfigSupport {
     private TlsConfigSupport() {
@@ -46,21 +40,6 @@ final class TlsConfigSupport {
         static final String DEFAULT_SESSION_TIMEOUT = "PT24H";
 
         private CustomMethods() {
-        }
-
-        @Prototype.RuntimeTypeFactoryMethod("privateKey")
-        static Optional<PrivateKey> createPrivateKey(Keys config) {
-            return config.privateKey();
-        }
-
-        @Prototype.RuntimeTypeFactoryMethod("privateKeyCertChain")
-        static List<X509Certificate> createPrivateKeyCertChain(Keys config) {
-            return config.certChain();
-        }
-
-        @Prototype.RuntimeTypeFactoryMethod("trust")
-        static List<X509Certificate> createTrust(Keys config) {
-            return config.certs();
         }
     }
 }

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigSupport.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,22 @@ final class TlsConfigSupport {
     }
 
     static final class CustomMethods {
+        /**
+         * The default protocol is set to {@value}.
+         */
+        @Prototype.Constant
+        static final String DEFAULT_PROTOCOL = "TLS";
+        /**
+         * The default session cache size as defined for unset value in {@link javax.net.ssl.SSLSessionContext#getSessionCacheSize()}.
+         */
+        @Prototype.Constant
+        static final int DEFAULT_SESSION_CACHE_SIZE = 20480;
+        /**
+         * The default session timeout as defined for unset value in {@link javax.net.ssl.SSLSessionContext#getSessionTimeout()}.
+         */
+        @Prototype.Constant
+        static final String DEFAULT_SESSION_TIMEOUT = "PT24H";
+
         private CustomMethods() {
         }
 

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsManager.java
@@ -16,7 +16,6 @@
 
 package io.helidon.common.tls;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
@@ -54,7 +53,7 @@ public interface TlsManager extends NamedService {
      */
     @Deprecated(forRemoval = true, since = "27.0.0")
     default void reload(Tls tls) {
-        Objects.requireNonNull(tls, "tls");
+        Tls.validateReloadSource(tls);
         reload(tls.prototype());
     }
 

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsManager.java
@@ -22,6 +22,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
+import io.helidon.common.DeprecationSupport;
 import io.helidon.config.NamedService;
 import io.helidon.service.registry.Service;
 
@@ -48,8 +49,30 @@ public interface TlsManager extends NamedService {
      *
      * @param tls the new tls instance
      * @see Tls#reload(Tls)
+     * @deprecated use {@link #reload(TlsMaterial)}, this method will be removed in the next major version of Helidon
      */
-    void reload(Tls tls);
+    @Deprecated(forRemoval = true, since = "27.0.0")
+    default void reload(Tls tls) {
+        reload((TlsMaterial) tls);
+    }
+
+    /**
+     * This method will multiplex the call to all {@link TlsReloadableComponent}s that are being managed by this manager.
+     *
+     * @param material the new TLS material
+     * @see Tls#reload(TlsMaterial)
+     */
+    default void reload(TlsMaterial material) {
+        // default to preserve backward compatibility - if this method is not implemented, the other one must be
+        // require the deprecated variant to be implemented
+        DeprecationSupport.requireOverride(this,
+                                           TlsManager.class,
+                                           "reload",
+                                           Tls.class);
+
+        // now call the original, deprecated method, as we know it exists, and we will not stack overflow
+        reload(TlsMaterialSupport.toTls(material));
+    }
 
     /**
      * SSL context created by this manager.

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsManager.java
@@ -16,6 +16,7 @@
 
 package io.helidon.common.tls;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
@@ -53,7 +54,8 @@ public interface TlsManager extends NamedService {
      */
     @Deprecated(forRemoval = true, since = "27.0.0")
     default void reload(Tls tls) {
-        reload((TlsMaterial) tls);
+        Objects.requireNonNull(tls, "tls");
+        reload(tls.prototype());
     }
 
     /**

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsMaterialBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsMaterialBlueprint.java
@@ -26,16 +26,16 @@ import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
 /**
- * TLS material used to set up or reload key and trust manager state.
+ * TLS key and trust material used to set up or reload manager state.
  */
 @Prototype.Blueprint
 @Prototype.Configured
-@Prototype.CustomMethods(TlsConfigSupport.CustomMethods.class)
+@Prototype.CustomMethods(TlsMaterialSupport.CustomMethods.class)
 interface TlsMaterialBlueprint {
 
     /**
-     * Private key to use. For server side TLS, this is required.
-     * For client side TLS, this is optional (used when mutual TLS is enabled).
+     * Private key to use.
+     * This is required when reloading key material and can be omitted when reloading only trust material.
      *
      * @return private key to use
      */

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsMaterialBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsMaterialBlueprint.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls;
+
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * TLS material used to set up or reload key and trust manager state.
+ */
+@Prototype.Blueprint
+@Prototype.Configured
+@Prototype.CustomMethods(TlsConfigSupport.CustomMethods.class)
+interface TlsMaterialBlueprint {
+
+    /**
+     * Private key to use. For server side TLS, this is required.
+     * For client side TLS, this is optional (used when mutual TLS is enabled).
+     *
+     * @return private key to use
+     */
+    @Option.Configured
+    Optional<PrivateKey> privateKey();
+
+    /**
+     * Certificate chain of the private key.
+     *
+     * @return private key certificate chain, only used when private key is configured
+     */
+    @Option.Singular
+    @Option.Configured("private-key")
+    // same config node as privateKey
+    List<X509Certificate> privateKeyCertChain();
+
+    /**
+     * List of certificates that form the trust manager.
+     *
+     * @return certificates to be trusted
+     */
+    @Option.Singular
+    @Option.Configured
+    List<X509Certificate> trust();
+
+    /**
+     * Explicit secure random to use.
+     *
+     * @return secure random to use
+     */
+    Optional<SecureRandom> secureRandom();
+
+    /**
+     * Provider to use when creating a new secure random.
+     * When defined, {@link #secureRandomAlgorithm()} must be defined as well.
+     *
+     * @return provider to use, by default no provider is specified
+     */
+    @Option.Configured
+    Optional<String> secureRandomProvider();
+
+    /**
+     * Algorithm to use when creating a new secure random.
+     *
+     * @return algorithm to use, by default uses {@link java.security.SecureRandom} constructor
+     */
+    @Option.Configured
+    Optional<String> secureRandomAlgorithm();
+
+    /**
+     * Algorithm of the key manager factory used when private key is defined.
+     * Defaults to {@link javax.net.ssl.KeyManagerFactory#getDefaultAlgorithm()}.
+     *
+     * @return algorithm to use
+     */
+    @Option.Configured
+    Optional<String> keyManagerFactoryAlgorithm();
+
+    /**
+     * Key manager factory provider.
+     *
+     * @return provider to use
+     */
+    @Option.Configured
+    Optional<String> keyManagerFactoryProvider();
+
+    /**
+     * Trust manager factory algorithm.
+     *
+     * @return algorithm to use
+     */
+    @Option.Configured
+    Optional<String> trustManagerFactoryAlgorithm();
+
+    /**
+     * Trust manager factory provider to use.
+     *
+     * @return provider to use
+     */
+    @Option.Configured
+    Optional<String> trustManagerFactoryProvider();
+
+    /**
+     * Trust any certificate provided by the other side of communication.
+     * <p>
+     * <b>This is a dangerous setting: </b> if set to {@code true}, any certificate will be accepted, throwing away
+     * most of the security advantages of TLS. <b>NEVER</b> do this in production.
+     *
+     * @return whether to trust all certificates, do not use in production
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean trustAll();
+
+    /**
+     * Type of the key stores used internally to create a key and trust manager factories.
+     *
+     * @return keystore type, defaults to {@link java.security.KeyStore#getDefaultType()}
+     */
+    @Option.Configured
+    Optional<String> internalKeystoreType();
+
+    /**
+     * Provider of the key stores used internally to create a key and trust manager factories.
+     *
+     * @return keystore provider, if not defined, provider is not specified
+     */
+    @Option.Configured
+    Optional<String> internalKeystoreProvider();
+
+    /**
+     * Certificate revocation check configuration.
+     *
+     * @return certificate revocation configuration
+     */
+    @Option.Configured
+    Optional<RevocationConfig> revocation();
+}

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsMaterialSupport.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsMaterialSupport.java
@@ -16,10 +16,37 @@
 
 package io.helidon.common.tls;
 
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.pki.Keys;
 
 final class TlsMaterialSupport {
     private TlsMaterialSupport() {
+    }
+
+    static final class CustomMethods {
+        private CustomMethods() {
+        }
+
+        @Prototype.RuntimeTypeFactoryMethod("privateKey")
+        static Optional<PrivateKey> createPrivateKey(Keys config) {
+            return config.privateKey();
+        }
+
+        @Prototype.RuntimeTypeFactoryMethod("privateKeyCertChain")
+        static List<X509Certificate> createPrivateKeyCertChain(Keys config) {
+            return config.certChain();
+        }
+
+        @Prototype.RuntimeTypeFactoryMethod("trust")
+        static List<X509Certificate> createTrust(Keys config) {
+            return config.certs();
+        }
     }
 
     static Tls toTls(TlsMaterial material) {

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsMaterialSupport.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsMaterialSupport.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls;
+
+import java.util.Objects;
+
+final class TlsMaterialSupport {
+    private TlsMaterialSupport() {
+    }
+
+    static Tls toTls(TlsMaterial material) {
+        Objects.requireNonNull(material, "material");
+
+        TlsConfig.Builder builder = Tls.builder()
+                .trustAll(material.trustAll());
+
+        material.privateKey().ifPresent(builder::privateKey);
+        if (!material.privateKeyCertChain().isEmpty()) {
+            builder.privateKeyCertChain(material.privateKeyCertChain());
+        }
+        if (!material.trust().isEmpty()) {
+            builder.trust(material.trust());
+        }
+        material.secureRandom().ifPresent(builder::secureRandom);
+        material.secureRandomAlgorithm().ifPresent(builder::secureRandomAlgorithm);
+        material.secureRandomProvider().ifPresent(builder::secureRandomProvider);
+        material.keyManagerFactoryAlgorithm().ifPresent(builder::keyManagerFactoryAlgorithm);
+        material.keyManagerFactoryProvider().ifPresent(builder::keyManagerFactoryProvider);
+        material.trustManagerFactoryAlgorithm().ifPresent(builder::trustManagerFactoryAlgorithm);
+        material.trustManagerFactoryProvider().ifPresent(builder::trustManagerFactoryProvider);
+        material.internalKeystoreType().ifPresent(builder::internalKeystoreType);
+        material.internalKeystoreProvider().ifPresent(builder::internalKeystoreProvider);
+        material.revocation().ifPresent(builder::revocation);
+
+        return builder.build();
+    }
+}

--- a/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
@@ -156,6 +156,21 @@ class ConfiguredTlsManagerTest {
     }
 
     @Test
+    void reloadCannotUseExplicitSslContextAsReplacement() {
+        Tls tls = Tls.create(it -> it.trustAll(true));
+        SSLContext sslContext = createSslContext();
+        Tls reload = Tls.create(it -> it.sslContext(sslContext));
+
+        assertThat(reload.sslContext(), sameInstance(sslContext));
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                                                               () -> tls.reload(reload));
+
+        assertThat(exception.getMessage(),
+                   is("TLS cannot be reloaded when an explicit instance of SSL context was used to create it"));
+    }
+
+    @Test
     void failedReinitializationDoesNotClearReloadableManagers() {
         ConfiguredTlsManager manager = new ConfiguredTlsManager();
         X509KeyManager keyManager = new TestKeyManager();

--- a/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
@@ -136,7 +136,8 @@ class ConfiguredTlsManagerTest {
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
                                                                () -> tls.reload(reload));
 
-        assertThat(exception.getMessage(), is("Cannot set trust manager if one was not set during server start"));
+        assertThat(exception.getMessage(),
+                   is("TLS cannot be reloaded when an explicit instance of SSL context was used to create it"));
     }
 
     @Test
@@ -150,7 +151,8 @@ class ConfiguredTlsManagerTest {
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
                                                                () -> tls.reload(reload));
 
-        assertThat(exception.getMessage(), is("Cannot reload key manager if one was not set during server start"));
+        assertThat(exception.getMessage(),
+                   is("TLS cannot be reloaded when an explicit instance of SSL context was used to create it"));
     }
 
     @Test
@@ -257,6 +259,7 @@ class ConfiguredTlsManagerTest {
         }
 
         @Override
+        @SuppressWarnings("removal")
         public void reload(Tls tls) {
         }
 

--- a/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
@@ -35,7 +35,9 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 class ConfiguredTlsManagerTest {
     @Test
@@ -47,6 +49,69 @@ class ConfiguredTlsManagerTest {
                                                                () -> tls.reload(reload));
 
         assertThat(exception.getMessage(), is("Cannot set trust manager if one was not set during server start"));
+    }
+
+    @Test
+    void reloadMaterialCannotAddTrustManagerAfterStartingWithoutOne() {
+        Tls tls = Tls.create(it -> { });
+        TlsMaterial material = TlsMaterial.builder()
+                .trustAll(true)
+                .build();
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                                                               () -> tls.reload(material));
+
+        assertThat(exception.getMessage(), is("Cannot set trust manager if one was not set during server start"));
+    }
+
+    @Test
+    void reloadMaterialRejectsEmptyMaterial() {
+        Tls tls = Tls.create(it -> it.trustAll(true));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> tls.reload(TlsMaterial.create()));
+
+        assertThat(exception.getMessage(), is("TLS material must define private key or trust material"));
+    }
+
+    @Test
+    void reloadMaterialRejectsTrustAllWithTrustCertificates() {
+        Tls tls = Tls.create(it -> it.trustAll(true));
+        TlsMaterial material = TlsMaterial.builder()
+                .trustAll(true)
+                .addTrust(mock(X509Certificate.class))
+                .build();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> tls.reload(material));
+
+        assertThat(exception.getMessage(), is("TLS material cannot combine trustAll and trust certificates"));
+    }
+
+    @Test
+    void reloadMaterialRejectsPrivateKeyWithoutCertificateChain() {
+        Tls tls = Tls.create(it -> it.trustAll(true));
+        TlsMaterial material = TlsMaterial.builder()
+                .privateKey(new TestPrivateKey("test"))
+                .build();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> tls.reload(material));
+
+        assertThat(exception.getMessage(), is("TLS material with private key must also define the certificate chain"));
+    }
+
+    @Test
+    void reloadMaterialRejectsCertificateChainWithoutPrivateKey() {
+        Tls tls = Tls.create(it -> it.trustAll(true));
+        TlsMaterial material = TlsMaterial.builder()
+                .addPrivateKeyCertChain(mock(X509Certificate.class))
+                .build();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> tls.reload(material));
+
+        assertThat(exception.getMessage(), is("TLS material certificate chain requires a private key"));
     }
 
     @Test
@@ -144,6 +209,23 @@ class ConfiguredTlsManagerTest {
 
         assertThat(exception.getMessage(), is("Cannot set trust manager if one was not set during server start"));
         assertThat(manager.reloadableKeyManager().getPrivateKey("test"), sameInstance(initialPrivateKey));
+    }
+
+    @Test
+    void reloadMaterialUpdatesTrustManager() {
+        ConfiguredTlsManager manager = new ConfiguredTlsManager();
+        X509TrustManager initialTrustManager = new TestTrustManager();
+
+        manager.initSslContext(Tls.builder().buildPrototype(),
+                               new SecureRandom(),
+                               new KeyManager[0],
+                               new TrustManager[] {initialTrustManager});
+
+        manager.reload(TlsMaterial.builder()
+                               .trustAll(true)
+                               .build());
+
+        assertNotSame(initialTrustManager, manager.trustManager().orElseThrow());
     }
 
     private static SSLContext createSslContext() {

--- a/common/tls/src/test/java/io/helidon/common/tls/StaticReloadTlsManagerProvider.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/StaticReloadTlsManagerProvider.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls;
+
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import io.helidon.common.tls.spi.TlsManagerProvider;
+import io.helidon.config.Config;
+
+public class StaticReloadTlsManagerProvider implements TlsManagerProvider {
+    static final String TYPE = "static-reload";
+    private static final ConcurrentMap<String, StaticReloadTlsManager> MANAGERS = new ConcurrentHashMap<>();
+
+    static void reset() {
+        MANAGERS.clear();
+    }
+
+    static StaticReloadTlsManager manager(String name) {
+        return Objects.requireNonNull(MANAGERS.get(name), "manager " + name);
+    }
+
+    static void reload(String name, String issuer) {
+        manager(name).reload(issuer);
+    }
+
+    @Override
+    public String configKey() {
+        return TYPE;
+    }
+
+    @Override
+    public TlsManager create(Config config, String name) {
+        return MANAGERS.computeIfAbsent(name,
+                                        it -> new StaticReloadTlsManager(name,
+                                                                        config.get("initial-issuer")
+                                                                                .asString()
+                                                                                .orElse("initial")));
+    }
+
+    static final class StaticReloadTlsManager extends ConfiguredTlsManager {
+        private final String initialIssuer;
+
+        private StaticReloadTlsManager(String name, String initialIssuer) {
+            super(name, TYPE);
+            this.initialIssuer = initialIssuer;
+        }
+
+        @Override
+        public void init(TlsConfig tls) {
+            initSslContext(tls,
+                           new SecureRandom(),
+                           new KeyManager[0],
+                           new TrustManager[] {new TrackingTrustManager(initialIssuer)});
+        }
+
+        private void reload(String issuer) {
+            reload(Optional.empty(), Optional.of(new TrackingTrustManager(issuer)));
+        }
+    }
+
+    static final class TrackingTrustManager implements X509TrustManager {
+        private final String issuer;
+
+        private TrackingTrustManager(String issuer) {
+            this.issuer = issuer;
+        }
+
+        String issuer() {
+            return issuer;
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+}

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsConfiguredProviderReloadTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsConfiguredProviderReloadTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls;
+
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TlsConfiguredProviderReloadTest {
+    private static final String MANAGER_NAME = "server-listener";
+
+    @BeforeEach
+    void resetProvider() {
+        StaticReloadTlsManagerProvider.reset();
+    }
+
+    @Test
+    void configuredProviderIsCreatedFromConfig() {
+        Tls tls = Tls.create(config("configured"));
+        TlsManager manager = StaticReloadTlsManagerProvider.manager(MANAGER_NAME);
+
+        assertThat(manager.name(), is(MANAGER_NAME));
+        assertThat(manager.type(), is(StaticReloadTlsManagerProvider.TYPE));
+        assertThat(issuer(tls), is("configured"));
+    }
+
+    @Test
+    void staticProviderReloadUpdatesCreatedTlsManager() {
+        Tls tls = Tls.create(config("configured"));
+        SSLContext sslContext = tls.sslContext();
+
+        StaticReloadTlsManagerProvider.reload(MANAGER_NAME, "reloaded");
+
+        assertThat(tls.sslContext(), sameInstance(sslContext));
+        assertThat(issuer(tls), is("reloaded"));
+        assertThat(tls.newEngine(), notNullValue());
+    }
+
+    private static Config config(String initialIssuer) {
+        return Config.just(ConfigSources.create(Map.of(
+                "manager." + MANAGER_NAME + ".type", StaticReloadTlsManagerProvider.TYPE,
+                "manager." + MANAGER_NAME + ".initial-issuer", initialIssuer)));
+    }
+
+    private static String issuer(Tls tls) {
+        return ((StaticReloadTlsManagerProvider.TrackingTrustManager) tls.trustManager().orElseThrow()).issuer();
+    }
+}

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsManagerCompatibilityTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsManagerCompatibilityTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls;
+
+import java.security.GeneralSecurityException;
+import java.util.Optional;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TlsManagerCompatibilityTest {
+    @Test
+    @SuppressWarnings("removal")
+    void deprecatedReloadTlsDelegatesToMaterialReload() {
+        MaterialReloadManager manager = new MaterialReloadManager();
+        Tls tls = Tls.create(it -> it.trustAll(true));
+
+        manager.reload(tls);
+
+        assertThat(manager.reloadedMaterial, sameInstance(tls.prototype()));
+    }
+
+    @Test
+    void materialReloadDelegatesToDeprecatedReload() {
+        DeprecatedReloadManager manager = new DeprecatedReloadManager();
+        TlsMaterial material = TlsMaterial.builder()
+                .trustAll(true)
+                .build();
+
+        manager.reload(material);
+
+        assertThat(manager.reloadedTls.prototype().trustAll(), is(true));
+    }
+
+    private abstract static class TestTlsManager implements TlsManager {
+        @Override
+        public void init(TlsConfig tls) {
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            try {
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(null, null, null);
+                return sslContext;
+            } catch (GeneralSecurityException e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        @Override
+        public Optional<X509KeyManager> keyManager() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<X509TrustManager> trustManager() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public String type() {
+            return "test";
+        }
+    }
+
+    private static final class MaterialReloadManager extends TestTlsManager {
+        private TlsMaterial reloadedMaterial;
+
+        @Override
+        public void reload(TlsMaterial material) {
+            this.reloadedMaterial = material;
+        }
+    }
+
+    private static final class DeprecatedReloadManager extends TestTlsManager {
+        private Tls reloadedTls;
+
+        @Override
+        @Deprecated(forRemoval = true, since = "27.0.0")
+        @SuppressWarnings("removal")
+        public void reload(Tls tls) {
+            this.reloadedTls = tls;
+        }
+    }
+}

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsMaterialConfigTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsMaterialConfigTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.common.tls;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -48,11 +49,23 @@ class TlsMaterialConfigTest {
         assertThat(tlsConfig.internalKeystoreType(), is(Optional.of("test-store")));
     }
 
+    @Test
+    void materialDoesNotExposeTlsSetupConstants() {
+        assertThat(hasPublicField("DEFAULT_PROTOCOL"), is(false));
+        assertThat(hasPublicField("DEFAULT_SESSION_CACHE_SIZE"), is(false));
+        assertThat(hasPublicField("DEFAULT_SESSION_TIMEOUT"), is(false));
+    }
+
     private static Config materialConfig() {
         return Config.just(ConfigSources.create(Map.of(
                 "trust-all", "true",
                 "key-manager-factory-algorithm", "test-kmf",
                 "trust-manager-factory-algorithm", "test-tmf",
                 "internal-keystore-type", "test-store")));
+    }
+
+    private static boolean hasPublicField(String name) {
+        return Arrays.stream(TlsMaterial.class.getFields())
+                .anyMatch(field -> field.getName().equals(name));
     }
 }

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsMaterialConfigTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsMaterialConfigTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TlsMaterialConfigTest {
+    @Test
+    void materialReadsConfiguredKeys() {
+        TlsMaterial material = TlsMaterial.create(materialConfig());
+
+        assertThat(material.trustAll(), is(true));
+        assertThat(material.keyManagerFactoryAlgorithm(), is(Optional.of("test-kmf")));
+        assertThat(material.trustManagerFactoryAlgorithm(), is(Optional.of("test-tmf")));
+        assertThat(material.internalKeystoreType(), is(Optional.of("test-store")));
+    }
+
+    @Test
+    void tlsConfigStillReadsInheritedMaterialKeys() {
+        TlsConfig tlsConfig = TlsConfig.create(materialConfig());
+
+        assertThat(tlsConfig.trustAll(), is(true));
+        assertThat(tlsConfig.keyManagerFactoryAlgorithm(), is(Optional.of("test-kmf")));
+        assertThat(tlsConfig.trustManagerFactoryAlgorithm(), is(Optional.of("test-tmf")));
+        assertThat(tlsConfig.internalKeystoreType(), is(Optional.of("test-store")));
+    }
+
+    private static Config materialConfig() {
+        return Config.just(ConfigSources.create(Map.of(
+                "trust-all", "true",
+                "key-manager-factory-algorithm", "test-kmf",
+                "trust-manager-factory-algorithm", "test-tmf",
+                "internal-keystore-type", "test-store")));
+    }
+}

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
@@ -20,18 +20,25 @@ import java.io.IOException;
 import java.security.AlgorithmConstraints;
 import java.security.AlgorithmParameters;
 import java.security.CryptoPrimitive;
+import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TlsTest {
     @Test
@@ -114,5 +121,72 @@ public class TlsTest {
         SSLParameters engineParameters = tls.newEngine().getSSLParameters();
         assertThat(engineParameters.getApplicationProtocols(), arrayContaining("h2"));
         assertThat(engineParameters.getEndpointIdentificationAlgorithm(), is(Tls.ENDPOINT_IDENTIFICATION_HTTPS));
+    }
+
+    @Test
+    public void explicitSslContextUsesProvidedContext() {
+        SSLContext sslContext = createSslContext();
+
+        Tls tls = Tls.create(it -> it.sslContext(sslContext)
+                .manager(new FailingTlsManager()));
+
+        assertThat(tls.sslContext(), sameInstance(sslContext));
+    }
+
+    @Test
+    public void explicitSslContextRejectsMaterialReload() {
+        SSLContext sslContext = createSslContext();
+        Tls tls = Tls.create(it -> it.sslContext(sslContext));
+        TlsMaterial material = TlsMaterial.builder()
+                .trustAll(true)
+                .build();
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                                                               () -> tls.reload(material));
+
+        assertThat(exception.getMessage(),
+                   is("TLS cannot be reloaded when an explicit instance of SSL context was used to create it"));
+    }
+
+    private static SSLContext createSslContext() {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, null, null);
+            return sslContext;
+        } catch (GeneralSecurityException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static final class FailingTlsManager implements TlsManager {
+        @Override
+        public void init(TlsConfig tls) {
+            throw new AssertionError("Explicit SSLContext should use ExplicitContextTlsManager");
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            throw new AssertionError("Explicit SSLContext should use ExplicitContextTlsManager");
+        }
+
+        @Override
+        public Optional<X509KeyManager> keyManager() {
+            throw new AssertionError("Explicit SSLContext should use ExplicitContextTlsManager");
+        }
+
+        @Override
+        public Optional<X509TrustManager> trustManager() {
+            throw new AssertionError("Explicit SSLContext should use ExplicitContextTlsManager");
+        }
+
+        @Override
+        public String name() {
+            return "failing";
+        }
+
+        @Override
+        public String type() {
+            return "failing";
+        }
     }
 }

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
@@ -35,6 +35,7 @@ import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -131,6 +132,7 @@ public class TlsTest {
                 .manager(new FailingTlsManager()));
 
         assertThat(tls.sslContext(), sameInstance(sslContext));
+        assertThat(tls.prototype().manager(), instanceOf(ExplicitContextTlsManager.class));
     }
 
     @Test

--- a/common/tls/src/test/resources/META-INF/services/io.helidon.common.tls.spi.TlsManagerProvider
+++ b/common/tls/src/test/resources/META-INF/services/io.helidon.common.tls.spi.TlsManagerProvider
@@ -1,0 +1,1 @@
+io.helidon.common.tls.StaticReloadTlsManagerProvider

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -180,7 +180,7 @@ SNI virtual hosts require listener TLS and the NIO socket-channel transport, whi
 ==== Reloading TLS Material
 
 You can reload the key and trust material used by an already running TLS listener.
-Build a `TlsMaterial` instance with the replacement private key, certificate chain, or trust material, and pass it
+Build a `TlsMaterial` instance with the replacement private key and certificate chain, trust material, or both, and pass it
 to the running `WebServer`.
 
 [source,java]
@@ -190,9 +190,11 @@ include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_41, indent=0]
 
 The same API can reload TLS material for a named socket by calling `reloadTls(TlsMaterial, String)`.
 
+TLS material reload depends on the configured TLS manager. TLS created from an explicit `SSLContext` cannot be reloaded.
 TLS material reload does not replace the listener, routing, SNI rules, application protocols, enabled protocols,
 cipher suites, endpoint identification, client-auth mode, session settings, or other TLS setup options.
-Existing connections continue to use their current TLS state. New TLS handshakes use the reloaded material.
+Existing connections continue to use their current TLS state. New full TLS handshakes use the reloaded material.
+Resumed TLS sessions can continue to use authentication state established before reload until the session is not reused.
 The initial TLS setup must include the key or trust manager that should be reloaded later; reload cannot add a
 manager that did not exist when the listener started.
 Reload fails if the target socket is not configured for TLS.

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -188,7 +188,7 @@ to the running `WebServer`.
 include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_41, indent=0]
 ----
 
-The same API can reload TLS material for a named socket by calling `reloadTls(String, TlsMaterial)`.
+The same API can reload TLS material for a named socket by calling `reloadTls(TlsMaterial, String)`.
 
 TLS material reload does not replace the listener, routing, SNI rules, application protocols, enabled protocols,
 cipher suites, endpoint identification, client-auth mode, session settings, or other TLS setup options.
@@ -204,7 +204,7 @@ For SNI virtual hosts, reload the material for one configured virtual-host name.
 include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_42, indent=0]
 ----
 
-The named-socket overload `reloadVirtualHostTls(String, String, TlsMaterial)` reloads a virtual host on a specific
+The named-socket overload `reloadVirtualHostTls(TlsMaterial, String, String)` reloads a virtual host on a specific
 socket. The virtual host must already be configured, otherwise reload fails. TLS reload does not add, remove, or remap
 virtual hosts.
 

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -177,6 +177,37 @@ server:
 
 SNI virtual hosts require listener TLS and the NIO socket-channel transport, which is the default.
 
+==== Reloading TLS Material
+
+You can reload the key and trust material used by an already running TLS listener.
+Build a `TlsMaterial` instance with the replacement private key, certificate chain, or trust material, and pass it
+to the running `WebServer`.
+
+[source,java]
+----
+include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_41, indent=0]
+----
+
+The same API can reload TLS material for a named socket by calling `reloadTls(String, TlsMaterial)`.
+
+TLS material reload does not replace the listener, routing, SNI rules, application protocols, enabled protocols,
+cipher suites, endpoint identification, client-auth mode, session settings, or other TLS setup options.
+Existing connections continue to use their current TLS state. New TLS handshakes use the reloaded material.
+The initial TLS setup must include the key or trust manager that should be reloaded later; reload cannot add a
+manager that did not exist when the listener started.
+Reload fails if the target socket is not configured for TLS.
+
+For SNI virtual hosts, reload the material for one configured virtual-host name.
+
+[source,java]
+----
+include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_42, indent=0]
+----
+
+The named-socket overload `reloadVirtualHostTls(String, String, TlsMaterial)` reloads a virtual host on a specific
+socket. The virtual host must already be configured, otherwise reload fails. TLS reload does not add, remove, or remap
+virtual hosts.
+
 ==== Configuring TLS in the Config File
 
 It is also possible to configure TLS via the config file.

--- a/docs/src/main/java/io/helidon/docs/se/WebServerSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/WebServerSnippets.java
@@ -413,7 +413,7 @@ class WebServerSnippets {
                                 .passphrase("password".toCharArray())))
                 .build();
 
-        server.reloadVirtualHostTls("api.example.com", apiMaterial);
+        server.reloadVirtualHostTls(apiMaterial, "api.example.com");
         // end::snippet_42[]
     }
 

--- a/docs/src/main/java/io/helidon/docs/se/WebServerSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/WebServerSnippets.java
@@ -27,6 +27,9 @@ import io.helidon.common.configurable.AllowList;
 // end::snippet_13[]
 // tag::snippet_16[]
 import io.helidon.common.tls.Tls;
+// end::snippet_16[]
+import io.helidon.common.tls.TlsMaterial;
+// tag::snippet_16[]
 import io.helidon.common.uri.UriInfo;
 // end::snippet_16[]
 import io.helidon.config.Config;
@@ -386,6 +389,32 @@ class WebServerSnippets {
             res.send(templateFor(matchedHost, requestedHost));
         });
         // end::snippet_40[]
+    }
+
+    void snippet_41(WebServer server) {
+        // tag::snippet_41[]
+        TlsMaterial material = TlsMaterial.builder()
+                .privateKey(pk -> pk
+                        .keystore(keys -> keys.keystore(it -> it.path(Paths.get("/etc/certs/server.p12")))
+                                .passphrase("password".toCharArray())))
+                .trust(trust -> trust
+                        .keystore(keys -> keys.keystore(it -> it.path(Paths.get("/etc/certs/trust.p12")))))
+                .build();
+
+        server.reloadTls(material);
+        // end::snippet_41[]
+    }
+
+    void snippet_42(WebServer server) {
+        // tag::snippet_42[]
+        TlsMaterial apiMaterial = TlsMaterial.builder()
+                .privateKey(pk -> pk
+                        .keystore(keys -> keys.keystore(it -> it.path(Paths.get("/etc/certs/api-server.p12")))
+                                .passphrase("password".toCharArray())))
+                .build();
+
+        server.reloadVirtualHostTls("api.example.com", apiMaterial);
+        // end::snippet_42[]
     }
 
     void snippet_32() {

--- a/webserver/tests/mtls/src/test/java/io/helidon/webserver/tests/mtls/MtlsTest.java
+++ b/webserver/tests/mtls/src/test/java/io/helidon/webserver/tests/mtls/MtlsTest.java
@@ -28,6 +28,7 @@ import io.helidon.common.pki.Keys;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.tls.Tls;
 import io.helidon.common.tls.TlsClientAuth;
+import io.helidon.common.tls.TlsMaterial;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.logging.common.LogConfig;
@@ -81,8 +82,7 @@ class MtlsTest {
                                     .passphrase("password"))
                             .build();
 
-                    Tls tls = Tls.builder()
-                            .clientAuth(TlsClientAuth.REQUIRED)
+                    TlsMaterial material = TlsMaterial.builder()
                             .privateKey(privateKeyConfig.privateKey().get())
                             .privateKeyCertChain(privateKeyConfig.certChain())
                             .trust(trust -> trust
@@ -92,7 +92,7 @@ class MtlsTest {
                                             .keystore(Resource.create("second-valid/server.p12"))))
                             .build();
 
-                    server.reloadTls(tls);
+                    server.reloadTls(material);
                     res.status(Status.OK_200).send();
                 })
                 .get("/serverCert", (req, res) -> {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -202,15 +202,15 @@ class LoomServer implements WebServer, Resumable {
     }
 
     @Override
-    public void reloadTls(String socketName, TlsMaterial material) {
+    public void reloadTls(TlsMaterial material, String socketName) {
         ServerListener listener = listener(socketName);
         listener.reloadTls(material);
     }
 
     @Override
-    public void reloadVirtualHostTls(String socketName, String host, TlsMaterial material) {
+    public void reloadVirtualHostTls(TlsMaterial material, String socketName, String host) {
         ServerListener listener = listener(socketName);
-        listener.reloadVirtualHostTls(host, material);
+        listener.reloadVirtualHostTls(material, host);
     }
 
     private ServerListener listener(String socketName) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.CancellationException;
@@ -45,6 +46,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.common.resumable.Resumable;
 import io.helidon.common.resumable.ResumableSupport;
 import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
 import io.helidon.service.registry.Service;
@@ -193,14 +195,32 @@ class LoomServer implements WebServer, Resumable {
     }
 
     @Override
+    @Deprecated
     public void reloadTls(String socketName, Tls tls) {
+        ServerListener listener = listener(socketName);
+        listener.reloadTls(tls);
+    }
+
+    @Override
+    public void reloadTls(String socketName, TlsMaterial material) {
+        ServerListener listener = listener(socketName);
+        listener.reloadTls(material);
+    }
+
+    @Override
+    public void reloadVirtualHostTls(String socketName, String host, TlsMaterial material) {
+        ServerListener listener = listener(socketName);
+        listener.reloadVirtualHostTls(host, material);
+    }
+
+    private ServerListener listener(String socketName) {
+        Objects.requireNonNull(socketName, "socketName");
         ServerListener listener = listeners.get(socketName);
         if (listener == null) {
             throw new IllegalArgumentException("Cannot reload TLS on socket " + socketName
                                                        + " since this socket does not exist");
-        } else {
-            listener.reloadTls(tls);
         }
+        return listener;
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.Timer;
@@ -56,6 +57,7 @@ import io.helidon.common.context.Context;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.task.HelidonTaskExecutor;
 import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
 import io.helidon.metrics.api.Tag;
@@ -282,6 +284,7 @@ class ServerListener implements ListenerContext {
         return localServerThread == null ? null : localServerThread.getState();
     }
 
+    @Deprecated
     void reloadTls(Tls tls) {
         if (!this.tls.enabled()) {
             throw new IllegalArgumentException("TLS is not enabled on the socket " + socketName
@@ -291,6 +294,21 @@ class ServerListener implements ListenerContext {
             throw new UnsupportedOperationException("TLS cannot be disabled by reloading on the socket " + socketName);
         }
         this.tls.reload(tls);
+    }
+
+    void reloadTls(TlsMaterial material) {
+        Objects.requireNonNull(material, "material");
+        if (!this.tls.enabled()) {
+            throw new IllegalArgumentException("TLS is not enabled on the socket " + socketName
+                                                       + " and therefore cannot be reloaded");
+        }
+        this.tls.reload(material);
+    }
+
+    void reloadVirtualHostTls(String host, TlsMaterial material) {
+        Objects.requireNonNull(host, "host");
+        Objects.requireNonNull(material, "material");
+        virtualHosts.reloadTls(host, material);
     }
 
     void suspend() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -305,10 +305,10 @@ class ServerListener implements ListenerContext {
         this.tls.reload(material);
     }
 
-    void reloadVirtualHostTls(String host, TlsMaterial material) {
-        Objects.requireNonNull(host, "host");
+    void reloadVirtualHostTls(TlsMaterial material, String host) {
         Objects.requireNonNull(material, "material");
-        virtualHosts.reloadTls(host, material);
+        Objects.requireNonNull(host, "host");
+        virtualHosts.reloadTls(material, host);
     }
 
     void suspend() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostRegistry.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostRegistry.java
@@ -108,7 +108,7 @@ final class VirtualHostRegistry {
         }
     }
 
-    void reloadTls(String configuredHost, TlsMaterial material) {
+    void reloadTls(TlsMaterial material, String configuredHost) {
         Objects.requireNonNull(material, "material");
         HostEntry.HostKey key = HostEntry.key(configuredHost);
         Map<String, HostEntry> target = key.wildcard() ? wildcardHosts : exactHosts;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostRegistry.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostRegistry.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
 import io.helidon.common.uri.UriAuthority;
 import io.helidon.common.uri.UriHost;
 
@@ -107,6 +108,18 @@ final class VirtualHostRegistry {
         }
     }
 
+    void reloadTls(String configuredHost, TlsMaterial material) {
+        Objects.requireNonNull(material, "material");
+        HostEntry.HostKey key = HostEntry.key(configuredHost);
+        Map<String, HostEntry> target = key.wildcard() ? wildcardHosts : exactHosts;
+        HostEntry entry = target.get(key.indexKey());
+        if (entry == null) {
+            throw new IllegalArgumentException("Virtual host " + key.configuredHost()
+                                                       + " is not configured on listener " + socketName);
+        }
+        entry.tls().reload(material);
+    }
+
     Selection select(String presentedHost) {
         String host = Objects.requireNonNull(presentedHost);
         HostEntry entry = match(host);
@@ -169,8 +182,14 @@ final class VirtualHostRegistry {
 
     private record HostEntry(String configuredHost, String indexKey, boolean wildcard, Tls tls) {
         private static HostEntry create(String configuredHost, Tls tls) {
+            HostKey key = key(configuredHost);
+            return new HostEntry(key.configuredHost(), key.indexKey(), key.wildcard(), tls);
+        }
+
+        private static HostKey key(String configuredHost) {
+            Objects.requireNonNull(configuredHost, "configuredHost");
             if (configuredHost.startsWith("*.")) {
-                return wildcard(configuredHost, tls);
+                return wildcard(configuredHost);
             }
             if (configuredHost.indexOf('*') >= 0) {
                 throw new IllegalArgumentException("Virtual host wildcard must be the complete left-most label: "
@@ -181,10 +200,10 @@ final class VirtualHostRegistry {
             if (host.kind() != UriHost.Kind.DNS) {
                 throw new IllegalArgumentException("Virtual host must be a DNS name: " + configuredHost);
             }
-            return new HostEntry(host.value(), host.value(), false, tls);
+            return new HostKey(host.value(), host.value(), false);
         }
 
-        private static HostEntry wildcard(String configuredHost, Tls tls) {
+        private static HostKey wildcard(String configuredHost) {
             if (configuredHost.indexOf('*', 1) != -1) {
                 throw new IllegalArgumentException("Virtual host wildcard must be the complete left-most label: "
                                                            + configuredHost);
@@ -194,7 +213,10 @@ final class VirtualHostRegistry {
             if (host.kind() != UriHost.Kind.DNS) {
                 throw new IllegalArgumentException("Virtual host wildcard suffix must be a DNS name: " + configuredHost);
             }
-            return new HostEntry("*." + host.value(), host.value(), true, tls);
+            return new HostKey("*." + host.value(), host.value(), true);
+        }
+
+        private record HostKey(String configuredHost, String indexKey, boolean wildcard) {
         }
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import io.helidon.builder.api.RuntimeType;
 import io.helidon.common.context.Context;
 import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
 
 /**
  * Server that opens server sockets and handles requests through routing.
@@ -146,7 +147,9 @@ public interface WebServer extends RuntimeType.Api<WebServerConfig> {
      * Reload TLS keystore and truststore configuration for the default socket.
      *
      * @param tls new TLS configuration
+     * @deprecated use {@link #reloadTls(TlsMaterial)}
      */
+    @Deprecated
     default void reloadTls(Tls tls) {
         reloadTls(DEFAULT_SOCKET_NAME, tls);
     }
@@ -156,6 +159,49 @@ public interface WebServer extends RuntimeType.Api<WebServerConfig> {
      *
      * @param socketName socket name to reload TLS configuration on
      * @param tls new TLS configuration
+     * @deprecated use {@link #reloadTls(io.helidon.common.tls.TlsMaterial, String)}
      */
+    @Deprecated
     void reloadTls(String socketName, Tls tls);
+
+    /**
+     * Reload TLS key and trust material for the default socket.
+     *
+     * @param material new TLS material
+     */
+    default void reloadTls(TlsMaterial material) {
+        reloadTls(material, DEFAULT_SOCKET_NAME);
+    }
+
+    /**
+     * Reload TLS key and trust material for the named socket.
+     *
+     * @param material new TLS material
+     * @param socketName socket name to reload TLS material on
+     */
+    default void reloadTls(TlsMaterial material, String socketName) {
+        throw new UnsupportedOperationException("TLS material reload is not supported by this WebServer implementation");
+    }
+
+    /**
+     * Reload TLS key and trust material for a virtual host configured on the default socket.
+     *
+     * @param material new TLS material
+     * @param host configured virtual host name
+     */
+    default void reloadVirtualHostTls(TlsMaterial material, String host) {
+        reloadVirtualHostTls(material, DEFAULT_SOCKET_NAME, host);
+    }
+
+    /**
+     * Reload TLS key and trust material for a virtual host configured on the named socket.
+     *
+     * @param material new TLS material
+     * @param socketName socket name containing the virtual host
+     * @param host configured virtual host name
+     */
+    default void reloadVirtualHostTls(TlsMaterial material, String socketName, String host) {
+        throw new UnsupportedOperationException("Virtual host TLS material reload is not supported by this WebServer "
+                                                        + "implementation");
+    }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/VirtualHostRegistryTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/VirtualHostRegistryTest.java
@@ -167,7 +167,7 @@ class VirtualHostRegistryTest {
         TlsMaterial material = material();
         VirtualHostRegistry registry = registry(defaultTls, virtualHost("api.example.com", exactTls));
 
-        registry.reloadTls("API.EXAMPLE.COM", material);
+        registry.reloadTls(material, "API.EXAMPLE.COM");
 
         verify(exactTls).reload(material);
         verify(defaultTls, never()).reload(material);
@@ -180,7 +180,7 @@ class VirtualHostRegistryTest {
         TlsMaterial material = material();
         VirtualHostRegistry registry = registry(defaultTls, virtualHost("*.example.com", wildcardTls));
 
-        registry.reloadTls("*.EXAMPLE.COM", material);
+        registry.reloadTls(material, "*.EXAMPLE.COM");
 
         verify(wildcardTls).reload(material);
         verify(defaultTls, never()).reload(material);
@@ -193,7 +193,7 @@ class VirtualHostRegistryTest {
         VirtualHostRegistry registry = registry(tls(), virtualHost("*.example.com", wildcardTls));
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                          () -> registry.reloadTls("api.example.com", material));
+                                                          () -> registry.reloadTls(material, "api.example.com"));
 
         assertThat(exception.getMessage(), is("Virtual host api.example.com is not configured on listener " + SOCKET_NAME));
         verify(wildcardTls, never()).reload(material);
@@ -205,7 +205,7 @@ class VirtualHostRegistryTest {
         VirtualHostRegistry registry = registry(tls());
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                          () -> registry.reloadTls("api.example.com", material));
+                                                          () -> registry.reloadTls(material, "api.example.com"));
 
         assertThat(exception.getMessage(), is("Virtual host api.example.com is not configured on listener " + SOCKET_NAME));
     }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/VirtualHostRegistryTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/VirtualHostRegistryTest.java
@@ -19,6 +19,7 @@ package io.helidon.webserver;
 import java.util.Optional;
 
 import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class VirtualHostRegistryTest {
     private static final String SOCKET_NAME = "test";
@@ -155,6 +160,65 @@ class VirtualHostRegistryTest {
         assertThat(unmatched.sendUnrecognizedNameAlert(), is(true));
     }
 
+    @Test
+    void reloadsExactConfiguredHost() {
+        Tls defaultTls = tls();
+        Tls exactTls = tls();
+        TlsMaterial material = material();
+        VirtualHostRegistry registry = registry(defaultTls, virtualHost("api.example.com", exactTls));
+
+        registry.reloadTls("API.EXAMPLE.COM", material);
+
+        verify(exactTls).reload(material);
+        verify(defaultTls, never()).reload(material);
+    }
+
+    @Test
+    void reloadsWildcardConfiguredHost() {
+        Tls defaultTls = tls();
+        Tls wildcardTls = tls();
+        TlsMaterial material = material();
+        VirtualHostRegistry registry = registry(defaultTls, virtualHost("*.example.com", wildcardTls));
+
+        registry.reloadTls("*.EXAMPLE.COM", material);
+
+        verify(wildcardTls).reload(material);
+        verify(defaultTls, never()).reload(material);
+    }
+
+    @Test
+    void reloadDoesNotMatchConcreteHostToWildcardEntry() {
+        Tls wildcardTls = tls();
+        TlsMaterial material = material();
+        VirtualHostRegistry registry = registry(tls(), virtualHost("*.example.com", wildcardTls));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> registry.reloadTls("api.example.com", material));
+
+        assertThat(exception.getMessage(), is("Virtual host api.example.com is not configured on listener " + SOCKET_NAME));
+        verify(wildcardTls, never()).reload(material);
+    }
+
+    @Test
+    void reloadFailsWhenNoVirtualHostsAreConfigured() {
+        TlsMaterial material = material();
+        VirtualHostRegistry registry = registry(tls());
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> registry.reloadTls("api.example.com", material));
+
+        assertThat(exception.getMessage(), is("Virtual host api.example.com is not configured on listener " + SOCKET_NAME));
+    }
+
+    private static VirtualHostRegistry registry(Tls defaultTls, VirtualHostConfig... virtualHosts) {
+        ListenerConfig.Builder builder = ListenerConfig.builder()
+                .tls(defaultTls);
+        for (VirtualHostConfig virtualHost : virtualHosts) {
+            builder.addVirtualHost(virtualHost);
+        }
+        return VirtualHostRegistry.create(SOCKET_NAME, builder.buildPrototype(), defaultTls);
+    }
+
     private static VirtualHostRegistry registry(String... hosts) {
         ListenerConfig.Builder builder = ListenerConfig.builder()
                 .tls(TLS);
@@ -165,9 +229,25 @@ class VirtualHostRegistryTest {
     }
 
     private static VirtualHostConfig virtualHost(String host) {
+        return virtualHost(host, TLS);
+    }
+
+    private static VirtualHostConfig virtualHost(String host, Tls tls) {
         return VirtualHostConfig.builder()
                 .host(host)
-                .tls(TLS)
+                .tls(tls)
+                .build();
+    }
+
+    private static Tls tls() {
+        Tls tls = mock(Tls.class);
+        when(tls.enabled()).thenReturn(true);
+        return tls;
+    }
+
+    private static TlsMaterial material() {
+        return TlsMaterial.builder()
+                .trustAll(true)
                 .build();
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/WebServerTlsReloadTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/WebServerTlsReloadTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WebServerTlsReloadTest {
+    @Test
+    void reloadTlsMaterialDefaultSocketDispatchesToListener() {
+        Tls tls = tls();
+        TlsMaterial material = material();
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .tls(tls)
+                .build();
+
+        server.reloadTls(material);
+
+        verify(tls).reload(material);
+    }
+
+    @Test
+    void reloadTlsMaterialNamedSocketDispatchesToListener() {
+        Tls tls = tls();
+        TlsMaterial material = material();
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .putSocket("admin", socket -> socket.tls(tls))
+                .build();
+
+        server.reloadTls(material, "admin");
+
+        verify(tls).reload(material);
+    }
+
+    @Test
+    void reloadVirtualHostTlsMaterialNamedSocketDispatchesToRegistry() {
+        Tls defaultTls = tls();
+        Tls virtualHostTls = tls();
+        TlsMaterial material = material();
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .putSocket("admin", socket -> socket.tls(defaultTls)
+                        .useNio(true)
+                        .addVirtualHost(virtualHost -> virtualHost.host("api.example.com")
+                                .tls(virtualHostTls)))
+                .build();
+
+        server.reloadVirtualHostTls(material, "admin", "api.example.com");
+
+        verify(virtualHostTls).reload(material);
+        verify(defaultTls, never()).reload(material);
+    }
+
+    private static Tls tls() {
+        Tls tls = mock(Tls.class);
+        when(tls.enabled()).thenReturn(true);
+        return tls;
+    }
+
+    private static TlsMaterial material() {
+        return TlsMaterial.builder()
+                .trustAll(true)
+                .build();
+    }
+}


### PR DESCRIPTION
Resolves #10785

Adds reloadable TLS material support across common TLS managers and WebServer listener APIs, including material-first reload methods, virtual-host/SNI reload support, explicit SSLContext reload rejection, documentation, and configuration-backed custom manager reload coverage.
