### PR TITLE
Normalize HTTP diagnostic log newlines on 4.x

### DIFF
--- a/http/http1/src/main/java/io/helidon/http/http1/Http1LoggingConnectionListener.java
+++ b/http/http1/src/main/java/io/helidon/http/http1/Http1LoggingConnectionListener.java
@@ -119,7 +119,7 @@ public class Http1LoggingConnectionListener implements Http1ConnectionListener {
     public void data(SocketContext ctx, BufferData data) {
         if (logger.isLoggable(TRACE)) {
             if (unsafeLogRawData) {
-                ctx.log(logger, TRACE, "%s data:%n%s",
+                ctx.log(logger, TRACE, "%s data:\n%s",
                         prefix,
                         data.debugDataHex(true));
             } else {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2LoggingFrameListener.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2LoggingFrameListener.java
@@ -84,7 +84,7 @@ public class Http2LoggingFrameListener implements Http2FrameListener {
     public void frameHeader(SocketContext ctx, int streamId, BufferData headerData) {
         if (logger.isLoggable(TRACE)) {
             if (unsafeLogRawData) {
-                ctx.log(logger, TRACE, "%s %d: frame header data%n%s", prefix, streamId, headerData.debugDataHex(true));
+                ctx.log(logger, TRACE, "%s %d: frame header data\n%s", prefix, streamId, headerData.debugDataHex(true));
             } else {
                 ctx.log(logger, TRACE, "%s %d: frame header bytes=%d", prefix, streamId, headerData.available());
             }
@@ -113,7 +113,7 @@ public class Http2LoggingFrameListener implements Http2FrameListener {
                 if (data.available() == 0) {
                     ctx.log(logger, TRACE, "%s %d: frame data - empty", prefix, streamId);
                 } else {
-                    ctx.log(logger, TRACE, "%s %d: frame data, %n%s", prefix, streamId, data.debugDataHex(true));
+                    ctx.log(logger, TRACE, "%s %d: frame data,\n%s", prefix, streamId, data.debugDataHex(true));
                 }
             } else {
                 ctx.log(logger, TRACE, "%s %d: frame data bytes=%d", prefix, streamId, data.available());
@@ -147,7 +147,7 @@ public class Http2LoggingFrameListener implements Http2FrameListener {
             if (unsafeLogRawData) {
                 ctx.log(logger,
                         TRACE,
-                        "%s %d: ping%n%s",
+                        "%s %d: ping\n%s",
                         prefix,
                         streamId,
                         BufferData.create(ping.getBytes()).debugDataHex(true));
@@ -169,7 +169,7 @@ public class Http2LoggingFrameListener implements Http2FrameListener {
         if (unsafeLogRawData && logger.isLoggable(TRACE) && go.details() != null && !go.details().isEmpty()) {
             ctx.log(logger,
                     TRACE,
-                    "%s %d: goaway details%n%s",
+                    "%s %d: goaway details\n%s",
                     prefix,
                     streamId,
                     BufferData.create(go.details().getBytes(StandardCharsets.UTF_8)).debugDataHex(true));
@@ -178,7 +178,7 @@ public class Http2LoggingFrameListener implements Http2FrameListener {
 
     @Override
     public void frame(SocketContext ctx, int streamId, Http2WindowUpdate windowUpdate) {
-        ctx.log(logger, DEBUG, "%s %d: (size_increment=%d)%n", prefix, streamId, windowUpdate.windowSizeIncrement());
+        ctx.log(logger, DEBUG, "%s %d: (size_increment=%d)", prefix, streamId, windowUpdate.windowSizeIncrement());
     }
 
     @Override
@@ -186,14 +186,14 @@ public class Http2LoggingFrameListener implements Http2FrameListener {
         if (logger.isLoggable(TRACE)) {
             ctx.log(logger,
                     TRACE,
-                    "%s %d: headers:%n%s",
+                    "%s %d: headers:\n%s",
                     prefix,
                     streamId,
                     format(headers, unsafeLogRawData));
         } else if (logger.isLoggable(DEBUG)) {
             ctx.log(logger,
                     DEBUG,
-                    "%s %d: headers:%n%s",
+                    "%s %d: headers:\n%s",
                     prefix,
                     streamId,
                     format(headers, false));

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2LoggingFrameListenerTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2LoggingFrameListenerTest.java
@@ -293,6 +293,8 @@ class Http2LoggingFrameListenerTest {
             String message = messages.getFirst();
             assertThat(message, containsString("73 65 63 72 65 74"));
             assertThat(message, containsString("secret"));
+            assertThat(message, containsString("frame data,\n"));
+            assertThat(message, not(containsString("\r")));
         } finally {
             logger.removeHandler(handler);
             logger.setLevel(previousLevel);
@@ -342,6 +344,77 @@ class Http2LoggingFrameListenerTest {
             String message = messages.getFirst();
             assertThat(message, containsString("Authorization: Bearer secret-token"));
             assertThat(message, containsString(":path: /path?access_token=query-secret#fragment"));
+            assertThat(message, containsString("headers:\n"));
+            assertThat(message, not(containsString("\r")));
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(previousLevel);
+            logger.setUseParentHandlers(previousUseParentHandlers);
+            handler.close();
+        }
+    }
+
+    @Test
+    void testMultilineDiagnosticLogsUseLf() {
+        SocketContext ctx = mock(SocketContext.class, CALLS_REAL_METHODS);
+        when(ctx.socketId()).thenReturn("server");
+        when(ctx.childSocketId()).thenReturn("connection");
+
+        Http2LoggingFrameListener listener = Http2LoggingFrameListener.create(HttpLogConfig.builder()
+                                                                                  .unsafeRawData(true)
+                                                                                  .build(),
+                                                                          "recv");
+        Http2Headers headers = Http2Headers.create(WritableHeaders.create()
+                                                           .add(HeaderNames.CONTENT_TYPE, "text/plain"));
+
+        List<String> messages = collectMessages(Level.FINER, () -> {
+            listener.frameHeader(ctx, 1, BufferData.create("head"));
+            listener.frame(ctx, 1, BufferData.create("secret"));
+            listener.frame(ctx, 1, Http2Ping.create(BufferData.create("12345678")));
+            listener.frame(ctx, 1, new Http2GoAway(1, Http2ErrorCode.NO_ERROR, "bye"));
+            listener.frame(ctx, 1, new Http2WindowUpdate(7));
+            listener.headers(ctx, 1, headers);
+        });
+
+        assertThat(messages.size(), is(7));
+        assertThat(messages.get(0), containsString("frame header data\n"));
+        assertThat(messages.get(1), containsString("frame data,\n"));
+        assertThat(messages.get(2), containsString("ping\n"));
+        assertThat(messages.get(3), not(containsString("\n")));
+        assertThat(messages.get(4), containsString("goaway details\n"));
+        assertThat(messages.get(5), not(containsString("\n")));
+        assertThat(messages.get(6), containsString("headers:\n"));
+        messages.forEach(message -> assertThat(message, not(containsString("\r"))));
+    }
+
+    private static List<String> collectMessages(Level level, Runnable task) {
+        Logger logger = Logger.getLogger(LOGGER_NAME);
+        Level previousLevel = logger.getLevel();
+        boolean previousUseParentHandlers = logger.getUseParentHandlers();
+        List<String> messages = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                messages.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        handler.setLevel(Level.ALL);
+        logger.addHandler(handler);
+        logger.setUseParentHandlers(false);
+        logger.setLevel(level);
+
+        try {
+            task.run();
+            return messages;
         } finally {
             logger.removeHandler(handler);
             logger.setLevel(previousLevel);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1LoggingConnectionListenerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1LoggingConnectionListenerTest.java
@@ -242,6 +242,8 @@ class Http1LoggingConnectionListenerTest {
             String message = messages.get(0);
             assertThat(message, containsString("73 65 63 72 65 74"));
             assertThat(message, containsString("secret"));
+            assertThat(message, containsString("data:\n"));
+            assertThat(message, not(containsString("\r")));
         } finally {
             logger.removeHandler(handler);
             logger.setLevel(previousLevel);


### PR DESCRIPTION
### Description

Follow-up for #12106 and #12136.

This applies the same HTTP diagnostic log newline normalization to `helidon-4.x`.

The HTTP/1 and HTTP/2 diagnostic log messages now use `\n` inside multi-line message bodies instead of platform-specific `%n`. This keeps the diagnostic output consistent across platforms and makes it easier to tell whether a `\r` came from the log format itself or from a value being logged.

Keeping this as draft until the `main` PR is merged.

Validation:
- Focused Maven tests run with JDK 21:
  `mvn -pl http/http2,webserver/webserver -am -Dtest=Http2LoggingFrameListenerTest,Http1LoggingConnectionListenerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

### Documentation

No doc impact.
