### PR TITLE
Stabilize HTTP/2 startup test handshake (27.x)

### DIFF
--- a/webserver/testing/junit5/http2/src/main/java/io/helidon/webserver/testing/junit5/http2/Http2TestConnection.java
+++ b/webserver/testing/junit5/http2/src/main/java/io/helidon/webserver/testing/junit5/http2/Http2TestConnection.java
@@ -39,6 +39,7 @@ import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2GoAway;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanDecoder;
+import io.helidon.http.http2.Http2Ping;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
@@ -137,6 +138,16 @@ public class Http2TestConnection implements AutoCloseable {
         return this;
     }
 
+    private void acknowledgeSettings() {
+        Http2Flag.SettingsFlags flags = Http2Flag.SettingsFlags.create(Http2Flag.ACK);
+        Http2FrameData frameData = new Http2FrameData(Http2FrameHeader.create(0,
+                                                                              Http2FrameTypes.SETTINGS,
+                                                                              flags,
+                                                                              0),
+                                                      BufferData.empty());
+        writer().write(frameData);
+    }
+
     /**
      * Return connection writer for direct frame sending.
      *
@@ -144,6 +155,20 @@ public class Http2TestConnection implements AutoCloseable {
      */
     public Http2ConnectionWriter writer() {
         return dataWriter;
+    }
+
+    /**
+     * Complete HTTP/2 startup frame exchange without opening a request stream.
+     *
+     * @param timeout timeout for each expected frame
+     */
+    public void completeHandshake(Duration timeout) {
+        assertSettings(timeout);
+        assertWindowsUpdate(0, timeout);
+        writer().write(Http2Ping.create().toFrameData());
+        assertSettingsAck(timeout);
+        Http2FrameData pingFrame = assertNextFrame(Http2FrameType.PING, timeout);
+        assertThat(pingFrame.header().flags(Http2FrameTypes.PING).ack(), Matchers.is(true));
     }
 
     /**
@@ -206,13 +231,24 @@ public class Http2TestConnection implements AutoCloseable {
     }
 
     /**
-     * Wait for the next frame and assert its frame type to be SETTINGS.
+     * Wait for the next frame, assert its frame type to be SETTINGS, and ACK it when needed.
      * @param timeout timeout for blocking
      * @return the frame
      */
     public Http2Settings assertSettings(Duration timeout) {
         Http2FrameData frame = assertNextFrame(Http2FrameType.SETTINGS, timeout);
-        return Http2Settings.create(frame.data());
+        Http2Flag.SettingsFlags flags = frame.header().flags(Http2FrameTypes.SETTINGS);
+        Http2Settings settings = Http2Settings.create(frame.data());
+        if (!flags.ack()) {
+            acknowledgeSettings();
+        }
+        return settings;
+    }
+
+    private void assertSettingsAck(Duration timeout) {
+        Http2FrameData frame = assertNextFrame(Http2FrameType.SETTINGS, timeout);
+        Http2Flag.SettingsFlags flags = frame.header().flags(Http2FrameTypes.SETTINGS);
+        assertThat(flags.ack(), Matchers.is(true));
     }
 
     /**
@@ -247,6 +283,9 @@ public class Http2TestConnection implements AutoCloseable {
      */
     public Http2FrameData assertNextFrame(Http2FrameType frameType, Duration timeout) {
         Http2FrameData frame = awaitNextFrame(timeout);
+        assertThat("Timed out waiting for HTTP/2 frame " + frameType + " after " + timeout,
+                   frame,
+                   Matchers.notNullValue());
         assertThat(frame.header().type(), Matchers.equalTo(frameType));
         return frame;
     }

