### PR TITLE
Backport @Configuration.Value generic mapper preservation to 4.5.1

### DIFF
--- a/config/config/src/main/java/io/helidon/config/ConfigMapperManager.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigMapperManager.java
@@ -17,6 +17,8 @@
 package io.helidon.config;
 
 import java.lang.reflect.Array;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -379,12 +381,26 @@ class ConfigMapperManager implements ConfigMapper {
                 return mapper1;
             }
 
-            if (!genericType.isClass()) {
-                return Optional.empty();
-            }
-
             // third try the specific class map
             Class<?> rawType = genericType.rawType();
+
+            if (!genericType.isClass()) {
+                if (!Map.class.equals(rawType)) {
+                    return Optional.empty();
+                }
+
+                Type type = genericType.type();
+                if (!(type instanceof ParameterizedType parameterizedType)) {
+                    return Optional.empty();
+                }
+
+                Type[] typeArguments = parameterizedType.getActualTypeArguments();
+                if (typeArguments.length != 2
+                        || !String.class.equals(typeArguments[0])
+                        || !String.class.equals(typeArguments[1])) {
+                    return Optional.empty();
+                }
+            }
 
             Function<Config, ?> configConverter = provider.mappers().get(rawType);
 

--- a/config/config/src/main/java/io/helidon/config/ConfigurationValueFactory.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigurationValueFactory.java
@@ -146,7 +146,7 @@ class ConfigurationValueFactory implements Service.QualifiedFactory<Object, Conf
         if (configAtKey.isList()) {
             values = listValues(qualifier, configAtKey, type);
         } else if (configAtKey.exists()) {
-            ConfigValue<?> configValue = configAtKey.as(type.rawType());
+            ConfigValue<?> configValue = configAtKey.as(type);
 
             if (configValue.isEmpty()) {
                 values = List.of();
@@ -157,17 +157,16 @@ class ConfigurationValueFactory implements Service.QualifiedFactory<Object, Conf
         return values;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private List<QualifiedInstance<Object>> listValues(Qualifier qualifier,
                                                        Config configAtKey,
                                                        GenericType<Object> type) {
-        ConfigValue list = configAtKey.asList(type.rawType());
+        ConfigValue<List<Config>> list = configAtKey.asNodeList();
         if (list.isEmpty()) {
             return List.of();
         }
-        return ((List<Object>) list.get())
+        return list.get()
                 .stream()
-                .map(it -> QualifiedInstance.create(it, qualifier))
+                .map(it -> QualifiedInstance.create(it.as(type).get(), qualifier))
                 .collect(Collectors.toUnmodifiableList());
     }
 

--- a/config/config/src/test/java/io/helidon/config/ConfigurationValueFactoryTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigurationValueFactoryTest.java
@@ -19,12 +19,16 @@ package io.helidon.config;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import io.helidon.common.Default;
 import io.helidon.common.GenericType;
 import io.helidon.common.mapper.DefaultsResolver;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeName;
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.config.spi.ConfigSource;
 import io.helidon.service.registry.Dependency;
 import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Qualifier;
@@ -35,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConfigurationValueFactoryTest {
     private static final TypeName TEST_DESCRIPTOR = TypeName.create(ConfigurationValueFactoryTest.class);
@@ -52,6 +57,149 @@ class ConfigurationValueFactoryTest {
 
         assertThat(values, hasSize(1));
         assertThat(values.getFirst().get(), is("Ahoj"));
+    }
+
+    @Test
+    void literalKeyUsesGenericTypeMapper() {
+        GenericType<Map<String, Integer>> mapType = new GenericType<Map<String, Integer>>() { };
+        Config config = configWithMapMapper(mapType, ConfigSources.create(Map.of("app.limit", "23")));
+        ConfigurationValueFactory factory = new ConfigurationValueFactory(() -> defaultsResolver(config), () -> config);
+
+        assertThat(config.get("app").as(mapType).get().get("limit"), is(23));
+
+        List<Service.QualifiedInstance<Object>> values = factory.list(Qualifier.create(Configuration.Value.class,
+                                                                                      "app"),
+                                                                      Lookup.create(Map.class),
+                                                                      asObjectType(mapType));
+
+        assertThat(values, hasSize(1));
+        Map<?, ?> value = (Map<?, ?>) values.getFirst().get();
+        assertThat(value.get("limit"), is(23));
+    }
+
+    @Test
+    void literalMapStringStringUsesClassMapperFallback() {
+        GenericType<Map<String, String>> mapType = new GenericType<Map<String, String>>() { };
+        Config config = configWithRawMapMapper(ConfigSources.create(Map.of("app.limit", "23")));
+        ConfigurationValueFactory factory = new ConfigurationValueFactory(() -> defaultsResolver(config), () -> config);
+
+        assertThat(config.get("app").as(mapType).get(), is(Map.of("raw-limit", "23")));
+
+        List<Service.QualifiedInstance<Object>> values = factory.list(Qualifier.create(Configuration.Value.class,
+                                                                                      "app"),
+                                                                      Lookup.create(Map.class),
+                                                                      asObjectType(mapType));
+
+        assertThat(values, hasSize(1));
+        assertThat(values.getFirst().get(), is(Map.of("raw-limit", "23")));
+    }
+
+    @Test
+    void literalMapStringIntegerDoesNotUseClassMapperFallback() {
+        GenericType<Map<String, Integer>> mapType = new GenericType<Map<String, Integer>>() { };
+        Config config = configWithRawMapMapper(ConfigSources.create(Map.of("app.limit", "23")));
+        ConfigurationValueFactory factory = new ConfigurationValueFactory(() -> defaultsResolver(config), () -> config);
+
+        assertThrows(ConfigMappingException.class,
+                     () -> factory.list(Qualifier.create(Configuration.Value.class,
+                                                         "app"),
+                                        Lookup.create(Map.class),
+                                        asObjectType(mapType)));
+    }
+
+    @Test
+    void listKeyUsesGenericTypeMapperForElements() {
+        GenericType<Map<String, Integer>> mapType = new GenericType<Map<String, Integer>>() { };
+        ConfigNode.ObjectNode first = ConfigNode.ObjectNode.builder()
+                .addValue("limit", "23")
+                .build();
+        ConfigNode.ObjectNode second = ConfigNode.ObjectNode.builder()
+                .addValue("limit", "42")
+                .build();
+        ConfigNode.ListNode list = ConfigNode.ListNode.builder()
+                .addObject(first)
+                .addObject(second)
+                .build();
+        ConfigNode.ObjectNode root = ConfigNode.ObjectNode.builder()
+                .addList("app", list)
+                .build();
+        Config config = configWithMapMapper(mapType, ConfigSources.create(root));
+        ConfigurationValueFactory factory = new ConfigurationValueFactory(() -> defaultsResolver(config), () -> config);
+
+        assertThat(config.get("app").isList(), is(true));
+        assertThat(config.get("app").asNodeList().get().getFirst().as(mapType).get().get("limit"), is(23));
+
+        List<Service.QualifiedInstance<Object>> values = factory.list(Qualifier.create(Configuration.Value.class,
+                                                                                      "app"),
+                                                                      Lookup.create(Map.class),
+                                                                      asObjectType(mapType));
+
+        assertThat(values, hasSize(2));
+        assertThat(values.stream()
+                           .map(Service.QualifiedInstance::get)
+                           .toList(),
+                   is(List.of(Map.of("limit", 23),
+                              Map.of("limit", 42))));
+    }
+
+    @Test
+    void listMapStringStringUsesClassMapperFallbackForElements() {
+        GenericType<Map<String, String>> mapType = new GenericType<Map<String, String>>() { };
+        ConfigNode.ObjectNode first = ConfigNode.ObjectNode.builder()
+                .addValue("limit", "23")
+                .build();
+        ConfigNode.ObjectNode second = ConfigNode.ObjectNode.builder()
+                .addValue("limit", "42")
+                .build();
+        ConfigNode.ListNode list = ConfigNode.ListNode.builder()
+                .addObject(first)
+                .addObject(second)
+                .build();
+        ConfigNode.ObjectNode root = ConfigNode.ObjectNode.builder()
+                .addList("app", list)
+                .build();
+        Config config = configWithRawMapMapper(ConfigSources.create(root));
+        ConfigurationValueFactory factory = new ConfigurationValueFactory(() -> defaultsResolver(config), () -> config);
+
+        assertThat(config.get("app").asNodeList().get().getFirst().as(mapType).get(), is(Map.of("raw-limit", "23")));
+
+        List<Service.QualifiedInstance<Object>> values = factory.list(Qualifier.create(Configuration.Value.class,
+                                                                                      "app"),
+                                                                      Lookup.create(Map.class),
+                                                                      asObjectType(mapType));
+
+        assertThat(values, hasSize(2));
+        assertThat(values.stream()
+                           .map(Service.QualifiedInstance::get)
+                           .toList(),
+                   is(List.of(Map.of("raw-limit", "23"),
+                              Map.of("raw-limit", "42"))));
+    }
+
+    @Test
+    void listMapStringIntegerDoesNotUseClassMapperFallbackForElements() {
+        GenericType<Map<String, Integer>> mapType = new GenericType<Map<String, Integer>>() { };
+        ConfigNode.ObjectNode first = ConfigNode.ObjectNode.builder()
+                .addValue("limit", "23")
+                .build();
+        ConfigNode.ObjectNode second = ConfigNode.ObjectNode.builder()
+                .addValue("limit", "42")
+                .build();
+        ConfigNode.ListNode list = ConfigNode.ListNode.builder()
+                .addObject(first)
+                .addObject(second)
+                .build();
+        ConfigNode.ObjectNode root = ConfigNode.ObjectNode.builder()
+                .addList("app", list)
+                .build();
+        Config config = configWithRawMapMapper(ConfigSources.create(root));
+        ConfigurationValueFactory factory = new ConfigurationValueFactory(() -> defaultsResolver(config), () -> config);
+
+        assertThrows(ConfigMappingException.class,
+                     () -> factory.list(Qualifier.create(Configuration.Value.class,
+                                                         "app"),
+                                        Lookup.create(Map.class),
+                                        asObjectType(mapType)));
     }
 
     @Test
@@ -156,6 +304,40 @@ class ConfigurationValueFactoryTest {
                 .build();
 
         return new ConfigurationValueFactory(() -> defaultsResolver(config), () -> config);
+    }
+
+    private static Config configWithMapMapper(GenericType<Map<String, Integer>> mapType,
+                                              Supplier<? extends ConfigSource> source) {
+        return Config.builder()
+                .sources(source)
+                .addMapper(mapType, node -> node.asMap()
+                        .orElseThrow()
+                        .entrySet()
+                        .stream()
+                        .collect(Collectors.toUnmodifiableMap(entry -> leaf(entry.getKey()),
+                                                              entry -> Integer.parseInt(entry.getValue()))))
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .disableFilterServices()
+                .build();
+    }
+
+    private static Config configWithRawMapMapper(Supplier<? extends ConfigSource> source) {
+        return Config.builder()
+                .sources(source)
+                .addMapper(Map.class, node -> ConfigMappers.toMap(node.detach())
+                        .entrySet()
+                        .stream()
+                        .collect(Collectors.toUnmodifiableMap(entry -> "raw-" + leaf(entry.getKey()),
+                                                              Map.Entry::getValue)))
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .disableFilterServices()
+                .build();
+    }
+
+    private static String leaf(String key) {
+        return key.substring(key.lastIndexOf('.') + 1);
     }
 
     private static DefaultsResolver defaultsResolver(Config config) {

--- a/docs/src/main/asciidoc/se/config/extensions.adoc
+++ b/docs/src/main/asciidoc/se/config/extensions.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -319,7 +319,11 @@ For `Config.as(Class)`:
 4. Check whether a conversion function is provided by any `ConfigMapperProvider` with method `mapper(GenericType)` for
     a generic type for the class requested.
 
-For `Config.as(GenericType)` - the first two steps are skipped.
+For `Config.as(GenericType)`, the config system checks generic type conversion
+first. If the requested generic type represents a raw class, the class
+conversion steps also apply. For parameterized types, class conversion is
+skipped except that `Map<String, String>` can fall back to the raw `Map.class`
+conversion for compatibility.
 
 The config system also uses the Java `ServiceLoader` mechanism to load automatically,
 for all builders, any mappers returned by the providers listed in the


### PR DESCRIPTION
Resolves #12105

Backports the generic `@Configuration.Value` mapper preservation fix from #12107 to 4.x, keeping the source change intact.