### PR TITLE
Fix HTTP/1 no-body and close-delimited responses (27.x)

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -263,17 +263,25 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     }
 
     ResponseHead readResponseHead(ClientConnection connection, DataReader reader, Predicate<Status> skippedResponse) {
+        return readResponseHead(connection, reader, skippedResponse, true);
+    }
+
+    ResponseHead readResponseHead(ClientConnection connection,
+                                  DataReader reader,
+                                  Predicate<Status> skippedResponse,
+                                  boolean closeOnReadFailure) {
         while (true) {
             Status responseStatus;
             try {
                 responseStatus = Http1StatusParser.readStatus(reader, protocolConfig.maxStatusLineLength());
             } catch (UncheckedIOException e) {
-                // if we get a timeout or connection close, we must close the resource (as otherwise we may receive
-                // data of this request on the next use of this connection
-                try {
-                    connection.closeResource();
-                } catch (Exception ex) {
-                    e.addSuppressed(ex);
+                if (closeOnReadFailure) {
+                    // Normal response reads cannot reuse a connection after a timeout or close while reading status.
+                    try {
+                        connection.closeResource();
+                    } catch (Exception ex) {
+                        e.addSuppressed(ex);
+                    }
                 }
                 throw e;
             }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -101,7 +101,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         WebClientServiceResponse.Builder builder = WebClientServiceResponse.builder();
         AtomicReference<WebClientServiceResponse> response = new AtomicReference<>();
 
-        if (mayHaveEntity(responseStatus, responseHeaders)) {
+        if (mayHaveEntity(serviceRequest.method(), responseStatus, responseHeaders)) {
             // this may be an entity (if content length is set to zero, we know there is no entity)
             builder.inputStream(inputStream(clientConfig,
                                             recvListener,
@@ -278,12 +278,18 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         return recvListener;
     }
 
-    private static boolean mayHaveEntity(Status responseStatus, ClientResponseHeaders responseHeaders) {
+    private static boolean mayHaveEntity(Method requestMethod, Status responseStatus, ClientResponseHeaders responseHeaders) {
+        if (requestMethod == Method.HEAD) {
+            return false;
+        }
         if (responseHeaders.contains(HeaderValues.CONTENT_LENGTH_ZERO)) {
             return false;
         }
-        // Why is NOT_MODIFIED_304 not added here too?
-        if (responseStatus.code() == Status.NO_CONTENT_204.code()) {
+        int statusCode = responseStatus.code();
+        if (responseStatus.family() == Status.Family.INFORMATIONAL
+                || statusCode == Status.NO_CONTENT_204.code()
+                || statusCode == Status.RESET_CONTENT_205.code()
+                || statusCode == Status.NOT_MODIFIED_304.code()) {
             return false;
         }
         if ((

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -24,6 +24,7 @@ import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import io.helidon.common.ParserHelper;
@@ -240,38 +241,56 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     WebClientServiceResponse readResponse(WebClientServiceRequest serviceRequest,
                                           ClientConnection connection,
                                           DataReader reader) {
-
-        Status responseStatus;
-        try {
-            responseStatus = Http1StatusParser.readStatus(reader, protocolConfig.maxStatusLineLength());
-        } catch (UncheckedIOException e) {
-            // if we get a timeout or connection close, we must close the resource (as otherwise we may receive
-            // data of this request on the next use of this connection
-            try {
-                connection.closeResource();
-            } catch (Exception ex) {
-                e.addSuppressed(ex);
-            }
-            throw e;
-        }
-
-        recvListener.status(connection.helidonSocket(), responseStatus);
-
-        ClientResponseHeaders responseHeaders = readHeaders(reader);
-
-        recvListener.headers(connection.helidonSocket(), responseHeaders);
+        ResponseHead responseHead = readResponseHead(connection, reader);
 
         return createServiceResponse(http1Client,
                                      serviceRequest,
                                      connection,
                                      reader,
-                                     responseStatus,
-                                     responseHeaders,
+                                     responseHead.status(),
+                                     responseHead.headers(),
                                      whenComplete);
     }
 
     Http1ConnectionListener sendListener() {
         return sendListener;
+    }
+
+    ResponseHead readResponseHead(ClientConnection connection, DataReader reader) {
+        return readResponseHead(connection, reader, Http1CallChainBase::isInterimResponse);
+    }
+
+    ResponseHead readResponseHead(ClientConnection connection, DataReader reader, Predicate<Status> skippedResponse) {
+        while (true) {
+            Status responseStatus;
+            try {
+                responseStatus = Http1StatusParser.readStatus(reader, protocolConfig.maxStatusLineLength());
+            } catch (UncheckedIOException e) {
+                // if we get a timeout or connection close, we must close the resource (as otherwise we may receive
+                // data of this request on the next use of this connection
+                try {
+                    connection.closeResource();
+                } catch (Exception ex) {
+                    e.addSuppressed(ex);
+                }
+                throw e;
+            }
+            recvListener.status(connection.helidonSocket(), responseStatus);
+            ClientResponseHeaders responseHeaders = readHeaders(reader);
+            recvListener.headers(connection.helidonSocket(), responseHeaders);
+
+            if (!skippedResponse.test(responseStatus)) {
+                return new ResponseHead(responseStatus, responseHeaders);
+            }
+        }
+    }
+
+    private static boolean isInterimResponse(Status responseStatus) {
+        return responseStatus.family() == Status.Family.INFORMATIONAL
+                && responseStatus.code() != Status.SWITCHING_PROTOCOLS_101.code();
+    }
+
+    record ResponseHead(Status status, ClientResponseHeaders headers) {
     }
 
     Http1ConnectionListener recvListener() {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -241,7 +241,9 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     WebClientServiceResponse readResponse(WebClientServiceRequest serviceRequest,
                                           ClientConnection connection,
                                           DataReader reader) {
-        ResponseHead responseHead = readResponseHead(connection, reader);
+        ResponseHead responseHead = originalRequest.outputStreamRedirect()
+                ? readResponseHead(connection, reader, Http1CallChainBase::isPreContinueInterimResponse)
+                : readResponseHead(connection, reader);
 
         return createServiceResponse(http1Client,
                                      serviceRequest,
@@ -283,6 +285,11 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                 return new ResponseHead(responseStatus, responseHeaders);
             }
         }
+    }
+
+    static boolean isPreContinueInterimResponse(Status responseStatus) {
+        return isInterimResponse(responseStatus)
+                && responseStatus.code() != Status.CONTINUE_100.code();
     }
 
     private static boolean isInterimResponse(Status responseStatus) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -19,6 +19,7 @@ package io.helidon.webclient.http1;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
@@ -409,14 +410,24 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                     connection.readTimeout(originalRequest.readContinueTimeout());
                     responseHead = callChain.readResponseHead(connection,
                                                               reader,
-                                                              Http1CallChainBase::isPreContinueInterimResponse);
-                } catch (UncheckedIOException ignored) {
-                    // we assume this is a timeout exception, if the socket got closed, next read will throw appropriate exception
-                    // we treat this as receiving 100-Continue
-                    responseHead = null;
-                    connection.allowExpectContinue(false);
+                                                              Http1CallChainBase::isPreContinueInterimResponse,
+                                                              false);
+                } catch (UncheckedIOException e) {
+                    if (e.getCause() instanceof SocketTimeoutException) {
+                        responseHead = null;
+                        connection.allowExpectContinue(false);
+                    } else {
+                        try {
+                            connection.closeResource();
+                        } catch (Exception ex) {
+                            e.addSuppressed(ex);
+                        }
+                        throw e;
+                    }
                 } finally {
-                    connection.readTimeout(originalRequest.readTimeout());
+                    if (connection.isConnected()) {
+                        connection.readTimeout(originalRequest.readTimeout());
+                    }
                 }
 
                 Status responseStatus = responseHead == null ? Status.CONTINUE_100 : responseHead.status();

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -402,14 +402,14 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             whenSent.complete(request);
 
             if (expects100Continue) {
-                ResponseHead responseHead;
+                ResponseHead responseHead = null;
 
                 try {
                     writer.flush();     // flush before a read
                     connection.readTimeout(originalRequest.readContinueTimeout());
                     responseHead = callChain.readResponseHead(connection,
                                                               reader,
-                                                              ClientConnectionOutputStream::isPreContinueInterimResponse);
+                                                              Http1CallChainBase::isPreContinueInterimResponse);
                 } catch (UncheckedIOException ignored) {
                     // we assume this is a timeout exception, if the socket got closed, next read will throw appropriate exception
                     // we treat this as receiving 100-Continue
@@ -445,12 +445,6 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                     }
                 }
             }
-        }
-
-        private static boolean isPreContinueInterimResponse(Status responseStatus) {
-            return responseStatus.family() == Status.Family.INFORMATIONAL
-                    && responseStatus.code() != Status.CONTINUE_100.code()
-                    && responseStatus.code() != Status.SWITCHING_PROTOCOLS_101.code();
         }
 
         private void redirect(Status lastStatus, Headers headerValues) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -34,7 +34,6 @@ import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
-import io.helidon.http.Http1HeadersParser;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
@@ -71,7 +70,8 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                                        DataReader reader,
                                        BufferData writeBuffer) {
 
-        ClientConnectionOutputStream cos = new ClientConnectionOutputStream(connection,
+        ClientConnectionOutputStream cos = new ClientConnectionOutputStream(this,
+                                                                            connection,
                                                                             writer,
                                                                             reader,
                                                                             writeBuffer,
@@ -103,30 +103,9 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
         reader = cos.reader;
         connection = cos.connection;
 
-        Status responseStatus;
-        try {
-            responseStatus = Http1StatusParser.readStatus(reader, http1Client.protocolConfig().maxStatusLineLength());
-            if (responseStatus == Status.CONTINUE_100) {
-                // skip the next empty end of line
-                readHeaders(reader);
-                responseStatus = Http1StatusParser.readStatus(reader, http1Client.protocolConfig().maxStatusLineLength());
-            }
-        } catch (UncheckedIOException e) {
-            // if we get a timeout or connection close, we must close the resource (as otherwise we may receive
-            // data of this request on the next use of this connection
-            try {
-                connection.closeResource();
-            } catch (Exception ex) {
-                e.addSuppressed(ex);
-            }
-            throw e;
-        }
-
-        recvListener().status(connection.helidonSocket(), responseStatus);
-
-        ClientResponseHeaders responseHeaders = readHeaders(reader);
-
-        recvListener().headers(connection.helidonSocket(), responseHeaders);
+        ResponseHead responseHead = readResponseHead(connection, reader);
+        Status responseStatus = responseHead.status();
+        ClientResponseHeaders responseHeaders = responseHead.headers();
 
         if (originalRequest().followRedirects()
                 && RedirectionProcessor.redirectionStatusCode(responseStatus)) {
@@ -179,9 +158,9 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
         private final Http1ClientRequestImpl originalRequest;
         private final CompletableFuture<WebClientServiceRequest> whenSent;
         private final CompletableFuture<WebClientServiceResponse> whenComplete;
+        private final Http1CallOutputStreamChain callChain;
         private final Http1ClientImpl http1Client;
         private final Http1ConnectionListener sendListener;
-        private final Http1ConnectionListener recvListener;
         private final HttpClientConfig clientConfig;
         private final Http1ClientProtocolConfig protocolConfig;
         private final WritableHeaders<?> headers;
@@ -202,7 +181,8 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
         private Http1ClientResponseImpl response;
         private WebClientServiceResponse serviceResponse;
 
-        private ClientConnectionOutputStream(ClientConnection connection,
+        private ClientConnectionOutputStream(Http1CallOutputStreamChain callChain,
+                                             ClientConnection connection,
                                              DataWriter writer,
                                              DataReader reader,
                                              BufferData prologue,
@@ -212,6 +192,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                                              Http1ClientRequestImpl originalRequest,
                                              CompletableFuture<WebClientServiceRequest> whenSent,
                                              CompletableFuture<WebClientServiceResponse> whenComplete) {
+            this.callChain = callChain;
             this.connection = connection;
             this.ctx = connection.helidonSocket();
             this.writer = writer;
@@ -229,7 +210,6 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             this.whenSent = whenSent;
             this.whenComplete = whenComplete;
             this.sendListener = http1Client.sendListener();
-            this.recvListener = http1Client.recvListener();
         }
 
         @Override
@@ -422,37 +402,27 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             whenSent.complete(request);
 
             if (expects100Continue) {
-                Status responseStatus;
+                ResponseHead responseHead;
 
                 try {
                     writer.flush();     // flush before a read
                     connection.readTimeout(originalRequest.readContinueTimeout());
-                    responseStatus = Http1StatusParser.readStatus(reader, protocolConfig.maxStatusLineLength());
-
-                    recvListener.status(connection.helidonSocket(), responseStatus);
+                    responseHead = callChain.readResponseHead(connection,
+                                                              reader,
+                                                              ClientConnectionOutputStream::isPreContinueInterimResponse);
                 } catch (UncheckedIOException ignored) {
                     // we assume this is a timeout exception, if the socket got closed, next read will throw appropriate exception
                     // we treat this as receiving 100-Continue
-                    responseStatus = null;
+                    responseHead = null;
                     connection.allowExpectContinue(false);
                 } finally {
                     connection.readTimeout(originalRequest.readTimeout());
                 }
-                if (responseStatus == Status.CONTINUE_100) {
-                    // there is the status and (usually) empty headers. We ignore such headers
-                    Http1HeadersParser.readHeaders(reader,
-                                                   protocolConfig.maxHeaderSize(),
-                                                   protocolConfig.validateResponseHeaders());
-                }
-                if (responseStatus == null) {
-                    responseStatus = Status.CONTINUE_100;
-                }
 
-                if (responseStatus != Status.CONTINUE_100) {
-                    WritableHeaders<?> responseHeaders = Http1HeadersParser.readHeaders(reader,
-                                                                                        protocolConfig.maxHeaderSize(),
-                                                                                        protocolConfig.validateResponseHeaders());
-                    recvListener.headers(connection.helidonSocket(), responseHeaders);
+                Status responseStatus = responseHead == null ? Status.CONTINUE_100 : responseHead.status();
+
+                if (responseStatus.code() != Status.CONTINUE_100.code()) {
+                    ClientResponseHeaders responseHeaders = responseHead.headers();
 
                     if (RedirectionProcessor.redirectionStatusCode(responseStatus) && originalRequest.followRedirects()) {
                         // redirect as needed
@@ -468,7 +438,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                                                                      connection,
                                                                      reader,
                                                                      responseStatus,
-                                                                     ClientResponseHeaders.create(responseHeaders),
+                                                                     responseHeaders,
                                                                      whenComplete);
                         //we are not sending anything by this OS, we need to interrupt it.
                         throw new OutputStreamInterruptedException();
@@ -477,7 +447,13 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             }
         }
 
-        private void redirect(Status lastStatus, WritableHeaders<?> headerValues) {
+        private static boolean isPreContinueInterimResponse(Status responseStatus) {
+            return responseStatus.family() == Status.Family.INFORMATIONAL
+                    && responseStatus.code() != Status.CONTINUE_100.code()
+                    && responseStatus.code() != Status.SWITCHING_PROTOCOLS_101.code();
+        }
+
+        private void redirect(Status lastStatus, Headers headerValues) {
             String redirectedUri = headerValues.get(HeaderNames.LOCATION).get();
             ClientUri lastUri = originalRequest.uri();
             Method method;

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -56,6 +56,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     private static final List<SourceHandlerProvider> SOURCE_HANDLERS
             = HelidonServiceLoader.builder(ServiceLoader.load(SourceHandlerProvider.class)).build().asList();
     private static final long ENTITY_LENGTH_CHUNKED = -1;
+    private static final long ENTITY_LENGTH_CLOSE_DELIMITED = -2;
     private final AtomicBoolean closed = new AtomicBoolean();
 
     private final HttpClientConfig clientConfig;
@@ -106,10 +107,14 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         ));
 
         OptionalLong contentLength = responseHeaders.contentLength();
-        if (contentLength.isPresent()) {
+        if (inputStream == null) {
+            this.entityLength = 0;
+        } else if (contentLength.isPresent()) {
             this.entityLength = contentLength.getAsLong();
         } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
             this.entityLength = ENTITY_LENGTH_CHUNKED;
+        } else {
+            this.entityLength = ENTITY_LENGTH_CLOSE_DELIMITED;
         }
 
         if (responseHeaders.contains(HeaderNames.TRAILER)) {
@@ -153,10 +158,14 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     public void close() {
         if (closed.compareAndSet(false, true)) {
             try {
-                if (headers().containsToken(HeaderValues.CONNECTION_CLOSE)) {
+                if (headers().containsToken(HeaderValues.CONNECTION_CLOSE)
+                        || entityLength == ENTITY_LENGTH_CLOSE_DELIMITED) {
                     connection.closeResource();
                 } else {
-                    if (entityFullyRead || entityLength == 0 || consumeUnreadEntity()) {
+                    // No-body response bytes cannot be consumed as entity; buffered data makes reuse unsafe.
+                    if (inputStream == null && connection.reader().available() > 0) {
+                        connection.closeResource();
+                    } else if (entityFullyRead || entityLength == 0 || consumeUnreadEntity()) {
                         connection.releaseResource();
                     } else {
                         connection.closeResource();

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
@@ -158,7 +158,8 @@ class Http1ClientResponseImplTest {
     private static WebClientServiceResponse serviceResponse(Method method,
                                                             Status status,
                                                             ClientResponseHeaders headers) {
-        return Http1CallChainBase.createServiceResponse(HttpClientConfig.builder().build(),
+        return Http1CallChainBase.createServiceResponse(new Http1ClientImpl(null,
+                                                                            Http1ClientConfig.builder().buildPrototype()),
                                                         new TestServiceRequest(method),
                                                         new TestConnection(),
                                                         DataReader.create(() -> null),

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http1;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.context.Context;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.PeerInfo;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.MediaContext;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientConfig;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class Http1ClientResponseImplTest {
+
+    @Test
+    void doesNotCreateEntityStreamForHeadResponseWithoutFraming() {
+        WebClientServiceResponse response = serviceResponse(Method.HEAD,
+                                                            Status.OK_200,
+                                                            ClientResponseHeaders.create(WritableHeaders.create()));
+
+        assertThat(response.inputStream().isEmpty(), is(true));
+    }
+
+    @Test
+    void doesNotCreateEntityStreamForHeadResponseWithContentLength() {
+        WebClientServiceResponse response = serviceResponse(Method.HEAD,
+                                                            Status.OK_200,
+                                                            contentLengthHeaders());
+
+        assertThat(response.inputStream().isEmpty(), is(true));
+    }
+
+    @Test
+    void doesNotCreateEntityStreamForNotModifiedWithoutFraming() {
+        WebClientServiceResponse response = serviceResponse(Method.GET,
+                                                            Status.NOT_MODIFIED_304,
+                                                            ClientResponseHeaders.create(WritableHeaders.create()));
+
+        assertThat(response.inputStream().isEmpty(), is(true));
+    }
+
+    @Test
+    void createsEntityStreamForUnframedGetResponse() {
+        WebClientServiceResponse response = serviceResponse(Method.GET,
+                                                            Status.OK_200,
+                                                            ClientResponseHeaders.create(WritableHeaders.create()));
+
+        assertThat(response.inputStream().isPresent(), is(true));
+    }
+
+    @Test
+    void closesCloseDelimitedResponseAfterEntityRead() {
+        TestConnection connection = new TestConnection();
+        Http1ClientResponseImpl response = response(ClientResponseHeaders.create(WritableHeaders.create()),
+                                                    inputStream("data"),
+                                                    connection);
+
+        assertThat(response.entity().as(String.class), is("data"));
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void closesUnreadCloseDelimitedResponse() {
+        TestConnection connection = new TestConnection();
+        Http1ClientResponseImpl response = response(ClientResponseHeaders.create(WritableHeaders.create()),
+                                                    inputStream("data"),
+                                                    connection);
+
+        response.close();
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void releasesNoEntityResponseWithContentLength() {
+        TestConnection connection = new TestConnection();
+        Http1ClientResponseImpl response = response(contentLengthHeaders(),
+                                                    null,
+                                                    connection);
+
+        response.close();
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void closesNoEntityResponseWithUnexpectedBufferedData() {
+        TestConnection connection = new TestConnection(dataReader("head"));
+        Http1ClientResponseImpl response = response(ClientResponseHeaders.create(WritableHeaders.create()),
+                                                    null,
+                                                    connection);
+
+        response.close();
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void releasesLengthDelimitedResponseAfterEntityRead() {
+        TestConnection connection = new TestConnection();
+        Http1ClientResponseImpl response = response(contentLengthHeaders(),
+                                                    inputStream("data"),
+                                                    connection);
+
+        assertThat(response.entity().as(String.class), is("data"));
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    private static WebClientServiceResponse serviceResponse(Method method,
+                                                            Status status,
+                                                            ClientResponseHeaders headers) {
+        return Http1CallChainBase.createServiceResponse(HttpClientConfig.builder().build(),
+                                                        new TestServiceRequest(method),
+                                                        new TestConnection(),
+                                                        DataReader.create(() -> null),
+                                                        status,
+                                                        headers,
+                                                        new CompletableFuture<>());
+    }
+
+    private static Http1ClientResponseImpl response(ClientResponseHeaders headers,
+                                                    InputStream inputStream,
+                                                    TestConnection connection) {
+        return new Http1ClientResponseImpl(HttpClientConfig.builder().build(),
+                                           Http1ClientProtocolConfig.create(),
+                                           Status.OK_200,
+                                           ClientRequestHeaders.create(WritableHeaders.create()),
+                                           headers,
+                                           connection,
+                                           inputStream,
+                                           MediaContext.create(),
+                                           ClientUri.create(URI.create("http://localhost/test")),
+                                           new CompletableFuture<>());
+    }
+
+    private static InputStream inputStream(String entity) {
+        return new ByteArrayInputStream(entity.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static DataReader dataReader(String entity) {
+        AtomicReference<byte[]> bytes = new AtomicReference<>(entity.getBytes(StandardCharsets.UTF_8));
+        DataReader reader = DataReader.create(() -> bytes.getAndSet(null));
+        reader.pullData();
+        return reader;
+    }
+
+    private static ClientResponseHeaders contentLengthHeaders() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.CONTENT_LENGTH, "4");
+        return ClientResponseHeaders.create(headers);
+    }
+
+    private static final class TestServiceRequest implements WebClientServiceRequest {
+        private final Method method;
+        private final ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        private final Context context = Context.create();
+        private final Map<String, String> properties = new HashMap<>();
+        private final CompletableFuture<WebClientServiceRequest> whenSent = new CompletableFuture<>();
+        private final CompletableFuture<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
+        private String requestId = "test";
+
+        private TestServiceRequest(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public ClientUri uri() {
+            return ClientUri.create(URI.create("http://localhost/test"));
+        }
+
+        @Override
+        public Method method() {
+            return method;
+        }
+
+        @Override
+        public String protocolId() {
+            return "http/1.1";
+        }
+
+        @Override
+        public ClientRequestHeaders headers() {
+            return headers;
+        }
+
+        @Override
+        public Context context() {
+            return context;
+        }
+
+        @Override
+        public String requestId() {
+            return requestId;
+        }
+
+        @Override
+        public void requestId(String requestId) {
+            this.requestId = requestId;
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceRequest> whenSent() {
+            return whenSent;
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceResponse> whenComplete() {
+            return whenComplete;
+        }
+
+        @Override
+        public Map<String, String> properties() {
+            return properties;
+        }
+    }
+
+    private static final class TestConnection implements ClientConnection {
+        private final AtomicInteger releaseCount = new AtomicInteger();
+        private final AtomicInteger closeCount = new AtomicInteger();
+        private final DataReader reader;
+
+        private TestConnection() {
+            this(DataReader.create(() -> null));
+        }
+
+        private TestConnection(DataReader reader) {
+            this.reader = reader;
+        }
+
+        @Override
+        public DataReader reader() {
+            return reader;
+        }
+
+        @Override
+        public DataWriter writer() {
+            return new NoopDataWriter();
+        }
+
+        @Override
+        public String channelId() {
+            return "test";
+        }
+
+        @Override
+        public HelidonSocket helidonSocket() {
+            return new TestSocket();
+        }
+
+        @Override
+        public void readTimeout(Duration readTimeout) {
+        }
+
+        @Override
+        public void releaseResource() {
+            releaseCount.incrementAndGet();
+        }
+
+        @Override
+        public void closeResource() {
+            closeCount.incrementAndGet();
+        }
+
+        private int releaseCount() {
+            return releaseCount.get();
+        }
+
+        private int closeCount() {
+            return closeCount.get();
+        }
+    }
+
+    private static final class NoopDataWriter implements DataWriter {
+        @Override
+        public void write(BufferData... buffers) {
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+        }
+
+        @Override
+        public void writeNow(BufferData... buffers) {
+        }
+
+        @Override
+        public void writeNow(BufferData buffer) {
+        }
+    }
+
+    private static final class TestSocket implements HelidonSocket {
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void idle() {
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+        }
+
+        @Override
+        public PeerInfo remotePeer() {
+            return null;
+        }
+
+        @Override
+        public PeerInfo localPeer() {
+            return null;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public String socketId() {
+            return "test";
+        }
+
+        @Override
+        public String childSocketId() {
+            return "test";
+        }
+
+        @Override
+        public byte[] get() {
+            return new byte[0];
+        }
+    }
+}

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -290,6 +290,62 @@ class Http1ClientTest {
     }
 
     @Test
+    void testInterimResponseIsSkipped() {
+        String rawResponse = "HTTP/1.1 103 Early Hints\r\n"
+                + "Link: </style.css>; rel=preload\r\n"
+                + "\r\n"
+                + "HTTP/1.1 200 OK\r\n"
+                + "Content-Length: 2\r\n"
+                + "\r\n"
+                + "OK";
+
+        Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(new FakeHttp1ClientConnection(rawResponse))
+                .request();
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity().as(String.class), is("OK"));
+    }
+
+    @Test
+    void testSwitchingProtocolsWithCustomReasonIsNotSkipped() {
+        String rawResponse = "HTTP/1.1 101 Custom Upgrade\r\n"
+                + "Upgrade: test\r\n"
+                + "\r\n"
+                + "upgraded-data\r\n";
+
+        Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(new FakeHttp1ClientConnection(rawResponse))
+                .request();
+
+        assertThat(response.status().code(), is(Status.SWITCHING_PROTOCOLS_101.code()));
+        assertThat(response.status().reasonPhrase(), is("Custom Upgrade"));
+    }
+
+    @Test
+    void testInterimResponseBeforeContinueIsSkipped() {
+        String rawContinueResponse = "HTTP/1.1 103 Early Hints\r\n"
+                + "Link: </style.css>; rel=preload\r\n"
+                + "\r\n"
+                + "HTTP/1.1 100 Continue\r\n"
+                + "\r\n";
+        String rawResponse = "HTTP/1.1 200 OK\r\n"
+                + "Content-Length: 2\r\n"
+                + "\r\n"
+                + "OK";
+        Http1Client expectContinueClient = Http1Client.builder()
+                .sendExpectContinue(true)
+                .build();
+        Http1ClientRequest request = expectContinueClient.put("http://localhost:" + dummyPort + "/test");
+        request.connection(new FakeHttp1ClientConnection(rawResponse, rawContinueResponse));
+
+        Http1ClientResponse response = getHttp1ClientResponseFromOutputStream(request, new String[] {"OK"});
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity().as(String.class), is("OK"));
+    }
+
+    @Test
     void testChunk() {
         String[] requestEntityParts = {"First", "Second", "Third"};
 
@@ -815,6 +871,8 @@ class Http1ClientTest {
         private final DataReader serverReader;
         private final DataWriter serverWriter;
         private final boolean includeKeepAliveHeader;
+        private final String rawResponse;
+        private final String rawContinueResponse;
         private Throwable serverException;
         private ExecutorService webServerEmulator;
         private String prologue;
@@ -826,6 +884,18 @@ class Http1ClientTest {
         }
 
         FakeHttp1ClientConnection(boolean includeKeepAliveHeader) {
+            this(includeKeepAliveHeader, null, null);
+        }
+
+        FakeHttp1ClientConnection(String rawResponse) {
+            this(rawResponse, null);
+        }
+
+        FakeHttp1ClientConnection(String rawResponse, String rawContinueResponse) {
+            this(true, rawResponse, rawContinueResponse);
+        }
+
+        FakeHttp1ClientConnection(boolean includeKeepAliveHeader, String rawResponse, String rawContinueResponse) {
             ArrayBlockingQueue<byte[]> serverToClient = new ArrayBlockingQueue<>(1024);
             ArrayBlockingQueue<byte[]> clientToServer = new ArrayBlockingQueue<>(1024);
 
@@ -834,6 +904,8 @@ class Http1ClientTest {
             this.serverReader = reader(clientToServer);
             this.serverWriter = writer(serverToClient);
             this.includeKeepAliveHeader = includeKeepAliveHeader;
+            this.rawResponse = rawResponse;
+            this.rawContinueResponse = rawContinueResponse;
         }
 
         @Override
@@ -983,8 +1055,10 @@ class Http1ClientTest {
                 if (reqHeaders.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
                     // Send 100-Continue if requested
                     if (reqHeaders.contains(HeaderValues.EXPECT_100)) {
-                        serverWriter.write(
-                                BufferData.create("HTTP/1.1 100 Continue\r\n\r\n".getBytes(StandardCharsets.UTF_8)));
+                        String continueResponse = rawContinueResponse == null
+                                ? "HTTP/1.1 100 Continue\r\n\r\n"
+                                : rawContinueResponse;
+                        serverWriter.write(BufferData.create(continueResponse.getBytes(StandardCharsets.UTF_8)));
                     }
 
                     // Assemble the entity from the chunks
@@ -1030,6 +1104,11 @@ class Http1ClientTest {
             if (getPrologue().contains(BAD_HEADER_PATH)) {
                 String[] header = entity.readString(entitySize, StandardCharsets.US_ASCII).split(HEADER_NAME_VALUE_DELIMETER);
                 resHeaders.add(HeaderValues.create(header[0], header[1]));
+            }
+
+            if (rawResponse != null) {
+                serverWriter.write(BufferData.create(rawResponse.getBytes(StandardCharsets.US_ASCII)));
+                return;
             }
 
             String responseMessage = !requestFailed ? "HTTP/1.1 200 OK\r\n" : "HTTP/1.1 400 Bad Request\r\n";

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class RoutingTest extends RoutingTestBase {
                 .post("/post", (req, res) -> res.send("post"))
                 .put("/put", (req, res) -> res.send("put"))
                 .delete("/delete", (req, res) -> res.send("delete"))
-                .head("/head", (req, res) -> res.send("head"))
+                .head("/head", (req, res) -> sendHead(res, "head"))
                 .options("/options", (req, res) -> res.send("options"))
                 .trace("/trace", (req, res) -> res.send("trace"))
                 .patch("/patch", (req, res) -> res.send("patch"))
@@ -66,7 +66,7 @@ class RoutingTest extends RoutingTestBase {
                 .post("/post_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("post_multi"))
                 .put("/put_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("put_multi"))
                 .delete("/delete_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("delete_multi"))
-                .head("/head_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("head_multi"))
+                .head("/head_multi", RoutingTestBase::multiHandler, (req, res) -> sendHead(res, "head_multi"))
                 .options("/options_multi",
                          RoutingTestBase::multiHandler,
                          (req, res) -> res.send("options_multi"))
@@ -77,7 +77,7 @@ class RoutingTest extends RoutingTestBase {
                 .post((req, res) -> res.send("post_catchall"))
                 .put((req, res) -> res.send("put_catchall"))
                 .delete((req, res) -> res.send("delete_catchall"))
-                .head((req, res) -> res.send("head_catchall"))
+                .head((req, res) -> sendHead(res, "head_catchall"))
                 .options((req, res) -> res.send("options_catchall"))
                 .trace((req, res) -> res.send("trace_catchall"))
                 .patch((req, res) -> res.send("patch_catchall")));

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,12 +38,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 // Use by both RoutingTest and RulesTest to share the same test methods
 abstract class RoutingTestBase {
     private static final Header MULTI_HANDLER = HeaderValues.createCached(
             HeaderNames.create("X-Multi-Handler"), "true");
+    private static final String HEAD_ROUTE_HEADER = "X-Head-Route";
     static Http1Client client;
     // Functions that will be used to execute http webclient shortcut methods
     private static Function<String, Http1ClientRequest> get = x -> client.get(x);
@@ -59,6 +61,11 @@ abstract class RoutingTestBase {
     static void multiHandler(ServerRequest req, ServerResponse res) {
         res.headers().set(MULTI_HANDLER);
         res.next();
+    }
+
+    static void sendHead(ServerResponse res, String responseMessage) {
+        res.headers().set(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage));
+        res.send(responseMessage);
     }
 
     @Test
@@ -105,10 +112,13 @@ abstract class RoutingTestBase {
 
     @ParameterizedTest
     @MethodSource("basic")
-    void testHttpShortcutMethods(Function<String, Http1ClientRequest> request, String path, String responseMessage) {
+    void testHttpShortcutMethods(Function<String, Http1ClientRequest> request,
+                                 String path,
+                                 String responseMessage,
+                                 boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
-            assertThat(response.as(String.class), is(responseMessage));
+            assertResponseEntity(response, responseMessage, hasResponseEntity);
         }
     }
 
@@ -116,10 +126,11 @@ abstract class RoutingTestBase {
     @MethodSource("withoutPathPattern")
     void testHttpShortcutMethodsWithoutPathPattern(Function<String, Http1ClientRequest> request,
                                                    String path,
-                                                   String responseMessage) {
+                                                   String responseMessage,
+                                                   boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
-            assertThat(response.as(String.class), is(responseMessage));
+            assertResponseEntity(response, responseMessage, hasResponseEntity);
         }
     }
 
@@ -138,40 +149,53 @@ abstract class RoutingTestBase {
     @MethodSource("withMultiHandlers")
     void testHttpShortcutMethodsWithMultiHandlers(Function<String, Http1ClientRequest> request,
                                                   String path,
-                                                  String responseMessage) {
+                                                  String responseMessage,
+                                                  boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers(), hasHeader(MULTI_HANDLER));
+            assertResponseEntity(response, responseMessage, hasResponseEntity);
+        }
+    }
+
+    private static void assertResponseEntity(Http1ClientResponse response,
+                                             String responseMessage,
+                                             boolean hasResponseEntity) {
+        if (hasResponseEntity) {
             assertThat(response.as(String.class), is(responseMessage));
+        } else {
+            assertThat(response.headers(),
+                       hasHeader(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage)));
+            assertThrows(IllegalStateException.class, () -> response.as(String.class));
         }
     }
 
     private static Stream<Arguments> basic() {
         return Stream.of(
-                arguments(get, "/get", "get"),
-                arguments(post, "/post", "post"),
-                arguments(put, "/put", "put"),
-                arguments(delete, "/delete", "delete"),
-                arguments(head, "/head", "head"),
-                arguments(options, "/options", "options"),
-                arguments(trace, "/trace", "trace"),
-                arguments(patch, "/patch", "patch"),
-                arguments(delete, "/any", "any"),
-                arguments(post, "/any", "any"),
-                arguments(get, "/any", "any")
+                arguments(get, "/get", "get", true),
+                arguments(post, "/post", "post", true),
+                arguments(put, "/put", "put", true),
+                arguments(delete, "/delete", "delete", true),
+                arguments(head, "/head", "head", false),
+                arguments(options, "/options", "options", true),
+                arguments(trace, "/trace", "trace", true),
+                arguments(patch, "/patch", "patch", true),
+                arguments(delete, "/any", "any", true),
+                arguments(post, "/any", "any", true),
+                arguments(get, "/any", "any", true)
         );
     }
 
     private static Stream<Arguments> withoutPathPattern() {
         return Stream.of(
-                arguments(get, "/get_catchall", "get_catchall"),
-                arguments(post, "/post_catchall", "post_catchall"),
-                arguments(put, "/put_catchall", "put_catchall"),
-                arguments(delete, "/delete_catchall", "delete_catchall"),
-                arguments(head, "/head_catchall", "head_catchall"),
-                arguments(options, "/options_catchall", "options_catchall"),
-                arguments(trace, "/trace_catchall", "trace_catchall"),
-                arguments(patch, "/patch_catchall", "patch_catchall")
+                arguments(get, "/get_catchall", "get_catchall", true),
+                arguments(post, "/post_catchall", "post_catchall", true),
+                arguments(put, "/put_catchall", "put_catchall", true),
+                arguments(delete, "/delete_catchall", "delete_catchall", true),
+                arguments(head, "/head_catchall", "head_catchall", false),
+                arguments(options, "/options_catchall", "options_catchall", true),
+                arguments(trace, "/trace_catchall", "trace_catchall", true),
+                arguments(patch, "/patch_catchall", "patch_catchall", true)
         );
     }
 
@@ -184,14 +208,14 @@ abstract class RoutingTestBase {
 
     private static Stream<Arguments> withMultiHandlers() {
         return Stream.of(
-                arguments(get, "/get_multi", "get_multi"),
-                arguments(post, "/post_multi", "post_multi"),
-                arguments(put, "/put_multi", "put_multi"),
-                arguments(delete, "/delete_multi", "delete_multi"),
-                arguments(head, "/head_multi", "head_multi"),
-                arguments(options, "/options_multi", "options_multi"),
-                arguments(trace, "/trace_multi", "trace_multi"),
-                arguments(patch, "/patch_multi", "patch_multi")
+                arguments(get, "/get_multi", "get_multi", true),
+                arguments(post, "/post_multi", "post_multi", true),
+                arguments(put, "/put_multi", "put_multi", true),
+                arguments(delete, "/delete_multi", "delete_multi", true),
+                arguments(head, "/head_multi", "head_multi", false),
+                arguments(options, "/options_multi", "options_multi", true),
+                arguments(trace, "/trace_multi", "trace_multi", true),
+                arguments(patch, "/patch_multi", "patch_multi", true)
         );
     }
 }

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class RulesTest extends RoutingTestBase {
                 .post("/post", (req, res) -> res.send("post"))
                 .put("/put", (req, res) -> res.send("put"))
                 .delete("/delete", (req, res) -> res.send("delete"))
-                .head("/head", (req, res) -> res.send("head"))
+                .head("/head", (req, res) -> sendHead(res, "head"))
                 .options("/options", (req, res) -> res.send("options"))
                 .trace("/trace", (req, res) -> res.send("trace"))
                 .patch("/patch", (req, res) -> res.send("patch"))
@@ -65,7 +65,7 @@ class RulesTest extends RoutingTestBase {
                 .post("/post_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("post_multi"))
                 .put("/put_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("put_multi"))
                 .delete("/delete_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("delete_multi"))
-                .head("/head_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("head_multi"))
+                .head("/head_multi", RoutingTestBase::multiHandler, (req, res) -> sendHead(res, "head_multi"))
                 .options("/options_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("options_multi"))
                 .trace("/trace_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("trace_multi"))
                 .patch("/patch_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("patch_multi"))
@@ -74,7 +74,7 @@ class RulesTest extends RoutingTestBase {
                 .post((req, res) -> res.send("post_catchall"))
                 .put((req, res) -> res.send("put_catchall"))
                 .delete((req, res) -> res.send("delete_catchall"))
-                .head((req, res) -> res.send("head_catchall"))
+                .head((req, res) -> sendHead(res, "head_catchall"))
                 .options((req, res) -> res.send("options_catchall"))
                 .trace((req, res) -> res.send("trace_catchall"))
                 .patch((req, res) -> res.send("patch_catchall"));


### PR DESCRIPTION
Resolves #12080

Treat HEAD and other no-body HTTP/1 responses as empty when building WebClient responses, and close unframed close-delimited responses instead of returning those connections to the cache. This also preserves HEAD route coverage in WebServer tests while asserting that HEAD responses have no entity.
