### PR TITLE
Fix config polling recovery after reload failure

### DIFF
--- a/config/config/src/main/java/io/helidon/config/AbstractConfigImpl.java
+++ b/config/config/src/main/java/io/helidon/config/AbstractConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,6 +181,11 @@ abstract class AbstractConfigImpl implements Config {
         @Override
         public Config reload() {
             return AbstractConfigImpl.this.contextConfig(AbstractConfigImpl.this.factory.context().reload());
+        }
+
+        @Override
+        public void stopChangeSupport() {
+            AbstractConfigImpl.this.factory.context().stopChangeSupport();
         }
     }
 }

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1137,6 +1137,15 @@ public interface Config {
          * @see Config.Builder
          */
         Config reload();
+
+        /**
+         * Stops background change support tasks associated with this context.
+         * <p>
+         * The current configuration tree remains usable after this method returns, including calls to
+         * {@link #last()} and {@link #reload()}.
+         */
+        default void stopChangeSupport() {
+        }
     }
 
     /**

--- a/config/config/src/main/java/io/helidon/config/ConfigProvider.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigProvider.java
@@ -73,6 +73,11 @@ class ConfigProvider implements Supplier<Config> {
         return config;
     }
 
+    @Service.PreDestroy
+    void preDestroy() {
+        config.context().stopChangeSupport();
+    }
+
     private void defaultConfigSources(io.helidon.config.Config.Builder configBuilder,
                                       Supplier<List<ConfigParser>> configParsers) {
 

--- a/config/config/src/main/java/io/helidon/config/ConfigSourceRuntime.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSourceRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,14 @@ public interface ConfigSourceRuntime {
      * @param change change listener
      */
     void onChange(BiConsumer<String, ConfigNode> change);
