### PR TITLE
Fix inherited declarative contract annotations

### DIFF
--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -30,8 +30,10 @@ import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.ElementSignature;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
 import io.helidon.common.types.TypedElementInfo;
 
 import static io.helidon.common.types.TypeNames.GENERATED;
@@ -42,6 +44,34 @@ import static io.helidon.common.types.TypeNames.INHERITED;
  */
 public final class TypeHierarchy {
     private TypeHierarchy() {
+    }
+
+    /**
+     * Create a method signature that treats method type-variable names as declaration-local aliases.
+     *
+     * @param method method element
+     * @return normalized method signature
+     */
+    @Api.Internal
+    public static ElementSignature methodSignature(TypedElementInfo method) {
+        Objects.requireNonNull(method);
+        if (method.kind() != ElementKind.METHOD) {
+            throw new CodegenException("Only method elements have a normalized method signature: " + method.kind());
+        }
+
+        Map<String, TypeName> methodTypeParameters = new LinkedHashMap<>();
+        List<TypeName> declaredTypeParameters = method.typeParameters();
+        for (TypeName typeParameter : declaredTypeParameters) {
+            methodTypeParameters.put(typeParameter.className(),
+                                     methodTypeErasure(typeParameter, new HashSet<>()));
+        }
+
+        List<TypeName> parameters = method.parameterArguments()
+                .stream()
+                .map(TypedElementInfo::typeName)
+                .map(it -> normalizeMethodType(it, methodTypeParameters))
+                .toList();
+        return ElementSignature.createMethod(method.typeName(), method.elementName(), parameters);
     }
 
     /**
@@ -678,6 +708,58 @@ public final class TypeHierarchy {
         return TypeInfo.builder(type)
                 .typeName(substituteTypeParameters(type.typeName(), substitutions))
                 .build();
+    }
+
+    private static TypeName normalizeMethodType(TypeName typeName, Map<String, TypeName> methodTypeParameters) {
+        if (typeName.array() && typeName.componentType().isPresent()) {
+            TypeName componentType = normalizeMethodType(typeName.componentType().orElseThrow(), methodTypeParameters);
+            return TypeName.builder(componentType)
+                    .array(true)
+                    .vararg(typeName.vararg())
+                    .componentType(componentType)
+                    .build();
+        }
+
+        TypeName replacement = typeName.generic()
+                ? methodTypeParameters.get(typeName.className())
+                : null;
+        if (replacement != null) {
+            return replacement;
+        }
+
+        TypeName.Builder builder = TypeName.builder(typeName)
+                .typeArguments(typeName.typeArguments()
+                                       .stream()
+                                       .map(it -> normalizeMethodType(it, methodTypeParameters))
+                                       .toList())
+                .lowerBounds(typeName.lowerBounds()
+                                     .stream()
+                                     .map(it -> normalizeMethodType(it, methodTypeParameters))
+                                     .toList())
+                .upperBounds(typeName.upperBounds()
+                                     .stream()
+                                     .map(it -> normalizeMethodType(it, methodTypeParameters))
+                                     .toList());
+
+        typeName.componentType()
+                .map(it -> normalizeMethodType(it, methodTypeParameters))
+                .ifPresent(builder::componentType);
+
+        return builder.build();
+    }
+
+    private static TypeName methodTypeErasure(TypeName typeName, Set<String> processed) {
+        if (!typeName.generic()) {
+            return typeName;
+        }
+        if (!processed.add(typeName.className())) {
+            return TypeNames.OBJECT;
+        }
+        return typeName.upperBounds()
+                .stream()
+                .findFirst()
+                .map(it -> methodTypeErasure(it, processed))
+                .orElse(TypeNames.OBJECT);
     }
 
     private static TypeName substituteTypeParameters(TypeName typeName, Map<String, TypeName> substitutions) {

--- a/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/TypeHierarchyTest.java
@@ -45,6 +45,92 @@ class TypeHierarchyTest {
     private static final CodegenContext CTX = new EmptyCodegenContext();
 
     @Test
+    void methodSignaturesNormalizeMethodTypeVariableNames() {
+        TypeName contractVariable = TypeName.createFromGenericDeclaration("T");
+        TypeName implementationVariable = TypeName.createFromGenericDeclaration("U");
+        TypedElementInfo contractMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("echo")
+                .typeName(TypeNames.STRING)
+                .addTypeParameter(contractVariable)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(TypeName.builder(TypeNames.LIST)
+                                                                .addTypeArgument(contractVariable)
+                                                                .build())
+                                              .build())
+                .build();
+        TypedElementInfo implementationMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("echo")
+                .typeName(TypeNames.STRING)
+                .addTypeParameter(implementationVariable)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("item")
+                                              .typeName(TypeName.builder(TypeNames.LIST)
+                                                                .addTypeArgument(implementationVariable)
+                                                                .build())
+                                              .build())
+                .build();
+
+        assertThat(TypeHierarchy.methodSignature(contractMethod),
+                   is(TypeHierarchy.methodSignature(implementationMethod)));
+    }
+
+    @Test
+    void methodSignaturesRetainMethodTypeVariableBounds() {
+        TypeName numberVariable = TypeName.builder(TypeName.createFromGenericDeclaration("T"))
+                .addUpperBound(TypeName.create(Number.class))
+                .build();
+        TypeName renamedNumberVariable = TypeName.builder(TypeName.createFromGenericDeclaration("U"))
+                .addUpperBound(TypeName.create(Number.class))
+                .build();
+        TypeName charSequenceVariable = TypeName.builder(TypeName.createFromGenericDeclaration("V"))
+                .addUpperBound(TypeName.create(CharSequence.class))
+                .build();
+        TypedElementInfo numberMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("accept")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addTypeParameter(numberVariable)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("value")
+                                              .typeName(numberVariable)
+                                              .build())
+                .build();
+        TypedElementInfo renamedNumberMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("accept")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addTypeParameter(renamedNumberVariable)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("item")
+                                              .typeName(renamedNumberVariable)
+                                              .build())
+                .build();
+        TypedElementInfo charSequenceMethod = TypedElementInfo.builder()
+                .kind(ElementKind.METHOD)
+                .elementName("accept")
+                .typeName(TypeNames.PRIMITIVE_VOID)
+                .addTypeParameter(charSequenceVariable)
+                .addParameterArgument(TypedElementInfo.builder()
+                                              .kind(ElementKind.PARAMETER)
+                                              .elementName("text")
+                                              .typeName(charSequenceVariable)
+                                              .build())
+                .build();
+
+        assertThat(TypeHierarchy.methodSignature(numberMethod),
+                   is(TypeHierarchy.methodSignature(renamedNumberMethod)));
+        assertThat(TypeHierarchy.methodSignature(numberMethod),
+                   not(TypeHierarchy.methodSignature(charSequenceMethod)));
+    }
+
+    @Test
     void nestedAnnotationsIncludeDeepGenericTypeArgumentAnnotations() {
         TypeName mapType = TypeName.builder(TypeNames.MAP)
                 .addTypeArgument(TypeNames.STRING)

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/common/DeclarativeElementInfo.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/common/DeclarativeElementInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.common;
+
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypedElementInfo;
+
+/**
+ * Utilities for declarative element processing.
+ */
+public final class DeclarativeElementInfo {
+    private DeclarativeElementInfo() {
+    }
+
+    /**
+     * Whether an effective element belongs to the service type being processed.
+     *
+     * @param typeInfo service type info
+     * @param element element to check
+     * @return whether the element belongs to the service type
+     */
+    public static boolean belongsToService(TypeInfo typeInfo, TypedElementInfo element) {
+        TypeName serviceType = typeInfo.typeName().genericTypeName();
+        return element.enclosingType()
+                .map(TypeName::genericTypeName)
+                .map(serviceType::equals)
+                .orElse(true);
+    }
+}

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/common/package-info.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/common/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common utilities for declarative code generation.
+ */
+package io.helidon.declarative.codegen.common;

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
@@ -49,6 +49,16 @@ public class FtExtensionProvider implements RegistryCodegenExtensionProvider {
     }
 
     @Override
+    public boolean supportsServiceContractAnnotations() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsFactoryProvidedServiceContractAnnotations() {
+        return false;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new FtExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtExtensionProvider.java
@@ -53,6 +53,9 @@ public class FtExtensionProvider implements RegistryCodegenExtensionProvider {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean supportsFactoryProvidedServiceContractAnnotations() {
         return false;

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtHandler.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/FtHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,22 @@
 
 package io.helidon.declarative.codegen.faulttolerance;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenUtil;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Field;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
+import io.helidon.declarative.codegen.common.DeclarativeElementInfo;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.RegistryRoundContext;
 
@@ -50,41 +52,34 @@ abstract class FtHandler {
     }
 
     void process(RegistryRoundContext roundCtx, Map<TypeName, TypeInfo> types) {
-        var elements = roundCtx.annotatedElements(annotation);
         int index = 0;
-        for (TypedElementInfo element : elements) {
-            var enclosingType = enclosingType(types, element);
-            var generatedType = generatedTypeName(enclosingType.typeName(), element, index);
-            process(roundCtx,
-                    enclosingType,
-                    element,
-                    element.annotation(annotation),
-                    generatedType,
-                    classBuilder(enclosingType.typeName(),
-                                 element,
-                                 generatedType));
-            index++;
-        }
-    }
+        Set<String> generatedTargets = new HashSet<>();
+        for (TypeInfo enclosingType : types.values()) {
+            if (enclosingType.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+            for (TypedElementInfo element : enclosingType.elementInfo()) {
+                if (!DeclarativeElementInfo.belongsToService(enclosingType, element)
+                        || !element.hasAnnotation(annotation)) {
+                    continue;
+                }
+                String target = elementTarget(enclosingType, element);
+                if (!generatedTargets.add(target)) {
+                    continue;
+                }
 
-    TypeInfo enclosingType(Map<TypeName, TypeInfo> types, TypedElementInfo element) {
-        if (element.enclosingType().isEmpty()) {
-            throw new CodegenException(
-                    annotation.className()
-                            + " annotation is only allowed on a method, yet this element does not have an enclosing type: "
-                            + element.elementName(),
-                    element.originatingElementValue());
+                var generatedType = generatedTypeName(enclosingType.typeName(), element, index);
+                process(roundCtx,
+                        enclosingType,
+                        element,
+                        element.annotation(annotation),
+                        generatedType,
+                        classBuilder(enclosingType,
+                                     element,
+                                     generatedType));
+                index++;
+            }
         }
-
-        TypeName enclosingType = element.enclosingType().get();
-        TypeInfo typeInfo = types.get(enclosingType);
-        if (typeInfo == null) {
-            throw new CodegenException(
-                    annotation.className() + " annotation is expected on a type processed as part of this processing round, "
-                            + "yet the type info is not available for type: " + enclosingType.fqName(),
-                    element.originatingElementValue());
-        }
-        return typeInfo;
     }
 
     abstract void process(RegistryRoundContext roundContext,
@@ -178,17 +173,24 @@ abstract class FtHandler {
                 .addContent(")");
     }
 
-    private ClassModel.Builder classBuilder(TypeName enclosingType,
+    private ClassModel.Builder classBuilder(TypeInfo enclosingType,
                                             TypedElementInfo element,
                                             TypeName generatedType) {
+        TypeName typeName = enclosingType.typeName();
         return ClassModel.builder()
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                 .addAnnotation(SINGLETON_ANNOTATION)
-                .addAnnotation(namedAnnotation(enclosingType, element))
-                .addAnnotation(CodegenUtil.generatedAnnotation(generator, enclosingType, generatedType, "1", ""))
-                .copyright(CodegenUtil.copyright(generator, enclosingType, generatedType))
+                .addAnnotation(namedAnnotation(elementTarget(enclosingType, element)))
+                .addAnnotation(CodegenUtil.generatedAnnotation(generator, typeName, generatedType, "1", ""))
+                .copyright(CodegenUtil.copyright(generator, typeName, generatedType))
                 .type(generatedType)
                 .sortStaticFields(false);
+    }
+
+    private String elementTarget(TypeInfo typeInfo, TypedElementInfo element) {
+        return element.enclosingType()
+                .orElse(typeInfo.typeName())
+                .fqName() + "." + element.signature().text();
     }
 
     private TypeName generatedTypeName(TypeName typeName, TypedElementInfo element, int index) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
@@ -17,7 +17,6 @@
 package io.helidon.declarative.codegen.metrics;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -31,9 +30,11 @@ import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.common.types.Annotated;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
+import io.helidon.declarative.codegen.common.DeclarativeElementInfo;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.RegistryRoundContext;
 import io.helidon.service.codegen.spi.RegistryCodegenExtension;
@@ -158,55 +159,73 @@ class MetricsExtension implements RegistryCodegenExtension {
     }
 
     private void generateCountedInterceptors(RegistryRoundContext roundContext, Map<TypeName, TypeInfo> types) {
-        Collection<TypedElementInfo> elements = roundContext.annotatedElements(ANNOTATION_COUNTED);
         Map<TypeName, AtomicInteger> counters = new HashMap<>();
         types.keySet()
                 .forEach(it -> counters.put(it, new AtomicInteger()));
 
         CountedHandler countedHandler = new CountedHandler(roundContext);
 
-        for (TypedElementInfo element : elements) {
-            TypeName enclosingType = enclosingType(element);
-            int counter = counters.computeIfAbsent(enclosingType, k -> new AtomicInteger())
-                    .getAndIncrement();
-
-            TypeInfo typeInfo = types.get(enclosingType);
-            if (typeInfo == null) {
-                typeInfo = ctx.typeInfo(enclosingType).orElseThrow(() -> new CodegenException("No type info found for type "
-                                                                                                      + enclosingType.fqName()));
+        for (TypeInfo typeInfo : types.values()) {
+            if (typeInfo.kind() == ElementKind.INTERFACE) {
+                continue;
             }
-            checkTypeIsService(roundContext, typeInfo);
-            countedHandler.handle(typeInfo, element, counter);
+            for (TypedElementInfo element : typeInfo.elementInfo()) {
+                if (!DeclarativeElementInfo.belongsToService(typeInfo, element)
+                        || !element.hasAnnotation(ANNOTATION_COUNTED)) {
+                    continue;
+                }
+
+                int counter = counters.computeIfAbsent(typeInfo.typeName(), k -> new AtomicInteger())
+                        .getAndIncrement();
+                checkTypeIsService(roundContext, typeInfo);
+                countedHandler.handle(typeInfo, element, counter);
+            }
         }
     }
 
     private void generateTimedInterceptors(RegistryRoundContext roundContext, Map<TypeName, TypeInfo> types) {
-        Collection<TypedElementInfo> elements = roundContext.annotatedElements(ANNOTATION_TIMED);
         Map<TypeName, AtomicInteger> counters = new HashMap<>();
         types.keySet()
                 .forEach(it -> counters.put(it, new AtomicInteger()));
 
         TimedHandler handler = new TimedHandler(roundContext);
 
-        for (TypedElementInfo element : elements) {
-            TypeName enclosingType = enclosingType(element);
-            int counter = counters.computeIfAbsent(enclosingType, k -> new AtomicInteger())
-                    .getAndIncrement();
-
-            TypeInfo typeInfo = types.get(enclosingType);
-            if (typeInfo == null) {
-                typeInfo = ctx.typeInfo(enclosingType).orElseThrow(() -> new CodegenException("No type info found for type "
-                                                                                                      + enclosingType.fqName()));
+        for (TypeInfo typeInfo : types.values()) {
+            if (typeInfo.kind() == ElementKind.INTERFACE) {
+                continue;
             }
-            checkTypeIsService(roundContext, typeInfo);
-            handler.handle(typeInfo, element, counter);
+            for (TypedElementInfo element : typeInfo.elementInfo()) {
+                if (!DeclarativeElementInfo.belongsToService(typeInfo, element)
+                        || !element.hasAnnotation(ANNOTATION_TIMED)) {
+                    continue;
+                }
+
+                int counter = counters.computeIfAbsent(typeInfo.typeName(), k -> new AtomicInteger())
+                        .getAndIncrement();
+                checkTypeIsService(roundContext, typeInfo);
+                handler.handle(typeInfo, element, counter);
+            }
         }
     }
 
     private void generateGaugeRegistrars(RegistryRoundContext roundContext, Map<TypeName, TypeInfo> types) {
         Map<TypeName, List<Gauge>> gaugeByType = new HashMap<>();
 
-        addGauges(roundContext, gaugeByType);
+        for (TypeInfo typeInfo : types.values()) {
+            if (typeInfo.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+            for (TypedElementInfo element : typeInfo.elementInfo()) {
+                if (!DeclarativeElementInfo.belongsToService(typeInfo, element)
+                        || !element.hasAnnotation(ANNOTATION_GAUGE)) {
+                    continue;
+                }
+
+                TypeName typeName = typeInfo.typeName();
+                var allGauges = gaugeByType.computeIfAbsent(typeName, k -> new ArrayList<>());
+                processGauge(roundContext, allGauges, typeName, element);
+            }
+        }
 
         GaugeHandler handler = new GaugeHandler(roundContext);
 
@@ -234,25 +253,6 @@ class MetricsExtension implements RegistryCodegenExtension {
                                                    + " or it must be a container-managed bean.",
                                            typeInfo.originatingElementValue());
             }
-        }
-    }
-
-    private TypeName enclosingType(TypedElementInfo element) {
-        Optional<TypeName> enclosingType = element.enclosingType();
-        if (enclosingType.isEmpty()) {
-            throw new CodegenException("Element " + element + " does not have an enclosing type",
-                                       element.originatingElementValue());
-        }
-        return enclosingType.get();
-    }
-
-    private void addGauges(RegistryRoundContext roundContext,
-                           Map<TypeName, List<Gauge>> gaugesByType) {
-        Collection<TypedElementInfo> elements = roundContext.annotatedElements(ANNOTATION_GAUGE);
-        for (TypedElementInfo element : elements) {
-            TypeName enclosingType = enclosingType(element);
-            var allGauges = gaugesByType.computeIfAbsent(enclosingType, k -> new ArrayList<>());
-            processGauge(roundContext, allGauges, enclosingType, element);
         }
     }
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtension.java
@@ -139,16 +139,15 @@ class MetricsExtension implements RegistryCodegenExtension {
     }
 
     private static List<Tag> elementTags(Annotated annotated) {
-        if (annotated.hasAnnotation(ANNOTATION_TAG)) {
-            return toTags(List.of(annotated.annotation(ANNOTATION_TAG)));
+        List<Tag> result = new ArrayList<>();
+        for (Annotation annotation : annotated.annotations()) {
+            if (ANNOTATION_TAG.equals(annotation.typeName())) {
+                result.addAll(toTags(List.of(annotation)));
+            } else if (ANNOTATION_TAGS.equals(annotation.typeName())) {
+                result.addAll(toTags(annotation.annotationValues().orElseGet(List::of)));
+            }
         }
-
-        if (annotated.hasAnnotation(ANNOTATION_TAGS)) {
-            return toTags(annotated.annotation(ANNOTATION_TAGS)
-                                  .annotationValues()
-                                  .orElseGet(List::of));
-        }
-        return List.of();
+        return List.copyOf(result);
     }
 
     private static List<Tag> toTags(List<Annotation> tags) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
@@ -53,6 +53,9 @@ public class MetricsExtensionProvider implements RegistryCodegenExtensionProvide
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean supportsFactoryProvidedServiceContractAnnotations() {
         return false;

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
@@ -49,6 +49,16 @@ public class MetricsExtensionProvider implements RegistryCodegenExtensionProvide
     }
 
     @Override
+    public boolean supportsServiceContractAnnotations() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsFactoryProvidedServiceContractAnnotations() {
+        return false;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new MetricsExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/MetricsExtensionProvider.java
@@ -45,7 +45,9 @@ public class MetricsExtensionProvider implements RegistryCodegenExtensionProvide
     public Set<TypeName> supportedAnnotations() {
         return Set.of(MetricsTypes.ANNOTATION_COUNTED,
                       MetricsTypes.ANNOTATION_TIMED,
-                      MetricsTypes.ANNOTATION_GAUGE);
+                      MetricsTypes.ANNOTATION_GAUGE,
+                      MetricsTypes.ANNOTATION_TAG,
+                      MetricsTypes.ANNOTATION_TAGS);
     }
 
     @Override

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.ElementInfoPredicates;
+import io.helidon.codegen.TypeHierarchy;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.ElementSignature;
@@ -77,7 +78,8 @@ class TracingExtension implements RegistryCodegenExtension {
 
             addTypeTracedMethods(tracedElementValue,
                                  effectiveType.elementInfo(),
-                                 type.findAnnotation(ANNOTATION_TRACED));
+                                 type.findAnnotation(ANNOTATION_TRACED),
+                                 type.typeName());
         }
 
         for (TypeInfo type : roundTypes) {
@@ -103,61 +105,26 @@ class TracingExtension implements RegistryCodegenExtension {
                     .forEach(contractEntry -> {
                         ResolvedType resolvedContract = contractEntry.getKey();
                         TypeInfo contract = contractEntry.getValue();
-                        List<String> typeParameters = contract.typeName().typeParameters();
-                        List<TypeName> typeArguments = resolvedContract.type().typeArguments();
-                        if (typeArguments.isEmpty()) {
-                            typeArguments = contract.typeName().typeArguments();
-                        }
-                        if (typeParameters.isEmpty()) {
-                            typeParameters = contract.declaredType()
-                                    .typeArguments()
-                                    .stream()
-                                    .filter(TypeName::generic)
-                                    .filter(Predicate.not(TypeName::wildcard))
-                                    .map(TypeName::className)
-                                    .map(TracingExtension::genericTypeName)
-                                    .toList();
-                        }
-                        final Map<String, TypeName> typeArgumentMapping;
-                        if (typeParameters.isEmpty() || typeArguments.isEmpty()) {
-                            typeArgumentMapping = Map.of();
-                        } else {
-                            Map<String, TypeName> result = new HashMap<>();
-                            for (int i = 0; i < Math.min(typeParameters.size(), typeArguments.size()); i++) {
-                                result.put(genericTypeName(typeParameters.get(i)), typeArguments.get(i));
-                            }
-                            typeArgumentMapping = result;
-                        }
+                        Map<String, TypeName> typeArgumentMapping = typeArgumentMapping(contract, resolvedContract.type());
                         Set<ElementSignature> contractMethods = contract.elementInfo()
                                 .stream()
                                 .filter(ElementInfoPredicates::isMethod)
                                 .filter(Predicate.not(ElementInfoPredicates::isStatic))
                                 .filter(Predicate.not(ElementInfoPredicates::isPrivate))
-                                .map(element -> {
-                                    if (typeArgumentMapping.isEmpty()) {
-                                        return element.signature();
-                                    }
-                                    List<TypedElementInfo> parameters = element.parameterArguments()
-                                            .stream()
-                                            .map(it -> TypedElementInfo.builder(it)
-                                                    .typeName(resolveTypeArguments(it.typeName(), typeArgumentMapping))
-                                                    .build())
-                                            .toList();
-
-                                    return TypedElementInfo.builder(element)
-                                            .typeName(resolveTypeArguments(element.typeName(), typeArgumentMapping))
-                                            .parameterArguments(parameters)
-                                            .build()
-                                            .signature();
-                                })
+                                .map(element -> resolveTypeArguments(element, typeArgumentMapping))
+                                .map(TypeHierarchy::methodSignature)
                                 .collect(Collectors.toUnmodifiableSet());
 
                         var contractAnnotation = contract.findAnnotation(ANNOTATION_TRACED);
                         var serviceMethods = type.elementInfo()
                                 .stream()
-                                .filter(it -> contractMethods.contains(it.signature()))
+                                .filter(it -> ElementInfoPredicates.isMethod(it)
+                                        && contractMethods.contains(TypeHierarchy.methodSignature(it)))
                                 .toList();
-                        addTypeTracedMethods(tracedElements(tracedElements, type), serviceMethods, contractAnnotation);
+                        addTypeTracedMethods(tracedElements(tracedElements, type),
+                                             serviceMethods,
+                                             contractAnnotation,
+                                             contract.typeName());
                     });
         }
 
@@ -197,7 +164,7 @@ class TracingExtension implements RegistryCodegenExtension {
                 processElement(handler,
                                serviceTypeInfo,
                                serviceType,
-                               element.typeAnnotation(),
+                               element.typeAnnotation().map(TracedTypeAnnotation::annotation),
                                element.element(),
                                index);
                 index++;
@@ -213,32 +180,151 @@ class TracingExtension implements RegistryCodegenExtension {
 
     private void addTypeTracedMethods(TracedElements tracedElementValue,
                                       Collection<TypedElementInfo> elements,
-                                      Optional<Annotation> typeAnnotation) {
+                                      Optional<Annotation> typeAnnotation,
+                                      TypeName annotationSource) {
         Map<ElementSignature, TracedElement> map = tracedElementValue.elements();
+        Optional<TracedTypeAnnotation> tracedTypeAnnotation = typeAnnotation
+                .map(it -> new TracedTypeAnnotation(it, annotationSource));
 
         elements
                 .stream()
+                .filter(element -> DeclarativeElementInfo.belongsToService(tracedElementValue.type(), element))
                 .filter(ElementInfoPredicates::isMethod)
                 .filter(Predicate.not(ElementInfoPredicates::isStatic))
                 .filter(Predicate.not(ElementInfoPredicates::isPrivate))
-                .forEach(element -> addTracedElement(map, element, typeAnnotation));
+                .forEach(element -> addTracedElement(map, element, tracedTypeAnnotation));
     }
 
     private void addTracedElement(Map<ElementSignature, TracedElement> map,
                                   TypedElementInfo element,
-                                  Optional<Annotation> typeAnnotation) {
-        map.compute(element.signature(), (key, existing) -> {
+                                  Optional<TracedTypeAnnotation> typeAnnotation) {
+        map.compute(TypeHierarchy.methodSignature(element), (key, existing) -> {
             if (existing == null) {
                 return new TracedElement(element, typeAnnotation);
             }
-            if (!existing.element().hasAnnotation(ANNOTATION_TRACED) && element.hasAnnotation(ANNOTATION_TRACED)) {
-                return new TracedElement(element, existing.typeAnnotation().or(() -> typeAnnotation));
+
+            TypedElementInfo selectedElement = existing.element();
+            if (!selectedElement.hasAnnotation(ANNOTATION_TRACED) && element.hasAnnotation(ANNOTATION_TRACED)) {
+                selectedElement = element;
             }
-            if (existing.typeAnnotation().isEmpty() && typeAnnotation.isPresent()) {
-                return new TracedElement(existing.element(), typeAnnotation);
+
+            Optional<TracedTypeAnnotation> selectedTypeAnnotation = existing.typeAnnotation();
+            if (selectedTypeAnnotation.isEmpty()) {
+                selectedTypeAnnotation = typeAnnotation;
+            } else if (typeAnnotation.isPresent()) {
+                TracedTypeAnnotation existingAnnotation = selectedTypeAnnotation.orElseThrow();
+                TracedTypeAnnotation candidateAnnotation = typeAnnotation.orElseThrow();
+                if (isSubtype(candidateAnnotation.source(), existingAnnotation.source())) {
+                    selectedTypeAnnotation = typeAnnotation;
+                } else if (!isSubtype(existingAnnotation.source(), candidateAnnotation.source())
+                        && !existingAnnotation.annotation().equals(candidateAnnotation.annotation())) {
+                    throw new CodegenException("Ambiguous tracing type annotations for " + element.signature().text()
+                                                       + " inherited from unrelated contracts "
+                                                       + existingAnnotation.source().fqName() + " and "
+                                                       + candidateAnnotation.source().fqName(),
+                                               element.originatingElementValue());
+                }
             }
-            return existing;
+
+            return new TracedElement(selectedElement, selectedTypeAnnotation);
         });
+    }
+
+    private boolean isSubtype(TypeName candidate, TypeName expectedSupertype) {
+        return isSubtype(candidate.genericTypeName(), expectedSupertype.genericTypeName(), new HashSet<>());
+    }
+
+    private boolean isSubtype(TypeName candidate, TypeName expectedSupertype, Set<TypeName> processed) {
+        if (candidate.equals(expectedSupertype)) {
+            return true;
+        }
+        if (!processed.add(candidate)) {
+            return false;
+        }
+
+        Optional<TypeInfo> candidateInfo = ctx.typeInfo(candidate)
+                .or(() -> ctx.typeInfo(candidate.genericTypeName()));
+        if (candidateInfo.isEmpty()) {
+            return false;
+        }
+
+        TypeInfo typeInfo = candidateInfo.orElseThrow();
+        for (TypeInfo interfaceType : typeInfo.interfaceTypeInfo()) {
+            if (isSubtype(interfaceType.typeName(), expectedSupertype, processed)) {
+                return true;
+            }
+        }
+        return typeInfo.superTypeInfo()
+                .map(it -> isSubtype(it.typeName(), expectedSupertype, processed))
+                .orElse(false);
+    }
+
+    private static Map<String, TypeName> typeArgumentMapping(TypeInfo contract, TypeName resolvedContract) {
+        List<String> typeParameters = contract.typeName().typeParameters();
+        List<TypeName> typeArguments = resolvedContract.typeArguments();
+        if (typeArguments.isEmpty()) {
+            typeArguments = contract.typeName().typeArguments();
+        }
+        if (typeParameters.isEmpty()) {
+            typeParameters = contract.declaredType()
+                    .typeArguments()
+                    .stream()
+                    .filter(TypeName::generic)
+                    .filter(Predicate.not(TypeName::wildcard))
+                    .map(TypeName::className)
+                    .map(TracingExtension::genericTypeName)
+                    .toList();
+        }
+        if (typeParameters.isEmpty() || typeArguments.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, TypeName> result = new HashMap<>();
+        for (int i = 0; i < Math.min(typeParameters.size(), typeArguments.size()); i++) {
+            result.put(genericTypeName(typeParameters.get(i)), typeArguments.get(i));
+        }
+        return Map.copyOf(result);
+    }
+
+    private TypedElementInfo resolveTypeArguments(TypedElementInfo element, Map<String, TypeName> typeArguments) {
+        if (typeArguments.isEmpty()) {
+            return element;
+        }
+
+        Map<String, TypeName> elementTypeArguments = typeArguments;
+        if (!element.typeParameters().isEmpty()) {
+            elementTypeArguments = new HashMap<>(typeArguments);
+            for (TypeName typeParameter : element.typeParameters()) {
+                elementTypeArguments.remove(typeParameter.className());
+            }
+        }
+        Map<String, TypeName> substitutions = elementTypeArguments;
+
+        List<TypedElementInfo> parameters = element.parameterArguments()
+                .stream()
+                .map(it -> TypedElementInfo.builder(it)
+                        .typeName(resolveTypeArguments(it.typeName(), substitutions))
+                        .build())
+                .toList();
+        List<TypeName> typeParameters = element.typeParameters()
+                .stream()
+                .map(it -> TypeName.builder(it)
+                        .lowerBounds(it.lowerBounds()
+                                             .stream()
+                                             .map(bound -> resolveTypeArguments(bound, substitutions))
+                                             .toList())
+                        .upperBounds(it.upperBounds()
+                                             .stream()
+                                             .map(bound -> resolveTypeArguments(bound, substitutions))
+                                             .toList())
+                        .build())
+                .toList();
+
+        return TypedElementInfo.builder(element)
+                .typeName(resolveTypeArguments(element.typeName(), substitutions))
+                .parameterArguments(parameters)
+                .typeParameters(typeParameters)
+                .build();
     }
 
     private static String genericTypeName(String typeParameter) {
@@ -270,10 +356,11 @@ class TracingExtension implements RegistryCodegenExtension {
         Optional<TypeName> resolvedComponentType = typeName.componentType()
                 .map(it -> resolveTypeArguments(it, typeArguments));
 
-        if (resolvedTypeArguments.equals(typeName.typeArguments())
-                && resolvedLowerBounds.equals(typeName.lowerBounds())
-                && resolvedUpperBounds.equals(typeName.upperBounds())
-                && resolvedComponentType.equals(typeName.componentType())) {
+        if (sameResolvedTypes(resolvedTypeArguments, typeName.typeArguments())
+                && sameResolvedTypes(resolvedLowerBounds, typeName.lowerBounds())
+                && sameResolvedTypes(resolvedUpperBounds, typeName.upperBounds())
+                && resolvedComponentType.map(ResolvedType::create)
+                .equals(typeName.componentType().map(ResolvedType::create))) {
             return typeName;
         }
 
@@ -283,6 +370,97 @@ class TracingExtension implements RegistryCodegenExtension {
                 .upperBounds(resolvedUpperBounds);
         resolvedComponentType.ifPresent(builder::componentType);
         return builder.build();
+    }
+
+    private static boolean sameResolvedTypes(List<TypeName> first, List<TypeName> second) {
+        return first.stream().map(ResolvedType::create).toList()
+                .equals(second.stream().map(ResolvedType::create).toList());
+    }
+
+    private String parameterTagName(TypeInfo serviceTypeInfo,
+                                    TypedElementInfo element,
+                                    TypedElementInfo effectiveParameter,
+                                    int parameterIndex) {
+        ElementSignature methodSignature = TypeHierarchy.methodSignature(element);
+        TypeInfo declaredService = ctx.typeInfo(serviceTypeInfo.typeName())
+                .or(() -> ctx.typeInfo(serviceTypeInfo.typeName().genericTypeName()))
+                .orElse(serviceTypeInfo);
+
+        for (TypedElementInfo declaredMethod : declaredService.elementInfo()) {
+            if (!ElementInfoPredicates.isMethod(declaredMethod)
+                    || !methodSignature.equals(TypeHierarchy.methodSignature(declaredMethod))
+                    || declaredMethod.parameterArguments().size() <= parameterIndex) {
+                continue;
+            }
+            TypedElementInfo declaredParameter = declaredMethod.parameterArguments().get(parameterIndex);
+            if (declaredParameter.hasAnnotation(ANNOTATION_TAG_PARAM)) {
+                return declaredParameter.annotation(ANNOTATION_TAG_PARAM)
+                        .value()
+                        .filter(Predicate.not(String::isBlank))
+                        .orElse(declaredParameter.elementName());
+            }
+        }
+
+        ServiceContracts serviceContracts = ServiceContracts.create(ctx.options(), ctx::typeInfo, declaredService);
+        Set<ResolvedType> contracts = new HashSet<>();
+        serviceContracts.addContracts(contracts, new HashSet<>(), declaredService);
+
+        ParameterTagSource selected = null;
+        for (ResolvedType unresolvedContract : contracts.stream()
+                .sorted(Comparator.comparing(it -> it.type().resolvedName()))
+                .toList()) {
+            TypeName resolvedContract = serviceContracts.resolveContractType(contracts, unresolvedContract.type());
+            Optional<TypeInfo> maybeContract = ctx.typeInfo(resolvedContract)
+                    .or(() -> ctx.typeInfo(resolvedContract.genericTypeName()));
+            if (maybeContract.isEmpty()) {
+                continue;
+            }
+
+            TypeInfo contract = maybeContract.orElseThrow();
+            Map<String, TypeName> typeArguments = typeArgumentMapping(contract, resolvedContract);
+            for (TypedElementInfo contractMethod : contract.elementInfo()) {
+                if (!ElementInfoPredicates.isMethod(contractMethod)
+                        || ElementInfoPredicates.isStatic(contractMethod)
+                        || ElementInfoPredicates.isPrivate(contractMethod)) {
+                    continue;
+                }
+
+                TypedElementInfo resolvedMethod = resolveTypeArguments(contractMethod, typeArguments);
+                if (!methodSignature.equals(TypeHierarchy.methodSignature(resolvedMethod))
+                        || resolvedMethod.parameterArguments().size() <= parameterIndex) {
+                    continue;
+                }
+
+                TypedElementInfo contractParameter = resolvedMethod.parameterArguments().get(parameterIndex);
+                if (!contractParameter.hasAnnotation(ANNOTATION_TAG_PARAM)) {
+                    continue;
+                }
+
+                Annotation annotation = contractParameter.annotation(ANNOTATION_TAG_PARAM);
+                String name = annotation.value()
+                        .filter(Predicate.not(String::isBlank))
+                        .orElse(contractParameter.elementName());
+                ParameterTagSource candidate = new ParameterTagSource(contract.typeName(), annotation, name);
+                if (selected == null || isSubtype(candidate.source(), selected.source())) {
+                    selected = candidate;
+                } else if (!isSubtype(selected.source(), candidate.source())
+                        && (!selected.annotation().equals(candidate.annotation()) || !selected.name().equals(candidate.name()))) {
+                    throw new CodegenException("Ambiguous tracing parameter annotations for " + element.signature().text()
+                                                       + " parameter " + parameterIndex
+                                                       + " inherited from unrelated contracts "
+                                                       + selected.source().fqName() + " and " + candidate.source().fqName(),
+                                               element.originatingElementValue());
+                }
+            }
+        }
+
+        if (selected != null) {
+            return selected.name();
+        }
+        return effectiveParameter.annotation(ANNOTATION_TAG_PARAM)
+                .value()
+                .filter(Predicate.not(String::isBlank))
+                .orElse(effectiveParameter.elementName());
     }
 
     private void processElement(TracedHandler handler,
@@ -358,11 +536,7 @@ class TracingExtension implements RegistryCodegenExtension {
         int i = 0;
         for (TypedElementInfo param : element.parameterArguments()) {
             if (param.hasAnnotation(ANNOTATION_TAG_PARAM)) {
-                String tagName = param.elementName();
-                var tagParam = param.annotation(ANNOTATION_TAG_PARAM);
-                tagName = tagParam.value()
-                        .filter(Predicate.not(String::isBlank))
-                        .orElse(tagName);
+                String tagName = parameterTagName(serviceTypeInfo, element, param, i);
                 tagParams.add(new TagParam(i, param.typeName(), tagName));
             }
             i++;
@@ -376,7 +550,16 @@ class TracingExtension implements RegistryCodegenExtension {
     }
 
     private record TracedElement(TypedElementInfo element,
-                                 Optional<Annotation> typeAnnotation) {
+                                 Optional<TracedTypeAnnotation> typeAnnotation) {
+    }
+
+    private record TracedTypeAnnotation(Annotation annotation,
+                                        TypeName source) {
+    }
+
+    private record ParameterTagSource(TypeName source,
+                                      Annotation annotation,
+                                      String name) {
     }
 
     record TagParam(int index, TypeName type, String name) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
@@ -18,21 +18,30 @@ package io.helidon.declarative.codegen.tracing;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.ElementInfoPredicates;
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.ElementSignature;
+import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
+import io.helidon.declarative.codegen.common.DeclarativeElementInfo;
 import io.helidon.service.codegen.RegistryCodegenContext;
 import io.helidon.service.codegen.RegistryRoundContext;
+import io.helidon.service.codegen.ServiceContracts;
 import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 
 import static io.helidon.declarative.codegen.tracing.TracingTypes.ANNOTATION_TAG_PARAM;
@@ -52,34 +61,114 @@ class TracingExtension implements RegistryCodegenExtension {
     public void process(RegistryRoundContext roundContext) {
         // collect all typeInfo + method that is traced
         Collection<TypeInfo> roundTypes = roundContext.types();
-        Map<TypeName, TypeInfo> usedTypes = new HashMap<>();
-        for (TypeInfo roundType : roundTypes) {
-            usedTypes.put(roundType.typeName(), roundType);
-        }
 
         Collection<TypeInfo> annotatedTypes = roundContext.annotatedTypes(ANNOTATION_TRACED);
-        Collection<TypedElementInfo> annotatedElements = roundContext.annotatedElements(ANNOTATION_TRACED);
 
         Map<TypeName, TracedElements> tracedElements = new HashMap<>();
 
         for (TypeInfo type : annotatedTypes) {
-            var tracedElementValue = tracedElements.computeIfAbsent(type.typeName(),
-                                                                    k -> new TracedElements(type, new HashMap<>()));
-            var map = tracedElementValue.elements();
+            if (type.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+            TracedElements tracedElementValue = tracedElements(tracedElements, type);
 
-            type.elementInfo()
-                    .stream()
-                    .filter(ElementInfoPredicates::isMethod)
-                    .filter(Predicate.not(ElementInfoPredicates::isStatic))
-                    .filter(Predicate.not(ElementInfoPredicates::isPrivate))
-                    .forEach(element -> map.put(element.signature(), element));
+            addTypeTracedMethods(tracedElementValue, type.elementInfo(), type.findAnnotation(ANNOTATION_TRACED));
         }
 
-        for (TypedElementInfo element : annotatedElements) {
-            TypeInfo type = typeForElement(roundContext, usedTypes, element);
-            tracedElements.computeIfAbsent(type.typeName(), k -> new TracedElements(type, new HashMap<>()))
-                    .elements()
-                    .put(element.signature(), element);
+        for (TypeInfo type : roundTypes) {
+            if (type.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+
+            Set<ResolvedType> contracts = new HashSet<>();
+            ServiceContracts.create(ctx.options(), roundContext::typeInfo, type)
+                    .addContracts(contracts, new HashSet<>(), type);
+
+            contracts.stream()
+                    .sorted(Comparator.comparing(contract -> contract.type().resolvedName()))
+                    .flatMap(contract -> roundContext.typeInfo(contract.type())
+                            .or(() -> roundContext.typeInfo(contract.type().genericTypeName()))
+                            .map(it -> Map.entry(contract, it))
+                            .stream())
+                    .filter(contract -> contract.getValue().hasAnnotation(ANNOTATION_TRACED))
+                    .forEach(contractEntry -> {
+                        ResolvedType resolvedContract = contractEntry.getKey();
+                        TypeInfo contract = contractEntry.getValue();
+                        List<String> typeParameters = contract.typeName().typeParameters();
+                        List<TypeName> typeArguments = resolvedContract.type().typeArguments();
+                        if (typeArguments.isEmpty()) {
+                            typeArguments = contract.typeName().typeArguments();
+                        }
+                        if (typeParameters.isEmpty()) {
+                            typeParameters = contract.declaredType()
+                                    .typeArguments()
+                                    .stream()
+                                    .filter(TypeName::generic)
+                                    .filter(Predicate.not(TypeName::wildcard))
+                                    .map(TypeName::className)
+                                    .map(TracingExtension::genericTypeName)
+                                    .toList();
+                        }
+                        final Map<String, TypeName> typeArgumentMapping;
+                        if (typeParameters.isEmpty() || typeArguments.isEmpty()) {
+                            typeArgumentMapping = Map.of();
+                        } else {
+                            Map<String, TypeName> result = new HashMap<>();
+                            for (int i = 0; i < Math.min(typeParameters.size(), typeArguments.size()); i++) {
+                                result.put(genericTypeName(typeParameters.get(i)), typeArguments.get(i));
+                            }
+                            typeArgumentMapping = result;
+                        }
+                        Set<ElementSignature> contractMethods = contract.elementInfo()
+                                .stream()
+                                .filter(ElementInfoPredicates::isMethod)
+                                .filter(Predicate.not(ElementInfoPredicates::isStatic))
+                                .filter(Predicate.not(ElementInfoPredicates::isPrivate))
+                                .map(element -> {
+                                    if (typeArgumentMapping.isEmpty()) {
+                                        return element.signature();
+                                    }
+                                    List<TypedElementInfo> parameters = element.parameterArguments()
+                                            .stream()
+                                            .map(it -> TypedElementInfo.builder(it)
+                                                    .typeName(resolveTypeArguments(it.typeName(), typeArgumentMapping))
+                                                    .build())
+                                            .toList();
+
+                                    return TypedElementInfo.builder(element)
+                                            .typeName(resolveTypeArguments(element.typeName(), typeArgumentMapping))
+                                            .parameterArguments(parameters)
+                                            .build()
+                                            .signature();
+                                })
+                                .collect(Collectors.toUnmodifiableSet());
+
+                        var contractAnnotation = contract.findAnnotation(ANNOTATION_TRACED);
+                        var serviceMethods = type.elementInfo()
+                                .stream()
+                                .filter(it -> contractMethods.contains(it.signature()))
+                                .toList();
+                        addTypeTracedMethods(tracedElements(tracedElements, type), serviceMethods, contractAnnotation);
+                    });
+        }
+
+        for (TypeInfo type : roundTypes) {
+            if (type.kind() == ElementKind.INTERFACE) {
+                continue;
+            }
+            for (TypedElementInfo element : type.elementInfo()) {
+                if (!DeclarativeElementInfo.belongsToService(type, element)
+                        || !ElementInfoPredicates.isMethod(element)
+                        || ElementInfoPredicates.isStatic(element)
+                        || ElementInfoPredicates.isPrivate(element)
+                        || !element.hasAnnotation(ANNOTATION_TRACED)) {
+                    continue;
+                }
+
+                addTracedElement(tracedElements(tracedElements, type).elements(),
+                                 element,
+                                 Optional.empty());
+            }
         }
 
         TracedHandler handler = new TracedHandler(roundContext);
@@ -92,19 +181,105 @@ class TracingExtension implements RegistryCodegenExtension {
             TypeName serviceType = tracedEntry.getKey();
             TracedElements tracedElementValue = tracedEntry.getValue();
             TypeInfo serviceTypeInfo = tracedElementValue.type();
-            Map<ElementSignature, TypedElementInfo> elements = tracedElementValue.elements();
+            Map<ElementSignature, TracedElement> elements = tracedElementValue.elements();
             int index = 0;
 
-            for (TypedElementInfo element : elements.values()) {
-                processElement(handler, serviceTypeInfo, serviceType, element, index);
+            for (TracedElement element : elements.values()) {
+                processElement(handler,
+                               serviceTypeInfo,
+                               serviceType,
+                               element.typeAnnotation(),
+                               element.element(),
+                               index);
                 index++;
             }
         }
     }
 
+    private TracedElements tracedElements(Map<TypeName, TracedElements> tracedElements,
+                                          TypeInfo type) {
+        return tracedElements.computeIfAbsent(type.typeName(),
+                                              key -> new TracedElements(type, new HashMap<>()));
+    }
+
+    private void addTypeTracedMethods(TracedElements tracedElementValue,
+                                      Collection<TypedElementInfo> elements,
+                                      Optional<Annotation> typeAnnotation) {
+        Map<ElementSignature, TracedElement> map = tracedElementValue.elements();
+
+        elements
+                .stream()
+                .filter(ElementInfoPredicates::isMethod)
+                .filter(Predicate.not(ElementInfoPredicates::isStatic))
+                .filter(Predicate.not(ElementInfoPredicates::isPrivate))
+                .forEach(element -> addTracedElement(map, element, typeAnnotation));
+    }
+
+    private void addTracedElement(Map<ElementSignature, TracedElement> map,
+                                  TypedElementInfo element,
+                                  Optional<Annotation> typeAnnotation) {
+        map.compute(element.signature(), (key, existing) -> {
+            if (existing == null) {
+                return new TracedElement(element, typeAnnotation);
+            }
+            if (!existing.element().hasAnnotation(ANNOTATION_TRACED) && element.hasAnnotation(ANNOTATION_TRACED)) {
+                return new TracedElement(element, existing.typeAnnotation().or(() -> typeAnnotation));
+            }
+            if (existing.typeAnnotation().isEmpty() && typeAnnotation.isPresent()) {
+                return new TracedElement(existing.element(), typeAnnotation);
+            }
+            return existing;
+        });
+    }
+
+    private static String genericTypeName(String typeParameter) {
+        String name = typeParameter.trim();
+        int index = name.indexOf(' ');
+        return index == -1 ? name : name.substring(0, index);
+    }
+
+    private TypeName resolveTypeArguments(TypeName typeName, Map<String, TypeName> typeArguments) {
+        if (typeName.generic()) {
+            TypeName resolved = typeArguments.get(typeName.className().trim());
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+
+        List<TypeName> resolvedTypeArguments = typeName.typeArguments()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        List<TypeName> resolvedLowerBounds = typeName.lowerBounds()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        List<TypeName> resolvedUpperBounds = typeName.upperBounds()
+                .stream()
+                .map(it -> resolveTypeArguments(it, typeArguments))
+                .toList();
+        Optional<TypeName> resolvedComponentType = typeName.componentType()
+                .map(it -> resolveTypeArguments(it, typeArguments));
+
+        if (resolvedTypeArguments.equals(typeName.typeArguments())
+                && resolvedLowerBounds.equals(typeName.lowerBounds())
+                && resolvedUpperBounds.equals(typeName.upperBounds())
+                && resolvedComponentType.equals(typeName.componentType())) {
+            return typeName;
+        }
+
+        TypeName.Builder builder = TypeName.builder(typeName)
+                .typeArguments(resolvedTypeArguments)
+                .lowerBounds(resolvedLowerBounds)
+                .upperBounds(resolvedUpperBounds);
+        resolvedComponentType.ifPresent(builder::componentType);
+        return builder.build();
+    }
+
     private void processElement(TracedHandler handler,
                                 TypeInfo serviceTypeInfo,
                                 TypeName serviceType,
+                                Optional<Annotation> typeAnnotation,
                                 TypedElementInfo element,
                                 int index) {
         // collect tags, kind etc. from all annotations
@@ -114,7 +289,7 @@ class TracingExtension implements RegistryCodegenExtension {
         String spanKind = DEFAULT_SPAN_KIND;
 
         // first gather data from type annotation
-        var maybeTraced = serviceTypeInfo.findAnnotation(ANNOTATION_TRACED);
+        var maybeTraced = typeAnnotation.or(() -> serviceTypeInfo.findAnnotation(ANNOTATION_TRACED));
         if (maybeTraced.isPresent()) {
             var traced = maybeTraced.get();
             nameTemplate = traced.value()
@@ -179,7 +354,7 @@ class TracingExtension implements RegistryCodegenExtension {
                 tagName = tagParam.value()
                         .filter(Predicate.not(String::isBlank))
                         .orElse(tagName);
-                tagParams.add(new TagParam(i, element.typeName(), tagName));
+                tagParams.add(new TagParam(i, param.typeName(), tagName));
             }
             i++;
         }
@@ -187,25 +362,12 @@ class TracingExtension implements RegistryCodegenExtension {
         handler.handle(serviceType, element, index, spanName, spanKind, tags, tagParams);
     }
 
-    private TypeInfo typeForElement(RegistryRoundContext roundContext,
-                                    Map<TypeName, TypeInfo> usedTypes,
-                                    TypedElementInfo element) {
-        var enclosing = element.enclosingType()
-                .orElseThrow(() -> new CodegenException("Annotated element does not have an enclosing type",
-                                                        element.originatingElementValue()));
-
-        var typeInfo = usedTypes.get(enclosing);
-        if (typeInfo != null) {
-            return typeInfo;
-        }
-        typeInfo = roundContext.typeInfo(enclosing)
-                .orElseThrow(() -> new CodegenException("Cannot find enclosing type " + enclosing.fqName(),
-                                                        element.originatingElementValue()));
-        usedTypes.put(enclosing, typeInfo);
-        return typeInfo;
+    private record TracedElements(TypeInfo type,
+                                  Map<ElementSignature, TracedElement> elements) {
     }
 
-    private record TracedElements(TypeInfo type, Map<ElementSignature, TypedElementInfo> elements) {
+    private record TracedElement(TypedElementInfo element,
+                                 Optional<Annotation> typeAnnotation) {
     }
 
     record TagParam(int index, TypeName type, String name) {

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtension.java
@@ -61,6 +61,8 @@ class TracingExtension implements RegistryCodegenExtension {
     public void process(RegistryRoundContext roundContext) {
         // collect all typeInfo + method that is traced
         Collection<TypeInfo> roundTypes = roundContext.types();
+        Map<TypeName, TypeInfo> effectiveTypes = new HashMap<>();
+        roundTypes.forEach(it -> effectiveTypes.put(it.typeName(), it));
 
         Collection<TypeInfo> annotatedTypes = roundContext.annotatedTypes(ANNOTATION_TRACED);
 
@@ -71,8 +73,11 @@ class TracingExtension implements RegistryCodegenExtension {
                 continue;
             }
             TracedElements tracedElementValue = tracedElements(tracedElements, type);
+            TypeInfo effectiveType = effectiveTypes.getOrDefault(type.typeName(), type);
 
-            addTypeTracedMethods(tracedElementValue, type.elementInfo(), type.findAnnotation(ANNOTATION_TRACED));
+            addTypeTracedMethods(tracedElementValue,
+                                 effectiveType.elementInfo(),
+                                 type.findAnnotation(ANNOTATION_TRACED));
         }
 
         for (TypeInfo type : roundTypes) {
@@ -81,15 +86,19 @@ class TracingExtension implements RegistryCodegenExtension {
             }
 
             Set<ResolvedType> contracts = new HashSet<>();
-            ServiceContracts.create(ctx.options(), roundContext::typeInfo, type)
-                    .addContracts(contracts, new HashSet<>(), type);
+            ServiceContracts serviceContracts = ServiceContracts.create(ctx.options(), roundContext::typeInfo, type);
+            serviceContracts.addContracts(contracts, new HashSet<>(), type);
 
             contracts.stream()
                     .sorted(Comparator.comparing(contract -> contract.type().resolvedName()))
-                    .flatMap(contract -> roundContext.typeInfo(contract.type())
-                            .or(() -> roundContext.typeInfo(contract.type().genericTypeName()))
-                            .map(it -> Map.entry(contract, it))
-                            .stream())
+                    .flatMap(contract -> {
+                        TypeName resolvedContractType = serviceContracts.resolveContractType(contracts,
+                                                                                             contract.type());
+                        return roundContext.typeInfo(resolvedContractType)
+                                .or(() -> roundContext.typeInfo(resolvedContractType.genericTypeName()))
+                                .map(it -> Map.entry(ResolvedType.create(resolvedContractType), it))
+                                .stream();
+                    })
                     .filter(contract -> contract.getValue().hasAnnotation(ANNOTATION_TRACED))
                     .forEach(contractEntry -> {
                         ResolvedType resolvedContract = contractEntry.getKey();

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
@@ -43,7 +43,8 @@ public class TracingExtensionProvider implements RegistryCodegenExtensionProvide
 
     @Override
     public Set<TypeName> supportedAnnotations() {
-        return Set.of(TracingTypes.ANNOTATION_TRACED);
+        return Set.of(TracingTypes.ANNOTATION_TRACED,
+                      TracingTypes.ANNOTATION_TAG_PARAM);
     }
 
     @Override

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
@@ -47,6 +47,16 @@ public class TracingExtensionProvider implements RegistryCodegenExtensionProvide
     }
 
     @Override
+    public boolean supportsServiceContractAnnotations() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsFactoryProvidedServiceContractAnnotations() {
+        return false;
+    }
+
+    @Override
     public RegistryCodegenExtension create(RegistryCodegenContext codegenContext) {
         return new TracingExtension(codegenContext);
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/tracing/TracingExtensionProvider.java
@@ -51,6 +51,9 @@ public class TracingExtensionProvider implements RegistryCodegenExtensionProvide
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean supportsFactoryProvidedServiceContractAnnotations() {
         return false;

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/FactoryProvidedContractAnnotationsCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/FactoryProvidedContractAnnotationsCodegenTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.GenericType;
+import io.helidon.common.types.Annotation;
+import io.helidon.faulttolerance.Ft;
+import io.helidon.faulttolerance.Retry;
+import io.helidon.metrics.api.Gauge;
+import io.helidon.metrics.api.Meter;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.Metrics;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracer;
+import io.helidon.tracing.Tracing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class FactoryProvidedContractAnnotationsCodegenTest {
+    private static final List<Class<?>> CLASSPATH = List.of(
+            Generated.class,
+            GenericType.class,
+            Annotation.class,
+            Prototype.class,
+            Service.class,
+            Ft.class,
+            Retry.class,
+            Metrics.class,
+            Meter.class,
+            Gauge.class,
+            MeterRegistry.class,
+            Tracing.class,
+            Span.class,
+            Tracer.class
+    );
+
+    @Test
+    void testSupplierProvidedFtContractDoesNotGenerateInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedFtApi.java", """
+                        package com.example;
+
+                        import io.helidon.faulttolerance.Ft;
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Contract
+                        interface ProvidedFtApi {
+                            @Ft.Retry(calls = 2)
+                            String value();
+                        }
+                        """)
+                .addSource("ProvidedFtApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class ProvidedFtApiSupplier implements Supplier<ProvidedFtApi> {
+                            @Override
+                            public ProvidedFtApi get() {
+                                return () -> "value";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput().resolve("com/example/ProvidedFtApiSupplier_value__Retry.java")),
+                   is(false));
+    }
+
+    @Test
+    void testSupplierProvidedMetricsContractDoesNotGenerateRegistrar() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedMetricsApi.java", """
+                        package com.example;
+
+                        import io.helidon.metrics.api.Meter;
+                        import io.helidon.metrics.api.Metrics;
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Contract
+                        interface ProvidedMetricsApi {
+                            @Metrics.Gauge(unit = Meter.BaseUnits.BYTES)
+                            long size();
+                        }
+                        """)
+                .addSource("ProvidedMetricsApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class ProvidedMetricsApiSupplier implements Supplier<ProvidedMetricsApi> {
+                            @Override
+                            public ProvidedMetricsApi get() {
+                                return () -> 42L;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput().resolve("com/example/ProvidedMetricsApiSupplier__GaugeRegistrar.java")),
+                   is(false));
+    }
+
+    @Test
+    void testSupplierProvidedTracingContractDoesNotGenerateInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedTracingApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        interface ProvidedTracingApi {
+                            @Tracing.Traced
+                            String traced();
+                        }
+                        """)
+                .addSource("ProvidedTracingApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class ProvidedTracingApiSupplier implements Supplier<ProvidedTracingApi> {
+                            @Override
+                            public ProvidedTracingApi get() {
+                                return () -> "traced";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(Files.exists(result.sourceOutput().resolve("com/example/ProvidedTracingApiSupplier__TracedInterceptor.java")),
+                   is(false));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/TracingContractAnnotationsCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/TracingContractAnnotationsCodegenTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.GenericType;
+import io.helidon.common.types.Annotation;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracer;
+import io.helidon.tracing.Tracing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TracingContractAnnotationsCodegenTest {
+    private static final List<Class<?>> CLASSPATH = List.of(
+            Generated.class,
+            GenericType.class,
+            Annotation.class,
+            Prototype.class,
+            Service.class,
+            Tracing.class,
+            Span.class,
+            Tracer.class
+    );
+
+    @Test
+    void testMethodTypeVariableNamesDoNotAffectMatching() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("GenericMethodContract.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        @Tracing.Traced
+                        interface GenericMethodContract {
+                            <T> String echo(T value);
+                        }
+                        """)
+                .addSource("GenericMethodService.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class GenericMethodService implements GenericMethodContract {
+                            @Override
+                            public <U> String echo(U value) {
+                                return value.toString();
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        assertThat(diagnostics,
+                   Files.exists(result.sourceOutput().resolve("com/example/GenericMethodService__TracedInterceptor.java")),
+                   is(true));
+    }
+
+    @Test
+    void testMethodTypeVariableBoundsResolveContractTypeArguments() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("BoundedMethodContract.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        @Tracing.Traced
+                        interface BoundedMethodContract<X> {
+                            <T extends X> T direct(T value);
+
+                            default <T extends Comparable<X>> T nested(T value) {
+                                return value;
+                            }
+                        }
+                        """)
+                .addSource("BoundedMethodService.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class BoundedMethodService implements BoundedMethodContract<Number> {
+                            @Override
+                            public <U extends Number> U direct(U value) {
+                                return value;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        String generated = Files.readString(
+                result.sourceOutput().resolve("com/example/BoundedMethodService__Intercepted.java"));
+        assertThat(diagnostics, generated, containsString("<T extends Comparable<Number>> T nested(T value)"));
+    }
+
+    @Test
+    void testMoreSpecificContractTypeAnnotationWins() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("BaseTracingContract.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        @Tracing.Traced("base-span")
+                        interface BaseTracingContract {
+                            String value();
+                        }
+                        """)
+                .addSource("SpecificTracingContract.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        @Tracing.Traced("specific-span")
+                        interface SpecificTracingContract extends BaseTracingContract {
+                            @Override
+                            String value();
+                        }
+                        """)
+                .addSource("SpecificTracingService.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class SpecificTracingService implements SpecificTracingContract {
+                            @Override
+                            public String value() {
+                                return "value";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        String generated = Files.readString(
+                result.sourceOutput().resolve("com/example/SpecificTracingService__TracedInterceptor.java"));
+        assertThat(generated, containsString("specific-span"));
+    }
+
+    @Test
+    void testUnrelatedContractTypeAnnotationsAreRejected() {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("FirstTracingContract.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        @Tracing.Traced("first-span")
+                        interface FirstTracingContract {
+                            String value();
+                        }
+                        """)
+                .addSource("SecondTracingContract.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        @Tracing.Traced("second-span")
+                        interface SecondTracingContract {
+                            String value();
+                        }
+                        """)
+                .addSource("AmbiguousTracingService.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class AmbiguousTracingService implements FirstTracingContract, SecondTracingContract {
+                            @Override
+                            public String value() {
+                                return "value";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(false));
+        assertThat(diagnostics, containsString("Ambiguous tracing type annotations"));
+    }
+
+    @Test
+    void testDefaultParameterTagUsesContractParameterName() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("TaggedContract.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        interface TaggedContract {
+                            String tagged(@Tracing.ParamTag int contractId);
+                        }
+                        """)
+                .addSource("TaggedService.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Singleton
+                        @Tracing.Traced
+                        class TaggedService implements TaggedContract {
+                            @Override
+                            public String tagged(int id) {
+                                return Integer.toString(id);
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+        String generated = Files.readString(
+                result.sourceOutput().resolve("com/example/TaggedService__TracedInterceptor.java"));
+        assertThat(generated, containsString(".tag(\"contractId\", contractId)"));
+    }
+
+    @Test
+    void testTypeTracedFactoryExcludesProvidedMethods() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("ProvidedApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Contract
+                        interface ProvidedApi {
+                            String providedOnly();
+                        }
+                        """)
+                .addSource("OrdinaryApi.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Contract
+                        interface OrdinaryApi {
+                            @Tracing.Traced
+                            String ordinary();
+                        }
+                        """)
+                .addSource("ProvidedApiSupplier.java", """
+                        package com.example;
+
+                        import java.util.function.Supplier;
+
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.tracing.Tracing;
+
+                        @Service.Singleton
+                        @Tracing.Traced
+                        class ProvidedApiSupplier implements Supplier<ProvidedApi>, OrdinaryApi {
+                            @Override
+                            public ProvidedApi get() {
+                                return () -> "provided";
+                            }
+
+                            @Override
+                            public String ordinary() {
+                                return "ordinary";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        boolean providedMethodInterceptor = false;
+        try (var files = Files.list(result.sourceOutput().resolve("com/example"))) {
+            for (var file : files.filter(it -> it.getFileName().toString().contains("__TracedInterceptor")).toList()) {
+                if (Files.readString(file).contains("ProvidedApiSupplier.providedOnly()")) {
+                    providedMethodInterceptor = true;
+                    break;
+                }
+            }
+        }
+        assertThat("Factory-provided methods must not be traced", providedMethodInterceptor, is(false));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/validation/ValidationCodegenTest.java
@@ -186,6 +186,88 @@ class ValidationCodegenTest {
     }
 
     @Test
+    void testImplicitServiceContractConstraintGeneratesInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        assertThat(Files.readString(interceptor, StandardCharsets.UTF_8),
+                   containsString("\"com.example.DefaultApiImpl.validate(java.lang.String)\""));
+    }
+
+    @Test
+    void testExternalContractConstraintGeneratesInterceptor() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addOption("-Ahelidon.registry.autoAddNonContractInterfaces=false")
+                .addSource("DefaultApi.java", """
+                        package com.example;
+
+                        import io.helidon.validation.Validation;
+
+                        public interface DefaultApi {
+                            String validate(@Validation.String.NotBlank String name);
+                        }
+                        """)
+                .addSource("DefaultApiImpl.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        @Service.ExternalContracts(DefaultApi.class)
+                        class DefaultApiImpl implements DefaultApi {
+                            @Override
+                            public String validate(String name) {
+                                return name;
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var interceptor = result.sourceOutput().resolve("com/example/DefaultApiImpl__ValidationInterceptor_0.java");
+        assertThat(Files.exists(interceptor), is(true));
+        assertThat(Files.readString(interceptor, StandardCharsets.UTF_8),
+                   containsString("\"com.example.DefaultApiImpl.validate(java.lang.String)\""));
+    }
+
+    @Test
     void testDescribeServiceContractConstraintGeneratesInterceptor() {
         var result = TestCompiler.builder()
                 .currentRelease()

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/InheritedFtClient.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/InheritedFtClient.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import io.helidon.faulttolerance.Ft;
+import io.helidon.http.Http;
+import io.helidon.webclient.api.RestClient;
+
+@SuppressWarnings("deprecation")
+@RestClient.Endpoint("${inherited-ft.client.uri:http://localhost:8080}")
+interface InheritedFtClient {
+    @Http.GET
+    @Http.Path("/inherited-ft/retry")
+    @Ft.Retry(calls = 2, delay = "PT0S", overallTimeout = "PT5S")
+    String retry();
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/InheritedFtEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/InheritedFtEndpoint.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.http.Http;
+import io.helidon.http.HttpException;
+import io.helidon.http.Status;
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Service.Singleton
+class InheritedFtEndpoint {
+    private static final AtomicInteger CALLS = new AtomicInteger();
+
+    @Service.Inject
+    InheritedFtEndpoint() {
+    }
+
+    static void reset() {
+        CALLS.set(0);
+    }
+
+    static int calls() {
+        return CALLS.get();
+    }
+
+    @Http.GET
+    @Http.Path("/inherited-ft/retry")
+    String retry() {
+        if (CALLS.incrementAndGet() == 1) {
+            throw new HttpException("Retry me", Status.SERVICE_UNAVAILABLE_503);
+        }
+        return "retried";
+    }
+}

--- a/declarative/tests/http/src/main/resources/application.yaml
+++ b/declarative/tests/http/src/main/resources/application.yaml
@@ -31,6 +31,9 @@ server:
 greet-service.client:
   uri: "http://localhost:${test.server.port}"
 
+inherited-ft.client:
+  uri: "http://localhost:${test.server.port}"
+
 security:
   providers:
     - abac:

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -63,6 +63,7 @@ class DeclarativeHttpTest {
     @BeforeEach
     void beforeEach() {
         SomeEntryPointInterceptor.reset();
+        InheritedFtEndpoint.reset();
     }
 
     @Test
@@ -87,6 +88,17 @@ class DeclarativeHttpTest {
         var all = typedClient.greetings();
 
         assertThat(all, hasItem(is(new GreetingDto("Hello"))));
+    }
+
+    @Test
+    void testInheritedClientRetry() {
+        InheritedFtClient typedClient = registry.get(Lookup.builder()
+                                                              .addContract(InheritedFtClient.class)
+                                                              .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                              .build());
+
+        assertThat(typedClient.retry(), is("retried"));
+        assertThat(InheritedFtEndpoint.calls(), is(2));
     }
 
     @Test

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
@@ -33,4 +33,15 @@ interface InheritedMetricsContract {
     @Metrics.Gauge(value = "inherited-gauge", absoluteName = true, unit = Meter.BaseUnits.BYTES)
     @Metrics.Tag(key = "contract", value = "gauge")
     int inheritedGaugeValue();
+
+    @Http.GET
+    @Http.Path("/split-counted")
+    @Metrics.Tag(key = "contract", value = "split-counted")
+    String splitCounted();
+
+    @Http.GET
+    @Http.Path("/split-timed")
+    @Metrics.Tag(key = "contract", value = "split-timed")
+    @Metrics.Tag(key = "declaration", value = "contract")
+    String splitTimed();
 }

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
@@ -27,8 +27,10 @@ interface InheritedMetricsContract {
     @Http.GET
     @Http.Path("/inherited-counted")
     @Metrics.Counted(value = "inherited-counted", absoluteName = true)
+    @Metrics.Tag(key = "contract", value = "counted")
     String inheritedCounted();
 
     @Metrics.Gauge(value = "inherited-gauge", absoluteName = true, unit = Meter.BaseUnits.BYTES)
+    @Metrics.Tag(key = "contract", value = "gauge")
     int inheritedGaugeValue();
 }

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/InheritedMetricsContract.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.metrics;
+
+import io.helidon.http.Http;
+import io.helidon.metrics.api.Meter;
+import io.helidon.metrics.api.Metrics;
+import io.helidon.service.registry.Service;
+
+@SuppressWarnings("deprecation")
+@Service.Contract
+interface InheritedMetricsContract {
+    @Http.GET
+    @Http.Path("/inherited-counted")
+    @Metrics.Counted(value = "inherited-counted", absoluteName = true)
+    String inheritedCounted();
+
+    @Metrics.Gauge(value = "inherited-gauge", absoluteName = true, unit = Meter.BaseUnits.BYTES)
+    int inheritedGaugeValue();
+}

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
@@ -61,6 +61,18 @@ class TestEndpoint implements InheritedMetricsContract {
         return gaugeValue.get() + 1;
     }
 
+    @Override
+    @Metrics.Counted(value = "split-counted", absoluteName = true)
+    public String splitCounted() {
+        return "split counted";
+    }
+
+    @Override
+    @Metrics.Timed(value = "split-timed", absoluteName = true)
+    public String splitTimed() {
+        return "split timed";
+    }
+
     @Http.GET
     @Http.Path("/timed")
     @Metrics.Timed(value = "my-timed-metric", absoluteName = true)

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
@@ -48,11 +48,15 @@ class TestEndpoint implements InheritedMetricsContract {
     }
 
     @Override
+    @Metrics.Tag(key = "implementationOne", value = "one")
+    @Metrics.Tag(key = "implementationTwo", value = "two")
     public String inheritedCounted() {
         return "inherited counted";
     }
 
     @Override
+    @Metrics.Tag(key = "implementationOne", value = "one")
+    @Metrics.Tag(key = "implementationTwo", value = "two")
     public int inheritedGaugeValue() {
         return gaugeValue.get() + 1;
     }

--- a/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
+++ b/declarative/tests/metrics/src/main/java/io/helidon/declarative/tests/metrics/TestEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import io.helidon.webserver.http.RestServer;
 @Service.Singleton
 @Metrics.Tag(key = "endpoint", value = "TestEndpoint")
 @Metrics.Tag(key = "application", value = "MyNiceApp")
-class TestEndpoint {
+class TestEndpoint implements InheritedMetricsContract {
     private final MeterRegistry meterRegistry;
     private final AtomicInteger gaugeValue = new AtomicInteger();
 
@@ -45,6 +45,16 @@ class TestEndpoint {
     @Metrics.Counted(tags = @Metrics.Tag(key = "location", value = "method"))
     String counted() {
         return "counted";
+    }
+
+    @Override
+    public String inheritedCounted() {
+        return "inherited counted";
+    }
+
+    @Override
+    public int inheritedGaugeValue() {
+        return gaugeValue.get() + 1;
     }
 
     @Http.GET

--- a/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
+++ b/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
@@ -121,12 +121,16 @@ class DeclarativeMetricsTest {
         assertThat(gauge, notNullValue());
         assertThat(gauge.intValue(), is(42));
 
-        BigDecimal inheritedCounted = appMetrics.numberValue("inherited-counted;application=MyNiceApp;endpoint=TestEndpoint")
+        BigDecimal inheritedCounted = appMetrics.numberValue("inherited-counted;application=MyNiceApp;contract=counted;"
+                                                                      + "endpoint=TestEndpoint;implementationOne=one;"
+                                                                      + "implementationTwo=two")
                 .orElse(null);
         assertThat(inheritedCounted, notNullValue());
         assertThat(inheritedCounted.intValue(), is(1));
 
-        BigDecimal inheritedGauge = appMetrics.numberValue("inherited-gauge;application=MyNiceApp;endpoint=TestEndpoint")
+        BigDecimal inheritedGauge = appMetrics.numberValue("inherited-gauge;application=MyNiceApp;contract=gauge;"
+                                                                    + "endpoint=TestEndpoint;implementationOne=one;"
+                                                                    + "implementationTwo=two")
                 .orElse(null);
         assertThat(inheritedGauge, notNullValue());
         assertThat(inheritedGauge.intValue(), is(43));

--- a/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
+++ b/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
@@ -97,6 +97,18 @@ class DeclarativeMetricsTest {
 
     @Test
     @Order(6)
+    void testSplitMetricAnnotations() {
+        var countedResponse = client.get("/endpoint/split-counted").request(String.class);
+        var timedResponse = client.get("/endpoint/split-timed").request(String.class);
+
+        assertThat(countedResponse.status(), is(Status.OK_200));
+        assertThat(countedResponse.entity(), is("split counted"));
+        assertThat(timedResponse.status(), is(Status.OK_200));
+        assertThat(timedResponse.entity(), is("split timed"));
+    }
+
+    @Test
+    @Order(7)
     void testMetricsObserver() {
         var response = client.get("/observe/metrics")
                 .header(HeaderValues.ACCEPT_JSON)
@@ -134,5 +146,19 @@ class DeclarativeMetricsTest {
                 .orElse(null);
         assertThat(inheritedGauge, notNullValue());
         assertThat(inheritedGauge.intValue(), is(43));
+
+        BigDecimal splitCounted = appMetrics.numberValue("split-counted;application=MyNiceApp;contract=split-counted;"
+                                                                  + "endpoint=TestEndpoint")
+                .orElse(null);
+        assertThat(splitCounted, notNullValue());
+        assertThat(splitCounted.intValue(), is(1));
+
+        JsonObject splitTimed = appMetrics.objectValue("split-timed").orElse(null);
+        assertThat("Application metrics: " + appMetrics, splitTimed, notNullValue());
+        BigDecimal splitTimedCount = splitTimed.numberValue("count;application=MyNiceApp;contract=split-timed;"
+                                                                    + "declaration=contract;endpoint=TestEndpoint")
+                .orElse(null);
+        assertThat("Split timed metric: " + splitTimed, splitTimedCount, notNullValue());
+        assertThat(splitTimedCount.intValue(), is(1));
     }
 }

--- a/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
+++ b/declarative/tests/metrics/src/test/java/io/helidon/declarative/tests/metrics/DeclarativeMetricsTest.java
@@ -87,6 +87,16 @@ class DeclarativeMetricsTest {
     }
 
     @Test
+    @Order(5)
+    void testInheritedCounted() {
+        var response = client.get("/endpoint/inherited-counted").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("inherited counted"));
+    }
+
+    @Test
+    @Order(6)
     void testMetricsObserver() {
         var response = client.get("/observe/metrics")
                 .header(HeaderValues.ACCEPT_JSON)
@@ -110,5 +120,15 @@ class DeclarativeMetricsTest {
                 .orElse(null);
         assertThat(gauge, notNullValue());
         assertThat(gauge.intValue(), is(42));
+
+        BigDecimal inheritedCounted = appMetrics.numberValue("inherited-counted;application=MyNiceApp;endpoint=TestEndpoint")
+                .orElse(null);
+        assertThat(inheritedCounted, notNullValue());
+        assertThat(inheritedCounted.intValue(), is(1));
+
+        BigDecimal inheritedGauge = appMetrics.numberValue("inherited-gauge;application=MyNiceApp;endpoint=TestEndpoint")
+                .orElse(null);
+        assertThat(inheritedGauge, notNullValue());
+        assertThat(inheritedGauge.intValue(), is(43));
     }
 }

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingContract.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+
+@SuppressWarnings("deprecation")
+@Service.Contract
+@Http.Path("/generic")
+@Tracing.Traced(value = "generic-type-%2$s",
+                tags = @Tracing.Tag(key = "source", value = "generic-contract-type"),
+                kind = Span.Kind.SERVER)
+interface GenericTracingContract<T> {
+    @Http.GET
+    @Http.Path("/type-traced")
+    T genericTypeTraced(@Http.QueryParam("name") T name);
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingEndpoint.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingEndpoint.java
@@ -21,7 +21,7 @@ import io.helidon.webserver.http.RestServer;
 
 @RestServer.Endpoint
 @Service.Singleton
-class GenericTracingEndpoint implements GenericTracingContract<String> {
+class GenericTracingEndpoint implements IntermediateTracingContract<String> {
     @Service.Inject
     GenericTracingEndpoint() {
     }

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingEndpoint.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/GenericTracingEndpoint.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Service.Singleton
+class GenericTracingEndpoint implements GenericTracingContract<String> {
+    @Service.Inject
+    GenericTracingEndpoint() {
+    }
+
+    @Override
+    public String genericTypeTraced(String name) {
+        return "generic " + name;
+    }
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingContract.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+
+@SuppressWarnings("deprecation")
+@Service.Contract
+@Http.Path("/inherited")
+@Tracing.Traced(value = "inherited-type-%2$s",
+                tags = @Tracing.Tag(key = "source", value = "contract-type"),
+                kind = Span.Kind.SERVER)
+interface InheritedTracingContract {
+    @Http.GET
+    @Http.Path("/traced")
+    @Tracing.Traced(value = "inherited-traced",
+                    tags = @Tracing.Tag(key = "source", value = "contract"),
+                    kind = Span.Kind.SERVER)
+    String inheritedTraced();
+
+    @Http.GET
+    @Http.Path("/type-traced")
+    String typeTraced();
+
+    @Http.GET
+    @Http.Path("/tagged")
+    @Tracing.Traced(value = "inherited-tagged", kind = Span.Kind.SERVER)
+    String inheritedTagged(@Http.QueryParam("id") @Tracing.ParamTag("id") int id);
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingEndpoint.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/InheritedTracingEndpoint.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Service.Singleton
+class InheritedTracingEndpoint implements InheritedTracingContract, UntracedTracingContract {
+    @Service.Inject
+    InheritedTracingEndpoint() {
+    }
+
+    @Override
+    public String inheritedTraced() {
+        return "inherited traced";
+    }
+
+    @Override
+    public String typeTraced() {
+        return "type traced";
+    }
+
+    @Override
+    public String inheritedTagged(int id) {
+        return "tagged " + id;
+    }
+
+    @Override
+    public String untraced() {
+        return "untraced";
+    }
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/IntermediateTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/IntermediateTracingContract.java
@@ -16,29 +16,14 @@
 
 package io.helidon.declarative.tests.tracing;
 
+import io.helidon.http.Http;
 import io.helidon.service.registry.Service;
-import io.helidon.tracing.Span;
-import io.helidon.tracing.Tracing;
-import io.helidon.webserver.http.RestServer;
 
-@RestServer.Endpoint
-@Service.Singleton
-@SuppressWarnings("deprecation")
-@Tracing.Traced(value = "implementation-type-%2$s",
-                tags = @Tracing.Tag(key = "source", value = "implementation-type"),
-                kind = Span.Kind.SERVER)
-class TypedTracingEndpoint implements TypedTracingContract {
-    @Service.Inject
-    TypedTracingEndpoint() {
-    }
-
+@Service.Contract
+@Http.Path("/generic")
+interface IntermediateTracingContract<T> extends GenericTracingContract<T> {
     @Override
-    public String contractMethod() {
-        return "typed contract";
-    }
-
-    @Override
-    public String typeContractParam(int id) {
-        return "typed " + id;
-    }
+    @Http.GET
+    @Http.Path("/type-traced")
+    T genericTypeTraced(@Http.QueryParam("name") T name);
 }

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingContract.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+
+@SuppressWarnings("deprecation")
+@Service.Contract
+@Http.Path("/typed")
+interface TypedTracingContract {
+    @Http.GET
+    @Http.Path("/method")
+    @Tracing.Traced(value = "contract-method",
+                    tags = @Tracing.Tag(key = "source", value = "contract-method"),
+                    kind = Span.Kind.SERVER)
+    String contractMethod();
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingContract.java
@@ -34,5 +34,5 @@ interface TypedTracingContract {
 
     @Http.GET
     @Http.Path("/type-param")
-    String typeContractParam(@Http.QueryParam("id") @Tracing.ParamTag("id") int id);
+    String typeContractParam(@Http.QueryParam("id") @Tracing.ParamTag int contractId);
 }

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingContract.java
@@ -31,4 +31,8 @@ interface TypedTracingContract {
                     tags = @Tracing.Tag(key = "source", value = "contract-method"),
                     kind = Span.Kind.SERVER)
     String contractMethod();
+
+    @Http.GET
+    @Http.Path("/type-param")
+    String typeContractParam(@Http.QueryParam("id") @Tracing.ParamTag("id") int id);
 }

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingEndpoint.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/TypedTracingEndpoint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.service.registry.Service;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracing;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Service.Singleton
+@SuppressWarnings("deprecation")
+@Tracing.Traced(value = "implementation-type-%2$s",
+                tags = @Tracing.Tag(key = "source", value = "implementation-type"),
+                kind = Span.Kind.SERVER)
+class TypedTracingEndpoint implements TypedTracingContract {
+    @Service.Inject
+    TypedTracingEndpoint() {
+    }
+
+    @Override
+    public String contractMethod() {
+        return "typed contract";
+    }
+}

--- a/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/UntracedTracingContract.java
+++ b/declarative/tests/tracing/src/main/java/io/helidon/declarative/tests/tracing/UntracedTracingContract.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.tracing;
+
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+
+@Service.Contract
+interface UntracedTracingContract {
+    @Http.GET
+    @Http.Path("/plain")
+    String untraced();
+}

--- a/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
+++ b/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
@@ -239,6 +239,205 @@ public class DeclarativeTracingTest {
         assertAttribute(attributes, "exception.type", NotFoundException.class.getName());
     }
 
+    @Test
+    @Order(4)
+    void testInheritedMethodTraced() {
+        var response = client.get("/inherited/traced").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("inherited traced"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing inherited traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("inherited-traced"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "contract");
+    }
+
+    @Test
+    @Order(5)
+    void testInheritedTypeTraced() {
+        var response = client.get("/inherited/type-traced").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("type traced"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing inherited type traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("inherited-type-typeTraced"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "contract-type");
+    }
+
+    @Test
+    @Order(6)
+    void testInheritedTaggedParam() {
+        var response = client.get("/inherited/tagged")
+                .queryParam("id", "7")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("tagged 7"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing inherited tagged traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("inherited-tagged"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "contract-type");
+        Long actualValue = tracedMethod.getAttributes().get(AttributeKey.longKey("id"));
+        assertThat("Long Attribute of key: id", actualValue, is(7L));
+    }
+
+    @Test
+    @Order(7)
+    void testInheritedTypeTracedDoesNotApplyToOtherContracts() {
+        var response = client.get("/inherited/plain").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("untraced"));
+
+        var data = exporter.spanData(2);
+        exporter.clear();
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(names, is(Set.of("HTTP Request", "content-write")));
+    }
+
+    @Test
+    @Order(8)
+    void testGenericInheritedTypeTraced() {
+        var response = client.get("/generic/type-traced")
+                .queryParam("name", "value")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("generic value"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing generic inherited type traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("generic-type-genericTypeTraced"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "generic-contract-type");
+    }
+
+    @Test
+    @Order(9)
+    void testInheritedMethodTracedOverridesImplementationTypeTraced() {
+        var response = client.get("/typed/method").request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("typed contract"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing inherited typed traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("contract-method"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "contract-method");
+    }
+
     private void assertAttribute(Attributes attributes, String key, String expectedValue) {
         var actualValue = attributes.get(AttributeKey.stringKey(key));
 

--- a/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
+++ b/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
@@ -473,8 +473,8 @@ public class DeclarativeTracingTest {
         assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
 
         assertAttribute(tracedMethod.getAttributes(), "source", "implementation-type");
-        Long actualValue = tracedMethod.getAttributes().get(AttributeKey.longKey("id"));
-        assertThat("Long Attribute of key: id", actualValue, is(11L));
+        Long actualValue = tracedMethod.getAttributes().get(AttributeKey.longKey("contractId"));
+        assertThat("Long Attribute of key: contractId", actualValue, is(11L));
     }
 
     private void assertAttribute(Attributes attributes, String key, String expectedValue) {

--- a/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
+++ b/declarative/tests/tracing/src/test/java/io/helidon/declarative/tests/tracing/DeclarativeTracingTest.java
@@ -438,6 +438,45 @@ public class DeclarativeTracingTest {
         assertAttribute(tracedMethod.getAttributes(), "source", "contract-method");
     }
 
+    @Test
+    @Order(10)
+    void testImplementationTypeTracedRetainsInheritedParamTag() {
+        var response = client.get("/typed/type-param")
+                .queryParam("id", "11")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("typed 11"));
+
+        var data = exporter.spanData(3);
+        exporter.clear();
+
+        SpanData tracedMethod = null;
+        for (SpanData spanDatum : data) {
+            switch (spanDatum.getName()) {
+            case "HTTP Request":
+            case "content-write":
+                break;
+            default:
+                tracedMethod = spanDatum;
+                break;
+            }
+        }
+
+        Set<String> names = data.stream()
+                .map(SpanData::getName)
+                .collect(Collectors.toSet());
+
+        assertThat("Found names: " + names + ", missing implementation type traced method", tracedMethod, notNullValue());
+        assertThat(tracedMethod.getName(), is("implementation-type-typeContractParam"));
+        assertThat(tracedMethod.getKind(), is(SpanKind.SERVER));
+        assertThat(tracedMethod.getStatus().getStatusCode(), is(StatusCode.UNSET));
+
+        assertAttribute(tracedMethod.getAttributes(), "source", "implementation-type");
+        Long actualValue = tracedMethod.getAttributes().get(AttributeKey.longKey("id"));
+        assertThat("Long Attribute of key: id", actualValue, is(11L));
+    }
+
     private void assertAttribute(Attributes attributes, String key, String expectedValue) {
         var actualValue = attributes.get(AttributeKey.stringKey(key));
 

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -267,6 +267,9 @@ include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_20, indent=0]
 
 Fault tolerance annotations allow adding features to methods on services.
 The annotations can be added to any method that supports interception (i.e. methods that are not private).
+Method-level fault tolerance annotations can also be declared on methods inherited from service contracts and typed
+HTTP client interfaces. Type-level fault tolerance annotations on interfaces are not inherited by service methods.
+Contracts provided by registry-managed service factories are not included.
 
 Method Annotations:
 
@@ -438,6 +441,8 @@ They are applied when the service instance is obtained from the service registry
 Constraints declared on matching service interface and implementation methods are combined. Implementation constraints do not
 replace or loosen constraints declared by the service interface, even when both methods use the same constraint type with
 different values.
+Service interfaces are discovered using the service registry contract rules, including `@Service.Contract`,
+implicit contracts when enabled, and `@Service.ExternalContracts`.
 The same applies to instances returned by registry-managed service factories, including `Supplier`,
 `Service.ServicesFactory`, `Service.InjectionPointFactory`, and `Service.QualifiedFactory` services.
 This can change runtime behavior for services that already declared interface validation: invalid calls through
@@ -505,6 +510,9 @@ Method annotations:
 - link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.Timed.html[`io.helidon.metrics.api.Metrics.Timed`] - adds a timer metric to the metric registry for method executions
 - link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.Gauge.html[`io.helidon.metrics.api.Metrics.Gauge`] - marks a method that returns a number as a gauge
 
+Metrics method annotations can also be declared on methods inherited from service contracts and typed HTTP client interfaces.
+Contracts provided by registry-managed service factories are not included.
+
 In addition, we can use link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.Tag.html[`io.helidon.metrics.api.Metrics.Tag`] annotation on a type, method, or as a `tags` property of an annotation to add tags to the metric. Tags from type definition will be added to all metrics on the type, tags on methods on all metrics on the method, and tags in the metric annotation will only be used by that metric.
 
 The example below shows additional tags. The counter on method `counted` will have the following tags: `service=Metered;method=counted` (and of course the scope tag that is always added).
@@ -527,6 +535,9 @@ include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_12, indent=0]
 
 Add support for tracing of methods.
 This feature will add a new span for each annotated method (or all methods on an annotated type).
+Tracing annotations can also be declared on methods inherited from service contracts and typed HTTP client interfaces.
+A type-level tracing annotation on a contract interface applies only to methods declared by that contract.
+Contracts provided by registry-managed service factories are not included.
 
 Annotations:
 

--- a/service/codegen/src/main/java/io/helidon/service/codegen/InterceptedTypeGenerator.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/InterceptedTypeGenerator.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import io.helidon.codegen.CodegenUtil;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Constructor;
+import io.helidon.codegen.classmodel.TypeArgument;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.Annotations;
@@ -85,7 +86,7 @@ class InterceptedTypeGenerator {
             classModel.addField(methodField -> methodField
                     .accessModifier(AccessModifier.PRIVATE)
                     .isFinal(true)
-                    .type(invokerType(interceptedMethod.info().typeName()))
+                    .type(invokerType(interceptedMethod.info()))
                     .name(interceptedMethod.invokerName()));
         }
     }
@@ -100,6 +101,10 @@ class InterceptedTypeGenerator {
                     .accessModifier(info.accessModifier())
                     .name(info.elementName())
                     .returnType(info.typeName())
+                    .update(it -> info.typeParameters()
+                            .stream()
+                            .map(TypeArgument::create)
+                            .forEach(it::addGenericArgument))
                     .update(it -> info.parameterArguments().forEach(arg -> it.addParameter(param -> param.type(arg.typeName())
                             .name(arg.elementName()))))
                     .update(it -> {
@@ -119,9 +124,16 @@ class InterceptedTypeGenerator {
                                 .collect(Collectors.joining(", "))
                                 + ");";
                         // body of the method
-                        it.addContentLine("try {")
-                                .addContent(interceptedMethod.isVoid() ? "" : "return ")
-                                .addContentLine(invokeLine)
+                        it.addContentLine("try {");
+                        if (!interceptedMethod.isVoid()) {
+                            it.addContent("return ");
+                            if (!info.typeName().equals(erasedMethodType(info, info.typeName()))) {
+                                it.addContent("(")
+                                        .addContent(info.typeName().fqName())
+                                        .addContent(") ");
+                            }
+                        }
+                        it.addContentLine(invokeLine)
                                 .addContent("}");
                         for (TypeName exceptionType : interceptedMethod.exceptionTypes()) {
                             it.addContent(" catch (")
@@ -159,6 +171,10 @@ class InterceptedTypeGenerator {
                     .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                     .name(interceptedMethod.delegateName())
                     .returnType(info.typeName())
+                    .update(it -> info.typeParameters()
+                            .stream()
+                            .map(TypeArgument::create)
+                            .forEach(it::addGenericArgument))
                     .update(it -> info.parameterArguments().forEach(arg -> it.addParameter(param -> param.type(arg.typeName())
                             .name(arg.elementName()))))
                     .update(it -> {
@@ -247,7 +263,8 @@ class InterceptedTypeGenerator {
             List<TypedElementInfo> args = interceptedMethod.info().parameterArguments();
             for (int i = 0; i < args.size(); i++) {
                 TypedElementInfo arg = args.get(i);
-                allArgs.add("(" + arg.typeName().resolvedName() + ") helidonInject__params[" + i + "]");
+                allArgs.add("(" + erasedMethodType(interceptedMethod.info(), arg.typeName()).resolvedName()
+                                    + ") helidonInject__params[" + i + "]");
                 if (!arg.typeName().typeArguments().isEmpty()) {
                     hasGenericType = true;
                 }
@@ -301,10 +318,55 @@ class InterceptedTypeGenerator {
         return classModel;
     }
 
-    private static TypeName invokerType(TypeName type) {
+    private static TypeName invokerType(TypedElementInfo method) {
         return TypeName.builder(INTERCEPT_INVOKER)
-                .addTypeArgument(type.boxed())
+                .addTypeArgument(erasedMethodType(method, method.typeName()).boxed())
                 .build();
+    }
+
+    private static TypeName erasedMethodType(TypedElementInfo method, TypeName type) {
+        Set<String> methodTypeParameters = method.typeParameters()
+                .stream()
+                .map(TypeName::className)
+                .collect(Collectors.toUnmodifiableSet());
+        return erasedMethodType(type, methodTypeParameters);
+    }
+
+    private static TypeName erasedMethodType(TypeName type, Set<String> methodTypeParameters) {
+        if (type.array() && type.componentType().isPresent()) {
+            TypeName componentType = erasedMethodType(type.componentType().orElseThrow(), methodTypeParameters);
+            return TypeName.builder(componentType)
+                    .array(true)
+                    .vararg(type.vararg())
+                    .componentType(componentType)
+                    .build();
+        }
+        if (type.generic() && methodTypeParameters.contains(type.className())) {
+            return type.upperBounds()
+                    .stream()
+                    .findFirst()
+                    .map(it -> erasedMethodType(it, methodTypeParameters))
+                    .orElse(TypeNames.OBJECT);
+        }
+        if (type.typeArguments()
+                .stream()
+                .anyMatch(it -> usesMethodTypeParameter(it, methodTypeParameters))) {
+            return TypeName.builder(type)
+                    .typeArguments(List.of())
+                    .generic(false)
+                    .build();
+        }
+        return type;
+    }
+
+    private static boolean usesMethodTypeParameter(TypeName type, Set<String> methodTypeParameters) {
+        if (type.generic() && methodTypeParameters.contains(type.className())) {
+            return true;
+        }
+        return type.typeArguments().stream().anyMatch(it -> usesMethodTypeParameter(it, methodTypeParameters))
+                || type.lowerBounds().stream().anyMatch(it -> usesMethodTypeParameter(it, methodTypeParameters))
+                || type.upperBounds().stream().anyMatch(it -> usesMethodTypeParameter(it, methodTypeParameters))
+                || type.componentType().map(it -> usesMethodTypeParameter(it, methodTypeParameters)).orElse(false);
     }
 
     private static String invokerArgument(TypedElementInfo arg) {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceContracts.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceContracts.java
@@ -17,6 +17,7 @@
 package io.helidon.service.codegen;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -26,6 +27,7 @@ import java.util.function.Function;
 
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenOptions;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
@@ -287,6 +289,20 @@ public class ServiceContracts {
                         processed,
                         it
                 ));
+    }
+
+    /**
+     * Resolve a possibly generic contract type through the complete service contract hierarchy.
+     *
+     * @param contracts contracts of the service
+     * @param contract  contract type to resolve
+     * @return resolved contract type, or the provided type if it cannot be resolved further
+     */
+    @Api.Internal
+    public TypeName resolveContractType(Collection<ResolvedType> contracts, TypeName contract) {
+        Objects.requireNonNull(contracts, "contracts is null");
+        Objects.requireNonNull(contract, "contract is null");
+        return TypedElements.resolveContractType(typeInfoFactory::apply, contracts, contract);
     }
 
     private static TypeInfo contractInfo(Function<TypeName, Optional<TypeInfo>> typeInfoFactory,

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
@@ -331,20 +331,24 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                                                               Map<TypeName, Set<TypeName>> supportedAnnotationsCache,
                                                               Map<TypeName, Set<TypeName>> metaAnnotationsCache,
                                                               Map<TypeName, Boolean> metaAnnotatedCache) {
-        if (!extension.supportsServiceContractAnnotations() || !ServiceTypes.isService(serviceType)) {
+        if (!ServiceTypes.isService(serviceType)
+                || (!extension.supportsServiceContractAnnotations()
+                && !extension.supportsFactoryProvidedServiceContractAnnotations())) {
             return Set.of();
         }
 
         ServiceContracts serviceContracts = ServiceContracts.create(ctx.options(), roundContext::typeInfo, serviceType);
-        Set<ResolvedType> contracts = new HashSet<>();
-        serviceContracts.addContracts(contracts, new HashSet<>(), serviceType);
-
-        Set<TypeName> result = new HashSet<>(supportedAnnotationsOnContracts(roundContext,
-                                                                             extension,
-                                                                             contracts,
-                                                                             supportedAnnotationsCache,
-                                                                             metaAnnotationsCache,
-                                                                             metaAnnotatedCache));
+        Set<TypeName> result = new HashSet<>();
+        if (extension.supportsServiceContractAnnotations()) {
+            Set<ResolvedType> contracts = new HashSet<>();
+            serviceContracts.addContracts(contracts, new HashSet<>(), serviceType);
+            result.addAll(supportedAnnotationsOnContracts(roundContext,
+                                                          extension,
+                                                          contracts,
+                                                          supportedAnnotationsCache,
+                                                          metaAnnotationsCache,
+                                                          metaAnnotatedCache));
+        }
         if (extension.supportsFactoryProvidedServiceContractAnnotations()) {
             result.addAll(supportedAnnotationsOnContracts(roundContext,
                                                           extension,

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
@@ -69,7 +69,8 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                                              discoveryPredicate(it.supportedAnnotations(),
                                                                 it.supportedAnnotationPackages()),
                                              it.supportedMetaAnnotations(),
-                                             it.supportsServiceContractAnnotations());
+                                             it.supportsServiceContractAnnotations(),
+                                             it.supportsFactoryProvidedServiceContractAnnotations());
                 })
                 .toList();
     }
@@ -344,12 +345,14 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
                                                                              supportedAnnotationsCache,
                                                                              metaAnnotationsCache,
                                                                              metaAnnotatedCache));
-        result.addAll(supportedAnnotationsOnContracts(roundContext,
-                                                      extension,
-                                                      ServiceTypes.factoryProvidedContracts(serviceContracts, serviceType),
-                                                      supportedAnnotationsCache,
-                                                      metaAnnotationsCache,
-                                                      metaAnnotatedCache));
+        if (extension.supportsFactoryProvidedServiceContractAnnotations()) {
+            result.addAll(supportedAnnotationsOnContracts(roundContext,
+                                                          extension,
+                                                          ServiceTypes.factoryProvidedContracts(serviceContracts, serviceType),
+                                                          supportedAnnotationsCache,
+                                                          metaAnnotationsCache,
+                                                          metaAnnotatedCache));
+        }
 
         return Set.copyOf(result);
     }
@@ -502,7 +505,8 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
     private record ExtensionInfo(RegistryCodegenExtension extension,
                                  Predicate<TypeName> supportedAnnotationsPredicate,
                                  Set<TypeName> supportedMetaAnnotations,
-                                 boolean supportsServiceContractAnnotations) {
+                                 boolean supportsServiceContractAnnotations,
+                                 boolean supportsFactoryProvidedServiceContractAnnotations) {
     }
 
     private record ElementKey(TypeName owner, ElementSignature signature) {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/TypedElements.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/TypedElements.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.ElementInfoPredicates;
@@ -87,9 +88,10 @@ final class TypedElements {
         return gatherElements(ctx::typeInfo, contracts, typeInfo);
     }
 
-    private static List<TypedElements.ElementMeta> gatherElements(TypeInfoFactory typeInfoFactory,
-                                                                  Collection<ResolvedType> contracts,
-                                                                  TypeInfo typeInfo) {
+    private static List<TypedElements.ElementMeta> gatherElements(
+            Function<TypeName, Optional<TypeInfo>> typeInfoFactory,
+            Collection<ResolvedType> contracts,
+            TypeInfo typeInfo) {
         List<TypedElements.ElementMeta> result = new ArrayList<>();
         Set<ElementSignature> processedSignatures = new HashSet<>();
         List<ContractInfo> contractInfos = contractInfos(typeInfoFactory, contracts);
@@ -159,13 +161,14 @@ final class TypedElements {
         return result;
     }
 
-    private static List<ContractInfo> contractInfos(TypeInfoFactory typeInfoFactory, Collection<ResolvedType> contracts) {
+    private static List<ContractInfo> contractInfos(Function<TypeName, Optional<TypeInfo>> typeInfoFactory,
+                                                    Collection<ResolvedType> contracts) {
         List<ContractInfo> contractInfos = contracts.stream()
                 .sorted(Comparator.comparing(it -> it.type().toString()))
                 .flatMap(it -> {
                     TypeName resolvedType = resolveContractType(typeInfoFactory, contracts, it.type());
-                    return typeInfoFactory.typeInfo(resolvedType)
-                            .or(() -> typeInfoFactory.typeInfo(it.type()))
+                    return typeInfoFactory.apply(resolvedType)
+                            .or(() -> typeInfoFactory.apply(it.type()))
                             .map(typeInfo -> new ContractInfo(ResolvedType.create(resolvedType), typeInfo))
                             .stream();
                 })
@@ -200,19 +203,20 @@ final class TypedElements {
                 || !typeParameterNames(info.declaredType().typeArguments()).isEmpty();
     }
 
-    private static boolean rawGenericContract(TypeInfoFactory typeInfoFactory, TypeName typeName) {
+    private static boolean rawGenericContract(Function<TypeName, Optional<TypeInfo>> typeInfoFactory,
+                                              TypeName typeName) {
         if (!typeName.typeArguments().isEmpty()) {
             return false;
         }
 
-        return typeInfoFactory.typeInfo(typeName)
+        return typeInfoFactory.apply(typeName)
                 .map(TypedElements::genericContract)
                 .orElse(false);
     }
 
-    private static TypeName resolveContractType(TypeInfoFactory typeInfoFactory,
-                                                Collection<ResolvedType> contracts,
-                                                TypeName typeName) {
+    static TypeName resolveContractType(Function<TypeName, Optional<TypeInfo>> typeInfoFactory,
+                                        Collection<ResolvedType> contracts,
+                                        TypeName typeName) {
         if (!hasGenericTypeArgument(typeName) && !rawGenericContract(typeInfoFactory, typeName)) {
             return typeName;
         }
@@ -225,7 +229,7 @@ final class TypedElements {
                 continue;
             }
 
-            Optional<TypeName> resolvedType = typeInfoFactory.typeInfo(candidateType)
+            Optional<TypeName> resolvedType = typeInfoFactory.apply(candidateType)
                     .flatMap(it -> resolveInheritedType(it, candidateType, typeName.genericTypeName(), new HashSet<>()));
             if (resolvedType.isPresent() && !hasGenericTypeArgument(resolvedType.get())) {
                 return resolvedType.get();
@@ -506,7 +510,4 @@ final class TypedElements {
                                 TypeInfo typeInfo) {
     }
 
-    private interface TypeInfoFactory {
-        Optional<TypeInfo> typeInfo(TypeName typeName);
-    }
 }

--- a/service/codegen/src/main/java/io/helidon/service/codegen/TypedElements.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/TypedElements.java
@@ -121,7 +121,7 @@ final class TypedElements {
                         }
                     }
                     result.add(new TypedElements.ElementMeta(declaredElement, abstractMethods));
-                    processedSignatures.add(declaredElement.signature());
+                    processedSignatures.add(elementSignature(declaredElement));
                 });
 
         // we have gathered all the declared elements, now let's gather inherited elements (default methods etc.)
@@ -137,16 +137,16 @@ final class TypedElements {
                     .map(it -> withEnclosingType(resolveTypeArguments(it, typeArguments), inheritedContract.typeName()))
                     .forEach(superElement -> {
                         TypedElementInfo targetElement = withTargetEnclosingType(superElement, typeInfo.typeName());
-                        if (processedSignatures.contains(targetElement.signature())) {
+                        if (processedSignatures.contains(elementSignature(targetElement))) {
                             // already processed
                             return;
                         }
                         if (targetElement.kind() == ElementKind.METHOD) {
-                            inheritedMethods.computeIfAbsent(targetElement.signature(), ignored -> new ArrayList<>())
+                            inheritedMethods.computeIfAbsent(elementSignature(targetElement), ignored -> new ArrayList<>())
                                     .add(new DeclaredElement(inheritedContract, superElement));
                             return;
                         }
-                        processedSignatures.add(targetElement.signature());
+                        processedSignatures.add(elementSignature(targetElement));
                         result.add(new TypedElements.ElementMeta(targetElement, List.of()));
                     });
         }
@@ -155,7 +155,7 @@ final class TypedElements {
             element = mergeAbstractMethods(element,
                                            abstractMethods.subList(1, abstractMethods.size()));
             result.add(new TypedElements.ElementMeta(element, abstractMethods));
-            processedSignatures.add(element.signature());
+            processedSignatures.add(elementSignature(element));
         }
 
         return result;
@@ -289,7 +289,7 @@ final class TypedElements {
                 // we want all methods from interfaces, but only abstract methods from abstract classes
                 .filter(it -> ElementInfoPredicates.isAbstract(it) || ElementInfoPredicates.isDefault(it))
                 .map(it -> withEnclosingType(resolveTypeArguments(it, typeArguments), resolvedType))
-                .filter(it -> declaredElement.signature().equals(it.signature()))
+                .filter(it -> elementSignature(declaredElement).equals(elementSignature(it)))
                 .findFirst()
                 .ifPresent(it -> abstractMethods.add(new TypedElements.DeclaredElement(info, it)));
     }
@@ -301,6 +301,12 @@ final class TypedElements {
         return TypedElementInfo.builder(element)
                 .enclosingType(enclosingType.genericTypeName())
                 .build();
+    }
+
+    private static ElementSignature elementSignature(TypedElementInfo element) {
+        return element.kind() == ElementKind.METHOD
+                ? TypeHierarchy.methodSignature(element)
+                : element.signature();
     }
 
     private static TypedElementInfo withTargetEnclosingType(TypedElementInfo element, TypeName enclosingType) {
@@ -321,16 +327,39 @@ final class TypedElements {
             return element;
         }
 
+        Map<String, TypeName> elementTypeArguments = typeArguments;
+        if (!element.typeParameters().isEmpty()) {
+            elementTypeArguments = new LinkedHashMap<>(typeArguments);
+            for (TypeName typeParameter : element.typeParameters()) {
+                elementTypeArguments.remove(typeParameter.className());
+            }
+        }
+        Map<String, TypeName> substitutions = elementTypeArguments;
+
         List<TypedElementInfo> parameters = element.parameterArguments()
                 .stream()
                 .map(it -> TypedElementInfo.builder(it)
-                        .typeName(resolveTypeArguments(it.typeName(), typeArguments))
+                        .typeName(resolveTypeArguments(it.typeName(), substitutions))
+                        .build())
+                .toList();
+        List<TypeName> typeParameters = element.typeParameters()
+                .stream()
+                .map(it -> TypeName.builder(it)
+                        .lowerBounds(it.lowerBounds()
+                                             .stream()
+                                             .map(bound -> resolveTypeArguments(bound, substitutions))
+                                             .toList())
+                        .upperBounds(it.upperBounds()
+                                             .stream()
+                                             .map(bound -> resolveTypeArguments(bound, substitutions))
+                                             .toList())
                         .build())
                 .toList();
 
         return TypedElementInfo.builder(element)
-                .typeName(resolveTypeArguments(element.typeName(), typeArguments))
+                .typeName(resolveTypeArguments(element.typeName(), substitutions))
                 .parameterArguments(parameters)
+                .typeParameters(typeParameters)
                 .build();
     }
 
@@ -404,10 +433,11 @@ final class TypedElements {
         Optional<TypeName> resolvedComponentType = typeName.componentType()
                 .map(it -> resolveTypeArguments(it, typeArguments));
 
-        if (resolvedTypeArguments.equals(typeName.typeArguments())
-                && resolvedLowerBounds.equals(typeName.lowerBounds())
-                && resolvedUpperBounds.equals(typeName.upperBounds())
-                && resolvedComponentType.equals(typeName.componentType())) {
+        if (sameResolvedTypes(resolvedTypeArguments, typeName.typeArguments())
+                && sameResolvedTypes(resolvedLowerBounds, typeName.lowerBounds())
+                && sameResolvedTypes(resolvedUpperBounds, typeName.upperBounds())
+                && resolvedComponentType.map(ResolvedType::create)
+                .equals(typeName.componentType().map(ResolvedType::create))) {
             return typeName;
         }
 
@@ -417,6 +447,11 @@ final class TypedElements {
                 .upperBounds(resolvedUpperBounds);
         resolvedComponentType.ifPresent(builder::componentType);
         return builder.build();
+    }
+
+    private static boolean sameResolvedTypes(List<TypeName> first, List<TypeName> second) {
+        return first.stream().map(ResolvedType::create).toList()
+                .equals(second.stream().map(ResolvedType::create).toList());
     }
 
     private static TypeName mergeTypeName(TypeName typeName, TypeName contractTypeName) {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/spi/RegistryCodegenExtensionProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/spi/RegistryCodegenExtensionProvider.java
@@ -29,9 +29,10 @@ public interface RegistryCodegenExtensionProvider extends CodegenProvider {
      * Whether this extension should also process services whose service contracts contain annotations
      * supported by this extension.
      * <p>
-     * Service contracts include direct service contracts and contracts provided by factory services. Contract annotations
-     * are discovered from nested contract metadata, including annotations on the contract type, methods, method parameters,
-     * parameter and return type arguments, and annotations matched through {@link #supportedMetaAnnotations()}.
+     * Service contracts include contracts discovered for the service type. Contract annotations are discovered from nested
+     * contract metadata, including annotations on the contract type, methods, method parameters, parameter and return type
+     * arguments, and annotations matched through {@link #supportedMetaAnnotations()}. Factory-provided contracts are
+     * controlled separately by {@link #supportsFactoryProvidedServiceContractAnnotations()}.
      * <p>
      * Matching services are passed to the extension through {@link io.helidon.service.codegen.RegistryRoundContext#types()}.
      * <p>
@@ -43,6 +44,18 @@ public interface RegistryCodegenExtensionProvider extends CodegenProvider {
      */
     default boolean supportsServiceContractAnnotations() {
         return false;
+    }
+
+    /**
+     * Whether this extension should also process factory services whose provided service contracts contain annotations
+     * supported by this extension.
+     * <p>
+     * This method follows {@link #supportsServiceContractAnnotations()} by default for backward compatibility.
+     *
+     * @return whether factory services with supported provided-contract annotations should be processed
+     */
+    default boolean supportsFactoryProvidedServiceContractAnnotations() {
+        return supportsServiceContractAnnotations();
     }
 
     /**


### PR DESCRIPTION
Resolves #12117

Carries forward the 4.x fix from #12122. Inherited annotations on service contract methods are applied to effective service elements for fault tolerance, metrics, tracing, and validation. Fault tolerance, metrics, and tracing exclude factory-provided contracts while validation preserves them; tracing also retains inherited-method precedence and generic contract signature resolution.
