### PR TITLE
Fix inherited declarative contract annotations

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/common/DeclarativeElementInfo.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/common/DeclarativeElementInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.common;
+
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypedElementInfo;
+
+/**
+ * Utilities for declarative element processing.
+ */
+public final class DeclarativeElementInfo {
+    private DeclarativeElementInfo() {
+    }
+
+    /**
+     * Whether an effective element belongs to the service type being processed.
+     *
+     * @param typeInfo service type info
+     * @param element element to check
+     * @return whether the element belongs to the service type
+     */
+    public static boolean belongsToService(TypeInfo typeInfo, TypedElementInfo element) {
+        TypeName serviceType = typeInfo.typeName().genericTypeName();
+        return element.enclosingType()
+                .map(TypeName::genericTypeName)
+                .map(serviceType::equals)
+                .orElse(true);
+    }
+}

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/common/package-info.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/common/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common utilities for declarative code generation.
+ */
+package io.helidon.declarative.codegen.common;

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
@@ -49,6 +49,11 @@ public class FtExtensionProvider implements RegistryCodegenExtensionProvider {
     }
 
     @Override
+    public boolean supportsServiceContractAnnotations() {
+        return true;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new FtExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
@@ -54,6 +54,11 @@ public class FtExtensionProvider implements RegistryCodegenExtensionProvider {
     }
 
     @Override
+    public boolean supportsFactoryProvidedServiceContractAnnotations() {
+        return false;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new FtExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtHandler.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtHandler.java
@@ -31,6 +31,7 @@ import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
+import io.helidon.declarative.codegen.common.DeclarativeElementInfo;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.RegistryRoundContext;
 
@@ -58,7 +59,8 @@ abstract class FtHandler {
                 continue;
             }
             for (TypedElementInfo element : enclosingType.elementInfo()) {
-                if (!element.hasAnnotation(annotation)) {
+                if (!DeclarativeElementInfo.belongsToService(enclosingType, element)
+                        || !element.hasAnnotation(annotation)) {
                     continue;
                 }
                 String target = elementTarget(enclosingType, element);

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtHandler.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,18 @@
 
 package io.helidon.declarative.codegen.faulttolerance;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenUtil;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Field;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
@@ -50,41 +51,33 @@ abstract class FtHandler {
     }
 
     void process(RegistryRoundContext roundCtx, Map<TypeName, TypeInfo> types) {
-        var elements = roundCtx.annotatedElements(annotation);
         int index = 0;
-        for (TypedElementInfo element : elements) {
-            var enclosingType = enclosingType(types, element);
-            var generatedType = generatedTypeName(enclosingType.typeName(), element, index);
-            process(roundCtx,
-                    enclosingType,
-                    element,
-                    element.annotation(annotation),
-                    generatedType,
-                    classBuilder(enclosingType.typeName(),
-                                 element,
-                                 generatedType));
-            index++;
-        }
-    }
+        Set<String> generatedTargets = new HashSet<>();
+        for (TypeInfo enclosingType : types.values()) {
+            if (enclosingType.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+            for (TypedElementInfo element : enclosingType.elementInfo()) {
+                if (!element.hasAnnotation(annotation)) {
+                    continue;
+                }
+                String target = elementTarget(enclosingType, element);
+                if (!generatedTargets.add(target)) {
+                    continue;
+                }
 
-    TypeInfo enclosingType(Map<TypeName, TypeInfo> types, TypedElementInfo element) {
-        if (element.enclosingType().isEmpty()) {
-            throw new CodegenException(
-                    annotation.className()
-                            + " annotation is only allowed on a method, yet this element does not have an enclosing type: "
-                            + element.elementName(),
-                    element.originatingElementValue());
+                var generatedType = generatedTypeName(enclosingType.typeName(), element, index);
+                process(roundCtx,
+                        enclosingType,
+                        element,
+                        element.annotation(annotation),
+                        generatedType,
+                        classBuilder(enclosingType,
+                                     element,
+                                     generatedType));
+                index++;
+            }
         }
-
-        TypeName enclosingType = element.enclosingType().get();
-        TypeInfo typeInfo = types.get(enclosingType);
-        if (typeInfo == null) {
-            throw new CodegenException(
-                    annotation.className() + " annotation is expected on a type processed as part of this processing round, "
-                            + "yet the type info is not available for type: " + enclosingType.fqName(),
-                    element.originatingElementValue());
-        }
-        return typeInfo;
     }
 
     abstract void process(RegistryRoundContext roundContext,
@@ -178,17 +171,24 @@ abstract class FtHandler {
                 .addContent(")");
     }
 
-    private ClassModel.Builder classBuilder(TypeName enclosingType,
+    private ClassModel.Builder classBuilder(TypeInfo enclosingType,
                                             TypedElementInfo element,
                                             TypeName generatedType) {
+        TypeName typeName = enclosingType.typeName();
         return ClassModel.builder()
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                 .addAnnotation(SINGLETON_ANNOTATION)
-                .addAnnotation(namedAnnotation(enclosingType, element))
-                .addAnnotation(CodegenUtil.generatedAnnotation(generator, enclosingType, generatedType, "1", ""))
-                .copyright(CodegenUtil.copyright(generator, enclosingType, generatedType))
+                .addAnnotation(namedAnnotation(elementTarget(enclosingType, element)))
+                .addAnnotation(CodegenUtil.generatedAnnotation(generator, typeName, generatedType, "1", ""))
+                .copyright(CodegenUtil.copyright(generator, typeName, generatedType))
                 .type(generatedType)
                 .sortStaticFields(false);
+    }
+
+    private String elementTarget(TypeInfo typeInfo, TypedElementInfo element) {
+        return element.enclosingType()
+                .orElse(typeInfo.typeName())
+                .fqName() + "." + element.signature().text();
     }
 
     private TypeName generatedTypeName(TypeName typeName, TypedElementInfo element, int index) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.common.types.Annotated;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
@@ -158,48 +159,50 @@ class MetricsExtension implements RegistryCodegenExtension {
     }
 
     private void generateCountedInterceptors(RegistryRoundContext roundContext, Map<TypeName, TypeInfo> types) {
-        Collection<TypedElementInfo> elements = roundContext.annotatedElements(ANNOTATION_COUNTED);
         Map<TypeName, AtomicInteger> counters = new HashMap<>();
         types.keySet()
                 .forEach(it -> counters.put(it, new AtomicInteger()));
 
         CountedHandler countedHandler = new CountedHandler(roundContext);
 
-        for (TypedElementInfo element : elements) {
-            TypeName enclosingType = enclosingType(element);
-            int counter = counters.computeIfAbsent(enclosingType, k -> new AtomicInteger())
-                    .getAndIncrement();
-
-            TypeInfo typeInfo = types.get(enclosingType);
-            if (typeInfo == null) {
-                typeInfo = ctx.typeInfo(enclosingType).orElseThrow(() -> new CodegenException("No type info found for type "
-                                                                                                      + enclosingType.fqName()));
+        for (TypeInfo typeInfo : types.values()) {
+            if (typeInfo.kind() == ElementKind.INTERFACE) {
+                continue;
             }
-            checkTypeIsService(roundContext, typeInfo);
-            countedHandler.handle(typeInfo, element, counter);
+            for (TypedElementInfo element : typeInfo.elementInfo()) {
+                if (!element.hasAnnotation(ANNOTATION_COUNTED)) {
+                    continue;
+                }
+
+                int counter = counters.computeIfAbsent(typeInfo.typeName(), k -> new AtomicInteger())
+                        .getAndIncrement();
+                checkTypeIsService(roundContext, typeInfo);
+                countedHandler.handle(typeInfo, element, counter);
+            }
         }
     }
 
     private void generateTimedInterceptors(RegistryRoundContext roundContext, Map<TypeName, TypeInfo> types) {
-        Collection<TypedElementInfo> elements = roundContext.annotatedElements(ANNOTATION_TIMED);
         Map<TypeName, AtomicInteger> counters = new HashMap<>();
         types.keySet()
                 .forEach(it -> counters.put(it, new AtomicInteger()));
 
         TimedHandler handler = new TimedHandler(roundContext);
 
-        for (TypedElementInfo element : elements) {
-            TypeName enclosingType = enclosingType(element);
-            int counter = counters.computeIfAbsent(enclosingType, k -> new AtomicInteger())
-                    .getAndIncrement();
-
-            TypeInfo typeInfo = types.get(enclosingType);
-            if (typeInfo == null) {
-                typeInfo = ctx.typeInfo(enclosingType).orElseThrow(() -> new CodegenException("No type info found for type "
-                                                                                                      + enclosingType.fqName()));
+        for (TypeInfo typeInfo : types.values()) {
+            if (typeInfo.kind() == ElementKind.INTERFACE) {
+                continue;
             }
-            checkTypeIsService(roundContext, typeInfo);
-            handler.handle(typeInfo, element, counter);
+            for (TypedElementInfo element : typeInfo.elementInfo()) {
+                if (!element.hasAnnotation(ANNOTATION_TIMED)) {
+                    continue;
+                }
+
+                int counter = counters.computeIfAbsent(typeInfo.typeName(), k -> new AtomicInteger())
+                        .getAndIncrement();
+                checkTypeIsService(roundContext, typeInfo);
+                handler.handle(typeInfo, element, counter);
+            }
         }
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
@@ -17,7 +17,6 @@
 package io.helidon.declarative.codegen.metrics;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -209,7 +208,20 @@ class MetricsExtension implements RegistryCodegenExtension {
     private void generateGaugeRegistrars(RegistryRoundContext roundContext, Map<TypeName, TypeInfo> types) {
         Map<TypeName, List<Gauge>> gaugeByType = new HashMap<>();
 
-        addGauges(roundContext, gaugeByType);
+        for (TypeInfo typeInfo : types.values()) {
+            if (typeInfo.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+            for (TypedElementInfo element : typeInfo.elementInfo()) {
+                if (!element.hasAnnotation(ANNOTATION_GAUGE)) {
+                    continue;
+                }
+
+                TypeName typeName = typeInfo.typeName();
+                var allGauges = gaugeByType.computeIfAbsent(typeName, k -> new ArrayList<>());
+                processGauge(roundContext, allGauges, typeName, element);
+            }
+        }
 
         GaugeHandler handler = new GaugeHandler(roundContext);
 
@@ -236,25 +248,6 @@ class MetricsExtension implements RegistryCodegenExtension {
                                                    + " or it must be a CDI bean (in Helidon MP).",
                                            typeInfo.originatingElementValue());
             }
-        }
-    }
-
-    private TypeName enclosingType(TypedElementInfo element) {
-        Optional<TypeName> enclosingType = element.enclosingType();
-        if (enclosingType.isEmpty()) {
-            throw new CodegenException("Element " + element + " does not have an enclosing type",
-                                       element.originatingElementValue());
-        }
-        return enclosingType.get();
-    }
-
-    private void addGauges(RegistryRoundContext roundContext,
-                           Map<TypeName, List<Gauge>> gaugesByType) {
-        Collection<TypedElementInfo> elements = roundContext.annotatedElements(ANNOTATION_GAUGE);
-        for (TypedElementInfo element : elements) {
-            TypeName enclosingType = enclosingType(element);
-            var allGauges = gaugesByType.computeIfAbsent(enclosingType, k -> new ArrayList<>());
-            processGauge(roundContext, allGauges, enclosingType, element);
         }
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
@@ -34,6 +34,7 @@ import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
+import io.helidon.declarative.codegen.common.DeclarativeElementInfo;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.RegistryRoundContext;
 import io.helidon.service.codegen.spi.RegistryCodegenExtension;
@@ -169,7 +170,8 @@ class MetricsExtension implements RegistryCodegenExtension {
                 continue;
             }
             for (TypedElementInfo element : typeInfo.elementInfo()) {
-                if (!element.hasAnnotation(ANNOTATION_COUNTED)) {
+                if (!DeclarativeElementInfo.belongsToService(typeInfo, element)
+                        || !element.hasAnnotation(ANNOTATION_COUNTED)) {
                     continue;
                 }
 
@@ -193,7 +195,8 @@ class MetricsExtension implements RegistryCodegenExtension {
                 continue;
             }
             for (TypedElementInfo element : typeInfo.elementInfo()) {
-                if (!element.hasAnnotation(ANNOTATION_TIMED)) {
+                if (!DeclarativeElementInfo.belongsToService(typeInfo, element)
+                        || !element.hasAnnotation(ANNOTATION_TIMED)) {
                     continue;
                 }
 
@@ -213,7 +216,8 @@ class MetricsExtension implements RegistryCodegenExtension {
                 continue;
             }
             for (TypedElementInfo element : typeInfo.elementInfo()) {
-                if (!element.hasAnnotation(ANNOTATION_GAUGE)) {
+                if (!DeclarativeElementInfo.belongsToService(typeInfo, element)
+                        || !element.hasAnnotation(ANNOTATION_GAUGE)) {
                     continue;
                 }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
@@ -49,6 +49,11 @@ public class MetricsExtensionProvider implements RegistryCodegenExtensionProvide
     }
 
     @Override
+    public boolean supportsServiceContractAnnotations() {
+        return true;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new MetricsExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
@@ -54,6 +54,11 @@ public class MetricsExtensionProvider implements RegistryCodegenExtensionProvide
     }
 
     @Override
+    public boolean supportsFactoryProvidedServiceContractAnnotations() {
+        return false;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new MetricsExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
@@ -38,6 +38,7 @@ import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
+import io.helidon.declarative.codegen.common.DeclarativeElementInfo;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.RegistryRoundContext;
 import io.helidon.service.codegen.ServiceContracts;
@@ -84,19 +85,62 @@ class TracingExtension implements RegistryCodegenExtension {
                     .addContracts(contracts, new HashSet<>(), type);
 
             contracts.stream()
-                    .map(ResolvedType::type)
-                    .sorted(Comparator.comparing(TypeName::resolvedName))
-                    .flatMap(contract -> roundContext.typeInfo(contract)
-                            .or(() -> roundContext.typeInfo(contract.genericTypeName()))
+                    .sorted(Comparator.comparing(contract -> contract.type().resolvedName()))
+                    .flatMap(contract -> roundContext.typeInfo(contract.type())
+                            .or(() -> roundContext.typeInfo(contract.type().genericTypeName()))
+                            .map(it -> Map.entry(contract, it))
                             .stream())
-                    .filter(contract -> contract.hasAnnotation(ANNOTATION_TRACED))
-                    .forEach(contract -> {
+                    .filter(contract -> contract.getValue().hasAnnotation(ANNOTATION_TRACED))
+                    .forEach(contractEntry -> {
+                        ResolvedType resolvedContract = contractEntry.getKey();
+                        TypeInfo contract = contractEntry.getValue();
+                        List<String> typeParameters = contract.typeName().typeParameters();
+                        List<TypeName> typeArguments = resolvedContract.type().typeArguments();
+                        if (typeArguments.isEmpty()) {
+                            typeArguments = contract.typeName().typeArguments();
+                        }
+                        if (typeParameters.isEmpty()) {
+                            typeParameters = contract.declaredType()
+                                    .typeArguments()
+                                    .stream()
+                                    .filter(TypeName::generic)
+                                    .filter(Predicate.not(TypeName::wildcard))
+                                    .map(TypeName::className)
+                                    .map(TracingExtension::genericTypeName)
+                                    .toList();
+                        }
+                        final Map<String, TypeName> typeArgumentMapping;
+                        if (typeParameters.isEmpty() || typeArguments.isEmpty()) {
+                            typeArgumentMapping = Map.of();
+                        } else {
+                            Map<String, TypeName> result = new HashMap<>();
+                            for (int i = 0; i < Math.min(typeParameters.size(), typeArguments.size()); i++) {
+                                result.put(genericTypeName(typeParameters.get(i)), typeArguments.get(i));
+                            }
+                            typeArgumentMapping = result;
+                        }
                         Set<ElementSignature> contractMethods = contract.elementInfo()
                                 .stream()
                                 .filter(ElementInfoPredicates::isMethod)
                                 .filter(Predicate.not(ElementInfoPredicates::isStatic))
                                 .filter(Predicate.not(ElementInfoPredicates::isPrivate))
-                                .map(TypedElementInfo::signature)
+                                .map(element -> {
+                                    if (typeArgumentMapping.isEmpty()) {
+                                        return element.signature();
+                                    }
+                                    List<TypedElementInfo> parameters = element.parameterArguments()
+                                            .stream()
+                                            .map(it -> TypedElementInfo.builder(it)
+                                                    .typeName(resolveTypeArguments(it.typeName(), typeArgumentMapping))
+                                                    .build())
+                                            .toList();
+
+                                    return TypedElementInfo.builder(element)
+                                            .typeName(resolveTypeArguments(element.typeName(), typeArgumentMapping))
+                                            .parameterArguments(parameters)
+                                            .build()
+                                            .signature();
+                                })
                                 .collect(Collectors.toUnmodifiableSet());
 
                         var contractAnnotation = contract.findAnnotation(ANNOTATION_TRACED);
@@ -113,7 +157,8 @@ class TracingExtension implements RegistryCodegenExtension {
                 continue;
             }
             for (TypedElementInfo element : type.elementInfo()) {
-                if (!ElementInfoPredicates.isMethod(element)
+                if (!DeclarativeElementInfo.belongsToService(type, element)
+                        || !ElementInfoPredicates.isMethod(element)
                         || ElementInfoPredicates.isStatic(element)
                         || ElementInfoPredicates.isPrivate(element)
                         || !element.hasAnnotation(ANNOTATION_TRACED)) {
@@ -177,11 +222,58 @@ class TracingExtension implements RegistryCodegenExtension {
             if (existing == null) {
                 return new TracedElement(element, typeAnnotation);
             }
+            if (!existing.element().hasAnnotation(ANNOTATION_TRACED) && element.hasAnnotation(ANNOTATION_TRACED)) {
+                return new TracedElement(element, existing.typeAnnotation().or(() -> typeAnnotation));
+            }
             if (existing.typeAnnotation().isEmpty() && typeAnnotation.isPresent()) {
                 return new TracedElement(existing.element(), typeAnnotation);
             }
             return existing;
         });
+    }
+
+    private static String genericTypeName(String typeParameter) {
+        String name = typeParameter.trim();
+        int index = name.indexOf(' ');
+        return index == -1 ? name : name.substring(0, index);
+    }
+
+    private TypeName resolveTypeArguments(TypeName typeName, Map<String, TypeName> typeArguments) {
+        if (typeName.generic()) {
+            TypeName resolved = typeArguments.get(typeName.className().trim());
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+
+        List<TypeName> resolvedTypeArguments = typeName.typeArguments()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        List<TypeName> resolvedLowerBounds = typeName.lowerBounds()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        List<TypeName> resolvedUpperBounds = typeName.upperBounds()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        Optional<TypeName> resolvedComponentType = typeName.componentType()
+                .map(it -> resolveTypeArguments(it, typeArguments));
+
+        if (resolvedTypeArguments.equals(typeName.typeArguments())
+                && resolvedLowerBounds.equals(typeName.lowerBounds())
+                && resolvedUpperBounds.equals(typeName.upperBounds())
+                && resolvedComponentType.equals(typeName.componentType())) {
+            return typeName;
+        }
+
+        TypeName.Builder builder = TypeName.builder(typeName)
+                .typeArguments(resolvedTypeArguments)
+                .lowerBounds(resolvedLowerBounds)
+                .upperBounds(resolvedUpperBounds);
+        resolvedComponentType.ifPresent(builder::componentType);
+        return builder.build();
     }
 
     private void processElement(TracedHandler handler,

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
@@ -27,6 +27,7 @@ import java.util.function.Predicate;
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.ElementInfoPredicates;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.ElementSignature;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
@@ -52,17 +53,15 @@ class TracingExtension implements RegistryCodegenExtension {
     public void process(RegistryRoundContext roundContext) {
         // collect all typeInfo + method that is traced
         Collection<TypeInfo> roundTypes = roundContext.types();
-        Map<TypeName, TypeInfo> usedTypes = new HashMap<>();
-        for (TypeInfo roundType : roundTypes) {
-            usedTypes.put(roundType.typeName(), roundType);
-        }
 
         Collection<TypeInfo> annotatedTypes = roundContext.annotatedTypes(ANNOTATION_TRACED);
-        Collection<TypedElementInfo> annotatedElements = roundContext.annotatedElements(ANNOTATION_TRACED);
 
         Map<TypeName, TracedElements> tracedElements = new HashMap<>();
 
         for (TypeInfo type : annotatedTypes) {
+            if (type.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
             var tracedElementValue = tracedElements.computeIfAbsent(type.typeName(),
                                                                     k -> new TracedElements(type, new HashMap<>()));
             var map = tracedElementValue.elements();
@@ -75,11 +74,22 @@ class TracingExtension implements RegistryCodegenExtension {
                     .forEach(element -> map.put(element.signature(), element));
         }
 
-        for (TypedElementInfo element : annotatedElements) {
-            TypeInfo type = typeForElement(roundContext, usedTypes, element);
-            tracedElements.computeIfAbsent(type.typeName(), k -> new TracedElements(type, new HashMap<>()))
-                    .elements()
-                    .put(element.signature(), element);
+        for (TypeInfo type : roundTypes) {
+            if (type.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+            for (TypedElementInfo element : type.elementInfo()) {
+                if (!ElementInfoPredicates.isMethod(element)
+                        || ElementInfoPredicates.isStatic(element)
+                        || ElementInfoPredicates.isPrivate(element)
+                        || !element.hasAnnotation(ANNOTATION_TRACED)) {
+                    continue;
+                }
+
+                tracedElements.computeIfAbsent(type.typeName(), k -> new TracedElements(type, new HashMap<>()))
+                        .elements()
+                        .put(element.signature(), element);
+            }
         }
 
         TracedHandler handler = new TracedHandler(roundContext);
@@ -185,24 +195,6 @@ class TracingExtension implements RegistryCodegenExtension {
         }
 
         handler.handle(serviceType, element, index, spanName, spanKind, tags, tagParams);
-    }
-
-    private TypeInfo typeForElement(RegistryRoundContext roundContext,
-                                    Map<TypeName, TypeInfo> usedTypes,
-                                    TypedElementInfo element) {
-        var enclosing = element.enclosingType()
-                .orElseThrow(() -> new CodegenException("Annotated element does not have an enclosing type",
-                                                        element.originatingElementValue()));
-
-        var typeInfo = usedTypes.get(enclosing);
-        if (typeInfo != null) {
-            return typeInfo;
-        }
-        typeInfo = roundContext.typeInfo(enclosing)
-                .orElseThrow(() -> new CodegenException("Cannot find enclosing type " + enclosing.fqName(),
-                                                        element.originatingElementValue()));
-        usedTypes.put(enclosing, typeInfo);
-        return typeInfo;
     }
 
     private record TracedElements(TypeInfo type, Map<ElementSignature, TypedElementInfo> elements) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.ElementInfoPredicates;
@@ -68,11 +69,9 @@ class TracingExtension implements RegistryCodegenExtension {
             if (type.kind() == ElementKind.INTERFACE) {
                 continue;
             }
-            TracedElements tracedElementValue = tracedElements(tracedElements,
-                                                               type,
-                                                               type.findAnnotation(ANNOTATION_TRACED));
+            TracedElements tracedElementValue = tracedElements(tracedElements, type);
 
-            addTypeTracedMethods(tracedElementValue, type);
+            addTypeTracedMethods(tracedElementValue, type.elementInfo(), type.findAnnotation(ANNOTATION_TRACED));
         }
 
         for (TypeInfo type : roundTypes) {
@@ -84,18 +83,29 @@ class TracingExtension implements RegistryCodegenExtension {
             ServiceContracts.create(ctx.options(), roundContext::typeInfo, type)
                     .addContracts(contracts, new HashSet<>(), type);
 
-            Optional<Annotation> contractTypeAnnotation = contracts.stream()
+            contracts.stream()
                     .map(ResolvedType::type)
                     .sorted(Comparator.comparing(TypeName::resolvedName))
                     .flatMap(contract -> roundContext.typeInfo(contract)
                             .or(() -> roundContext.typeInfo(contract.genericTypeName()))
                             .stream())
-                    .flatMap(contract -> contract.findAnnotation(ANNOTATION_TRACED).stream())
-                    .findFirst();
+                    .filter(contract -> contract.hasAnnotation(ANNOTATION_TRACED))
+                    .forEach(contract -> {
+                        Set<ElementSignature> contractMethods = contract.elementInfo()
+                                .stream()
+                                .filter(ElementInfoPredicates::isMethod)
+                                .filter(Predicate.not(ElementInfoPredicates::isStatic))
+                                .filter(Predicate.not(ElementInfoPredicates::isPrivate))
+                                .map(TypedElementInfo::signature)
+                                .collect(Collectors.toUnmodifiableSet());
 
-            if (contractTypeAnnotation.isPresent()) {
-                addTypeTracedMethods(tracedElements(tracedElements, type, contractTypeAnnotation), type);
-            }
+                        var contractAnnotation = contract.findAnnotation(ANNOTATION_TRACED);
+                        var serviceMethods = type.elementInfo()
+                                .stream()
+                                .filter(it -> contractMethods.contains(it.signature()))
+                                .toList();
+                        addTypeTracedMethods(tracedElements(tracedElements, type), serviceMethods, contractAnnotation);
+                    });
         }
 
         for (TypeInfo type : roundTypes) {
@@ -110,9 +120,9 @@ class TracingExtension implements RegistryCodegenExtension {
                     continue;
                 }
 
-                tracedElements(tracedElements, type, Optional.empty())
-                        .elements()
-                        .put(element.signature(), element);
+                addTracedElement(tracedElements(tracedElements, type).elements(),
+                                 element,
+                                 Optional.empty());
             }
         }
 
@@ -126,15 +136,15 @@ class TracingExtension implements RegistryCodegenExtension {
             TypeName serviceType = tracedEntry.getKey();
             TracedElements tracedElementValue = tracedEntry.getValue();
             TypeInfo serviceTypeInfo = tracedElementValue.type();
-            Map<ElementSignature, TypedElementInfo> elements = tracedElementValue.elements();
+            Map<ElementSignature, TracedElement> elements = tracedElementValue.elements();
             int index = 0;
 
-            for (TypedElementInfo element : elements.values()) {
+            for (TracedElement element : elements.values()) {
                 processElement(handler,
                                serviceTypeInfo,
                                serviceType,
-                               tracedElementValue.typeAnnotation(),
-                               element,
+                               element.typeAnnotation(),
+                               element.element(),
                                index);
                 index++;
             }
@@ -142,28 +152,36 @@ class TracingExtension implements RegistryCodegenExtension {
     }
 
     private TracedElements tracedElements(Map<TypeName, TracedElements> tracedElements,
-                                          TypeInfo type,
-                                          Optional<Annotation> typeAnnotation) {
-        return tracedElements.compute(type.typeName(), (key, existing) -> {
-            if (existing == null) {
-                return new TracedElements(type, typeAnnotation, new HashMap<>());
-            }
-            if (existing.typeAnnotation().isEmpty() && typeAnnotation.isPresent()) {
-                return new TracedElements(existing.type(), typeAnnotation, existing.elements());
-            }
-            return existing;
-        });
+                                          TypeInfo type) {
+        return tracedElements.computeIfAbsent(type.typeName(),
+                                              key -> new TracedElements(type, new HashMap<>()));
     }
 
-    private void addTypeTracedMethods(TracedElements tracedElementValue, TypeInfo type) {
-        Map<ElementSignature, TypedElementInfo> map = tracedElementValue.elements();
+    private void addTypeTracedMethods(TracedElements tracedElementValue,
+                                      Collection<TypedElementInfo> elements,
+                                      Optional<Annotation> typeAnnotation) {
+        Map<ElementSignature, TracedElement> map = tracedElementValue.elements();
 
-        type.elementInfo()
+        elements
                 .stream()
                 .filter(ElementInfoPredicates::isMethod)
                 .filter(Predicate.not(ElementInfoPredicates::isStatic))
                 .filter(Predicate.not(ElementInfoPredicates::isPrivate))
-                .forEach(element -> map.put(element.signature(), element));
+                .forEach(element -> addTracedElement(map, element, typeAnnotation));
+    }
+
+    private void addTracedElement(Map<ElementSignature, TracedElement> map,
+                                  TypedElementInfo element,
+                                  Optional<Annotation> typeAnnotation) {
+        map.compute(element.signature(), (key, existing) -> {
+            if (existing == null) {
+                return new TracedElement(element, typeAnnotation);
+            }
+            if (existing.typeAnnotation().isEmpty() && typeAnnotation.isPresent()) {
+                return new TracedElement(existing.element(), typeAnnotation);
+            }
+            return existing;
+        });
     }
 
     private void processElement(TracedHandler handler,
@@ -253,8 +271,11 @@ class TracingExtension implements RegistryCodegenExtension {
     }
 
     private record TracedElements(TypeInfo type,
-                                  Optional<Annotation> typeAnnotation,
-                                  Map<ElementSignature, TypedElementInfo> elements) {
+                                  Map<ElementSignature, TracedElement> elements) {
+    }
+
+    private record TracedElement(TypedElementInfo element,
+                                 Optional<Annotation> typeAnnotation) {
     }
 
     record TagParam(int index, TypeName type, String name) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
@@ -18,10 +18,14 @@ package io.helidon.declarative.codegen.tracing;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import io.helidon.codegen.CodegenException;
@@ -29,11 +33,13 @@ import io.helidon.codegen.ElementInfoPredicates;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.ElementSignature;
+import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.RegistryRoundContext;
+import io.helidon.service.codegen.ServiceContracts;
 import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 
 import static io.helidon.declarative.codegen.tracing.TracingTypes.ANNOTATION_TAG_PARAM;
@@ -62,16 +68,34 @@ class TracingExtension implements RegistryCodegenExtension {
             if (type.kind() == ElementKind.INTERFACE) {
                 continue;
             }
-            var tracedElementValue = tracedElements.computeIfAbsent(type.typeName(),
-                                                                    k -> new TracedElements(type, new HashMap<>()));
-            var map = tracedElementValue.elements();
+            TracedElements tracedElementValue = tracedElements(tracedElements,
+                                                               type,
+                                                               type.findAnnotation(ANNOTATION_TRACED));
 
-            type.elementInfo()
-                    .stream()
-                    .filter(ElementInfoPredicates::isMethod)
-                    .filter(Predicate.not(ElementInfoPredicates::isStatic))
-                    .filter(Predicate.not(ElementInfoPredicates::isPrivate))
-                    .forEach(element -> map.put(element.signature(), element));
+            addTypeTracedMethods(tracedElementValue, type);
+        }
+
+        for (TypeInfo type : roundTypes) {
+            if (type.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+
+            Set<ResolvedType> contracts = new HashSet<>();
+            ServiceContracts.create(ctx.options(), roundContext::typeInfo, type)
+                    .addContracts(contracts, new HashSet<>(), type);
+
+            Optional<Annotation> contractTypeAnnotation = contracts.stream()
+                    .map(ResolvedType::type)
+                    .sorted(Comparator.comparing(TypeName::resolvedName))
+                    .flatMap(contract -> roundContext.typeInfo(contract)
+                            .or(() -> roundContext.typeInfo(contract.genericTypeName()))
+                            .stream())
+                    .flatMap(contract -> contract.findAnnotation(ANNOTATION_TRACED).stream())
+                    .findFirst();
+
+            if (contractTypeAnnotation.isPresent()) {
+                addTypeTracedMethods(tracedElements(tracedElements, type, contractTypeAnnotation), type);
+            }
         }
 
         for (TypeInfo type : roundTypes) {
@@ -86,7 +110,7 @@ class TracingExtension implements RegistryCodegenExtension {
                     continue;
                 }
 
-                tracedElements.computeIfAbsent(type.typeName(), k -> new TracedElements(type, new HashMap<>()))
+                tracedElements(tracedElements, type, Optional.empty())
                         .elements()
                         .put(element.signature(), element);
             }
@@ -106,15 +130,46 @@ class TracingExtension implements RegistryCodegenExtension {
             int index = 0;
 
             for (TypedElementInfo element : elements.values()) {
-                processElement(handler, serviceTypeInfo, serviceType, element, index);
+                processElement(handler,
+                               serviceTypeInfo,
+                               serviceType,
+                               tracedElementValue.typeAnnotation(),
+                               element,
+                               index);
                 index++;
             }
         }
     }
 
+    private TracedElements tracedElements(Map<TypeName, TracedElements> tracedElements,
+                                          TypeInfo type,
+                                          Optional<Annotation> typeAnnotation) {
+        return tracedElements.compute(type.typeName(), (key, existing) -> {
+            if (existing == null) {
+                return new TracedElements(type, typeAnnotation, new HashMap<>());
+            }
+            if (existing.typeAnnotation().isEmpty() && typeAnnotation.isPresent()) {
+                return new TracedElements(existing.type(), typeAnnotation, existing.elements());
+            }
+            return existing;
+        });
+    }
+
+    private void addTypeTracedMethods(TracedElements tracedElementValue, TypeInfo type) {
+        Map<ElementSignature, TypedElementInfo> map = tracedElementValue.elements();
+
+        type.elementInfo()
+                .stream()
+                .filter(ElementInfoPredicates::isMethod)
+                .filter(Predicate.not(ElementInfoPredicates::isStatic))
+                .filter(Predicate.not(ElementInfoPredicates::isPrivate))
+                .forEach(element -> map.put(element.signature(), element));
+    }
+
     private void processElement(TracedHandler handler,
                                 TypeInfo serviceTypeInfo,
                                 TypeName serviceType,
+                                Optional<Annotation> typeAnnotation,
                                 TypedElementInfo element,
                                 int index) {
         // collect tags, kind etc. from all annotations
@@ -124,7 +179,7 @@ class TracingExtension implements RegistryCodegenExtension {
         String spanKind = DEFAULT_SPAN_KIND;
 
         // first gather data from type annotation
-        var maybeTraced = serviceTypeInfo.findAnnotation(ANNOTATION_TRACED);
+        var maybeTraced = typeAnnotation.or(() -> serviceTypeInfo.findAnnotation(ANNOTATION_TRACED));
         if (maybeTraced.isPresent()) {
             var traced = maybeTraced.get();
             nameTemplate = traced.value()
@@ -189,7 +244,7 @@ class TracingExtension implements RegistryCodegenExtension {
                 tagName = tagParam.value()
                         .filter(Predicate.not(String::isBlank))
                         .orElse(tagName);
-                tagParams.add(new TagParam(i, element.typeName(), tagName));
+                tagParams.add(new TagParam(i, param.typeName(), tagName));
             }
             i++;
         }
@@ -197,7 +252,9 @@ class TracingExtension implements RegistryCodegenExtension {
         handler.handle(serviceType, element, index, spanName, spanKind, tags, tagParams);
     }
 
-    private record TracedElements(TypeInfo type, Map<ElementSignature, TypedElementInfo> elements) {
+    private record TracedElements(TypeInfo type,
+                                  Optional<Annotation> typeAnnotation,
+                                  Map<ElementSignature, TypedElementInfo> elements) {
     }
 
     record TagParam(int index, TypeName type, String name) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
@@ -52,6 +52,11 @@ public class TracingExtensionProvider implements RegistryCodegenExtensionProvide
     }
 
     @Override
+    public boolean supportsFactoryProvidedServiceContractAnnotations() {
+        return false;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new TracingExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
@@ -47,6 +47,11 @@ public class TracingExtensionProvider implements RegistryCodegenExtensionProvide
     }
 
     @Override
+    public boolean supportsServiceContractAnnotations() {
+        return true;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new TracingExtension(codegenContext);
     }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/FactoryProvidedContractAnnotationsCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/FactoryProvidedContractAnnotationsCodegenTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.GenericType;
+import io.helidon.common.types.Annotation;
+import io.helidon.faulttolerance.Ft;
+import io.helidon.faulttolerance.Retry;
+import io.helidon.metrics.api.Gauge;
+import io.helidon.metrics.api.Meter;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.Metrics;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracer;
+import io.helidon.tracing.Tracing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class FactoryProvidedContractAnnotationsCodegenTest {
+    private static final List<Class<?>> CLASSPATH = List.of(
+            Generated.class,
+            GenericType.class,
+            Annotation.class,
+            Prototype.class,
+            Service.class,
+            Ft.class,
+            Retry.class,
+            Metrics.class,
+            Meter.class,
+            Gauge.class,
+            MeterRegistry.class,
+            Tracing.class,
+            Span.class,
+            Tracer.class
+    );
+
+    @Test
+    void testSupplierProvidedFtContractDoesNotGenerateInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedFtApi.java", """
+                        package com.example;
+
+                        import io.helidon.faulttolerance.Ft;
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Contract
+                        interface ProvidedFtApi {
+                            @Ft.Retry(calls = 2)
+                            String value();
+                        }
+                        """)
+                .addSource("ProvidedFtApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class ProvidedFtApiSupplier implements Supplier<ProvidedFtApi> {
+                            @Override
+                            public ProvidedFtApi get() {
+                                return () -> "value";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput().resolve("com/example/ProvidedFtApiSupplier_value__Retry.java")),
+                   is(false));
+    }
+
+    @Test
+    void testSupplierProvidedMetricsContractDoesNotGenerateRegistrar() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedMetricsApi.java", """
+                        package com.example;
+
+                        import io.helidon.metrics.api.Meter;
+                        import io.helidon.metrics.api.Metrics;
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Contract
+                        interface ProvidedMetricsApi {
+                            @Metrics.Gauge(unit = Meter.BaseUnits.BYTES)
+                            long size();
+                        }
+                        """)
+                .addSource("ProvidedMetricsApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class ProvidedMetricsApiSupplier implements Supplier<ProvidedMetricsApi> {
+                            @Override
+                            public ProvidedMetricsApi get() {
+                                return () -> 42L;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput().resolve("com/example/ProvidedMetricsApiSupplier__GaugeRegistrar.java")),
+                   is(false));
+    }
+
+    @Test
+    void testSupplierProvidedTracingContractDoesNotGenerateInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedTracingApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        interface ProvidedTracingApi {
+                            @Tracing.Traced
+                            String traced();
+                        }
+                        """)
+                .addSource("ProvidedTracingApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class ProvidedTracingApiSupplier implements Supplier<ProvidedTracingApi> {
+                            @Override
+                            public ProvidedTracingApi get() {
+                                return () -> "traced";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput().resolve("com/example/ProvidedTracingApiSupplier__TracedInterceptor.java")),
+                   is(false));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -186,6 +186,88 @@ public class ValidationCodegenTest {
     }
 
     @Test
+    void testImplicitServiceContractConstraintGeneratesInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        assertThat(Files.readString(interceptor, StandardCharsets.UTF_8),
+                   containsString("\"com.example.DefaultApiImpl.validate(java.lang.String)\""));
+    }
+
+    @Test
+    void testExternalContractConstraintGeneratesInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addOption("-Ahelidon.registry.autoAddNonContractInterfaces=false")
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        @Service.ExternalContracts(DefaultApi.class)
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        assertThat(Files.readString(interceptor, StandardCharsets.UTF_8),
+                   containsString("\"com.example.DefaultApiImpl.validate(java.lang.String)\""));
+    }
+
+    @Test
     void testDescribeServiceContractConstraintGeneratesInterceptor() {
         var result = TestCompiler.builder()
                 .currentRelease()

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/InheritedFtClient.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/InheritedFtClient.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import io.helidon.faulttolerance.Ft;
+import io.helidon.http.Http;
+import io.helidon.webclient.api.RestClient;
+
+@SuppressWarnings("deprecation")
+@RestClient.Endpoint("${inherited-ft.client.uri:http://localhost:8080}")
+interface InheritedFtClient {
+    @Http.GET
+    @Http.Path("/inherited-ft/retry")
+    @Ft.Retry(calls = 2, delay = "PT0S", overallTimeout = "PT5S")
+    String retry();
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/InheritedFtEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/InheritedFtEndpoint.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.http.Http;
+import io.helidon.http.HttpException;
+import io.helidon.http.Status;
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Service.Singleton
+class InheritedFtEndpoint {
+    private static final AtomicInteger CALLS = new AtomicInteger();
+
+    @Service.Inject
+    InheritedFtEndpoint() {
+    }
+
+    static void reset() {
+        CALLS.set(0);
+    }
+
+    static int calls() {
+        return CALLS.get();
+    }
+
+    @Http.GET
+    @Http.Path("/inherited-ft/retry")
+    String retry() {
+        if (CALLS.incrementAndGet() == 1) {
+            throw new HttpException("Retry me", Status.SERVICE_UNAVAILABLE_503);
+        }
+        return "retried";
+    }
+}

--- a/declarative/tests/http/src/main/resources/application.yaml
+++ b/declarative/tests/http/src/main/resources/application.yaml
@@ -31,6 +31,9 @@ server:
 greet-service.client:
   uri: "http://localhost:${test.server.port}"
 
+inherited-ft.client:
+  uri: "http://localhost:${test.server.port}"
+
 security:
   providers:
     - abac:

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -60,6 +60,7 @@ class DeclarativeHttpTest {
     @BeforeEach
     void beforeEach() {
         SomeEntryPointInterceptor.reset();
+        InheritedFtEndpoint.reset();
     }
 
     @Test
@@ -84,6 +85,17 @@ class DeclarativeHttpTest {
         var all = typedClient.greetings();
 
         assertThat(all, hasItem(is(new GreetingDto("Hello"))));
+    }
+
+    @Test
+    void testInheritedClientRetry() {
+        InheritedFtClient typedClient = registry.get(Lookup.builder()
+                                                              .addContract(InheritedFtClient.class)
+                                                              .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                              .build());
+
+        assertThat(typedClient.retry(), is("retried"));
+        assertThat(InheritedFtEndpoint.calls(), is(2));
     }
 
     @Test

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
@@ -17,6 +17,7 @@
 package io.helidon.declarative.tests.metrics;
 
 import io.helidon.http.Http;
+import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.Metrics;
 import io.helidon.service.registry.Service;
 
@@ -27,4 +28,7 @@ interface InheritedMetricsContract {
     @Http.Path("/inherited-counted")
     @Metrics.Counted(value = "inherited-counted", absoluteName = true)
     String inheritedCounted();
+
+    @Metrics.Gauge(value = "inherited-gauge", absoluteName = true, unit = Meter.BaseUnits.BYTES)
+    int inheritedGaugeValue();
 }

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.metrics;
+
+import io.helidon.http.Http;
+import io.helidon.metrics.api.Metrics;
+import io.helidon.service.registry.Service;
+
+@SuppressWarnings("deprecation")
+@Service.Contract
+interface InheritedMetricsContract {
+    @Http.GET
+    @Http.Path("/inherited-counted")
+    @Metrics.Counted(value = "inherited-counted", absoluteName = true)
+    String inheritedCounted();
+}

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
@@ -31,7 +31,7 @@ import io.helidon.webserver.http.RestServer;
 @Service.Singleton
 @Metrics.Tag(key = "endpoint", value = "TestEndpoint")
 @Metrics.Tag(key = "application", value = "MyNiceApp")
-class TestEndpoint {
+class TestEndpoint implements InheritedMetricsContract {
     private final MeterRegistry meterRegistry;
     private final AtomicInteger gaugeValue = new AtomicInteger();
 
@@ -45,6 +45,11 @@ class TestEndpoint {
     @Metrics.Counted(tags = @Metrics.Tag(key = "location", value = "method"))
     String counted() {
         return "counted";
+    }
+
+    @Override
+    public String inheritedCounted() {
+        return "inherited counted";
     }
 
     @Http.GET

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
@@ -52,6 +52,11 @@ class TestEndpoint implements InheritedMetricsContract {
         return "inherited counted";
     }
 
+    @Override
+    public int inheritedGaugeValue() {
+        return gaugeValue.get() + 1;
+    }
+
     @Http.GET
     @Http.Path("/timed")
     @Metrics.Timed(value = "my-timed-metric", absoluteName = true)

--- a/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
+++ b/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
@@ -125,5 +125,10 @@ class DeclarativeMetricsTest {
                 .orElse(null);
         assertThat(inheritedCounted, notNullValue());
         assertThat(inheritedCounted.intValue(), is(1));
+
+        BigDecimal inheritedGauge = appMetrics.numberValue("inherited-gauge;application=MyNiceApp;endpoint=TestEndpoint")
+                .orElse(null);
+        assertThat(inheritedGauge, notNullValue());
+        assertThat(inheritedGauge.intValue(), is(43));
     }
 }

--- a/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
+++ b/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
@@ -87,6 +87,16 @@ class DeclarativeMetricsTest {
     }
 
     @Test
+    @Order(5)
+    void testInheritedCounted() {
+        var response = client.get("/endpoint/inherited-counted").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("inherited counted"));
+    }
+
+    @Test
+    @Order(6)
     void testMetricsObserver() {
         var response = client.get("/observe/metrics")
                 .header(HeaderValues.ACCEPT_JSON)
@@ -110,5 +120,10 @@ class DeclarativeMetricsTest {
                 .orElse(null);
         assertThat(gauge, notNullValue());
         assertThat(gauge.intValue(), is(42));
+
+        BigDecimal inheritedCounted = appMetrics.numberValue("inherited-counted;application=MyNiceApp;endpoint=TestEndpoint")
+                .orElse(null);
+        assertThat(inheritedCounted, notNullValue());
+        assertThat(inheritedCounted.intValue(), is(1));
     }
 }

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingContract.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+
+@SuppressWarnings("deprecation")
+@Service.Contract
+@Http.Path("/generic")
+@Tracing.Traced(value = "generic-type-%2$s",
+                tags = @Tracing.Tag(key = "source", value = "generic-contract-type"),
+                kind = Span.Kind.SERVER)
+interface GenericTracingContract<T> {
+    @Http.GET
+    @Http.Path("/type-traced")
+    T genericTypeTraced(@Http.QueryParam("name") T name);
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingEndpoint.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingEndpoint.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Service.Singleton
+class GenericTracingEndpoint implements GenericTracingContract<String> {
+    @Service.Inject
+    GenericTracingEndpoint() {
+    }
+
+    @Override
+    public String genericTypeTraced(String name) {
+        return "generic " + name;
+    }
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingContract.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+
+@SuppressWarnings("deprecation")
+@Service.Contract
+@Http.Path("/inherited")
+interface InheritedTracingContract {
+    @Http.GET
+    @Http.Path("/traced")
+    @Tracing.Traced(value = "inherited-traced",
+                    tags = @Tracing.Tag(key = "source", value = "contract"),
+                    kind = Span.Kind.SERVER)
+    String inheritedTraced();
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingContract.java
@@ -24,6 +24,9 @@ import io.helidon.tracing.Tracing;
 @SuppressWarnings("deprecation")
 @Service.Contract
 @Http.Path("/inherited")
+@Tracing.Traced(value = "inherited-type-%2$s",
+                tags = @Tracing.Tag(key = "source", value = "contract-type"),
+                kind = Span.Kind.SERVER)
 interface InheritedTracingContract {
     @Http.GET
     @Http.Path("/traced")
@@ -31,4 +34,13 @@ interface InheritedTracingContract {
                     tags = @Tracing.Tag(key = "source", value = "contract"),
                     kind = Span.Kind.SERVER)
     String inheritedTraced();
+
+    @Http.GET
+    @Http.Path("/type-traced")
+    String typeTraced();
+
+    @Http.GET
+    @Http.Path("/tagged")
+    @Tracing.Traced(value = "inherited-tagged", kind = Span.Kind.SERVER)
+    String inheritedTagged(@Http.QueryParam("id") @Tracing.ParamTag("id") int id);
 }

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingEndpoint.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingEndpoint.java
@@ -30,4 +30,14 @@ class InheritedTracingEndpoint implements InheritedTracingContract {
     public String inheritedTraced() {
         return "inherited traced";
     }
+
+    @Override
+    public String typeTraced() {
+        return "type traced";
+    }
+
+    @Override
+    public String inheritedTagged(int id) {
+        return "tagged " + id;
+    }
 }

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingEndpoint.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingEndpoint.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Service.Singleton
+class InheritedTracingEndpoint implements InheritedTracingContract {
+    @Service.Inject
+    InheritedTracingEndpoint() {
+    }
+
+    @Override
+    public String inheritedTraced() {
+        return "inherited traced";
+    }
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingContract.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+
+@SuppressWarnings("deprecation")
+@Service.Contract
+@Http.Path("/typed")
+interface TypedTracingContract {
+    @Http.GET
+    @Http.Path("/method")
+    @Tracing.Traced(value = "contract-method",
+                    tags = @Tracing.Tag(key = "source", value = "contract-method"),
+                    kind = Span.Kind.SERVER)
+    String contractMethod();
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingEndpoint.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingEndpoint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Service.Singleton
+@SuppressWarnings("deprecation")
+@Tracing.Traced(value = "implementation-type-%2$s",
+                tags = @Tracing.Tag(key = "source", value = "implementation-type"),
+                kind = Span.Kind.SERVER)
+class TypedTracingEndpoint implements TypedTracingContract {
+    @Service.Inject
+    TypedTracingEndpoint() {
+    }
+
+    @Override
+    public String contractMethod() {
+        return "typed contract";
+    }
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/UntracedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/UntracedTracingContract.java
@@ -16,33 +16,12 @@
 
 package io.helidon.declarative.tests.tracing;
 
+import io.helidon.http.Http;
 import io.helidon.service.registry.Service;
-import io.helidon.webserver.http.RestServer;
 
-@RestServer.Endpoint
-@Service.Singleton
-class InheritedTracingEndpoint implements InheritedTracingContract, UntracedTracingContract {
-    @Service.Inject
-    InheritedTracingEndpoint() {
-    }
-
-    @Override
-    public String inheritedTraced() {
-        return "inherited traced";
-    }
-
-    @Override
-    public String typeTraced() {
-        return "type traced";
-    }
-
-    @Override
-    public String inheritedTagged(int id) {
-        return "tagged " + id;
-    }
-
-    @Override
-    public String untraced() {
-        return "untraced";
-    }
+@Service.Contract
+interface UntracedTracingContract {
+    @Http.GET
+    @Http.Path("/plain")
+    String untraced();
 }

--- a/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
+++ b/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
@@ -239,6 +239,41 @@ public class DeclarativeTracingTest {
         assertAttribute(attributes, "exception.type", NotFoundException.class.getName());
     }
 
+    @Test
+    @Order(4)
+    void testInheritedMethodTraced() {
+        var response = client.get("/inherited/traced").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("inherited traced"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing inherited traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("inherited-traced"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "contract");
+    }
+
     private void assertAttribute(Attributes attributes, String key, String expectedValue) {
         var actualValue = attributes.get(AttributeKey.stringKey(key));
 

--- a/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
+++ b/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
@@ -348,6 +348,24 @@ public class DeclarativeTracingTest {
         assertThat("Long Attribute of key: id", actualValue, is(7L));
     }
 
+    @Test
+    @Order(7)
+    void testInheritedTypeTracedDoesNotApplyToOtherContracts() {
+        var response = client.get("/inherited/plain").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("untraced"));
+
+        var data = exporter.spanData(2);
+        exporter.clear();
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(names, is(Set.of("HTTP Request", "content-write")));
+    }
+
     private void assertAttribute(Attributes attributes, String key, String expectedValue) {
         var actualValue = attributes.get(AttributeKey.stringKey(key));
 

--- a/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
+++ b/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
@@ -366,6 +366,78 @@ public class DeclarativeTracingTest {
         assertThat(names, is(Set.of("HTTP Request", "content-write")));
     }
 
+    @Test
+    @Order(8)
+    void testGenericInheritedTypeTraced() {
+        var response = client.get("/generic/type-traced")
+                .queryParam("name", "value")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("generic value"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing generic inherited type traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("generic-type-genericTypeTraced"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "generic-contract-type");
+    }
+
+    @Test
+    @Order(9)
+    void testInheritedMethodTracedOverridesImplementationTypeTraced() {
+        var response = client.get("/typed/method").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("typed contract"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing inherited typed traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("contract-method"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "contract-method");
+    }
+
     private void assertAttribute(Attributes attributes, String key, String expectedValue) {
         var actualValue = attributes.get(AttributeKey.stringKey(key));
 

--- a/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
+++ b/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
@@ -274,6 +274,80 @@ public class DeclarativeTracingTest {
         assertAttribute(tracedMethod.getAttributes(), "source", "contract");
     }
 
+    @Test
+    @Order(5)
+    void testInheritedTypeTraced() {
+        var response = client.get("/inherited/type-traced").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("type traced"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing inherited type traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("inherited-type-typeTraced"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "contract-type");
+    }
+
+    @Test
+    @Order(6)
+    void testInheritedTaggedParam() {
+        var response = client.get("/inherited/tagged")
+                .queryParam("id", "7")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("tagged 7"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing inherited tagged traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("inherited-tagged"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "contract-type");
+        Long actualValue = tracedMethod.getAttributes().get(AttributeKey.longKey("id"));
+        assertThat("Long Attribute of key: id", actualValue, is(7L));
+    }
+
     private void assertAttribute(Attributes attributes, String key, String expectedValue) {
         var actualValue = attributes.get(AttributeKey.stringKey(key));
 

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -206,6 +206,8 @@ include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_3, indent=0]
 
 Fault tolerance annotations allow adding features to methods on services.
 The annotations can be added to any method that supports interception (i.e. methods that are not private).
+Method-level fault tolerance annotations can also be declared on methods inherited from service contracts and typed
+HTTP client interfaces. Type-level fault tolerance annotations on interfaces are not inherited by service methods.
 
 Method Annotations:
 
@@ -374,6 +376,8 @@ include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_7, indent=0]
 
 Constraint annotations and `@Validation.Valid` can also be declared on non-private instance methods of service interfaces.
 They are applied when the service instance is obtained from the service registry.
+Service interfaces are discovered using the service registry contract rules, including `@Service.Contract`,
+implicit contracts when enabled, and `@Service.ExternalContracts`.
 The same applies to instances returned by registry-managed service factories, including `Supplier`,
 `Service.ServicesFactory`, `Service.InjectionPointFactory`, and `Service.QualifiedFactory` services.
 This can change runtime behavior for services that already declared interface validation: invalid calls through
@@ -441,6 +445,8 @@ Method annotations:
 - link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.Timed.html[`io.helidon.metrics.api.Metrics.Timed`] - adds a timer metric to the metric registry for method executions
 - link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.Gauge.html[`io.helidon.metrics.api.Metrics.Gauge`] - marks a method that returns a number as a gauge
 
+Metrics method annotations can also be declared on methods inherited from service contracts and typed HTTP client interfaces.
+
 In addition, we can use link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.Tag.html[`io.helidon.metrics.api.Metrics.Tag`] annotation on a type, method, or as a `tags` property of an annotation to add tags to the metric. Tags from type definition will be added to all metrics on the type, tags on methods on all metrics on the method, and tags in the metric annotation will only be used by that metric.
 
 The example below shows additional tags. The counter on method `counted` will have the following tags: `service=Metered;method=counted` (and of course the scope tag that is always added).
@@ -463,6 +469,8 @@ include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_12, indent=0]
 
 Add support for tracing of methods.
 This feature will add a new span for each annotated method (or all methods on an annotated type).
+Tracing annotations can also be declared on methods inherited from service contracts and typed HTTP client interfaces.
+A type-level tracing annotation on a contract interface applies only to methods declared by that contract.
 
 Annotations:
 

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -208,6 +208,7 @@ Fault tolerance annotations allow adding features to methods on services.
 The annotations can be added to any method that supports interception (i.e. methods that are not private).
 Method-level fault tolerance annotations can also be declared on methods inherited from service contracts and typed
 HTTP client interfaces. Type-level fault tolerance annotations on interfaces are not inherited by service methods.
+Contracts provided by registry-managed service factories are not included.
 
 Method Annotations:
 
@@ -446,6 +447,7 @@ Method annotations:
 - link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.Gauge.html[`io.helidon.metrics.api.Metrics.Gauge`] - marks a method that returns a number as a gauge
 
 Metrics method annotations can also be declared on methods inherited from service contracts and typed HTTP client interfaces.
+Contracts provided by registry-managed service factories are not included.
 
 In addition, we can use link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.Tag.html[`io.helidon.metrics.api.Metrics.Tag`] annotation on a type, method, or as a `tags` property of an annotation to add tags to the metric. Tags from type definition will be added to all metrics on the type, tags on methods on all metrics on the method, and tags in the metric annotation will only be used by that metric.
 
@@ -471,6 +473,7 @@ Add support for tracing of methods.
 This feature will add a new span for each annotated method (or all methods on an annotated type).
 Tracing annotations can also be declared on methods inherited from service contracts and typed HTTP client interfaces.
 A type-level tracing annotation on a contract interface applies only to methods declared by that contract.
+Contracts provided by registry-managed service factories are not included.
 
 Annotations:
 

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
@@ -69,7 +69,8 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                                              discoveryPredicate(it.supportedAnnotations(),
                                                                 it.supportedAnnotationPackages()),
                                              it.supportedMetaAnnotations(),
-                                             it.supportsServiceContractAnnotations());
+                                             it.supportsServiceContractAnnotations(),
+                                             it.supportsFactoryProvidedServiceContractAnnotations());
                 })
                 .toList();
     }
@@ -344,12 +345,14 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                                                                              supportedAnnotationsCache,
                                                                              metaAnnotationsCache,
                                                                              metaAnnotatedCache));
-        result.addAll(supportedAnnotationsOnContracts(roundContext,
-                                                      extension,
-                                                      ServiceTypes.factoryProvidedContracts(serviceContracts, serviceType),
-                                                      supportedAnnotationsCache,
-                                                      metaAnnotationsCache,
-                                                      metaAnnotatedCache));
+        if (extension.supportsFactoryProvidedServiceContractAnnotations()) {
+            result.addAll(supportedAnnotationsOnContracts(roundContext,
+                                                          extension,
+                                                          ServiceTypes.factoryProvidedContracts(serviceContracts, serviceType),
+                                                          supportedAnnotationsCache,
+                                                          metaAnnotationsCache,
+                                                          metaAnnotatedCache));
+        }
 
         return Set.copyOf(result);
     }
@@ -502,7 +505,8 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
     private record ExtensionInfo(RegistryCodegenExtension extension,
                                  Predicate<TypeName> supportedAnnotationsPredicate,
                                  Set<TypeName> supportedMetaAnnotations,
-                                 boolean supportsServiceContractAnnotations) {
+                                 boolean supportsServiceContractAnnotations,
+                                 boolean supportsFactoryProvidedServiceContractAnnotations) {
     }
 
     private record ElementKey(TypeName owner, ElementSignature signature) {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/spi/RegistryCodegenExtensionProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/spi/RegistryCodegenExtensionProvider.java
@@ -29,9 +29,10 @@ public interface RegistryCodegenExtensionProvider extends CodegenProvider {
      * Whether this extension should also process services whose service contracts contain annotations
      * supported by this extension.
      * <p>
-     * Service contracts include direct service contracts and contracts provided by factory services. Contract annotations
-     * are discovered from nested contract metadata, including annotations on the contract type, methods, method parameters,
-     * parameter and return type arguments, and annotations matched through {@link #supportedMetaAnnotations()}.
+     * Service contracts include contracts discovered for the service type. Contract annotations are discovered from nested
+     * contract metadata, including annotations on the contract type, methods, method parameters, parameter and return type
+     * arguments, and annotations matched through {@link #supportedMetaAnnotations()}. Factory-provided contracts are
+     * controlled separately by {@link #supportsFactoryProvidedServiceContractAnnotations()}.
      * <p>
      * Matching services are passed to the extension through {@link io.helidon.service.codegen.RegistryRoundContext#types()}.
      * <p>
@@ -43,6 +44,18 @@ public interface RegistryCodegenExtensionProvider extends CodegenProvider {
      */
     default boolean supportsServiceContractAnnotations() {
         return false;
+    }
+
+    /**
+     * Whether this extension should also process factory services whose provided service contracts contain annotations
+     * supported by this extension.
+     * <p>
+     * This method follows {@link #supportsServiceContractAnnotations()} by default for backward compatibility.
+     *
+     * @return whether factory services with supported provided-contract annotations should be processed
+     */
+    default boolean supportsFactoryProvidedServiceContractAnnotations() {
+        return supportsServiceContractAnnotations();
     }
 
     /**


### PR DESCRIPTION
Resolves #12118

This change aligns declarative code generation with 4.x service contract discovery while keeping the behavior narrow:

- inherited annotations on service contract methods are considered for FT, Metrics, Tracing, and Validation;
- FT, Metrics, and Tracing process only the service contract methods and opt out of factory-provided contracts;
- Validation preserves implicit, external, and factory-provided contract behavior;
- Tracing preserves method-over-type precedence, including method annotations inherited from an interface, and resolves generic contract method signatures.

The declarative docs are updated to describe the inherited contract-method behavior and the factory-provided contract exclusions.
