### PR TITLE
Add TOML media type

### DIFF
--- a/common/media-type/src/main/java/io/helidon/common/media/type/MediaTypeEnum.java
+++ b/common/media-type/src/main/java/io/helidon/common/media/type/MediaTypeEnum.java
@@ -43,6 +43,7 @@ enum MediaTypeEnum implements MediaType {
     APPLICATION_YAML("application", "yaml"),
     TEXT_X_YAML("text", "x-yaml"),
     TEXT_YAML("text", "yaml"),
+    APPLICATION_TOML("application", "toml"),
     APPLICATION_JAVASCRIPT("application", "javascript"),
     TEXT_EVENT_STREAM("text", "event-stream"),
     APPLICATION_X_NDJSON("application", "x-ndjson"),

--- a/common/media-type/src/main/java/io/helidon/common/media/type/MediaTypes.java
+++ b/common/media-type/src/main/java/io/helidon/common/media/type/MediaTypes.java
@@ -123,6 +123,10 @@ public final class MediaTypes {
      */
     public static final MediaType TEXT_YAML = MediaTypeEnum.TEXT_YAML;
     /**
+     * {@code application/toml} media type.
+     */
+    public static final MediaType APPLICATION_TOML = MediaTypeEnum.APPLICATION_TOML;
+    /**
      * {@code application/javascript} media type.
      */
     public static final MediaType APPLICATION_JAVASCRIPT = MediaTypeEnum.APPLICATION_JAVASCRIPT;
@@ -231,6 +235,10 @@ public final class MediaTypes {
      * String value of media type: {@value}.
      */
     public static final String TEXT_YAML_VALUE = "text/yaml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_TOML_VALUE = "application/toml";
     /**
      * String value of media type: {@value}.
      */

--- a/common/media-type/src/main/resources/io/helidon/common/media/type/default-media-types.properties
+++ b/common/media-type/src/main/resources/io/helidon/common/media/type/default-media-types.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -163,6 +163,7 @@ texi=application/x-texinfo
 texinfo=application/x-texinfo
 tif=image/tiff
 tiff=image/tiff
+toml=application/toml
 tr=application/x-troff
 ts=video/mp2t
 tsv=text/tab-separated-values

--- a/common/media-type/src/test/java/io/helidon/common/media/type/MediaTypesTest.java
+++ b/common/media-type/src/test/java/io/helidon/common/media/type/MediaTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,6 +131,10 @@ class MediaTypesTest {
         Optional<MediaType> hocon = MediaTypes.detectExtensionType("json");
 
         assertThat(hocon, optionalValue(is(MediaTypes.APPLICATION_HOCON)));
+
+        Optional<MediaType> toml = MediaTypes.detectExtensionType("toml");
+
+        assertThat(toml, optionalValue(is(MediaTypes.APPLICATION_TOML)));
     }
 
     @Test


### PR DESCRIPTION
Part of #416.

Adds `application/toml` to the common media type constants and maps the `.toml`
extension to that media type.

The TOML parser and Helidon Config support are being moved to the
`helidon-extensions` repository.

The parser and config parser will be added to our extensions repository.
