### PR TITLE
Fix HTTP/2 concurrent stream close accounting

### DIFF
--- a/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
@@ -90,6 +90,30 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
 
     @Override
     public int writeHeaders(Http2Headers headers, int streamId, Http2Flag.HeaderFlags flags, FlowControl.Outbound flowControl) {
+        return writeHeaders(headers, streamId, flags, flowControl, NO_OP);
+    }
+
+    /**
+     * Write headers and notify when an {@code END_STREAM} headers frame has
+     * been written.
+     *
+     * @param headers                   headers
+     * @param streamId                  stream ID
+     * @param flags                     flags to use
+     * @param flowControl               flow control
+     * @param onEndStreamFrameWritten   action to run after the {@code END_STREAM}
+     *                                  headers frame is written
+     * @return number of bytes written
+     */
+    public int writeHeaders(Http2Headers headers,
+                            int streamId,
+                            Http2Flag.HeaderFlags flags,
+                            FlowControl.Outbound flowControl,
+                            Runnable onEndStreamFrameWritten) {
+        Objects.requireNonNull(headers);
+        Objects.requireNonNull(flags);
+        Objects.requireNonNull(flowControl);
+        Objects.requireNonNull(onEndStreamFrameWritten);
         // this is executing in the thread of the stream
         // we must enforce parallelism of exactly 1, to make sure the dynamic table is updated
         // and then immediately written
@@ -113,6 +137,9 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
                 written += Http2FrameHeader.LENGTH;
 
                 noLockWrite(new Http2FrameData(frameHeader, headerBuffer));
+                if (flags.endOfStream()) {
+                    onEndStreamFrameWritten.run();
+                }
                 return written;
             }
 
@@ -152,6 +179,9 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
             written += frameHeader.length();
             written += Http2FrameHeader.LENGTH;
             noLockWrite(new Http2FrameData(frameHeader, fragment));
+            if (flags.endOfStream()) {
+                onEndStreamFrameWritten.run();
+            }
             return written;
         } finally {
             streamLock.unlock();
@@ -164,10 +194,34 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
                             Http2Flag.HeaderFlags flags,
                             Http2FrameData dataFrame,
                             FlowControl.Outbound flowControl) {
+        return writeHeaders(headers, streamId, flags, dataFrame, flowControl, NO_OP);
+    }
+
+    /**
+     * Write headers and entity, and notify when an {@code END_STREAM} data
+     * frame has been written and accounted for.
+     *
+     * @param headers                   headers
+     * @param streamId                  stream ID
+     * @param flags                     header flags
+     * @param dataFrame                 data frame
+     * @param flowControl               flow control
+     * @param onEndStreamFrameWritten   action to run after the {@code END_STREAM}
+     *                                  data frame is written and accounted for
+     * @return number of bytes written
+     */
+    public int writeHeaders(Http2Headers headers,
+                            int streamId,
+                            Http2Flag.HeaderFlags flags,
+                            Http2FrameData dataFrame,
+                            FlowControl.Outbound flowControl,
+                            Runnable onEndStreamFrameWritten) {
+        Objects.requireNonNull(dataFrame);
+        Objects.requireNonNull(onEndStreamFrameWritten);
         // Executed on stream thread
         int bytesWritten = 0;
         bytesWritten += writeHeaders(headers, streamId, flags, flowControl);
-        writeData(dataFrame, flowControl);
+        writeData(dataFrame, flowControl, onEndStreamFrameWritten);
         bytesWritten += Http2FrameHeader.LENGTH;
         bytesWritten += dataFrame.header().length();
 

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
@@ -17,6 +17,7 @@
 package io.helidon.http.http2;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -28,6 +29,8 @@ import io.helidon.common.socket.SocketContext;
  * HTTP/2 connection writer.
  */
 public class Http2ConnectionWriter implements Http2StreamWriter {
+    private static final Runnable NO_OP = () -> { };
+
     private final DataWriter writer;
 
     private final Lock streamLock = new ReentrantLock(true);
@@ -61,9 +64,28 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
 
     @Override
     public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+        writeData(frame, flowControl, NO_OP);
+    }
+
+    /**
+     * Write a frame with flow control and notify when an {@code END_STREAM}
+     * data frame has been written and accounted for.
+     *
+     * @param frame                   data frame
+     * @param flowControl             outbound flow control
+     * @param onEndStreamFrameWritten action to run after the {@code END_STREAM}
+     *                                data frame is written and accounted for
+     * @return number of bytes written
+     */
+    public int writeData(Http2FrameData frame, FlowControl.Outbound flowControl, Runnable onEndStreamFrameWritten) {
+        Objects.requireNonNull(frame);
+        Objects.requireNonNull(flowControl);
+        Objects.requireNonNull(onEndStreamFrameWritten);
+        int written = 0;
         for (Http2FrameData f : frame.split(flowControl.maxFrameSize())) {
-            splitAndWrite(f, flowControl);
+            written += splitAndWrite(f, flowControl, onEndStreamFrameWritten);
         }
+        return written;
     }
 
     @Override
@@ -201,25 +223,48 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
         }
     }
 
