### PR TITLE
Fix HTTP/2 rejected stream close accounting

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -814,6 +814,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
             try {
                 writeState.updateAndGet(s -> s.checkAndMove(WriteState.END));
                 boolean remoteAlreadyComplete = remoteAlreadyComplete();
+                streams.deactivate(this.streamId);
                 if (resetRequestBody && !remoteResetReceived && (forceReset || !remoteAlreadyComplete)) {
                     writeResetStream(resetCode);
                     resetStreamSent = true;

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -229,6 +229,27 @@ class Http2ServerStreamSniTest {
     }
 
     @Test
+    void rejectedStreamDeactivatesBeforeResetWrite() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingConnectionWriter writer = new RecordingConnectionWriter();
+        writer.beforeResetWrite = () -> assertThat(streams.isActive(STREAM_ID), is(false));
+        Http2ServerStream stream = stream(streams, writer);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        streams.activate(STREAM_ID);
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority("1"), false);
+
+        stream.run();
+
+        assertThat(writer.hasPendingTerminalCallback(), is(true));
+        assertThat(streams.isActive(STREAM_ID), is(true));
+
+        writer.completeTerminalWrite();
+
+        assertThat(streams.isActive(STREAM_ID), is(false));
+    }
+
+    @Test
     void rejectedStreamCompletionRestoresConnectionFlowControlForPrecheckedData() {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingConnectionWriter writer = new RecordingConnectionWriter();
@@ -722,6 +743,7 @@ class Http2ServerStreamSniTest {
         private final CountDownLatch terminalCallbackReady = new CountDownLatch(1);
         private final CountDownLatch terminalCallbackMayRun = new CountDownLatch(1);
         private final CountDownLatch terminalCallbackCompleted = new CountDownLatch(1);
+        private Runnable beforeResetWrite = () -> { };
         private Runnable terminalCallback;
         private int rstStreamCount;
 
@@ -737,6 +759,7 @@ class Http2ServerStreamSniTest {
         @Override
         public void write(Http2FrameData frame) {
             if (frame.header().type() == Http2FrameTypes.RST_STREAM.type()) {
+                beforeResetWrite.run();
                 rstStreamCount++;
             }
         }


### PR DESCRIPTION
Fix an HTTP/2 race where a client could observe `RST_STREAM` for a rejected request and open a replacement stream before the server released the old stream from `SETTINGS_MAX_CONCURRENT_STREAMS` accounting.

Deactivate the stream immediately before writing the reset while retaining deferred stream-context cleanup for late frames. This prevents a spurious connection-level `GOAWAY(REFUSED_STREAM)` response. Add a deterministic regression test that verifies deactivation at the reset-write boundary.
