### PR TITLE
Normalize OpenAPI diagnostic log newlines on 4.x

### DIFF
--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/FilteredIndexViewsBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/FilteredIndexViewsBuilder.java
@@ -147,15 +147,13 @@ class FilteredIndexViewsBuilder {
         FilteredIndexView result = new FilteredIndexView(view, filteringOpenApiConfig);
 
         if (LOGGER.isLoggable(Level.TRACE)) {
-            LOGGER.log(Level.TRACE, String.format(
-                    "FilteredIndexView for %n"
-                            + "  application class %s%n"
-                            + "  with explicitly-referenced classes %s%n"
-                            + "  yields exclude list: %s%n  and known classes: %n  %s",
-                    appClassName,
-                    explicitClassNames,
-                    excludedClasses,
-                    String.join("," + System.lineSeparator() + "    ", knownClassNames(result))));
+            LOGGER.log(Level.TRACE,
+                    "FilteredIndexView for \n"
+                            + "  application class " + appClassName + "\n"
+                            + "  with explicitly-referenced classes " + explicitClassNames + "\n"
+                            + "  yields exclude list: " + excludedClasses + "\n"
+                            + "  and known classes: \n  "
+                            + String.join(",\n    ", knownClassNames(result)));
         }
 
         return result;

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MpOpenApiManager.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MpOpenApiManager.java
@@ -132,10 +132,9 @@ final class MpOpenApiManager implements OpenApiManager<OpenAPI> {
             OpenApiAnnotationScanner scanner = new OpenApiAnnotationScanner(openApiConfig, indexView, scannerExtensions);
             OpenAPI scanned = scanner.scan();
             if (LOGGER.isLoggable(Level.DEBUG)) {
-                LOGGER.log(Level.DEBUG, String.format(
-                        "Intermediate scanned from filtered index view %s:%n%s",
-                        indexView.getKnownClasses(),
-                        format(scanned, OpenApiFormat.YAML)));
+                LOGGER.log(Level.DEBUG,
+                        "Intermediate scanned from filtered index view " + indexView.getKnownClasses() + ":\n"
+                                + format(scanned, OpenApiFormat.YAML));
             }
             model = MergeUtil.merge(model, scanned).openapi(scanned.getOpenapi()); // SmallRye's merge skips openapi value.
         }

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/FilteredIndexViewsBuilderTest.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/FilteredIndexViewsBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,13 @@
  */
 package io.helidon.microprofile.openapi;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import io.helidon.microprofile.openapi.other.TestApp2;
 import io.helidon.microprofile.server.JaxRsApplication;
@@ -27,6 +32,8 @@ import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.microprofile.openapi.TestUtil.config;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -68,5 +75,64 @@ class FilteredIndexViewsBuilderTest {
                 .findFirst()
                 .orElse(null);
         assertThat(testApp2Info, notNullValue());
+    }
+
+    @Test
+    void testDiagnosticLogNewlines() {
+        List<String> messages = collectMessages(FilteredIndexViewsBuilder.class.getName(), () -> {
+            List<String> indexPaths = List.of("META-INF/jandex.idx", "META-INF/other.idx");
+
+            List<JaxRsApplication> apps = List.of(
+                    JaxRsApplication.create(new TestApp()),
+                    JaxRsApplication.create(new TestApp2()));
+
+            new FilteredIndexViewsBuilder(config(), apps, Set.of(), indexPaths, false).buildViews();
+        });
+
+        String message = messages.stream()
+                .filter(it -> it.contains("FilteredIndexView for "))
+                .findFirst()
+                .orElse("");
+
+        assertThat(message, containsString("FilteredIndexView for \n"));
+        assertThat(message, containsString("known classes: \n"));
+        assertThat(message, not(containsString("\r")));
+    }
+
+    private static List<String> collectMessages(String loggerName, Runnable task) {
+        Logger logger = Logger.getLogger(loggerName);
+        Level previousLevel = logger.getLevel();
+        boolean previousUseParentHandlers = logger.getUseParentHandlers();
+        List<String> messages = new ArrayList<>();
+
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                messages.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        handler.setLevel(Level.ALL);
+        logger.addHandler(handler);
+        logger.setUseParentHandlers(false);
+        logger.setLevel(Level.ALL);
+
+        try {
+            task.run();
+            return messages;
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(previousLevel);
+            logger.setUseParentHandlers(previousUseParentHandlers);
+            handler.close();
+        }
     }
 }


### PR DESCRIPTION
### Description

Part of #12106.

Normalizes newlines in the 4.x OpenAPI DEBUG/TRACE log messages to use explicit `\n` instead of platform-specific `%n` / `System.lineSeparator()`.

This is limited to OpenAPI diagnostic log message bodies and does not change log formatting, file output, exceptions, or HTTP logging.

Validation:
- `mvn -pl microprofile/openapi -am -DskipTests -DskipITs install`
- `mvn -pl microprofile/openapi -Dtest=FilteredIndexViewsBuilderTest,BasicServerTest test`
- `git diff --check`

### Documentation

No doc impact.