-    private void splitAndWrite(Http2FrameData frame, FlowControl.Outbound flowControl) {
+    private int splitAndWrite(Http2FrameData frame,
+                              FlowControl.Outbound flowControl,
+                              Runnable onEndStreamFrameWritten) {
+        int written = 0;
         Http2FrameData currFrame = frame;
         while (true) {
             Http2FrameData[] splitFrames = flowControl.cut(currFrame);
             if (splitFrames.length == 1) {
                 // windows are wide enough
-                lockedWrite(currFrame);
-                flowControl.decrementWindowSize(currFrame.header().length());
+                written += lockedWriteData(currFrame, flowControl, onEndStreamFrameWritten);
                 break;
             } else if (splitFrames.length == 0) {
                 // block until window update
                 flowControl.blockTillUpdate();
             } else if (splitFrames.length == 2) {
                 // write send-able part and block until window update with the rest
-                lockedWrite(splitFrames[0]);
-                flowControl.decrementWindowSize(splitFrames[0].header().length());
+                written += lockedWriteData(splitFrames[0], flowControl, onEndStreamFrameWritten);
                 flowControl.blockTillUpdate();
                 currFrame = splitFrames[1];
             }
         }
+        return written;
+    }
+
+    private int lockedWriteData(Http2FrameData frame,
+                                FlowControl.Outbound flowControl,
+                                Runnable onEndStreamFrameWritten) {
+        lock();
+        try {
+            noLockWrite(frame);
+            flowControl.decrementWindowSize(frame.header().length());
+            if (frame.header().type() == Http2FrameType.DATA
+                    && frame.header().flags(Http2FrameTypes.DATA).endOfStream()) {
+                onEndStreamFrameWritten.run();
+            }
+            return frameBytes(frame);
+        } finally {
+            streamLock.unlock();
+        }
+    }
+
+    private static int frameBytes(Http2FrameData frame) {
+        return frame.header().length() + Http2FrameHeader.LENGTH;
     }
 }

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2StreamWriter.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2StreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
@@ -19,23 +19,126 @@ package io.helidon.http.http2;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketContext;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Http2ConnectionWriterTest {
+
+    @Test
+    void endStreamCallbackRunsAfterHeadersAreWritten() {
+        DataWriter dataWriter = mock(DataWriter.class);
+        AtomicBoolean callbackCalled = new AtomicBoolean();
+        AtomicBoolean writeReturned = new AtomicBoolean();
+        doAnswer(invocation -> {
+            assertThat(callbackCalled.get(), is(false));
+            writeReturned.set(true);
+            return null;
+        }).when(dataWriter).writeNow(any(BufferData.class));
+
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of());
+
+        int written = writer.writeHeaders(headers(),
+                                          1,
+                                          Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                          flowControl(),
+                                          () -> {
+                                              assertThat(writeReturned.get(), is(true));
+                                              callbackCalled.set(true);
+                                          });
+
+        assertThat(callbackCalled.get(), is(true));
+        assertThat(written, greaterThan(Http2FrameHeader.LENGTH));
+        verify(dataWriter).writeNow(any(BufferData.class));
+    }
+
+    @Test
+    void endStreamCallbackRunsAfterHeadersAndDataAreWritten() {
+        DataWriter dataWriter = mock(DataWriter.class);
+        AtomicBoolean callbackCalled = new AtomicBoolean();
+        AtomicBoolean flowControlDebited = new AtomicBoolean();
+        AtomicInteger writes = new AtomicInteger();
+        doAnswer(invocation -> {
+            assertThat(callbackCalled.get(), is(false));
+            writes.incrementAndGet();
+            return null;
+        }).when(dataWriter).writeNow(any(BufferData.class));
+        byte[] data = "payload".getBytes(StandardCharsets.UTF_8);
+        FlowControl.Outbound flowControl = flowControl();
+        when(flowControl.cut(any(Http2FrameData.class))).thenAnswer(invocation -> new Http2FrameData[] {invocation.getArgument(0)});
+        doAnswer(invocation -> {
+            assertThat(callbackCalled.get(), is(false));
+            flowControlDebited.set(true);
+            return null;
+        }).when(flowControl).decrementWindowSize(data.length);
+
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of());
+        Http2FrameData frame = new Http2FrameData(Http2FrameHeader.create(data.length,
+                                                                          Http2FrameTypes.DATA,
+                                                                          Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                          1),
+                                                  BufferData.create(data));
+
+        int written = writer.writeHeaders(headers(),
+                                          1,
+                                          Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                          frame,
+                                          flowControl,
+                                          () -> {
+                                              assertThat(writes.get(), is(2));
+                                              assertThat(flowControlDebited.get(), is(true));
+                                              callbackCalled.set(true);
+                                          });
+
+        assertThat(callbackCalled.get(), is(true));
+        assertThat(written, greaterThan(data.length + Http2FrameHeader.LENGTH));
+        verify(dataWriter, times(2)).writeNow(any(BufferData.class));
+        verify(flowControl).decrementWindowSize(data.length);
+    }
+
+    @Test
+    void writeHeadersWithDataRejectsNullsBeforeWriting() {
+        DataWriter dataWriter = mock(DataWriter.class);
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of());
+        Http2FrameData frame = new Http2FrameData(Http2FrameHeader.create(0,
+                                                                          Http2FrameTypes.DATA,
+                                                                          Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                          1),
+                                                  BufferData.empty());
+
+        assertThrows(NullPointerException.class,
+                     () -> writer.writeHeaders(headers(),
+                                               1,
+                                               Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                               null,
+                                               flowControl(),
+                                               () -> { }));
+        assertThrows(NullPointerException.class,
+                     () -> writer.writeHeaders(headers(),
+                                               1,
+                                               Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                               frame,
+                                               flowControl(),
+                                               null));
+        verify(dataWriter, times(0)).writeNow(any(BufferData.class));
+    }
 
     @Test
     void endStreamCallbackRunsAfterDataIsWritten() {
@@ -90,5 +193,16 @@ class Http2ConnectionWriterTest {
         assertThrows(NullPointerException.class, () -> writer.writeData(null, FlowControl.Outbound.NOOP, () -> { }));
         assertThrows(NullPointerException.class, () -> writer.writeData(frame, null, () -> { }));
         assertThrows(NullPointerException.class, () -> writer.writeData(frame, FlowControl.Outbound.NOOP, null));
+    }
+
+    private static Http2Headers headers() {
+        return Http2Headers.create(WritableHeaders.create())
+                .status(Status.OK_200);
+    }
+
+    private static FlowControl.Outbound flowControl() {
+        FlowControl.Outbound flowControl = mock(FlowControl.Outbound.class);
+        when(flowControl.maxFrameSize()).thenReturn(16384);
+        return flowControl;
     }
 }

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.http2;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.SocketContext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class Http2ConnectionWriterTest {
+
+    @Test
+    void endStreamCallbackRunsAfterDataIsWritten() {
+        DataWriter dataWriter = mock(DataWriter.class);
+        AtomicBoolean callbackCalled = new AtomicBoolean();
+        AtomicBoolean writeReturned = new AtomicBoolean();
+        AtomicBoolean flowControlDebited = new AtomicBoolean();
+        doAnswer(invocation -> {
+            assertThat(callbackCalled.get(), is(false));
+            writeReturned.set(true);
+            return null;
+        }).when(dataWriter).writeNow(any(BufferData.class));
+        byte[] data = "payload".getBytes(StandardCharsets.UTF_8);
+        FlowControl.Outbound flowControl = mock(FlowControl.Outbound.class);
+        when(flowControl.maxFrameSize()).thenReturn(16384);
+        when(flowControl.cut(any(Http2FrameData.class))).thenAnswer(invocation -> new Http2FrameData[] {invocation.getArgument(0)});
+        doAnswer(invocation -> {
+            assertThat(callbackCalled.get(), is(false));
+            flowControlDebited.set(true);
+            return null;
+        }).when(flowControl).decrementWindowSize(data.length);
+
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of());
+        Http2FrameData frame = new Http2FrameData(Http2FrameHeader.create(data.length,
+                                                                          Http2FrameTypes.DATA,
+                                                                          Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                          1),
+                                                  BufferData.create(data));
+
+        int written = writer.writeData(frame, flowControl, () -> {
+            assertThat(writeReturned.get(), is(true));
+            assertThat(flowControlDebited.get(), is(true));
+            callbackCalled.set(true);
+        });
+
+        assertThat(callbackCalled.get(), is(true));
+        assertThat(written, is(data.length + Http2FrameHeader.LENGTH));
+        verify(dataWriter).writeNow(any(BufferData.class));
+        verify(flowControl).decrementWindowSize(data.length);
+    }
+
+    @Test
+    void callbackAwareWriteDataRejectsNullArguments() {
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), mock(DataWriter.class), List.of());
+        byte[] data = "payload".getBytes(StandardCharsets.UTF_8);
+        Http2FrameData frame = new Http2FrameData(Http2FrameHeader.create(data.length,
+                                                                          Http2FrameTypes.DATA,
+                                                                          Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                          1),
+                                                  BufferData.create(data));
+
+        assertThrows(NullPointerException.class, () -> writer.writeData(null, FlowControl.Outbound.NOOP, () -> { }));
+        assertThrows(NullPointerException.class, () -> writer.writeData(frame, null, () -> { }));
+        assertThrows(NullPointerException.class, () -> writer.writeData(frame, FlowControl.Outbound.NOOP, null));
+    }
+}

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>helidon-webclient-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-http2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media-json-binding</artifactId>
         </dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/HttpJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/HttpJmhTest.java