+
+    /**
+     * Stops background change support tasks associated with this runtime.
+     * <p>
+     * The runtime remains usable after this method returns.
+     */
+    default void stopChangeSupport() {
+    }
 
     /**
      * Load the config source if it is eager (such as {@link io.helidon.config.spi.ParsableSource} or

--- a/config/config/src/main/java/io/helidon/config/ConfigSourceRuntimeImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSourceRuntimeImpl.java
@@ -57,7 +57,7 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
     private final ConfigSource configSource;
     private final boolean changesSupported;
     private final Supplier<Optional<ObjectNode>> reloader;
-    private final Runnable changesRunnable;
+    private final ChangeSupport changeSupport;
     private final Function<String, Optional<ConfigNode>> singleNodeFunction;
     private final boolean isLazy;
 
@@ -114,7 +114,7 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
 
         // change support
         boolean changesSupported = false;
-        Runnable changesRunnable = null;
+        ChangeSupport changeSupport = null;
 
         if (configSource instanceof WatchableSource) {
             WatchableSource<Object> watchable = (WatchableSource<Object>) source;
@@ -122,12 +122,12 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
 
             if (changeWatcher.isPresent()) {
                 changesSupported = true;
-                changesRunnable = new WatchableChangesStarter(configContext,
-                                                              listeners,
-                                                              reloader,
-                                                              source,
-                                                              watchable,
-                                                              changeWatcher.get());
+                changeSupport = new WatchableChangesStarter(configContext,
+                                                            listeners,
+                                                            reloader,
+                                                            source,
+                                                            watchable,
+                                                            changeWatcher.get());
             }
         }
 
@@ -137,22 +137,32 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
 
             if (pollingStrategy.isPresent()) {
                 changesSupported = true;
-                changesRunnable = new PollingStrategyStarter(configContext,
-                                                             listeners,
-                                                             reloader,
-                                                             source,
-                                                             pollable,
-                                                             pollingStrategy.get(),
-                                                             lastStamp);
+                changeSupport = new PollingStrategyStarter(configContext,
+                                                           listeners,
+                                                           reloader,
+                                                           source,
+                                                           pollable,
+                                                           pollingStrategy.get(),
+                                                           lastStamp);
             }
         }
 
         if (!changesSupported && (configSource instanceof EventConfigSource event)) {
             changesSupported = true;
-            changesRunnable = () -> event.onChange((key, config) -> listeners.forEach(it -> it.accept(key, config)));
+            changeSupport = new ChangeSupport() {
+                @Override
+                public void start() {
+                    event.onChange((key, config) -> listeners.forEach(it -> it.accept(key, config)));
+                }
+
+                @Override
+                public void stop() {
+                    event.stopChangeSupport();
+                }
+            };
         }
 
-        this.changesRunnable = changesRunnable;
+        this.changeSupport = changeSupport;
         this.changesSupported = changesSupported;
     }
 
@@ -165,6 +175,11 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
         this.listeners.add(change);
         this.changesWanted = true;
         startChanges();
+    }
+
+    @Override
+    public void stopChangeSupport() {
+        stopChanges();
     }
 
     @Override
@@ -279,7 +294,14 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
     private void startChanges() {
         if (!changesStarted && changesWanted && (dataLoaded || isLazy)) {
             changesStarted = true;
-            changesRunnable.run();
+            changeSupport.start();
+        }
+    }
+
+    void stopChanges() {
+        if (changesSupported && changesStarted) {
+            changesStarted = false;
+            changeSupport.stop();
         }
     }
 
@@ -296,7 +318,14 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
 
     }
 
-    private static final class PollingStrategyStarter implements Runnable {
+    private interface ChangeSupport {
+        void start();
+
+        default void stop() {
+        }
+    }
+
+    private static final class PollingStrategyStarter implements ChangeSupport {
         private final PollingStrategy pollingStrategy;
         private final PollingStrategyListener listener;
 
@@ -313,8 +342,13 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
         }
 
         @Override
-        public void run() {
+        public void start() {
             pollingStrategy.start(listener);
+        }
+
+        @Override
+        public void stop() {
+            pollingStrategy.stop();
         }
     }
 
@@ -364,7 +398,7 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
         }
     }
 
-    private static final class WatchableChangesStarter implements Runnable {
+    private static final class WatchableChangesStarter implements ChangeSupport {
         private final WatchableSource<Object> watchable;
         private final WatchableListener listener;
         private final ChangeWatcher<Object> changeWatcher;
@@ -381,9 +415,14 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
         }
 
         @Override
-        public void run() {
+        public void start() {
             Object target = watchable.target();
             changeWatcher.start(target, listener);
+        }
+
+        @Override
+        public void stop() {
+            changeWatcher.stop();
         }
     }
 

--- a/config/config/src/main/java/io/helidon/config/ConfigSourcesRuntime.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSourcesRuntime.java
@@ -107,6 +107,12 @@ final class ConfigSourcesRuntime {
                         }));
     }
 
+    void stopChanges() {
+        loadedData.stream()
+                .filter(loaded -> loaded.runtime().changesSupported())
+                .forEach(loaded -> loaded.runtime().stopChanges());
+    }
+
     // update the runtime with the new data set
     private void processChange(RuntimeWithData runtimeWithData, String changedKey, ConfigNode changeNode) {
         ConfigKeyImpl key = ConfigKeyImpl.of(changedKey);

--- a/config/config/src/main/java/io/helidon/config/OverrideSourceRuntime.java
+++ b/config/config/src/main/java/io/helidon/config/OverrideSourceRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class OverrideSourceRuntime {
     private static final System.Logger LOGGER = System.getLogger(OverrideSourceRuntime.class.getName());
 
     private final OverrideReloader reloader;
-    private final Runnable changesRunnable;
+    private final ChangeSupport changeSupport;
     private final OverrideSource source;
     // we only want to start change support if changes are supported by the source
     private final boolean changesSupported;
@@ -62,7 +62,7 @@ class OverrideSourceRuntime {
 
         // change support
         boolean changesSupported = false;
-        Runnable changesRunnable = null;
+        ChangeSupport changeSupport = null;
 
         if (overrideSource instanceof WatchableSource) {
             WatchableSource<Object> watchable = (WatchableSource<Object>) source;
@@ -70,7 +70,7 @@ class OverrideSourceRuntime {
 
             if (changeWatcher.isPresent()) {
                 changesSupported = true;
-                changesRunnable = new WatchableChangesStarter(
+                changeSupport = new WatchableChangesStarter(
                         lastData,
                         reloader,
                         source,
@@ -86,7 +86,7 @@ class OverrideSourceRuntime {
 
             if (pollingStrategy.isPresent()) {
                 changesSupported = true;
-                changesRunnable = new PollingStrategyStarter(
+                changeSupport = new PollingStrategyStarter(
                         lastData,
                         reloader,
                         source,
@@ -97,7 +97,7 @@ class OverrideSourceRuntime {
             }
         }
 
-        this.changesRunnable = changesRunnable;
+        this.changeSupport = changeSupport;
         this.changesSupported = changesSupported;
     }
 
@@ -122,7 +122,14 @@ class OverrideSourceRuntime {
     void startChanges() {
         if (!changesStarted && dataLoaded && changesSupported) {
             changesStarted = true;
-            changesRunnable.run();
+            changeSupport.start();
+        }
+    }
+
+    void stopChanges() {
+        if (changesStarted && changesSupported) {
+            changesStarted = false;
+            changeSupport.stop();
         }
     }
 
@@ -191,7 +198,14 @@ class OverrideSourceRuntime {
         this.changeListener.set(listener);
     }
 
-    private static final class PollingStrategyStarter implements Runnable {
+    private interface ChangeSupport {
+        void start();
+
+        default void stop() {
+        }
+    }
+
+    private static final class PollingStrategyStarter implements ChangeSupport {
         private final PollingStrategy pollingStrategy;
         private final PollingStrategyListener listener;
 
@@ -208,8 +222,13 @@ class OverrideSourceRuntime {
         }
 
         @Override
-        public void run() {
+        public void start() {
             pollingStrategy.start(listener);
+        }
+
+        @Override
+        public void stop() {
+            pollingStrategy.stop();
         }
     }
 
@@ -262,7 +281,7 @@ class OverrideSourceRuntime {
         }
     }
 
-    private static final class WatchableChangesStarter implements Runnable {
+    private static final class WatchableChangesStarter implements ChangeSupport {
         private final WatchableSource<Object> watchable;
         private final WatchableListener listener;
         private final ChangeWatcher<Object> changeWatcher;
@@ -279,9 +298,14 @@ class OverrideSourceRuntime {
         }
 
         @Override
-        public void run() {
+        public void start() {
             Object target = watchable.target();
             changeWatcher.start(target, listener);
+        }
+
+        @Override
+        public void stop() {
+            changeWatcher.stop();
         }
     }
 

--- a/config/config/src/main/java/io/helidon/config/PrefixedConfigSource.java
+++ b/config/config/src/main/java/io/helidon/config/PrefixedConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,13 @@ public final class PrefixedConfigSource implements ConfigSource,
     @Override
     public void onChange(BiConsumer<String, ConfigNode> changedNode) {
         this.listener = changedNode;
+    }
+
+    @Override
+    public void stopChangeSupport() {
+        if (sourceRuntime != null) {
+            sourceRuntime.stopChangeSupport();
+        }
     }
 
     @Override

--- a/config/config/src/main/java/io/helidon/config/ProviderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ProviderImpl.java
@@ -116,6 +116,12 @@ class ProviderImpl implements Config.Context {
         return lastConfigInstance();
     }
 
+    @Override
+    public void stopChangeSupport() {
+        configSource.stopChanges();
+        overrideSource.stopChanges();
+    }
+
     Optional<ConfigNode> lazyValue(String string) {
         return configSource.lazyValue(string);
     }

--- a/config/config/src/main/java/io/helidon/config/ScheduledPollingStrategy.java
+++ b/config/config/src/main/java/io/helidon/config/ScheduledPollingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.config;
 import java.lang.System.Logger.Level;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -49,6 +50,7 @@ public final class ScheduledPollingStrategy implements PollingStrategy {
     private ScheduledExecutorService executor;
     private ScheduledFuture<?> scheduledFuture;
     private Polled polled;
+    private boolean pollFailureLogged;
 
     private ScheduledPollingStrategy(Builder builder) {
         this.recurringPolicy = builder.recurringPolicy;
@@ -89,6 +91,8 @@ public final class ScheduledPollingStrategy implements PollingStrategy {
 
     @Override
     public synchronized void start(Polled polled) {
+        Objects.requireNonNull(polled, "polled");
+
         if (defaultExecutor && executor.isShutdown()) {
             executor = Executors.newSingleThreadScheduledExecutor(new ConfigThreadFactory("file-watch-polling"));
         }
@@ -98,6 +102,7 @@ public final class ScheduledPollingStrategy implements PollingStrategy {
         }
 
         this.polled = polled;
+        this.pollFailureLogged = false;
         scheduleNext();
     }
 
@@ -128,7 +133,24 @@ public final class ScheduledPollingStrategy implements PollingStrategy {
     }
 
     private synchronized void fireEvent() {
-        ChangeEventType event = polled.poll(Instant.now());
+        ChangeEventType event;
+        try {
+            event = polled.poll(Instant.now());
+        } catch (RuntimeException e) {
+            if (!pollFailureLogged) {
+                LOGGER.log(Level.WARNING, "Failed to poll config source, polling will continue; "
+                        + "further failures are logged at debug.", e);
+                pollFailureLogged = true;
+            } else {
+                LOGGER.log(Level.DEBUG, "Config polling failure", e);
+            }
+            scheduleNext();
+            return;
+        }
+
+        Objects.requireNonNull(event, "Change event type must not be null");
+        pollFailureLogged = false;
+
         switch (event) {
         case CHANGED:
         case DELETED:

--- a/config/config/src/main/java/io/helidon/config/UrlConfigSource.java
+++ b/config/config/src/main/java/io/helidon/config/UrlConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public final class UrlConfigSource extends AbstractConfigSource
 
     @Override
     protected String uid() {
-        return url.toString();
+        return UrlHelper.configuredLocation(url);
     }
 
     @Override
@@ -147,7 +147,8 @@ public final class UrlConfigSource extends AbstractConfigSource
         } catch (ConfigException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new ConfigException("Configuration at url '" + url + "' is not accessible.", ex);
+            throw new ConfigException("Configuration at url '" + UrlHelper.configuredLocation(url)
+                                              + "' is not accessible.", ex);
         }
     }
 
@@ -184,8 +185,8 @@ public final class UrlConfigSource extends AbstractConfigSource
             } catch (ConfigException e) {
                 throw e;
             } catch (Exception e) {
-                throw new ConfigException("Configuration at url '" + url + "' with path + " + path
-                                                  + " is not accessible.", e);
+                throw new ConfigException("Configuration at url '" + UrlHelper.configuredLocation(url)
+                                                  + "' with relative path '" + it + "' is not accessible.", e);
             }
         };
     }
@@ -209,7 +210,10 @@ public final class UrlConfigSource extends AbstractConfigSource
             connection.connect();
         } catch (IOException e) {
             // considering this to be unavailable
-            LOGGER.log(Level.TRACE, "Failed to connect to " + url + ", considering this source to be missing", e);
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE, "Failed to connect to " + UrlHelper.configuredLocation(url)
+                        + ", considering this source to be missing", e);
+            }
             return Optional.empty();
         }
 
@@ -227,7 +231,10 @@ public final class UrlConfigSource extends AbstractConfigSource
             connection.connect();
         } catch (IOException e) {
             // considering this to be unavailable
-            LOGGER.log(Level.TRACE, "Failed to connect to " + url + ", considering this source to be missing", e);
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE, "Failed to connect to " + UrlHelper.configuredLocation(url)
+                        + ", considering this source to be missing", e);
+            }
             return Optional.empty();
         }
 
@@ -239,8 +246,11 @@ public final class UrlConfigSource extends AbstractConfigSource
         final Instant timestamp;
         if (connection.getLastModified() == 0) {
             timestamp = Instant.now();
-            LOGGER.log(Level.TRACE, "Missing GET '" + url + "' response header 'Last-Modified'. Used current time '"
-                    + timestamp + "' as a content timestamp.");
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE, "Missing GET '" + UrlHelper.configuredLocation(url)
+                        + "' response header 'Last-Modified'. Used current time '"
+                        + timestamp + "' as a content timestamp.");
+            }
         } else {
             timestamp = Instant.ofEpochMilli(connection.getLastModified());
         }

--- a/config/config/src/main/java/io/helidon/config/UrlHelper.java
+++ b/config/config/src/main/java/io/helidon/config/UrlHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.config;
 import java.io.IOException;
 import java.lang.System.Logger.Level;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.time.Instant;
@@ -58,13 +59,78 @@ final class UrlHelper {
                 }
             }
         } catch (IOException ex) {
-            LOGGER.log(Level.TRACE, () -> "Configuration at url '" + url + "' HEAD is not accessible.", ex);
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE,
+                           "Configuration at url '" + configuredLocation(url) + "' HEAD is not accessible.",
+                           ex);
+            }
             return Optional.empty();
         }
 
         Instant timestamp = Instant.MIN;
-        LOGGER.log(Level.TRACE, "Missing HEAD '" + url + "' response header 'Last-Modified'. Used time '"
-                             + timestamp + "' as a content timestamp.");
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            LOGGER.log(Level.TRACE, "Missing HEAD '" + configuredLocation(url)
+                    + "' response header 'Last-Modified'. Used time '"
+                                 + timestamp + "' as a content timestamp.");
+        }
         return Optional.of(timestamp);
+    }
+
+    static String configuredLocation(URL url) {
+        StringBuilder result = new StringBuilder();
+
+        result.append(url.getProtocol()).append(':');
+
+        String host = url.getHost();
+        String path = "jar".equals(url.getProtocol()) ? url.getFile() : url.getPath();
+        if (!host.isEmpty()) {
+            result.append("//").append(host);
+
+            int port = url.getPort();
+            if (port != -1) {
+                result.append(':').append(port);
+            }
+        } else {
+            int nestedSeparator = path.indexOf("!/");
+            if (nestedSeparator > 0) {
+                String nestedLocation = path.substring(0, nestedSeparator);
+                try {
+                    nestedLocation = configuredLocation(new URL(nestedLocation));
+                } catch (MalformedURLException ignored) {
+                    int nestedScheme = nestedLocation.indexOf("://");
+                    if (nestedScheme >= 0) {
+                        int authorityStart = nestedScheme + 3;
+                        int authorityEnd = nestedLocation.indexOf('/', authorityStart);
+                        int at = nestedLocation.indexOf('@', authorityStart);
+                        if (at >= 0 && (authorityEnd == -1 || at < authorityEnd)) {
+                            nestedLocation = nestedLocation.substring(0, authorityStart)
+                                    + nestedLocation.substring(at + 1);
+                        }
+                    }
+                    int query = nestedLocation.indexOf('?');
+                    if (query != -1) {
+                        nestedLocation = nestedLocation.substring(0, query);
+                    }
+                    int fragment = nestedLocation.indexOf('#');
+                    if (fragment != -1) {
+                        nestedLocation = nestedLocation.substring(0, fragment);
+                    }
+                }
+                String entry = path.substring(nestedSeparator);
+                int query = entry.indexOf('?');
+                if (query != -1) {
+                    entry = entry.substring(0, query);
+                }
+                int fragment = entry.indexOf('#');
+                if (fragment != -1) {
+                    entry = entry.substring(0, fragment);
+                }
+                path = nestedLocation + entry;
+            }
+        }
+
+        result.append(path);
+
+        return result.toString();
     }
 }

--- a/config/config/src/main/java/io/helidon/config/UrlOverrideSource.java
+++ b/config/config/src/main/java/io/helidon/config/UrlOverrideSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,8 +112,11 @@ public class UrlOverrideSource extends AbstractSource
             Instant timestamp;
             if (connection.getLastModified() == 0) {
                 timestamp = Instant.now();
-                LOGGER.log(Level.DEBUG, "Missing GET '" + url + "' response header 'Last-Modified'. Used current time '"
-                                    + timestamp + "' as a content timestamp.");
+                if (LOGGER.isLoggable(Level.DEBUG)) {
+                    LOGGER.log(Level.DEBUG, "Missing GET '" + UrlHelper.configuredLocation(url)
+                                        + "' response header 'Last-Modified'. Used current time '"
+                                        + timestamp + "' as a content timestamp.");
+                }
             } else {
                 timestamp = Instant.ofEpochMilli(connection.getLastModified());
             }
@@ -129,14 +132,15 @@ public class UrlOverrideSource extends AbstractSource
         } catch (ConfigException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new ConfigException("Configuration at url '" + url + "' GET is not accessible.", ex);
+            throw new ConfigException("Configuration at url '" + UrlHelper.configuredLocation(url)
+                                              + "' GET is not accessible.", ex);
 
         }
     }
 
     @Override
     protected String uid() {
-        return url.toString();
+        return UrlHelper.configuredLocation(url);
     }
 
     /**

--- a/config/config/src/main/java/io/helidon/config/spi/EventConfigSource.java
+++ b/config/config/src/main/java/io/helidon/config/spi/EventConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,4 +30,12 @@ public interface EventConfigSource {
      *                    use empty string as a key
      */
     void onChange(BiConsumer<String, ConfigNode> changedNode);
