### PR TITLE
Update version to 1.4.20-SNAPSHOT

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-applications-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-mp</artifactId>
     <packaging>pom</packaging>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-dependencies</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../dependencies/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.applications</groupId>

--- a/applications/se/pom.xml
+++ b/applications/se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-applications-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-se</artifactId>
     <packaging>pom</packaging>

--- a/archetypes/mp/pom.xml
+++ b/archetypes/mp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-mp</artifactId>
     <packaging>maven-archetype</packaging>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.archetypes</groupId>
     <artifactId>helidon-archetypes-project</artifactId>

--- a/archetypes/se/pom.xml
+++ b/archetypes/se/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-se</artifactId>
     <packaging>maven-archetype</packaging>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-parent</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon</groupId>
@@ -32,7 +32,7 @@
     <name>Helidon BOM POM</name>
 
     <properties>
-        <helidon.version>1.4.19-SNAPSHOT</helidon.version>
+        <helidon.version>1.4.20-SNAPSHOT</helidon.version>
     </properties>
 
     <dependencyManagement>

--- a/bundles/config/pom.xml
+++ b/bundles/config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-bundles-config</artifactId>

--- a/bundles/jersey/pom.xml
+++ b/bundles/jersey/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-bundles-jersey</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modules>
         <module>config</module>

--- a/bundles/security/pom.xml
+++ b/bundles/security/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-bundles-security</artifactId>

--- a/bundles/webserver/pom.xml
+++ b/bundles/webserver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-bundles-webserver</artifactId>

--- a/common/common/pom.xml
+++ b/common/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common</artifactId>
     <name>Helidon Common</name>

--- a/common/configurable/pom.xml
+++ b/common/configurable/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <name>Helidon Common Configurable</name>
     <artifactId>helidon-common-configurable</artifactId>

--- a/common/context/pom.xml
+++ b/common/context/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-context</artifactId>
     <name>Helidon Common Context</name>

--- a/common/http/pom.xml
+++ b/common/http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-common-project</artifactId>
         <groupId>io.helidon.common</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-common-http</artifactId>

--- a/common/key-util/pom.xml
+++ b/common/key-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-key-util</artifactId>
     <name>Helidon Common Key Util</name>

--- a/common/mapper/pom.xml
+++ b/common/mapper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-common-project</artifactId>
         <groupId>io.helidon.common</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/media-type/pom.xml
+++ b/common/media-type/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-media-type</artifactId>
 

--- a/common/metrics/pom.xml
+++ b/common/metrics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-metrics</artifactId>
     

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.common</groupId>
     <artifactId>helidon-common-project</artifactId>

--- a/common/reactive/pom.xml
+++ b/common/reactive/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-reactive</artifactId>
     <name>Helidon Common Reactive</name>

--- a/common/service-loader/pom.xml
+++ b/common/service-loader/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-common-project</artifactId>
         <groupId>io.helidon.common</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config</artifactId>
     <name>Helidon Config</name>

--- a/config/encryption/pom.xml
+++ b/config/encryption/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-config-encryption</artifactId>

--- a/config/etcd/pom.xml
+++ b/config/etcd/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-etcd</artifactId>
     <name>Helidon Config Etcd</name>

--- a/config/git/pom.xml
+++ b/config/git/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-git</artifactId>
     <name>Helidon Config Git</name>

--- a/config/hocon/pom.xml
+++ b/config/hocon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-hocon</artifactId>
     <name>Helidon Config HOCON</name>

--- a/config/object-mapping/pom.xml
+++ b/config/object-mapping/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-config-project</artifactId>
         <groupId>io.helidon.config</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.config</groupId>
     <artifactId>helidon-config-project</artifactId>

--- a/config/test-infrastructure/pom.xml
+++ b/config/test-infrastructure/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-test-infrastructure</artifactId>
     <name>Helidon Config Test Infrastructure</name>

--- a/config/testing/pom.xml
+++ b/config/testing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-testing</artifactId>
     <name>Helidon Config Testing</name>

--- a/config/tests/integration-tests/pom.xml
+++ b/config/tests/integration-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-integration-tests</artifactId>
     <name>Helidon Config Tests Integration</name>

--- a/config/tests/module-mappers-1-base/pom.xml
+++ b/config/tests/module-mappers-1-base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-mappers-1-base</artifactId>
     <name>Helidon Config Tests Mappers 1</name>

--- a/config/tests/module-mappers-2-override/pom.xml
+++ b/config/tests/module-mappers-2-override/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-mappers-2-override</artifactId>
     <name>Helidon Config Tests Parser 2</name>

--- a/config/tests/module-meta-source-1/pom.xml
+++ b/config/tests/module-meta-source-1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-meta-source-1</artifactId>
     <name>Helidon Config Tests Meta Source 1</name>

--- a/config/tests/module-meta-source-2/pom.xml
+++ b/config/tests/module-meta-source-2/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-meta-source-2</artifactId>
     <name>Helidon Config Tests Meta Source 2</name>

--- a/config/tests/module-parsers-1-override/pom.xml
+++ b/config/tests/module-parsers-1-override/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-parsers-1-override</artifactId>
     <name>Helidon Config Tests Parser 1</name>

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.config.tests</groupId>
     <artifactId>helidon-config-tests-project</artifactId>

--- a/config/tests/test-bundle/pom.xml
+++ b/config/tests/test-bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-bundle</artifactId>
     <name>Helidon Config Tests Bundle</name>

