### PR TITLE
Correct the calc of OTel http server sem conv; capture end time in whenSent instead of in the filter

### DIFF
--- a/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
+++ b/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.observe.telemetry.metrics;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.config.Config;
 import io.helidon.http.Status;
@@ -123,27 +124,24 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
         @Override
         public void filter(FilterChain chain, RoutingRequest req, RoutingResponse res) {
             var startTime = System.nanoTime();
+            var exception = new AtomicReference<Exception>();
             /*
-            Duplicating the synch/async handling in the normal and exception case avoids the overhead of using an Optional to hold
-            the exception (if any) for use in a lambda.
-            */
+            Update the timer in whenSent rather than here in this filter. That way we include time spent in running succeeding
+            filters and in preparing the response entity, to more accurately capture as much as possible the full time the
+            server spent responding to the request.
+             */
+            res.whenSent(() -> {
+                try {
+                    updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), exception.get());
+                } catch (Throwable e) {
+                    LOGGER.log(WARNING, "Failed to record HTTP request metrics", e);
+                }
+            });
+
             try {
                 chain.proceed();
-                Thread.ofVirtual().start(() -> {
-                    try {
-                        updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), null);
-                    } catch (Throwable e) {
-                        LOGGER.log(WARNING, "Failed to record HTTP request metrics", e);
-                    }
-                });
             } catch (Exception e) {
-                Thread.ofVirtual().start(() -> {
-                    try {
-                        updateMetricsIfMeasured(req, res, startTime, System.nanoTime(), e);
-                    } catch (Throwable metricsUpdateFailure) {
-                        LOGGER.log(WARNING, "Failed to record HTTP request metrics", metricsUpdateFailure);
-                    }
-                });
+                exception.set(e);
                 throw e;
             }
         }
@@ -187,7 +185,7 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
             don't currently have a way to get the HTTP version at runtime from a request.
              */
 
-            httpRequestDuration.record((endTime - startTime) / 1_000_000.0, attrBuilder.build());
+            httpRequestDuration.record((endTime - startTime) / 1_000_000_000.0, attrBuilder.build());
         }
 
         private String errorType(RoutingResponse resp, Exception exception) {

--- a/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
+++ b/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
@@ -168,7 +168,7 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
             attrBuilder.put(AttributeKey.stringKey(HTTP_METHOD), req.prologue().method().text())
                     .put(AttributeKey.stringKey(URL_SCHEME), req.prologue().protocol())
                     .put(AttributeKey.stringKey(ERROR_TYPE), errorType(resp, exception))
-                    .put(AttributeKey.longKey(STATUS_CODE), statusCode(resp, exception))
+                    .put(AttributeKey.longKey(STATUS_CODE), resp.status().code())
                     .put(AttributeKey.stringKey(HTTP_ROUTE), req.matchingPattern().orElse(""))
                     .put(AttributeKey.stringKey(SOCKET_NAME), req.listenerContext().config().name());
 
@@ -196,10 +196,5 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
                             : resp.status().codeText();
         }
 
-        private long statusCode(RoutingResponse resp, Exception exception) {
-            return (exception != null)
-                    ? 0L
-                    : resp.status().code();
-        }
     }
 }

--- a/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
+++ b/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
@@ -65,9 +65,11 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
     void filterLogsMetricsFailureAfterSuccessfulChain() throws Exception {
         AssertionError failure = new AssertionError("metrics failure");
         Filter filter = filter(failure);
+        AtomicReference<Runnable> whenSent = new AtomicReference<>();
 
         try (TestLogHandler handler = TestLogHandler.install()) {
-            filter.filter(mock(FilterChain.class), request(), response());
+            filter.filter(mock(FilterChain.class), request(), response(whenSent));
+            whenSent.get().run();
 
             LogRecord record = handler.await();
             assertThat(record.getMessage(), containsString("Failed to record HTTP request metrics"));
@@ -82,11 +84,13 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
         IllegalArgumentException chainFailure = new IllegalArgumentException("chain failure");
         Filter filter = filter(metricsFailure);
         FilterChain chain = mock(FilterChain.class);
+        AtomicReference<Runnable> whenSent = new AtomicReference<>();
         doThrow(chainFailure).when(chain).proceed();
 
         try (TestLogHandler handler = TestLogHandler.install()) {
             IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                             () -> filter.filter(chain, request(), response()));
+                                                             () -> filter.filter(chain, request(), response(whenSent)));
+            whenSent.get().run();
             LogRecord record = handler.await();
 
             assertThat(exception, sameInstance(chainFailure));
@@ -139,9 +143,13 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
         return request;
     }
 
