### PR TITLE
Fix API stability record constructor errors on JDK 26 (4.x)

### DIFF
--- a/codegen/api-stability/src/main/java/io/helidon/codegen/api/stability/ApiStabilityProcessor.java
+++ b/codegen/api-stability/src/main/java/io/helidon/codegen/api/stability/ApiStabilityProcessor.java
@@ -153,6 +153,13 @@ public class ApiStabilityProcessor extends AbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         try {
+            if (previewAction == Action.IGNORE
+                    && incubatingAction == Action.IGNORE
+                    && internalAction == Action.IGNORE
+                    && deprecatedAction == Action.IGNORE) {
+                return false;
+            }
+
             var trees = Trees.instance(processingEnv);
 
             for (var rootElement : roundEnv.getRootElements()) {
@@ -175,12 +182,18 @@ public class ApiStabilityProcessor extends AbstractProcessor {
             Set<Ref> deprecatedApis = new LinkedHashSet<>();
 
             for (var unit : compilationUnits) {
-                var scanner = new ApiStabilityScanner(trees, unit);
-                scanner.scan(unit, null);
-                previewApis.addAll(scanner.previewApis());
-                incubatingApis.addAll(scanner.incubatingApis());
-                privateApis.addAll(scanner.internalApis());
-                deprecatedApis.addAll(scanner.deprecatedApis());
+                try {
+                    var scanner = new ApiStabilityScanner(trees, unit);
+                    scanner.scan(unit, null);
+                    previewApis.addAll(scanner.previewApis());
+                    incubatingApis.addAll(scanner.incubatingApis());
+                    privateApis.addAll(scanner.internalApis());
+                    deprecatedApis.addAll(scanner.deprecatedApis());
+                } catch (Throwable e) {
+                    messager.printWarning("Failed to scan a source file in ApiStabilityProcessor. "
+                                                  + "API stability diagnostics may be incomplete. Exception class: "
+                                                  + e.getClass().getName() + ", message: " + e.getMessage());
+                }
             }
 
             scanModuleDirectives(modules, previewApis, incubatingApis, privateApis, deprecatedApis);

--- a/codegen/api-stability/src/main/java/io/helidon/codegen/api/stability/ApiStabilityScanner.java
+++ b/codegen/api-stability/src/main/java/io/helidon/codegen/api/stability/ApiStabilityScanner.java
@@ -34,6 +34,7 @@ import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
@@ -104,7 +105,7 @@ class ApiStabilityScanner extends TreeScanner<Void, Void> {
     private Void visit(TreePath path, Supplier<Void> superCall) {
 
         if (path != null) {
-            var elt = trees.getElement(path);
+            var elt = element(path);
             if (elt instanceof TypeElement || elt instanceof ExecutableElement) {
                 if (checkAnnotation(path, elt, Api.Internal.class, internalApis, SUPPRESS_INTERNAL)) {
                     return null;
@@ -160,7 +161,7 @@ class ApiStabilityScanner extends TreeScanner<Void, Void> {
         while (node != null) {
             switch (node.getLeaf().getKind()) {
             case CLASS, INTERFACE, ENUM, RECORD, ANNOTATION_TYPE, MODULE, PACKAGE -> {
-                var elt = trees.getElement(node);
+                var elt = element(node);
                 if (elt != null) {
                     return sourceRef(node, elt);
                 }
@@ -207,7 +208,7 @@ class ApiStabilityScanner extends TreeScanner<Void, Void> {
             return null;
         }
         var path = trees.getPath(compilationUnit, tree);
-        return path == null ? null : trees.getElement(path);
+        return path == null ? null : element(path);
     }
 
     /**
@@ -264,7 +265,7 @@ class ApiStabilityScanner extends TreeScanner<Void, Void> {
         while (n != null) {
             switch (n.getLeaf().getKind()) {
             case VARIABLE, METHOD, CLASS, INTERFACE, ENUM, RECORD, ANNOTATION_TYPE, MODULE, PACKAGE -> {
-                var elt = trees.getElement(n);
+                var elt = element(n);
                 if (elt != null) {
                     return elt;
                 }
@@ -275,7 +276,29 @@ class ApiStabilityScanner extends TreeScanner<Void, Void> {
             }
             n = n.getParentPath();
         }
-        return trees.getElement(node);
+        return element(node);
+    }
+
+    private Element element(TreePath path) {
+        /*
+         * JDK 26 javac can report a bogus record canonical constructor error when an annotation
+         * processor asks Trees.getElement for nodes inside record constructors.
+         */
+        return inRecordConstructor(path) ? null : trees.getElement(path);
+    }
+
+    private boolean inRecordConstructor(TreePath path) {
+        var current = path;
+        while (current != null) {
+            if (current.getLeaf() instanceof MethodTree method
+                    && method.getReturnType() == null
+                    && current.getParentPath() != null
+                    && current.getParentPath().getLeaf().getKind() == Tree.Kind.RECORD) {
+                return true;
+            }
+            current = current.getParentPath();
+        }
+        return false;
     }
 
     record SourceRef(int line,

--- a/codegen/api-stability/src/test/java/io/helidon/codegen/api/stability/ApiStabilityProcessorTest.java
+++ b/codegen/api-stability/src/test/java/io/helidon/codegen/api/stability/ApiStabilityProcessorTest.java
@@ -172,6 +172,64 @@ public class ApiStabilityProcessorTest {
     }
 
     @Test
+    void testRecordCompactConstructorCompiles() {
+        var result = TestCompiler.builder()
+                .addProcessor(new ApiStabilityProcessor())
+                .addClasspath(Api.class)
+                .currentRelease()
+                .addOption("-Xlint:none")
+                .addSource("Repro.java", """
+                        package com.example;
+
+                        record Repro(String name) {
+                            Repro {
+                                name = name.trim();
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(result.success(), is(true));
+        assertThat(result.diagnostics(), empty());
+    }
+
+    @Test
+    void testRecordCompactConstructorInternalUsageDoesNotFailCompilation() {
+        var result = TestCompiler.builder()
+                .addProcessor(new ApiStabilityProcessor())
+                .addClasspath(Api.class)
+                .currentRelease()
+                .addOption("-Xlint:none")
+                .addOptions(List.of("-Ahelidon.api.internal=fail"))
+                .addSource("InternalApi.java", """
+                        package com.example;
+
+                        import io.helidon.common.Api;
+
+                        @Api.Internal
+                        public class InternalApi {
+                        }
+                        """)
+                .addSource("Repro.java", """
+                        package com.example;
+
+                        record Repro(String name) {
+                            Repro {
+                                InternalApi api = new InternalApi();
+                                name = name.trim();
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+        var messages = result.diagnostics();
+
+        assertThat(result.success(), is(true));
+        assertThat(messages, not(hasItem(containsString("invalid canonical constructor"))));
+    }
+
+    @Test
     void testGlobalWarnOptionDowngradesDefaultFailures() {
         var result = TestCompiler.builder()
                 .addProcessor(new ApiStabilityProcessor())


### PR DESCRIPTION
Resolves #12132

Avoid JDK 26 javac side effects from API stability scanning in record constructors, and keep API stability diagnostics fail-open when source scanning hits an unexpected processor error.