+
+    /**
+     * Stops background change support tasks associated with this source.
+     * <p>
+     * The source remains usable after this method returns.
+     */
+    default void stopChangeSupport() {
+    }
 }

--- a/config/config/src/test/java/io/helidon/config/ConfigContextTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,13 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import io.helidon.config.spi.ConfigNode.ObjectNode;
+import io.helidon.config.spi.PollingStrategy;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -264,6 +267,63 @@ public class ConfigContextTest {
         assertThat(c.config.context().timestamp(), is(c.config.timestamp()));
         assertThat(c.config.context().last(), is(c.config));
         assertThat(c.config.context().last().key(), is(c.config.key()));
+    }
+
+    @Test
+    public void testStopChangeSupportStopsPollingStrategy() {
+        AtomicBoolean stopped = new AtomicBoolean();
+        PollingStrategy pollingStrategy = new PollingStrategy() {
+            @Override
+            public void start(Polled polled) {
+            }
+
+            @Override
+            public void stop() {
+                stopped.set(true);
+            }
+        };
+        Config config = Config.builder()
+                .addSource(TestingConfigSource.builder()
+                                   .objectNode(createSource("old"))
+                                   .pollingStrategy(pollingStrategy)
+                                   .build())
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .build();
+
+        config.get("sub").context().stopChangeSupport();
+
+        assertThat(stopped.get(), is(true));
+        assertThat(config.get(PROP1).asString().get(), is("oldVal_1_1"));
+    }
+
+    @Test
+    public void testStopChangeSupportStopsPrefixedSourcePollingStrategy() {
+        AtomicBoolean stopped = new AtomicBoolean();
+        PollingStrategy pollingStrategy = new PollingStrategy() {
+            @Override
+            public void start(Polled polled) {
+            }
+
+            @Override
+            public void stop() {
+                stopped.set(true);
+            }
+        };
+        Config config = Config.builder()
+                .addSource(ConfigSources.prefixed("prefix",
+                                                  () -> TestingConfigSource.builder()
+                                                          .objectNode(createSource("old"))
+                                                          .pollingStrategy(pollingStrategy)
+                                                          .build()))
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .build();
+
+        config.get("prefix.sub").context().stopChangeSupport();
+
+        assertThat(stopped.get(), is(true));
+        assertThat(config.get("prefix." + PROP1).asString().get(), is("oldVal_1_1"));
     }
 
 }