--- a/config/tests/test-default_config-1-properties/pom.xml
+++ b/config/tests/test-default_config-1-properties/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-1-properties</artifactId>
     <name>Helidon Config Tests Default Config 1</name>

--- a/config/tests/test-default_config-2-hocon-json/pom.xml
+++ b/config/tests/test-default_config-2-hocon-json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-2-hocon-json</artifactId>
     <name>Helidon Config Tests Default Config 2</name>

--- a/config/tests/test-default_config-3-hocon/pom.xml
+++ b/config/tests/test-default_config-3-hocon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-3-hocon</artifactId>
     <name>Helidon Config Tests Default Config 3</name>

--- a/config/tests/test-default_config-4-yaml/pom.xml
+++ b/config/tests/test-default_config-4-yaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-4-yaml</artifactId>
     <name>Helidon Config Tests Default Config 4</name>

--- a/config/tests/test-default_config-5-env_vars/pom.xml
+++ b/config/tests/test-default_config-5-env_vars/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-5-env_vars</artifactId>
     <name>Helidon Config Tests Default Config 5</name>

--- a/config/tests/test-default_config-6-meta-properties/pom.xml
+++ b/config/tests/test-default_config-6-meta-properties/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-6-meta-properties</artifactId>
     <name>Helidon Config Tests Default Config 6</name>

--- a/config/tests/test-default_config-7-meta-hocon-json/pom.xml
+++ b/config/tests/test-default_config-7-meta-hocon-json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-7-meta-hocon-json</artifactId>
     <name>Helidon Config Tests Default Config 7</name>

--- a/config/tests/test-default_config-8-meta-hocon/pom.xml
+++ b/config/tests/test-default_config-8-meta-hocon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-8-meta-hocon</artifactId>
     <name>Helidon Config Tests Default Config 8</name>

--- a/config/tests/test-default_config-9-meta-yaml/pom.xml
+++ b/config/tests/test-default_config-9-meta-yaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-9-meta-yaml</artifactId>
     <name>Helidon Config Tests Default Config 9</name>

--- a/config/tests/test-mappers-1-common/pom.xml
+++ b/config/tests/test-mappers-1-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-mappers-1-common</artifactId>
     <name>Helidon Config Tests Mappers Common 1</name>

--- a/config/tests/test-mappers-2-complex/pom.xml
+++ b/config/tests/test-mappers-2-complex/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-mappers-2-complex</artifactId>
     <name>Helidon Config Tests Parsers 2</name>

--- a/config/tests/test-meta-source/pom.xml
+++ b/config/tests/test-meta-source/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-meta-source</artifactId>
     <name>Helidon Config Tests Meta Source</name>

--- a/config/tests/test-parsers-1-complex/pom.xml
+++ b/config/tests/test-parsers-1-complex/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-parsers-1-complex</artifactId>
     <name>Helidon Config Tests Parsers 1</name>

--- a/config/yaml/pom.xml
+++ b/config/yaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-yaml</artifactId>
     <name>Helidon Config YAML</name>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-bom</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../bom/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dependencies</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-docs</artifactId>
     <name>Helidon Documentation</name>

--- a/examples/config/basics/pom.xml
+++ b/examples/config/basics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/changes/pom.xml
+++ b/examples/config/changes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/git/pom.xml
+++ b/examples/config/git/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/mapping/pom.xml
+++ b/examples/config/mapping/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/overrides/pom.xml
+++ b/examples/config/overrides/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/pom.xml
+++ b/examples/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.config</groupId>
     <artifactId>helidon-examples-config-project</artifactId>

--- a/examples/config/sources/pom.xml
+++ b/examples/config/sources/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/employee-app/pom.xml
+++ b/examples/employee-app/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.employee</groupId>

--- a/examples/grpc/basics/pom.xml
+++ b/examples/grpc/basics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/common/pom.xml
+++ b/examples/grpc/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/metrics/pom.xml
+++ b/examples/grpc/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/microprofile/basic-client/pom.xml
+++ b/examples/grpc/microprofile/basic-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples.grpc.microprofile</groupId>
         <artifactId>helidon-examples-grpc-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-examples-grpc-microprofile-client</artifactId>
     <name>Helidon Microprofile gRPC Client Example</name>

--- a/examples/grpc/microprofile/basic-server-implicit/pom.xml
+++ b/examples/grpc/microprofile/basic-server-implicit/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples.grpc.microprofile</groupId>
         <artifactId>helidon-examples-grpc-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-examples-grpc-microprofile-basic-implicit</artifactId>
     <name>Helidon Microprofile Examples gRPC Implicit Server</name>

--- a/examples/grpc/microprofile/metrics/pom.xml
+++ b/examples/grpc/microprofile/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples.grpc.microprofile</groupId>
         <artifactId>helidon-examples-grpc-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-examples-grpc-microprofile-metrics</artifactId>
     <name>Helidon Microprofile Examples gRPC Metrics</name>

--- a/examples/grpc/microprofile/pom.xml
+++ b/examples/grpc/microprofile/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples.grpc</groupId>
         <artifactId>helidon-examples-grpc-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.examples.grpc.microprofile</groupId>

--- a/examples/grpc/opentracing/pom.xml
+++ b/examples/grpc/opentracing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/pom.xml
+++ b/examples/grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>
     <artifactId>helidon-examples-grpc-project</artifactId>

