### PR TITLE
Fix MP fault tolerance request scope retention (4.x)

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -112,10 +112,6 @@ class MethodInvoker implements FtSupplier<Object> {
      */
     private final AtomicBoolean fallbackCalled = new AtomicBoolean(false);
     /**
-     * Helper to properly propagate active request scope to other threads.
-     */
-    private final RequestScopeHelper requestScopeHelper;
-    /**
      * FT handler for this invoker.
      */
     private final FtHandlerTyped<Object> handler;
@@ -173,10 +169,6 @@ class MethodInvoker implements FtSupplier<Object> {
 
         // Create a new method handler to ensure correct context in fallback
         handler = createMethodHandler(methodState);
-
-        // Gather information about current request scope if active
-        requestScopeHelper = new RequestScopeHelper();
-        requestScopeHelper.saveScope();
 
         registerMetrics();
     }
@@ -332,6 +324,8 @@ class MethodInvoker implements FtSupplier<Object> {
     }
 
     private CompletableFuture<Object> callSupplierNewThread(FtSupplier<Object> supplier) {
+        RequestScopeHelper requestScopeHelper = new RequestScopeHelper();
+        requestScopeHelper.saveScope();
         FtSupplier<Object> wrappedSupplier = requestScopeHelper.wrapInScope(supplier);
 
         // Call supplier in new thread

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/RequestScopeRetentionTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/RequestScopeRetentionTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.faulttolerance;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.microprofile.testing.AddBean;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.glassfish.jersey.process.internal.RequestContext;
+import org.glassfish.jersey.process.internal.RequestScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@AddBean(RequestScopeRetentionTest.TestBean.class)
+@AddBean(value = RequestScopeRetentionTest.TrackingRequestScope.class, scope = Dependent.class)
+class RequestScopeRetentionTest extends FaultToleranceTest {
+
+    @Inject
+    private TestBean bean;
+
+    @BeforeEach
+    void resetCounters() {
+        TrackingRequestScope.CREATED.set(0);
+        TrackingRequestScope.DESTROYED.set(0);
+    }
+
+    @Test
+    void synchronousInvocationDoesNotCreateRequestScope() {
+        assertThat(bean.synchronous(), is("done"));
+        assertThat(TrackingRequestScope.CREATED.get(), is(0));
+        assertThat(TrackingRequestScope.DESTROYED.get(), is(0));
+    }
+
+    @Test
+    void asynchronousInvocationReleasesRequestScope() throws Exception {
+        CompletionStage<String> result = bean.asynchronous();
+
+        assertThat(result.toCompletableFuture().get(5, TimeUnit.SECONDS), is("done"));
+        assertThat(TrackingRequestScope.CREATED.get(), is(1));
+        assertThat(TrackingRequestScope.DESTROYED.get(), is(1));
+    }
+
+    static class TestBean {
+
+        @Timeout(value = 1, unit = ChronoUnit.MINUTES)
+        String synchronous() {
+            return "done";
+        }
+
+        @Asynchronous
+        CompletionStage<String> asynchronous() {
+            return CompletableFuture.completedFuture("done");
+        }
+    }
+
+    @Alternative
+    @Priority(1)
+    static class TrackingRequestScope extends RequestScope {
+        private static final AtomicInteger CREATED = new AtomicInteger();
+        private static final AtomicInteger DESTROYED = new AtomicInteger();
+
+        TrackingRequestScope() {
+            CREATED.incrementAndGet();
+        }
+
+        @Override
+        public RequestContext createContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #12130

Capture Jersey and CDI request scope only for asynchronous fault-tolerance invocations. This avoids retaining dependent request-scope bridge instances for synchronous calls while preserving asynchronous propagation and cleanup.