@@ -50,6 +50,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Benchmark)
@@ -61,6 +62,7 @@ public class HttpJmhTest {
     private static final Header CONTENT_LENGTH = HeaderValues.createCached(HeaderNames.CONTENT_LENGTH, "13");
     private static final int LARGE_RESPONSE_SIZE = 128 * 1024;
     private static final int HTTP2_REUSE_REQUESTS = 16;
+    private static final int HTTP2_REUSE_THREADS = 1;
     private static final Header LARGE_CONTENT_LENGTH = HeaderValues.createCached(HeaderNames.CONTENT_LENGTH,
                                                                                  String.valueOf(LARGE_RESPONSE_SIZE));
     private static final Header SERVER = HeaderValues.createCached(HeaderNames.SERVER, "Helidon");
@@ -171,6 +173,7 @@ public class HttpJmhTest {
     }
 
     @Benchmark
+    @Threads(HTTP2_REUSE_THREADS)
     public void http2MaxConcurrentStreamReuseLargeResponse(Blackhole bh) {
         for (int i = 0; i < HTTP2_REUSE_REQUESTS; i++) {
             try (Http2ClientResponse response = helidonHttp2Client.get("/http2-large").request()) {

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/HttpJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/HttpJmhTest.java
@@ -27,17 +27,23 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Arrays;
 
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.logging.common.LogConfig;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webclient.http2.Http2ClientResponse;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.Handler;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http1.Http1Route;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2ConnectionSelector;
+import io.helidon.webserver.http2.Http2Route;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
@@ -53,24 +59,42 @@ public class HttpJmhTest {
     private static final Header CONTENT_TYPE = HeaderValues.createCached(HeaderNames.CONTENT_TYPE,
                                                                          "text/plain; charset=UTF-8");
     private static final Header CONTENT_LENGTH = HeaderValues.createCached(HeaderNames.CONTENT_LENGTH, "13");
+    private static final int LARGE_RESPONSE_SIZE = 128 * 1024;
+    private static final int HTTP2_REUSE_REQUESTS = 16;
+    private static final Header LARGE_CONTENT_LENGTH = HeaderValues.createCached(HeaderNames.CONTENT_LENGTH,
+                                                                                 String.valueOf(LARGE_RESPONSE_SIZE));
     private static final Header SERVER = HeaderValues.createCached(HeaderNames.SERVER, "Helidon");
     private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] LARGE_RESPONSE_BYTES = new byte[LARGE_RESPONSE_SIZE];
     private static final byte[] HTTP_1_CLOSE_REQUEST = """
             GET /plaintext HTTP/1.1\r
             Host: localhost\r
             Connection: close\r
             \r
             """.getBytes(StandardCharsets.US_ASCII);
+
+    static {
+        Arrays.fill(LARGE_RESPONSE_BYTES, (byte) 'H');
+    }
+
     private WebServer server;
     private int serverPort;
     private HttpClient http1Client;
     private HttpClient http2Client;
+    private Http2Client helidonHttp2Client;
 
     @Setup
     public void setup() {
         LogConfig.configureRuntime();
+        Http2Config http2Config = Http2Config.builder()
+                .maxConcurrentStreams(1)
+                .build();
 
         server = WebServer.builder()
+                .addProtocol(http2Config)
+                .addConnectionSelector(Http2ConnectionSelector.builder()
+                                               .http2Config(http2Config)
+                                               .build())
                 .connectionOptions(builder -> builder
                         .readTimeout(Duration.ZERO)
                         .connectTimeout(Duration.ZERO)
@@ -79,7 +103,9 @@ public class HttpJmhTest {
                 .writeQueueLength(4000)
                 .host(SERVER_HOST)
                 .backlog(8192)
-                .routing(router -> router.route(Http1Route.route(Method.GET, "/plaintext", new PlaintextHandler())))
+                .routing(router -> router
+                        .route(Http1Route.route(Method.GET, "/plaintext", new PlaintextHandler()))
+                        .route(Http2Route.route(Method.GET, "/http2-large", new LargeHttp2Handler())))
                 .build()
                 .start();
 
@@ -94,10 +120,17 @@ public class HttpJmhTest {
                 .version(HttpClient.Version.HTTP_1_1)
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
+
+        helidonHttp2Client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .protocolConfig(http2 -> http2.priorKnowledge(true))
+                .baseUri("http://" + SERVER_HOST + ":" + serverPort)
+                .build();
     }
 
     @TearDown
     public void tearDown() {
+        helidonHttp2Client.closeResource();
         server.stop();
     }
 
@@ -135,6 +168,16 @@ public class HttpJmhTest {
                 .build();
         HttpResponse<byte[]> response = http2Client.send(request, HttpResponse.BodyHandlers.ofByteArray());
         bh.consume(response);
+    }
+
+    @Benchmark
+    public void http2MaxConcurrentStreamReuseLargeResponse(Blackhole bh) {
+        for (int i = 0; i < HTTP2_REUSE_REQUESTS; i++) {
+            try (Http2ClientResponse response = helidonHttp2Client.get("/http2-large").request()) {
+                bh.consume(response.status());
+                bh.consume(response.entity().as(byte[].class));
+            }
+        }
     }
 
     private static int readResponse(InputStream input, byte[] responseBuffer) throws IOException {
@@ -187,6 +230,16 @@ public class HttpJmhTest {
             res.header(CONTENT_TYPE);
             res.header(SERVER);
             res.send(RESPONSE_BYTES);
+        }
+    }
+
+    private static class LargeHttp2Handler implements Handler {
+        @Override
+        public void handle(ServerRequest req, ServerResponse res) {
+            res.header(LARGE_CONTENT_LENGTH);
+            res.header(CONTENT_TYPE);
+            res.header(SERVER);
+            res.send(LARGE_RESPONSE_BYTES);
         }
     }
 }

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/JunitJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/JunitJmhRunnerTest.java
@@ -90,6 +90,7 @@ public class JunitJmhRunnerTest {
     private static ChainedOptionsBuilder optionsBuilder(String resultFile) {
         return new OptionsBuilder()
                 .forks(1)
+                .shouldFailOnError(true)
                 .resultFormat(ResultFormatType.JSON)
                 .result(resultFile)
                 .warmupIterations(10)

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/JunitJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/JunitJmhRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.hamcrest.MatcherAssert;
@@ -32,6 +35,7 @@ import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
@@ -39,23 +43,29 @@ import org.openjdk.jmh.runner.options.TimeValue;
 public class JunitJmhRunnerTest {
 
     private static final String ERROR_MARGIN_PERCENT_DEFAULT = "15";
+    private static final String ALL_BENCHMARKS = ".*JmhTest";
+    private static final String HTTP2_REUSE_BENCHMARK =
+            ".*HttpJmhTest.http2MaxConcurrentStreamReuseLargeResponse";
+    private static final int DEFAULT_THREADS = 8;
+    private static final int HTTP2_REUSE_THREADS = 1;
     private static final int ERROR_MARGIN =
             Integer.parseInt(System.getProperty("webserver.jmh.errorMargin", ERROR_MARGIN_PERCENT_DEFAULT));
 
     static Stream<Histogram.Benchmark> httpBenchmarks() throws RunnerException, IOException {
-        Options opt = new OptionsBuilder()
-                .include(".*JmhTest")
-                .forks(1)
-                .threads(8)
-                .resultFormat(ResultFormatType.JSON)
-                .result("./target/benchmark-result.json")
-                .warmupIterations(10)
-                .warmupTime(TimeValue.seconds(1))
-                .measurementIterations(8)
-                .measurementTime(TimeValue.seconds(2))
+        Options defaultOptions = optionsBuilder("./target/benchmark-result.json")
+                .include(ALL_BENCHMARKS)
+                .exclude(HTTP2_REUSE_BENCHMARK)
+                .threads(DEFAULT_THREADS)
                 .build();
 
-        Collection<RunResult> runResults = new Runner(opt).run();
+        Options http2ReuseOptions = optionsBuilder("./target/benchmark-result-http2-reuse.json")
+                .include(HTTP2_REUSE_BENCHMARK)
+                .threads(HTTP2_REUSE_THREADS)
+                .build();
+
+        Collection<RunResult> runResults = new ArrayList<>();
+        runResults.addAll(new Runner(defaultOptions).run());
+        runResults.addAll(new Runner(http2ReuseOptions).run());
 
         boolean resetBaseline = Boolean.parseBoolean(System.getProperty("webserver.jmh.resetBaseline", "false"));
 
@@ -63,8 +73,9 @@ public class JunitJmhRunnerTest {
         Map<String, BaseLine> baseLineMap;
         if (resetBaseline || !baseLineFile.exists()) {
             Files.deleteIfExists(baseLineFile.toPath());
-            baseLineMap = BaseLine.load(Path.of("./target/benchmark-result.json"));
-            Files.copy(Path.of("./target/benchmark-result.json"), baseLineFile.toPath());
+            baseLineMap = runResults.stream()
+                    .map(BaseLine::create)
+                    .collect(Collectors.toMap(BaseLine::getBenchmark, Function.identity()));
         } else {
             baseLineMap = BaseLine.load(baseLineFile.toPath());
         }
@@ -74,6 +85,17 @@ public class JunitJmhRunnerTest {
         BaseLine.save(baseLineFile.toPath(), baseLineMap);
 
         return histogram.benchmarks.stream();
+    }
+
+    private static ChainedOptionsBuilder optionsBuilder(String resultFile) {
+        return new OptionsBuilder()
+                .forks(1)
+                .resultFormat(ResultFormatType.JSON)
+                .result(resultFile)
+                .warmupIterations(10)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(8)
+                .measurementTime(TimeValue.seconds(2));
     }
 
     @ParameterizedTest(name = "{0}")

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConcurrentConnectionStreams.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConcurrentConnectionStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,4 +27,11 @@ sealed interface Http2ConcurrentConnectionStreams permits Http2ConnectionStreams
      * @param streamId id of the stream to be removed at nearest maintenance
      */
     void remove(int streamId);
+
+    /**
+     * Stop counting a stream as active while retaining its context for late frames.
+     *
+     * @param streamId id of the stream to deactivate
+     */
+    void deactivate(int streamId);
 }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -559,10 +559,11 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                 }
                 return;
             }
+            if (!streams.isActive(streamId)) {
+                return;
+            }
             try {
-                if (streams.isActive(streamId)) {
-                    this.lastRequestTimestamp = DateTime.timestamp();
-                }
+                this.lastRequestTimestamp = DateTime.timestamp();
                 stream.stream().windowUpdate(windowUpdate);
             } catch (Http2Exception ignored) {
                 // stream closed

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConnectionStreams.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConnectionStreams.java
@@ -38,9 +38,7 @@ final class Http2ConnectionStreams implements Http2ConcurrentConnectionStreams {
 
     @Override
     public void remove(int streamId) {
-        if (activeStreamIds.remove(streamId)) {
-            activeStreams.decrementAndGet();
-        }
+        deactivate(streamId);
         forRemoval.add(streamId);
     }
 
@@ -51,6 +49,13 @@ final class Http2ConnectionStreams implements Http2ConcurrentConnectionStreams {
     void activate(int streamId) {
         if (activeStreamIds.add(streamId)) {
             activeStreams.incrementAndGet();
+        }
+    }
+
+    @Override
+    public void deactivate(int streamId) {
+        if (activeStreamIds.remove(streamId)) {
+            activeStreams.decrementAndGet();
         }
     }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -43,6 +43,7 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.http.encoding.ContentDecoder;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.http2.ConnectionFlowControl;
+import io.helidon.http.http2.Http2ConnectionWriter;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Flag;
@@ -83,6 +84,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                   Http2FrameTypes.DATA,
                                                   Http2Flag.DataFlags.create(Http2Flag.DataFlags.END_OF_STREAM),
                                                   0), BufferData.empty());
+    private static final Runnable NO_OP = () -> { };
     private static final System.Logger LOGGER = System.getLogger(Http2Stream.class.getName());
     private static final Set<Http2StreamState> DATA_RECEIVABLE_STATES =
             Set.of(Http2StreamState.OPEN, Http2StreamState.HALF_CLOSED_LOCAL);
@@ -94,6 +96,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private final Http2Settings serverSettings;
     private final Http2Settings clientSettings;
     private final Http2StreamWriter writer;
+    private final Http2ConnectionWriter connectionWriter;
     private final Router router;
     private final Http2ConnectionChecks connectionAttackVectorMetrics;
     private final IntConsumer locallyResetStreams;
@@ -152,6 +155,9 @@ class Http2ServerStream implements Runnable, Http2Stream {
         this.serverSettings = serverSettings;
         this.clientSettings = clientSettings;
         this.writer = writer;
+        this.connectionWriter = writer instanceof Http2ConnectionWriter http2ConnectionWriter
+                ? http2ConnectionWriter
+                : null;
         this.router = ctx.router();
         this.connectionAttackVectorMetrics = connectionAttackVectorMetrics;
         this.locallyResetStreams = locallyResetStreams;
@@ -461,9 +467,11 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     int writeHeadersWithData(Http2Headers http2Headers, int contentLength, BufferData bufferData, boolean endOfStream) {
-        writeState.updateAndGet(s -> s
-                .checkAndMove(WriteState.HEADERS_SENT)
-                .checkAndMove(WriteState.DATA_SENT));
+        writeState.updateAndGet(s -> {
+            WriteState newState = s.checkAndMove(WriteState.HEADERS_SENT)
+                    .checkAndMove(WriteState.DATA_SENT);
+            return endOfStream ? newState.checkAndMove(WriteState.END) : newState;
+        });
 
         Http2FrameData frameData =
                 new Http2FrameData(Http2FrameHeader.create(contentLength,
@@ -472,17 +480,21 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                            streamId),
                                    bufferData);
         try {
-            return writer.writeHeaders(http2Headers, streamId,
+            return writer.writeHeaders(http2Headers,
+                                       streamId,
                                        Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
-                                       frameData,
-                                       flowControl.outbound());
+                                       flowControl.outbound())
+                    + writeDataFrame(frameData, endOfStream);
         } catch (UncheckedIOException e) {
-            throw new ServerConnectionException("Failed to write headers", e);
-        } finally {
             if (endOfStream) {
-                writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
                 closeFromLocal();
             }
+            throw new ServerConnectionException("Failed to write headers", e);
+        } catch (RuntimeException e) {
+            if (endOfStream) {
+                closeFromLocal();
+            }
+            throw e;
         }
     }
 
@@ -503,14 +515,18 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                    bufferData);
 
         try {
-            writer.writeData(frameData, flowControl.outbound());
+            return writeDataFrame(frameData, endOfStream);
         } catch (UncheckedIOException e) {
+            if (endOfStream) {
+                closeFromLocal();
+            }
             throw new ServerConnectionException("Failed to write frame data", e);
+        } catch (RuntimeException e) {
+            if (endOfStream) {
+                closeFromLocal();
+            }
+            throw e;
         }
-        if (endOfStream) {
-            closeFromLocal();
-        }
-        return frameData.header().length() + Http2FrameHeader.LENGTH;
     }
 
     int writeTrailers(Http2Headers http2trailers) {
@@ -581,7 +597,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private void closeFromLocal() {
         if (state == Http2StreamState.HALF_CLOSED_REMOTE || state == Http2StreamState.CLOSED) {
             state = Http2StreamState.CLOSED;
-            streams.remove(this.streamId);
+            streams.deactivate(this.streamId);
         } else {
             state = Http2StreamState.HALF_CLOSED_LOCAL;
         }
@@ -589,6 +605,19 @@ class Http2ServerStream implements Runnable, Http2Stream {
 
     void prologue(HttpPrologue prologue) {
         this.prologue = prologue;
+    }
+
+    private int writeDataFrame(Http2FrameData frameData, boolean endOfStream) {
+        if (connectionWriter == null) {
+            writer.writeData(frameData, flowControl.outbound());
+            if (endOfStream) {
+                closeFromLocal();
+            }
+            return frameData.header().length() + Http2FrameHeader.LENGTH;
+        }
+        return connectionWriter.writeData(frameData,
+                                          flowControl.outbound(),
+                                          endOfStream ? this::closeFromLocal : NO_OP);
     }
 
     ConnectionContext connectionContext() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -470,14 +470,20 @@ class Http2ServerStream implements Runnable, Http2Stream {
         Http2Flag.HeaderFlags flags;
 
         if (endOfStream) {
-            closeFromLocal();
             flags = Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM);
         } else {
             flags = Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS);
         }
 
         try {
-            return writer.writeHeaders(http2Headers, streamId, flags, flowControl.outbound());
+            if (endOfStream && connectionWriter != null) {
+                return connectionWriter.writeHeaders(http2Headers, streamId, flags, flowControl.outbound(), this::closeFromLocal);
+            }
+            int written = writer.writeHeaders(http2Headers, streamId, flags, flowControl.outbound());
+            if (endOfStream) {
+                closeFromLocal();
+            }
+            return written;
         } catch (UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write headers", e);
         }
@@ -548,13 +554,20 @@ class Http2ServerStream implements Runnable, Http2Stream {
 
     int writeTrailers(Http2Headers http2trailers) {
         writeState.updateAndGet(s -> s.checkAndMove(WriteState.TRAILERS_SENT));
-        closeFromLocal();
 
         try {
-            return writer.writeHeaders(http2trailers,
-                                       streamId,
-                                       Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
-                                       flowControl.outbound());
+            Http2Flag.HeaderFlags flags =
+                    Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM);
+            if (connectionWriter != null) {
+                return connectionWriter.writeHeaders(http2trailers,
+                                                     streamId,
+                                                     flags,
+                                                     flowControl.outbound(),
+                                                     this::closeFromLocal);
+            }
+            int written = writer.writeHeaders(http2trailers, streamId, flags, flowControl.outbound());
+            closeFromLocal();
+            return written;
         } catch (UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write trailers", e);
         }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -398,22 +398,39 @@ class Http2ServerStream implements Runnable, Http2Stream {
             Http2Headers http2Headers = Http2Headers.create(headers)
                     .status(e.status());
             if (entity.length == 0) {
-                writer.writeHeaders(http2Headers,
-                                    streamId,
-                                    Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
-                                    flowControl.outbound());
+                Http2Flag.HeaderFlags flags =
+                        Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM);
+                if (connectionWriter == null) {
+                    writer.writeHeaders(http2Headers, streamId, flags, flowControl.outbound());
+                    closeRejectedStream();
+                } else {
+                    connectionWriter.writeHeaders(http2Headers,
+                                                  streamId,
+                                                  flags,
+                                                  flowControl.outbound(),
+                                                  this::closeRejectedStream);
+                }
             } else {
                 Http2FrameHeader dataHeader = Http2FrameHeader.create(entity.length,
                                                                       Http2FrameTypes.DATA,
                                                                       Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
                                                                       streamId);
-                writer.writeHeaders(http2Headers,
-                                    streamId,
-                                    Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
-                                    new Http2FrameData(dataHeader, BufferData.create(message)),
-                                    flowControl.outbound());
+                if (connectionWriter == null) {
+                    writer.writeHeaders(http2Headers,
+                                        streamId,
+                                        Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                        new Http2FrameData(dataHeader, BufferData.create(message)),
+                                        flowControl.outbound());
+                    closeRejectedStream();
+                } else {
+                    connectionWriter.writeHeaders(http2Headers,
+                                                  streamId,
+                                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                                  new Http2FrameData(dataHeader, BufferData.create(message)),
+                                                  flowControl.outbound(),
+                                                  this::closeRejectedStream);
+                }
             }
-            closeRejectedStream();
         } catch (Http2Exception e) {
             ctx.log(LOGGER, DEBUG, "Intentional HTTP/2 stream exception, code: %s, message: %s",
                     e.code(),

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
@@ -16,8 +16,27 @@
 
 package io.helidon.webserver.http2;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.SocketContext;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.ConnectionFlowControl;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2ConnectionWriter;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.http.DirectHandlers;
+import io.helidon.webserver.http.HttpRouting;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -31,6 +50,7 @@ import static org.mockito.Mockito.when;
 class ConnectionStreamTest {
 
     private static final int SETTINGS_MAX_CONCURRENT_STREAMS = 50;
+    private static final int STREAM_ID = 1;
 
     @Test
     void concurrentModification() throws InterruptedException {
@@ -120,9 +140,165 @@ class ConnectionStreamTest {
         assertThat(streams.isEmpty(), Matchers.is(true));
     }
 
+    @Test
+    void terminalHeadersDeactivateAfterConnectionWriterCallback() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter();
+        Http2ServerStream stream = stream(streams, writer);
+
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        streams.activate(STREAM_ID);
+        assertThat(streams.isActive(STREAM_ID), Matchers.is(true));
+        stream.closeFromRemote();
+        assertThat(streams.isActive(STREAM_ID), Matchers.is(true));
+
+        stream.writeHeaders(responseHeaders(), true);
+
+        assertThat(writer.hasPendingTerminalCallback(), Matchers.is(true));
+        assertThat(streams.isActive(STREAM_ID), Matchers.is(true));
+
+        writer.completeTerminalWrite();
+
+        assertThat(streams.isActive(STREAM_ID), Matchers.is(false));
+    }
+
+    @Test
+    void terminalTrailersDeactivateAfterConnectionWriterCallback() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter();
+        Http2ServerStream stream = stream(streams, writer);
+
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        streams.activate(STREAM_ID);
+        assertThat(streams.isActive(STREAM_ID), Matchers.is(true));
+        stream.closeFromRemote();
+        assertThat(streams.isActive(STREAM_ID), Matchers.is(true));
+        stream.writeHeaders(responseHeaders(), false);
+
+        stream.writeTrailers(responseHeaders());
+
+        assertThat(writer.hasPendingTerminalCallback(), Matchers.is(true));
+        assertThat(streams.isActive(STREAM_ID), Matchers.is(true));
+
+        writer.completeTerminalWrite();
+
+        assertThat(streams.isActive(STREAM_ID), Matchers.is(false));
+    }
+
     private static Http2ServerStream mockStream(int streamId) {
         Http2ServerStream s = mock(Http2ServerStream.class);
         when(s.streamId()).thenReturn(streamId);
         return s;
+    }
+
+    private static Http2ServerStream stream(Http2ConnectionStreams streams, Http2ConnectionWriter writer) {
+        Http2Config config = Http2Config.builder()
+                .initialWindowSize(8192)
+                .maxFrameSize(16384)
+                .build();
+        ConnectionFlowControl flowControl = ConnectionFlowControl.serverBuilder((streamId, windowUpdate) -> { })
+                .initialWindowSize(config.initialWindowSize())
+                .maxFrameSize(config.maxFrameSize())
+                .build();
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.config()).thenReturn(ListenerConfig.create());
+        when(listenerContext.directHandlers()).thenReturn(DirectHandlers.create());
+
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.listenerContext()).thenReturn(listenerContext);
+
+        return new Http2ServerStream(ctx,
+                                     streams,
+                                     streamId -> { },
+                                     HttpRouting.empty(),
+                                     config,
+                                     List.of(),
+                                     STREAM_ID,
+                                     Http2Settings.builder().build(),
+                                     Http2Settings.builder().build(),
+                                     writer,
+                                     flowControl,
+                                     new Http2ConnectionChecks(config, mock(Http2Connection.class)));
+    }
+
+    private static Http2Headers responseHeaders() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderValues.createCached(Http2Headers.STATUS_NAME, 200));
+        return Http2Headers.create(headers);
+    }
+
+    private static final class RecordingConnectionWriter extends Http2ConnectionWriter {
+        private Runnable terminalCallback;
+
+        private RecordingConnectionWriter() {
+            super(mock(SocketContext.class), mock(DataWriter.class), List.of());
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                FlowControl.Outbound flowControl) {
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                FlowControl.Outbound flowControl,
+                                Runnable onEndStreamFrameWritten) {
+            if (flags.endOfStream()) {
+                terminalCallback = onEndStreamFrameWritten;
+            }
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                Http2FrameData dataFrame,
+                                FlowControl.Outbound flowControl) {
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                Http2FrameData dataFrame,
+                                FlowControl.Outbound flowControl,
+                                Runnable onEndStreamFrameWritten) {
+            terminalCallback = onEndStreamFrameWritten;
+            return 0;
+        }
+
+        @Override
+        public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+        }
+
+        @Override
+        public int writeData(Http2FrameData frame,
+                             FlowControl.Outbound flowControl,
+                             Runnable onEndStreamFrameWritten) {
+            terminalCallback = onEndStreamFrameWritten;
+            return 0;
+        }
+
+        @Override
+        public void write(Http2FrameData frame) {
+        }
+
+        private void completeTerminalWrite() {
+            assertThat(terminalCallback, Matchers.notNullValue());
+            terminalCallback.run();
+            terminalCallback = null;
+        }
+
+        private boolean hasPendingTerminalCallback() {
+            return terminalCallback != null;
+        }
     }
 }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
@@ -23,6 +23,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,6 +67,28 @@ class ConnectionStreamTest {
 
         assertThat(streams.size(), Matchers.is(0));
         assertThat(streams.isEmpty(), Matchers.is(true));
+    }
+
+    @Test
+    void deactivatedStreamRemainsAvailableUntilRemoved() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        Http2ServerStream s = mockStream(1);
+        Http2Connection.StreamContext ctx = new Http2Connection.StreamContext(1, 8192, s);
+
+        streams.put(ctx);
+        streams.activate(1);
+        streams.deactivate(1);
+
+        assertThat(streams.size(), Matchers.is(0));
+        assertThat(streams.isEmpty(), Matchers.is(true));
+        assertThat(streams.get(1), sameInstance(ctx));
+
+        streams.doMaintenance();
+        assertThat(streams.get(1), sameInstance(ctx));
+
+        streams.remove(1);
+        streams.doMaintenance();
+        assertThat(streams.get(1), nullValue());
     }
 
     @Test

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.RequestException;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.FlowControl;
@@ -61,6 +62,7 @@ class ConcurrentStreamsLimitTest {
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
     private static final int MAX_CONCURRENT_STREAMS = 1;
     private static final String BLOCKING_PATH = "/blocking";
+    private static final String REJECTED_PATH = "/rejected";
 
     private static volatile CountDownLatch requestsStarted;
     private static volatile CountDownLatch releaseHandlers;
@@ -82,6 +84,12 @@ class ConcurrentStreamsLimitTest {
                 Thread.currentThread().interrupt();
                 throw new IllegalStateException("Interrupted while waiting to release HTTP/2 handler", e);
             }
+        }));
+        router.route(Http2Route.route(POST, REJECTED_PATH, (req, res) -> {
+            throw RequestException.builder()
+                    .status(Status.BAD_REQUEST_400)
+                    .message("Rejected request")
+                    .build();
         }));
     }
 
@@ -235,6 +243,52 @@ class ConcurrentStreamsLimitTest {
 
             h2conn.request(3, POST, BLOCKING_PATH, WritableHeaders.create(), BufferData.create(new byte[0]));
             assertOkResponse(h2conn, 3);
+        }
+    }
+
+    @Test
+    void rejectedRequestDoesNotConsumeConcurrentStreamLimit(Http2TestClient client) throws InterruptedException {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            h2conn.request(1, POST, REJECTED_PATH, WritableHeaders.create(), BufferData.create(new byte[0]));
+            assertErrorResponse(h2conn, 1, Status.BAD_REQUEST_400);
+
+            h2conn.request(3, POST, BLOCKING_PATH, WritableHeaders.create(), BufferData.create(new byte[0]));
+            assertThat("Replacement stream did not start",
+                       requestsStarted.await(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                       is(true));
+
+            releaseHandlers.countDown();
+            assertOkResponse(h2conn, 3);
+        }
+    }
+
+    private void assertErrorResponse(Http2TestConnection h2conn, int streamId, Status status) {
+        boolean headersSeen = false;
+        boolean dataSeen = false;
+
+        while (!headersSeen || !dataSeen) {
+            Http2FrameData frame = h2conn.awaitNextFrame(TIMEOUT);
+            assertThat("Timed out waiting for error response frame", frame, notNullValue());
+
+            if (frame.header().type() == Http2FrameType.GO_AWAY) {
+                Http2GoAway goAway = Http2GoAway.create(frame.data());
+                fail("Unexpected GOAWAY " + goAway.errorCode() + ": " + frame.data().readString(frame.data().available()));
+            }
+            if (frame.header().streamId() == 0) {
+                continue;
+            }
+            assertThat("Unexpected response stream", frame.header().streamId(), is(streamId));
+
+            if (frame.header().type() == Http2FrameType.HEADERS) {
+                Http2Headers headers = Http2Headers.create(null, responseDynamicTable, responseHuffman, frame);
+                assertThat(headers.status(), is(status));
+                headersSeen = true;
+            } else if (frame.header().type() == Http2FrameType.DATA) {
+                assertThat(frame.header().flags(Http2FrameTypes.DATA).endOfStream(), is(true));
+                dataSeen = true;
+            } else {
+                fail("Unexpected HTTP/2 frame " + frame.header().type() + " for stream " + frame.header().streamId());
+            }
         }
     }
 


### PR DESCRIPTION
Fix an HTTP/2 server race where a client could observe a response DATA END_STREAM and open another stream before the server stopped counting the completed stream against SETTINGS_MAX_CONCURRENT_STREAMS.

The fix separates active stream accounting from deferred stream-context cleanup, ignores late WINDOW_UPDATE frames for retained inactive streams, and moves final DATA END_STREAM deactivation to the concrete connection writer boundary after the raw DATA write and outbound flow-control accounting complete.

This keeps closed stream contexts available for late control-frame handling without counting them against the concurrent-stream limit after the terminal response frame has been written.
