### PR TITLE
Fix main build validation failures

### DIFF
--- a/http/http1/src/main/java/io/helidon/http/http1/Http1LoggingConnectionListener.java
+++ b/http/http1/src/main/java/io/helidon/http/http1/Http1LoggingConnectionListener.java
@@ -98,11 +98,11 @@ public class Http1LoggingConnectionListener implements Http1ConnectionListener {
     @Override
     public void headers(SocketContext ctx, Headers headers) {
         if (logger.isLoggable(TRACE)) {
-            ctx.log(logger, TRACE, "%s headers: %n%s",
+            ctx.log(logger, TRACE, "%s headers: \n%s",
                     prefix,
                     unsafeLogRawData ? logFormatter.formatAll(headers) : logFormatter.format(headers));
         } else if (logger.isLoggable(DEBUG)) {
-            ctx.log(logger, DEBUG, "%s headers: %n%s",
+            ctx.log(logger, DEBUG, "%s headers: \n%s",
                     prefix,
                     logFormatter.format(headers));
         }

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
@@ -34,6 +34,12 @@ public class ConfigUserStore implements SecureUserStore {
     private final Map<String, ConfigUser> users = new HashMap<>();
 
     /**
+     * Create an empty configuration-backed user store.
+     */
+    public ConfigUserStore() {
+    }
+
+    /**
      * Create an instance from config. Expects key "users" to be the current key.
      * Example:
      * <pre>

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
@@ -412,6 +412,15 @@ public abstract class IdcsRoleMapperProviderBase implements SubjectMappingProvid
             this(webClient, tokenEndpointUri, tokenRefreshSkew, null, null);
         }
 
+        /**
+         * Create an application token cache with client credentials.
+         *
+         * @param webClient web client to request tokens
+         * @param tokenEndpointUri token endpoint URI
+         * @param tokenRefreshSkew token refresh skew
+         * @param clientId client ID
+         * @param clientSecret client secret
+         */
         protected AppToken(WebClient webClient,
                            URI tokenEndpointUri,
                            Duration tokenRefreshSkew,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -119,6 +119,17 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         this.recvListener = recvListener;
     }
 
+    /**
+     * Create a new HTTP/2 client stream.
+     *
+     * @param connection client connection
+     * @param serverSettings server settings
+     * @param ctx socket context
+     * @param http2StreamConfig stream configuration
+     * @param http2ClientConfig client configuration
+     * @param streamIdSeq stream ID sequence
+     * @param http2Client HTTP/2 client
+     */
     protected Http2ClientStream(Http2ClientConnection connection,
                                 Http2Settings serverSettings,
                                 SocketContext ctx,

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSocketSecurityUpgradeTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSocketSecurityUpgradeTest.java
@@ -269,7 +269,7 @@ class WebSocketSecurityUpgradeTest {
         UPGRADE_GATE_INVOKED.set(0);
         HTTP_HANDLER_INVOKED.set(0);
 
-        String wsResponse = sendRequest(
+        String wsResponse = sendRequestAndAwaitOpen(
                 "GET /admin HTTP/1.1\r\n"
                         + "Host: localhost:" + port + "\r\n"
                         + "Upgrade: websocket\r\n"
@@ -302,7 +302,7 @@ class WebSocketSecurityUpgradeTest {
         UPGRADE_GATE_INVOKED.set(0);
         HTTP_HANDLER_INVOKED.set(0);
 
-        String wsResponse = sendRequest(
+        String wsResponse = sendRequestAndAwaitOpen(
                 "GET /admin HTTP/1.1\r\n"
                         + "Host: localhost:" + port + "\r\n"
                         + "Upgrade: websocket\r\n"
@@ -433,7 +433,7 @@ class WebSocketSecurityUpgradeTest {
         SERVICE_UPGRADE_GATE_INVOKED.set(0);
         SERVICE_HTTP_HANDLER_INVOKED.set(0);
 
-        String authenticatedWsResponse = sendRequest(
+        String authenticatedWsResponse = sendRequestAndAwaitOpen(
                 "GET /service HTTP/1.1\r\n"
                         + "Host: localhost:" + port + "\r\n"
                         + "Upgrade: websocket\r\n"
@@ -486,7 +486,7 @@ class WebSocketSecurityUpgradeTest {
         HTTP1_UPGRADE_GATE_INVOKED.set(0);
         HTTP1_HTTP_HANDLER_INVOKED.set(0);
 
-        String authenticatedWsResponse = sendRequest(
+        String authenticatedWsResponse = sendRequestAndAwaitOpen(
                 "GET /http1 HTTP/1.1\r\n"
                         + "Host: localhost:" + port + "\r\n"
                         + "Upgrade: websocket\r\n"
@@ -540,7 +540,7 @@ class WebSocketSecurityUpgradeTest {
 
     @Test
     void successfulUpgradeSendsGateResponse() throws Exception {
-        String wsResponse = sendRequest(
+        String wsResponse = sendRequestAndAwaitOpen(
                 "GET /finalization HTTP/1.1\r\n"
                         + "Host: localhost:" + port + "\r\n"
                         + "Upgrade: websocket\r\n"
@@ -691,7 +691,15 @@ class WebSocketSecurityUpgradeTest {
         assertThat(WS_OPENED.get(), is(false));
     }
 
-    private String sendRequest(String request) throws IOException {
+    private String sendRequest(String request) throws IOException, InterruptedException {
+        return sendRequest(request, false);
+    }
+
+    private String sendRequestAndAwaitOpen(String request) throws IOException, InterruptedException {
+        return sendRequest(request, true);
+    }
+
+    private String sendRequest(String request, boolean awaitOpen) throws IOException, InterruptedException {
         try (Socket socket = new Socket("127.0.0.1", port)) {
             socket.setSoTimeout(5000);
             socket.getOutputStream().write(request.getBytes(StandardCharsets.US_ASCII));
@@ -717,7 +725,11 @@ class WebSocketSecurityUpgradeTest {
                     state = next == '\r' ? 3 : 0;
                 } else {
                     if (next == '\n') {
-                        return buffer.toString(StandardCharsets.US_ASCII);
+                        String response = buffer.toString(StandardCharsets.US_ASCII);
+                        if (awaitOpen && response.contains("HTTP/1.1 101")) {
+                            WS_OPEN_LATCH.get().await(5, TimeUnit.SECONDS);
+                        }
+                        return response;
                     }
                     state = next == '\r' ? 1 : 0;
                 }


### PR DESCRIPTION
Fixes main build validation failures that surfaced on #12107 but are unrelated to that PR's config changes.

- port the HTTP/1 header logging newline fix from release-4.5.0 commit f6bc8d3d6575bb8a6756a4d33e441e83c3c60463 so Windows log assertions do not see CRLF injected by `%n`
- add missing Javadocs in the main-only modules that failed the core javadoc job
