### PR TITLE
Fix HTTP/1 close-delimited response reuse

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -322,7 +322,6 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         int statusCode = responseStatus.code();
         if (responseStatus.family() == Status.Family.INFORMATIONAL
                 || statusCode == Status.NO_CONTENT_204.code()
-                || statusCode == Status.RESET_CONTENT_205.code()
                 || statusCode == Status.NOT_MODIFIED_304.code()) {
             return false;
         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -22,6 +22,7 @@ import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -320,14 +321,28 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                 && statusCode != Status.NOT_MODIFIED_304.code();
     }
 
+    static boolean isChunkedFinalTransferCoding(Headers headers) {
+        if (!headers.contains(HeaderNames.TRANSFER_ENCODING)) {
+            return false;
+        }
+        List<String> values = headers.get(HeaderNames.TRANSFER_ENCODING).allValues();
+        String lastValue = values.get(values.size() - 1);
+        int lastSeparator = lastValue.lastIndexOf(',');
+        String finalCoding = lastValue.substring(lastSeparator + 1).trim();
+        return HeaderValues.TRANSFER_ENCODING_CHUNKED.get().equalsIgnoreCase(finalCoding);
+    }
+
     private static boolean mayExposeEntity(Method requestMethod, Status responseStatus, ClientResponseHeaders responseHeaders) {
         if (requestMethod == Method.HEAD) {
             return false;
         }
-        if (responseHeaders.contains(HeaderValues.CONTENT_LENGTH_ZERO)) {
+        if (!statusAllowsEntity(responseStatus)) {
             return false;
         }
-        if (!statusAllowsEntity(responseStatus)) {
+        if (responseHeaders.contains(HeaderNames.TRANSFER_ENCODING)) {
+            return true;
+        }
+        if (responseHeaders.contains(HeaderValues.CONTENT_LENGTH_ZERO)) {
             return false;
         }
         if ((
@@ -363,7 +378,10 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             decoder = ContentDecoder.NO_OP;
         }
         InputStream inputStream;
-        if (responseHeaders.contains(HeaderNames.CONTENT_LENGTH)) {
+        if (isChunkedFinalTransferCoding(responseHeaders)) {
+            inputStream = new ChunkedInputStream(helidonSocket, reader, whenComplete, response, recvListener);
+        } else if (!responseHeaders.contains(HeaderNames.TRANSFER_ENCODING)
+                && responseHeaders.contains(HeaderNames.CONTENT_LENGTH)) {
             long length = responseHeaders.contentLength().getAsLong();
             inputStream = new ContentLengthInputStream(helidonSocket,
                                                        reader,
@@ -371,8 +389,6 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                                                        response,
                                                        length,
                                                        recvListener);
-        } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
-            inputStream = new ChunkedInputStream(helidonSocket, reader, whenComplete, response, recvListener);
         } else {
             // we assume the rest of the connection is entity (valid for HTTP/1.0, HTTP CONNECT method etc.
             inputStream = new EverythingInputStream(helidonSocket, reader, whenComplete, response, recvListener);

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -102,16 +102,20 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         Http1ConnectionListener recvListener = http1Client.recvListener();
         WebClientServiceResponse.Builder builder = WebClientServiceResponse.builder();
         AtomicReference<WebClientServiceResponse> response = new AtomicReference<>();
+        boolean successfulConnect = isSuccessfulConnect(serviceRequest.method(), responseStatus);
 
         if (mayExposeEntity(serviceRequest.method(), responseStatus, responseHeaders)) {
             // this may be an entity (if content length is set to zero, we know there is no entity)
-            builder.inputStream(inputStream(clientConfig,
-                                            recvListener,
-                                            connection.helidonSocket(),
-                                            response,
-                                            responseHeaders,
-                                            reader,
-                                            whenComplete));
+            InputStream inputStream = successfulConnect
+                    ? new EverythingInputStream(connection.helidonSocket(), reader, whenComplete, response, recvListener)
+                    : inputStream(clientConfig,
+                                  recvListener,
+                                  connection.helidonSocket(),
+                                  response,
+                                  responseHeaders,
+                                  reader,
+                                  whenComplete);
+            builder.inputStream(inputStream);
         }
 
         WebClientServiceResponse serviceResponse = builder
@@ -321,6 +325,10 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                 && statusCode != Status.NOT_MODIFIED_304.code();
     }
 
+    static boolean isSuccessfulConnect(Method requestMethod, Status responseStatus) {
+        return requestMethod == Method.CONNECT && responseStatus.family() == Status.Family.SUCCESSFUL;
+    }
+
     static boolean isChunkedFinalTransferCoding(Headers headers) {
         if (!headers.contains(HeaderNames.TRANSFER_ENCODING)) {
             return false;
@@ -333,6 +341,9 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     }
 
     private static boolean mayExposeEntity(Method requestMethod, Status responseStatus, ClientResponseHeaders responseHeaders) {
+        if (isSuccessfulConnect(requestMethod, responseStatus)) {
+            return true;
+        }
         if (requestMethod == Method.HEAD) {
             return false;
         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -102,7 +102,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         WebClientServiceResponse.Builder builder = WebClientServiceResponse.builder();
         AtomicReference<WebClientServiceResponse> response = new AtomicReference<>();
 
-        if (mayHaveEntity(serviceRequest.method(), responseStatus, responseHeaders)) {
+        if (mayExposeEntity(serviceRequest.method(), responseStatus, responseHeaders)) {
             // this may be an entity (if content length is set to zero, we know there is no entity)
             builder.inputStream(inputStream(clientConfig,
                                             recvListener,
@@ -312,17 +312,22 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         return recvListener;
     }
 
-    private static boolean mayHaveEntity(Method requestMethod, Status responseStatus, ClientResponseHeaders responseHeaders) {
+    static boolean statusAllowsEntity(Status responseStatus) {
+        int statusCode = responseStatus.code();
+        return responseStatus.family() != Status.Family.INFORMATIONAL
+                && statusCode != Status.NO_CONTENT_204.code()
+                && statusCode != Status.RESET_CONTENT_205.code()
+                && statusCode != Status.NOT_MODIFIED_304.code();
+    }
+
+    private static boolean mayExposeEntity(Method requestMethod, Status responseStatus, ClientResponseHeaders responseHeaders) {
         if (requestMethod == Method.HEAD) {
             return false;
         }
         if (responseHeaders.contains(HeaderValues.CONTENT_LENGTH_ZERO)) {
             return false;
         }
-        int statusCode = responseStatus.code();
-        if (responseStatus.family() == Status.Family.INFORMATIONAL
-                || statusCode == Status.NO_CONTENT_204.code()
-                || statusCode == Status.NOT_MODIFIED_304.code()) {
+        if (!statusAllowsEntity(responseStatus)) {
             return false;
         }
         if ((
@@ -373,6 +378,26 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             inputStream = new EverythingInputStream(helidonSocket, reader, whenComplete, response, recvListener);
         }
         return decoder.apply(inputStream);
+    }
+
+    static int readChunkSize(DataReader reader) {
+        int endOfChunkSize = reader.findNewLine(256);
+        if (endOfChunkSize == 256) {
+            throw new IllegalStateException("Cannot read chunked entity, end of line not found within 256 bytes");
+        }
+        String chunkSizeLine = reader.readAsciiString(endOfChunkSize);
+        reader.skip(2); // CRLF
+        return parseChunkSizeLine(chunkSizeLine);
+    }
+
+    static int parseChunkSizeLine(String chunkSizeLine) {
+        int extension = chunkSizeLine.indexOf(';');
+        String hex = (extension == -1 ? chunkSizeLine : chunkSizeLine.substring(0, extension)).strip();
+        try {
+            return ParserHelper.parseNonNegative(hex, 16, INVALID_SIZE_EXCEPTION_SUPPLIER);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Chunk size is not a number");
+        }
     }
 
     private ClientConnection obtainConnection(WebClientServiceRequest request) {
@@ -615,18 +640,12 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                 return;
             }
             // chunked encoding - I will just read each chunk fully into memory, as that is how the protocol is designed
-            int endOfChunkSize = reader.findNewLine(256);
-            if (endOfChunkSize == 256) {
-                entityProcessedRunnable.run();
-                throw new IllegalStateException("Cannot read chunked entity, end of line not found within 256 bytes");
-            }
-            String hex = reader.readAsciiString(endOfChunkSize);
-            reader.skip(2); // CRLF
             int length;
             try {
-                length = ParserHelper.parseNonNegative(hex, 16, INVALID_SIZE_EXCEPTION_SUPPLIER);
-            } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Chunk size is not a number");
+                length = readChunkSize(reader);
+            } catch (IllegalStateException e) {
+                entityProcessedRunnable.run();
+                throw e;
             }
             if (length == 0) {
                 if (reader.startsWithNewLine()) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -299,6 +299,7 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         return new Http1ClientResponseImpl(clientConfig(),
                                            http1Client().protocolConfig(),
                                            serviceResponse.status(),
+                                           serviceResponse.serviceRequest().method(),
                                            serviceResponse.serviceRequest().headers(),
                                            serviceResponse.headers(),
                                            callChain.connection(),

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -107,7 +107,8 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         this.parserMode = clientConfig.mediaTypeParserMode();
         this.lastEndpointUri = lastEndpointUri;
         this.whenComplete = whenComplete;
-        this.entityAllowed = Http1CallChainBase.statusAllowsEntity(responseStatus);
+        boolean successfulConnect = Http1CallChainBase.isSuccessfulConnect(requestMethod, responseStatus);
+        this.entityAllowed = successfulConnect || Http1CallChainBase.statusAllowsEntity(responseStatus);
         this.trailers = LazyValue.create(this::readTrailers);
 
         boolean transferEncoded = responseHeaders.contains(HeaderNames.TRANSFER_ENCODING);
@@ -118,7 +119,9 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
                 || responseStatus.family() == Status.Family.INFORMATIONAL
                 || statusCode == Status.NO_CONTENT_204.code()
                 || statusCode == Status.NOT_MODIFIED_304.code();
-        if (headerTerminated) {
+        if (successfulConnect) {
+            this.entityLength = ENTITY_LENGTH_CLOSE_DELIMITED;
+        } else if (headerTerminated) {
             this.entityLength = 0;
         } else if (statusCode == Status.RESET_CONTENT_205.code()) {
             if (chunked) {
@@ -142,7 +145,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
             this.entityLength = ENTITY_LENGTH_CLOSE_DELIMITED;
         }
 
-        if (responseHeaders.contains(HeaderNames.TRAILER)) {
+        if (!successfulConnect && responseHeaders.contains(HeaderNames.TRAILER)) {
             this.hasTrailers = true;
             this.trailerNames = responseHeaders.get(HeaderNames.TRAILER).allValues(true);
         } else {
@@ -234,6 +237,9 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     }
 
     private Headers readTrailers() {
+        if (!entityAllowed && entityLength != ENTITY_LENGTH_CHUNKED) {
+            throw new IllegalStateException("Response trailers require chunked transfer coding");
+        }
         boolean consumeNoEntityFraming = !entityAllowed
                 && entityLength == ENTITY_LENGTH_CHUNKED
                 && !entityFullyRead;
@@ -244,11 +250,15 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
             invalidNoEntityChunkedFraming = true;
             readNoEntityChunkedFraming();
         }
+        DataReader reader = connection.reader();
         Headers result = Http1HeadersParser.readHeaders(
-                connection.reader(),
+                reader,
                 protocolConfig.maxHeaderSize(),
                 protocolConfig.validateResponseHeaders()
         );
+        if (!entityAllowed && reader.available() > 0) {
+            throw new IllegalStateException("Unexpected data after response trailers");
+        }
         entityFullyRead = true;
         invalidNoEntityChunkedFraming = false;
         return result;
@@ -292,7 +302,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
             }
             BufferData bufferData = reader.getBuffer(available);
             int endOfChunkSize = bufferData.indexOf(Bytes.CR_BYTE);
-            if (endOfChunkSize == -1 || endOfChunkSize >= 256 || endOfChunkSize + 3 >= available) {
+            if (endOfChunkSize == -1 || endOfChunkSize >= 256 || endOfChunkSize + 4 != available) {
                 return false;
             }
             if (bufferData.get(endOfChunkSize + 1) != Bytes.LF_BYTE

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -40,6 +40,7 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.Http1HeadersParser;
+import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.ReadableEntity;
@@ -72,6 +73,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     private final boolean hasTrailers;
     private final List<String> trailerNames;
     private final boolean entityAllowed;
+    private final boolean headerTerminated;
     // Media type parsing mode configured on client.
     private final ParserMode parserMode;
     private final ClientUri lastEndpointUri;
@@ -81,10 +83,12 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     private boolean entityRequested;
     private long entityLength;
     private boolean entityFullyRead = false;
+    private boolean invalidNoEntityChunkedFraming;
 
     Http1ClientResponseImpl(HttpClientConfig clientConfig,
                             Http1ClientProtocolConfig protocolConfig,
                             Status responseStatus,
+                            Method requestMethod,
                             ClientRequestHeaders requestHeaders,
                             ClientResponseHeaders responseHeaders,
                             ClientConnection connection,
@@ -106,21 +110,34 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         this.entityAllowed = Http1CallChainBase.statusAllowsEntity(responseStatus);
         this.trailers = LazyValue.create(this::readTrailers);
 
-        OptionalLong contentLength = responseHeaders.contentLength();
-        if (responseStatus.code() == Status.RESET_CONTENT_205.code()) {
-            if (contentLength.isPresent()) {
-                this.entityLength = contentLength.getAsLong();
-            } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+        boolean transferEncoded = responseHeaders.contains(HeaderNames.TRANSFER_ENCODING);
+        boolean chunked = Http1CallChainBase.isChunkedFinalTransferCoding(responseHeaders);
+        OptionalLong contentLength = transferEncoded ? OptionalLong.empty() : responseHeaders.contentLength();
+        int statusCode = responseStatus.code();
+        this.headerTerminated = requestMethod == Method.HEAD
+                || responseStatus.family() == Status.Family.INFORMATIONAL
+                || statusCode == Status.NO_CONTENT_204.code()
+                || statusCode == Status.NOT_MODIFIED_304.code();
+        if (headerTerminated) {
+            this.entityLength = 0;
+        } else if (statusCode == Status.RESET_CONTENT_205.code()) {
+            if (chunked) {
                 this.entityLength = ENTITY_LENGTH_CHUNKED;
+            } else if (transferEncoded) {
+                this.entityLength = ENTITY_LENGTH_CLOSE_DELIMITED;
+            } else if (contentLength.isPresent()) {
+                this.entityLength = contentLength.getAsLong();
             } else {
                 this.entityLength = ENTITY_LENGTH_CLOSE_DELIMITED;
             }
         } else if (inputStream == null) {
             this.entityLength = 0;
+        } else if (chunked) {
+            this.entityLength = ENTITY_LENGTH_CHUNKED;
+        } else if (transferEncoded) {
+            this.entityLength = ENTITY_LENGTH_CLOSE_DELIMITED;
         } else if (contentLength.isPresent()) {
             this.entityLength = contentLength.getAsLong();
-        } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
-            this.entityLength = ENTITY_LENGTH_CHUNKED;
         } else {
             this.entityLength = ENTITY_LENGTH_CLOSE_DELIMITED;
         }
@@ -146,10 +163,13 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
 
     @Override
     public ClientResponseTrailers trailers() {
+        if (hasTrailers && !this.entityRequested) {
+            throw new IllegalStateException("Trailers requested before reading entity.");
+        }
+        if (headerTerminated) {
+            return ClientResponseTrailers.create();
+        }
         if (hasTrailers) {
-            if (!this.entityRequested) {
-                throw new IllegalStateException("Trailers requested before reading entity.");
-            }
             return ClientResponseTrailers.create(this.trailers.get());
         } else {
             return ClientResponseTrailers.create();
@@ -170,7 +190,10 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
                         || entityLength == ENTITY_LENGTH_CLOSE_DELIMITED) {
                     connection.closeResource();
                 } else {
-                    if (inputStream == null && hasTrailers && !trailers.isLoaded()) {
+                    if (inputStream == null
+                            && entityLength == ENTITY_LENGTH_CHUNKED
+                            && hasTrailers
+                            && !trailers.isLoaded()) {
                         connection.closeResource();
                     } else if (entityFullyRead || consumeUnreadEntity()) {
                         connection.releaseResource();
@@ -211,7 +234,14 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     }
 
     private Headers readTrailers() {
-        if (!entityAllowed && entityLength == ENTITY_LENGTH_CHUNKED && !entityFullyRead) {
+        boolean consumeNoEntityFraming = !entityAllowed
+                && entityLength == ENTITY_LENGTH_CHUNKED
+                && !entityFullyRead;
+        if (consumeNoEntityFraming) {
+            if (invalidNoEntityChunkedFraming) {
+                throw new IllegalStateException("Response framing cannot be read after a previous failure");
+            }
+            invalidNoEntityChunkedFraming = true;
             readNoEntityChunkedFraming();
         }
         Headers result = Http1HeadersParser.readHeaders(
@@ -220,6 +250,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
                 protocolConfig.validateResponseHeaders()
         );
         entityFullyRead = true;
+        invalidNoEntityChunkedFraming = false;
         return result;
     }
 
@@ -230,7 +261,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         DataReader reader = connection.reader();
         int length = Http1CallChainBase.readChunkSize(reader);
         if (length != 0) {
-            return;
+            throw new IllegalStateException("Response status " + responseStatus.code() + " must not have content");
         }
         if (!hasTrailers && reader.startsWithNewLine()) {
             reader.skip(2);

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -55,6 +55,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     @SuppressWarnings("rawtypes")
     private static final List<SourceHandlerProvider> SOURCE_HANDLERS
             = HelidonServiceLoader.builder(ServiceLoader.load(SourceHandlerProvider.class)).build().asList();
+    private static final byte[] CHUNKED_EMPTY_MESSAGE = {'0', '\r', '\n', '\r', '\n'};
     private static final long ENTITY_LENGTH_CHUNKED = -1;
     private static final long ENTITY_LENGTH_CLOSE_DELIMITED = -2;
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -69,6 +70,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     private final CompletableFuture<Void> whenComplete;
     private final boolean hasTrailers;
     private final List<String> trailerNames;
+    private final boolean entityAllowed;
     // Media type parsing mode configured on client.
     private final ParserMode parserMode;
     private final ClientUri lastEndpointUri;
@@ -100,6 +102,11 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         this.parserMode = clientConfig.mediaTypeParserMode();
         this.lastEndpointUri = lastEndpointUri;
         this.whenComplete = whenComplete;
+        int statusCode = responseStatus.code();
+        this.entityAllowed = responseStatus.family() != Status.Family.INFORMATIONAL
+                && statusCode != Status.NO_CONTENT_204.code()
+                && statusCode != Status.RESET_CONTENT_205.code()
+                && statusCode != Status.NOT_MODIFIED_304.code();
         this.trailers = LazyValue.create(() -> Http1HeadersParser.readHeaders(
                 connection.reader(),
                 protocolConfig.maxHeaderSize(),
@@ -200,15 +207,33 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
 
     /**
      * Attempts to consume an unread entity for the purpose of re-using a cached
-     * connection. Only works for length-prefixed responses and when the entity
-     * has been loaded and has not been partially read. This method shall never
+     * connection. Only works for length-prefixed responses or no-entity
+     * statuses with already-buffered chunked framing. This method shall never
      * block on a read operation.
      *
      * @return {@code true} if consumed, {@code false} otherwise
      */
     private boolean consumeUnreadEntity() {
-        if (entityLength == ENTITY_LENGTH_CHUNKED || entityLength == ENTITY_LENGTH_CLOSE_DELIMITED) {
+        if (entityLength == ENTITY_LENGTH_CLOSE_DELIMITED || (!entityAllowed && entityLength > 0)) {
             return false;
+        }
+        if (entityLength == ENTITY_LENGTH_CHUNKED) {
+            if (entityAllowed || hasTrailers) {
+                return false;
+            }
+            DataReader reader = connection.reader();
+            if (reader.available() != CHUNKED_EMPTY_MESSAGE.length) {
+                return false;
+            }
+            BufferData bufferData = reader.getBuffer(CHUNKED_EMPTY_MESSAGE.length);
+            for (int i = 0; i < CHUNKED_EMPTY_MESSAGE.length; i++) {
+                if (bufferData.get(i) != CHUNKED_EMPTY_MESSAGE[i]) {
+                    return false;
+                }
+            }
+            reader.skip(CHUNKED_EMPTY_MESSAGE.length);
+            entityFullyRead = true;
+            return true;
         }
         DataReader reader = connection.reader();
         if (reader.available() != entityLength) {
@@ -226,7 +251,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
 
     private ReadableEntity entity(ClientRequestHeaders requestHeaders,
                                   ClientResponseHeaders responseHeaders) {
-        if (inputStream == null) {
+        if (inputStream == null || !entityAllowed) {
             return ReadableEntityBase.empty();
         }
         return ClientResponseEntity.create(

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -207,7 +207,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
      * @return {@code true} if consumed, {@code false} otherwise
      */
     private boolean consumeUnreadEntity() {
-        if (entityLength == ENTITY_LENGTH_CHUNKED) {
+        if (entityLength == ENTITY_LENGTH_CHUNKED || entityLength == ENTITY_LENGTH_CLOSE_DELIMITED) {
             return false;
         }
         DataReader reader = connection.reader();

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -19,6 +19,7 @@ package io.helidon.webclient.http1;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.System.Logger.Level;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.ServiceLoader;
@@ -29,6 +30,7 @@ import io.helidon.common.GenericType;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.Bytes;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.media.type.ParserMode;
 import io.helidon.http.ClientRequestHeaders;
@@ -55,7 +57,6 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     @SuppressWarnings("rawtypes")
     private static final List<SourceHandlerProvider> SOURCE_HANDLERS
             = HelidonServiceLoader.builder(ServiceLoader.load(SourceHandlerProvider.class)).build().asList();
-    private static final byte[] CHUNKED_EMPTY_MESSAGE = {'0', '\r', '\n', '\r', '\n'};
     private static final long ENTITY_LENGTH_CHUNKED = -1;
     private static final long ENTITY_LENGTH_CLOSE_DELIMITED = -2;
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -102,19 +103,19 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         this.parserMode = clientConfig.mediaTypeParserMode();
         this.lastEndpointUri = lastEndpointUri;
         this.whenComplete = whenComplete;
-        int statusCode = responseStatus.code();
-        this.entityAllowed = responseStatus.family() != Status.Family.INFORMATIONAL
-                && statusCode != Status.NO_CONTENT_204.code()
-                && statusCode != Status.RESET_CONTENT_205.code()
-                && statusCode != Status.NOT_MODIFIED_304.code();
-        this.trailers = LazyValue.create(() -> Http1HeadersParser.readHeaders(
-                connection.reader(),
-                protocolConfig.maxHeaderSize(),
-                protocolConfig.validateResponseHeaders()
-        ));
+        this.entityAllowed = Http1CallChainBase.statusAllowsEntity(responseStatus);
+        this.trailers = LazyValue.create(this::readTrailers);
 
         OptionalLong contentLength = responseHeaders.contentLength();
-        if (inputStream == null) {
+        if (responseStatus.code() == Status.RESET_CONTENT_205.code()) {
+            if (contentLength.isPresent()) {
+                this.entityLength = contentLength.getAsLong();
+            } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+                this.entityLength = ENTITY_LENGTH_CHUNKED;
+            } else {
+                this.entityLength = ENTITY_LENGTH_CLOSE_DELIMITED;
+            }
+        } else if (inputStream == null) {
             this.entityLength = 0;
         } else if (contentLength.isPresent()) {
             this.entityLength = contentLength.getAsLong();
@@ -169,10 +170,14 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
                         || entityLength == ENTITY_LENGTH_CLOSE_DELIMITED) {
                     connection.closeResource();
                 } else {
-                    // No-body response bytes cannot be consumed as entity; buffered data makes reuse unsafe.
-                    if (inputStream == null && connection.reader().available() > 0) {
+                    if (inputStream == null && hasTrailers && !trailers.isLoaded()) {
                         connection.closeResource();
-                    } else if (entityFullyRead || entityLength == 0 || consumeUnreadEntity()) {
+                    } else if (entityFullyRead || consumeUnreadEntity()) {
+                        connection.releaseResource();
+                    } else if (inputStream == null && connection.reader().available() > 0) {
+                        // No-body response bytes that cannot be consumed as safe framing make reuse unsafe.
+                        connection.closeResource();
+                    } else if (entityLength == 0) {
                         connection.releaseResource();
                     } else {
                         connection.closeResource();
@@ -205,6 +210,34 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         return connection;
     }
 
+    private Headers readTrailers() {
+        if (!entityAllowed && entityLength == ENTITY_LENGTH_CHUNKED && !entityFullyRead) {
+            readNoEntityChunkedFraming();
+        }
+        Headers result = Http1HeadersParser.readHeaders(
+                connection.reader(),
+                protocolConfig.maxHeaderSize(),
+                protocolConfig.validateResponseHeaders()
+        );
+        entityFullyRead = true;
+        return result;
+    }
+
+    private void readNoEntityChunkedFraming() {
+        if (entityFullyRead) {
+            return;
+        }
+        DataReader reader = connection.reader();
+        int length = Http1CallChainBase.readChunkSize(reader);
+        if (length != 0) {
+            return;
+        }
+        if (!hasTrailers && reader.startsWithNewLine()) {
+            reader.skip(2);
+            entityFullyRead = true;
+        }
+    }
+
     /**
      * Attempts to consume an unread entity for the purpose of re-using a cached
      * connection. Only works for length-prefixed responses or no-entity
@@ -222,18 +255,31 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
                 return false;
             }
             DataReader reader = connection.reader();
-            if (reader.available() != CHUNKED_EMPTY_MESSAGE.length) {
+            int available = reader.available();
+            if (available == 0) {
                 return false;
             }
-            BufferData bufferData = reader.getBuffer(CHUNKED_EMPTY_MESSAGE.length);
-            for (int i = 0; i < CHUNKED_EMPTY_MESSAGE.length; i++) {
-                if (bufferData.get(i) != CHUNKED_EMPTY_MESSAGE[i]) {
-                    return false;
-                }
+            BufferData bufferData = reader.getBuffer(available);
+            int endOfChunkSize = bufferData.indexOf(Bytes.CR_BYTE);
+            if (endOfChunkSize == -1 || endOfChunkSize >= 256 || endOfChunkSize + 3 >= available) {
+                return false;
             }
-            reader.skip(CHUNKED_EMPTY_MESSAGE.length);
-            entityFullyRead = true;
-            return true;
+            if (bufferData.get(endOfChunkSize + 1) != Bytes.LF_BYTE
+                    || bufferData.get(endOfChunkSize + 2) != Bytes.CR_BYTE
+                    || bufferData.get(endOfChunkSize + 3) != Bytes.LF_BYTE) {
+                return false;
+            }
+            try {
+                if (Http1CallChainBase.parseChunkSizeLine(bufferData.readString(endOfChunkSize,
+                                                                                StandardCharsets.US_ASCII)) == 0) {
+                    reader.skip(endOfChunkSize + 4);
+                    entityFullyRead = true;
+                    return true;
+                }
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.DEBUG, "Exception while consuming chunked framing", e);
+            }
+            return false;
         }
         DataReader reader = connection.reader();
         if (reader.available() != entityLength) {

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
@@ -37,6 +37,7 @@ import io.helidon.common.socket.PeerInfo;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
@@ -53,6 +54,17 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class Http1ClientResponseImplTest {
+
+    @Test
+    void chunkedMustBeFinalTransferCoding() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderValues.create(HeaderNames.TRANSFER_ENCODING, "chunked, gzip"));
+        assertThat(Http1CallChainBase.isChunkedFinalTransferCoding(headers), is(false));
+
+        headers = WritableHeaders.create();
+        headers.add(HeaderValues.create(HeaderNames.TRANSFER_ENCODING, "gzip, chunked"));
+        assertThat(Http1CallChainBase.isChunkedFinalTransferCoding(headers), is(true));
+    }
 
     @Test
     void doesNotCreateEntityStreamForHeadResponseWithoutFraming() {
@@ -183,6 +195,7 @@ class Http1ClientResponseImplTest {
         return new Http1ClientResponseImpl(HttpClientConfig.builder().build(),
                                            Http1ClientProtocolConfig.create(),
                                            Status.OK_200,
+                                           Method.GET,
                                            ClientRequestHeaders.create(WritableHeaders.create()),
                                            headers,
                                            connection,

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.http1;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -109,6 +110,45 @@ class Http1ClientResponseImplTest {
                                                             ClientResponseHeaders.create(WritableHeaders.create()));
 
         assertThat(response.inputStream().isPresent(), is(true));
+    }
+
+    @Test
+    void successfulConnectIgnoresFramingHeadersAndClosesTunnel() throws IOException {
+        String tunnelData = "4\r\ndata\r\n0\r\n\r\n";
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+        headers.add(HeaderValues.CONTENT_LENGTH_ZERO);
+        ClientResponseHeaders responseHeaders = ClientResponseHeaders.create(headers);
+        TestServiceRequest serviceRequest = new TestServiceRequest(Method.CONNECT);
+        TestConnection connection = new TestConnection(dataReader(tunnelData));
+        WebClientServiceResponse serviceResponse = Http1CallChainBase.createServiceResponse(
+                new Http1ClientImpl(null, Http1ClientConfig.builder().buildPrototype()),
+                serviceRequest,
+                connection,
+                connection.reader(),
+                Status.NO_CONTENT_204,
+                responseHeaders,
+                new CompletableFuture<>());
+        InputStream serviceStream = serviceResponse.inputStream().orElseThrow();
+        Http1ClientResponseImpl response = new Http1ClientResponseImpl(HttpClientConfig.builder().build(),
+                                                                       Http1ClientProtocolConfig.create(),
+                                                                       Status.NO_CONTENT_204,
+                                                                       Method.CONNECT,
+                                                                       serviceRequest.headers(),
+                                                                       responseHeaders,
+                                                                       connection,
+                                                                       serviceStream,
+                                                                       MediaContext.create(),
+                                                                       ClientUri.create(URI.create("http://localhost/test")),
+                                                                       new CompletableFuture<>());
+        InputStream tunnelStream = response.inputStream();
+
+        byte[] actual = new byte[tunnelData.length()];
+        assertThat(tunnelStream.read(actual), is(actual.length));
+        assertThat(new String(actual, StandardCharsets.US_ASCII), is(tunnelData));
+        response.close();
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
     }
 
     @Test

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
@@ -82,6 +82,15 @@ class Http1ClientResponseImplTest {
     }
 
     @Test
+    void doesNotCreateEntityStreamForResetContentWithoutFraming() {
+        WebClientServiceResponse response = serviceResponse(Method.GET,
+                                                            Status.RESET_CONTENT_205,
+                                                            ClientResponseHeaders.create(WritableHeaders.create()));
+
+        assertThat(response.inputStream().isEmpty(), is(true));
+    }
+
+    @Test
     void createsEntityStreamForUnframedGetResponse() {
         WebClientServiceResponse response = serviceResponse(Method.GET,
                                                             Status.OK_200,

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.http1;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -52,6 +53,8 @@ import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PeerInfo;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -69,6 +72,8 @@ import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaContextConfig;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientConfig;
 import io.helidon.webclient.api.HttpClientRequest;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.Proxy;
@@ -162,6 +167,106 @@ class Http1ClientTest {
         assertThat(response.status(), is(Status.OK_200));
         assertThat(response.headers(), noHeader(HeaderNames.CONNECTION));
         assertThat(response.entity().as(String.class), is("Sending Something"));
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testCloseDelimitedResponseClosesConnectionAfterEntityConsumed() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection();
+        Http1ClientResponse response = new Http1ClientResponseImpl(HttpClientConfig.builder().build(),
+                                                                   Http1ClientProtocolConfig.create(),
+                                                                   Status.OK_200,
+                                                                   ClientRequestHeaders.create(WritableHeaders.create()),
+                                                                   ClientResponseHeaders.create(WritableHeaders.create()),
+                                                                   connection,
+                                                                   new ByteArrayInputStream(
+                                                                           "body".getBytes(StandardCharsets.US_ASCII)),
+                                                                   MediaContext.create(),
+                                                                   ClientUri.create(URI.create("http://localhost/test")),
+                                                                   new CompletableFuture<>());
+
+        try (response) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers(), noHeader(HeaderNames.CONTENT_LENGTH));
+            assertThat(response.entity().as(String.class), is("body"));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void testHeadResponseWithoutLengthReusesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.OK_200, false);
+
+        try (Http1ClientResponse response = client.head("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers(), noHeader(HeaderNames.CONTENT_LENGTH));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testHeadResponseWithBufferedEntityClosesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.OK_200,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.create(
+                                                                                     HeaderNames.CONTENT_LENGTH, "4")),
+                                                                             "body".getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.head("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers(), hasHeader(HeaderNames.CONTENT_LENGTH, "4"));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("noBodyStatusResponses")
+    void testNoBodyStatusResponseWithoutLengthReusesConnection(Status status) {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(status, false);
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(status));
+            assertThat(response.headers(), noHeader(HeaderNames.CONTENT_LENGTH));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("notModifiedResponseMetadata")
+    void testNotModifiedResponseWithEntityMetadataReusesConnection(Header responseHeader) {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.NOT_MODIFIED_304,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(responseHeader),
+                                                                             null);
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.NOT_MODIFIED_304));
+            assertThat(response.headers(), hasHeader(HeaderNames.create(responseHeader.name()), responseHeader.get()));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
         assertThat(connection.releaseCount(), is(1));
         assertThat(connection.closeCount(), is(0));
     }
@@ -762,6 +867,21 @@ class Http1ClientTest {
         );
     }
 
+    private static Stream<Arguments> noBodyStatusResponses() {
+        return Stream.of(
+                arguments(Status.NO_CONTENT_204),
+                arguments(Status.RESET_CONTENT_205),
+                arguments(Status.NOT_MODIFIED_304)
+        );
+    }
+
+    private static Stream<Arguments> notModifiedResponseMetadata() {
+        return Stream.of(
+                arguments(HeaderValues.create(HeaderNames.CONTENT_LENGTH, "4")),
+                arguments(HeaderValues.TRANSFER_ENCODING_CHUNKED)
+        );
+    }
+
     private static Stream<Arguments> headerValues() {
         return Stream.of(
                 // Valid header values
@@ -873,6 +993,10 @@ class Http1ClientTest {
         private final boolean includeKeepAliveHeader;
         private final String rawResponse;
         private final String rawContinueResponse;
+        private final Status responseStatus;
+        private final boolean includeContentLength;
+        private final List<Header> additionalResponseHeaders;
+        private final byte[] responseEntity;
         private Throwable serverException;
         private ExecutorService webServerEmulator;
         private String prologue;
@@ -884,7 +1008,7 @@ class Http1ClientTest {
         }
 
         FakeHttp1ClientConnection(boolean includeKeepAliveHeader) {
-            this(includeKeepAliveHeader, null, null);
+            this(Status.OK_200, includeKeepAliveHeader, true);
         }
 
         FakeHttp1ClientConnection(String rawResponse) {
@@ -896,6 +1020,32 @@ class Http1ClientTest {
         }
 
         FakeHttp1ClientConnection(boolean includeKeepAliveHeader, String rawResponse, String rawContinueResponse) {
+            this(Status.OK_200, includeKeepAliveHeader, true, List.of(), null, rawResponse, rawContinueResponse);
+        }
+
+        FakeHttp1ClientConnection(Status responseStatus, boolean includeContentLength) {
+            this(responseStatus, true, includeContentLength);
+        }
+
+        FakeHttp1ClientConnection(Status responseStatus, boolean includeKeepAliveHeader, boolean includeContentLength) {
+            this(responseStatus, includeKeepAliveHeader, includeContentLength, List.of(), null);
+        }
+
+        FakeHttp1ClientConnection(Status responseStatus,
+                                  boolean includeKeepAliveHeader,
+                                  boolean includeContentLength,
+                                  List<Header> additionalResponseHeaders,
+                                  byte[] responseEntity) {
+            this(responseStatus, includeKeepAliveHeader, includeContentLength, additionalResponseHeaders, responseEntity, null, null);
+        }
+
+        private FakeHttp1ClientConnection(Status responseStatus,
+                                          boolean includeKeepAliveHeader,
+                                          boolean includeContentLength,
+                                          List<Header> additionalResponseHeaders,
+                                          byte[] responseEntity,
+                                          String rawResponse,
+                                          String rawContinueResponse) {
             ArrayBlockingQueue<byte[]> serverToClient = new ArrayBlockingQueue<>(1024);
             ArrayBlockingQueue<byte[]> clientToServer = new ArrayBlockingQueue<>(1024);
 
@@ -906,6 +1056,10 @@ class Http1ClientTest {
             this.includeKeepAliveHeader = includeKeepAliveHeader;
             this.rawResponse = rawResponse;
             this.rawContinueResponse = rawContinueResponse;
+            this.responseStatus = responseStatus;
+            this.includeContentLength = includeContentLength;
+            this.additionalResponseHeaders = additionalResponseHeaders;
+            this.responseEntity = responseEntity;
         }
 
         @Override
@@ -1111,21 +1265,33 @@ class Http1ClientTest {
                 return;
             }
 
-            String responseMessage = !requestFailed ? "HTTP/1.1 200 OK\r\n" : "HTTP/1.1 400 Bad Request\r\n";
+            String responseMessage = !requestFailed
+                    ? "HTTP/1.1 " + responseStatus.code() + " " + responseStatus.reasonPhrase() + "\r\n"
+                    : "HTTP/1.1 400 Bad Request\r\n";
             serverWriter.write(BufferData.create(responseMessage.getBytes(StandardCharsets.UTF_8)));
 
             // Send the headers
-            resHeaders.add(HeaderNames.CONTENT_LENGTH, Integer.toString(entitySize));
+            if (includeContentLength) {
+                resHeaders.add(HeaderNames.CONTENT_LENGTH, Integer.toString(entitySize));
+            }
+            for (Header header : additionalResponseHeaders) {
+                resHeaders.add(header);
+            }
             BufferData entityBuffer = BufferData.growing(128);
             for (Header header : resHeaders) {
                 header.writeHttp1Header(entityBuffer);
             }
             entityBuffer.write(Bytes.CR_BYTE);
             entityBuffer.write(Bytes.LF_BYTE);
-            serverWriter.write(entityBuffer);
 
             // Send the entity if it exist
-            if (entitySize > 0) {
+            if (responseEntity == null) {
+                serverWriter.write(entityBuffer);
+            } else {
+                entityBuffer.write(responseEntity);
+                serverWriter.write(entityBuffer);
+            }
+            if (responseEntity == null && entitySize > 0) {
                 serverWriter.write(entity);
             }
         }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -19,7 +19,6 @@ package io.helidon.webclient.http1;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.StandardProtocolFamily;
@@ -260,6 +259,7 @@ class Http1ClientTest {
                 .request()) {
             assertThat(response.status(), is(Status.RESET_CONTENT_205));
             assertThat(response.headers(), noHeader(HeaderNames.CONTENT_LENGTH));
+            assertThat(response.entity().hasEntity(), is(false));
         }
 
         assertThat(connection.releaseCount(), is(0));
@@ -295,13 +295,77 @@ class Http1ClientTest {
                 .request()) {
             assertThat(response.status(), is(Status.RESET_CONTENT_205));
             assertThat(response.headers(), hasHeader(HeaderNames.TRANSFER_ENCODING, "chunked"));
-            try (InputStream entity = response.entity().inputStream()) {
-                assertThat(entity.read(), is(-1));
-            }
+            assertThat(response.entity().hasEntity(), is(false));
         }
 
         assertThat(connection.releaseCount(), is(1));
         assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testResetContentResponseWithContentLengthBodyClosesConnectionWithoutEntity() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.create(
+                                                                                     HeaderNames.CONTENT_LENGTH, "4")),
+                                                                             "body".getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.headers(), hasHeader(HeaderNames.CONTENT_LENGTH, "4"));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void testResetContentResponseWithChunkedBodyClosesConnectionWithoutEntity() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED),
+                                                                             "4\r\nbody\r\n0\r\n\r\n"
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.headers(), hasHeader(HeaderNames.TRANSFER_ENCODING, "chunked"));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void testResetContentResponseWithChunkedTrailersClosesConnectionWithoutEntity() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED,
+                                                                                     HeaderValues.create(
+                                                                                             HeaderNames.TRAILER,
+                                                                                             "X-Test")),
+                                                                             "0\r\nX-Test: value\r\n\r\n"
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.headers(), hasHeader(HeaderNames.TRANSFER_ENCODING, "chunked"));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
     }
 
     @ParameterizedTest

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -177,6 +177,7 @@ class Http1ClientTest {
         Http1ClientResponse response = new Http1ClientResponseImpl(HttpClientConfig.builder().build(),
                                                                    Http1ClientProtocolConfig.create(),
                                                                    Status.OK_200,
+                                                                   Method.GET,
                                                                    ClientRequestHeaders.create(WritableHeaders.create()),
                                                                    ClientResponseHeaders.create(WritableHeaders.create()),
                                                                    connection,
@@ -197,6 +198,90 @@ class Http1ClientTest {
     }
 
     @Test
+    void testTransferEncodingOverridesContentLengthZero() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.OK_200,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.CONTENT_LENGTH_ZERO,
+                                                                                     HeaderValues.TRANSFER_ENCODING_CHUNKED),
+                                                                             "4\r\nbody\r\n0\r\n\r\n"
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().as(String.class), is("body"));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testTransferEncodingIgnoresInvalidContentLength() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.OK_200,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.create(
+                                                                                     HeaderNames.CONTENT_LENGTH,
+                                                                                     "invalid"),
+                                                                                     HeaderValues.TRANSFER_ENCODING_CHUNKED),
+                                                                             "4\r\nbody\r\n0\r\n\r\n"
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().as(String.class), is("body"));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testUnreadTransferEncodingWithContentLengthZeroClosesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.OK_200,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.CONTENT_LENGTH_ZERO,
+                                                                                     HeaderValues.TRANSFER_ENCODING_CHUNKED),
+                                                                             null);
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void testUnreadNonChunkedTransferEncodingWithContentLengthZeroClosesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.OK_200,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.CONTENT_LENGTH_ZERO,
+                                                                                     HeaderValues.create(
+                                                                                             HeaderNames.TRANSFER_ENCODING,
+                                                                                             "gzip")),
+                                                                             null);
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
     void testHeadResponseWithoutLengthReusesConnection() {
         FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.OK_200, false);
 
@@ -205,6 +290,49 @@ class Http1ClientTest {
                 .request()) {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers(), noHeader(HeaderNames.CONTENT_LENGTH));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testHeadResponseWithTrailerHeaderReusesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.OK_200,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.create(
+                                                                                     HeaderNames.TRAILER,
+                                                                                     "X-Test")),
+                                                                             null);
+
+        try (Http1ClientResponse response = client.head("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers(), hasHeader(HeaderNames.TRAILER, "X-Test"));
+            assertThrows(IllegalStateException.class, response::trailers);
+            assertThat(response.entity().hasEntity(), is(false));
+            assertThat(response.trailers().size(), is(0));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testHeadResetContentWithFramingMetadataReusesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED),
+                                                                             null);
+
+        try (Http1ClientResponse response = client.head("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
             assertThat(response.entity().hasEntity(), is(false));
         }
 
@@ -387,6 +515,88 @@ class Http1ClientTest {
 
         assertThat(connection.releaseCount(), is(1));
         assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testResetContentResponseWithChunkedBodyDoesNotExposeBodyAsTrailers() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED,
+                                                                                     HeaderValues.create(
+                                                                                             HeaderNames.TRAILER,
+                                                                                             "X-Test")),
+                                                                             ("10\r\n"
+                                                                                     + "X-Test: body\r\n\r\n"
+                                                                                     + "\r\n0\r\n"
+                                                                                     + "X-Test: trailer\r\n\r\n")
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.entity().hasEntity(), is(false));
+            assertThrows(IllegalStateException.class, response::trailers);
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void testResetContentResponseWithChunkedBodyRejectsRepeatedTrailerAccess() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED,
+                                                                                     HeaderValues.create(
+                                                                                             HeaderNames.TRAILER,
+                                                                                             "X-Test")),
+                                                                             ("13\r\n"
+                                                                                     + "0\r\nX-Test: body\r\n\r\n"
+                                                                                     + "\r\n0\r\n"
+                                                                                     + "X-Test: trailer\r\n\r\n")
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.entity().hasEntity(), is(false));
+            assertThrows(IllegalStateException.class, response::trailers);
+            IllegalStateException exception = assertThrows(IllegalStateException.class, response::trailers);
+            assertThat(exception.getMessage(), is("Response framing cannot be read after a previous failure"));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void testResetContentResponseWithInvalidChunkSizeRejectsRepeatedTrailerAccess() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED,
+                                                                                     HeaderValues.create(
+                                                                                             HeaderNames.TRAILER,
+                                                                                             "X-Test")),
+                                                                             ("invalid\r\n"
+                                                                                     + "0\r\n"
+                                                                                     + "X-Test: value\r\n\r\n")
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.entity().hasEntity(), is(false));
+            assertThrows(IllegalArgumentException.class, response::trailers);
+            IllegalStateException exception = assertThrows(IllegalStateException.class, response::trailers);
+            assertThat(exception.getMessage(), is("Response framing cannot be read after a previous failure"));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
     }
 
     @ParameterizedTest

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -283,12 +283,32 @@ class Http1ClientTest {
     }
 
     @Test
-    void testResetContentResponseWithChunkedTerminatorReusesConnection() throws IOException {
+    void testResetContentResponseWithChunkedTerminatorReusesConnectionWithoutEntityAccess() throws IOException {
         FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
                                                                              true,
                                                                              false,
                                                                              List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED),
                                                                              "0\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.headers(), hasHeader(HeaderNames.TRANSFER_ENCODING, "chunked"));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testResetContentResponseWithChunkedTerminatorExtensionReusesConnection() throws IOException {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED),
+                                                                             "0;ext=value\r\n\r\n"
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
 
         try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
                 .connection(connection)
@@ -345,7 +365,7 @@ class Http1ClientTest {
     }
 
     @Test
-    void testResetContentResponseWithChunkedTrailersClosesConnectionWithoutEntity() {
+    void testResetContentResponseWithChunkedTrailersReusesConnectionAfterTrailersRead() {
         FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
                                                                              true,
                                                                              false,
@@ -353,7 +373,7 @@ class Http1ClientTest {
                                                                                      HeaderValues.create(
                                                                                              HeaderNames.TRAILER,
                                                                                              "X-Test")),
-                                                                             "0\r\nX-Test: value\r\n\r\n"
+                                                                             "0;ext=value\r\nX-Test: value\r\n\r\n"
                                                                                      .getBytes(StandardCharsets.US_ASCII));
 
         try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
@@ -362,10 +382,11 @@ class Http1ClientTest {
             assertThat(response.status(), is(Status.RESET_CONTENT_205));
             assertThat(response.headers(), hasHeader(HeaderNames.TRANSFER_ENCODING, "chunked"));
             assertThat(response.entity().hasEntity(), is(false));
+            assertThat(response.trailers(), hasHeader(HeaderNames.create("X-Test"), "value"));
         }
 
-        assertThat(connection.releaseCount(), is(0));
-        assertThat(connection.closeCount(), is(1));
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
     }
 
     @ParameterizedTest

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -430,6 +430,26 @@ class Http1ClientTest {
     }
 
     @Test
+    void testResetContentResponseWithChunkedTerminatorAndStaleBytesClosesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED),
+                                                                             "0\r\n\r\nstale"
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
     void testResetContentResponseWithChunkedTerminatorExtensionReusesConnection() throws IOException {
         FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
                                                                              true,
@@ -465,6 +485,30 @@ class Http1ClientTest {
             assertThat(response.status(), is(Status.RESET_CONTENT_205));
             assertThat(response.headers(), hasHeader(HeaderNames.CONTENT_LENGTH, "4"));
             assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void testResetContentResponseWithContentLengthDoesNotParseBodyAsTrailers() {
+        byte[] responseEntity = "X-Test: body\r\n\r\nstale".getBytes(StandardCharsets.US_ASCII);
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.create(
+                                                                                             HeaderNames.CONTENT_LENGTH,
+                                                                                             Integer.toString(responseEntity.length)),
+                                                                                     HeaderValues.create(HeaderNames.TRAILER,
+                                                                                                         "X-Test")),
+                                                                             responseEntity);
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.entity().hasEntity(), is(false));
+            assertThrows(IllegalStateException.class, response::trailers);
         }
 
         assertThat(connection.releaseCount(), is(0));
@@ -515,6 +559,30 @@ class Http1ClientTest {
 
         assertThat(connection.releaseCount(), is(1));
         assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testResetContentResponseWithChunkedTrailersAndStaleBytesClosesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED,
+                                                                                     HeaderValues.create(HeaderNames.TRAILER,
+                                                                                                         "X-Test")),
+                                                                             ("0\r\n"
+                                                                                     + "X-Test: value\r\n\r\n"
+                                                                                     + "stale")
+                                                                                     .getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.entity().hasEntity(), is(false));
+            assertThrows(IllegalStateException.class, response::trailers);
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
     }
 
     @Test

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -19,6 +19,7 @@ package io.helidon.webclient.http1;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.StandardProtocolFamily;
@@ -235,7 +236,7 @@ class Http1ClientTest {
 
     @ParameterizedTest
     @MethodSource("noBodyStatusResponses")
-    void testNoBodyStatusResponseWithoutLengthReusesConnection(Status status) {
+    void testHeaderTerminatedNoBodyStatusResponseWithoutLengthReusesConnection(Status status) {
         FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(status, false);
 
         try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
@@ -244,6 +245,59 @@ class Http1ClientTest {
             assertThat(response.status(), is(status));
             assertThat(response.headers(), noHeader(HeaderNames.CONTENT_LENGTH));
             assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testResetContentResponseWithoutLengthClosesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205, false);
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.headers(), noHeader(HeaderNames.CONTENT_LENGTH));
+        }
+
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void testResetContentResponseWithContentLengthZeroReusesConnection() {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205, true);
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.headers(), hasHeader(HeaderNames.CONTENT_LENGTH, "0"));
+            assertThat(response.entity().hasEntity(), is(false));
+        }
+
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testResetContentResponseWithChunkedTerminatorReusesConnection() throws IOException {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(Status.RESET_CONTENT_205,
+                                                                             true,
+                                                                             false,
+                                                                             List.of(HeaderValues.TRANSFER_ENCODING_CHUNKED),
+                                                                             "0\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+
+        try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .request()) {
+            assertThat(response.status(), is(Status.RESET_CONTENT_205));
+            assertThat(response.headers(), hasHeader(HeaderNames.TRANSFER_ENCODING, "chunked"));
+            try (InputStream entity = response.entity().inputStream()) {
+                assertThat(entity.read(), is(-1));
+            }
         }
 
         assertThat(connection.releaseCount(), is(1));
@@ -870,7 +924,6 @@ class Http1ClientTest {
     private static Stream<Arguments> noBodyStatusResponses() {
         return Stream.of(
                 arguments(Status.NO_CONTENT_204),
-                arguments(Status.RESET_CONTENT_205),
                 arguments(Status.NOT_MODIFIED_304)
         );
     }

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcSseTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcSseTest.java
@@ -52,35 +52,19 @@ class JsonRpcSseTest extends JsonRpcBaseTest {
 
     @Test
     void testSse() throws ExecutionException, InterruptedException, TimeoutException {
-        CompletableFuture<List<String>> future = new CompletableFuture<>();
+        assertSseMethods();
+    }
 
+    @Test
+    void testSseCloseDoesNotPoisonConnectionCache() throws ExecutionException, InterruptedException, TimeoutException {
         try (var res = client().post("/rpc/sse")
                 .contentType(MediaTypes.APPLICATION_JSON)
                 .accept(MediaTypes.TEXT_EVENT_STREAM)
                 .submit(SSE_METHOD)) {
             assertThat(res.status().code(), is(200));
-
-            res.source(SseSource.TYPE, new SseSource() {
-                private final List<String> methods = new ArrayList<>();
-
-                @Override
-                public void onEvent(SseEvent value) {
-                    String jsonRpc = value.data(String.class);
-                    JsonObject json = JsonParser.create(jsonRpc).readJsonObject();
-                    methods.add(json.stringValue("method").orElseThrow());
-                }
-
-                @Override
-                public void onClose() {
-                    future.complete(methods);
-                }
-            });
-
-            List<String> methods = future.get(5, TimeUnit.SECONDS);
-            assertThat(methods.size(), is(2));
-            assertThat(methods.getFirst(), is("start"));
-            assertThat(methods.getLast(), is("stop"));
         }
+
+        assertSseMethods();
     }
 
     @Test
@@ -113,6 +97,38 @@ class JsonRpcSseTest extends JsonRpcBaseTest {
             assertThat(results.size(), is(2));
             assertThat(results.getFirst(), is("RUNNING"));
             assertThat(results.getLast(), is("RUNNING"));
+        }
+    }
+
+    private void assertSseMethods() throws ExecutionException, InterruptedException, TimeoutException {
+        CompletableFuture<List<String>> future = new CompletableFuture<>();
+
+        try (var res = client().post("/rpc/sse")
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .accept(MediaTypes.TEXT_EVENT_STREAM)
+                .submit(SSE_METHOD)) {
+            assertThat(res.status().code(), is(200));
+
+            res.source(SseSource.TYPE, new SseSource() {
+                private final List<String> methods = new ArrayList<>();
+
+                @Override
+                public void onEvent(SseEvent value) {
+                    String jsonRpc = value.data(String.class);
+                    JsonObject json = JsonParser.create(jsonRpc).readJsonObject();
+                    methods.add(json.stringValue("method").orElseThrow());
+                }
+
+                @Override
+                public void onClose() {
+                    future.complete(methods);
+                }
+            });
+
+            List<String> methods = future.get(5, TimeUnit.SECONDS);
+            assertThat(methods.size(), is(2));
+            assertThat(methods.getFirst(), is("start"));
+            assertThat(methods.getLast(), is("stop"));
         }
     }
 }

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcSseTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcSseTest.java
@@ -26,9 +26,12 @@ import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.sse.SseEvent;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
+import io.helidon.webclient.api.HttpClient;
+import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
 import io.helidon.webclient.sse.SseSource;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.testing.junit5.ServerTest;
 
 import org.junit.jupiter.api.Test;
@@ -46,25 +49,36 @@ class JsonRpcSseTest extends JsonRpcBaseTest {
                 "id": 1}
             """;
 
-    JsonRpcSseTest(Http1Client client, JsonRpcClient jsonRpcClient) {
+    private final String baseUri;
+
+    JsonRpcSseTest(WebServer server, Http1Client client, JsonRpcClient jsonRpcClient) {
         super(client, jsonRpcClient);
+        this.baseUri = "http://localhost:" + server.port();
     }
 
     @Test
     void testSse() throws ExecutionException, InterruptedException, TimeoutException {
-        assertSseMethods();
+        assertSseMethods(client());
     }
 
     @Test
     void testSseCloseDoesNotPoisonConnectionCache() throws ExecutionException, InterruptedException, TimeoutException {
-        try (var res = client().post("/rpc/sse")
-                .contentType(MediaTypes.APPLICATION_JSON)
-                .accept(MediaTypes.TEXT_EVENT_STREAM)
-                .submit(SSE_METHOD)) {
-            assertThat(res.status().code(), is(200));
-        }
+        WebClient webClient = WebClient.builder()
+                .baseUri(baseUri)
+                .protocolPreference(List.of(Http1Client.PROTOCOL_ID))
+                .build();
+        try {
+            try (var res = webClient.post("/rpc/sse")
+                    .contentType(MediaTypes.APPLICATION_JSON)
+                    .accept(MediaTypes.TEXT_EVENT_STREAM)
+                    .submit(SSE_METHOD)) {
+                assertThat(res.status().code(), is(200));
+            }
 
-        assertSseMethods();
+            assertSseMethods(webClient);
+        } finally {
+            webClient.closeResource();
+        }
     }
 
     @Test
@@ -100,10 +114,10 @@ class JsonRpcSseTest extends JsonRpcBaseTest {
         }
     }
 
-    private void assertSseMethods() throws ExecutionException, InterruptedException, TimeoutException {
+    private void assertSseMethods(HttpClient<?> client) throws ExecutionException, InterruptedException, TimeoutException {
         CompletableFuture<List<String>> future = new CompletableFuture<>();
 
-        try (var res = client().post("/rpc/sse")
+        try (var res = client.post("/rpc/sse")
                 .contentType(MediaTypes.APPLICATION_JSON)
                 .accept(MediaTypes.TEXT_EVENT_STREAM)
                 .submit(SSE_METHOD)) {


### PR DESCRIPTION
Fix intermittent JSON-RPC SSE failures caused by returning close-delimited HTTP/1 response connections to the keep-alive cache.

The HTTP/1 client now distinguishes real close-delimited responses from length-prefixed, chunked, and semantically body-less responses. Closing an unconsumed or fully consumed close-delimited response now closes the socket instead of reusing it, while body-less statuses and unrequested HEAD responses can still keep the connection when no stale bytes are buffered.

The regression coverage exercises abandoned SSE responses, fully consumed close-delimited responses, no-body status handling, 304 metadata, and forbidden buffered bytes after HEAD.
