### PR TITLE
Propagate late WebClient Content-Type updates

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
@@ -16,6 +16,9 @@
 
 package io.helidon.webclient.api;
 
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.net.UnixDomainSocketAddress;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +28,10 @@ import io.helidon.common.LruCache;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Headers;
 import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
 import io.helidon.webclient.spi.HttpClientSpi;
 
 /**
@@ -100,7 +106,10 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
 
     @Override
     protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamConsumer) {
-        return discoverHttpImplementation().outputStream(outputStreamConsumer);
+        Headers initialHeaders = WritableHeaders.create(headers());
+        ClientRequest<?> protocolRequest = discoverHttpImplementation();
+        return protocolRequest.outputStream(outputStream -> outputStreamConsumer.handle(
+                new ContentTypeSyncOutputStream(outputStream, initialHeaders, headers(), protocolRequest.headers())));
     }
 
     private ClientRequest<?> discoverHttpImplementation() {
@@ -279,6 +288,57 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
                                                        + "willing to handle it. HTTP versions supported: " + clients.keySet());
         }
         return tcpProtocols.getFirst().spi().clientRequest(this, resolvedUri);
+    }
+
+    static final class ContentTypeSyncOutputStream extends FilterOutputStream {
+        private final Headers initialHeaders;
+        private final ClientRequestHeaders sourceHeaders;
+        private final ClientRequestHeaders targetHeaders;
+        private boolean contentTypeSynced;
+
+        ContentTypeSyncOutputStream(OutputStream delegate,
+                                    Headers initialHeaders,
+                                    ClientRequestHeaders sourceHeaders,
+                                    ClientRequestHeaders targetHeaders) {
+            super(delegate);
+            this.initialHeaders = initialHeaders;
+            this.sourceHeaders = sourceHeaders;
+            this.targetHeaders = targetHeaders;
+        }
+
+        @Override
+        public void write(int data) throws IOException {
+            syncContentType();
+            out.write(data);
+        }
+
+        @Override
+        public void write(byte[] data, int offset, int length) throws IOException {
+            syncContentType();
+            out.write(data, offset, length);
+        }
+
+        @Override
+        public void close() throws IOException {
+            syncContentType();
+            super.close();
+        }
+
+        private void syncContentType() {
+            if (!contentTypeSynced) {
+                sourceHeaders.find(HeaderNames.CONTENT_TYPE)
+                        .ifPresentOrElse(contentType -> {
+                            if (!initialHeaders.contains(contentType)) {
+                                targetHeaders.set(contentType);
+                            }
+                        }, () -> {
+                            if (initialHeaders.contains(HeaderNames.CONTENT_TYPE)) {
+                                targetHeaders.remove(HeaderNames.CONTENT_TYPE);
+                            }
+                        });
+                contentTypeSynced = true;
+            }
+        }
     }
 
     private static SniSupport.Selection sniSelection(ClientUri uri,

--- a/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientRequestTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientRequestTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Headers;
+import io.helidon.http.WritableHeaders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class HttpClientRequestTest {
+    private static final HeaderName UNRELATED = HeaderNames.create("x-unrelated");
+    private static final HeaderName PROTOCOL = HeaderNames.create("x-protocol");
+
+    @Test
+    void syncsUpdatedContentTypeBeforeFirstWrite() throws IOException {
+        WritableHeaders<?> mutableInitialHeaders = WritableHeaders.create();
+        mutableInitialHeaders.set(HeaderNames.CONTENT_TYPE, "multipart/form-data");
+        mutableInitialHeaders.set(UNRELATED, "before");
+        Headers initialHeaders = mutableInitialHeaders;
+
+        ClientRequestHeaders sourceHeaders = ClientRequestHeaders.create(initialHeaders);
+        sourceHeaders.set(HeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=generated");
+        sourceHeaders.set(UNRELATED, "after");
+
+        ClientRequestHeaders targetHeaders = ClientRequestHeaders.create(initialHeaders);
+        targetHeaders.set(UNRELATED, "protocol-adjusted");
+        targetHeaders.set(PROTOCOL, "owned");
+
+        ByteArrayOutputStream delegate = new ByteArrayOutputStream();
+        try (var output = new HttpClientRequest.ContentTypeSyncOutputStream(delegate,
+                                                                            initialHeaders,
+                                                                            sourceHeaders,
+                                                                            targetHeaders)) {
+            output.write('a');
+            sourceHeaders.set(HeaderNames.CONTENT_TYPE, "too-late");
+            output.write('b');
+        }
+
+        assertThat(targetHeaders.get(HeaderNames.CONTENT_TYPE).get(), is("multipart/form-data; boundary=generated"));
+        assertThat(targetHeaders.get(UNRELATED).get(), is("protocol-adjusted"));
+        assertThat(targetHeaders.get(PROTOCOL).get(), is("owned"));
+        assertThat(delegate.toString(StandardCharsets.UTF_8), is("ab"));
+    }
+
+    @Test
+    void syncsAddedContentTypeWhenClosingEmptyBody() throws IOException {
+        Headers initialHeaders = WritableHeaders.create();
+        ClientRequestHeaders sourceHeaders = ClientRequestHeaders.create(initialHeaders);
+        ClientRequestHeaders targetHeaders = ClientRequestHeaders.create(initialHeaders);
+        sourceHeaders.set(HeaderValues.CONTENT_TYPE_TEXT_PLAIN);
+
+        new HttpClientRequest.ContentTypeSyncOutputStream(new ByteArrayOutputStream(),
+                                                          initialHeaders,
+                                                          sourceHeaders,
+                                                          targetHeaders).close();
+
+        assertThat(targetHeaders.get(HeaderNames.CONTENT_TYPE).get(), is("text/plain"));
+    }
+
+    @Test
+    void syncsRemovedContentType() throws IOException {
+        WritableHeaders<?> mutableInitialHeaders = WritableHeaders.create();
+        mutableInitialHeaders.set(HeaderValues.CONTENT_TYPE_TEXT_PLAIN);
+        Headers initialHeaders = mutableInitialHeaders;
+        ClientRequestHeaders sourceHeaders = ClientRequestHeaders.create(initialHeaders);
+        ClientRequestHeaders targetHeaders = ClientRequestHeaders.create(initialHeaders);
+        sourceHeaders.remove(HeaderNames.CONTENT_TYPE);
+
+        new HttpClientRequest.ContentTypeSyncOutputStream(new ByteArrayOutputStream(),
+                                                          initialHeaders,
+                                                          sourceHeaders,
+                                                          targetHeaders).close();
+
+        assertThat(targetHeaders.contains(HeaderNames.CONTENT_TYPE), is(false));
+    }
+
+    @Test
+    void waitsForWriteAfterFlush() throws IOException {
+        Headers initialHeaders = WritableHeaders.create();
+        ClientRequestHeaders sourceHeaders = ClientRequestHeaders.create(initialHeaders);
+        ClientRequestHeaders targetHeaders = ClientRequestHeaders.create(initialHeaders);
+        var output = new HttpClientRequest.ContentTypeSyncOutputStream(new ByteArrayOutputStream(),
+                                                                       initialHeaders,
+                                                                       sourceHeaders,
+                                                                       targetHeaders);
+
+        output.flush();
+        sourceHeaders.set(HeaderValues.CONTENT_TYPE_TEXT_PLAIN);
+        output.write('a');
+        output.close();
+
+        assertThat(targetHeaders.get(HeaderNames.CONTENT_TYPE).get(), is("text/plain"));
+    }
+}

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
@@ -17,7 +17,7 @@
 package io.helidon.webclient.http2;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import io.helidon.common.context.Context;
@@ -28,11 +28,11 @@ import io.helidon.webclient.http1.Http1ClientResponse;
 
 final class Http1FallbackHandler {
     private final CompletableFuture<WebClientServiceRequest> whenSent;
-    private final Function<Http1ClientRequest, Http1ClientResponse> responseFunction;
+    private final BiFunction<Http1ClientRequest, WebClientServiceRequest, Http1ClientResponse> responseFunction;
     private final boolean upgradeFailureResponseAllowed;
 
     Http1FallbackHandler(CompletableFuture<WebClientServiceRequest> whenSent,
-                         Function<Http1ClientRequest, Http1ClientResponse> responseFunction,
+                         BiFunction<Http1ClientRequest, WebClientServiceRequest, Http1ClientResponse> responseFunction,
                          boolean upgradeFailureResponseAllowed) {
         this.whenSent = whenSent;
         this.responseFunction = responseFunction;
@@ -40,7 +40,7 @@ final class Http1FallbackHandler {
     }
 
     Http1ClientResponse apply(Http1ClientRequest request, WebClientServiceRequest serviceRequest) {
-        return invoke(request, serviceRequest, () -> responseFunction.apply(request));
+        return invoke(request, serviceRequest, () -> responseFunction.apply(request, serviceRequest));
     }
 
     <T> T invoke(Http1ClientRequest request,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
@@ -43,7 +43,7 @@ class Http2CallEntityChain extends Http2CallChainBase {
               request,
               whenComplete,
               new Http1FallbackHandler(whenSent,
-                                       http1Request -> http1Request.submit(entity),
+                                       (http1Request, ignored) -> http1Request.submit(entity),
                                        bodyless(entity)));
         this.whenSent = whenSent;
         this.entity = entity;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.http2;
 
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -57,7 +58,14 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
               http2ClientRequest,
               whenComplete,
               new Http1FallbackHandler(whenSent,
-                                       http1Request -> http1Request.outputStream(streamHandler),
+                                       (http1Request, serviceRequest) -> {
+                                           Headers initialHeaders = WritableHeaders.create(serviceRequest.headers());
+                                           return http1Request.outputStream(outputStream -> streamHandler.handle(
+                                                   new ContentTypeSyncOutputStream(outputStream,
+                                                                                   initialHeaders,
+                                                                                   serviceRequest.headers(),
+                                                                                   http1Request.headers())));
+                                       },
                                        false));
 
         this.client = http2Client;
@@ -376,5 +384,55 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
 
     }
 
+    private static final class ContentTypeSyncOutputStream extends FilterOutputStream {
+        private final Headers initialHeaders;
+        private final ClientRequestHeaders sourceHeaders;
+        private final ClientRequestHeaders targetHeaders;
+        private boolean contentTypeSynced;
+
+        private ContentTypeSyncOutputStream(OutputStream delegate,
+                                            Headers initialHeaders,
+                                            ClientRequestHeaders sourceHeaders,
+                                            ClientRequestHeaders targetHeaders) {
+            super(delegate);
+            this.initialHeaders = initialHeaders;
+            this.sourceHeaders = sourceHeaders;
+            this.targetHeaders = targetHeaders;
+        }
+
+        @Override
+        public void write(int data) throws IOException {
+            syncContentType();
+            out.write(data);
+        }
+
+        @Override
+        public void write(byte[] data, int offset, int length) throws IOException {
+            syncContentType();
+            out.write(data, offset, length);
+        }
+
+        @Override
+        public void close() throws IOException {
+            syncContentType();
+            super.close();
+        }
+
+        private void syncContentType() {
+            if (!contentTypeSynced) {
+                sourceHeaders.find(HeaderNames.CONTENT_TYPE)
+                        .ifPresentOrElse(contentType -> {
+                            if (!initialHeaders.contains(contentType)) {
+                                targetHeaders.set(contentType);
+                            }
+                        }, () -> {
+                            if (initialHeaders.contains(HeaderNames.CONTENT_TYPE)) {
+                                targetHeaders.remove(HeaderNames.CONTENT_TYPE);
+                            }
+                        });
+                contentTypeSynced = true;
+            }
+        }
+    }
 
 }

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2ClientTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/Http2ClientTest.java
@@ -532,7 +532,7 @@ class Http2ClientTest {
     }
 
     @Test
-    void testGenericHostHeaderSniHttp1FallbackOutputStreamInvokesServicesOnce() throws Exception {
+    void testGenericHostHeaderSniHttp1FallbackOutputStream() throws Exception {
         NoAlpnHttp1TlsServer server = NoAlpnHttp1TlsServer.start();
         AtomicInteger serviceInvocations = new AtomicInteger();
         byte[] entity = "fallback-output-stream".getBytes(StandardCharsets.US_ASCII);
@@ -546,10 +546,12 @@ class Http2ClientTest {
                     return chain.proceed(request);
                 })
                 .build();
-        try (HttpClientResponse response = client.post()
+        HttpClientRequest request = client.post()
                 .path("/stream")
                 .header(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length))
-                .outputStream(it -> {
+                .header(HeaderNames.CONTENT_TYPE, "multipart/form-data");
+        try (HttpClientResponse response = request.outputStream(it -> {
+                    request.header(HeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=generated");
                     it.write(entity);
                     it.close();
                 })) {
@@ -563,6 +565,9 @@ class Http2ClientTest {
             assertThat(hasHeader(requestLines,
                                  HeaderNames.HOST.defaultCase(),
                                  "host-header.example:" + server.port()), is(true));
+            assertThat(hasHeader(requestLines,
+                                 HeaderNames.CONTENT_TYPE.defaultCase(),
+                                 "multipart/form-data; boundary=generated"), is(true));
             assertThat(server.requestBody(), is(new String(entity, StandardCharsets.US_ASCII)));
         } finally {
             client.closeResource();


### PR DESCRIPTION
### Description

Propagates `Content-Type` changes made by output stream handlers before request headers are sent. This lets integrations such as Jersey multipart serialization provide the generated boundary without changing framing or unrelated headers.

The change also reaches the actual HTTP/1 request when an HTTP/2 client falls back after TLS negotiation. The direct update and fallback paths are covered by WebClient tests; Checkstyle, copyright, and SpotBugs pass.

### Result

Relevant wire excerpt from the HTTP/1 fallback regression:

```http
POST /stream HTTP/1.1
Content-Type: multipart/form-data; boundary=generated

fallback-output-stream
```

The response status is `200 OK` and the response body is `http1`.

The corresponding Jersey integration and multipart tests are in helidon-io/helidon-microprofile#63.

Related to #12015

### Documentation

None
