### PR TITLE
Fix Jersey multipart boundary handling

### DIFF
--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonConnector.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package io.helidon.jersey.connector;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -43,6 +45,7 @@ import io.helidon.webclient.spi.ProtocolConfig;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientRequest;
 import org.glassfish.jersey.client.ClientResponse;
@@ -284,6 +287,17 @@ class HelidonConnector implements Connector {
     @Override
     public ClientResponse apply(ClientRequest request) {
         HttpClientResponse httpResponse;
+        if (request.hasEntity()) {
+            // Jersey multipart writers generate the boundary during serialization, after WebClient maps the headers.
+            MediaType mediaType = request.getMediaType();
+            if (mediaType != null
+                    && "multipart".equalsIgnoreCase(mediaType.getType())
+                    && !mediaType.getParameters().containsKey("boundary")) {
+                Map<String, String> parameters = new HashMap<>(mediaType.getParameters());
+                parameters.put("boundary", "Boundary_" + UUID.randomUUID());
+                request.type(new MediaType(mediaType.getType(), mediaType.getSubtype(), parameters));
+            }
+        }
         HttpClientRequest httpRequest = mapRequest(request);
 
         if (request.hasEntity()) {

--- a/jersey/tests/connector/pom.xml
+++ b/jersey/tests/connector/pom.xml
@@ -34,6 +34,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.jersey</groupId>
             <artifactId>helidon-jersey-connector</artifactId>
             <scope>test</scope>

--- a/jersey/tests/connector/src/test/java/io/helidon/jersey/connector/ConnectorBase.java
+++ b/jersey/tests/connector/src/test/java/io/helidon/jersey/connector/ConnectorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package io.helidon.jersey.connector;
 
+import java.io.IOException;
 import java.util.Arrays;
 
+import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
 import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webserver.http.HttpRules;
@@ -31,13 +33,21 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
 
 abstract class ConnectorBase {
+
+    private static final String RECEIVED_CONTENT_TYPE = "x-received-content-type";
 
     private String baseURI;
     private Client client;
@@ -49,7 +59,7 @@ abstract class ConnectorBase {
     }
 
     public void client(Client client) {
-        this.client = client;
+        this.client = client.register(MultiPartFeature.class);
     }
 
     public void protocolId(String protocolId) {
@@ -60,6 +70,7 @@ abstract class ConnectorBase {
     static void routing(HttpRules rules) {
         rules.get("/basic/get", ConnectorBase::basicGet)
              .post("/basic/post", ConnectorBase::basicPost)
+             .post("/basic/multipart", ConnectorBase::basicMultipart)
              .get("/basic/getquery", ConnectorBase::basicGetQuery)
              .get("/basic/headers", ConnectorBase::basicHeaders);
     }
@@ -79,6 +90,14 @@ abstract class ConnectorBase {
     static void basicPost(ServerRequest request, ServerResponse response) {
         String entity = request.content().as(String.class);
         response.status(Status.OK_200).send(entity + entity);
+    }
+
+    static void basicMultipart(ServerRequest request, ServerResponse response) {
+        String contentType = request.headers().get(HeaderNames.CONTENT_TYPE).get();
+        String entity = request.content().as(String.class);
+        response.header(RECEIVED_CONTENT_TYPE, contentType)
+                .status(Status.OK_200)
+                .send(entity);
     }
 
     static void basicGetQuery(ServerRequest request, ServerResponse response) {
@@ -109,6 +128,22 @@ abstract class ConnectorBase {
                 .buildPost(Entity.entity("ok", MediaType.TEXT_PLAIN_TYPE)).invoke()) {
             assertThat(response.getStatus(), is(200));
             assertThat(response.readEntity(String.class), is("okok"));
+        }
+    }
+
+    @Test
+    public void testMultipartBoundary() throws IOException {
+        try (FormDataMultiPart multipart = new FormDataMultiPart().field("field", "value");
+             Response response = target("basic").path("multipart").request()
+                     .post(Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE))) {
+            assertThat(response.getStatus(), is(200));
+            MediaType contentType = MediaType.valueOf(response.getHeaderString(RECEIVED_CONTENT_TYPE));
+            String boundary = contentType.getParameters().get("boundary");
+            assertThat(boundary, not(isEmptyOrNullString()));
+
+            String entity = response.readEntity(String.class);
+            assertThat(entity, startsWith("--" + boundary + "\r\n"));
+            assertThat(entity, endsWith("\r\n--" + boundary + "--\r\n"));
         }
     }
 


### PR DESCRIPTION
Resolves #12015

Preassign the boundary for multipart Jersey requests before mapping headers into WebClient so the writer and transport use the same Content-Type.

Add connector integration coverage across HTTP/1.1 and HTTP/2 variants.