-    private static RoutingResponse response() {
+    private static RoutingResponse response(AtomicReference<Runnable> whenSent) {
         RoutingResponse response = mock(RoutingResponse.class);
         when(response.status()).thenReturn(Status.OK_200);
+        when(response.whenSent(any(Runnable.class))).thenAnswer(invocation -> {
+            whenSent.set(invocation.getArgument(0));
+            return response;
+        });
         return response;
     }
 

--- a/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/TestOpenTelemetrySemanticConventions.java
+++ b/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/TestOpenTelemetrySemanticConventions.java
@@ -295,6 +295,7 @@ class TestOpenTelemetrySemanticConventions {
                         .isPresent())
                 .forEach(metricsEntry -> {
                     var unit = metricsEntry.stringValue("unit").orElseThrow();
+                    assertThat("Duration unit", unit, is("s"));
 
                     metricsEntry.objectValue("histogram").orElseThrow()
                             .arrayValue("dataPoints").orElseThrow()
@@ -307,11 +308,7 @@ class TestOpenTelemetrySemanticConventions {
                                     .get(HTTP_ROUTE)))
                             .forEach(dataPoint -> {
                                 var duration = dataPoint.doubleValue("sum").orElseThrow();
-                                var durationNanos = switch (unit) {
-                                case "s" -> Math.round(duration * 1_000_000_000.0);
-                                case "ms" -> Math.round(duration * 1_000_000.0);
-                                default -> throw new IllegalStateException("Unexpected duration unit: " + unit);
-                                };
+                                var durationNanos = Math.round(duration * 1_000_000_000.0);
 
                                 personalizedGreetingTimeNanos.addAndGet(durationNanos);
                                 personalizedGreetingCount.addAndGet(Long.parseLong(dataPoint.stringValue("count").orElseThrow()));

--- a/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/TestOpenTelemetrySemanticConventions.java
+++ b/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/TestOpenTelemetrySemanticConventions.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -55,6 +56,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -129,7 +131,6 @@ class TestOpenTelemetrySemanticConventions {
     @Test
     void checkAutoMetrics() {
 
-        // Use default socket.
         try (Http1ClientResponse defaultResponse = defaultClient.get("/greet/Joe")
                 .accept(MediaTypes.TEXT_PLAIN)
                 .request();
@@ -166,34 +167,8 @@ class TestOpenTelemetrySemanticConventions {
 
             var root = JsonParser.create(jsonText.getFirst()).readJsonObject();
 
-            var top = root.arrayValue("resourceMetrics");
-
-            Stream<JsonValue> scopeMetricsEntries;
-
-            /*
-            The top node might be resourceMetrics which is an array of resource/scopeMetrics tuples, or it might be a single
-            resource/scopeMetrics tuple.
-             */
-            if (top.isPresent()) {
-                scopeMetricsEntries =
-                        top.get().asArray().values().stream()
-                                .flatMap(resourceMetricEntry -> resourceMetricEntry.asArray().values().stream())
-                                .map(JsonValue::asObject)
-                                .flatMap(resourceMetric -> resourceMetric.arrayValue("scopeMetrics").stream());
-            } else {
-                scopeMetricsEntries = root.arrayValue("scopeMetrics").orElseThrow().values().stream();
-            }
-
-            List<JsonObject> metricsEntries = scopeMetricsEntries
-                    .flatMap(scopeMetricsEntry -> scopeMetricsEntry.asObject()
-                            .arrayValue("metrics")
-                            .orElseThrow()
-                            .values()
-                            .stream())
-                    .map(JsonValue::asObject)
-                    .toList();
-
             Set<String> routesSeen = new HashSet<>();
+            var metricsEntries = metricsEntries(root);
 
             for (JsonObject metricsEntry : metricsEntries) {
 
@@ -270,4 +245,113 @@ class TestOpenTelemetrySemanticConventions {
         }
 
     }
+
+    @Test
+    void checkPersonalizedGreetingTime() {
+
+        // Use default socket.
+        try (TestLogHandler testLogHandler = TestLogHandler.create(
+                    Logger.getLogger(OtlpJsonLoggingMetricExporter.class.getName()))) {
+
+            try (Http1ClientResponse defaultResponse = defaultClient.get("/greet/Joe")
+                    .accept(MediaTypes.TEXT_PLAIN)
+                    .request()) {
+                assertThat("Greet endpoint", defaultResponse.status().code(), is(200));
+            }
+
+            var beforeJsonText = testLogHandler.messages(2);
+            var beforeRoot = JsonParser.create(beforeJsonText.getLast()).readJsonObject();
+            var beforeMeasurement = personalizedGreetingMeasurement(beforeRoot);
+
+            var startTime = System.nanoTime();
+            try (Http1ClientResponse defaultResponse = defaultClient.get("/greet/Joe")
+                    .accept(MediaTypes.TEXT_PLAIN)
+                    .request()) {
+                assertThat("Greet endpoint", defaultResponse.status().code(), is(200));
+            }
+            var elapsedTimeFromClient = System.nanoTime() - startTime;
+
+            var afterJsonText = testLogHandler.messages(2);
+            var afterRoot = JsonParser.create(afterJsonText.getLast()).readJsonObject();
+            var afterMeasurement = personalizedGreetingMeasurement(afterRoot);
+
+            var personalizedGreetingCount = afterMeasurement.count() - beforeMeasurement.count();
+            var personalizedGreetingTimeNanos = afterMeasurement.timeNanos() - beforeMeasurement.timeNanos();
+
+            assertThat("Personalized greeting count", personalizedGreetingCount, is(1L));
+            assertThat("Personalized greeting time",
+                       personalizedGreetingTimeNanos,
+                       allOf(greaterThan(0L), lessThanOrEqualTo(elapsedTimeFromClient)));
+        }
+    }
+
+    private static PersonalizedGreetingMeasurement personalizedGreetingMeasurement(JsonObject root) {
+        var personalizedGreetingTimeNanos = new AtomicLong();
+        var personalizedGreetingCount = new AtomicLong();
+
+        metricsEntries(root).stream()
+                .filter(metricsEntry -> metricsEntry.stringValue("name")
+                        .filter(OpenTelemetryMetricsHttpSemanticConventions.TIMER_NAME::equals)
+                        .isPresent())
+                .forEach(metricsEntry -> {
+                    var unit = metricsEntry.stringValue("unit").orElseThrow();
+
+                    metricsEntry.objectValue("histogram").orElseThrow()
+                            .arrayValue("dataPoints").orElseThrow()
+                            .values()
+                            .stream()
+                            .map(JsonValue::asObject)
+                            .filter(dataPoint -> "/greet/{name}".equals(dataPoint.arrayValue("attributes")
+                                    .map(JsonTestUtil::asAttributesMap)
+                                    .orElseGet(Map::of)
+                                    .get(HTTP_ROUTE)))
+                            .forEach(dataPoint -> {
+                                var duration = dataPoint.doubleValue("sum").orElseThrow();
+                                var durationNanos = switch (unit) {
+                                case "s" -> Math.round(duration * 1_000_000_000.0);
+                                case "ms" -> Math.round(duration * 1_000_000.0);
+                                default -> throw new IllegalStateException("Unexpected duration unit: " + unit);
+                                };
+
+                                personalizedGreetingTimeNanos.addAndGet(durationNanos);
+                                personalizedGreetingCount.addAndGet(Long.parseLong(dataPoint.stringValue("count").orElseThrow()));
+                            });
+                });
+
+        return new PersonalizedGreetingMeasurement(personalizedGreetingCount.get(), personalizedGreetingTimeNanos.get());
+    }
+
+    private record PersonalizedGreetingMeasurement(long count, long timeNanos) {
+    }
+
+    static List<JsonObject> metricsEntries(JsonObject root) {
+
+        var top = root.arrayValue("resourceMetrics");
+
+        Stream<JsonValue> scopeMetricsEntries;
+
+            /*
+            The top node might be resourceMetrics which is an array of resource/scopeMetrics tuples, or it might be a single
+            resource/scopeMetrics tuple.
+             */
+        if (top.isPresent()) {
+            scopeMetricsEntries =
+                    top.get().asArray().values().stream()
+                            .flatMap(resourceMetricEntry -> resourceMetricEntry.asArray().values().stream())
+                            .map(JsonValue::asObject)
+                            .flatMap(resourceMetric -> resourceMetric.arrayValue("scopeMetrics").stream());
+        } else {
+            scopeMetricsEntries = root.arrayValue("scopeMetrics").orElseThrow().values().stream();
+        }
+
+        return scopeMetricsEntries
+                .flatMap(scopeMetricsEntry -> scopeMetricsEntry.asObject()
+                        .arrayValue("metrics")
+                        .orElseThrow()
+                        .values()
+                        .stream())
+                .map(JsonValue::asObject)
+                .toList();
+    }
+
 }


### PR DESCRIPTION
### Description
Resolves #12097 

### Release Note
____
Helidon now correctly expresses the `http.server.request.duration` OpenTelemetry metric in seconds, and correctly includes all processing (including all filters and payload preparation).
____


### PR overview
As noted in the issue, the code actually and incorrectly converted the duration to ms instead of seconds.

Further, the original code updated the timer as if all processing of the request finished in the filter, which is inaccurate. The PR changes this to compute the ending time of the duration in `whenSent` which includes all filters and time spent actually sending the response. 


### Documentation
No impact
