### PR TITLE
4.x: upgrade jackson and parsson

### DIFF
--- a/data/sql/testing/pom.xml
+++ b/data/sql/testing/pom.xml
@@ -35,6 +35,7 @@
         <!-- due to a package split in testcontainers, we cannot use module-info.java -->
         <helidon.services.skip>true</helidon.services.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <dependency-check.skip>true</dependency-check.skip>
     </properties>
 
     <dependencies>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -73,7 +73,7 @@
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.21.4</version.lib.jackson>
+        <version.lib.jackson>2.21.5</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.1.3</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.1.1</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>4.0.1</version.lib.jakarta.cdi-api>
@@ -158,7 +158,7 @@
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.perfmark-api>0.25.0</version.lib.perfmark-api>
-        <version.lib.parsson>1.1.7</version.lib.parsson>
+        <version.lib.parsson>1.1.9</version.lib.parsson>
         <version.lib.postgresql>42.7.11</version.lib.postgresql>
         <version.lib.prometheus>0.16.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>

--- a/pom.xml
+++ b/pom.xml
@@ -669,16 +669,6 @@
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <!-- Bump up from 24 to 72 to reduce token use -->
                         <ossIndexAnalyzerCacheValidForHours>72</ossIndexAnalyzerCacheValidForHours>
-                        <excludes>
-                            <!-- Exclude stuff we do not deploy -->
-                            <exclude>io.helidon.tracing:helidon-tracing-tests</exclude>
-                            <exclude>io.helidon.config.tests*</exclude>
-                            <exclude>io.helidon.test*</exclude>
-                            <exclude>io.helidon.examples*</exclude>
-                            <exclude>io.helidon.microprofile.tests*</exclude>
-                            <!-- This should be excluded by above, but for some reason it persists -->
-                            <exclude>org.testng:testng</exclude>
-                        </excludes>
                         <formats>
                             <format>HTML</format>
                         </formats>


### PR DESCRIPTION
### Description

- Upgrade Jackson to 2.21.5
- Upgrade Parsson to 1.1.9

Also update the `dependency-check-maven` plugin configuration to remove `<excludes>`. Instead we rely on setting `dependency-check.skip` to `true` in Helidon modules that we don't deploy (like test only modules).

