### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/backport-issues.yml
+++ b/.github/workflows/backport-issues.yml
@@ -52,5 +52,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: etc/scripts/backport-issues.sh $GITHUB_REPOSITORY ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }} ${{ github.event.inputs.target-2 }} ${{ github.event.inputs.target-3 }} ${{ github.event.inputs.target-4 }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -62,7 +62,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: tests/${{ matrix.moduleSet }}-${{matrix.platform}}-latest-java
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       version: ${{ steps.create-tag.outputs.version }}
       tag: ${{ steps.create-tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
           token: ${{ secrets.SERVICE_ACCOUNT_TOKEN }}
@@ -62,11 +62,11 @@ jobs:
     timeout-minutes: 30
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
           ref: ${{ needs.create-tag.outputs.tag }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: "{javadoc-jars-${{ matrix.moduleSet }},docs}"
           merge-multiple: true
@@ -97,11 +97,11 @@ jobs:
     outputs:
       deployment_id: ${{ steps.deploy.outputs.deployment_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
           ref: ${{ needs.create-tag.outputs.tag }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: io-helidon-artifacts-part-*
           path: staging
@@ -115,7 +115,7 @@ jobs:
           etc/scripts/upload.sh upload_release \
             --dir="staging" \
             --description="Helidon v%{version}" >> ${GITHUB_OUTPUT}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: io-helidon-artifacts-${{ needs.create-tag.outputs.version }}
           path: staging
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
           ref: ${{ needs.create-tag.outputs.tag }}
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: smoketest/${{ matrix.archetype }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
           ref: ${{ needs.create-tag.outputs.tag }}

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -44,7 +44,7 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
       - id: get-version
@@ -62,10 +62,10 @@ jobs:
     timeout-minutes: 30
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: "{javadoc-jars-${{ matrix.moduleSet }},docs}"
           merge-multiple: true
@@ -94,10 +94,10 @@ jobs:
     timeout-minutes: 40
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: io-helidon-artifacts-part-*
           path: staging
@@ -109,7 +109,7 @@ jobs:
         run: |
           etc/scripts/upload.sh upload_snapshot \
             --dir="staging"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: io-helidon-artifacts-${{ needs.get-version.outputs.version }}
           path: staging

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -108,7 +108,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: tests/${{ matrix.moduleSet }}-${{matrix.platform}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: spotbugs/${{ matrix.moduleSet }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -153,7 +153,7 @@ jobs:
         moduleSet: [ core, others ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -205,7 +205,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: examples/${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -231,7 +231,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: archetypes/${{ matrix.group }}-${{ matrix.packaging }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -255,7 +255,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: archetypes/legacy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
@@ -284,7 +284,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: tests/packaging-${{ matrix.packaging }}-${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Defense against supply-chain attacks via mutable tags. Version tags retained as inline comments. See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions