### PR TITLE
3.x: upgrade Jackson to 2.21.4

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -70,7 +70,7 @@
         <version.lib.hibernate-validator>7.0.5.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.21.3</version.lib.jackson>
+        <version.lib.jackson>2.21.4</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.0.1</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.0.0</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>3.0.0</version.lib.jakarta.cdi-api>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -430,7 +430,7 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <notes><![CDATA[
    file name: neo4j-java-driver-5.28.3.jar
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.neo4j\.driver/neo4j-java-driver@.*$</packageUrl>
+   <packageUrl regex="true">^pkg:maven/org\.neo4j\.driver/.*@.*$</packageUrl>
    <cve>CVE-2026-1337</cve>
 </suppress>
 <suppress>
@@ -438,7 +438,7 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    file name: neo4j-bolt-connection-1.0.0.jar
    file name: neo4j-bolt-connection-netty-1.0.0.jar
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.neo4j\.bolt/neo4j-bolt-connection.*$</packageUrl>
+   <packageUrl regex="true">^pkg:maven/org\.neo4j\.bolt/.*@.*$</packageUrl>
    <cve>CVE-2026-1337</cve>
 </suppress>
 <suppress>
@@ -447,6 +447,55 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/io\.helidon\.integrations\.neo4j/helidon-integrations-neo4j.*$</packageUrl>
    <cve>CVE-2026-1337</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: neo4j-bolt-connection-1.0.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.neo4j\.bolt/.*@.*$</packageUrl>
+    <cve>CVE-2026-1471</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: neo4j-bolt-connection-1.0.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.neo4j\.bolt/.*@.*$</packageUrl>
+    <cve>CVE-2026-1524</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: neo4j-bolt-connection-1.0.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.neo4j\.bolt/.*@.*$</packageUrl>
+    <cve>CVE-2026-1497</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: io.helidon.integrations.neo4j:helidon-integrations-neo4j:3.2.19-SNAPSHOT
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.helidon\.integrations\.neo4j/helidon-integrations-neo4j@.*$</packageUrl>
+    <cve>CVE-2026-1471</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: io.helidon.integrations.neo4j:helidon-integrations-neo4j:3.2.19-SNAPSHOT
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.helidon\.integrations\.neo4j/helidon-integrations-neo4j@.*$</packageUrl>
+    <cve>CVE-2026-1471</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: io.helidon.integrations.neo4j:helidon-integrations-neo4j:3.2.19-SNAPSHOT
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.helidon\.integrations\.neo4j/helidon-integrations-neo4j@.*$</packageUrl>
+    <cve>CVE-2026-1497</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: io.helidon.integrations.neo4j:helidon-integrations-neo4j:3.2.19-SNAPSHOT
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.helidon\.integrations\.neo4j/helidon-integrations-neo4j@.*$</packageUrl>
+    <cve>CVE-2026-1524</cve>
 </suppress>
 
 <!-- 

--- a/pom.xml
+++ b/pom.xml
@@ -568,6 +568,8 @@
                         <skipTestScope>true</skipTestScope>
                         <failBuildOnCVSS>0</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <!-- Bump up from 24 to 72 to reduce token use -->
+                        <ossIndexAnalyzerCacheValidForHours>72</ossIndexAnalyzerCacheValidForHours>
 			# If provide improves rate limits
 			<nvdApiKey>${nvd-api-key}</nvdApiKey>
                         <excludes>


### PR DESCRIPTION
### Description

Upgrade Jackson to 2.21.4
Suppress more neo4j false positives.
Dependency check: increase ossIndexAnalyzerCacheValidForHours to reduce token use.