--- a/webserver/testing/junit5/http2/src/main/java/io/helidon/webserver/testing/junit5/http2/Http2TestConnection.java
+++ b/webserver/testing/junit5/http2/src/main/java/io/helidon/webserver/testing/junit5/http2/Http2TestConnection.java
@@ -164,9 +164,8 @@ public class Http2TestConnection implements AutoCloseable {
      */
     public void completeHandshake(Duration timeout) {
         assertSettings(timeout);
-        assertWindowsUpdate(0, timeout);
         writer().write(Http2Ping.create().toFrameData());
-        assertSettingsAck(timeout);
+        assertOptionalWindowsUpdateThenSettingsAck(timeout);
         Http2FrameData pingFrame = assertNextFrame(Http2FrameType.PING, timeout);
         assertThat(pingFrame.header().flags(Http2FrameTypes.PING).ack(), Matchers.is(true));
     }
@@ -245,10 +244,19 @@ public class Http2TestConnection implements AutoCloseable {
         return settings;
     }
 
-    private void assertSettingsAck(Duration timeout) {
-        Http2FrameData frame = assertNextFrame(Http2FrameType.SETTINGS, timeout);
+    private void assertSettingsAck(Http2FrameData frame) {
+        assertThat(frame.header().type(), Matchers.equalTo(Http2FrameType.SETTINGS));
         Http2Flag.SettingsFlags flags = frame.header().flags(Http2FrameTypes.SETTINGS);
         assertThat(flags.ack(), Matchers.is(true));
+    }
+
+    private void assertOptionalWindowsUpdateThenSettingsAck(Duration timeout) {
+        Http2FrameData frame = assertNextFrame("HTTP/2 startup SETTINGS ACK or WINDOW_UPDATE frame", timeout);
+        if (frame.header().type() == Http2FrameType.WINDOW_UPDATE) {
+            assertWindowsUpdate(frame, 0);
+            frame = assertNextFrame(Http2FrameType.SETTINGS, timeout);
+        }
+        assertSettingsAck(frame);
     }
 
     /**
@@ -259,8 +267,13 @@ public class Http2TestConnection implements AutoCloseable {
      */
     public Http2WindowUpdate assertWindowsUpdate(int streamId, Duration timeout) {
         Http2FrameData frame = assertNextFrame(Http2FrameType.WINDOW_UPDATE, timeout);
-        assertThat(frame.header().streamId(), Matchers.equalTo(streamId));
+        assertWindowsUpdate(frame, streamId);
         return Http2WindowUpdate.create(frame.data());
+    }
+
+    private void assertWindowsUpdate(Http2FrameData frame, int streamId) {
+        assertThat(frame.header().type(), Matchers.equalTo(Http2FrameType.WINDOW_UPDATE));
+        assertThat(frame.header().streamId(), Matchers.equalTo(streamId));
     }
 
     /**
@@ -282,11 +295,14 @@ public class Http2TestConnection implements AutoCloseable {
      * @return the frame
      */
     public Http2FrameData assertNextFrame(Http2FrameType frameType, Duration timeout) {
-        Http2FrameData frame = awaitNextFrame(timeout);
-        assertThat("Timed out waiting for HTTP/2 frame " + frameType + " after " + timeout,
-                   frame,
-                   Matchers.notNullValue());
+        Http2FrameData frame = assertNextFrame("HTTP/2 frame " + frameType, timeout);
         assertThat(frame.header().type(), Matchers.equalTo(frameType));
+        return frame;
+    }
+
+    private Http2FrameData assertNextFrame(String expectedFrame, Duration timeout) {
+        Http2FrameData frame = awaitNextFrame(timeout);
+        assertThat("Timed out waiting for " + expectedFrame + " after " + timeout, frame, Matchers.notNullValue());
         return frame;
     }
 

--- a/webserver/testing/junit5/http2/src/test/java/io/helidon/webserver/testing/junit5/http2/Http2SocketTestingTest.java
+++ b/webserver/testing/junit5/http2/src/test/java/io/helidon/webserver/testing/junit5/http2/Http2SocketTestingTest.java
@@ -18,9 +18,17 @@ package io.helidon.webserver.testing.junit5.http2;
 
 import java.time.Duration;
 
+import io.helidon.http.Method;
 import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2Route;
 import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.Socket;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,10 +38,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
 class Http2SocketTestingTest extends Http2AbstractTestingTest {
+    private static final String DEFAULT_WINDOW_SOCKET = "default-window";
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
 
     Http2SocketTestingTest(Http2Client httpClient) {
         super(httpClient);
+    }
+
+    @SetUpRoute(DEFAULT_WINDOW_SOCKET)
+    static void defaultWindowSocket(ListenerConfig.Builder listener, HttpRules rules) {
+        listener.addProtocol(Http2Config.builder()
+                                     .initialWindowSize(WindowSize.DEFAULT_WIN_SIZE)
+                                     .build());
+        rules.route(Http2Route.route(Method.GET, "/greet", (req, res) -> res.send("default-window")));
     }
 
     @Test
@@ -45,6 +62,13 @@ class Http2SocketTestingTest extends Http2AbstractTestingTest {
                                                () -> h2conn.assertNextFrame(Http2FrameType.GO_AWAY,
                                                                            Duration.ofMillis(25)));
             assertThat(error.getMessage(), containsString("Timed out waiting for HTTP/2 frame GO_AWAY"));
+        }
+    }
+
+    @Test
+    void handshakeAllowsDefaultWindowSize(@Socket(DEFAULT_WINDOW_SOCKET) Http2TestClient client) {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            h2conn.completeHandshake(TIMEOUT);
         }
     }
 }

--- a/webserver/testing/junit5/http2/src/test/java/io/helidon/webserver/testing/junit5/http2/Http2SocketTestingTest.java
+++ b/webserver/testing/junit5/http2/src/test/java/io/helidon/webserver/testing/junit5/http2/Http2SocketTestingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,35 @@
 
 package io.helidon.webserver.testing.junit5.http2;
 