--- a/config/config/src/test/java/io/helidon/config/ScheduledPollingStrategyTest.java
+++ b/config/config/src/test/java/io/helidon/config/ScheduledPollingStrategyTest.java
@@ -76,12 +76,16 @@ public class ScheduledPollingStrategyTest {
                 .recurringPolicy(() -> POLLING_STRATEGY_DURATION)
                 .build();
 
-        pollingStrategy.start(when -> {
-            nextLatch.countDown();
-            return ChangeEventType.UNCHANGED;
-        });
+        try {
+            pollingStrategy.start(when -> {
+                nextLatch.countDown();
+                return ChangeEventType.UNCHANGED;
+            });
 
-        assertThat(nextLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+            assertThat(nextLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+        } finally {
+            pollingStrategy.stop();
+        }
     }
 
     @Test
@@ -127,11 +131,17 @@ public class ScheduledPollingStrategyTest {
         Logger logger = Logger.getLogger(ScheduledPollingStrategy.class.getName());
         Level originalLevel = logger.getLevel();
         boolean originalUseParentHandlers = logger.getUseParentHandlers();
+        ConfigException firstFailure = new ConfigException("First reload failure");
+        ConfigException repeatedFailure = new ConfigException("Repeated reload failure");
+        ConfigException failureAfterRecovery = new ConfigException("Failure after recovery");
         Handler handler = new Handler() {
             @Override
             public void publish(LogRecord record) {
-                logRecords.add(record);
-                thirdLogLatch.countDown();
+                Throwable thrown = record.getThrown();
+                if (thrown == firstFailure || thrown == repeatedFailure || thrown == failureAfterRecovery) {
+                    logRecords.add(record);
+                    thirdLogLatch.countDown();
+                }
             }
 
             @Override
@@ -146,9 +156,6 @@ public class ScheduledPollingStrategyTest {
         ScheduledPollingStrategy pollingStrategy = ScheduledPollingStrategy.builder()
                 .recurringPolicy(() -> Duration.ofMillis(20))
                 .build();
-        ConfigException firstFailure = new ConfigException("First reload failure");
-        ConfigException repeatedFailure = new ConfigException("Repeated reload failure");
-        ConfigException failureAfterRecovery = new ConfigException("Failure after recovery");
 
         try {
             logger.addHandler(handler);
@@ -232,30 +239,34 @@ public class ScheduledPollingStrategyTest {
         ScheduledPollingStrategy pollingStrategy = ScheduledPollingStrategy.create(() -> POLLING_STRATEGY_DURATION,
                                                                                    executor);
 
-        pollingStrategy.start(when -> {
-            firstLatch.countDown();
-            return ChangeEventType.UNCHANGED;
-        });
+        try {
+            pollingStrategy.start(when -> {
+                firstLatch.countDown();
+                return ChangeEventType.UNCHANGED;
+            });
 
-        assertThat(firstLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+            assertThat(firstLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
 
-        //cancel subscription
-        pollingStrategy.stop();
-        assertThat("Custom executor should not get shut down",
-                   pollingStrategy.executor().isShutdown(),
-                   is(false));
+            //cancel subscription
+            pollingStrategy.stop();
+            assertThat("Custom executor should not get shut down",
+                       pollingStrategy.executor().isShutdown(),
+                       is(false));
 
-        CountDownLatch secondLatch = new CountDownLatch(1);
+            CountDownLatch secondLatch = new CountDownLatch(1);
 
-        //subscribe again
-        pollingStrategy.start(when -> {
-            secondLatch.countDown();
-            return ChangeEventType.UNCHANGED;
-        });
+            //subscribe again
+            pollingStrategy.start(when -> {
+                secondLatch.countDown();
+                return ChangeEventType.UNCHANGED;
+            });
 
-        assertThat(secondLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+            assertThat(secondLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+        } finally {
+            pollingStrategy.stop();
+            executor.shutdown();
+        }
 
-        executor.shutdown();
     }
 
     @Test
@@ -266,27 +277,31 @@ public class ScheduledPollingStrategyTest {
                 .recurringPolicy(() -> POLLING_STRATEGY_DURATION)
                 .build();
 
-        pollingStrategy.start(when -> {
-            firstLatch.countDown();
-            return ChangeEventType.UNCHANGED;
-        });
+        try {
+            pollingStrategy.start(when -> {
+                firstLatch.countDown();
+                return ChangeEventType.UNCHANGED;
+            });
 
-        assertThat(firstLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+            assertThat(firstLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
 
-        //cancel subscription
-        pollingStrategy.stop();
-        assertThat("Default executor should get shut down",
-                   pollingStrategy.executor().isShutdown(),
-                   is(true));
+            //cancel subscription
+            pollingStrategy.stop();
+            assertThat("Default executor should get shut down",
+                       pollingStrategy.executor().isShutdown(),
+                       is(true));
 
-        CountDownLatch secondLatch = new CountDownLatch(1);
+            CountDownLatch secondLatch = new CountDownLatch(1);
 
-        //subscribe again
-        pollingStrategy.start(when -> {
-            secondLatch.countDown();
-            return ChangeEventType.UNCHANGED;
-        });
+            //subscribe again
+            pollingStrategy.start(when -> {
+                secondLatch.countDown();
+                return ChangeEventType.UNCHANGED;
+            });
 
-        assertThat(secondLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+            assertThat(secondLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+        } finally {
+            pollingStrategy.stop();
+        }
     }
 }

--- a/config/config/src/test/java/io/helidon/config/ScheduledPollingStrategyTest.java
+++ b/config/config/src/test/java/io/helidon/config/ScheduledPollingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,30 @@
 package io.helidon.config;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import io.helidon.config.spi.ChangeEventType;
+import io.helidon.config.spi.PollingStrategy;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link io.helidon.config.ScheduledPollingStrategy}.
@@ -70,6 +82,124 @@ public class ScheduledPollingStrategyTest {
         });
 
         assertThat(nextLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+    }
+
+    @Test
+    public void testStartPollingRequiresPolled() {
+        ScheduledPollingStrategy pollingStrategy = ScheduledPollingStrategy.builder()
+                .recurringPolicy(() -> POLLING_STRATEGY_DURATION)
+                .build();
+
+        assertThrows(NullPointerException.class, () -> pollingStrategy.start(null));
+    }
+
+    @Test
+    public void testPollingContinuesAfterTransientFailure() throws InterruptedException {
+        CountDownLatch recoveredLatch = new CountDownLatch(1);
+        AtomicInteger pollCount = new AtomicInteger();
+
+        ScheduledPollingStrategy pollingStrategy = ScheduledPollingStrategy.builder()
+                .recurringPolicy(() -> POLLING_STRATEGY_DURATION)
+                .build();
+
+        try {
+            pollingStrategy.start(when -> {
+                if (pollCount.incrementAndGet() == 1) {
+                    throw new ConfigException("Transient reload failure");
+                }
+                recoveredLatch.countDown();
+                return ChangeEventType.UNCHANGED;
+            });
+
+            assertThat("Polling should continue after a transient reload failure",
+                       recoveredLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS),
+                       is(true));
+        } finally {
+            pollingStrategy.stop();
+        }
+    }
+
+    @Test
+    public void testRepeatedPollingFailureLoggingResetsAfterSuccess() throws InterruptedException {
+        CountDownLatch thirdLogLatch = new CountDownLatch(3);
+        AtomicInteger pollCount = new AtomicInteger();
+        List<LogRecord> logRecords = new CopyOnWriteArrayList<>();
+        Logger logger = Logger.getLogger(ScheduledPollingStrategy.class.getName());
+        Level originalLevel = logger.getLevel();
+        boolean originalUseParentHandlers = logger.getUseParentHandlers();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logRecords.add(record);
+                thirdLogLatch.countDown();
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() throws SecurityException {
+            }
+        };
+
+        ScheduledPollingStrategy pollingStrategy = ScheduledPollingStrategy.builder()
+                .recurringPolicy(() -> Duration.ofMillis(20))
+                .build();
+        ConfigException firstFailure = new ConfigException("First reload failure");
+        ConfigException repeatedFailure = new ConfigException("Repeated reload failure");
+        ConfigException failureAfterRecovery = new ConfigException("Failure after recovery");
+
+        try {
+            logger.addHandler(handler);
+            logger.setUseParentHandlers(false);
+            logger.setLevel(Level.FINE);
+
+            PollingStrategy.Polled polled = when -> {
+                switch (pollCount.incrementAndGet()) {
+                case 1:
+                    throw firstFailure;
+                case 2:
+                    throw repeatedFailure;
+                case 3:
+                    return ChangeEventType.UNCHANGED;
+                case 4:
+                    throw failureAfterRecovery;
+                default:
+                    return ChangeEventType.UNCHANGED;
+                }
+            };
+
+            pollingStrategy.start(polled);
+
+            assertThat("Third log record should be published",
+                       thirdLogLatch.await(NEXT_LATCH_WAIT_MILLIS, TimeUnit.MILLISECONDS),
+                       is(true));
+            pollingStrategy.stop();
+
+            assertThat(logRecords.stream().map(LogRecord::getLevel).toList(),
+                       is(List.of(Level.WARNING, Level.FINE, Level.WARNING)));
+            assertThat(logRecords.get(0).getMessage(), containsString("Failed to poll config source"));
+            assertThat(logRecords.get(0).getThrown(), instanceOf(ConfigException.class));
+            assertThat(logRecords.get(0).getThrown(), sameInstance(firstFailure));
+            assertThat(logRecords.get(0).getThrown().getMessage(),
+                       containsString("First reload failure"));
+            assertThat(logRecords.get(1).getMessage(), is("Config polling failure"));
+            assertThat(logRecords.get(1).getThrown(), instanceOf(ConfigException.class));
+            assertThat(logRecords.get(1).getThrown(), sameInstance(repeatedFailure));
+            assertThat(logRecords.get(1).getThrown().getMessage(),
+                       containsString("Repeated reload failure"));
+            assertThat(logRecords.get(2).getMessage(), containsString("Failed to poll config source"));
+            assertThat(logRecords.get(2).getThrown(), instanceOf(ConfigException.class));
+            assertThat(logRecords.get(2).getThrown(), sameInstance(failureAfterRecovery));
+            assertThat(logRecords.get(2).getThrown().getMessage(),
+                       containsString("Failure after recovery"));
+        } finally {
+            pollingStrategy.stop();
+            logger.setLevel(originalLevel);
+            logger.setUseParentHandlers(originalUseParentHandlers);
+            logger.removeHandler(handler);
+        }
     }
 
     @Test

--- a/config/config/src/test/java/io/helidon/config/UrlConfigSourceTest.java
+++ b/config/config/src/test/java/io/helidon/config/UrlConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.config;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -26,7 +27,11 @@ import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.spi.ConfigSource;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -54,6 +59,37 @@ public class UrlConfigSourceTest {
                 .build();
 
         assertThat(configSource.description(), is("UrlConfig[http://config-service/application.json]?"));
+    }
+
+    @Test
+    public void testDescriptionOmitsSensitiveUrlParts() throws MalformedURLException {
+        ConfigSource configSource = ConfigSources
+                .url(new URL("http://user:password@config-service:8080/application.json?token=secret#fragment"))
+                .build();
+
+        assertThat(configSource.description(), is("UrlConfig[http://config-service:8080/application.json]"));
+    }
+
+    @Test
+    public void testDescriptionOmitsSensitiveNestedUrlParts() throws MalformedURLException {
+        ConfigSource configSource = ConfigSources
+                .url(new URL("jar:http://user:password@config-service:8080/application.jar"
+                                     + "?token=secret!/application.json"))
+                .build();
+
+        assertThat(configSource.description(),
+                   is("UrlConfig[jar:http://config-service:8080/application.jar!/application.json]"));
+    }
+
+    @Test
+    public void testDescriptionOmitsSensitiveNestedEntryUrlParts() throws MalformedURLException {
+        ConfigSource configSource = ConfigSources
+                .url(new URL("jar:http://user:password@config-service:8080/application.jar"
+                                     + "!/application.json?token=secret#fragment"))
+                .build();
+
+        assertThat(configSource.description(),
+                   is("UrlConfig[jar:http://config-service:8080/application.jar!/application.json]"));
     }
 
     @Test
@@ -98,6 +134,53 @@ public class UrlConfigSourceTest {
 
         ConfigException ex = assertThrows(ConfigException.class, runtime::load);
         assertThat(ex.getMessage(), startsWith("Cannot load data from mandatory source: "));
+    }
+
+    @Test
+    public void testLoadNotExistsOmitsSensitiveUrlParts() throws MalformedURLException {
+        UrlConfigSource configSource = ConfigSources
+                .url(new URL("http://user:password@config-service:8080/application.unknown?token=secret#fragment"))
+                .build();
+
+        BuilderImpl.ConfigContextImpl context = mock(BuilderImpl.ConfigContextImpl.class);
+        ConfigSourceRuntimeImpl runtime = new ConfigSourceRuntimeImpl(context, configSource);
+
+        ConfigException ex = assertThrows(ConfigException.class, runtime::load);
+        assertThat(ex.getMessage(), containsString("http://config-service:8080/application.unknown"));
+        assertThat(ex.getMessage(), not(containsString("password")));
+        assertThat(ex.getMessage(), not(containsString("token=secret")));
+        assertThat(ex.getMessage(), not(containsString("fragment")));
+    }
+
+    @Test
+    public void testLoadFailureMessageOmitsSensitiveUrlPartsAndPreservesCause(@TempDir Path directory)
+            throws MalformedURLException {
+        URL url = new URL("jar:" + directory.resolve("missing.jar").toUri()
+                                  + "?token=secret!/application.json");
+
+        UrlConfigSource configSource = ConfigSources.url(url).build();
+
+        ConfigException ex = assertThrows(ConfigException.class, configSource::load);
+        assertThat(ex.getMessage(), containsString("missing.jar!/application.json"));
+        assertThat(ex.getMessage(), not(containsString("token=secret")));
+        assertThat(ex.getCause(), notNullValue());
+    }
+
+    @Test
+    public void testRelativeResolverFailureMessageOmitsSensitiveNestedUrlParts() throws MalformedURLException {
+        UrlConfigSource configSource = ConfigSources
+                .url(new URL("jar:http://user:password@config-service:8080/application.jar"
+                                     + "!/config/application.yaml?token=secret#fragment"))
+                .build();
+
+        ConfigException ex = assertThrows(ConfigException.class,
+                                          () -> configSource.relativeResolver().apply("include.yaml"));
+        assertThat(ex.getMessage(),
+                   containsString("jar:http://config-service:8080/application.jar!/config/application.yaml"));
+        assertThat(ex.getMessage(), containsString("include.yaml"));
+        assertThat(ex.getMessage(), not(containsString("password")));
+        assertThat(ex.getMessage(), not(containsString("token=secret")));
+        assertThat(ex.getMessage(), not(containsString("fragment")));
     }
 
     @Test

--- a/config/config/src/test/java/io/helidon/config/UrlOverrideSourceServerMockTest.java
+++ b/config/config/src/test/java/io/helidon/config/UrlOverrideSourceServerMockTest.java
@@ -67,6 +67,7 @@ public class UrlOverrideSourceServerMockTest {
     private static final String NEW_WILDCARDS = "*.*.url = URL2";
 
     private StubServer server;
+    private Config config;
 
     @BeforeEach
     public void before() {
@@ -75,7 +76,13 @@ public class UrlOverrideSourceServerMockTest {
 
     @AfterEach
     public void after() {
-        server.stop();
+        try {
+            if (config != null) {
+                config.context().stopChangeSupport();
+            }
+        } finally {
+            server.stop();
+        }
     }
 
     @Test
@@ -97,7 +104,7 @@ public class UrlOverrideSourceServerMockTest {
                         stringContent(WILDCARDS)
                 );
 
-        Config config = Config.builder()
+        config = Config.builder()
                 .sources(ConfigSources.create(
                         Map.of(
                                 "aaa.bbb.url", "URL0"
@@ -130,7 +137,7 @@ public class UrlOverrideSourceServerMockTest {
                         stringContent(MULTIPLE_WILDCARDS)
                 );
 
-        Config config = Config.builder()
+        config = Config.builder()
                 .sources(ConfigSources.create(
                         Map.of(
                                 "aaa.bbb.url", "URL0"
@@ -162,7 +169,7 @@ public class UrlOverrideSourceServerMockTest {
                         stringContent(MULTIPLE_WILDCARDS_ANOTHER_ORDERING)
                 );
 
-        Config config = Config.builder()
+        config = Config.builder()
                 .sources(ConfigSources.create(
                         Map.of(
                                 "aaa.bbb.url", "URL0"
@@ -194,7 +201,7 @@ public class UrlOverrideSourceServerMockTest {
                         stringContent(CONFIG)
                 );
 
-        Config config = Config.builder()
+        config = Config.builder()
                 .sources(ConfigSources.url(getUrl("/config", server.getPort())))
                 .overrides(url(getUrl("/override", server.getPort()))
                                    .pollingStrategy(PollingStrategies.regular(Duration.ofMillis(50)).build()).build())
@@ -244,7 +251,7 @@ public class UrlOverrideSourceServerMockTest {
                         stringContent(CONFIG)
                 );
 
-        Config config = Config.builder()
+        config = Config.builder()
                 .sources(ConfigSources.url(getUrl("/config", server.getPort())))
                 .overrides(url(getUrl("/override", server.getPort()))
                                    .pollingStrategy(PollingStrategies.regular(Duration.ofMillis(10)).build())
@@ -286,7 +293,7 @@ public class UrlOverrideSourceServerMockTest {
                         stringContent(CONFIG)
                 );
 
-        Config config = Config.builder()
+        config = Config.builder()
                 .sources(ConfigSources.url(getUrl("/config", server.getPort()))
                                  .pollingStrategy(PollingStrategies.regular(Duration.ofMillis(10)).build()))
                 .overrides(url(getUrl("/override", server.getPort()))
@@ -330,7 +337,7 @@ public class UrlOverrideSourceServerMockTest {
                         stringContent(CONFIG)
                 );
 
-        Config config = Config.builder()
+        config = Config.builder()
                 .sources(ConfigSources.url(getUrl("/config", server.getPort()))
                                  .pollingStrategy(PollingStrategies.regular(Duration.ofMillis(10)).build()))
                 .overrides(url(getUrl("/override", server.getPort())).build())

--- a/config/config/src/test/java/io/helidon/config/UrlOverrideSourceTest.java
+++ b/config/config/src/test/java/io/helidon/config/UrlOverrideSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -52,6 +53,37 @@ public class UrlOverrideSourceTest {
     }
 
     @Test
+    public void testDescriptionOmitsSensitiveUrlParts() throws MalformedURLException {
+        OverrideSource overrideSource = OverrideSources
+                .url(new URL("http://user:password@config-service:8080/application.json?token=secret#fragment"))
+                .build();
+
+        assertThat(overrideSource.description(), Is.is("UrlOverride[http://config-service:8080/application.json]"));
+    }
+
+    @Test
+    public void testDescriptionOmitsSensitiveNestedUrlParts() throws MalformedURLException {
+        OverrideSource overrideSource = OverrideSources
+                .url(new URL("jar:http://user:password@config-service:8080/application.jar"
+                                     + "?token=secret!/application.json"))
+                .build();
+
+        assertThat(overrideSource.description(),
+                   Is.is("UrlOverride[jar:http://config-service:8080/application.jar!/application.json]"));
+    }
+
+    @Test
+    public void testDescriptionOmitsSensitiveNestedEntryUrlParts() throws MalformedURLException {
+        OverrideSource overrideSource = OverrideSources
+                .url(new URL("jar:http://user:password@config-service:8080/application.jar"
+                                     + "!/application.json?token=secret#fragment"))
+                .build();
+
+        assertThat(overrideSource.description(),
+                   Is.is("UrlOverride[jar:http://config-service:8080/application.jar!/application.json]"));
+    }
+
+    @Test
     public void testLoadNotExists() throws MalformedURLException {
         UrlOverrideSource overrideSource = OverrideSources
                 .url(new URL("http://config-service/application.unknown"))
@@ -60,5 +92,19 @@ public class UrlOverrideSourceTest {
         ConfigException ex = assertThrows(ConfigException.class, overrideSource::load);
         assertThat(ex.getCause(), instanceOf(UnknownHostException.class));
         assertThat(ex.getMessage(), containsString("config-service"));
+    }
+
+    @Test
+    public void testLoadNotExistsOmitsSensitiveUrlParts() throws MalformedURLException {
+        UrlOverrideSource overrideSource = OverrideSources
+                .url(new URL("http://user:password@config-service:8080/application.unknown?token=secret#fragment"))
+                .build();
+
+        ConfigException ex = assertThrows(ConfigException.class, overrideSource::load);
+        assertThat(ex.getCause(), instanceOf(UnknownHostException.class));
+        assertThat(ex.getMessage(), containsString("http://config-service:8080/application.unknown"));
+        assertThat(ex.getMessage(), not(containsString("password")));
+        assertThat(ex.getMessage(), not(containsString("token=secret")));
+        assertThat(ex.getMessage(), not(containsString("fragment")));
     }
 }

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigProducerTest.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,9 @@ class ConfigProducerTest {
     @Order(0)
         // this must be first, as once we set global config, this method will always fail
     void testConfig() {
+        TestConfigSource.POLLING_STARTED.set(false);
+        TestConfigSource.POLLING_STOPPED.set(false);
+
         registryManager = ServiceRegistryManager.create();
         GlobalServiceRegistry.registry(registryManager.registry());
 
@@ -58,6 +61,12 @@ class ConfigProducerTest {
         // make sure we can get the config from registry as io.helidon.config.Config as well
         io.helidon.config.Config helidonConfig = Services.get(io.helidon.config.Config.class);
         assertThat(helidonConfig.get("app.value").asString().asOptional(), is(Optional.of("source")));
+        assertThat(TestConfigSource.POLLING_STARTED.get(), is(true));
+
+        registryManager.shutdown();
+        registryManager = null;
+
+        assertThat(TestConfigSource.POLLING_STOPPED.get(), is(true));
     }
 
     @Test

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/TestConfigSource.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/TestConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,36 @@
 
 package io.helidon.config.tests.service.registry;
 
+import java.time.Instant;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.helidon.common.Weight;
 import io.helidon.config.ConfigException;
 import io.helidon.config.spi.ConfigContent;
 import io.helidon.config.spi.ConfigNode;
 import io.helidon.config.spi.NodeConfigSource;
+import io.helidon.config.spi.PollableSource;
+import io.helidon.config.spi.PollingStrategy;
 import io.helidon.service.registry.Service;
 
 @Service.Singleton
 @Weight(200)
-class TestConfigSource implements NodeConfigSource {
+class TestConfigSource implements NodeConfigSource, PollableSource<Instant> {
+    static final AtomicBoolean POLLING_STARTED = new AtomicBoolean();
+    static final AtomicBoolean POLLING_STOPPED = new AtomicBoolean();
+
+    private static final PollingStrategy POLLING_STRATEGY = new PollingStrategy() {
+        @Override
+        public void start(Polled polled) {
+            POLLING_STARTED.set(true);
+        }
+
+        @Override
+        public void stop() {
+            POLLING_STOPPED.set(true);
+        }
+    };
 
     @Override
     public Optional<ConfigContent.NodeContent> load() throws ConfigException {
@@ -36,5 +54,15 @@ class TestConfigSource implements NodeConfigSource {
                                                  .addValue("app.value", "source")
                                                  .build())
                                    .build());
+    }
+
+    @Override
+    public boolean isModified(Instant stamp) {
+        return false;
+    }
+
+    @Override
+    public Optional<PollingStrategy> pollingStrategy() {
+        return Optional.of(POLLING_STRATEGY);
     }
 }

--- a/docs/src/main/asciidoc/se/config/mutability-support.adoc
+++ b/docs/src/main/asciidoc/se/config/mutability-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -68,6 +68,9 @@ that used the context.
 |`Config reload()` |Reloads the
 entire config tree from the current contents of the same config sources used to
 load the tree in which the current node resides.
+|`void stopChangeSupport()` |Stops background change support tasks associated
+with this context. The current config tree remains usable, and your application
+can still invoke `last()` and `reload()`.
 |===
 
 Note that the config context describes or replaces a currently-loaded config tree.


### PR DESCRIPTION
Resolves #12101

Fixes config polling so one transient reload failure does not stop later polling attempts, and adds regression coverage for polling and URL-based config and override sources.
