### PR TITLE
Document MicroProfile MpConfigFilter SPI

### DIFF
--- a/docs/src/main/asciidoc/mp/config/advanced-configuration.adoc
+++ b/docs/src/main/asciidoc/mp/config/advanced-configuration.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ include::{rootdir}/includes/mp.adoc[]
 
 - <<Creating MicroProfile Config Sources for Manual Setup of Config, Creating MicroProfile Config Sources for Manual Setup of Config>>
 - <<Creating Custom Config Sources, Creating Custom Config Sources>>
+- <<Creating Custom Config Filters, Creating Custom Config Filters>>
 - <<Creating MicroProfile Config Sources from meta-config, Creating MicroProfile Config Sources from meta-config>>
 - <<Extending Meta-Config to Create a Custom Config Source Type, Extending Meta-Config to Create a Custom Config Source Type>>
 - <<Creating MicroProfile Config Source from Helidon SE Config Source, Creating MicroProfile Config Source from Helidon SE Config Source>>
@@ -107,6 +108,51 @@ include::{sourcedir}/mp/config/AdvancedConfigurationSnippets.java[tag=snippet_3,
 <2> Returns the properties in this Config Source as a map.
 <3> Returns the value of the requested key, or `null` if the key is not available
 <4> Returns the ordinal of this Config Source.
+
+== Creating Custom Config Filters
+
+The MicroProfile Config specification does not define an SPI to intercept configuration values before they are
+returned to the application. Helidon provides `io.helidon.config.mp.spi.MpConfigFilter` for this purpose
+(for example to decrypt secrets, normalize values, or apply environment-specific transformations).
+
+Custom config filters are loaded using the Java Service Loader pattern by implementing
+`io.helidon.config.mp.spi.MpConfigFilter` and registering it as a service
+(using pass:normal[`META-INF/services/io.helidon.config.mp.spi.MpConfigFilter`] when using the classpath, or
+using the `provides` statement in `module-info.java` when using the module path).
+
+The interface `io.helidon.config.mp.spi.MpConfigFilter` defines the following methods:
+
+* `default void init(Config config)` - optional setup using a config instance that only includes filters with higher priority
+* `String apply(String propertyName, String value)` - transform the current value for the given property key
+
+Filters discovered on the classpath are applied automatically to every MicroProfile Config value retrieval.
+Use Helidon `@Weight` (or Jakarta `@Priority`) to control filter order. Helidon's built-in encryption support
+is implemented as an `MpConfigFilter`; see xref:{rootdir}/mp/security/configuration-secrets.adoc[Configuration Secrets].
+
+=== Example of a Custom Config Filter
+
+[source,java]
+----
+include::{sourcedir}/mp/config/AdvancedConfigurationSnippets.java[tag=snippet_7, indent=0]
+----
+<1> Optional initialization using higher-priority configuration.
+<2> Transforms the value for keys that start with `app.`.
+<3> Returns unchanged values for all other keys.
+
+Register the filter as a Java service:
+
+[source]
+.Classpath registration (`META-INF/services/io.helidon.config.mp.spi.MpConfigFilter`)
+----
+io.helidon.examples.TrimAppPropertiesFilter
+----
+
+[source,java]
+.Module-path registration (`module-info.java`)
+----
+provides io.helidon.config.mp.spi.MpConfigFilter
+    with io.helidon.examples.TrimAppPropertiesFilter;
+----
 
 == Creating MicroProfile Config Sources from meta-config
 

--- a/docs/src/main/asciidoc/mp/config/introduction.adoc
+++ b/docs/src/main/asciidoc/mp/config/introduction.adoc
@@ -38,7 +38,7 @@ include::{rootdir}/includes/mp.adoc[]
 
 == Overview
 
-Helidon {spec-name} is an implementation of https://github.com/eclipse/microprofile-config/[Eclipse {spec-name}]. You can configure your applications using MicroProfile's config configuration sources and APIs. You can also extend the configuration using MicroProfile SPI to add custom `ConfigSource` and `Converter`.
+Helidon {spec-name} is an implementation of https://github.com/eclipse/microprofile-config/[Eclipse {spec-name}]. You can configure your applications using MicroProfile's config configuration sources and APIs. You can also extend the configuration using MicroProfile SPI to add custom `ConfigSource` and `Converter` implementations, and using Helidon's `MpConfigFilter` SPI to intercept and transform configuration values.
 
 include::{rootdir}/includes/dependencies.adoc[]
 
@@ -198,6 +198,7 @@ See link:{jdk-javadoc-url}/java.base/java/nio/file/WatchService.html
 ==== Encryption
 You can encrypt secrets using a master password and store them in a configuration file.
 The config encryption filter in MicroProfile Config is enabled by default.
+It is implemented as an `MpConfigFilter` (see <<Config-Filters, Config Filters>> below).
 For more information, see xref:{rootdir}/mp/security/configuration-secrets.adoc[Configuration Secrets].
 
 [source,properties]
@@ -211,6 +212,25 @@ client_secret_pke=${RSA=mYRkg+4Q4hua1kvpCCI2hg==}
 # The system needs to be configured to accept clear text
 client_secret_clear=${CLEAR=known_password}
 ----
+
+==== Config Filters [[Config-Filters]]
+The MicroProfile Config specification does not define a way to intercept configuration values as they are
+delivered to the application. Helidon provides the `io.helidon.config.mp.spi.MpConfigFilter` SPI for this purpose.
+
+Filters are discovered automatically through the Java Service Loader and applied to every value retrieved
+from MicroProfile Config. A built-in example is the encryption filter described above. You can also
+implement and register your own filters.
+
+To create a custom filter:
+
+1. Implement `io.helidon.config.mp.spi.MpConfigFilter`.
+2. Optionally implement `init(Config)` to set the filter up from higher-priority configuration.
+3. Register the implementation as a Java service (`META-INF/services/io.helidon.config.mp.spi.MpConfigFilter`
+   on the classpath, or a `provides` clause in `module-info.java` on the module path).
+
+Filter order can be controlled with Helidon `@Weight` (or Jakarta `@Priority`).
+See xref:advanced-configuration.adoc#_creating_custom_config_filters[Creating Custom Config Filters]
+for a complete example.
 
 ==== Meta Configuration
 You can configure the Config using Helidon MP Config meta configuration feature. The meta-config allows configuration of config sources and other

--- a/docs/src/main/java/io/helidon/docs/mp/config/AdvancedConfigurationSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/config/AdvancedConfigurationSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigSources;
 import io.helidon.config.ConfigValue;
 import io.helidon.config.mp.MpConfigSources;
+import io.helidon.config.mp.spi.MpConfigFilter;
 import io.helidon.config.mp.spi.MpMetaConfigProvider;
 import io.helidon.config.yaml.mp.YamlMpConfigSource;
 
@@ -176,6 +177,25 @@ class AdvancedConfigurationSnippets {
                 .withSources(MpConfigSources.create(helidonConfig)) // <2>
                 .build();
         // end::snippet_6[]
+    }
+
+    class Snippet7 {
+        // tag::snippet_7[]
+        public class TrimAppPropertiesFilter implements MpConfigFilter {
+            @Override
+            public void init(Config config) { // <1>
+                // Optional: read higher-priority configuration to set up this filter
+            }
+
+            @Override
+            public String apply(String propertyName, String value) {
+                if (propertyName.startsWith("app.") && value != null) { // <2>
+                    return value.trim();
+                }
+                return value; // <3>
+            }
+        }
+        // end::snippet_7[]
     }
 
 }


### PR DESCRIPTION
### Description

Documents Helidon's `io.helidon.config.mp.spi.MpConfigFilter` SPI in the MicroProfile Config docs.

The MP Config pages already describe custom `ConfigSource` / `Converter` extension, but did not mention config filters. This SPI is how Helidon supports value interception (including the built-in encryption filter).

### Documentation

- Adds a Config Filters section to the MP Config introduction
- Adds Creating Custom Config Filters to advanced configuration, with a service-loader example
- Links encryption docs as the built-in `MpConfigFilter` use case

Fixes helidon-io/helidon-microprofile#77