+import java.time.Duration;
+
+import io.helidon.http.http2.Http2FrameType;
 import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webserver.testing.junit5.ServerTest;
 
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 @ServerTest
 class Http2SocketTestingTest extends Http2AbstractTestingTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
     Http2SocketTestingTest(Http2Client httpClient) {
         super(httpClient);
+    }
+
+    @Test
+    void nextFrameTimeoutReportsExpectedFrame(Http2TestClient client) {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            h2conn.completeHandshake(TIMEOUT);
+
+            AssertionError error = assertThrows(AssertionError.class,
+                                               () -> h2conn.assertNextFrame(Http2FrameType.GO_AWAY,
+                                                                           Duration.ofMillis(25)));
+            assertThat(error.getMessage(), containsString("Timed out waiting for HTTP/2 frame GO_AWAY"));
+        }
     }
 }

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
@@ -345,13 +345,10 @@ class ContentLengthTest {
     @Test
     void equalRepeatedContentLengthRejected(Http2TestClient client) {
         Http2TestConnection h2conn = client.createConnection();
+        h2conn.completeHandshake(TIMEOUT);
 
         var headers = requestHeadersWithContentLength(5, 5);
         h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
 
         h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
                             "Content-Length header must have exactly one value.",

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
@@ -232,143 +232,65 @@ class ContentLengthTest {
 
     @Test
     void negativeContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-
-        var headers = requestHeadersWithContentLength(-1);
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must be a number.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLength(-1),
+                                    "Content-Length header must be a number.");
     }
 
     @Test
     void signedContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-
-        var headers = requestHeadersWithContentLengthValue("+5");
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must be a number.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLengthValue("+5"),
+                                    "Content-Length header must be a number.");
     }
 
     @Test
     void negativeZeroContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-
-        var headers = requestHeadersWithContentLengthValue("-0");
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must be a number.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLengthValue("-0"),
+                                    "Content-Length header must be a number.");
     }
 
     @Test
     void repeatedNegativeContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-
-        var headers = requestHeadersWithContentLength(5, -1);
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must have exactly one value.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLength(5, -1),
+                                    "Content-Length header must have exactly one value.");
     }
 
     @Test
     void conflictingContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-
-        var headers = requestHeadersWithContentLength(5, 4);
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must have exactly one value.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLength(5, 4),
+                                    "Content-Length header must have exactly one value.");
     }
 
     @Test
     void conflictingCommaSeparatedContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-
-        var headers = requestHeadersWithContentLengthValue("5, 4");
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must have exactly one value.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLengthValue("5, 4"),
+                                    "Content-Length header must have exactly one value.");
     }
 
     @Test
     void equalCommaSeparatedContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-
-        var headers = requestHeadersWithContentLengthValue("5, 5");
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must have exactly one value.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLengthValue("5, 5"),
+                                    "Content-Length header must have exactly one value.");
     }
 
     @Test
     void equalRepeatedContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-        h2conn.completeHandshake(TIMEOUT);
-
-        var headers = requestHeadersWithContentLength(5, 5);
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must have exactly one value.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLength(5, 5),
+                                    "Content-Length header must have exactly one value.");
     }
 
     @Test
     void controlCharacterContentLengthRejected(Http2TestClient client) {
-        Http2TestConnection h2conn = client.createConnection();
-
-        var headers = requestHeadersWithContentLengthValue("5\u000b");
-        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
-
-        h2conn.assertSettings(TIMEOUT);
-        h2conn.assertWindowsUpdate(0, TIMEOUT);
-        h2conn.assertSettings(TIMEOUT);
-
-        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL,
-                            "Content-Length header must be a number.",
-                            TIMEOUT);
+        assertContentLengthRejected(client,
+                                    requestHeadersWithContentLengthValue("5\u000b"),
+                                    "Content-Length header must be a number.");
     }
 
     @Test
@@ -578,6 +500,17 @@ class ContentLengthTest {
             headers.add(HeaderNames.CONTENT_LENGTH, contentLength);
         }
         return headers;
+    }
+
+    private void assertContentLengthRejected(Http2TestClient client,
+                                             WritableHeaders<?> headers,
+                                             String message) {
+        Http2TestConnection h2conn = client.createConnection();
+        h2conn.completeHandshake(TIMEOUT);
+
+        h2conn.request(1, POST, LONGER_DATA_PATH, headers, BufferData.create("frank"));
+
+        h2conn.assertGoAway(Http2ErrorCode.PROTOCOL, message, TIMEOUT);
     }
 
     private void writeRequestHeaders(Http2TestConnection h2conn,


### PR DESCRIPTION
Investigates and stabilizes the HTTP/2 test failure seen on PR 12124.

The low-level HTTP/2 test connection helper now fails with an assertion when an expected frame does not arrive instead of dereferencing `null`, ACKs received non-ACK SETTINGS frames, and exposes a handshake helper that drains startup frames before a request stream is opened.

`ContentLengthTest.equalRepeatedContentLengthRejected` now completes the startup handshake before sending the malformed repeated `Content-Length` request, so the test continues to assert the intended connection-fatal protocol error rather than depending on startup-frame timing.