--- a/examples/grpc/security-abac/pom.xml
+++ b/examples/grpc/security-abac/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/security-outbound/pom.xml
+++ b/examples/grpc/security-outbound/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/security/pom.xml
+++ b/examples/grpc/security/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/health/basics/pom.xml
+++ b/examples/health/basics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.health</groupId>

--- a/examples/health/pom.xml
+++ b/examples/health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-examples-project</artifactId>
         <groupId>io.helidon.examples</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.health</groupId>
     <artifactId>helidon-examples-health-project</artifactId>

--- a/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/jedis/pom.xml
+++ b/examples/integrations/cdi/jedis/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/jpa/pom.xml
+++ b/examples/integrations/cdi/jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/oci-objectstorage/pom.xml
+++ b/examples/integrations/cdi/oci-objectstorage/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/pom.xml
+++ b/examples/integrations/cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples.integrations</groupId>
         <artifactId>helidon-examples-integrations-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>
     <artifactId>helidon-examples-integrations-cdi-project</artifactId>

--- a/examples/integrations/pom.xml
+++ b/examples/integrations/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.integrations</groupId>
     <artifactId>helidon-examples-integrations-project</artifactId>

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-examples-microprofile-hello-world-explicit</artifactId>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/idcs/pom.xml
+++ b/examples/microprofile/idcs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/mp1_1-security/pom.xml
+++ b/examples/microprofile/mp1_1-security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/mp1_1-static-content/pom.xml
+++ b/examples/microprofile/mp1_1-static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/oidc/pom.xml
+++ b/examples/microprofile/oidc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/pom.xml
+++ b/examples/microprofile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/openapi/pom.xml
+++ b/examples/openapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples</groupId>
     <artifactId>helidon-examples-project</artifactId>

