### PR TITLE
Fix HTTP/2 reset stream cleanup race

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConfigBlueprint.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConfigBlueprint.java
@@ -126,7 +126,8 @@ interface Http2ConfigBlueprint extends ProtocolConfig, HttpConfig {
 
     /**
      * Maximum number of rapid client resets within the check period and server-side resets over the connection lifetime
-     * before GOAWAY is sent, or {@code -1} to disable both checks.
+     * before GOAWAY is sent, or {@code -1} to disable both reset-count checks; fixed internal bounds still apply to
+     * frames received after the server has locally reset a stream.
      * Rapid client resets are stream RST frames sent by the client before any data have been sent by the server.
      * Default value is {@code 50}.
      *

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -96,8 +96,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     private static final int FRAME_HEADER_LENGTH = 9;
     private static final int MAX_LOCALLY_RESET_STREAMS = 8192;
     private static final int MIN_LOCALLY_RESET_STREAMS = 64;
-    private static final long MAX_LOCALLY_RESET_STREAM_DATA = 64 * 1024;
-    private static final int MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS = 64;
+    private static final long MAX_LOCALLY_RESET_STREAM_HEADER_BYTES = 64 * 1024;
     private static final Set<Http2StreamState> REMOVABLE_STREAMS =
             Set.of(Http2StreamState.CLOSED, Http2StreamState.HALF_CLOSED_LOCAL);
     private static final Set<HeaderName> SERVER_CONTROLLED_REQUEST_HEADERS = Set.of(X_HELIDON_CN);
@@ -166,8 +165,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         this.reader = ctx.dataReader();
         this.sendErrorDetails = http2Config.sendErrorDetails();
         this.maxClientConcurrentStreams = http2Config.maxConcurrentStreams();
-        this.locallyResetStreams = new LocallyResetStreams(maxLocallyResetStreams(http2Config),
-                                                           maxLocallyResetStreamData(http2Config));
+        this.locallyResetStreams = new LocallyResetStreams(maxLocallyResetStreams(http2Config));
 
         // Flow control is initialized by RFC 9113 default values
         this.flowControl = ConnectionFlowControl.serverBuilder(this::writeWindowUpdateFrame)
@@ -179,7 +177,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         this.connectionHeaders = WritableHeaders.create();
         this.initConnectionHeaders = true;
         this.locallyResetHeaders = new PendingDroppedHeaders(http2Config.maxHeaderListSize(),
-                                                             maxLocallyResetStreamData(http2Config));
+                                                             Math.max(http2Config.maxFrameSize(),
+                                                                      MAX_LOCALLY_RESET_STREAM_HEADER_BYTES));
     }
 
     @Override
@@ -678,10 +677,6 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         long configuredLimit = Math.max(config.maxConcurrentStreams(), config.maxRapidResets());
         return (int) Math.max(MIN_LOCALLY_RESET_STREAMS,
                               Math.min(MAX_LOCALLY_RESET_STREAMS, configuredLimit));
-    }
-
-    private static long maxLocallyResetStreamData(Http2Config config) {
-        return Math.max(config.maxFrameSize(), MAX_LOCALLY_RESET_STREAM_DATA);
     }
 
     private void dataFrame() {
@@ -1189,24 +1184,22 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         private final Map<Integer, StreamState> streams = new HashMap<>();
         private final Map<Integer, Boolean> completedStreams = new LinkedHashMap<>();
         private final int maxTracked;
-        private final long maxData;
         private volatile boolean empty = true;
         private volatile boolean overflow;
 
-        private LocallyResetStreams(int maxTracked, long maxData) {
+        private LocallyResetStreams(int maxTracked) {
             this.maxTracked = maxTracked;
-            this.maxData = maxData;
         }
 
         @Override
-        public void add(int streamId) {
+        public void add(int streamId, Http2ServerStream.LocallyResetStreamState streamState) {
             lock.lock();
             try {
                 if (streams.containsKey(streamId)) {
                     return;
                 }
                 completedStreams.remove(streamId);
-                streams.put(streamId, new StreamState(streamId));
+                streams.put(streamId, new StreamState(streamId, false, false, streamState));
                 empty = false;
                 trim();
             } finally {
@@ -1292,12 +1285,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                 if (current == null) {
                     return true;
                 }
-                StreamState updated = current.withDiscardedData(length);
-                if (updated.discardedData > maxData) {
-                    return false;
-                }
-                streams.put(streamId, updated);
-                return true;
+                return current.discardState.discardData(length);
             } finally {
                 lock.unlock();
             }
@@ -1310,13 +1298,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                 if (current == null) {
                     return true;
                 }
-                StreamState updated = current.withDiscardedHeaders(length);
-                if (updated.discardedHeaderBytes > maxData
-                        || updated.discardedHeaderBlocks > MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS) {
-                    return false;
-                }
-                streams.put(streamId, updated);
-                return true;
+                return current.discardState.discardHeaders(length);
             } finally {
                 lock.unlock();
             }
@@ -1332,47 +1314,19 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         private record StreamState(int streamId,
                                    boolean localComplete,
                                    boolean remoteComplete,
-                                   long discardedData,
-                                   int discardedHeaderBlocks,
-                                   long discardedHeaderBytes) {
-            private StreamState(int streamId) {
-                this(streamId, false, false, 0, 0, 0);
-            }
-
+                                   Http2ServerStream.LocallyResetStreamState discardState) {
             private StreamState withLocalComplete() {
                 return new StreamState(streamId,
                                        true,
                                        remoteComplete,
-                                       discardedData,
-                                       discardedHeaderBlocks,
-                                       discardedHeaderBytes);
+                                       discardState);
             }
 
             private StreamState withRemoteComplete() {
                 return new StreamState(streamId,
                                        localComplete,
                                        true,
-                                       discardedData,
-                                       discardedHeaderBlocks,
-                                       discardedHeaderBytes);
-            }
-
-            private StreamState withDiscardedData(int length) {
-                return new StreamState(streamId,
-                                       localComplete,
-                                       remoteComplete,
-                                       discardedData + length,
-                                       discardedHeaderBlocks,
-                                       discardedHeaderBytes);
-            }
-
-            private StreamState withDiscardedHeaders(long length) {
-                return new StreamState(streamId,
-                                       localComplete,
-                                       remoteComplete,
-                                       discardedData,
-                                       discardedHeaderBlocks + 1,
-                                       discardedHeaderBytes + length);
+                                       discardState);
             }
 
             private boolean complete() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -21,10 +21,13 @@ import java.net.SocketException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -58,9 +61,11 @@ import io.helidon.http.http2.Http2Priority;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2Stream;
 import io.helidon.http.http2.Http2StreamState;
 import io.helidon.http.http2.Http2Util;
 import io.helidon.http.http2.Http2WindowUpdate;
+import io.helidon.http.http2.StreamFlowControl;
 import io.helidon.http.http2.WindowSize;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
@@ -89,11 +94,18 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
 
     private static final System.Logger LOGGER = System.getLogger(Http2Connection.class.getName());
     private static final int FRAME_HEADER_LENGTH = 9;
+    private static final int MAX_LOCALLY_RESET_STREAMS = 8192;
+    private static final int MIN_LOCALLY_RESET_STREAMS = 64;
+    private static final long MAX_LOCALLY_RESET_STREAM_DATA = 64 * 1024;
+    private static final int MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS = 64;
     private static final Set<Http2StreamState> REMOVABLE_STREAMS =
             Set.of(Http2StreamState.CLOSED, Http2StreamState.HALF_CLOSED_LOCAL);
     private static final Set<HeaderName> SERVER_CONTROLLED_REQUEST_HEADERS = Set.of(X_HELIDON_CN);
+    private static final Http2Headers EMPTY_INBOUND_HEADERS = Http2Headers.create(WritableHeaders.create());
+    private static final Http2Stream DROPPED_INBOUND_HEADERS_STREAM = new DroppedInboundHeadersStream();
     private final Http2ConnectionStreams streams = new Http2ConnectionStreams();
-    private final Set<Integer> locallyResetStreams = ConcurrentHashMap.newKeySet();
+    private final LocallyResetStreams locallyResetStreams;
+    private final PendingDroppedHeaders locallyResetHeaders;
     private final ConnectionContext ctx;
     private final Http2Config http2Config;
     private final HttpRouting routing;
@@ -154,6 +166,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         this.reader = ctx.dataReader();
         this.sendErrorDetails = http2Config.sendErrorDetails();
         this.maxClientConcurrentStreams = http2Config.maxConcurrentStreams();
+        this.locallyResetStreams = new LocallyResetStreams(maxLocallyResetStreams(http2Config),
+                                                           maxLocallyResetStreamData(http2Config));
 
         // Flow control is initialized by RFC 9113 default values
         this.flowControl = ConnectionFlowControl.serverBuilder(this::writeWindowUpdateFrame)
@@ -164,6 +178,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         this.lastRequestTimestamp = DateTime.timestamp();
         this.connectionHeaders = WritableHeaders.create();
         this.initConnectionHeaders = true;
+        this.locallyResetHeaders = new PendingDroppedHeaders(http2Config.maxHeaderListSize(),
+                                                             maxLocallyResetStreamData(http2Config));
     }
 
     @Override
@@ -387,6 +403,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     private void doHandle(Limit limit) throws InterruptedException {
         myThread = Thread.currentThread();
         while (canRun && state != State.FINISHED) {
+            locallyResetStreams.checkOverflow();
             if (expectPreface && state != State.WRITE_SERVER_SETTINGS) {
                 readPreface();
                 expectPreface = false;
@@ -400,6 +417,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                     throw new CloseConnectionException("Connection closed by client", e);
                 }
             }
+            locallyResetStreams.checkOverflow();
 
             dispatchHandler(limit);
         }
@@ -502,8 +520,34 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
 
     private void doContinuation() {
         Http2Flag.ContinuationFlags flags = frameHeader.flags(Http2FrameTypes.CONTINUATION);
+        int streamId = frameHeader.streamId();
+        boolean locallyReset = locallyResetStreams.contains(streamId);
+        Http2ServerStream resettingStream = locallyReset ? null : discardingStream(streamId);
 
-        stream(frameHeader.streamId())
+        if (locallyReset || resettingStream != null) {
+            boolean endOfHeaders = flags.endOfHeaders();
+            trackDroppedContinuation(endOfHeaders);
+            locallyResetHeaders.add(frameHeader, inProgressFrame());
+            if (flags.endOfHeaders()) {
+                if (locallyReset) {
+                    completeDroppedInboundHeaders(streamId,
+                                                  locallyResetHeaders.endOfStream(),
+                                                  locallyResetHeaders.headerBlockLength(),
+                                                  locallyResetHeaders.frames());
+                } else {
+                    completeDroppedInboundHeaders(resettingStream,
+                                                  locallyResetHeaders.endOfStream(),
+                                                  locallyResetHeaders.headerBlockLength(),
+                                                  locallyResetHeaders.frames());
+                }
+                locallyResetHeaders.clear();
+                continuationExpectedStreamId = 0;
+            }
+            state = State.READ_FRAME;
+            return;
+        }
+
+        stream(streamId)
                 .addContinuation(new Http2FrameData(frameHeader, inProgressFrame()));
 
         if (flags.endOfHeaders()) {
@@ -630,6 +674,16 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         return contentLength.orElse(0) > 0 || httpHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED);
     }
 
+    private static int maxLocallyResetStreams(Http2Config config) {
+        long configuredLimit = Math.max(config.maxConcurrentStreams(), config.maxRapidResets());
+        return (int) Math.max(MIN_LOCALLY_RESET_STREAMS,
+                              Math.min(MAX_LOCALLY_RESET_STREAMS, configuredLimit));
+    }
+
+    private static long maxLocallyResetStreamData(Http2Config config) {
+        return Math.max(config.maxFrameSize(), MAX_LOCALLY_RESET_STREAM_DATA);
+    }
+
     private void dataFrame() {
         BufferData buffer;
 
@@ -695,20 +749,62 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         if (length > 0) {
             emptyFrames = 0;
             flowControl.decrementInboundConnectionWindowSize(length);
-            flowControl.incrementInboundConnectionWindowSize(length);
         } else if (emptyFrames++ > maxEmptyFrames && !endOfStream) {
             throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM, "Too much subsequent empty frames received.");
         }
         BufferData frameData = inProgressFrame();
         frameData.skip(frameData.available());
+        if (length > 0) {
+            if (!locallyResetStreams.discardData(streamId, length)) {
+                throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                                         "Too much data after stream reset.");
+            }
+            flowControl.incrementInboundConnectionWindowSize(length);
+        }
         if (endOfStream) {
-            locallyResetStreams.remove(streamId);
+            locallyResetStreams.remoteComplete(streamId);
         }
     }
 
     private void doHeaders(Limit limit) {
         int streamId = frameHeader.streamId();
+        if (locallyResetStreams.contains(streamId)) {
+            boolean endOfHeaders = frameHeader.flags(Http2FrameTypes.HEADERS).endOfHeaders();
+            if (!endOfHeaders) {
+                locallyResetHeaders.begin(frameHeader, inProgressFrame().copy());
+                this.continuationExpectedStreamId = streamId;
+                this.state = State.READ_FRAME;
+                return;
+            }
+
+            boolean endOfStream = frameHeader.flags(Http2FrameTypes.HEADERS).endOfStream();
+            completeDroppedInboundHeaders(streamId,
+                                          endOfStream,
+                                          frameHeader.length(),
+                                          new Http2FrameData(frameHeader, inProgressFrame()));
+            state = State.READ_FRAME;
+            return;
+        }
+
         StreamContext streamContext = stream(streamId);
+        Http2ServerStream resettingStream = streamContext.stream();
+        if (resettingStream.discardsInboundAfterReset()) {
+            boolean endOfHeaders = frameHeader.flags(Http2FrameTypes.HEADERS).endOfHeaders();
+            if (!endOfHeaders) {
+                locallyResetHeaders.begin(frameHeader, inProgressFrame().copy());
+                this.continuationExpectedStreamId = streamId;
+                this.state = State.READ_FRAME;
+                return;
+            }
+
+            boolean endOfStream = frameHeader.flags(Http2FrameTypes.HEADERS).endOfStream();
+            completeDroppedInboundHeaders(resettingStream,
+                                          endOfStream,
+                                          frameHeader.length(),
+                                          new Http2FrameData(frameHeader, inProgressFrame()));
+            state = State.READ_FRAME;
+            return;
+        }
 
         boolean trailers = streamContext.stream().checkHeadersReceivable();
         boolean newStream = !trailers;
@@ -818,6 +914,55 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                 .submit(new StreamRunnable(streams, stream, Thread.currentThread()));
     }
 
+    private void decodeDroppedInboundHeaders(Http2FrameData... headerFrames) {
+        Http2Headers.create(DROPPED_INBOUND_HEADERS_STREAM,
+                            requestDynamicTable,
+                            requestHuffman,
+                            EMPTY_INBOUND_HEADERS,
+                            SERVER_CONTROLLED_REQUEST_HEADERS,
+                            headerFrames);
+    }
+
+    private void completeDroppedInboundHeaders(int streamId,
+                                               boolean endOfStream,
+                                               long headerBlockLength,
+                                               Http2FrameData... headerFrames) {
+        if (!locallyResetStreams.discardHeaders(streamId, headerBlockLength)) {
+            throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                                     "Too many headers after stream reset.");
+        }
+        decodeDroppedInboundHeaders(headerFrames);
+        if (endOfStream) {
+            locallyResetStreams.remoteComplete(streamId);
+        }
+    }
+
+    private void completeDroppedInboundHeaders(Http2ServerStream stream,
+                                               boolean endOfStream,
+                                               long headerBlockLength,
+                                               Http2FrameData... headerFrames) {
+        stream.headersAfterReset(endOfStream, headerBlockLength);
+        decodeDroppedInboundHeaders(headerFrames);
+    }
+
+    private Http2ServerStream discardingStream(int streamId) {
+        StreamContext streamContext = streams.get(streamId);
+        if (streamContext != null && streamContext.stream().discardsInboundAfterReset()) {
+            return streamContext.stream();
+        }
+        return null;
+    }
+
+    private void trackDroppedContinuation(boolean endOfHeaders) {
+        if (frameHeader.length() == 0) {
+            if (emptyFrames++ > maxEmptyFrames && !endOfHeaders) {
+                throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM, "Too much subsequent empty frames received.");
+            }
+        } else {
+            emptyFrames = 0;
+        }
+    }
+
     private void activateStream(int streamId) {
         streams.doMaintenance();
         if (streams.size() + 1 > maxClientConcurrentStreams) {
@@ -888,6 +1033,12 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         int streamId = frameHeader.streamId();
         receiveFrameListener.frame(ctx, streamId, rstStream);
 
+        if (locallyResetStreams.remoteReset(streamId)) {
+            streams.remove(streamId);
+            state = State.READ_FRAME;
+            return;
+        }
+
         try {
             StreamContext streamContext = stream(streamId);
             boolean rapidReset = streamContext.stream().rstStream(rstStream);
@@ -901,7 +1052,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             }
             throw e;
         } finally {
-            locallyResetStreams.remove(streamId);
+            locallyResetStreams.remoteComplete(streamId);
             streams.remove(streamId);
         }
     }
@@ -942,7 +1093,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                                               http2Config.maxHeaderListSize(),
                                               new Http2ServerStream(ctx,
                                                                     streams,
-                                                                    locallyResetStreams::add,
+                                                                    locallyResetStreams,
                                                                     routing,
                                                                     http2Config,
                                                                     subProviders,
@@ -1030,6 +1181,336 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                     streams.remove(stream.streamId());
                 }
             }
+        }
+    }
+
+    private static final class LocallyResetStreams implements Http2ServerStream.LocallyResetStreamTracker {
+        private final ReentrantLock lock = new ReentrantLock();
+        private final Map<Integer, StreamState> streams = new HashMap<>();
+        private final Map<Integer, Boolean> completedStreams = new LinkedHashMap<>();
+        private final int maxTracked;
+        private final long maxData;
+        private volatile boolean empty = true;
+        private volatile boolean overflow;
+
+        private LocallyResetStreams(int maxTracked, long maxData) {
+            this.maxTracked = maxTracked;
+            this.maxData = maxData;
+        }
+
+        @Override
+        public void add(int streamId) {
+            lock.lock();
+            try {
+                if (streams.containsKey(streamId)) {
+                    return;
+                }
+                completedStreams.remove(streamId);
+                streams.put(streamId, new StreamState(streamId));
+                empty = false;
+                trim();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private boolean contains(int streamId) {
+            if (empty) {
+                return false;
+            }
+            lock.lock();
+            try {
+                return streams.containsKey(streamId);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private void checkOverflow() {
+            if (overflow) {
+                throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                                         "Too many locally reset streams.");
+            }
+        }
+
+        @Override
+        public void remoteComplete(int streamId) {
+            complete(streamId, false);
+        }
+
+        @Override
+        public void localComplete(int streamId) {
+            complete(streamId, true);
+        }
+
+        private boolean remoteReset(int streamId) {
+            lock.lock();
+            try {
+                if (streams.containsKey(streamId)) {
+                    completeLocked(streamId, false);
+                    return true;
+                }
+                return completedStreams.containsKey(streamId);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private boolean complete(int streamId, boolean local) {
+            lock.lock();
+            try {
+                return completeLocked(streamId, local);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private boolean completeLocked(int streamId, boolean local) {
+            StreamState current = streams.get(streamId);
+            if (current == null) {
+                return false;
+            }
+            StreamState updated = local ? current.withLocalComplete() : current.withRemoteComplete();
+            if (updated.complete()) {
+                streams.remove(streamId);
+                completedStreams.put(streamId, Boolean.TRUE);
+                while (completedStreams.size() > maxTracked) {
+                    Integer oldest = completedStreams.keySet().iterator().next();
+                    completedStreams.remove(oldest);
+                }
+            } else {
+                streams.put(streamId, updated);
+            }
+            trim();
+            return true;
+        }
+
+        private boolean discardData(int streamId, int length) {
+            lock.lock();
+            try {
+                StreamState current = streams.get(streamId);
+                if (current == null) {
+                    return true;
+                }
+                StreamState updated = current.withDiscardedData(length);
+                if (updated.discardedData > maxData) {
+                    return false;
+                }
+                streams.put(streamId, updated);
+                return true;
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private boolean discardHeaders(int streamId, long length) {
+            lock.lock();
+            try {
+                StreamState current = streams.get(streamId);
+                if (current == null) {
+                    return true;
+                }
+                StreamState updated = current.withDiscardedHeaders(length);
+                if (updated.discardedHeaderBytes > maxData
+                        || updated.discardedHeaderBlocks > MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS) {
+                    return false;
+                }
+                streams.put(streamId, updated);
+                return true;
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private void trim() {
+            if (streams.size() > maxTracked) {
+                overflow = true;
+            }
+            empty = streams.isEmpty();
+        }
+
+        private record StreamState(int streamId,
+                                   boolean localComplete,
+                                   boolean remoteComplete,
+                                   long discardedData,
+                                   int discardedHeaderBlocks,
+                                   long discardedHeaderBytes) {
+            private StreamState(int streamId) {
+                this(streamId, false, false, 0, 0, 0);
+            }
+
+            private StreamState withLocalComplete() {
+                return new StreamState(streamId,
+                                       true,
+                                       remoteComplete,
+                                       discardedData,
+                                       discardedHeaderBlocks,
+                                       discardedHeaderBytes);
+            }
+
+            private StreamState withRemoteComplete() {
+                return new StreamState(streamId,
+                                       localComplete,
+                                       true,
+                                       discardedData,
+                                       discardedHeaderBlocks,
+                                       discardedHeaderBytes);
+            }
+
+            private StreamState withDiscardedData(int length) {
+                return new StreamState(streamId,
+                                       localComplete,
+                                       remoteComplete,
+                                       discardedData + length,
+                                       discardedHeaderBlocks,
+                                       discardedHeaderBytes);
+            }
+
+            private StreamState withDiscardedHeaders(long length) {
+                return new StreamState(streamId,
+                                       localComplete,
+                                       remoteComplete,
+                                       discardedData,
+                                       discardedHeaderBlocks + 1,
+                                       discardedHeaderBytes + length);
+            }
+
+            private boolean complete() {
+                return localComplete && remoteComplete;
+            }
+        }
+    }
+
+    private static final class PendingDroppedHeaders {
+        private final List<Http2FrameData> headerFrames = new ArrayList<>();
+        private final long maxHeaderListSize;
+        private final long maxHeaderBlockLength;
+        private Http2FrameHeader firstHeader;
+        private long headerListSize;
+        private long headerBlockLength;
+
+        private PendingDroppedHeaders(long maxHeaderListSize, long maxHeaderBlockLength) {
+            this.maxHeaderListSize = maxHeaderListSize;
+            this.maxHeaderBlockLength = maxHeaderBlockLength;
+        }
+
+        private void begin(Http2FrameHeader frameHeader, BufferData data) {
+            clear();
+            addAndValidateHeaderListSize(frameHeader.length());
+            Http2FrameData headerFrame = firstHeader(frameHeader, data);
+            firstHeader = headerFrame.header();
+            headerFrames.add(headerFrame);
+        }
+
+        private void add(Http2FrameHeader frameHeader, BufferData data) {
+            if (headerFrames.isEmpty()) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received continuation without headers.");
+            }
+            addAndValidateHeaderListSize(frameHeader.length());
+            if (frameHeader.length() > 0) {
+                headerFrames.add(new Http2FrameData(frameHeader, data));
+            }
+        }
+
+        private Http2FrameData[] frames() {
+            return headerFrames.toArray(new Http2FrameData[0]);
+        }
+
+        private long headerBlockLength() {
+            return headerBlockLength;
+        }
+
+        private boolean endOfStream() {
+            if (firstHeader == null) {
+                throw new IllegalStateException("No inbound headers are pending.");
+            }
+            return firstHeader.flags(Http2FrameTypes.HEADERS).endOfStream();
+        }
+
+        private void clear() {
+            headerFrames.clear();
+            firstHeader = null;
+            headerListSize = 0;
+            headerBlockLength = 0;
+        }
+
+        private void addAndValidateHeaderListSize(int headerSizeIncrement) {
+            headerListSize += headerSizeIncrement;
+            headerBlockLength += headerSizeIncrement;
+            if (headerListSize > maxHeaderListSize) {
+                throw new Http2Exception(Http2ErrorCode.REQUEST_HEADER_FIELDS_TOO_LARGE,
+                                         "Request Header Fields Too Large");
+            }
+            if (headerBlockLength > maxHeaderBlockLength) {
+                throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                                         "Too many headers after stream reset.");
+            }
+        }
+
+        private static Http2FrameData firstHeader(Http2FrameHeader frameHeader, BufferData data) {
+            Http2Flag.HeaderFlags flags = frameHeader.flags(Http2FrameTypes.HEADERS);
+            if (!flags.padded()) {
+                return new Http2FrameData(frameHeader, data);
+            }
+
+            int padLength = data.read();
+            int dataLength = frameHeader.length() - padLength - 1;
+            if (dataLength < 0) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Invalid pad length");
+            }
+            BufferData headerData = dataLength == 0 ? BufferData.empty() : BufferData.create(dataLength);
+            if (dataLength > 0) {
+                headerData.write(data, dataLength);
+            }
+            data.skip(padLength);
+            Http2Flag.HeaderFlags headerFlags = Http2Flag.HeaderFlags.create(flags.value() & ~Http2Flag.PADDED);
+            return new Http2FrameData(Http2FrameHeader.create(dataLength,
+                                                              Http2FrameTypes.HEADERS,
+                                                              headerFlags,
+                                                              frameHeader.streamId()),
+                                      headerData);
+        }
+    }
+
+    private static final class DroppedInboundHeadersStream implements Http2Stream {
+        private static final StreamFlowControl FLOW_CONTROL = ConnectionFlowControl.serverBuilder((streamId, windowUpdate) -> { })
+                .build()
+                .createStreamFlowControl(0, WindowSize.DEFAULT_WIN_SIZE, WindowSize.DEFAULT_MAX_FRAME_SIZE);
+
+        @Override
+        public boolean rstStream(Http2RstStream rstStream) {
+            return false;
+        }
+
+        @Override
+        public void windowUpdate(Http2WindowUpdate windowUpdate) {
+        }
+
+        @Override
+        public void headers(Http2Headers headers, boolean endOfStream) {
+        }
+
+        @Override
+        public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
+        }
+
+        @Override
+        public void priority(Http2Priority http2Priority) {
+        }
+
+        @Override
+        public int streamId() {
+            return 0;
+        }
+
+        @Override
+        public Http2StreamState streamState() {
+            return Http2StreamState.CLOSED;
+        }
+
+        @Override
+        public StreamFlowControl flowControl() {
+            return FLOW_CONTROL;
         }
     }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -21,10 +21,10 @@ import java.net.SocketException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -93,7 +93,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             Set.of(Http2StreamState.CLOSED, Http2StreamState.HALF_CLOSED_LOCAL);
     private static final Set<HeaderName> SERVER_CONTROLLED_REQUEST_HEADERS = Set.of(X_HELIDON_CN);
     private final Http2ConnectionStreams streams = new Http2ConnectionStreams();
-    private final Set<Integer> locallyResetStreams = new HashSet<>();
+    private final Set<Integer> locallyResetStreams = ConcurrentHashMap.newKeySet();
     private final ConnectionContext ctx;
     private final Http2Config http2Config;
     private final HttpRouting routing;

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -87,7 +89,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                   Http2Flag.DataFlags.create(Http2Flag.DataFlags.END_OF_STREAM),
                                                   0), BufferData.empty());
     private static final Runnable NO_OP = () -> { };
-    private static final long MAX_LOCALLY_RESET_STREAM_DATA = 64 * 1024;
+    private static final long MAX_LOCALLY_RESET_STREAM_HEADER_BYTES = 64 * 1024;
     private static final int MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS = 64;
     private static final System.Logger LOGGER = System.getLogger(Http2Stream.class.getName());
     private static final Set<Http2StreamState> DATA_RECEIVABLE_STATES =
@@ -95,7 +97,6 @@ class Http2ServerStream implements Runnable, Http2Stream {
 
     private final ConnectionContext ctx;
     private final Http2Config http2Config;
-    private final long maxLocallyResetStreamData;
     private final List<Http2SubProtocolSelector> subProviders;
     private final int streamId;
     private final Http2Settings serverSettings;
@@ -106,6 +107,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private final Http2ConnectionChecks connectionAttackVectorMetrics;
     private final LocallyResetStreamTracker locallyResetStreamTracker;
     private final ArrayBlockingQueue<DataFrame> inboundData = new ArrayBlockingQueue<>(32);
+    private final ConnectionFlowControl connectionFlowControl;
     private final StreamFlowControl flowControl;
     private final Http2ConcurrentConnectionStreams streams;
     private final HttpRouting routing;
@@ -113,10 +115,8 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private final ReentrantLock resetCompletionLock = new ReentrantLock();
     private boolean wasLastDataFrame = false;
     private boolean hasEntity = true;
-    private long ignoredInboundDataAfterReset;
-    private long ignoredInboundHeaderBytesAfterReset;
-    private int ignoredInboundHeaderBlocksAfterReset;
     private volatile Http2Headers headers;
+    private volatile LocallyResetStreamState locallyResetStreamState;
     private volatile Http2Priority priority;
     private boolean remoteResetReceived;
     private volatile boolean resetStreamSent;
@@ -162,7 +162,6 @@ class Http2ServerStream implements Runnable, Http2Stream {
         this.streams = streams;
         this.routing = routing;
         this.http2Config = http2Config;
-        this.maxLocallyResetStreamData = Math.max(http2Config.maxFrameSize(), MAX_LOCALLY_RESET_STREAM_DATA);
         this.subProviders = subProviders;
         this.streamId = streamId;
         this.serverSettings = serverSettings;
@@ -174,6 +173,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
         this.router = ctx.router();
         this.connectionAttackVectorMetrics = connectionAttackVectorMetrics;
         this.locallyResetStreamTracker = Objects.requireNonNull(locallyResetStreamTracker);
+        this.connectionFlowControl = connectionFlowControl;
         this.flowControl = connectionFlowControl.createStreamFlowControl(
                 streamId,
                 http2Config.initialWindowSize(),
@@ -304,11 +304,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
         int dataLength = data.available();
         if (ignoreInboundDataAfterReset) {
-            flowControl.inbound().incrementWindowSize(header.length());
-            if (!discardDataAfterReset(header.length())) {
-                throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
-                                         "Too much data after stream reset.");
-            }
+            discardDataAfterReset(header.length());
             if (endOfStream) {
                 remoteCompleteAfterReset();
             }
@@ -341,18 +337,60 @@ class Http2ServerStream implements Runnable, Http2Stream {
 
     // Package-private for deterministic rejection race tests.
     void enqueueDataAfterPrecheck(Http2FrameHeader header, BufferData data, boolean endOfStream) {
+        DataFrame frame = enqueueData(header, data);
+        completeDataEnqueue(frame, endOfStream, ignoreInboundDataAfterReset);
+    }
+
+    // Package-private for deterministic reset race tests.
+    void enqueueDataAfterPrecheck(Http2FrameHeader header,
+                                  BufferData data,
+                                  boolean endOfStream,
+                                  Runnable afterResetStateSnapshot) {
+        DataFrame frame = enqueueData(header, data);
+        boolean ignoringInboundDataSnapshot = ignoreInboundDataAfterReset;
+        afterResetStateSnapshot.run();
+        completeDataEnqueue(frame, endOfStream, ignoringInboundDataSnapshot);
+    }
+
+    private DataFrame enqueueData(Http2FrameHeader header, BufferData data) {
         DataFrame frame = new DataFrame(header, data);
         try {
             inboundData.put(frame);
         } catch (InterruptedException e) {
             throw new Http2Exception(Http2ErrorCode.INTERNAL, "Interrupted", e);
         }
-        boolean ignoringInboundData = ignoreInboundDataAfterReset;
+        return frame;
+    }
+
+    private void completeDataEnqueue(DataFrame frame,
+                                     boolean endOfStream,
+                                     boolean ignoringInboundDataSnapshot) {
+        if (!endOfStream) {
+            completeDataEnqueueState(frame, false, ignoringInboundDataSnapshot);
+            return;
+        }
+
+        resetCompletionLock.lock();
+        try {
+            completeDataEnqueueState(frame, true, ignoringInboundDataSnapshot);
+        } finally {
+            resetCompletionLock.unlock();
+        }
+    }
+
+    private void completeDataEnqueueState(DataFrame frame,
+                                          boolean endOfStream,
+                                          boolean ignoringInboundDataSnapshot) {
+        boolean ignoringInboundData = ignoringInboundDataSnapshot || ignoreInboundDataAfterReset;
         if (ignoringInboundData || !DATA_RECEIVABLE_STATES.contains(state)) {
             if (inboundData.remove(frame)) {
-                flowControl.inbound().incrementWindowSize(header.length());
+                if (ignoringInboundData) {
+                    discardDataAfterReset(frame.header().length());
+                } else {
+                    flowControl.inbound().incrementWindowSize(frame.header().length());
+                }
             }
-            if (ignoringInboundData && endOfStream) {
+            if (endOfStream && ignoringInboundData) {
                 remoteCompleteAfterReset();
             }
             return;
@@ -395,7 +433,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     void headersAfterReset(boolean endOfStream, long headerBlockLength) {
-        if (!discardHeadersAfterReset(headerBlockLength)) {
+        if (!locallyResetStreamState().discardHeaders(headerBlockLength)) {
             throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
                                      "Too many headers after stream reset.");
         }
@@ -673,9 +711,11 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     private void resetInvalidContentLength(int currentFrameLength, boolean endOfStream) {
+        LocallyResetStreamState resetState = locallyResetStreamState();
+        ignoreInboundDataAfterReset = true;
         state = Http2StreamState.CLOSED;
         writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
-        locallyResetStreamTracker.add(this.streamId);
+        locallyResetStreamTracker.add(this.streamId, resetState);
         streams.remove(this.streamId);
         Http2RstStream rst = new Http2RstStream(Http2ErrorCode.PROTOCOL);
         try {
@@ -689,13 +729,13 @@ class Http2ServerStream implements Runnable, Http2Stream {
         connectionAttackVectorMetrics.madeYouResetCheck();
 
         if (currentFrameLength > 0) {
-            flowControl.inbound().incrementWindowSize(currentFrameLength);
+            discardDataAfterReset(currentFrameLength);
         }
         DataFrame frame = inboundData.poll();
         while (frame != null) {
             int frameLength = frame.header().length();
             if (frameLength > 0) {
-                flowControl.inbound().incrementWindowSize(frameLength);
+                discardDataAfterReset(frameLength);
             }
             frame = inboundData.poll();
         }
@@ -743,7 +783,12 @@ class Http2ServerStream implements Runnable, Http2Stream {
         DataFrame frame;
         try {
             frame = inboundData.take();
-            flowControl.inbound().incrementWindowSize(frame.header().length());
+            int frameLength = frame.header().length();
+            if (ignoreInboundDataAfterReset) {
+                discardDataAfterReset(frameLength);
+            } else {
+                flowControl.inbound().incrementWindowSize(frameLength);
+            }
         } catch (InterruptedException e) {
             // this stream was interrupted, does not make sense to do anything else
             return BufferData.empty();
@@ -772,7 +817,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 if (resetRequestBody && !remoteResetReceived && (forceReset || !remoteAlreadyComplete)) {
                     writeResetStream(resetCode);
                     resetStreamSent = true;
-                    locallyResetStreamTracker.add(this.streamId);
+                    locallyResetStreamTracker.add(this.streamId, locallyResetStreamState());
                     if (remoteCompleteAfterReset || remoteAlreadyComplete) {
                         locallyResetStreamTracker.remoteComplete(this.streamId);
                     }
@@ -792,13 +837,50 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     private boolean prepareRejectedStream(boolean forceReset) {
-        boolean resetRequestBody = forceReset || hasEntity && state != Http2StreamState.HALF_CLOSED_REMOTE;
-        ignoreInboundDataAfterReset = resetRequestBody;
-        restoreInboundFlowControl();
-        if (!inboundData.offer(TERMINATING_FRAME)) {
-            throw new Http2Exception(Http2ErrorCode.INTERNAL, "Failed to close stream data queue.");
+        resetCompletionLock.lock();
+        try {
+            boolean resetRequestBody = forceReset || !remoteAlreadyComplete();
+            if (resetRequestBody) {
+                locallyResetStreamState();
+            }
+            ignoreInboundDataAfterReset = resetRequestBody;
+            DataFrame frame;
+            while ((frame = inboundData.poll()) != null) {
+                discardDataAfterReset(frame.header().length());
+            }
+            if (!inboundData.offer(TERMINATING_FRAME)) {
+                throw new Http2Exception(Http2ErrorCode.INTERNAL, "Failed to close stream data queue.");
+            }
+            return resetRequestBody;
+        } finally {
+            resetCompletionLock.unlock();
         }
-        return resetRequestBody;
+    }
+
+    private void discardDataAfterReset(int length) {
+        connectionFlowControl.incrementInboundConnectionWindowSize(length);
+        if (!locallyResetStreamState().discardData(length)) {
+            throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                                     "Too much data after stream reset.");
+        }
+    }
+
+    private LocallyResetStreamState locallyResetStreamState() {
+        LocallyResetStreamState resetState = locallyResetStreamState;
+        if (resetState == null) {
+            resetCompletionLock.lock();
+            try {
+                resetState = locallyResetStreamState;
+                if (resetState == null) {
+                    long maxHeaderBytes = Math.max(http2Config.maxFrameSize(), MAX_LOCALLY_RESET_STREAM_HEADER_BYTES);
+                    resetState = new LocallyResetStreamState(http2Config.initialWindowSize(), maxHeaderBytes);
+                    locallyResetStreamState = resetState;
+                }
+            } finally {
+                resetCompletionLock.unlock();
+            }
+        }
+        return resetState;
     }
 
     private void writeResetStream(Http2ErrorCode resetCode) {
@@ -809,18 +891,6 @@ class Http2ServerStream implements Runnable, Http2Stream {
             throw new ServerConnectionException("Failed to write reset stream", e);
         }
         connectionAttackVectorMetrics.madeYouResetCheck();
-    }
-
-    private boolean discardDataAfterReset(int length) {
-        ignoredInboundDataAfterReset += length;
-        return ignoredInboundDataAfterReset <= maxLocallyResetStreamData;
-    }
-
-    private boolean discardHeadersAfterReset(long length) {
-        ignoredInboundHeaderBlocksAfterReset++;
-        ignoredInboundHeaderBytesAfterReset += length;
-        return ignoredInboundHeaderBlocksAfterReset <= MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS
-                && ignoredInboundHeaderBytesAfterReset <= maxLocallyResetStreamData;
     }
 
     private void remoteCompleteAfterReset() {
@@ -841,13 +911,6 @@ class Http2ServerStream implements Runnable, Http2Stream {
             state = Http2StreamState.CLOSED;
         } else {
             state = Http2StreamState.HALF_CLOSED_REMOTE;
-        }
-    }
-
-    private void restoreInboundFlowControl() {
-        DataFrame frame;
-        while ((frame = inboundData.poll()) != null) {
-            flowControl.inbound().incrementWindowSize(frame.header().length());
         }
     }
 
@@ -998,11 +1061,37 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     interface LocallyResetStreamTracker {
-        void add(int streamId);
+        void add(int streamId, LocallyResetStreamState streamState);
 
         void localComplete(int streamId);
 
         void remoteComplete(int streamId);
+    }
+
+    static final class LocallyResetStreamState {
+        private final long maxData;
+        private final long maxHeaderBytes;
+        private final AtomicLong discardedData = new AtomicLong();
+        private final AtomicInteger discardedHeaderBlocks = new AtomicInteger();
+        private final AtomicLong discardedHeaderBytes = new AtomicLong();
+
+        private LocallyResetStreamState(long maxData, long maxHeaderBytes) {
+            this.maxData = maxData;
+            this.maxHeaderBytes = maxHeaderBytes;
+        }
+
+        boolean discardData(int length) {
+            return discardedData.addAndGet(length) <= maxData;
+        }
+
+        boolean discardHeaders(long length) {
+            return discardedHeaderBlocks.incrementAndGet() <= MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS
+                    && discardedHeaderBytes.addAndGet(length) <= maxHeaderBytes;
+        }
+
+        long discardedData() {
+            return discardedData.get();
+        }
     }
 
     private enum WriteState {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -85,6 +85,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                   Http2Flag.DataFlags.create(Http2Flag.DataFlags.END_OF_STREAM),
                                                   0), BufferData.empty());
     private static final Runnable NO_OP = () -> { };
+    private static final IntConsumer NO_OP_INT = i -> { };
     private static final System.Logger LOGGER = System.getLogger(Http2Stream.class.getName());
     private static final Set<Http2StreamState> DATA_RECEIVABLE_STATES =
             Set.of(Http2StreamState.OPEN, Http2StreamState.HALF_CLOSED_LOCAL);
@@ -160,7 +161,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 : null;
         this.router = ctx.router();
         this.connectionAttackVectorMetrics = connectionAttackVectorMetrics;
-        this.locallyResetStreams = locallyResetStreams;
+        this.locallyResetStreams = locallyResetStreams == null ? NO_OP_INT : locallyResetStreams;
         this.flowControl = connectionFlowControl.createStreamFlowControl(
                 streamId,
                 http2Config.initialWindowSize(),
@@ -397,18 +398,17 @@ class Http2ServerStream implements Runnable, Http2Stream {
             }
             Http2Headers http2Headers = Http2Headers.create(headers)
                     .status(e.status());
+            boolean resetRequestBody = closeRejectedStreamState(false);
             if (entity.length == 0) {
                 Http2Flag.HeaderFlags flags =
                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM);
                 if (connectionWriter == null) {
                     writer.writeHeaders(http2Headers, streamId, flags, flowControl.outbound());
-                    closeRejectedStream();
                 } else {
                     connectionWriter.writeHeaders(http2Headers,
                                                   streamId,
                                                   flags,
-                                                  flowControl.outbound(),
-                                                  this::closeRejectedStream);
+                                                  flowControl.outbound());
                 }
             } else {
                 Http2FrameHeader dataHeader = Http2FrameHeader.create(entity.length,
@@ -421,15 +421,16 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
                                         new Http2FrameData(dataHeader, BufferData.create(message)),
                                         flowControl.outbound());
-                    closeRejectedStream();
                 } else {
                     connectionWriter.writeHeaders(http2Headers,
                                                   streamId,
                                                   Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
                                                   new Http2FrameData(dataHeader, BufferData.create(message)),
-                                                  flowControl.outbound(),
-                                                  this::closeRejectedStream);
+                                                  flowControl.outbound());
                 }
+            }
+            if (resetRequestBody) {
+                writeResetStream(Http2ErrorCode.CANCEL);
             }
         } catch (Http2Exception e) {
             ctx.log(LOGGER, DEBUG, "Intentional HTTP/2 stream exception, code: %s, message: %s",
@@ -678,29 +679,37 @@ class Http2ServerStream implements Runnable, Http2Stream {
         return frame.data();
     }
 
-    private void closeRejectedStream() {
-        closeRejectedStream(Http2ErrorCode.CANCEL, false);
+    private void closeRejectedStream(Http2ErrorCode resetCode, boolean forceReset) {
+        boolean resetRequestBody = closeRejectedStreamState(forceReset);
+        if (resetRequestBody) {
+            writeResetStream(resetCode);
+        }
     }
 
-    private void closeRejectedStream(Http2ErrorCode resetCode, boolean forceReset) {
+    private boolean closeRejectedStreamState(boolean forceReset) {
         boolean resetRequestBody = forceReset || hasEntity && state != Http2StreamState.HALF_CLOSED_REMOTE;
         ignoreInboundDataAfterReset = resetRequestBody;
         this.state = Http2StreamState.CLOSED;
         writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
+        if (resetRequestBody) {
+            locallyResetStreams.accept(this.streamId);
+        }
         streams.remove(this.streamId);
         restoreInboundFlowControl();
         if (!inboundData.offer(TERMINATING_FRAME)) {
             throw new Http2Exception(Http2ErrorCode.INTERNAL, "Failed to close stream data queue.");
         }
-        if (resetRequestBody) {
-            Http2RstStream rst = new Http2RstStream(resetCode);
-            try {
-                writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
-            } catch (SocketWriterException | UncheckedIOException e) {
-                throw new ServerConnectionException("Failed to write reset stream", e);
-            }
-            connectionAttackVectorMetrics.madeYouResetCheck();
+        return resetRequestBody;
+    }
+
+    private void writeResetStream(Http2ErrorCode resetCode) {
+        Http2RstStream rst = new Http2RstStream(resetCode);
+        try {
+            writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+        } catch (SocketWriterException | UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write reset stream", e);
         }
+        connectionAttackVectorMetrics.madeYouResetCheck();
     }
 
     private void restoreInboundFlowControl() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -18,12 +18,14 @@ package io.helidon.webserver.http2;
 
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.IntConsumer;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.concurrency.limits.FixedLimit;
@@ -85,13 +87,23 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                   Http2Flag.DataFlags.create(Http2Flag.DataFlags.END_OF_STREAM),
                                                   0), BufferData.empty());
     private static final Runnable NO_OP = () -> { };
-    private static final IntConsumer NO_OP_INT = i -> { };
+    private static final long MAX_LOCALLY_RESET_STREAM_DATA = 64 * 1024;
+    private static final int MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS = 64;
     private static final System.Logger LOGGER = System.getLogger(Http2Stream.class.getName());
     private static final Set<Http2StreamState> DATA_RECEIVABLE_STATES =
             Set.of(Http2StreamState.OPEN, Http2StreamState.HALF_CLOSED_LOCAL);
 
+    interface LocallyResetStreamTracker {
+        void add(int streamId);
+
+        void localComplete(int streamId);
+
+        void remoteComplete(int streamId);
+    }
+
     private final ConnectionContext ctx;
     private final Http2Config http2Config;
+    private final long maxLocallyResetStreamData;
     private final List<Http2SubProtocolSelector> subProviders;
     private final int streamId;
     private final Http2Settings serverSettings;
@@ -100,16 +112,23 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private final Http2ConnectionWriter connectionWriter;
     private final Router router;
     private final Http2ConnectionChecks connectionAttackVectorMetrics;
-    private final IntConsumer locallyResetStreams;
+    private final LocallyResetStreamTracker locallyResetStreamTracker;
     private final ArrayBlockingQueue<DataFrame> inboundData = new ArrayBlockingQueue<>(32);
     private final StreamFlowControl flowControl;
     private final Http2ConcurrentConnectionStreams streams;
     private final HttpRouting routing;
     private final AtomicReference<WriteState> writeState = new AtomicReference<>(WriteState.INIT);
+    private final ReentrantLock resetCompletionLock = new ReentrantLock();
     private boolean wasLastDataFrame = false;
     private boolean hasEntity = true;
+    private long ignoredInboundDataAfterReset;
+    private long ignoredInboundHeaderBytesAfterReset;
+    private int ignoredInboundHeaderBlocksAfterReset;
     private volatile Http2Headers headers;
     private volatile Http2Priority priority;
+    private boolean remoteResetReceived;
+    private volatile boolean resetStreamSent;
+    private volatile boolean remoteCompleteAfterReset;
     private volatile boolean ignoreInboundDataAfterReset;
     // used from this instance and from connection
     private volatile Http2StreamState state = Http2StreamState.IDLE;
@@ -133,11 +152,11 @@ class Http2ServerStream implements Runnable, Http2Stream {
      * @param clientSettings        client settings
      * @param writer                writer
      * @param connectionFlowControl connection flow control
-     * @param locallyResetStreams   stream reset notification
+     * @param locallyResetStreamTracker stream reset lifecycle tracker
      */
     Http2ServerStream(ConnectionContext ctx,
                       Http2ConcurrentConnectionStreams streams,
-                      IntConsumer locallyResetStreams,
+                      LocallyResetStreamTracker locallyResetStreamTracker,
                       HttpRouting routing,
                       Http2Config http2Config,
                       List<Http2SubProtocolSelector> subProviders,
@@ -151,6 +170,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
         this.streams = streams;
         this.routing = routing;
         this.http2Config = http2Config;
+        this.maxLocallyResetStreamData = Math.max(http2Config.maxFrameSize(), MAX_LOCALLY_RESET_STREAM_DATA);
         this.subProviders = subProviders;
         this.streamId = streamId;
         this.serverSettings = serverSettings;
@@ -161,7 +181,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 : null;
         this.router = ctx.router();
         this.connectionAttackVectorMetrics = connectionAttackVectorMetrics;
-        this.locallyResetStreams = locallyResetStreams == null ? NO_OP_INT : locallyResetStreams;
+        this.locallyResetStreamTracker = Objects.requireNonNull(locallyResetStreamTracker);
         this.flowControl = connectionFlowControl.createStreamFlowControl(
                 streamId,
                 http2Config.initialWindowSize(),
@@ -176,7 +196,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
      * @throws Http2Exception in case data cannot be received
      */
     public void checkDataReceivable() throws Http2Exception {
-        if (ignoreInboundDataAfterReset) {
+        if (resetStreamSent && ignoreInboundDataAfterReset) {
             return;
         }
         if (!DATA_RECEIVABLE_STATES.contains(state)) {
@@ -218,10 +238,20 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                      "Received RST_STREAM for stream "
                                              + streamId + " in IDLE state");
         }
+        boolean rapidReset;
+        resetCompletionLock.lock();
+        try {
+            remoteResetReceived = true;
+            rapidReset = writeState.get() == WriteState.INIT;
+        } finally {
+            resetCompletionLock.unlock();
+        }
+        if (ignoreInboundDataAfterReset) {
+            remoteCompleteAfterReset();
+        }
         if (subProtocolHandler != null) {
             subProtocolHandler.rstStream(rstStream);
         }
-        boolean rapidReset = writeState.get() == WriteState.INIT;
         this.state = Http2StreamState.CLOSED;
         boolean wakeupOffered = inboundData.offer(TERMINATING_FRAME);
         if (!wakeupOffered && LOGGER.isLoggable(DEBUG)) {
@@ -281,6 +311,17 @@ class Http2ServerStream implements Runnable, Http2Stream {
     @Override
     public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
         int dataLength = data.available();
+        if (ignoreInboundDataAfterReset) {
+            flowControl.inbound().incrementWindowSize(header.length());
+            if (!discardDataAfterReset(header.length())) {
+                throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                                         "Too much data after stream reset.");
+            }
+            if (endOfStream) {
+                remoteCompleteAfterReset();
+            }
+            return;
+        }
         if (!DATA_RECEIVABLE_STATES.contains(state)) {
             flowControl.inbound().incrementWindowSize(header.length());
             return;
@@ -303,14 +344,25 @@ class Http2ServerStream implements Runnable, Http2Stream {
             }
             return;
         }
+        enqueueDataAfterPrecheck(header, data, endOfStream);
+    }
+
+    // Package-private for deterministic rejection race tests.
+    void enqueueDataAfterPrecheck(Http2FrameHeader header, BufferData data, boolean endOfStream) {
         DataFrame frame = new DataFrame(header, data);
         try {
             inboundData.put(frame);
         } catch (InterruptedException e) {
             throw new Http2Exception(Http2ErrorCode.INTERNAL, "Interrupted", e);
         }
-        if (!DATA_RECEIVABLE_STATES.contains(state) && inboundData.remove(frame)) {
-            flowControl.inbound().incrementWindowSize(header.length());
+        boolean ignoringInboundData = ignoreInboundDataAfterReset;
+        if (ignoringInboundData || !DATA_RECEIVABLE_STATES.contains(state)) {
+            if (inboundData.remove(frame)) {
+                flowControl.inbound().incrementWindowSize(header.length());
+            }
+            if (ignoringInboundData && endOfStream) {
+                remoteCompleteAfterReset();
+            }
             return;
         }
         if (endOfStream) {
@@ -344,6 +396,20 @@ class Http2ServerStream implements Runnable, Http2Stream {
     @Override
     public StreamFlowControl flowControl() {
         return this.flowControl;
+    }
+
+    boolean discardsInboundAfterReset() {
+        return ignoreInboundDataAfterReset;
+    }
+
+    void headersAfterReset(boolean endOfStream, long headerBlockLength) {
+        if (!discardHeadersAfterReset(headerBlockLength)) {
+            throw new Http2Exception(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                                     "Too many headers after stream reset.");
+        }
+        if (endOfStream) {
+            remoteCompleteAfterReset();
+        }
     }
 
     @Override
@@ -398,39 +464,55 @@ class Http2ServerStream implements Runnable, Http2Stream {
             }
             Http2Headers http2Headers = Http2Headers.create(headers)
                     .status(e.status());
-            boolean resetRequestBody = closeRejectedStreamState(false);
-            if (entity.length == 0) {
-                Http2Flag.HeaderFlags flags =
-                        Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM);
-                if (connectionWriter == null) {
-                    writer.writeHeaders(http2Headers, streamId, flags, flowControl.outbound());
-                } else {
-                    connectionWriter.writeHeaders(http2Headers,
-                                                  streamId,
-                                                  flags,
-                                                  flowControl.outbound());
+            boolean resetRequestBody = prepareRejectedStream(false);
+            AtomicBoolean rejectedStreamCompleted = new AtomicBoolean();
+            Runnable completeRejectedStream = () -> {
+                if (rejectedStreamCompleted.compareAndSet(false, true)) {
+                    completeRejectedStream(Http2ErrorCode.CANCEL, resetRequestBody, false);
                 }
-            } else {
-                Http2FrameHeader dataHeader = Http2FrameHeader.create(entity.length,
-                                                                      Http2FrameTypes.DATA,
-                                                                      Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
-                                                                      streamId);
-                if (connectionWriter == null) {
-                    writer.writeHeaders(http2Headers,
-                                        streamId,
-                                        Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
-                                        new Http2FrameData(dataHeader, BufferData.create(message)),
-                                        flowControl.outbound());
+            };
+            try {
+                if (entity.length == 0) {
+                    Http2Flag.HeaderFlags flags =
+                            Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM);
+                    if (connectionWriter == null) {
+                        writer.writeHeaders(http2Headers, streamId, flags, flowControl.outbound());
+                        completeRejectedStream.run();
+                    } else {
+                        connectionWriter.writeHeaders(http2Headers,
+                                                      streamId,
+                                                      flags,
+                                                      flowControl.outbound(),
+                                                      completeRejectedStream);
+                    }
                 } else {
-                    connectionWriter.writeHeaders(http2Headers,
-                                                  streamId,
-                                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
-                                                  new Http2FrameData(dataHeader, BufferData.create(message)),
-                                                  flowControl.outbound());
+                    Http2FrameHeader dataHeader = Http2FrameHeader.create(entity.length,
+                                                                          Http2FrameTypes.DATA,
+                                                                          Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                          streamId);
+                    if (connectionWriter == null) {
+                        writer.writeHeaders(http2Headers,
+                                            streamId,
+                                            Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                            new Http2FrameData(dataHeader, BufferData.create(message)),
+                                            flowControl.outbound());
+                        completeRejectedStream.run();
+                    } else {
+                        connectionWriter.writeHeaders(http2Headers,
+                                                      streamId,
+                                                      Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                                      new Http2FrameData(dataHeader, BufferData.create(message)),
+                                                      flowControl.outbound(),
+                                                      completeRejectedStream);
+                    }
                 }
-            }
-            if (resetRequestBody) {
-                writeResetStream(Http2ErrorCode.CANCEL);
+            } catch (RuntimeException writeFailure) {
+                try {
+                    completeRejectedStream.run();
+                } catch (RuntimeException cleanupFailure) {
+                    writeFailure.addSuppressed(cleanupFailure);
+                }
+                throw writeFailure;
             }
         } catch (Http2Exception e) {
             ctx.log(LOGGER, DEBUG, "Intentional HTTP/2 stream exception, code: %s, message: %s",
@@ -601,12 +683,17 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private void resetInvalidContentLength(int currentFrameLength, boolean endOfStream) {
         state = Http2StreamState.CLOSED;
         writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
-        if (!endOfStream) {
-            locallyResetStreams.accept(this.streamId);
-        }
+        locallyResetStreamTracker.add(this.streamId);
         streams.remove(this.streamId);
         Http2RstStream rst = new Http2RstStream(Http2ErrorCode.PROTOCOL);
-        writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+        try {
+            writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+            if (endOfStream) {
+                locallyResetStreamTracker.remoteComplete(this.streamId);
+            }
+        } finally {
+            locallyResetStreamTracker.localComplete(this.streamId);
+        }
         connectionAttackVectorMetrics.madeYouResetCheck();
 
         if (currentFrameLength > 0) {
@@ -680,21 +767,41 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     private void closeRejectedStream(Http2ErrorCode resetCode, boolean forceReset) {
-        boolean resetRequestBody = closeRejectedStreamState(forceReset);
-        if (resetRequestBody) {
-            writeResetStream(resetCode);
+        boolean resetRequestBody = prepareRejectedStream(forceReset);
+        completeRejectedStream(resetCode, resetRequestBody, forceReset);
+    }
+
+    private void completeRejectedStream(Http2ErrorCode resetCode, boolean resetRequestBody, boolean forceReset) {
+        try {
+            resetCompletionLock.lock();
+            try {
+                writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
+                boolean remoteAlreadyComplete = remoteAlreadyComplete();
+                if (resetRequestBody && !remoteResetReceived && (forceReset || !remoteAlreadyComplete)) {
+                    writeResetStream(resetCode);
+                    resetStreamSent = true;
+                    locallyResetStreamTracker.add(this.streamId);
+                    if (remoteCompleteAfterReset || remoteAlreadyComplete) {
+                        locallyResetStreamTracker.remoteComplete(this.streamId);
+                    }
+                }
+            } finally {
+                resetCompletionLock.unlock();
+            }
+        } finally {
+            this.state = Http2StreamState.CLOSED;
+            locallyResetStreamTracker.localComplete(this.streamId);
+            streams.remove(this.streamId);
         }
     }
 
-    private boolean closeRejectedStreamState(boolean forceReset) {
+    private boolean remoteAlreadyComplete() {
+        return state == Http2StreamState.HALF_CLOSED_REMOTE || state == Http2StreamState.CLOSED;
+    }
+
+    private boolean prepareRejectedStream(boolean forceReset) {
         boolean resetRequestBody = forceReset || hasEntity && state != Http2StreamState.HALF_CLOSED_REMOTE;
         ignoreInboundDataAfterReset = resetRequestBody;
-        this.state = Http2StreamState.CLOSED;
-        writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
-        if (resetRequestBody) {
-            locallyResetStreams.accept(this.streamId);
-        }
-        streams.remove(this.streamId);
         restoreInboundFlowControl();
         if (!inboundData.offer(TERMINATING_FRAME)) {
             throw new Http2Exception(Http2ErrorCode.INTERNAL, "Failed to close stream data queue.");
@@ -710,6 +817,39 @@ class Http2ServerStream implements Runnable, Http2Stream {
             throw new ServerConnectionException("Failed to write reset stream", e);
         }
         connectionAttackVectorMetrics.madeYouResetCheck();
+    }
+
+    private boolean discardDataAfterReset(int length) {
+        ignoredInboundDataAfterReset += length;
+        return ignoredInboundDataAfterReset <= maxLocallyResetStreamData;
+    }
+
+    private boolean discardHeadersAfterReset(long length) {
+        ignoredInboundHeaderBlocksAfterReset++;
+        ignoredInboundHeaderBytesAfterReset += length;
+        return ignoredInboundHeaderBlocksAfterReset <= MAX_LOCALLY_RESET_STREAM_HEADER_BLOCKS
+                && ignoredInboundHeaderBytesAfterReset <= maxLocallyResetStreamData;
+    }
+
+    private void remoteCompleteAfterReset() {
+        resetCompletionLock.lock();
+        try {
+            closeIgnoredInboundDataFromRemote();
+            remoteCompleteAfterReset = true;
+            if (resetStreamSent) {
+                locallyResetStreamTracker.remoteComplete(this.streamId);
+            }
+        } finally {
+            resetCompletionLock.unlock();
+        }
+    }
+
+    private void closeIgnoredInboundDataFromRemote() {
+        if (state == Http2StreamState.HALF_CLOSED_LOCAL || state == Http2StreamState.CLOSED) {
+            state = Http2StreamState.CLOSED;
+        } else {
+            state = Http2StreamState.HALF_CLOSED_REMOTE;
+        }
     }
 
     private void restoreInboundFlowControl() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -93,14 +93,6 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private static final Set<Http2StreamState> DATA_RECEIVABLE_STATES =
             Set.of(Http2StreamState.OPEN, Http2StreamState.HALF_CLOSED_LOCAL);
 
-    interface LocallyResetStreamTracker {
-        void add(int streamId);
-
-        void localComplete(int streamId);
-
-        void remoteComplete(int streamId);
-    }
-
     private final ConnectionContext ctx;
     private final Http2Config http2Config;
     private final long maxLocallyResetStreamData;
@@ -1003,6 +995,14 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 this.state = subProtocolHandler.streamState();
             }
         }
+    }
+
+    interface LocallyResetStreamTracker {
+        void add(int streamId);
+
+        void localComplete(int streamId);
+
+        void remoteComplete(int streamId);
     }
 
     private enum WriteState {

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
@@ -231,7 +231,7 @@ class ConnectionStreamTest {
 
     private static final class NoOpResetTracker implements Http2ServerStream.LocallyResetStreamTracker {
         @Override
-        public void add(int streamId) {
+        public void add(int streamId, Http2ServerStream.LocallyResetStreamState streamState) {
         }
 
         @Override

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
@@ -51,6 +51,7 @@ class ConnectionStreamTest {
 
     private static final int SETTINGS_MAX_CONCURRENT_STREAMS = 50;
     private static final int STREAM_ID = 1;
+    private static final Http2ServerStream.LocallyResetStreamTracker NO_OP_RESET_TRACKER = new NoOpResetTracker();
 
     @Test
     void concurrentModification() throws InterruptedException {
@@ -210,7 +211,7 @@ class ConnectionStreamTest {
 
         return new Http2ServerStream(ctx,
                                      streams,
-                                     streamId -> { },
+                                     NO_OP_RESET_TRACKER,
                                      HttpRouting.empty(),
                                      config,
                                      List.of(),
@@ -226,6 +227,20 @@ class ConnectionStreamTest {
         WritableHeaders<?> headers = WritableHeaders.create();
         headers.add(HeaderValues.createCached(Http2Headers.STATUS_NAME, 200));
         return Http2Headers.create(headers);
+    }
+
+    private static final class NoOpResetTracker implements Http2ServerStream.LocallyResetStreamTracker {
+        @Override
+        public void add(int streamId) {
+        }
+
+        @Override
+        public void localComplete(int streamId) {
+        }
+
+        @Override
+        public void remoteComplete(int streamId) {
+        }
     }
 
     private static final class RecordingConnectionWriter extends Http2ConnectionWriter {

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -19,16 +19,23 @@ package io.helidon.webserver.http2;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.SocketContext;
 import io.helidon.common.uri.UriAuthority;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
+import io.helidon.http.RequestException;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.ConnectionFlowControl;
 import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2ConnectionWriter;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Flag;
@@ -40,6 +47,7 @@ import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Settings;
 import io.helidon.http.http2.Http2StreamState;
 import io.helidon.http.http2.Http2StreamWriter;
+import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.ListenerContext;
@@ -48,6 +56,8 @@ import io.helidon.webserver.SniContext;
 import io.helidon.webserver.SniMatchType;
 import io.helidon.webserver.http.DirectHandlers;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
+import io.helidon.webserver.http2.spi.SubProtocolResult;
 
 import org.junit.jupiter.api.Test;
 
@@ -62,6 +72,7 @@ import static org.mockito.Mockito.when;
 
 class Http2ServerStreamSniTest {
     private static final int STREAM_ID = 1;
+    private static final Http2ServerStream.LocallyResetStreamTracker NO_OP_RESET_TRACKER = new NoOpResetTracker();
     private static final HttpPrologue PROLOGUE = HttpPrologue.create(Http2Connection.FULL_PROTOCOL,
                                                                      Http2Connection.PROTOCOL,
                                                                      Http2Connection.PROTOCOL_VERSION,
@@ -139,6 +150,183 @@ class Http2ServerStreamSniTest {
     }
 
     @Test
+    void blockedRejectedStreamRestoresRacingDataFlowControl() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter();
+        List<WindowUpdate> windowUpdates = new ArrayList<>();
+        Http2ServerStream stream = stream(streams, writer, windowUpdates);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        byte[] entity = "hello".getBytes();
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(String.valueOf(entity.length)), false);
+        stream.checkDataReceivable();
+        stream.flowControl().inbound().decrementWindowSize(entity.length);
+
+        stream.run();
+
+        assertThat(writer.hasPendingTerminalCallback(), is(true));
+        assertDoesNotThrow(stream::checkDataReceivable);
+        stream.data(Http2FrameHeader.create(entity.length,
+                                            Http2FrameTypes.DATA,
+                                            Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                            STREAM_ID),
+                    BufferData.create(entity),
+                    true);
+
+        assertThat(windowUpdates, hasItems(new WindowUpdate(STREAM_ID, entity.length),
+                                           new WindowUpdate(0, entity.length)));
+
+        writer.completeTerminalWrite();
+        assertThat(writer.rstStreamCount, is(0));
+    }
+
+    @Test
+    void rejectedStreamCompletionRestoresPrecheckedDataFlowControl() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority("1"), false);
+
+        try {
+            stream.run();
+            assertThat(writer.hasPendingTerminalCallback(), is(true));
+            stream.flowControl().inbound().decrementWindowSize(1);
+            stream.enqueueDataAfterPrecheck(Http2FrameHeader.create(1,
+                                                                    Http2FrameTypes.DATA,
+                                                                    Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                    STREAM_ID),
+                                                BufferData.create(new byte[1]),
+                                                true);
+            writer.completeTerminalWrite();
+
+            assertThat(stream.flowControl().inbound().getRemainingWindowSize(), is(8192));
+            assertThat(writer.rstStreamCount, is(0));
+        } finally {
+            if (writer.hasPendingTerminalCallback()) {
+                writer.completeTerminalWrite();
+            }
+        }
+    }
+
+    @Test
+    void blockedRejectedStreamBoundsRacingDataBeforeReset() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority("70000"), false);
+
+        stream.run();
+
+        try {
+            assertThat(writer.hasPendingTerminalCallback(), is(true));
+            for (int i = 0; i < 64; i++) {
+                assertDoesNotThrow(() -> writeRacingData(stream, 1024));
+            }
+
+            Http2Exception exception = assertThrows(Http2Exception.class, () -> writeRacingData(stream, 1024));
+            assertThat(exception.code(), is(Http2ErrorCode.ENHANCE_YOUR_CALM));
+        } finally {
+            if (writer.hasPendingTerminalCallback()) {
+                writer.completeTerminalWrite();
+            }
+        }
+    }
+
+    @Test
+    void peerResetBeforeRejectedStreamCompletionSuppressesServerReset() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority("1"), false);
+
+        stream.run();
+
+        assertThat(writer.hasPendingTerminalCallback(), is(true));
+        boolean rapidReset = stream.rstStream(new Http2RstStream(Http2ErrorCode.CANCEL));
+        assertThat(rapidReset, is(true));
+        writer.completeTerminalWrite();
+
+        assertThat(writer.rstStreamCount, is(0));
+        assertThat(stream.streamState(), is(Http2StreamState.CLOSED));
+    }
+
+    @Test
+    void rejectedStreamCompletionCannotUndercountPeerReset() throws Exception {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter(true);
+        Http2SubProtocolSelector.SubProtocolHandler handler = new Http2SubProtocolSelector.SubProtocolHandler() {
+            @Override
+            public void init() {
+                throw RequestException.builder()
+                        .status(Status.BAD_REQUEST_400)
+                        .message("Rejected request")
+                        .build();
+            }
+
+            @Override
+            public Http2StreamState streamState() {
+                return Http2StreamState.OPEN;
+            }
+
+            @Override
+            public void rstStream(Http2RstStream rstStream) {
+                writer.terminalCallbackMayRun.countDown();
+                try {
+                    if (!writer.terminalCallbackCompleted.await(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("Timed out waiting for terminal callback completion");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while waiting for terminal callback completion", e);
+                }
+            }
+
+            @Override
+            public void windowUpdate(Http2WindowUpdate update) {
+            }
+
+            @Override
+            public void data(Http2FrameHeader header, BufferData data) {
+            }
+        };
+        Http2SubProtocolSelector selector = (_, _, _, _, _, _, _, _, _, _) -> new SubProtocolResult(true, handler);
+        Http2ServerStream stream = stream(streams,
+                                          writer,
+                                          new ArrayList<>(),
+                                          sniContext(),
+                                          NO_OP_RESET_TRACKER,
+                                          List.of(selector));
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(Http2Headers.METHOD_NAME, Method.GET.text());
+        headers.add(Http2Headers.PATH_NAME, "/");
+        headers.add(Http2Headers.SCHEME_NAME, "https");
+        headers.add(Http2Headers.AUTHORITY_NAME, "api.example.com");
+        headers.add(HeaderNames.CONTENT_LENGTH, "1");
+        stream.headers(Http2Headers.create(headers), false);
+
+        CompletableFuture<Void> streamTask = CompletableFuture.runAsync(stream);
+        try {
+            assertThat(writer.terminalCallbackReady.await(5, TimeUnit.SECONDS), is(true));
+            boolean rapidReset = stream.rstStream(new Http2RstStream(Http2ErrorCode.CANCEL));
+            assertThat(rapidReset, is(true));
+            streamTask.get(5, TimeUnit.SECONDS);
+        } finally {
+            writer.terminalCallbackMayRun.countDown();
+        }
+
+        assertThat(writer.rstStreamCount, is(0));
+        assertThat(stream.streamState(), is(Http2StreamState.CLOSED));
+    }
+
+    @Test
     void rejectedStreamAllowsRacingDataAfterConnectionPrecheck() {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingStreamWriter writer = new RecordingStreamWriter();
@@ -168,7 +356,8 @@ class Http2ServerStreamSniTest {
     void invalidAuthoritySyntaxResetsStreamWithProtocolError() {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingStreamWriter writer = new RecordingStreamWriter();
-        Http2ServerStream stream = stream(streams, writer, parsingSniContext());
+        RecordingResetTracker resetTracker = new RecordingResetTracker();
+        Http2ServerStream stream = stream(streams, writer, new ArrayList<>(), parsingSniContext(), resetTracker);
         streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
         stream.prologue(PROLOGUE);
         stream.headers(headersWithAuthority("bad authority"), true);
@@ -180,6 +369,9 @@ class Http2ServerStreamSniTest {
         assertThat(writer.rstStreamCodes, hasItems(Http2ErrorCode.PROTOCOL));
         assertThat(stream.streamState(), is(Http2StreamState.CLOSED));
         assertThat(streams.get(STREAM_ID), is(nullValue()));
+        assertThat(resetTracker.adds, is(1));
+        assertThat(resetTracker.localCompletes, is(1));
+        assertThat(resetTracker.remoteCompletes, is(1));
     }
 
     private static Http2ServerStream stream(Http2ConnectionStreams streams, Http2StreamWriter writer) {
@@ -202,6 +394,23 @@ class Http2ServerStreamSniTest {
                                             Http2StreamWriter writer,
                                             List<WindowUpdate> windowUpdates,
                                             SniContext sniContext) {
+        return stream(streams, writer, windowUpdates, sniContext, NO_OP_RESET_TRACKER);
+    }
+
+    private static Http2ServerStream stream(Http2ConnectionStreams streams,
+                                            Http2StreamWriter writer,
+                                            List<WindowUpdate> windowUpdates,
+                                            SniContext sniContext,
+                                            Http2ServerStream.LocallyResetStreamTracker resetTracker) {
+        return stream(streams, writer, windowUpdates, sniContext, resetTracker, List.of());
+    }
+
+    private static Http2ServerStream stream(Http2ConnectionStreams streams,
+                                            Http2StreamWriter writer,
+                                            List<WindowUpdate> windowUpdates,
+                                            SniContext sniContext,
+                                            Http2ServerStream.LocallyResetStreamTracker resetTracker,
+                                            List<Http2SubProtocolSelector> subProtocolSelectors) {
         Http2Config config = Http2Config.builder()
                 .initialWindowSize(8192)
                 .maxFrameSize(16384)
@@ -213,10 +422,10 @@ class Http2ServerStreamSniTest {
                 .build();
         return new Http2ServerStream(connectionContext(sniContext),
                                      streams,
-                                     null,
+                                     resetTracker,
                                      HttpRouting.empty(),
                                      config,
-                                     List.of(),
+                                     subProtocolSelectors,
                                      STREAM_ID,
                                      Http2Settings.builder().build(),
                                      Http2Settings.builder().build(),
@@ -312,7 +521,54 @@ class Http2ServerStreamSniTest {
         return Http2Headers.create(headers);
     }
 
+    private static void writeRacingData(Http2ServerStream stream, int length) {
+        byte[] entity = new byte[length];
+        stream.checkDataReceivable();
+        stream.flowControl().inbound().decrementWindowSize(entity.length);
+        stream.data(Http2FrameHeader.create(entity.length,
+                                            Http2FrameTypes.DATA,
+                                            Http2Flag.DataFlags.create(0),
+                                            STREAM_ID),
+                    BufferData.create(entity),
+                    false);
+    }
+
     private record WindowUpdate(int streamId, int increment) {
+    }
+
+    private static final class NoOpResetTracker implements Http2ServerStream.LocallyResetStreamTracker {
+        @Override
+        public void add(int streamId) {
+        }
+
+        @Override
+        public void localComplete(int streamId) {
+        }
+
+        @Override
+        public void remoteComplete(int streamId) {
+        }
+    }
+
+    private static final class RecordingResetTracker implements Http2ServerStream.LocallyResetStreamTracker {
+        private int adds;
+        private int localCompletes;
+        private int remoteCompletes;
+
+        @Override
+        public void add(int streamId) {
+            adds++;
+        }
+
+        @Override
+        public void localComplete(int streamId) {
+            localCompletes++;
+        }
+
+        @Override
+        public void remoteComplete(int streamId) {
+            remoteCompletes++;
+        }
     }
 
     private static final class RecordingStreamWriter implements Http2StreamWriter {
@@ -349,6 +605,112 @@ class Http2ServerStreamSniTest {
                                 FlowControl.Outbound flowControl) {
             this.status = headers.status();
             return 0;
+        }
+    }
+
+    private static final class RecordingConnectionWriter extends Http2ConnectionWriter {
+        private final boolean blockTerminalCallback;
+        private final CountDownLatch terminalCallbackReady = new CountDownLatch(1);
+        private final CountDownLatch terminalCallbackMayRun = new CountDownLatch(1);
+        private final CountDownLatch terminalCallbackCompleted = new CountDownLatch(1);
+        private Runnable terminalCallback;
+        private int rstStreamCount;
+
+        private RecordingConnectionWriter() {
+            this(false);
+        }
+
+        private RecordingConnectionWriter(boolean blockTerminalCallback) {
+            super(mock(SocketContext.class), mock(DataWriter.class), List.of());
+            this.blockTerminalCallback = blockTerminalCallback;
+        }
+
+        @Override
+        public void write(Http2FrameData frame) {
+            if (frame.header().type() == Http2FrameTypes.RST_STREAM.type()) {
+                rstStreamCount++;
+            }
+        }
+
+        @Override
+        public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+        }
+
+        @Override
+        public int writeData(Http2FrameData frame,
+                             FlowControl.Outbound flowControl,
+                             Runnable onEndStreamFrameWritten) {
+            captureTerminalCallback(onEndStreamFrameWritten);
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                FlowControl.Outbound flowControl) {
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                FlowControl.Outbound flowControl,
+                                Runnable onEndStreamFrameWritten) {
+            if (flags.endOfStream()) {
+                captureTerminalCallback(onEndStreamFrameWritten);
+            }
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                Http2FrameData dataFrame,
+                                FlowControl.Outbound flowControl) {
+            return 0;
+        }
+
+        @Override
+        public int writeHeaders(Http2Headers headers,
+                                int streamId,
+                                Http2Flag.HeaderFlags flags,
+                                Http2FrameData dataFrame,
+                                FlowControl.Outbound flowControl,
+                                Runnable onEndStreamFrameWritten) {
+            captureTerminalCallback(onEndStreamFrameWritten);
+            return 0;
+        }
+
+        private void captureTerminalCallback(Runnable callback) {
+            terminalCallback = callback;
+            if (!blockTerminalCallback) {
+                return;
+            }
+            terminalCallbackReady.countDown();
+            try {
+                if (!terminalCallbackMayRun.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to run terminal callback");
+                }
+                completeTerminalWrite();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting to run terminal callback", e);
+            } finally {
+                terminalCallbackCompleted.countDown();
+            }
+        }
+
+        private void completeTerminalWrite() {
+            assertThat(terminalCallback, is(org.hamcrest.Matchers.notNullValue()));
+            terminalCallback.run();
+            terminalCallback = null;
+        }
+
+        private boolean hasPendingTerminalCallback() {
+            return terminalCallback != null;
         }
     }
 }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -100,7 +100,58 @@ class Http2ServerStreamSniTest {
     }
 
     @Test
-    void rejectedStreamRestoresQueuedDataFlowControl() {
+    void rejectedContentLengthZeroStreamResetsOpenRemoteSide() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        RecordingResetTracker resetTracker = new RecordingResetTracker();
+        Http2ServerStream stream = stream(streams, writer, new ArrayList<>(), sniContext(), resetTracker);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority("0"), false);
+
+        stream.run();
+
+        assertThat(writer.rstStreamCount, is(1));
+        assertThat(resetTracker.adds, is(1));
+        assertThat(resetTracker.localCompletes, is(1));
+        assertThat(resetTracker.remoteCompletes, is(0));
+        assertDoesNotThrow(stream::checkDataReceivable);
+        assertDoesNotThrow(() -> stream.data(Http2FrameHeader.create(0,
+                                                                     Http2FrameTypes.DATA,
+                                                                     Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                     STREAM_ID),
+                                                   BufferData.empty(),
+                                                   true));
+        assertThat(resetTracker.remoteCompletes, is(1));
+    }
+
+    @Test
+    void resetStartingAfterStaleSnapshotStillCompletesRemoteSide() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        RecordingResetTracker resetTracker = new RecordingResetTracker();
+        Http2ServerStream stream = stream(streams, writer, new ArrayList<>(), sniContext(), resetTracker);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority("2"), false);
+
+        stream.flowControl().inbound().decrementWindowSize(1);
+        assertDoesNotThrow(() -> stream.enqueueDataAfterPrecheck(
+                Http2FrameHeader.create(1,
+                                        Http2FrameTypes.DATA,
+                                        Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                        STREAM_ID),
+                BufferData.create(new byte[1]),
+                true,
+                stream::run));
+
+        assertThat(resetTracker.adds, is(1));
+        assertThat(resetTracker.streamState.discardedData(), is(1L));
+        assertThat(resetTracker.remoteCompletes, is(1));
+    }
+
+    @Test
+    void rejectedStreamRestoresQueuedDataConnectionFlowControl() {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingStreamWriter writer = new RecordingStreamWriter();
         List<WindowUpdate> windowUpdates = new ArrayList<>();
@@ -119,12 +170,11 @@ class Http2ServerStreamSniTest {
 
         stream.run();
 
-        assertThat(windowUpdates, hasItems(new WindowUpdate(STREAM_ID, entity.length),
-                                           new WindowUpdate(0, entity.length)));
+        assertThat(windowUpdates, is(List.of(new WindowUpdate(0, entity.length))));
     }
 
     @Test
-    void rejectedStreamRestoresRacingDataFlowControl() {
+    void rejectedStreamRestoresRacingDataConnectionFlowControl() {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingStreamWriter writer = new RecordingStreamWriter();
         List<WindowUpdate> windowUpdates = new ArrayList<>();
@@ -145,12 +195,11 @@ class Http2ServerStreamSniTest {
                     BufferData.create(entity),
                     false);
 
-        assertThat(windowUpdates, hasItems(new WindowUpdate(STREAM_ID, entity.length),
-                                           new WindowUpdate(0, entity.length)));
+        assertThat(windowUpdates, is(List.of(new WindowUpdate(0, entity.length))));
     }
 
     @Test
-    void blockedRejectedStreamRestoresRacingDataFlowControl() {
+    void blockedRejectedStreamRestoresRacingDataConnectionFlowControl() {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingConnectionWriter writer = new RecordingConnectionWriter();
         List<WindowUpdate> windowUpdates = new ArrayList<>();
@@ -173,18 +222,18 @@ class Http2ServerStreamSniTest {
                     BufferData.create(entity),
                     true);
 
-        assertThat(windowUpdates, hasItems(new WindowUpdate(STREAM_ID, entity.length),
-                                           new WindowUpdate(0, entity.length)));
+        assertThat(windowUpdates, is(List.of(new WindowUpdate(0, entity.length))));
 
         writer.completeTerminalWrite();
         assertThat(writer.rstStreamCount, is(0));
     }
 
     @Test
-    void rejectedStreamCompletionRestoresPrecheckedDataFlowControl() {
+    void rejectedStreamCompletionRestoresConnectionFlowControlForPrecheckedData() {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingConnectionWriter writer = new RecordingConnectionWriter();
-        Http2ServerStream stream = stream(streams, writer);
+        List<WindowUpdate> windowUpdates = new ArrayList<>();
+        Http2ServerStream stream = stream(streams, writer, windowUpdates);
         streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
         stream.prologue(PROLOGUE);
         stream.headers(headersWithoutAuthority("1"), false);
@@ -201,7 +250,7 @@ class Http2ServerStreamSniTest {
                                                 true);
             writer.completeTerminalWrite();
 
-            assertThat(stream.flowControl().inbound().getRemainingWindowSize(), is(8192));
+            assertThat(windowUpdates, is(List.of(new WindowUpdate(0, 1))));
             assertThat(writer.rstStreamCount, is(0));
         } finally {
             if (writer.hasPendingTerminalCallback()) {
@@ -211,19 +260,62 @@ class Http2ServerStreamSniTest {
     }
 
     @Test
-    void blockedRejectedStreamBoundsRacingDataBeforeReset() {
+    void blockedRejectedStreamAllowsAdvertisedWindowBeforeReset() {
+        int initialWindowSize = 128 * 1024;
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingConnectionWriter writer = new RecordingConnectionWriter();
-        Http2ServerStream stream = stream(streams, writer);
+        RecordingResetTracker resetTracker = new RecordingResetTracker();
+        Http2ServerStream stream = stream(streams,
+                                          writer,
+                                          new ArrayList<>(),
+                                          sniContext(),
+                                          resetTracker,
+                                          List.of(),
+                                          initialWindowSize);
         streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
         stream.prologue(PROLOGUE);
-        stream.headers(headersWithoutAuthority("70000"), false);
+        stream.headers(headersWithoutAuthority(String.valueOf(initialWindowSize)), false);
 
         stream.run();
 
         try {
             assertThat(writer.hasPendingTerminalCallback(), is(true));
-            for (int i = 0; i < 64; i++) {
+            for (int i = 0; i < 80; i++) {
+                assertDoesNotThrow(() -> writeRacingData(stream, 1024));
+            }
+            writer.completeTerminalWrite();
+
+            assertThat(resetTracker.streamState.discardedData(), is(80L * 1024));
+            assertThat(resetTracker.streamState.discardData(48 * 1024), is(true));
+            assertThat(resetTracker.streamState.discardData(1), is(false));
+        } finally {
+            if (writer.hasPendingTerminalCallback()) {
+                writer.completeTerminalWrite();
+            }
+        }
+    }
+
+    @Test
+    void blockedRejectedStreamBoundsRacingDataByAdvertisedWindow() {
+        int initialWindowSize = 128 * 1024;
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter();
+        Http2ServerStream stream = stream(streams,
+                                          writer,
+                                          new ArrayList<>(),
+                                          sniContext(),
+                                          NO_OP_RESET_TRACKER,
+                                          List.of(),
+                                          initialWindowSize);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(String.valueOf(initialWindowSize + 1024)), false);
+
+        stream.run();
+
+        try {
+            assertThat(writer.hasPendingTerminalCallback(), is(true));
+            for (int i = 0; i < initialWindowSize / 1024; i++) {
                 assertDoesNotThrow(() -> writeRacingData(stream, 1024));
             }
 
@@ -348,8 +440,7 @@ class Http2ServerStreamSniTest {
                     BufferData.create(entity),
                     false);
 
-        assertThat(windowUpdates, hasItems(new WindowUpdate(STREAM_ID, entity.length),
-                                           new WindowUpdate(0, entity.length)));
+        assertThat(windowUpdates, is(List.of(new WindowUpdate(0, entity.length))));
     }
 
     @Test
@@ -411,8 +502,24 @@ class Http2ServerStreamSniTest {
                                             SniContext sniContext,
                                             Http2ServerStream.LocallyResetStreamTracker resetTracker,
                                             List<Http2SubProtocolSelector> subProtocolSelectors) {
+        return stream(streams,
+                      writer,
+                      windowUpdates,
+                      sniContext,
+                      resetTracker,
+                      subProtocolSelectors,
+                      8192);
+    }
+
+    private static Http2ServerStream stream(Http2ConnectionStreams streams,
+                                            Http2StreamWriter writer,
+                                            List<WindowUpdate> windowUpdates,
+                                            SniContext sniContext,
+                                            Http2ServerStream.LocallyResetStreamTracker resetTracker,
+                                            List<Http2SubProtocolSelector> subProtocolSelectors,
+                                            int initialWindowSize) {
         Http2Config config = Http2Config.builder()
-                .initialWindowSize(8192)
+                .initialWindowSize(initialWindowSize)
                 .maxFrameSize(16384)
                 .build();
         ConnectionFlowControl flowControl = ConnectionFlowControl.serverBuilder((streamId, windowUpdate) ->
@@ -538,7 +645,7 @@ class Http2ServerStreamSniTest {
 
     private static final class NoOpResetTracker implements Http2ServerStream.LocallyResetStreamTracker {
         @Override
-        public void add(int streamId) {
+        public void add(int streamId, Http2ServerStream.LocallyResetStreamState streamState) {
         }
 
         @Override
@@ -554,10 +661,12 @@ class Http2ServerStreamSniTest {
         private int adds;
         private int localCompletes;
         private int remoteCompletes;
+        private Http2ServerStream.LocallyResetStreamState streamState;
 
         @Override
-        public void add(int streamId) {
+        public void add(int streamId, Http2ServerStream.LocallyResetStreamState streamState) {
             adds++;
+            this.streamState = streamState;
         }
 
         @Override

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.tests.http2;
 
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
@@ -633,14 +634,21 @@ class ConcurrentStreamsLimitTest {
             Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
             assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
 
-            for (int i = 0; i < 70; i++) {
-                BufferData delayedBody = BufferData.create(new byte[1024]);
-                h2conn.writer().writeData(new Http2FrameData(Http2FrameHeader.create(delayedBody.available(),
-                                                                                     Http2FrameTypes.DATA,
-                                                                                     Http2Flag.DataFlags.create(0),
-                                                                                     1),
-                                                             delayedBody),
-                                          FlowControl.Outbound.NOOP);
+            Http2Config defaultConfig = Http2Config.builder().build();
+            int frameSize = defaultConfig.maxFrameSize();
+            int frameCount = defaultConfig.initialWindowSize() / frameSize + 1;
+            for (int i = 0; i < frameCount; i++) {
+                BufferData delayedBody = BufferData.create(new byte[frameSize]);
+                try {
+                    h2conn.writer().writeData(new Http2FrameData(Http2FrameHeader.create(delayedBody.available(),
+                                                                                         Http2FrameTypes.DATA,
+                                                                                         Http2Flag.DataFlags.create(0),
+                                                                                         1),
+                                                                 delayedBody),
+                                              FlowControl.Outbound.NOOP);
+                } catch (UncheckedIOException _) {
+                    break;
+                }
             }
 
             assertGoAwayError(h2conn, Http2ErrorCode.ENHANCE_YOUR_CALM);

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
@@ -29,6 +29,7 @@ import io.helidon.http.http2.FlowControl;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2GoAway;
@@ -262,6 +263,43 @@ class ConcurrentStreamsLimitTest {
         }
     }
 
+    @Test
+    void delayedDataForRejectedRequestDoesNotCloseConnection(Http2TestClient client) throws InterruptedException {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
+            Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+
+            assertErrorResponse(h2conn, 1, Status.UNSUPPORTED_MEDIA_TYPE_415);
+            Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+
+            h2conn.request(3, POST, BLOCKING_PATH, WritableHeaders.create(), BufferData.create(new byte[0]));
+            assertThat("Replacement stream did not start",
+                       requestsStarted.await(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                       is(true));
+
+            h2conn.writer().writeData(new Http2FrameData(Http2FrameHeader.create(0,
+                                                                                 Http2FrameTypes.DATA,
+                                                                                 Http2Flag.DataFlags.create(
+                                                                                         Http2Flag.END_OF_STREAM),
+                                                                                 1),
+                                                         BufferData.empty()),
+                                      FlowControl.Outbound.NOOP);
+
+            releaseHandlers.countDown();
+            assertOkResponse(h2conn, 3);
+        }
+    }
+
     private void assertErrorResponse(Http2TestConnection h2conn, int streamId, Status status) {
         boolean headersSeen = false;
         boolean dataSeen = false;
@@ -283,6 +321,9 @@ class ConcurrentStreamsLimitTest {
                 Http2Headers headers = Http2Headers.create(null, responseDynamicTable, responseHuffman, frame);
                 assertThat(headers.status(), is(status));
                 headersSeen = true;
+                if (frame.header().flags(Http2FrameTypes.HEADERS).endOfStream()) {
+                    return;
+                }
             } else if (frame.header().type() == Http2FrameType.DATA) {
                 assertThat(frame.header().flags(Http2FrameTypes.DATA).endOfStream(), is(true));
                 dataSeen = true;

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webserver.tests.http2;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -35,9 +36,11 @@ import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2GoAway;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanDecoder;
+import io.helidon.http.http2.Http2HuffmanEncoder;
 import io.helidon.http.http2.Http2Priority;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
+import io.helidon.http.http2.Http2Settings;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
@@ -71,6 +74,7 @@ class ConcurrentStreamsLimitTest {
     private final Http2Headers.DynamicTable responseDynamicTable =
             Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
     private final Http2HuffmanDecoder responseHuffman = Http2HuffmanDecoder.create();
+    private Http2Headers.DynamicTable requestDynamicTable;
 
     @SetUpRoute
     static void router(HttpRouting.Builder router) {
@@ -98,7 +102,9 @@ class ConcurrentStreamsLimitTest {
     static void setup(WebServerConfig.Builder server) {
         server.addProtocol(Http2Config.builder()
                                    .sendErrorDetails(true)
+                                   .maxRapidResets(-1)
                                    .maxConcurrentStreams(MAX_CONCURRENT_STREAMS)
+                                   .maxHeaderListSize(128_000)
                                    .build());
     }
 
@@ -106,6 +112,7 @@ class ConcurrentStreamsLimitTest {
     void resetLatches() {
         requestsStarted = new CountDownLatch(MAX_CONCURRENT_STREAMS);
         releaseHandlers = new CountDownLatch(1);
+        requestDynamicTable = Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
     }
 
     @Test
@@ -264,7 +271,7 @@ class ConcurrentStreamsLimitTest {
     }
 
     @Test
-    void delayedDataForRejectedRequestDoesNotCloseConnection(Http2TestClient client) throws InterruptedException {
+    void delayedDataAndTrailersForRejectedRequestDoNotCloseConnection(Http2TestClient client) throws InterruptedException {
         try (Http2TestConnection h2conn = client.createConnection()) {
             WritableHeaders<?> requestHeaders = WritableHeaders.create();
             requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
@@ -287,16 +294,490 @@ class ConcurrentStreamsLimitTest {
                        requestsStarted.await(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
                        is(true));
 
-            h2conn.writer().writeData(new Http2FrameData(Http2FrameHeader.create(0,
+            BufferData delayedBody = BufferData.create("late body");
+            h2conn.writer().writeData(new Http2FrameData(Http2FrameHeader.create(delayedBody.available(),
                                                                                  Http2FrameTypes.DATA,
-                                                                                 Http2Flag.DataFlags.create(
-                                                                                         Http2Flag.END_OF_STREAM),
+                                                                                 Http2Flag.DataFlags.create(0),
                                                                                  1),
-                                                         BufferData.empty()),
+                                                         delayedBody),
+                                      FlowControl.Outbound.NOOP);
+            Http2Headers trailers = Http2Headers.create(WritableHeaders.create()
+                                                                    .add(HeaderNames.create("x-trailer"), "done"));
+            h2conn.writer().writeHeaders(trailers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                         FlowControl.Outbound.NOOP);
+
+            releaseHandlers.countDown();
+            assertOkResponse(h2conn, 3);
+        }
+    }
+
+    @Test
+    void resetForLocallyResetRequestDoesNotCloseConnection(Http2TestClient client) throws InterruptedException {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
+            Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+
+            assertErrorResponse(h2conn, 1, Status.UNSUPPORTED_MEDIA_TYPE_415);
+            Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+
+            h2conn.request(3, POST, BLOCKING_PATH, WritableHeaders.create(), BufferData.create(new byte[0]));
+            assertThat("Replacement stream did not start",
+                       requestsStarted.await(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                       is(true));
+
+            Http2RstStream resetFrame = new Http2RstStream(Http2ErrorCode.CANCEL);
+            h2conn.writer().writeData(resetFrame.toFrameData(Http2Settings.builder().build(),
+                                                             1,
+                                                             Http2Flag.NoFlags.create()),
                                       FlowControl.Outbound.NOOP);
 
             releaseHandlers.countDown();
             assertOkResponse(h2conn, 3);
+        } finally {
+            releaseHandlers.countDown();
+        }
+    }
+
+    @Test
+    void lateResetForAlreadyEndedLocallyResetRequestDoesNotCloseConnection(Http2TestClient client) throws InterruptedException {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.add(HeaderNames.CONTENT_LENGTH, 1);
+            Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                         FlowControl.Outbound.NOOP);
+
+            for (;;) {
+                Http2FrameData frame = h2conn.awaitNextFrame(TIMEOUT);
+                assertThat("Timed out waiting for RST_STREAM frame", frame, notNullValue());
+                if (frame.header().streamId() == 0) {
+                    continue;
+                }
+                assertThat("Unexpected response stream", frame.header().streamId(), is(1));
+                assertThat("Unexpected frame type", frame.header().type(), is(Http2FrameType.RST_STREAM));
+                Http2RstStream rstStream = Http2RstStream.create(frame.data());
+                assertThat(rstStream.errorCode(), is(Http2ErrorCode.PROTOCOL));
+                break;
+            }
+
+            writeEmptyPostRequest(h2conn, 3);
+            assertThat("Replacement stream did not start",
+                       requestsStarted.await(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                       is(true));
+
+            Http2RstStream resetFrame = new Http2RstStream(Http2ErrorCode.CANCEL);
+            h2conn.writer().writeData(resetFrame.toFrameData(Http2Settings.builder().build(),
+                                                             1,
+                                                             Http2Flag.NoFlags.create()),
+                                      FlowControl.Outbound.NOOP);
+
+            releaseHandlers.countDown();
+            assertOkResponse(h2conn, 3);
+        } finally {
+            releaseHandlers.countDown();
+        }
+    }
+
+    @Test
+    void abandonedLocallyResetRequestsAreBounded(Http2TestClient client) {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            for (int streamId = 1; streamId < 128; streamId += 2) {
+                writeRejectedRequestHeaders(h2conn, streamId);
+
+                assertErrorResponse(h2conn, streamId, Status.UNSUPPORTED_MEDIA_TYPE_415);
+                Http2RstStream rstStream = h2conn.assertRstStream(streamId, TIMEOUT);
+                assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+            }
+            writeRejectedRequestHeaders(h2conn, 129);
+            if (assertResetOverflowOrRejectedStream(h2conn, 129)) {
+                return;
+            }
+
+            BufferData delayedBody = BufferData.create("late body");
+            h2conn.writer().writeData(new Http2FrameData(Http2FrameHeader.create(delayedBody.available(),
+                                                                                 Http2FrameTypes.DATA,
+                                                                                 Http2Flag.DataFlags.create(
+                                                                                         Http2Flag.END_OF_STREAM),
+                                                                                 1),
+                                                         delayedBody),
+                                      FlowControl.Outbound.NOOP);
+
+            assertGoAwayError(h2conn, Http2ErrorCode.ENHANCE_YOUR_CALM);
+        }
+    }
+
+    @Test
+    void abandonedLocallyResetRequestHeadersAreNotReused(Http2TestClient client) {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            for (int streamId = 1; streamId < 128; streamId += 2) {
+                writeRejectedRequestHeaders(h2conn, streamId);
+
+                assertErrorResponse(h2conn, streamId, Status.UNSUPPORTED_MEDIA_TYPE_415);
+                Http2RstStream rstStream = h2conn.assertRstStream(streamId, TIMEOUT);
+                assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+            }
+            writeRejectedRequestHeaders(h2conn, 129);
+            if (assertResetOverflowOrRejectedStream(h2conn, 129)) {
+                return;
+            }
+
+            Http2Headers h2Headers = Http2Headers.create(WritableHeaders.create());
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                         FlowControl.Outbound.NOOP);
+
+            assertGoAwayError(h2conn, Http2ErrorCode.ENHANCE_YOUR_CALM);
+        }
+    }
+
+    @Test
+    void nonTerminalHeadersForRejectedRequestDoNotCloseConnection(Http2TestClient client) throws InterruptedException {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
+            Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+
+            assertErrorResponse(h2conn, 1, Status.UNSUPPORTED_MEDIA_TYPE_415);
+            Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+
+            Http2Headers trailers = Http2Headers.create(WritableHeaders.create()
+                                                                        .add(HeaderNames.create("x-trailer"), "done"));
+            h2conn.writer().writeHeaders(trailers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+
+            h2conn.request(3, POST, BLOCKING_PATH, WritableHeaders.create(), BufferData.create(new byte[0]));
+            assertThat("Replacement stream did not start",
+                       requestsStarted.await(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                       is(true));
+
+            BufferData delayedBody = BufferData.create("late body");
+            h2conn.writer().writeData(new Http2FrameData(Http2FrameHeader.create(delayedBody.available(),
+                                                                                 Http2FrameTypes.DATA,
+                                                                                 Http2Flag.DataFlags.create(
+                                                                                         Http2Flag.END_OF_STREAM),
+                                                                                 1),
+                                                         delayedBody),
+                                      FlowControl.Outbound.NOOP);
+
+            releaseHandlers.countDown();
+            assertOkResponse(h2conn, 3);
+        } finally {
+            releaseHandlers.countDown();
+        }
+    }
+
+    @Test
+    void paddedContinuedHeadersForRejectedRequestDoNotCloseConnection(Http2TestClient client) throws InterruptedException {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
+            Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+
+            assertErrorResponse(h2conn, 1, Status.UNSUPPORTED_MEDIA_TYPE_415);
+            Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+
+            Http2Headers trailers = Http2Headers.create(WritableHeaders.create()
+                                                                        .add(HeaderNames.create("x-hpack-proof"), "done"));
+            BufferData headerBlock = BufferData.growing(256);
+            trailers.write(requestDynamicTable, Http2HuffmanEncoder.create(), headerBlock);
+            byte[] headerBytes = headerBlock.readBytes();
+            int split = Math.max(1, headerBytes.length / 2);
+            BufferData firstFragment = BufferData.growing(split + 2);
+            firstFragment.write(1);
+            firstFragment.write(Arrays.copyOf(headerBytes, split));
+            firstFragment.write(0);
+
+            h2conn.writer().write(new Http2FrameData(
+                    Http2FrameHeader.create(firstFragment.available(),
+                                            Http2FrameTypes.HEADERS,
+                                            Http2Flag.HeaderFlags.create(Http2Flag.PADDED | Http2Flag.END_OF_STREAM),
+                                            1),
+                    firstFragment));
+            h2conn.writer().write(new Http2FrameData(
+                    Http2FrameHeader.create(headerBytes.length - split,
+                                            Http2FrameTypes.CONTINUATION,
+                                            Http2Flag.ContinuationFlags.create(Http2Flag.END_OF_HEADERS),
+                                            1),
+                    BufferData.create(Arrays.copyOfRange(headerBytes, split, headerBytes.length))));
+
+            writeEmptyPostRequest(h2conn, 3);
+            releaseHandlers.countDown();
+            assertOkResponse(h2conn, 3);
+        } finally {
+            releaseHandlers.countDown();
+        }
+    }
+
+    @Test
+    void completeHeadersFloodForRejectedRequestIsBounded(Http2TestClient client) {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            writeRejectedRequestHeaders(h2conn, 1);
+
+            assertErrorResponse(h2conn, 1, Status.UNSUPPORTED_MEDIA_TYPE_415);
+            Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+
+            for (int i = 0; i < 65; i++) {
+                Http2Headers trailers = Http2Headers.create(WritableHeaders.create()
+                                                                            .add(HeaderNames.create("x-trailer"),
+                                                                                 String.valueOf(i)));
+                h2conn.writer().writeHeaders(trailers,
+                                             1,
+                                             Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                             FlowControl.Outbound.NOOP);
+            }
+
+            assertGoAwayError(h2conn, Http2ErrorCode.ENHANCE_YOUR_CALM);
+        }
+    }
+
+    @Test
+    void emptyContinuationFloodForRejectedRequestIsBounded(Http2TestClient client) {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
+            Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+
+            assertErrorResponse(h2conn, 1, Status.UNSUPPORTED_MEDIA_TYPE_415);
+            Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+
+            Http2Headers trailers = Http2Headers.create(WritableHeaders.create()
+                                                                        .add(HeaderNames.create("x-trailer"), "done"));
+            h2conn.writer().writeHeaders(trailers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(0),
+                                         FlowControl.Outbound.NOOP);
+
+            for (int i = 0; i < 12; i++) {
+                h2conn.writer().write(new Http2FrameData(Http2FrameHeader.create(0,
+                                                                                 Http2FrameTypes.CONTINUATION,
+                                                                                 Http2Flag.ContinuationFlags.create(0),
+                                                                                 1),
+                                                     BufferData.empty()));
+            }
+
+            h2conn.assertGoAway(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                                "Too much subsequent empty frames received.",
+                                TIMEOUT);
+        }
+    }
+
+    @Test
+    void nonTerminalDataFloodForRejectedRequestIsBounded(Http2TestClient client) {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
+            Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+
+            assertErrorResponse(h2conn, 1, Status.UNSUPPORTED_MEDIA_TYPE_415);
+            Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+
+            for (int i = 0; i < 70; i++) {
+                BufferData delayedBody = BufferData.create(new byte[1024]);
+                h2conn.writer().writeData(new Http2FrameData(Http2FrameHeader.create(delayedBody.available(),
+                                                                                     Http2FrameTypes.DATA,
+                                                                                     Http2Flag.DataFlags.create(0),
+                                                                                     1),
+                                                             delayedBody),
+                                          FlowControl.Outbound.NOOP);
+            }
+
+            assertGoAwayError(h2conn, Http2ErrorCode.ENHANCE_YOUR_CALM);
+        }
+    }
+
+    @Test
+    void nonEmptyContinuationFloodForRejectedRequestIsBounded(Http2TestClient client) {
+        try (Http2TestConnection h2conn = client.createConnection()) {
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
+            Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+            h2Headers.method(POST);
+            h2Headers.path(BLOCKING_PATH);
+            h2Headers.scheme(h2conn.clientUri().scheme());
+            h2Headers.authority(h2conn.clientUri().authority());
+            h2conn.writer().writeHeaders(h2Headers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+
+            assertErrorResponse(h2conn, 1, Status.UNSUPPORTED_MEDIA_TYPE_415);
+            Http2RstStream rstStream = h2conn.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+
+            Http2Headers trailers = Http2Headers.create(WritableHeaders.create()
+                                                                        .add(HeaderNames.create("x-trailer"), "done"));
+            h2conn.writer().writeHeaders(trailers,
+                                         1,
+                                         Http2Flag.HeaderFlags.create(0),
+                                         FlowControl.Outbound.NOOP);
+
+            for (int i = 0; i < 70; i++) {
+                BufferData continuation = BufferData.create(new byte[1024]);
+                h2conn.writer().write(new Http2FrameData(Http2FrameHeader.create(continuation.available(),
+                                                                                 Http2FrameTypes.CONTINUATION,
+                                                                                 Http2Flag.ContinuationFlags.create(0),
+                                                                                 1),
+                                                     continuation));
+            }
+
+            assertGoAwayError(h2conn, Http2ErrorCode.ENHANCE_YOUR_CALM);
+        }
+    }
+
+    private void assertRejectedStreamTerminal(Http2TestConnection h2conn, int streamId) {
+        for (;;) {
+            Http2FrameData frame = h2conn.awaitNextFrame(TIMEOUT);
+            assertThat("Timed out waiting for rejected stream terminal frame", frame, notNullValue());
+
+            if (frame.header().type() == Http2FrameType.GO_AWAY) {
+                Http2GoAway goAway = Http2GoAway.create(frame.data());
+                fail("Unexpected GOAWAY " + goAway.errorCode() + ": " + frame.data().readString(frame.data().available()));
+            }
+            if (frame.header().streamId() == 0) {
+                continue;
+            }
+            assertThat("Unexpected response stream", frame.header().streamId(), is(streamId));
+            if (frame.header().type() == Http2FrameType.DATA) {
+                assertThat(frame.header().flags(Http2FrameTypes.DATA).endOfStream(), is(true));
+                return;
+            } else if (frame.header().type() == Http2FrameType.RST_STREAM) {
+                Http2RstStream rstStream = Http2RstStream.create(frame.data());
+                assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+                return;
+            } else {
+                fail("Unexpected HTTP/2 frame " + frame.header().type() + " for stream " + frame.header().streamId());
+            }
+        }
+    }
+
+    private void writeRejectedRequestHeaders(Http2TestConnection h2conn, int streamId) {
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        requestHeaders.add(HeaderNames.CONTENT_ENCODING, "unsupported-test-encoding");
+        Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+        h2Headers.method(POST);
+        h2Headers.path(BLOCKING_PATH);
+        h2Headers.scheme(h2conn.clientUri().scheme());
+        h2Headers.authority(h2conn.clientUri().authority());
+        h2conn.writer().writeHeaders(h2Headers,
+                                     streamId,
+                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                         FlowControl.Outbound.NOOP);
+    }
+
+    private void writeEmptyPostRequest(Http2TestConnection h2conn, int streamId) {
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        requestHeaders.add(HeaderNames.CONTENT_LENGTH, "0");
+        requestHeaders.add(HeaderNames.create("x-hpack-proof"), "done");
+        Http2Headers h2Headers = Http2Headers.create(requestHeaders);
+        h2Headers.method(POST);
+        h2Headers.path(BLOCKING_PATH);
+        h2Headers.scheme(h2conn.clientUri().scheme());
+        h2Headers.authority(h2conn.clientUri().authority());
+        BufferData headerBlock = BufferData.growing(256);
+        h2Headers.write(requestDynamicTable, Http2HuffmanEncoder.create(), headerBlock);
+        h2conn.writer().write(new Http2FrameData(
+                Http2FrameHeader.create(headerBlock.available(),
+                                        Http2FrameTypes.HEADERS,
+                                        Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                        streamId),
+                headerBlock));
+    }
+
+    private boolean assertResetOverflowOrRejectedStream(Http2TestConnection h2conn, int streamId) {
+        for (;;) {
+            Http2FrameData frame = h2conn.awaitNextFrame(TIMEOUT);
+            assertThat("Timed out waiting for rejected stream terminal frame", frame, notNullValue());
+
+            if (frame.header().type() == Http2FrameType.GO_AWAY) {
+                Http2GoAway goAway = Http2GoAway.create(frame.data());
+                assertThat(goAway.errorCode(), is(Http2ErrorCode.ENHANCE_YOUR_CALM));
+                return true;
+            }
+            if (frame.header().streamId() != streamId) {
+                continue;
+            }
+            if (frame.header().type() == Http2FrameType.RST_STREAM) {
+                Http2RstStream rstStream = Http2RstStream.create(frame.data());
+                assertThat(rstStream.errorCode(), is(Http2ErrorCode.CANCEL));
+                return false;
+            }
+        }
+    }
+
+    private void assertGoAwayError(Http2TestConnection h2conn, Http2ErrorCode errorCode) {
+        for (;;) {
+            Http2FrameData frame = h2conn.awaitNextFrame(TIMEOUT);
+            assertThat("Timed out waiting for GOAWAY", frame, notNullValue());
+
+            if (frame.header().type() != Http2FrameType.GO_AWAY) {
+                continue;
+            }
+
+            Http2GoAway goAway = Http2GoAway.create(frame.data());
+            assertThat(goAway.errorCode(), is(errorCode));
+            return;
         }
     }
 


### PR DESCRIPTION
A rejected HTTP/2 stream can reset before the request body is fully received. If delayed DATA arrives after the stream was removed, the connection can treat it as an unexpected stream update and prevent a replacement stream from starting. This updates reset cleanup so unread-body resets are registered before removal and adds a regression test for delayed DATA after a rejected request.