### PR TITLE
4.x: Upgrade Netty to 4.1.135.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -140,7 +140,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.133.Final</version.lib.netty>
+        <version.lib.netty>4.1.135.Final</version.lib.netty>
         <version.lib.oci>3.86.2</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>


### PR DESCRIPTION
### Description

### Description

- Upgrades Netty to 4.1.135.Final. Why does 4.x manage Netty version? See #9645