--- a/examples/quickstarts/helidon-quickstart-mp/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/build.gradle
@@ -29,7 +29,7 @@ tasks.withType(JavaCompile) {
 }
 
 ext {
-    helidonversion = '1.4.19-SNAPSHOT'
+    helidonversion = '1.4.20-SNAPSHOT'
 }
 
 repositories {

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/quickstarts/helidon-quickstart-se/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/build.gradle
@@ -29,7 +29,7 @@ tasks.withType(JavaCompile) {
 }
 
 ext {
-    helidonversion = '1.4.19-SNAPSHOT'
+    helidonversion = '1.4.20-SNAPSHOT'
 }
 
 test {

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>
     <artifactId>helidon-quickstart-se</artifactId>
-    <version>1.4.19-SNAPSHOT</version>
+    <version>1.4.20-SNAPSHOT</version>
     <name>Helidon Quickstart SE Example</name>
 
     <properties>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -22,11 +22,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon.examples.quickstarts</groupId>
     <artifactId>helidon-standalone-quickstart-mp</artifactId>
-    <version>1.4.19-SNAPSHOT</version>
+    <version>1.4.20-SNAPSHOT</version>
     <name>Helidon Standalone Quickstart MP Example</name>
 
     <properties>
-        <helidon.version>1.4.19-SNAPSHOT</helidon.version>
+        <helidon.version>1.4.20-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.examples.quickstart.mp.Main</mainClass>
 
         <maven.compiler.source>8</maven.compiler.source>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -22,11 +22,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon.examples.quickstarts</groupId>
     <artifactId>helidon-standalone-quickstart-se</artifactId>
-    <version>1.4.19-SNAPSHOT</version>
+    <version>1.4.20-SNAPSHOT</version>
     <name>Helidon Standalone Quickstart SE Example</name>
 
     <properties>
-        <helidon.version>1.4.19-SNAPSHOT</helidon.version>
+        <helidon.version>1.4.20-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.examples.quickstart.se.Main</mainClass>
 
         <maven.compiler.source>8</maven.compiler.source>

--- a/examples/quickstarts/pom.xml
+++ b/examples/quickstarts/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.quickstarts</groupId>
     <artifactId>examples-quickstarts-project</artifactId>

--- a/examples/security/attribute-based-access-control/pom.xml
+++ b/examples/security/attribute-based-access-control/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/google-login/pom.xml
+++ b/examples/security/google-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/idcs-login/pom.xml
+++ b/examples/security/idcs-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/jersey/pom.xml
+++ b/examples/security/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/nohttp-programmatic/pom.xml
+++ b/examples/security/nohttp-programmatic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/outbound-override/pom.xml
+++ b/examples/security/outbound-override/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/pom.xml
+++ b/examples/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.security</groupId>
     <artifactId>helidon-examples-security-project</artifactId>

--- a/examples/security/spi-examples/pom.xml
+++ b/examples/security/spi-examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/webserver-digest-auth/pom.xml
+++ b/examples/security/webserver-digest-auth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/webserver-signatures/pom.xml
+++ b/examples/security/webserver-signatures/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/todo-app/backend/pom.xml
+++ b/examples/todo-app/backend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.todos</groupId>

--- a/examples/todo-app/frontend/pom.xml
+++ b/examples/todo-app/frontend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.todo</groupId>

--- a/examples/todo-app/pom.xml
+++ b/examples/todo-app/pom.xml
@@ -25,7 +25,7 @@
     <groupId>io.helidon.examples.todos</groupId>
     <artifactId>example-todo-app-project</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.19-SNAPSHOT</version>
+    <version>1.4.20-SNAPSHOT</version>
     <name>Helidon Examples TODO Demo</name>
 
     <description>

--- a/examples/translator-app/backend/pom.xml
+++ b/examples/translator-app/backend/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>
     <artifactId>helidon-examples-translator-backend</artifactId>
-    <version>1.4.19-SNAPSHOT</version>
+    <version>1.4.20-SNAPSHOT</version>
     <name>Helidon Examples Translator Backend</name>
 
     <description>

--- a/examples/translator-app/frontend/pom.xml
+++ b/examples/translator-app/frontend/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>
     <artifactId>helidon-examples-translator-frontend</artifactId>
-    <version>1.4.19-SNAPSHOT</version>
+    <version>1.4.20-SNAPSHOT</version>
     <name>Helidon Examples Translator Frontend</name>
 
     <description>

--- a/examples/translator-app/pom.xml
+++ b/examples/translator-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>
     <artifactId>helidon-examples-translator-project</artifactId>

--- a/examples/webserver/basics/pom.xml
+++ b/examples/webserver/basics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/comment-aas/pom.xml
+++ b/examples/webserver/comment-aas/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/jersey/pom.xml
+++ b/examples/webserver/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/opentracing/pom.xml
+++ b/examples/webserver/opentracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/pom.xml
+++ b/examples/webserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>
     <artifactId>helidon-examples-webserver-project</artifactId>

--- a/examples/webserver/static-content/pom.xml
+++ b/examples/webserver/static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/streaming/pom.xml
+++ b/examples/webserver/streaming/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/tutorial/pom.xml
+++ b/examples/webserver/tutorial/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/grpc/client/pom.xml
+++ b/grpc/client/pom.xml
@@ -25,7 +25,7 @@
     <parent>
       <groupId>io.helidon.grpc</groupId>
       <artifactId>helidon-grpc-project</artifactId>
-      <version>1.4.19-SNAPSHOT</version>
+      <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-grpc-client</artifactId>

--- a/grpc/core/pom.xml
+++ b/grpc/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-grpc-core</artifactId>

--- a/grpc/io.grpc/pom.xml
+++ b/grpc/io.grpc/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.grpc</artifactId>

--- a/grpc/metrics/pom.xml
+++ b/grpc/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-grpc-metrics</artifactId>

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>helidon-project</artifactId>
         <groupId>io.helidon</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.grpc</groupId>

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-grpc-server</artifactId>

--- a/health/common/pom.xml
+++ b/health/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-health-project</artifactId>
         <groupId>io.helidon.health</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/health/health-checks/pom.xml
+++ b/health/health-checks/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.health</groupId>
         <artifactId>helidon-health-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-health-checks</artifactId>

--- a/health/health/pom.xml
+++ b/health/health/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-health-project</artifactId>
         <groupId>io.helidon.health</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/integrations/cdi/common-cdi/delegates/pom.xml
+++ b/integrations/cdi/common-cdi/delegates/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-delegates</artifactId>
     <name>Helidon CDI Integrations Common Delegates</name>

--- a/integrations/cdi/common-cdi/pom.xml
+++ b/integrations/cdi/common-cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-common-project</artifactId>
     <packaging>pom</packaging>

--- a/integrations/cdi/common-cdi/reference-counted-context/pom.xml
+++ b/integrations/cdi/common-cdi/reference-counted-context/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-common-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-reference-counted-context</artifactId>
     <name>Helidon CDI Integrations Common Reference Counted Context</name>

--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
     <name>Helidon CDI Integrations HikariCP DataSource</name>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-datasource-ucp</artifactId>
     <name>Helidon CDI Integrations UCP DataSource</name>

--- a/integrations/cdi/datasource/pom.xml
+++ b/integrations/cdi/datasource/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-datasource</artifactId>
     <name>Helidon CDI Integrations DataSource</name>

--- a/integrations/cdi/eclipselink-cdi/pom.xml
+++ b/integrations/cdi/eclipselink-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-eclipselink</artifactId>
     <name>Helidon CDI Integrations Eclipselink</name>

--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-hibernate</artifactId>
     <name>Helidon CDI Integrations Hibernate</name>

--- a/integrations/cdi/jedis-cdi/pom.xml
+++ b/integrations/cdi/jedis-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jedis</artifactId>
     <name>Helidon CDI Integrations Jedis</name>

--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jpa</artifactId>
     <name>Helidon CDI Integrations JPA</name>

--- a/integrations/cdi/jpa-weld/pom.xml
+++ b/integrations/cdi/jpa-weld/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jpa-weld</artifactId>
     <name>Helidon CDI Integrations JPA Weld</name>

--- a/integrations/cdi/jta-cdi/pom.xml
+++ b/integrations/cdi/jta-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jta</artifactId>
     <name>Helidon CDI Integrations JTA</name>

--- a/integrations/cdi/jta-weld/pom.xml
+++ b/integrations/cdi/jta-weld/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jta-weld</artifactId>
     <name>Helidon CDI Integrations JTA Weld</name>

--- a/integrations/cdi/oci-objectstorage-cdi/pom.xml
+++ b/integrations/cdi/oci-objectstorage-cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-oci-objectstorage</artifactId>
     <name>Helidon CDI Integrations OCI Object Storage</name>

--- a/integrations/cdi/pom.xml
+++ b/integrations/cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.integrations.cdi</groupId>
     <artifactId>helidon-integrations-cdi-project</artifactId>

--- a/integrations/graal/native-image-extension/pom.xml
+++ b/integrations/graal/native-image-extension/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.integrations.graal</groupId>
         <artifactId>helidon-integrations-graal-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/graal/pom.xml
+++ b/integrations/graal/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.graal</groupId>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.integrations</groupId>
     <artifactId>helidon-integrations-project</artifactId>

--- a/integrations/serviceconfiguration/pom.xml
+++ b/integrations/serviceconfiguration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.serviceconfiguration</groupId>
     <artifactId>helidon-serviceconfiguration-project</artifactId>

--- a/integrations/serviceconfiguration/serviceconfiguration-api/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-api</artifactId>
     <name>Helidon Service Configuration API</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-config-source/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-config-source/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-config-source</artifactId>
     <name>Helidon Service Configuration ConfigSource</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
     <name>Helidon ServiceConfiguration HikariCP ACCS</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp-localhost/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp-localhost/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
     <name>Helidon ServiceConfiguration HikariCP Localhost</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
     <name>Helidon ServiceConfiguration HikariCP Implementation</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-system-kubernetes/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-system-kubernetes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-system-kubernetes</artifactId>
     <name>Helidon Kubernetes System Implementation</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-system-oracle-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-system-oracle-accs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-system-oracle-accs</artifactId>
     <name>Helidon Oracle ACCS System Implementation</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-ucp-accs</artifactId>
     <name>Helidon ServiceConfiguration UCP ACCS</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-ucp-localhost</artifactId>
     <name>Helidon ServiceConfiguration UCP Localhost</name>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.serviceconfiguration</groupId>
         <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-serviceconfiguration-ucp</artifactId>
     <name>Helidon ServiceConfiguration UCP Implementation</name>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-javadocs</artifactId>
     <name>Helidon Javadocs</name>

--- a/jersey/client/pom.xml
+++ b/jersey/client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.jersey</groupId>
         <artifactId>helidon-jersey-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jersey/common/pom.xml
+++ b/jersey/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-jersey-project</artifactId>
         <groupId>io.helidon.jersey</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jersey/jsonp/pom.xml
+++ b/jersey/jsonp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-jersey-project</artifactId>
         <groupId>io.helidon.jersey</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jersey/pom.xml
+++ b/jersey/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-project</artifactId>
         <groupId>io.helidon</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/jersey/server/pom.xml
+++ b/jersey/server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.jersey</groupId>
         <artifactId>helidon-jersey-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-jersey-server</artifactId>

--- a/media/common/pom.xml
+++ b/media/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/media/jackson/common/pom.xml
+++ b/media/jackson/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-media-jackson-project</artifactId>
         <groupId>io.helidon.media.jackson</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/media/jackson/pom.xml
+++ b/media/jackson/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/media/jackson/server/pom.xml
+++ b/media/jackson/server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-media-jackson-project</artifactId>
         <groupId>io.helidon.media.jackson</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/media/jsonb/common/pom.xml
+++ b/media/jsonb/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-media-jsonb-project</artifactId>
         <groupId>io.helidon.media.jsonb</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/media/jsonb/pom.xml
+++ b/media/jsonb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/media/jsonb/server/pom.xml
+++ b/media/jsonb/server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-media-jsonb-project</artifactId>
         <groupId>io.helidon.media.jsonb</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/media/jsonp/common/pom.xml
+++ b/media/jsonp/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-media-jsonp-project</artifactId>
         <groupId>io.helidon.media.jsonp</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/media/jsonp/pom.xml
+++ b/media/jsonp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/media/jsonp/server/pom.xml
+++ b/media/jsonp/server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-media-jsonp-project</artifactId>
         <groupId>io.helidon.media.jsonp</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/media/pom.xml
+++ b/media/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.media</groupId>

--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-metrics</artifactId>
     <name>Helidon Metrics</name>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.metrics</groupId>

--- a/metrics/prometheus/pom.xml
+++ b/metrics/prometheus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-metrics-prometheus</artifactId>
     <name>Helidon Metrics Prometheus</name>

--- a/metrics2/metrics2/pom.xml
+++ b/metrics2/metrics2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics2-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-metrics2</artifactId>
     <name>Helidon Metrics2</name>

--- a/metrics2/pom.xml
+++ b/metrics2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.metrics</groupId>

--- a/microprofile/access-log/pom.xml
+++ b/microprofile/access-log/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-microprofile-project</artifactId>
         <groupId>io.helidon.microprofile</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/bundles/helidon-microprofile-1.0/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-1.0/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-1.0</artifactId>
     <name>Helidon Microprofile Bundles 1.0</name>

--- a/microprofile/bundles/helidon-microprofile-1.1/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-1.1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-1.1</artifactId>
     <name>Helidon Microprofile Bundles 1.1</name>

--- a/microprofile/bundles/helidon-microprofile-1.2/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-1.2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-1.2</artifactId>
     <name>Helidon Microprofile Bundles 1.2</name>

--- a/microprofile/bundles/helidon-microprofile-2.2/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-2.2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-2.2</artifactId>
     <name>Helidon Microprofile Bundles 2.2</name>

--- a/microprofile/bundles/helidon-microprofile-3.0/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-3.0/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-3.0</artifactId>
     <name>Helidon Microprofile Bundles 3.0</name>

--- a/microprofile/bundles/helidon-microprofile-3.1/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-3.1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-3.1</artifactId>
     <name>Helidon Microprofile Bundles 3.1</name>

--- a/microprofile/bundles/helidon-microprofile-core/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-core</artifactId>
     <name>Helidon Microprofile Core Bundle</name>

--- a/microprofile/bundles/helidon-microprofile/pom.xml
+++ b/microprofile/bundles/helidon-microprofile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile</artifactId>
     <name>Helidon Microprofile Full Bundle</name>

--- a/microprofile/bundles/internal-test-libs/pom.xml
+++ b/microprofile/bundles/internal-test-libs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>internal-test-libs</artifactId>
     <name>Helidon Microprofile Bundles Test Libraries</name>

--- a/microprofile/bundles/pom.xml
+++ b/microprofile/bundles/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.bundles</groupId>

--- a/microprofile/config/config-cdi/pom.xml
+++ b/microprofile/config/config-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.config</groupId>
         <artifactId>helidon-microprofile-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-config-cdi</artifactId>
     <name>Helidon Microprofile Config CDI</name>

--- a/microprofile/config/config/pom.xml
+++ b/microprofile/config/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.config</groupId>
         <artifactId>helidon-microprofile-config-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-config</artifactId>
     <name>Helidon Microprofile Config</name>

--- a/microprofile/config/pom.xml
+++ b/microprofile/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.config</groupId>

--- a/microprofile/fault-tolerance/pom.xml
+++ b/microprofile/fault-tolerance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-fault-tolerance</artifactId>
     <name>Helidon Microprofile Fault Tolerance</name>

--- a/microprofile/grpc/client/pom.xml
+++ b/microprofile/grpc/client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.grpc</groupId>
         <artifactId>helidon-microprofile-grpc</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-grpc-client</artifactId>

--- a/microprofile/grpc/core/pom.xml
+++ b/microprofile/grpc/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.grpc</groupId>
         <artifactId>helidon-microprofile-grpc</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-grpc-core</artifactId>

--- a/microprofile/grpc/metrics/pom.xml
+++ b/microprofile/grpc/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.grpc</groupId>
         <artifactId>helidon-microprofile-grpc</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-grpc-metrics</artifactId>

--- a/microprofile/grpc/pom.xml
+++ b/microprofile/grpc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.grpc</groupId>

--- a/microprofile/grpc/server/pom.xml
+++ b/microprofile/grpc/server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.grpc</groupId>
         <artifactId>helidon-microprofile-grpc</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-grpc-server</artifactId>

--- a/microprofile/health/pom.xml
+++ b/microprofile/health/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.health</groupId>
     <artifactId>helidon-microprofile-health</artifactId>

--- a/microprofile/jwt-auth/jwt-auth-cdi/pom.xml
+++ b/microprofile/jwt-auth/jwt-auth-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>helidon-microprofile-jwt-project</artifactId>
         <groupId>io.helidon.microprofile.jwt</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-jwt-auth-cdi</artifactId>

--- a/microprofile/jwt-auth/jwt-auth/pom.xml
+++ b/microprofile/jwt-auth/jwt-auth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-microprofile-jwt-project</artifactId>
         <groupId>io.helidon.microprofile.jwt</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/jwt-auth/pom.xml
+++ b/microprofile/jwt-auth/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.jwt</groupId>

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.metrics</groupId>
     <artifactId>helidon-microprofile-metrics</artifactId>

--- a/microprofile/metrics2/pom.xml
+++ b/microprofile/metrics2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.metrics</groupId>
     <artifactId>helidon-microprofile-metrics2</artifactId>

--- a/microprofile/oidc/pom.xml
+++ b/microprofile/oidc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-oidc</artifactId>
     <name>Helidon Microprofile Security OIDC Integration</name>

--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.openapi</groupId>
     <artifactId>helidon-microprofile-openapi</artifactId>

--- a/microprofile/pom.xml
+++ b/microprofile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile</groupId>

--- a/microprofile/rest-client/pom.xml
+++ b/microprofile/rest-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.rest-client</groupId>

--- a/microprofile/security/pom.xml
+++ b/microprofile/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-security</artifactId>
     <name>Helidon Microprofile Security Integration</name>

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.server</groupId>
     <artifactId>helidon-microprofile-server</artifactId>

--- a/microprofile/tests/arquillian/pom.xml
+++ b/microprofile/tests/arquillian/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-arquillian</artifactId>
     <name>Helidon Microprofile Arquillian Integration</name>

--- a/microprofile/tests/pom.xml
+++ b/microprofile/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.tests</groupId>

--- a/microprofile/tests/tck/pom.xml
+++ b/microprofile/tests/tck/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/microprofile/tests/tck/tck-config/pom.xml
+++ b/microprofile/tests/tck/tck-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>tck-config</artifactId>
     <name>Helidon Microprofile Tests TCK Config</name>

--- a/microprofile/tests/tck/tck-fault-tolerance/pom.xml
+++ b/microprofile/tests/tck/tck-fault-tolerance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>tck-fault-tolerance</artifactId>
     <name>Helidon Microprofile Tests TCK Fault Tolerance</name>

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tests/tck/tck-jwt-auth/pom.xml
+++ b/microprofile/tests/tck/tck-jwt-auth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>tck-project</artifactId>
         <groupId>io.helidon.microprofile.tests</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>tck-jwt-auth</artifactId>
     <name>Helidon Microprofile Tests TCK JWT-Auth</name>

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>tck-metrics</artifactId>
     <name>Helidon Microprofile Tests TCK Metrics</name>

--- a/microprofile/tests/tck/tck-metrics2/pom.xml
+++ b/microprofile/tests/tck/tck-metrics2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>tck-metrics2</artifactId>
     <name>Helidon Microprofile Tests TCK Metrics 2</name>

--- a/microprofile/tests/tck/tck-openapi/pom.xml
+++ b/microprofile/tests/tck/tck-openapi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>tck-project</artifactId>
         <groupId>io.helidon.microprofile.tests</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>tck-opentracing</artifactId>
     <name>Helidon Microprofile Tests TCK Opentracing</name>

--- a/microprofile/tests/tck/tck-rest-client/pom.xml
+++ b/microprofile/tests/tck/tck-rest-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>tck-project</artifactId>
         <groupId>io.helidon.microprofile.tests</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tracing/pom.xml
+++ b/microprofile/tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-microprofile-project</artifactId>
         <groupId>io.helidon.microprofile</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.tracing</groupId>
     <artifactId>helidon-microprofile-tracing</artifactId>

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.openapi</groupId>
     <artifactId>helidon-openapi</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon</groupId>
     <artifactId>helidon-parent</artifactId>
-    <version>1.4.19-SNAPSHOT</version>
+    <version>1.4.20-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Helidon Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-dependencies</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>./dependencies/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-project</artifactId>

--- a/security/abac/policy-el/pom.xml
+++ b/security/abac/policy-el/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-security-abac-policy-el</artifactId>

--- a/security/abac/policy/pom.xml
+++ b/security/abac/policy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-abac-policy</artifactId>
     <name>Helidon Security Validators Policy</name>

--- a/security/abac/pom.xml
+++ b/security/abac/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/security/abac/role/pom.xml
+++ b/security/abac/role/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-abac-role</artifactId>
     <name>Helidon Security Validators Role</name>

--- a/security/abac/scope/pom.xml
+++ b/security/abac/scope/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-abac-scope</artifactId>
     <name>Helidon Security Validators Scope</name>

--- a/security/abac/time/pom.xml
+++ b/security/abac/time/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-abac-time</artifactId>
     <name>Helidon Security Validators Time</name>

--- a/security/annotations/pom.xml
+++ b/security/annotations/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-annotations</artifactId>
     <name>Helidon Security Integration Annotations</name>

--- a/security/integration/common/pom.xml
+++ b/security/integration/common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-common</artifactId>
     <name>Helidon Security Integration Common</name>

--- a/security/integration/grpc/pom.xml
+++ b/security/integration/grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-grpc</artifactId>
     <name>Helidon Security Integration gRPC Server</name>

--- a/security/integration/jersey-client/pom.xml
+++ b/security/integration/jersey-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-jersey-client</artifactId>
     <name>Helidon Security Integration Jersey Client</name>

--- a/security/integration/jersey/pom.xml
+++ b/security/integration/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-jersey</artifactId>
     <name>Helidon Security Integration Jersey</name>

--- a/security/integration/pom.xml
+++ b/security/integration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/security/integration/webserver/pom.xml
+++ b/security/integration/webserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-webserver</artifactId>
     <name>Helidon Security Integration Webserver</name>

--- a/security/jwt/pom.xml
+++ b/security/jwt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-jwt</artifactId>
     <name>Helidon Security JWT</name>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.security</groupId>

--- a/security/providers/abac/pom.xml
+++ b/security/providers/abac/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-abac</artifactId>
     <name>Helidon Security Providers ABAC</name>

--- a/security/providers/common/pom.xml
+++ b/security/providers/common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-common</artifactId>
     <name>Helidon Security Providers Common</name>

--- a/security/providers/google-login/pom.xml
+++ b/security/providers/google-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-google-login</artifactId>
     <name>Helidon Security Providers Google Login</name>

--- a/security/providers/header/pom.xml
+++ b/security/providers/header/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-header</artifactId>
     <name>Helidon Security Providers Header authentication</name>

--- a/security/providers/http-auth/pom.xml
+++ b/security/providers/http-auth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-http-auth</artifactId>
     <name>Helidon Security Providers HTTP Authentication</name>

--- a/security/providers/http-sign/pom.xml
+++ b/security/providers/http-sign/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-http-sign</artifactId>
     <name>Helidon Security Providers HTTP Signature</name>

--- a/security/providers/idcs-mapper/pom.xml
+++ b/security/providers/idcs-mapper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/security/providers/jwt/pom.xml
+++ b/security/providers/jwt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-jwt</artifactId>
     <name>Helidon Security Providers JWT</name>

--- a/security/providers/oidc-common/pom.xml
+++ b/security/providers/oidc-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-security-providers-oidc-common</artifactId>

--- a/security/providers/oidc/pom.xml
+++ b/security/providers/oidc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-security-providers-oidc</artifactId>

--- a/security/providers/pom.xml
+++ b/security/providers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.security.providers</groupId>
     <artifactId>helidon-security-providers-project</artifactId>

--- a/security/security/pom.xml
+++ b/security/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security</artifactId>
     <name>Helidon Security</name>

--- a/security/util/pom.xml
+++ b/security/util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-util</artifactId>
     <name>Helidon Security Utilities</name>

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.apps.bookstore.bookstore-mp</groupId>

--- a/tests/apps/bookstore/bookstore-se/pom.xml
+++ b/tests/apps/bookstore/bookstore-se/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.apps.bookstore.bookstore-se</groupId>

--- a/tests/apps/bookstore/common/pom.xml
+++ b/tests/apps/bookstore/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.apps.bookstore.common</groupId>

--- a/tests/apps/bookstore/pom.xml
+++ b/tests/apps/bookstore/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests.apps</groupId>
         <artifactId>helidon-tests-apps-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.apps.bookstore</groupId>

--- a/tests/apps/pom.xml
+++ b/tests/apps/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.apps</groupId>

--- a/tests/functional/bookstore/pom.xml
+++ b/tests/functional/bookstore/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tests.functional</groupId>
         <artifactId>helidon-tests-functional-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.tests.functional.bookstore</groupId>
     <artifactId>helidon-tests-functional-bookstore</artifactId>

--- a/tests/functional/context-propagation/pom.xml
+++ b/tests/functional/context-propagation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-functional-context-propagation</artifactId>

--- a/tests/functional/jax-rs-subresource/pom.xml
+++ b/tests/functional/jax-rs-subresource/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-tests-functional-jax-rs-subresource</artifactId>
     <name>Helidon Functional Test: JAX-RS Subresources</name>

--- a/tests/functional/multiport/pom.xml
+++ b/tests/functional/multiport/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-tests-functional-multiport</artifactId>
     <name>Helidon Functional Test: Multiport with MP</name>

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.functional</groupId>

--- a/tests/integration/gh-5792/pom.xml
+++ b/tests/integration/gh-5792/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>
     <artifactId>helidon-tests-integration-yaml-parsing</artifactId>
-    <version>1.4.19-SNAPSHOT</version>
+    <version>1.4.20-SNAPSHOT</version>
     <name>${project.artifactId}</name>
 
     <properties>

--- a/tests/integration/health/mp-disabled/pom.xml
+++ b/tests/integration/health/mp-disabled/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration.health</groupId>

--- a/tests/integration/health/pom.xml
+++ b/tests/integration/health/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.tests.integration.health</groupId>
     <artifactId>helidon-tests-integration-health-project</artifactId>

--- a/tests/integration/mp-autodiscovery/pom.xml
+++ b/tests/integration/mp-autodiscovery/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/mp-gh-1468/pom.xml
+++ b/tests/integration/mp-gh-1468/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-gh-1538/pom.xml
+++ b/tests/integration/mp-gh-1538/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-jaeger-3052/pom.xml
+++ b/tests/integration/mp-jaeger-3052/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-security-client/pom.xml
+++ b/tests/integration/mp-security-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/mp-ws-services/pom.xml
+++ b/tests/integration/mp-ws-services/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/native-image/pom.xml
+++ b/tests/integration/native-image/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/tests/integration/native-image/se-1/pom.xml
+++ b/tests/integration/native-image/se-1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/native-image/static-content/pom.xml
+++ b/tests/integration/native-image/static-content/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/security/gh1487/pom.xml
+++ b/tests/integration/security/gh1487/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/security/path-params/pom.xml
+++ b/tests/integration/security/path-params/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/security/pom.xml
+++ b/tests/integration/security/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/integration/zipkin-mp-2.2/pom.xml
+++ b/tests/integration/zipkin-mp-2.2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests</groupId>

--- a/tracing/config/pom.xml
+++ b/tracing/config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-config</artifactId>

--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-jaeger</artifactId>

--- a/tracing/jersey-client/pom.xml
+++ b/tracing/jersey-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-jersey-client</artifactId>

--- a/tracing/jersey/pom.xml
+++ b/tracing/jersey/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-jersey</artifactId>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.tracing</groupId>

--- a/tracing/tests/it-tracing-client-zipkin/pom.xml
+++ b/tracing/tests/it-tracing-client-zipkin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-tests</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-tests-it1</artifactId>

--- a/tracing/tests/pom.xml
+++ b/tracing/tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tracing/tracer-resolver/pom.xml
+++ b/tracing/tracer-resolver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-tracer-resolver</artifactId>

--- a/tracing/tracing/pom.xml
+++ b/tracing/tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing</artifactId>

--- a/tracing/zipkin/pom.xml
+++ b/tracing/zipkin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-zipkin</artifactId>

--- a/webclient/jaxrs/pom.xml
+++ b/webclient/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-webclient-project</artifactId>
         <groupId>io.helidon.webclient</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webclient/pom.xml
+++ b/webclient/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.webclient</groupId>

--- a/webserver/access-log/pom.xml
+++ b/webserver/access-log/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-webserver-project</artifactId>
         <groupId>io.helidon.webserver</groupId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webserver/jersey/pom.xml
+++ b/webserver/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-webserver-jersey</artifactId>
     <name>Helidon WebServer Jersey</name>

--- a/webserver/pom.xml
+++ b/webserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.webserver</groupId>
     <artifactId>helidon-webserver-project</artifactId>

--- a/webserver/test-support/pom.xml
+++ b/webserver/test-support/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-webserver-test-support</artifactId>
     <name>Helidon WebServer Test Support</name>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>1.4.19-SNAPSHOT</version>
+        <version>1.4.20-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-webserver</artifactId>
     <name>Helidon WebServer</name>


### PR DESCRIPTION
Updates Helidon 1.x version references to 1.4.20-SNAPSHOT after the 1.4.19 release.