### PR TITLE
3.x: upgrade jackson

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -70,7 +70,7 @@
         <version.lib.hibernate-validator>7.0.5.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.21.4</version.lib.jackson>
+        <version.lib.jackson>2.21.5</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.0.1</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.0.0</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>3.0.0</version.lib.jakarta.cdi-api>

--- a/pom.xml
+++ b/pom.xml
@@ -572,16 +572,6 @@
                         <ossIndexAnalyzerCacheValidForHours>72</ossIndexAnalyzerCacheValidForHours>
 			# If provide improves rate limits
 			<nvdApiKey>${nvd-api-key}</nvdApiKey>
-                        <excludes>
-                            <!-- Exclude stuff we do not deploy -->
-                            <exclude>io.helidon.tracing:helidon-tracing-tests</exclude>
-                            <exclude>io.helidon.config.tests*</exclude>
-                            <exclude>io.helidon.test*</exclude>
-                            <exclude>io.helidon.examples*</exclude>
-                            <exclude>io.helidon.microprofile.tests*</exclude>
-                            <!-- This should be excluded by above, but for some reason it persists -->
-                            <exclude>org.testng:testng</exclude>
-                        </excludes>
                         <formats>
                             <format>HTML</format>
                             <format>CSV</format>


### PR DESCRIPTION
### Description

Upgrade Jackson to 2.21.5

Also update the `dependency-check-maven` plugin configuration to remove `<excludes>`. Instead we rely on setting `dependency-check.skip` to true in Helidon modules that we don't deploy (like test only modules).