### PR TITLE
Remove invalid MP flavor from WebServer GraphQL module

### DIFF
--- a/webserver/graphql/src/main/java/module-info.java
+++ b/webserver/graphql/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import io.helidon.common.features.api.Preview;
 @Features.Name("GraphQL")
 @Features.Description("WebServer GraphQL support")
 @Features.Flavor(HelidonFlavor.SE)
-@Features.InvalidFlavor(HelidonFlavor.MP)
 module io.helidon.webserver.graphql {
 
     requires io.helidon.common.configurable;


### PR DESCRIPTION
## Description

The `io.helidon.webserver.graphql` module declares `@Features.InvalidFlavor(HelidonFlavor.MP)`. However, this SE module is a required dependency of `io.helidon.microprofile.graphql.server`, so it is always loaded in MicroProfile GraphQL applications. This produces a spurious warning on every MP startup:

```
Invalid modules are used: Module "io.helidon.webserver.graphql" (GraphQL) is not designed for Helidon MP, it should only be used in Helidon [SE]
```

SE modules that are legitimately consumed by their MicroProfile counterparts (for example `io.helidon.webserver.cors`) only declare `@Features.Flavor(SE)` and do not mark MP as invalid. This change aligns the WebServer GraphQL module with that convention by removing the `InvalidFlavor` declaration, eliminating the false-positive warning.

Fixes #9511

## Documentation

No doc impact: None