### PR TITLE
Update metrics factory documentation (4.x)

### DIFF
--- a/docs/src/main/asciidoc/se/guides/metrics.adoc
+++ b/docs/src/main/asciidoc/se/guides/metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -161,7 +161,7 @@ The `Counter` {metric} is a monotonically increasing number. The following examp
 include::{sourcedir}/se/guides/MetricsSnippets.java[tag=snippet_3, indent=0]
 ----
 <1> Declare a `Counter` member field.
-<2> Create and register the `Counter` {metric} in the global meter registry`.  This `Counter` will exist for the lifetime of
+<2> Create and register the `Counter` {metric} in the global meter registry using a builder from `MetricsFactory`. This `Counter` will exist for the lifetime of
 the application.
 <3> Increment the count.
 
@@ -204,8 +204,8 @@ endpoint is called, the code updates the `Timer` with additional timing informat
 include::{sourcedir}/se/guides/MetricsSnippets.java[tag=snippet_5, indent=0]
 ----
 <1> Declare a `Timer` member field.
-<2> Create and register the `Timer` metric in the global meter registry.
-<3> Create a timer sample which, among other things, automatically records the starting time.
+<2> Create and register the `Timer` metric in the global meter registry using a builder from `MetricsFactory`.
+<3> Create a timer sample from `MetricsFactory` which, among other things, automatically records the starting time.
 <4> Arrange for the timer sample to be stopped and applied to the `cardTimer` once Helidon sends the response to the client.
 
 
@@ -251,7 +251,7 @@ the `/cards` endpoint is invoked.
 include::{sourcedir}/se/guides/MetricsSnippets.java[tag=snippet_6, indent=0]
 ----
 <1> Declare a `DistributionSummary` member field.
-<2> Create and register the `DistributionSummary` {metric} in the global meter registry
+<2> Create and register the `DistributionSummary` {metric} in the global meter registry using a builder from `MetricsFactory`.
 <3> Update the distribution summary with a random number multiple times for each request.
 
 
@@ -294,7 +294,7 @@ how a `Gauge` is used to get the current temperature.
 ----
 include::{sourcedir}/se/guides/MetricsSnippets.java[tag=snippet_7, indent=0]
 ----
-<1> Register the `Gauge`, passing a `Supplier<Double>` which furnishes a random temperature from 0 to 100.0 each time the metrics system interrogates the gauge.
+<1> Register the `Gauge` using a builder from `MetricsFactory`, passing a `Supplier<Double>` which furnishes a random temperature from 0 to 100.0 each time the metrics system interrogates the gauge.
 
 
 [source,bash,subs="attributes+"]
@@ -328,4 +328,3 @@ This guide demonstrated how to use metrics in a Helidon SE application using var
 Refer to the following references for additional information:
 
 * link:{javadoc-base-url}/index.html?overview-summary.html[Helidon Javadoc]
-

--- a/docs/src/main/asciidoc/se/guides/webclient.adoc
+++ b/docs/src/main/asciidoc/se/guides/webclient.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -256,7 +256,7 @@ The following example shows how a `Counter` metric can be defined, created and m
 include::{sourcedir}/se/guides/WebclientSnippets.java[tag=snippet_6, indent=0]
 ----
 <1> Specify the metric name.
-<2> From the `MeterRegistry`, create a Counter metric using the specified metric name.
+<2> From the `MeterRegistry`, create a `Counter` metric using a builder from `MetricsFactory` and the specified metric name.
 <3> Specify how the name of the metric will be generated using the `nameFormat`.
 <4> Build a WebClient Metric Service that can count number of GET requests made.
 
@@ -326,7 +326,7 @@ be measured.
 include::{sourcedir}/se/guides/WebclientSnippets.java[tag=snippet_9, indent=0]
 ----
 <1> Choose the metric name.
-<2> Create counter metric from `MeterRegistry`.
+<2> Create a counter metric from `MeterRegistry` using a builder from `MetricsFactory`.
 <3> Create a Helidon Config instance from default config file `application.yaml`.
 <4> Configure the WebClient using the `client` section from `application.yaml`.
 <5> Send an HTTP GET request

--- a/docs/src/main/asciidoc/se/metrics/metrics.adoc
+++ b/docs/src/main/asciidoc/se/metrics/metrics.adoc
@@ -109,7 +109,7 @@ include::{rootdir}/includes/metrics/metrics-shared.adoc[tag=usage-body]
 
 === Meter Registry
 Helidon stores all meters in a _meter registry_. Typically, applications use the global meter registry which is the registry where Helidon stores built-in meters.
-Application code refers to the global registry using `Metrics.globalRegistry()`.
+Application code obtains the global registry using `Services.get(MeterRegistry.class)`.
 
 [[usage-publishing]]
 include::{rootdir}/includes/metrics/metrics-shared.adoc[tag=usage-retrieving]
@@ -133,8 +133,8 @@ include::{sourcedir}/se/metrics/MetricsSnippets.java[tag=snippet_1, indent=0]
 == API
 To work with Helidon Metrics in your code, follow these steps:
 
-. Use the static `globalRegistry` method on the link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.html[`Metrics`] interface to get a reference to the global  link:{metrics-javadoc-base-url}/io/helidon/metrics/api/MeterRegistry.html[`MeterRegistry`] instance.
-. Use the `MeterRegistry` instance to register new {metrics} and look up previously-registered {metrics}.
+. Use `Services.get(MeterRegistry.class)` to get a reference to the global link:{metrics-javadoc-base-url}/io/helidon/metrics/api/MeterRegistry.html[`MeterRegistry`] instance.
+. Use the `MeterRegistry` instance with builders from link:{metrics-javadoc-base-url}/io/helidon/metrics/api/MetricsFactory.html[`MetricsFactory`] to register new {metrics} and look up previously-registered {metrics}.
 . Use the {metric} reference returned from the `MeterRegistry` to update the {metric} or get its value.
 
 You can also use the `MeterRegistry` to remove an existing {metric}.
@@ -169,11 +169,11 @@ Each {metric} type has its own set of methods for updating and retrieving the va
 
 === The `MeterRegistry` API
 To register or look up {meters} programmatically, your service code uses the global `MeterRegistry`.
-Simply invoke `Metrics.globalRegistry()` to get a reference to the global meter registry.
+Use `Services.get(MeterRegistry.class)` to get a reference to the global meter registry.
 
 To locate an existing meter or register a new one, your code:
 
-. Creates a builder of the appropriate type of meter, setting the name and possibly other characteristics of the meter.
+. Creates a builder of the appropriate type of meter using `MetricsFactory`, setting the name and possibly other characteristics of the meter.
 . Invokes the `MeterRegistry.getOrCreate` method, passing the builder.
 
 The meter registry returns a reference to a previously-registered meter with the specified name and tags or, if none exists, a newly-registered meter.
@@ -216,8 +216,8 @@ The following example, based on the Helidon SE QuickStart application, shows how
 ----
 include::{sourcedir}/se/metrics/MetricsSnippets.java[tag=snippet_2, indent=0]
 ----
-<1> Get the global meter registry.
-<2> Create (or find) a counter named "accessctr" in the global registry.
+<1> Get the global meter registry from the service registry.
+<2> Create (or find) a counter named "accessctr" in the global registry using a counter builder from `MetricsFactory`.
 <3> Route every request to the `countAccess` method.
 <4> Increment the access counter for every request.
 

--- a/docs/src/main/java/io/helidon/docs/se/guides/MetricsSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/guides/MetricsSnippets.java
@@ -106,10 +106,12 @@ class MetricsSnippets {
             private final Counter cardCounter; // <1>
 
             GreetingCards() {
-                cardCounter = Services.get(MeterRegistry.class)
-                        .getOrCreate(Services.get(MetricsFactory.class)
-                                             .counterBuilder("cardCount")
-                                             .description("Counts card retrievals")); // <2>
+                var metricsFactory = Services.get(MetricsFactory.class);
+                var meterRegistry = Services.get(MeterRegistry.class);
+
+                cardCounter = meterRegistry.getOrCreate(metricsFactory
+                                                                .counterBuilder("cardCount")
+                                                                .description("Counts card retrievals")); // <2>
             }
 
             @Override
@@ -161,11 +163,14 @@ class MetricsSnippets {
         public class GreetingCards implements HttpService {
 
             private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
-            private final MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+            private final MetricsFactory metricsFactory;
             private final Timer cardTimer; // <1>
 
             GreetingCards() {
-                cardTimer = Services.get(MeterRegistry.class)
+                this.metricsFactory = Services.get(MetricsFactory.class);
+                var meterRegistry = Services.get(MeterRegistry.class);
+
+                this.cardTimer = meterRegistry
                         .getOrCreate(metricsFactory.timerBuilder("cardTimer") // <2>
                                              .description("Times card retrievals"));
             }
@@ -195,11 +200,14 @@ class MetricsSnippets {
         public class GreetingCards implements HttpService {
 
             private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
-            private final MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+            private final MetricsFactory metricsFactory;
             private final DistributionSummary cardSummary; // <1>
 
             GreetingCards() {
-                cardSummary = Services.get(MeterRegistry.class)
+                this.metricsFactory = Services.get(MetricsFactory.class);
+                var meterRegistry = Services.get(MeterRegistry.class);
+
+                cardSummary = meterRegistry
                         .getOrCreate(metricsFactory.distributionSummaryBuilder(
                                              "cardDist",
                                              metricsFactory.distributionStatisticsConfigBuilder())
@@ -236,8 +244,11 @@ class MetricsSnippets {
 
             GreetingCards() {
                 Random r = new Random();
-                Services.get(MeterRegistry.class)
-                        .getOrCreate(Services.get(MetricsFactory.class)
+
+                var metricsFactory = Services.get(MetricsFactory.class);
+                var meterRegistry = Services.get(MeterRegistry.class);
+
+                meterRegistry.getOrCreate(metricsFactory
                                              .gaugeBuilder("temperature",
                                                            () -> r.nextDouble(100.0))
                                              .description("Ambient temperature")); // <1>

--- a/docs/src/main/java/io/helidon/docs/se/guides/MetricsSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/guides/MetricsSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.DistributionSummary;
-import io.helidon.metrics.api.Gauge;
 import io.helidon.metrics.api.KeyPerformanceIndicatorMetricsConfig;
-import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.MetricsConfig;
 import io.helidon.metrics.api.Timer;
+import io.helidon.service.registry.Services;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.HttpRules;
@@ -105,8 +106,9 @@ class MetricsSnippets {
             private final Counter cardCounter; // <1>
 
             GreetingCards() {
-                cardCounter = Metrics.globalRegistry()
-                        .getOrCreate(Counter.builder("cardCount")
+                cardCounter = Services.get(MeterRegistry.class)
+                        .getOrCreate(Services.get(MetricsFactory.class)
+                                             .counterBuilder("cardCount")
                                              .description("Counts card retrievals")); // <2>
             }
 
@@ -159,11 +161,12 @@ class MetricsSnippets {
         public class GreetingCards implements HttpService {
 
             private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
+            private final MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
             private final Timer cardTimer; // <1>
 
             GreetingCards() {
-                cardTimer = Metrics.globalRegistry()
-                        .getOrCreate(Timer.builder("cardTimer") // <2>
+                cardTimer = Services.get(MeterRegistry.class)
+                        .getOrCreate(metricsFactory.timerBuilder("cardTimer") // <2>
                                              .description("Times card retrievals"));
             }
 
@@ -173,7 +176,7 @@ class MetricsSnippets {
             }
 
             private void getDefaultMessageHandler(ServerRequest request, ServerResponse response) {
-                Timer.Sample timerSample = Timer.start(); // <3>
+                Timer.Sample timerSample = metricsFactory.timerStart(); // <3>
                 response.whenSent(() -> timerSample.stop(cardTimer)); // <4>
                 sendResponse(response, "Here are some cards ...");
             }
@@ -192,11 +195,14 @@ class MetricsSnippets {
         public class GreetingCards implements HttpService {
 
             private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
+            private final MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
             private final DistributionSummary cardSummary; // <1>
 
             GreetingCards() {
-                cardSummary = Metrics.globalRegistry()
-                        .getOrCreate(DistributionSummary.builder("cardDist")
+                cardSummary = Services.get(MeterRegistry.class)
+                        .getOrCreate(metricsFactory.distributionSummaryBuilder(
+                                             "cardDist",
+                                             metricsFactory.distributionStatisticsConfigBuilder())
                                              .description("random card distribution")); // <2>
             }
 
@@ -230,9 +236,10 @@ class MetricsSnippets {
 
             GreetingCards() {
                 Random r = new Random();
-                Metrics.globalRegistry()
-                        .getOrCreate(Gauge.builder("temperature",
-                                                   () -> r.nextDouble(100.0))
+                Services.get(MeterRegistry.class)
+                        .getOrCreate(Services.get(MetricsFactory.class)
+                                             .gaugeBuilder("temperature",
+                                                           () -> r.nextDouble(100.0))
                                              .description("Ambient temperature")); // <1>
             }
 

--- a/docs/src/main/java/io/helidon/docs/se/guides/WebclientSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/guides/WebclientSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ import io.helidon.config.Config;
 import io.helidon.http.Method;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.service.registry.Services;
 import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.metrics.WebClientMetrics;
@@ -86,11 +87,12 @@ class WebclientSnippets {
 
     void snippet_6_7_8() {
         // tag::snippet_6[]
-        MeterRegistry METER_REGISTRY = Metrics.globalRegistry();
+        MeterRegistry meterRegistry = Services.get(MeterRegistry.class);
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
 
         String metricName = "counter.GET.localhost"; // <1>
 
-        Counter counter = METER_REGISTRY.getOrCreate(Counter.builder(metricName)); // <2>
+        Counter counter = meterRegistry.getOrCreate(metricsFactory.counterBuilder(metricName)); // <2>
         System.out.println(metricName + ": " + counter.count());
 
         WebClientService clientServiceMetric = WebClientMetrics.counter()
@@ -118,11 +120,12 @@ class WebclientSnippets {
 
     void snippet_9(String[] args) {
         // tag::snippet_9[]
-        MeterRegistry METER_REGISTRY = Metrics.globalRegistry();
+        MeterRegistry meterRegistry = Services.get(MeterRegistry.class);
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
 
         String counterName = "counter.GET.localhost"; // <1>
 
-        Counter counter = METER_REGISTRY.getOrCreate(Counter.builder(counterName)); // <2>
+        Counter counter = meterRegistry.getOrCreate(metricsFactory.counterBuilder(counterName)); // <2>
         System.out.println(counterName + ": " + counter.count());
 
         Config config = Config.create(); // <3>

--- a/docs/src/main/java/io/helidon/docs/se/metrics/MetricsSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/metrics/MetricsSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@ package io.helidon.docs.se.metrics;
 
 import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
-import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
 // tag::snippet_4[]
 import io.helidon.metrics.prometheus.PrometheusSupport;
 // end::snippet_4[]
+import io.helidon.service.registry.Services;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.HttpRules;
@@ -67,8 +69,10 @@ class MetricsSnippets {
     // tag::snippet_2[]
     public class GreetService implements HttpService {
 
-        private final Counter accessCtr = Metrics.globalRegistry() // <1>
-                .getOrCreate(Counter.builder("accessctr")); // <2>
+        private final MeterRegistry meterRegistry = Services.get(MeterRegistry.class); // <1>
+        private final Counter accessCtr = meterRegistry
+                .getOrCreate(Services.get(MetricsFactory.class)
+                                     .counterBuilder("accessctr")); // <2>
 
         @Override
         public void routing(HttpRules rules) {

--- a/docs/src/main/java/io/helidon/docs/se/metrics/MetricsSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/metrics/MetricsSnippets.java
@@ -69,10 +69,15 @@ class MetricsSnippets {
     // tag::snippet_2[]
     public class GreetService implements HttpService {
 
-        private final MeterRegistry meterRegistry = Services.get(MeterRegistry.class); // <1>
-        private final Counter accessCtr = meterRegistry
-                .getOrCreate(Services.get(MetricsFactory.class)
-                                     .counterBuilder("accessctr")); // <2>
+        private final Counter accessCtr;
+
+        GreetService() {
+            var metricsFactory = Services.get(MetricsFactory.class);
+            var meterRegistry = Services.get(MeterRegistry.class); // <1>
+
+            this.accessCtr = meterRegistry
+                    .getOrCreate(metricsFactory.counterBuilder("accessctr")); // <2>
+        }
 
         @Override
         public void routing(HttpRules rules) {

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Clock.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Clock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,10 @@ public interface Clock extends Wrapper {
      * <p>
      * The system clock methods are functionally equivalent to {@link System#currentTimeMillis()}
      * and {@link System#nanoTime()}.
+     * </p>
+     * <p>
+     * For new code, prefer {@link MetricsFactory#clockSystem()} on the {@link MetricsFactory} instance used by the
+     * application.
      * </p>
      *
      * @return the system clock

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Counter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,10 @@ public interface Counter extends Meter {
 
     /**
      * Creates a new builder for a counter.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#counterBuilder(String)} on the {@link MetricsFactory} instance used by
+     * the application.
+     * </p>
      *
      * @param name counter name
      * @return new builder

--- a/metrics/api/src/main/java/io/helidon/metrics/api/DistributionStatisticsConfig.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/DistributionStatisticsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,10 @@ public interface DistributionStatisticsConfig extends Wrapper {
 
     /**
      * Creates a builder for a new {@link io.helidon.metrics.api.DistributionStatisticsConfig} instance.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#distributionStatisticsConfigBuilder()} on the
+     * {@link MetricsFactory} instance used by the application.
+     * </p>
      *
      * @return new builder
      */

--- a/metrics/api/src/main/java/io/helidon/metrics/api/DistributionSummary.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/DistributionSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,11 @@ public interface DistributionSummary extends Meter {
 
     /**
      * Creates a builder for a new {@link io.helidon.metrics.api.DistributionSummary} using the specified statistics builder.
+     * <p>
+     * For new code, prefer
+     * {@link MetricsFactory#distributionSummaryBuilder(String, DistributionStatisticsConfig.Builder)} on the
+     * {@link MetricsFactory} instance used by the application.
+     * </p>
      *
      * @param name          name for the summary
      * @param configBuilder distribution stats config for the summary
@@ -39,6 +44,12 @@ public interface DistributionSummary extends Meter {
 
     /**
      * Creates a builder for a new {@link io.helidon.metrics.api.DistributionSummary} using default distribution statistics.
+     * <p>
+     * For new code, prefer
+     * {@link MetricsFactory#distributionSummaryBuilder(String, DistributionStatisticsConfig.Builder)} with a
+     * {@link MetricsFactory#distributionStatisticsConfigBuilder()} from the {@link MetricsFactory} instance used by the
+     * application.
+     * </p>
      *
      * @param name name for the summary
      * @return new builder

--- a/metrics/api/src/main/java/io/helidon/metrics/api/FunctionalCounter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/FunctionalCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,10 @@ public interface FunctionalCounter extends Meter {
 
     /**
      * Returns a builder for registering or locating a functional counter.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#functionalCounterBuilder(String, Object, java.util.function.Function)}
+     * on the {@link MetricsFactory} instance used by the application.
+     * </p>
      *
      * @param name        functional counter name
      * @param stateObject object which provides the counter value on demand

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Gauge.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Gauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,10 @@ public interface Gauge<N extends Number> extends Meter {
 
     /**
      * Creates a builder for creating a new gauge based on applying a function to a state object.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#gaugeBuilder(String, Object, java.util.function.ToDoubleFunction)}
+     * on the {@link MetricsFactory} instance used by the application.
+     * </p>
      *
      * @param name        gauge name
      * @param stateObject state object which maintains the gauge value
@@ -41,6 +45,10 @@ public interface Gauge<N extends Number> extends Meter {
 
     /**
      * Creates a builder for a supplier-based gauge.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#gaugeBuilder(String, java.util.function.Supplier)} on the
+     * {@link MetricsFactory} instance used by the application.
+     * </p>
      *
      * @param name           gauge name
      * @param numberSupplier {@link java.util.function.Supplier} for an instance of a type which extends {@link Number}

--- a/metrics/api/src/main/java/io/helidon/metrics/api/HistogramSnapshot.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/HistogramSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,10 @@ public interface HistogramSnapshot extends Wrapper {
 
     /**
      * Returns an "empty" snapshot which has summary values but no data points.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#histogramSnapshotEmpty(long, double, double)} on the
+     * {@link MetricsFactory} instance used by the application.
+     * </p>
      *
      * @param count count of observations the snapshot should report
      * @param total total value of observations the snapshot should report

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MeterRegistry.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MeterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,12 @@ public interface MeterRegistry extends Wrapper {
     /**
      * Creates a meter registry, not saved as the global registry, using default metrics config information based on global
      * config.
+     * <p>
+     * For new code which needs the shared registry, prefer
+     * {@link io.helidon.service.registry.Services#get(java.lang.Class) Services.get(MeterRegistry.class)}. To create a
+     * custom registry, prefer {@link MetricsFactory#createMeterRegistry(MetricsConfig)} on the {@link MetricsFactory}
+     * instance used by the application.
+     * </p>
      *
      * @return new meter registry
      */
@@ -38,6 +44,10 @@ public interface MeterRegistry extends Wrapper {
 
     /**
      * Creates a meter registry, not saved as the global registry, based on the provided metrics config.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#createMeterRegistry(MetricsConfig)} on the {@link MetricsFactory}
+     * instance used by the application.
+     * </p>
      *
      * @param metricsConfig metrics config
      * @return new meter registry

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Metrics.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Metrics.java
@@ -38,8 +38,8 @@ public interface Metrics {
      * Returns the global meter registry.
      *
      * @return the global meter registry
-     * @deprecated global instances are deprecated in general, and {@link io.helidon.service.registry.Services} can be used
-     * to get such an instance; until these methods are removed, the behavior may differ
+     * @deprecated use
+     * {@link io.helidon.service.registry.Services#get(java.lang.Class) Services.get(MeterRegistry.class)} instead
      */
     @Deprecated(since = "4.4.0", forRemoval = true)
     static MeterRegistry globalRegistry() {
@@ -51,7 +51,8 @@ public interface Metrics {
      *
      * @param metricsConfig metrics config
      * @return new meter registry
-     * @deprecated use {@link io.helidon.metrics.api.MeterRegistry#create(MetricsConfig)} instead
+     * @deprecated use {@link MetricsFactory#createMeterRegistry(MetricsConfig)} on the application's
+     * {@link MetricsFactory} instead
      */
     @Deprecated(since = "4.4.0", forRemoval = true)
     static MeterRegistry createMeterRegistry(MetricsConfig metricsConfig) {
@@ -63,7 +64,8 @@ public interface Metrics {
      * config.
      *
      * @return new meter registry
-     * @deprecated use {@link MeterRegistry#create()} instead
+     * @deprecated use {@link MetricsFactory#createMeterRegistry(MetricsConfig)} with {@link MetricsConfig#create()} on
+     * the application's {@link MetricsFactory} instead
      */
     @Deprecated(since = "4.4.0", forRemoval = true)
     static MeterRegistry createMeterRegistry() {
@@ -222,7 +224,8 @@ public interface Metrics {
      * @param key   tag key
      * @param value tag value
      * @return new tag
-     * @deprecated use {@link io.helidon.metrics.api.Tag#create(String, String)} instead
+     * @deprecated use {@link MetricsFactory#tagCreate(String, String)} on the application's {@link MetricsFactory}
+     * instead
      */
     @Deprecated(since = "4.4.0", forRemoval = true)
     static io.helidon.metrics.api.Tag tag(String key, String value) {
@@ -235,7 +238,8 @@ public interface Metrics {
      *
      * @param keyValuePairs pairs of tag name/tag value pairs
      * @return tags corresponding to the tag name/tag value pairs
-     * @deprecated use {@link io.helidon.metrics.api.Tag#create(String, String)} instead
+     * @deprecated use {@link MetricsFactory#tagCreate(String, String)} on the application's {@link MetricsFactory}
+     * instead
      */
     @Deprecated(since = "4.4.0", forRemoval = true)
     static Iterable<io.helidon.metrics.api.Tag> tags(String... keyValuePairs) {

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
@@ -26,14 +26,11 @@ import io.helidon.config.Config;
  * The basic contract for implementations of the Helidon metrics API, mostly acting as a factory for
  * meter <em>builders</em> rather than for meters themselves.
  * <p>
- * This is not intended to be the interface which developers use to work with Helidon metrics. Instead use
- *     <ul>
- *         <li>the {@link io.helidon.metrics.api.Metrics} interface and its static convenience methods,</li>
- *         <li>the static methods on the various meter interfaces in the API (such as {@link io.helidon.metrics.api.Timer},
- *         or</li>
- *         <li>{@link io.helidon.metrics.api.Metrics#globalRegistry()} and use the returned
- *      {@link io.helidon.metrics.api.MeterRegistry} directly</li>
- *     </ul>
+ * Applications commonly use
+ * {@link io.helidon.service.registry.Services#get(java.lang.Class) Services.get(MeterRegistry.class)} to obtain the
+ * shared meter registry, or
+ * {@link io.helidon.service.registry.Services#get(java.lang.Class) Services.get(MetricsFactory.class)} when they need a
+ * metrics factory for programmatic builder or custom registry creation.
  * <p>
  * An implementation of this interface provides instance methods for each
  * of the static methods on the Helidon metrics API interfaces. The prefix of each method
@@ -119,11 +116,8 @@ public interface MetricsFactory {
      * Returns the global {@link io.helidon.metrics.api.MeterRegistry} for this metrics factory.
      *
      * <p>
-     * The metric factory creates its global registry on-demand using
-     * {@link #getInstance()}.{@link #createMeterRegistry(MetricsConfig)} with a
-     * {@link MetricsConfig} instance derived from the root {@link io.helidon.config.Config} most recently passed to
-     * {@link #getInstance(io.helidon.config.Config)}, or if none then the config from
-     * current {@link io.helidon.config.Config}.
+     * The metric factory creates its global registry on-demand using {@link #createMeterRegistry(MetricsConfig)} with a
+     * {@link MetricsConfig} instance derived from the current {@link io.helidon.config.Config}.
      *
      * @return the global meter registry
      */

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManager.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@ public interface SystemTagsManager {
 
     /**
      * Returns the initialized instance of the tags manager.
+     * <p>
+     * Application code rarely needs direct access to the shared system tags manager. Prefer configuring metrics through
+     * {@link MetricsConfig} and creating meters through {@link MeterRegistry} or {@link MetricsFactory}.
+     * </p>
      *
      * @return current instance of the tags manager
      */
@@ -50,6 +54,10 @@ public interface SystemTagsManager {
     /**
      * Creates a new system tags manager using the provide metrics settings, saving the new instance as the initialized
      * singleton which will be returned to subsequent invocations of {@link #instance()}.
+     * <p>
+     * For code which needs an isolated manager for a specific metrics configuration, prefer {@link #create(MetricsConfig)}
+     * because it does not replace the shared instance.
+     * </p>
      *
      * @param metricsConfig settings containing the global and app-level tags (if any)
      * @return new (and saved) tags manager

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Tag.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Tag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,10 @@ public interface Tag extends Wrapper {
 
     /**
      * Creates a new tag using the specified key and value.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#tagCreate(String, String)} on the {@link MetricsFactory} instance used
+     * by the application.
+     * </p>
      *
      * @param key   the tag's key
      * @param value the tag's value

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Timer.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,10 @@ public interface Timer extends Meter, HistogramSupport {
 
     /**
      * Creates a builder for a new {@link io.helidon.metrics.api.Timer}.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#timerBuilder(String)} on the {@link MetricsFactory} instance used by
+     * the application.
+     * </p>
      *
      * @param name timer name
      * @return new builder
@@ -40,6 +44,10 @@ public interface Timer extends Meter, HistogramSupport {
 
     /**
      * Starts a timing sample using the default system clock.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#timerStart()} on the {@link MetricsFactory} instance used by the
+     * application.
+     * </p>
      *
      * @return new sample
      */
@@ -49,6 +57,10 @@ public interface Timer extends Meter, HistogramSupport {
 
     /**
      * Starts a timing sample using the clock associated with the specified {@link io.helidon.metrics.api.MeterRegistry}.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#timerStart(MeterRegistry)} on the {@link MetricsFactory} instance used
+     * by the application.
+     * </p>
      *
      * @param registry the meter registry whose clock is to be used for measuring the interval
      * @return new sample with start time recorded
@@ -59,6 +71,10 @@ public interface Timer extends Meter, HistogramSupport {
 
     /**
      * Starts a timing sample using the specified clock.
+     * <p>
+     * For new code, prefer {@link MetricsFactory#timerStart(Clock)} on the {@link MetricsFactory} instance used by the
+     * application.
+     * </p>
      *
      * @param clock a clock to be used
      * @return new sample with start time recorded

--- a/metrics/api/src/main/java/io/helidon/metrics/spi/MetricsProgrammaticConfig.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/spi/MetricsProgrammaticConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@ public interface MetricsProgrammaticConfig {
 
     /**
      * Returns the singleton instance of the metrics programmatic settings.
+     * <p>
+     * Runtime code normally does not need to call this method. Metrics factory creation applies discovered
+     * {@link MetricsProgrammaticConfig} services to {@link MetricsConfig} automatically.
+     * </p>
      *
      * @return the singleton
      */


### PR DESCRIPTION
Resolves #12126

Updates metrics API Javadocs and SE documentation snippets to use the 4.x metrics factory and service registry APIs instead of static factory shortcuts deprecated on main.
