### PR TITLE
Reject missing declarative request entities

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
@@ -63,6 +63,7 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 
 import static io.helidon.codegen.CodegenUtil.toConstantName;
 import static io.helidon.declarative.codegen.DeclarativeTypes.SINGLETON_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.BAD_REQUEST_EXCEPTION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_ENTITY_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD;
@@ -465,6 +466,19 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                                     RestMethod restMethod,
                                     Map<String, String> headerProducers,
                                     int methodIndex) {
+        restMethod.entityParameter()
+                .ifPresent(entity -> method.addContent("if (!")
+                        .addContent(REQUEST_PARAM_NAME)
+                        .addContentLine(".content().hasEntity()) {")
+                        .increaseContentPadding()
+                        .addContent("throw new ")
+                        .addContent(BAD_REQUEST_EXCEPTION)
+                        .addContent("(\"Entity ")
+                        .addContent(entity.name())
+                        .addContentLine(" is not present in the request.\");")
+                        .decreaseContentPadding()
+                        .addContentLine("}"));
+
         // parameters
         for (RestMethodParameter parameter : restMethod.parameters()) {
             String paramName = userVariableName(parameter.name());

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/EntityGenericTypeCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/EntityGenericTypeCodegenTest.java
@@ -135,6 +135,9 @@ class EntityGenericTypeCodegenTest {
         }
 
         String generated = generatedContent.toString();
+        assertThat(generated, containsString("if (!req.content().hasEntity())"));
+        assertThat(generated,
+                   containsString("throw new BadRequestException(\"Entity entity is not present in the request.\");"));
         assertThat(generated, containsString(".content().as(GTYPE"));
         assertThat(generated, not(containsString("List<String>.class")));
     }

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
@@ -16,6 +16,9 @@
 
 package io.helidon.declarative.tests.http;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -273,6 +276,14 @@ class GreetServiceEndpoint implements GreetService {
         ServerRequest serverRequest = serverRequestSupplier.get();
         OptionalValue<String> greet = serverRequest.query().first("greet");
         return greet.get();
+    }
+
+    @Http.POST
+    @Http.Path("/input-stream")
+    String inputStreamEntity(@Http.Entity InputStream inputStream) throws IOException {
+        try (inputStream) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 
     private JsonObject response(String name) {

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -303,4 +303,22 @@ class DeclarativeHttpTest {
         assertThat(response.status(), is(Status.OK_200));
         assertThat(response.entity(), is("hello"));
     }
+
+    @Test
+    void testInputStreamEntityEcho() {
+        var response = client.post("/greet/input-stream")
+                .submit("hello", String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("hello"));
+    }
+
+    @Test
+    void testInputStreamEntityEmptyContentLengthFailure() {
+        var response = client.post("/greet/input-stream")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Entity inputStream is not present in the request."));
+    }
 }


### PR DESCRIPTION
Resolves #12147

Generated declarative server bindings now reject a required `@Http.Entity` parameter before decoding when the request has no entity. This turns the `Content-Length: 0` path into a bad-request response instead of allowing `request.content().as(InputStream.class)` to fail while binding the user method parameter.

The HTTP test coverage includes both the original `InputStream` echo path and the empty request entity failure path.
