### PR TITLE
4.x: Improve HTTP/1 WebClient throughput with direct bulk response reads

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/DataReader.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/DataReader.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -28,6 +29,7 @@ import java.util.function.Supplier;
  */
 public class DataReader {
     private final Supplier<byte[]> bytesSupplier;
+    private final ByteArrayReader byteArrayReader;
     private final boolean ignoreLoneEol;
     private Node head;
     private Node tail;
@@ -42,11 +44,7 @@ public class DataReader {
      */
     @Deprecated(forRemoval = true, since = "4.4.0")
     public DataReader(Supplier<byte[]> bytesSupplier) {
-        this.ignoreLoneEol = false;
-        this.bytesSupplier = bytesSupplier;
-        // we cannot block until data is actually ready to be consumed
-        this.head = new Node(BufferData.EMPTY_BYTES);
-        this.tail = this.head;
+        this(bytesSupplier, null, false);
     }
 
     /**
@@ -58,8 +56,15 @@ public class DataReader {
      */
     @Deprecated(forRemoval = true, since = "4.4.0")
     public DataReader(Supplier<byte[]> bytesSupplier, boolean ignoreLoneEol) {
+        this(bytesSupplier, null, ignoreLoneEol);
+    }
+
+    private DataReader(Supplier<byte[]> bytesSupplier,
+                       ByteArrayReader byteArrayReader,
+                       boolean ignoreLoneEol) {
         this.ignoreLoneEol = ignoreLoneEol;
-        this.bytesSupplier = bytesSupplier;
+        this.bytesSupplier = Objects.requireNonNull(bytesSupplier);
+        this.byteArrayReader = byteArrayReader;
         // we cannot block until data is actually ready to be consumed
         this.head = new Node(BufferData.EMPTY_BYTES);
         this.tail = this.head;
@@ -87,6 +92,18 @@ public class DataReader {
     }
 
     /**
+     * Data reader from a supplier of bytes with an optional direct bulk-read path.
+     * The bulk reader is used only when no previously supplied bytes remain buffered.
+     *
+     * @param bytesSupplier supplier used by parsing and other buffered reads
+     * @param byteArrayReader reader that can read directly into a caller-provided array
+     * @return data reader using the supplied buffered and direct read paths
+     */
+    public static DataReader create(Supplier<byte[]> bytesSupplier, ByteArrayReader byteArrayReader) {
+        return new DataReader(bytesSupplier, Objects.requireNonNull(byteArrayReader), false);
+    }
+
+    /**
      * Number of bytes available in the currently pulled data.
      *
      * @return number of bytes available
@@ -110,6 +127,54 @@ public class DataReader {
         Node n = new Node(bytes);
         tail.next = n;
         tail = n;
+    }
+
+    /**
+     * Read bytes into a caller-provided array. Already buffered bytes are always consumed before the direct reader.
+     *
+     * @param bytes destination array
+     * @param offset destination offset
+     * @param length maximum number of bytes to read
+     * @return number of bytes read, or {@code -1} at end of input
+     */
+    public int read(byte[] bytes, int offset, int length) {
+        Objects.checkFromIndexSize(offset, length, bytes.length);
+        if (length == 0) {
+            return 0;
+        }
+
+        int buffered = available();
+        if (buffered > 0) {
+            int toRead = Math.min(buffered, length);
+            return readBuffer(toRead).read(bytes, offset, toRead);
+        }
+        if (byteArrayReader != null) {
+            return byteArrayReader.read(bytes, offset, length);
+        }
+
+        try {
+            ensureAvailable();
+        } catch (InsufficientDataAvailableException e) {
+            return -1;
+        }
+        int toRead = Math.min(available(), length);
+        return readBuffer(toRead).read(bytes, offset, toRead);
+    }
+
+    /**
+     * Direct reader of bytes into a caller-provided array.
+     */
+    @FunctionalInterface
+    public interface ByteArrayReader {
+        /**
+         * Read bytes.
+         *
+         * @param bytes destination array
+         * @param offset destination offset
+         * @param length maximum number of bytes to read
+         * @return number of bytes read, or {@code -1} at end of input
+         */
+        int read(byte[] bytes, int offset, int length);
     }
 
     /**

--- a/common/buffers/src/test/java/io/helidon/common/buffers/DataReaderTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/DataReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,60 @@
 package io.helidon.common.buffers;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 class DataReaderTest {
+
+    @Test
+    void directReadDrainsBufferedBytesFirst() {
+        var supplied = new AtomicReference<>(new byte[] {1, 2, 3});
+        var directCalls = new AtomicInteger();
+        var direct = new AtomicReference<>(new byte[] {4, 5, 6, 7});
+        DataReader dataReader = DataReader.create(
+                () -> supplied.getAndSet(null),
+                (bytes, offset, length) -> {
+                    directCalls.incrementAndGet();
+                    byte[] source = direct.getAndSet(null);
+                    if (source == null) {
+                        return -1;
+                    }
+                    int read = Math.min(source.length, length);
+                    System.arraycopy(source, 0, bytes, offset, read);
+                    return read;
+                });
+        dataReader.ensureAvailable();
+        byte[] target = new byte[7];
+
+        assertThat(dataReader.read(target, 0, target.length), is(3));
+        assertThat(directCalls.get(), is(0));
+        assertThat(dataReader.read(target, 3, target.length - 3), is(4));
+        assertThat(directCalls.get(), is(1));
+        assertArrayEquals(new byte[] {1, 2, 3, 4, 5, 6, 7}, target);
+    }
+
+    @Test
+    void bulkReadFallsBackToBufferedSupplier() {
+        var supplied = new AtomicReference<>(new byte[] {1, 2, 3});
+        DataReader dataReader = DataReader.create(() -> supplied.getAndSet(null));
+        byte[] target = new byte[5];
+
+        assertThat(dataReader.read(target, 1, 3), is(3));
+        assertArrayEquals(new byte[] {0, 1, 2, 3, 0}, target);
+    }
+
+    @Test
+    void bulkReadReturnsEndOfInputForExhaustedSupplier() {
+        DataReader dataReader = DataReader.create(() -> null);
+
+        assertThat(dataReader.read(new byte[1], 0, 1), is(-1));
+    }
 
     @Test
     void testFindNewLineWithLoneCR() {

--- a/common/socket/src/main/java/io/helidon/common/socket/PlainSocket.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/PlainSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,6 +131,24 @@ public sealed class PlainSocket implements HelidonSocket permits TlsSocket {
     @Override
     public int read(BufferData buffer) {
         return buffer.readFrom(inputStream);
+    }
+
+    /**
+     * Read bytes directly from the socket input stream into a caller-provided array.
+     *
+     * @param bytes destination array
+     * @param offset destination offset
+     * @param length maximum number of bytes to read
+     * @return number of bytes read, or {@code -1} at end of input
+     * @throws IndexOutOfBoundsException if the offset or length is outside the destination array
+     * @throws UncheckedIOException if the socket read fails
+     */
+    public int read(byte[] bytes, int offset, int length) {
+        try {
+            return inputStream.read(bytes, offset, length);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientResponse.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,9 @@ public interface HttpClientResponse extends AutoCloseable, ClientResponseBase {
 
     /**
      * Entity input stream.
-     * This is a shortcut to {@link #entity()} and {@link io.helidon.http.media.ReadableEntity#inputStream()}.
+     * The default implementation is a shortcut to {@link #entity()} and
+     * {@link io.helidon.http.media.ReadableEntity#inputStream()}. Implementations may provide a direct stream with
+     * equivalent response lifecycle behavior.
      *
      * @return input stream
      */

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -137,6 +137,7 @@ public class TcpClientConnection implements ClientConnection {
         }
 
 
+        PlainSocket connectedSocket;
         if (tls.enabled()) {
             SSLSocket sslSocket = tls.createSocket(tcpProtocolIds, socket, targetAddress);
             try {
@@ -152,12 +153,13 @@ public class TcpClientConnection implements ClientConnection {
             if (LOGGER.isLoggable(TRACE)) {
                 debugTls(sslSocket, channelId);
             }
-            this.helidonSocket = TlsSocket.client(sslSocket, channelId);
+            connectedSocket = TlsSocket.client(sslSocket, channelId);
         } else {
-            this.helidonSocket = PlainSocket.client(socket, channelId);
+            connectedSocket = PlainSocket.client(socket, channelId);
         }
 
-        this.reader = DataReader.create(helidonSocket);
+        this.helidonSocket = connectedSocket;
+        this.reader = DataReader.create(connectedSocket, connectedSocket::read);
         int writeBufferSize = webClient.prototype().writeBufferSize();
         this.writer = new BufferedDataWriter(helidonSocket, writeBufferSize);
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -22,6 +22,7 @@ import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -407,16 +408,35 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
 
         @Override
         public int read(byte[] b, int off, int len) {
+            Objects.checkFromIndexSize(off, len, b.length);
+            if (len == 0) {
+                return 0;
+            }
             if (finished) {
                 return -1;
             }
-            int maxRemaining = maxRemaining(len);
-            ensureBuffer(maxRemaining);
-            if (finished || currentBuffer == null) {
+            if (remainingLength == 0) {
+                completeEntity();
                 return -1;
             }
-            int read = currentBuffer.read(b, off, len);
+            int maxRemaining = maxRemaining(len);
+            int read;
+            if (currentBuffer != null && !currentBuffer.consumed()) {
+                read = currentBuffer.read(b, off, maxRemaining);
+            } else {
+                currentBuffer = null;
+                read = reader.read(b, off, maxRemaining);
+                if (read < 0) {
+                    throw new DataReader.InsufficientDataAvailableException();
+                }
+                if (read > 0 && recvListener.enabled()) {
+                    recvListener.data(socket, BufferData.createReadOnly(b, off, read));
+                }
+            }
             remainingLength -= read;
+            if (remainingLength == 0) {
+                completeEntity();
+            }
             return read;
         }
 
@@ -426,10 +446,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
 
         private void ensureBuffer(int estimate) {
             if (remainingLength == 0) {
-                entityProcessedRunnable.run();
-                // we have fully read the entity
-                finished = true;
-                currentBuffer = null;
+                completeEntity();
                 return;
             }
 
@@ -448,6 +465,13 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             } else {
                 recvListener.data(socket, currentBuffer);
             }
+        }
+
+        private void completeEntity() {
+            entityProcessedRunnable.run();
+            // we have fully read the entity
+            finished = true;
+            currentBuffer = null;
         }
     }
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -18,8 +18,10 @@ package io.helidon.webclient.http1;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.lang.System.Logger.Level;
 import java.util.List;
+import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
@@ -150,6 +152,20 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     }
 
     @Override
+    public InputStream inputStream() {
+        this.entityRequested = true;
+
+        if (inputStream == null) {
+            return InputStream.nullInputStream();
+        }
+
+        return new ResponseInputStream(inputStream,
+                                       directContentLength(),
+                                       this::closeFullyReadEntity,
+                                       this::close);
+    }
+
+    @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {
             try {
@@ -231,12 +247,27 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
 
     private void entityFullyRead() {
         try {
-            this.entityFullyRead = true;
-            inputStream.close();
-            this.close();
+            closeFullyReadEntity();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
+    }
+
+    private void closeFullyReadEntity() throws IOException {
+        this.entityFullyRead = true;
+        try {
+            inputStream.close();
+        } finally {
+            this.close();
+        }
+    }
+
+    private long directContentLength() {
+        // Content-Length describes the encoded representation, not the decoded stream returned to callers.
+        if (responseHeaders.contains(HeaderNames.CONTENT_ENCODING)) {
+            return -1;
+        }
+        return responseHeaders.contentLength().orElse(-1);
     }
 
     private BufferData readBytes(int estimate) {
@@ -246,5 +277,80 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
             return null;
         }
         return bufferData;
+    }
+
+    @FunctionalInterface
+    private interface IoRunnable {
+        void run() throws IOException;
+    }
+
+    private static final class ResponseInputStream extends InputStream {
+        private final InputStream delegate;
+        private final IoRunnable entityFullyReadRunnable;
+        private final Runnable closeResponseRunnable;
+        private long remainingLength;
+        private boolean closed;
+
+        private ResponseInputStream(InputStream delegate,
+                                    long contentLength,
+                                    IoRunnable entityFullyReadRunnable,
+                                    Runnable closeResponseRunnable) {
+            this.delegate = delegate;
+            this.remainingLength = contentLength;
+            this.entityFullyReadRunnable = entityFullyReadRunnable;
+            this.closeResponseRunnable = closeResponseRunnable;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (closed) {
+                return -1;
+            }
+            int read = delegate.read();
+            return completeAfterRead(read, read == -1 ? 0 : 1);
+        }
+
+        @Override
+        public int read(byte[] bytes, int offset, int length) throws IOException {
+            Objects.checkFromIndexSize(offset, length, bytes.length);
+            if (length == 0) {
+                return 0;
+            }
+            if (closed) {
+                return -1;
+            }
+            int read = delegate.read(bytes, offset, length);
+            return completeAfterRead(read, Math.max(read, 0));
+        }
+
+        @Override
+        public int available() throws IOException {
+            return closed ? 0 : delegate.available();
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!closed) {
+                closed = true;
+                try {
+                    delegate.close();
+                } finally {
+                    closeResponseRunnable.run();
+                }
+            }
+        }
+
+        private int completeAfterRead(int read, int bytesRead) throws IOException {
+            if (!closed) {
+                if (remainingLength >= 0) {
+                    remainingLength -= bytesRead;
+                }
+                if (read == -1 || remainingLength == 0) {
+                    closed = true;
+                    entityFullyReadRunnable.run();
+                }
+            }
+            return read;
+        }
     }
 }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientResponseImplTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http1;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.MediaContext;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientUri;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Http1ClientResponseImplTest {
+    @Test
+    void inputStreamReadsDirectlyIntoCallerBuffer() throws IOException {
+        byte[] content = "response content".getBytes(StandardCharsets.UTF_8);
+        var delegate = new TrackingInputStream(content);
+        var connection = new TestConnection();
+        var complete = new CompletableFuture<Void>();
+        var response = response(delegate, content.length, connection, complete);
+        byte[] target = new byte[content.length + 4];
+
+        try (InputStream input = response.inputStream()) {
+            int read = input.read(target, 2, content.length);
+
+            assertThat(read, is(content.length));
+            assertThat(delegate.destination(), sameInstance(target));
+            assertThat(Arrays.copyOfRange(target, 2, 2 + content.length), is(content));
+        }
+
+        assertThat(complete.isDone(), is(true));
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+        assertThat(delegate.closeCount(), is(1));
+    }
+
+    @Test
+    void inputStreamClosesResponseAtEndOfStream() throws IOException {
+        var delegate = new TrackingInputStream(new byte[] {1});
+        var connection = new TestConnection();
+        var complete = new CompletableFuture<Void>();
+        var response = response(delegate, 1, connection, complete);
+        InputStream input = response.inputStream();
+
+        assertThat(input.read(), is(1));
+        assertThat(input.available(), is(0));
+        assertThat(input.read(), is(-1));
+        assertThat(complete.isDone(), is(true));
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+
+        input.close();
+        assertThat(delegate.closeCount(), is(1));
+        assertThat(connection.releaseCount(), is(1));
+    }
+
+    @Test
+    void inputStreamDoesNotUseEncodedContentLengthToDetectEnd() throws IOException {
+        var delegate = new TrackingInputStream(new byte[] {1, 2});
+        var connection = new TestConnection();
+        var complete = new CompletableFuture<Void>();
+        var responseHeaders = ClientResponseHeaders.create(WritableHeaders.create()
+                .add(HeaderValues.create(HeaderNames.CONTENT_LENGTH, 1))
+                .add(HeaderValues.create(HeaderNames.CONTENT_ENCODING, "test")));
+        InputStream input = response(delegate, responseHeaders, connection, complete).inputStream();
+
+        assertThat(input.read(), is(1));
+        assertThat(complete.isDone(), is(false));
+        assertThat(input.read(), is(2));
+        assertThat(complete.isDone(), is(false));
+        assertThat(input.read(), is(-1));
+
+        assertThat(complete.isDone(), is(true));
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void inputStreamClosesConnectionWhenClosedBeforeEndOfStream() throws IOException {
+        var delegate = new TrackingInputStream(new byte[] {1, 2});
+        var connection = new TestConnection();
+        var complete = new CompletableFuture<Void>();
+        InputStream input = response(delegate, 2, connection, complete).inputStream();
+
+        assertThat(input.read(), is(1));
+        input.close();
+
+        assertThat(complete.isDone(), is(true));
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+        assertThat(delegate.closeCount(), is(1));
+    }
+
+    @Test
+    void inputStreamHonorsBulkReadContract() throws IOException {
+        var delegate = new TrackingInputStream(new byte[0]);
+        var connection = new TestConnection();
+        InputStream input = response(delegate, 0, connection, new CompletableFuture<>()).inputStream();
+
+        assertThat(input.read(), is(-1));
+
+        byte[] target = new byte[1];
+        assertThat(input.read(target, 0, 0), is(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> input.read(target, 1, 1));
+        assertThrows(NullPointerException.class, () -> input.read(null, 0, 1));
+        assertThat(delegate.destination(), nullValue());
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(delegate.closeCount(), is(1));
+    }
+
+    @Test
+    void inputStreamClosesResponseWhenDelegateCloseFails() throws IOException {
+        var delegate = new FailingCloseInputStream();
+        var connection = new TestConnection();
+        var complete = new CompletableFuture<Void>();
+        InputStream input = response(delegate, 1, connection, complete).inputStream();
+
+        IOException exception = assertThrows(IOException.class, input::close);
+
+        assertThat(exception.getMessage(), is("delegate close failed"));
+        assertThat(delegate.closeCount(), is(1));
+        assertThat(complete.isDone(), is(true));
+        assertThat(connection.releaseCount(), is(0));
+        assertThat(connection.closeCount(), is(1));
+
+        input.close();
+        assertThat(delegate.closeCount(), is(1));
+        assertThat(connection.closeCount(), is(1));
+    }
+
+    @Test
+    void inputStreamReportsDelegateCloseFailureAsIOExceptionAtEndOfStream() throws IOException {
+        var delegate = new FailingCloseInputStream();
+        var connection = new TestConnection();
+        var complete = new CompletableFuture<Void>();
+        InputStream input = response(delegate, 1, connection, complete).inputStream();
+
+        IOException exception = assertThrows(IOException.class, input::read);
+
+        assertThat(exception.getMessage(), is("delegate close failed"));
+        assertThat(delegate.closeCount(), is(1));
+        assertThat(complete.isDone(), is(true));
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+
+        input.close();
+        assertThat(delegate.closeCount(), is(1));
+        assertThat(connection.releaseCount(), is(1));
+    }
+
+    private static Http1ClientResponseImpl response(InputStream inputStream,
+                                                    long contentLength,
+                                                    TestConnection connection,
+                                                    CompletableFuture<Void> complete) {
+        var responseHeaders = ClientResponseHeaders.create(WritableHeaders.create()
+                .add(HeaderValues.create(HeaderNames.CONTENT_LENGTH, contentLength)));
+        return response(inputStream, responseHeaders, connection, complete);
+    }
+
+    private static Http1ClientResponseImpl response(InputStream inputStream,
+                                                    ClientResponseHeaders responseHeaders,
+                                                    TestConnection connection,
+                                                    CompletableFuture<Void> complete) {
+        var config = Http1ClientConfig.builder().buildPrototype();
+        return new Http1ClientResponseImpl(config,
+                                           config.protocolConfig(),
+                                           Status.OK_200,
+                                           ClientRequestHeaders.create(WritableHeaders.create()),
+                                           responseHeaders,
+                                           connection,
+                                           inputStream,
+                                           MediaContext.create(),
+                                           ClientUri.create(URI.create("http://localhost")),
+                                           complete);
+    }
+
+    private static final class TestConnection implements ClientConnection {
+        private final DataReader reader = DataReader.create(() -> null);
+        private int releaseCount;
+        private int closeCount;
+
+        @Override
+        public DataReader reader() {
+            return reader;
+        }
+
+        @Override
+        public DataWriter writer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String channelId() {
+            return "test";
+        }
+
+        @Override
+        public HelidonSocket helidonSocket() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void readTimeout(Duration readTimeout) {
+        }
+
+        @Override
+        public void releaseResource() {
+            releaseCount++;
+        }
+
+        @Override
+        public void closeResource() {
+            closeCount++;
+        }
+
+        private int releaseCount() {
+            return releaseCount;
+        }
+
+        private int closeCount() {
+            return closeCount;
+        }
+    }
+
+    private static final class TrackingInputStream extends InputStream {
+        private final byte[] content;
+        private int offset;
+        private byte[] destination;
+        private int closeCount;
+        private boolean closed;
+
+        private TrackingInputStream(byte[] content) {
+            this.content = content;
+        }
+
+        @Override
+        public int read() throws IOException {
+            checkOpen();
+            if (offset == content.length) {
+                return -1;
+            }
+            return content[offset++] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] bytes, int destinationOffset, int length) throws IOException {
+            checkOpen();
+            destination = bytes;
+            if (offset == content.length) {
+                return -1;
+            }
+            int read = Math.min(length, content.length - offset);
+            System.arraycopy(content, offset, bytes, destinationOffset, read);
+            offset += read;
+            return read;
+        }
+
+        @Override
+        public void close() {
+            closeCount++;
+            closed = true;
+        }
+
+        @Override
+        public int available() throws IOException {
+            checkOpen();
+            return content.length - offset;
+        }
+
+        private byte[] destination() {
+            return destination;
+        }
+
+        private int closeCount() {
+            return closeCount;
+        }
+
+        private void checkOpen() throws IOException {
+            if (closed) {
+                throw new IOException("stream closed");
+            }
+        }
+    }
+
+    private static final class FailingCloseInputStream extends InputStream {
+        private int closeCount;
+
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCount++;
+            throw new IOException("delegate close failed");
+        }
+
+        private int closeCount() {
+            return closeCount;
+        }
+    }
+}

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webclient.http1;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -149,6 +151,25 @@ class Http1ClientTest {
         assertThat(response.status(), is(Status.OK_200));
         assertThat(response.headers(), noHeader(HeaderNames.CONNECTION));
         assertThat(response.entity().as(String.class), is("Sending Something"));
+        assertThat(connection.releaseCount(), is(1));
+        assertThat(connection.closeCount(), is(0));
+    }
+
+    @Test
+    void testInputStreamReadsExactContentLengthAndReleasesConnection() throws IOException {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection(false);
+        String content = "Sending Something";
+        byte[] expected = content.getBytes(StandardCharsets.UTF_8);
+
+        Http1ClientResponse response = client.put("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .submit(content);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.headers(), noHeader(HeaderNames.CONNECTION));
+        try (response; InputStream input = response.inputStream()) {
+            assertThat(input.readNBytes(expected.length), is(expected));
+        }
         assertThat(connection.releaseCount(), is(1));
         assertThat(connection.closeCount(), is(0));
     }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ContentLengthInputStreamTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ContentLengthInputStreamTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http1;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.PeerInfo;
+import io.helidon.http.http1.Http1ConnectionListener;
+import io.helidon.webclient.api.WebClientServiceResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class Http1ContentLengthInputStreamTest {
+    private static final HelidonSocket SOCKET = new TestSocket();
+    private static final Http1ConnectionListener LISTENER = Http1ConnectionListener.create(List.of());
+
+    @Test
+    void zeroLengthEntityIsImmediatelyComplete() {
+        var directCalls = new AtomicInteger();
+        var reader = DataReader.create(
+                () -> null,
+                (bytes, offset, length) -> {
+                    directCalls.incrementAndGet();
+                    return -1;
+                });
+        var completed = new CompletableFuture<WebClientServiceResponse>();
+        var input = new Http1CallChainBase.ContentLengthInputStream(
+                SOCKET, reader, completed, new AtomicReference<>(), 0, LISTENER);
+        byte[] target = new byte[1];
+
+        assertThat(input.read(target, 0, target.length), is(-1));
+        assertThat(directCalls.get(), is(0));
+        assertThat(completed.isDone(), is(true));
+    }
+
+    @Test
+    void bulkReadDoesNotConsumeTheNextResponse() {
+        byte[] contentAndNextResponse = {1, 2, 3, 4, 99};
+        var source = new ByteArrayInputStream(contentAndNextResponse);
+        var directCalls = new AtomicInteger();
+        var reader = DataReader.create(
+                () -> null,
+                (bytes, offset, length) -> {
+                    directCalls.incrementAndGet();
+                    return source.read(bytes, offset, length);
+                });
+        var completed = new CompletableFuture<WebClientServiceResponse>();
+        var input = new Http1CallChainBase.ContentLengthInputStream(
+                SOCKET, reader, completed, new AtomicReference<>(), 4, LISTENER);
+        byte[] target = new byte[8];
+
+        assertThat(input.read(target, 2, target.length - 2), is(4));
+        assertArrayEquals(new byte[] {0, 0, 1, 2, 3, 4, 0, 0}, target);
+        assertThat(directCalls.get(), is(1));
+        assertThat(completed.isDone(), is(true));
+        assertThat(input.read(target, 0, target.length), is(-1));
+        assertThat(source.read(), is(99));
+    }
+
+    @Test
+    void bulkReadDrainsParserBytesBeforeReadingTheSocket() {
+        var buffered = new AtomicReference<>(new byte[] {1, 2});
+        var source = new ByteArrayInputStream(new byte[] {3, 4});
+        var directCalls = new AtomicInteger();
+        var reader = DataReader.create(
+                () -> buffered.getAndSet(null),
+                (bytes, offset, length) -> {
+                    directCalls.incrementAndGet();
+                    return source.read(bytes, offset, length);
+                });
+        reader.ensureAvailable();
+        var completed = new CompletableFuture<WebClientServiceResponse>();
+        var input = new Http1CallChainBase.ContentLengthInputStream(
+                SOCKET, reader, completed, new AtomicReference<>(), 4, LISTENER);
+        byte[] target = new byte[4];
+
+        assertThat(input.read(target, 0, target.length), is(2));
+        assertThat(directCalls.get(), is(0));
+        assertThat(input.read(target, 2, 2), is(2));
+        assertThat(directCalls.get(), is(1));
+        assertArrayEquals(new byte[] {1, 2, 3, 4}, target);
+        assertThat(completed.isDone(), is(true));
+    }
+
+    private static final class TestSocket implements HelidonSocket {
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void idle() {
+        }
+
+        @Override
+        public boolean isConnected() {
+            return true;
+        }
+
+        @Override
+        public int read(BufferData buffer) {
+            return -1;
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+        }
+
+        @Override
+        public PeerInfo remotePeer() {
+            return null;
+        }
+
+        @Override
+        public PeerInfo localPeer() {
+            return null;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public String socketId() {
+            return "test";
+        }
+
+        @Override
+        public String childSocketId() {
+            return "test";
+        }
+
+        @Override
+        public byte[] get() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### Description

Fixes #12170.

Improves HTTP/1 WebClient throughput for large fixed-length response entities by eliminating intermediate response-body copies.

`Http1ClientResponse.inputStream()` now provides a protocol-specific stream that bypasses intermediate entity staging while preserving response lifecycle behavior. Fully consumed responses release reusable connections, while early stream closure closes the connection. Encoded responses do not use the encoded wire `Content-Length` to determine decoded-stream completion.

For fixed-length entities, `DataReader` can optionally read socket data directly into caller-provided buffers after draining any bytes buffered during response parsing. Reads remain limited to the remaining `Content-Length`, preventing consumption of data belonging to the next response on a persistent connection.

The existing supplier path remains available for transports without direct bulk reads. Chunked, unknown-length, Unix-domain, and NIO response paths retain their existing behavior.

The change includes coverage for:

- Direct reads into caller-provided buffers
- Parser-buffer ordering
- Exact content-length enforcement
- Persistent connection reuse
- Early stream closure
- Encoded and zero-length responses
- Supplier EOF
- Checked `IOException` and close-failure behavior

In a loopback benchmark reading a validated 128 MiB file-backed range repeatedly, the existing HTTP/1 client path measured approximately 1.16-1.32 GiB/s. The direct bulk-read path measured approximately 2.19 GiB/s on the same workload.

### Helidon 27 follow-up

The same intermediate-copy path exists on `main`. Because the HTTP/1 response lifecycle has diverged, support for Helidon 27 would be submitted as a separate adapted PR after this approach is reviewed.

### Documentation

No user-guide changes are required. The `HttpClientResponse.inputStream()` Javadoc is updated to permit protocol-specific direct streams with equivalent response lifecycle behavior.

### Testing

- `mvn -pl webclient/http1 -am test`
- `mvn validate -Pcheckstyle`
- `mvn validate -Pcopyright`