### PR TITLE
27.x: Upgrade Jackson, Parsson and Handlebars

### DIFF
--- a/data/sql/testing/pom.xml
+++ b/data/sql/testing/pom.xml
@@ -35,6 +35,7 @@
         <!-- due to a package split in testcontainers, we cannot use module-info.java -->
         <helidon.services.skip>true</helidon.services.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <dependency-check.skip>true</dependency-check.skip>
     </properties>
 
     <dependencies>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -53,11 +53,11 @@
         <version.lib.guava>33.3.1-jre</version.lib.guava>
         <version.lib.h2>2.4.240</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
-        <version.lib.handlebars>4.5.1</version.lib.handlebars>
+        <version.lib.handlebars>4.5.2</version.lib.handlebars>
         <version.lib.hibernate.family>6.3</version.lib.hibernate.family>
         <version.lib.hibernate>${version.lib.hibernate.family}.1.Final</version.lib.hibernate>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
-        <version.lib.jackson>2.21.3</version.lib.jackson>
+        <version.lib.jackson>2.21.5</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.1.3</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.1.1</version.lib.jakarta.annotation-api>
         <!-- Needed for transaction/jta -->
@@ -88,7 +88,7 @@
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>
         <version.lib.opentelemetry.semconv>1.37.0</version.lib.opentelemetry.semconv>
         <version.lib.opentelemetry>1.58.0</version.lib.opentelemetry>
-        <version.lib.parsson>1.1.7</version.lib.parsson>
+        <version.lib.parsson>1.1.9</version.lib.parsson>
         <version.lib.postgresql>42.7.11</version.lib.postgresql>
         <version.lib.prometheus>0.16.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>

--- a/pom.xml
+++ b/pom.xml
@@ -528,15 +528,6 @@
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <!-- Bump up from 24 to 72 to reduce token use -->
                         <ossIndexAnalyzerCacheValidForHours>72</ossIndexAnalyzerCacheValidForHours>
-                        <excludes>
-                            <!-- Exclude stuff we do not deploy -->
-                            <exclude>io.helidon.tracing:helidon-tracing-tests</exclude>
-                            <exclude>io.helidon.config.tests*</exclude>
-                            <exclude>io.helidon.test*</exclude>
-                            <exclude>io.helidon.examples*</exclude>
-                            <!-- This should be excluded by above, but for some reason it persists -->
-                            <exclude>org.testng:testng</exclude>
-                        </excludes>
                         <formats>
                             <format>HTML</format>
                         </formats>


### PR DESCRIPTION
### Description

- Upgrade Jackson to 2.21.5
- Upgrade handlebars to 4.5.2
- Upgrade Parsson to 1.1.9

Also rupdate the `dependency-check-maven` plugin configuration to remove `<excludes>`. Instead we rely on setting `dependency-check.skip` to `true` in Helidon modules that we don't deploy (like test only modules).

