### PR TITLE
Add support for RFC 10008 (The HTTP QUERY Method)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/RestExtensionBase.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/RestExtensionBase.java
@@ -66,7 +66,7 @@ public abstract class RestExtensionBase {
                                                                 + element.elementName(),
                                                         element.originatingElementValue()));
         return switch (method) {
-            case "GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS", "PATCH", "TRACE" -> new HttpMethod(method, true);
+            case "GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS", "PATCH", "TRACE", "QUERY" -> new HttpMethod(method, true);
             default -> new HttpMethod(method, false);
         };
     }

--- a/http/http/src/main/java/io/helidon/http/ClientResponseHeaders.java
+++ b/http/http/src/main/java/io/helidon/http/ClientResponseHeaders.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import io.helidon.common.media.type.ParserMode;
 
 import static io.helidon.http.HeaderNames.ACCEPT_PATCH;
+import static io.helidon.http.HeaderNames.ACCEPT_QUERY;
 import static io.helidon.http.HeaderNames.EXPIRES;
 import static io.helidon.http.HeaderNames.LAST_MODIFIED;
 import static io.helidon.http.HeaderNames.LOCATION;
@@ -65,6 +66,40 @@ public interface ClientResponseHeaders extends Headers {
         List<HttpMediaType> mediaTypes = new ArrayList<>(all.size());
         for (String value : all) {
             mediaTypes.add(HttpMediaType.create(value));
+        }
+        return mediaTypes;
+    }
+
+    /**
+     * Accepted queries.
+     *
+     * @return list of accepted queries media types
+     */
+    default List<HttpMediaType> acceptQueries() {
+        if (!contains(ACCEPT_QUERY)) {
+            return List.of();
+        }
+        List<String> all = get(ACCEPT_QUERY).allValues(true);
+        List<HttpMediaType> mediaTypes = new ArrayList<>(all.size());
+        for (String val : all) {
+            String trimmed = val.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int semi = trimmed.indexOf(';');
+            String mediaRange;
+            String params;
+            if (semi != -1) {
+                mediaRange = trimmed.substring(0, semi).trim();
+                params = trimmed.substring(semi);
+            } else {
+                mediaRange = trimmed;
+                params = "";
+            }
+            if (mediaRange.startsWith("\"") && mediaRange.endsWith("\"") && mediaRange.length() > 1) {
+                mediaRange = mediaRange.substring(1, mediaRange.length() - 1).trim();
+            }
+            mediaTypes.add(HttpMediaType.create(mediaRange + params));
         }
         return mediaTypes;
     }

--- a/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
@@ -32,6 +32,7 @@ enum HeaderNameEnum implements HeaderName {
     ACCEPT_ENCODING(Strings.ACCEPT_ENCODING_NAME),
     ACCEPT_LANGUAGE(Strings.ACCEPT_LANGUAGE_NAME),
     ACCEPT_DATETIME(Strings.ACCEPT_DATETIME_NAME),
+    ACCEPT_QUERY(Strings.ACCEPT_QUERY_NAME),
     ACCESS_CONTROL_ALLOW_CREDENTIALS(Strings.ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME),
     ACCESS_CONTROL_ALLOW_HEADERS(Strings.ACCESS_CONTROL_ALLOW_HEADERS_NAME),
     ACCESS_CONTROL_ALLOW_METHODS(Strings.ACCESS_CONTROL_ALLOW_METHODS_NAME),
@@ -167,6 +168,7 @@ enum HeaderNameEnum implements HeaderName {
         static final String ACCEPT_ENCODING_NAME = "Accept-Encoding";
         static final String ACCEPT_LANGUAGE_NAME = "Accept-Language";
         static final String ACCEPT_DATETIME_NAME = "Accept-Datetime";
+        static final String ACCEPT_QUERY_NAME = "Accept-Query";
         static final String ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME = "Access-Control-Allow-Credentials";
         static final String ACCESS_CONTROL_ALLOW_HEADERS_NAME = "Access-Control-Allow-Headers";
         static final String ACCESS_CONTROL_ALLOW_METHODS_NAME = "Access-Control-Allow-Methods";

--- a/http/http/src/main/java/io/helidon/http/HeaderNames.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNames.java
@@ -77,6 +77,16 @@ public final class HeaderNames {
     public static final HeaderName ACCEPT_DATETIME = HeaderNameEnum.ACCEPT_DATETIME;
     /**
      * The {@value} header name.
+     * Specifies which query document formats this server supports.
+     */
+    public static final String ACCEPT_QUERY_NAME = Strings.ACCEPT_QUERY_NAME;
+    /**
+     * The {@value #ACCEPT_QUERY_NAME} header name.
+     * Specifies which query document formats this server supports.
+     */
+    public static final HeaderName ACCEPT_QUERY = HeaderNameEnum.ACCEPT_QUERY;
+    /**
+     * The {@value} header name.
      * CORS configuration.
      */
     public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME = Strings.ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME;

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -340,6 +340,15 @@ public final class Http {
     }
 
     /**
+     * QUERY method of an HTTP endpoint.
+     */
+    @Retention(RetentionPolicy.CLASS)
+    @Documented
+    @HttpMethod(Method.QUERY_NAME)
+    public @interface QUERY {
+    }
+
+    /**
      * What media type(s) this method produces.
      * <p>
      * If the method may produce more than one type, the response headers must be crafted by hand. If it produces

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -340,6 +340,15 @@ public final class Http {
     }
 
     /**
+     * QUERY method of an HTTP endpoint.
+     */
+    @Retention(RetentionPolicy.CLASS)
+    @Documented
+    @HttpMethod(Method.QUERY_NAME)
+    public @interface QUERY {
+    }
+
+    /**
      * What media type(s) an endpoint or method produces.
      * <p>
      * If the method may produce more than one type, the response headers must be crafted by hand. If it produces

--- a/http/http/src/main/java/io/helidon/http/Method.java
+++ b/http/http/src/main/java/io/helidon/http/Method.java
@@ -69,6 +69,11 @@ public final class Method {
      * {@value} method name.
      */
     public static final String CONNECT_NAME = "CONNECT";
+    /**
+     * {@value} method name.
+     */
+    public static final String QUERY_NAME = "QUERY";
+
 
     /**
      * The GET method means retrieve whatever information (in the form of an entity) is identified by the Request-URI.
@@ -141,6 +146,14 @@ public final class Method {
      * The HTTP CONNECT method starts two-way communications with the requested resource. It can be used to open a tunnel.
      */
     public static final Method CONNECT = new Method(CONNECT_NAME, true);
+
+    /**
+     * The HTTP QUERY method as described on RFC 10008 is used to perform a safe, idempotent request with a body.
+     * This is in contrast with GET, which does not define a body, and POST, which is not considered safe or idempotent.
+     * The response to a QUERY request should not have any side effects on the server, and it should return the requested
+     * information in the response body.
+     */
+    public static final Method QUERY = new Method(QUERY_NAME, true);
 
     static {
         // THIS MUST BE AFTER THE LAST CONSTANT
@@ -255,6 +268,46 @@ public final class Method {
      */
     public int length() {
         return length;
+    }
+
+    /**
+     * Whether this method is safe (see RFC 9110 Section 9.2.1).
+     *
+     * @return {@code true} if safe
+     */
+    public boolean isSafe() {
+        return this.equals(GET)
+                || this.equals(HEAD)
+                || this.equals(OPTIONS)
+                || this.equals(TRACE)
+                || this.equals(QUERY);
+    }
+
+    /**
+     * Whether this method is idempotent (see RFC 9110 Section 9.2.2).
+     *
+     * @return {@code true} if idempotent
+     */
+    public boolean isIdempotent() {
+        return this.equals(GET)
+                || this.equals(HEAD)
+                || this.equals(OPTIONS)
+                || this.equals(TRACE)
+                || this.equals(PUT)
+                || this.equals(DELETE)
+                || this.equals(QUERY);
+    }
+
+    /**
+     * Whether this method is cacheable (see RFC 9110 Section 9.2.3 and RFC 10008 Section 2.7).
+     *
+     * @return {@code true} if cacheable
+     */
+    public boolean isCacheable() {
+        return this.equals(GET)
+                || this.equals(HEAD)
+                || this.equals(POST)
+                || this.equals(QUERY);
     }
 
     @Override

--- a/http/http/src/main/java/io/helidon/http/ServerResponseHeaders.java
+++ b/http/http/src/main/java/io/helidon/http/ServerResponseHeaders.java
@@ -71,6 +71,23 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
     }
 
     /**
+     * Adds one or more acceptedTypes query document formats
+     * (header {@link HeaderNames#ACCEPT_QUERY}).
+     *
+     * @param acceptableMediaTypes media types to add.
+     * @return this instance
+     */
+    default ServerResponseHeaders addAcceptQueries(MediaType... acceptableMediaTypes) {
+        String[] values = new String[acceptableMediaTypes.length];
+        for (int i = 0; i < acceptableMediaTypes.length; i++) {
+            MediaType acceptableMediaType = acceptableMediaTypes[i];
+            values[i] = acceptableMediaType.text();
+        }
+        return add(HeaderValues.create(HeaderNames.ACCEPT_QUERY,
+                                       values));
+    }
+
+    /**
      * Adds {@code Set-Cookie} header specified in <a href="https://tools.ietf.org/html/rfc6265">RFC6265</a>.
      *
      * @param cookie a cookie definition

--- a/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
+++ b/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
@@ -135,6 +135,18 @@ class HeaderNamesTest {
     }
 
     @Test
+    void testAcceptQueryHeaderName() {
+        HeaderName acceptQuery = HeaderNames.ACCEPT_QUERY;
+
+        assertAll(
+                () -> assertThat(HeaderNames.ACCEPT_QUERY_NAME, is("Accept-Query")),
+                () -> assertThat(acceptQuery.defaultCase(), is("Accept-Query")),
+                () -> assertThat(acceptQuery.lowerCase(), is("accept-query")),
+                () -> assertThat(HeaderNames.create("Accept-Query"), equalTo(acceptQuery))
+        );
+    }
+
+    @Test
     void testAllConstantsHaveStringAndHeaderName() throws Exception {
         Map<String, String> stringConstantValues = new HashMap<>();
         Map<String, String> headerNameConstantValues = new HashMap<>();

--- a/http/http/src/test/java/io/helidon/http/HttpMethodTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpMethodTest.java
@@ -91,4 +91,29 @@ class HttpMethodTest {
             assertThat(constant + " has duplicate value: " + value, allValues.add(value), is(true));
         }
     }
+
+    @Test
+    void testMethodProperties() {
+        assertAll(
+                () -> assertThat(Method.GET.isSafe(), is(true)),
+                () -> assertThat(Method.GET.isIdempotent(), is(true)),
+                () -> assertThat(Method.GET.isCacheable(), is(true)),
+
+                () -> assertThat(Method.POST.isSafe(), is(false)),
+                () -> assertThat(Method.POST.isIdempotent(), is(false)),
+                () -> assertThat(Method.POST.isCacheable(), is(true)),
+
+                () -> assertThat(Method.QUERY.isSafe(), is(true)),
+                () -> assertThat(Method.QUERY.isIdempotent(), is(true)),
+                () -> assertThat(Method.QUERY.isCacheable(), is(true)),
+
+                () -> assertThat(Method.PUT.isSafe(), is(false)),
+                () -> assertThat(Method.PUT.isIdempotent(), is(true)),
+                () -> assertThat(Method.PUT.isCacheable(), is(false)),
+
+                () -> assertThat(Method.DELETE.isSafe(), is(false)),
+                () -> assertThat(Method.DELETE.isIdempotent(), is(true)),
+                () -> assertThat(Method.DELETE.isCacheable(), is(false))
+        );
+    }
 }

--- a/http/http/src/test/java/io/helidon/http/HttpTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpTest.java
@@ -108,6 +108,19 @@ class HttpTest {
         );
     }
 
+    @Test
+    void testAcceptQueryStructuredFields() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.ACCEPT_QUERY, "\"application/jsonpath\", application/sql;charset=\"UTF-8\"");
+        ClientResponseHeaders clientHeaders = ClientResponseHeaders.create(headers, io.helidon.common.media.type.ParserMode.STRICT);
+        List<HttpMediaType> parsed = clientHeaders.acceptQueries();
+
+        assertThat(parsed.size(), is(2));
+        assertThat(parsed.get(0).mediaType().text(), is("application/jsonpath"));
+        assertThat(parsed.get(1).mediaType().text(), is("application/sql"));
+        assertThat(parsed.get(1).parameters().get("charset"), is("UTF-8"));
+    }
+
     private static final class SingleValueHeader extends HeaderValueBase {
         private SingleValueHeader(String value) {
             super(HeaderNames.ACCEPT, false, false, value);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClient.java
@@ -190,4 +190,23 @@ public interface HttpClient<REQ extends ClientRequest<REQ>> extends ReleasableRe
     default REQ patch() {
         return method(Method.PATCH);
     }
+
+    /**
+     * Shortcut for query method with a path.
+     *
+     * @param uri path to resolve against base URI, or full URI
+     * @return a new request (not thread safe)
+     */
+    default REQ query(String uri) {
+        return (REQ) method(Method.QUERY).uri(uri);
+    }
+
+    /**
+     * Shortcut for query method with default path.
+     *
+     * @return a new request (not thread safe)
+     */
+    default REQ query() {
+        return method(Method.QUERY);
+    }
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -119,7 +119,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                 redirectUri.host(resolvedUri.host());
                 redirectUri.port(resolvedUri.port());
             }
-            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(responseStatus);
+            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(cos.lastRequest.method(), responseStatus);
             ClientRequest.OutputStreamHandler handler = osHandler;
             if (sendEntity && !cos.lastRequest.canReplayEntityTo(redirectUri)) {
                 // Replaying a 307/308 output-stream body to a new origin can leak credentials or form data.
@@ -507,8 +507,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             ClientUri lastUri = originalRequest.uri();
             Method method;
             boolean sendEntity;
-            if (lastStatus == Status.TEMPORARY_REDIRECT_307
-                    || lastStatus == Status.PERMANENT_REDIRECT_308) {
+            if (RedirectionProcessor.keepsMethodAndEntity(originalRequest.method(), lastStatus)) {
                 method = originalRequest.method();
                 sendEntity = true;
             } else {
@@ -564,8 +563,13 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                         checkRedirectHeaders(response.headers());
                         if (response.status() != Status.TEMPORARY_REDIRECT_307
                                 && response.status() != Status.PERMANENT_REDIRECT_308) {
-                            method = Method.GET;
-                            sendEntity = false;
+                            if (originalRequest.method() == Method.QUERY && response.status() != Status.SEE_OTHER_303) {
+                                method = Method.QUERY;
+                                sendEntity = true;
+                            } else {
+                                method = Method.GET;
+                                sendEntity = false;
+                            }
                         }
                         redirectedUri = response.headers().get(HeaderNames.LOCATION).get();
                     } finally {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
@@ -36,16 +36,19 @@ class RedirectionProcessor {
             && status.family() == Status.Family.REDIRECTION;
     }
 
-    static boolean keepsMethodAndEntity(Status status) {
-        return status == Status.TEMPORARY_REDIRECT_307
-                || status == Status.PERMANENT_REDIRECT_308;
+    static boolean keepsMethodAndEntity(Method method, Status status) {
+        if (status == Status.TEMPORARY_REDIRECT_307
+                || status == Status.PERMANENT_REDIRECT_308) {
+            return true;
+        }
+        return method == Method.QUERY && status != Status.SEE_OTHER_303;
     }
 
     static void validateEntityRedirect(Http1ClientRequestImpl request,
                                        Status status,
                                        ClientUri redirectUri,
                                        byte[] entity) {
-        if (keepsMethodAndEntity(status)
+        if (keepsMethodAndEntity(request.method(), status)
                 && entity.length > 0
                 && !request.canReplayEntityTo(redirectUri)) {
             throw new IllegalStateException("Cross-origin redirect with request entity is disabled.");
@@ -99,7 +102,7 @@ class RedirectionProcessor {
                 }
                 //Method and entity is required to be the same as with original request with 307 and 308 requests
                 validateEntityRedirect(clientRequest, clientResponse.status(), redirectUri, entityToBeSent);
-                if (keepsMethodAndEntity(clientResponse.status())) {
+                if (keepsMethodAndEntity(clientRequest.method(), clientResponse.status())) {
                     clientRequest = new Http1ClientRequestImpl(clientRequest,
                                                                clientRequest.method(),
                                                                redirectUri,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
@@ -101,7 +101,7 @@ class Http2CallEntityChain extends Http2CallChainBase {
 
     @Override
     protected WebClientServiceResponse doProceed(WebClientServiceRequest serviceRequest, HttpClientResponse response) {
-        if (RedirectionProcessor.keepsMethodAndEntity(response.status())) {
+        if (RedirectionProcessor.keepsMethodAndEntity(serviceRequest.method(), response.status())) {
             // HTTP/1 fallback can receive a redirect before an HTTP/2 stream exists. Do not serialize the body here;
             // redirect policy must be able to reject cross-origin replay before invoking media writers.
             hasRequestEntity = mayHaveEntity(entityHolder.entity());

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -127,7 +127,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 redirectUri.host(resolvedUri.host());
                 redirectUri.port(resolvedUri.port());
             }
-            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(responseHeaders.status());
+            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(outputStream.lastRequest.method(), responseHeaders.status());
             ClientRequest.OutputStreamHandler handler = streamHandler;
             if (sendEntity && !outputStream.lastRequest.canReplayEntityTo(redirectUri)) {
                 // Replaying a 307/308 output-stream body to a new origin can leak credentials or form data.
@@ -199,7 +199,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 redirectUri.port(resolvedUri.port());
             }
 
-            if (RedirectionProcessor.keepsMethodAndEntity(response.status())) {
+            if (RedirectionProcessor.keepsMethodAndEntity(clientRequest().method(), response.status())) {
                 method = clientRequest().method();
                 sendEntity = true;
             } else {
@@ -474,8 +474,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             ClientUri lastUri = originalRequest.uri();
             Method method;
             boolean sendEntity;
-            if (lastStatus == Status.TEMPORARY_REDIRECT_307
-                    || lastStatus == Status.PERMANENT_REDIRECT_308) {
+            if (RedirectionProcessor.keepsMethodAndEntity(originalRequest.method(), lastStatus)) {
                 method = originalRequest.method();
                 sendEntity = true;
             } else {
@@ -533,8 +532,13 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                             checkRedirectHeaders(response.headers());
                             if (response.status() != Status.TEMPORARY_REDIRECT_307
                                     && response.status() != Status.PERMANENT_REDIRECT_308) {
-                                method = Method.GET;
-                                sendEntity = false;
+                                if (originalRequest.method() == Method.QUERY && response.status() != Status.SEE_OTHER_303) {
+                                    method = Method.QUERY;
+                                    sendEntity = true;
+                                } else {
+                                    method = Method.GET;
+                                    sendEntity = false;
+                                }
                             }
                             redirectedUri = response.headers().get(HeaderNames.LOCATION).get();
                         }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -133,7 +133,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 redirectUri.host(resolvedUri.host());
                 redirectUri.port(resolvedUri.port());
             }
-            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(responseHeaders.status());
+            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(outputStream.lastRequest.method(), responseHeaders.status());
             ClientRequest.OutputStreamHandler handler = streamHandler;
             if (sendEntity && !outputStream.lastRequest.canReplayEntityTo(redirectUri)) {
                 // Replaying a 307/308 output-stream body to a new origin can leak credentials or form data.
@@ -205,7 +205,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 redirectUri.port(resolvedUri.port());
             }
 
-            if (RedirectionProcessor.keepsMethodAndEntity(response.status())) {
+            if (RedirectionProcessor.keepsMethodAndEntity(clientRequest().method(), response.status())) {
                 method = clientRequest().method();
                 sendEntity = true;
             } else {
@@ -474,8 +474,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             ClientUri lastUri = originalRequest.uri();
             Method method;
             boolean sendEntity;
-            if (lastStatus == Status.TEMPORARY_REDIRECT_307
-                    || lastStatus == Status.PERMANENT_REDIRECT_308) {
+            if (RedirectionProcessor.keepsMethodAndEntity(originalRequest.method(), lastStatus)) {
                 method = originalRequest.method();
                 sendEntity = true;
             } else {
@@ -535,8 +534,13 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                             checkRedirectHeaders(response.headers());
                             if (response.status() != Status.TEMPORARY_REDIRECT_307
                                     && response.status() != Status.PERMANENT_REDIRECT_308) {
-                                method = Method.GET;
-                                sendEntity = false;
+                                if (originalRequest.method() == Method.QUERY && response.status() != Status.SEE_OTHER_303) {
+                                    method = Method.QUERY;
+                                    sendEntity = true;
+                                } else {
+                                    method = Method.GET;
+                                    sendEntity = false;
+                                }
                             }
                             redirectedUri = response.headers().get(HeaderNames.LOCATION).get();
                         }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -259,7 +259,7 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         }
 
         boolean retainRequestEntity = followRedirects()
-                && RedirectionProcessor.keepsMethodAndEntity(serviceResponse.status());
+                && RedirectionProcessor.keepsMethodAndEntity(method(), serviceResponse.status());
         boolean hasRequestEntity = retainRequestEntity && callChain.hasRequestEntity();
         Object requestEntity = retainRequestEntity ? callChain.requestEntity() : null;
         long maxBufferedEntitySize = http2Client.protocolConfig().maxBufferedEntitySize().toBytes();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/RedirectionProcessor.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/RedirectionProcessor.java
@@ -35,16 +35,19 @@ class RedirectionProcessor {
         return status.family() == Status.Family.REDIRECTION;
     }
 
-    static boolean keepsMethodAndEntity(Status status) {
-        return status == Status.TEMPORARY_REDIRECT_307
-                || status == Status.PERMANENT_REDIRECT_308;
+    static boolean keepsMethodAndEntity(Method method, Status status) {
+        if (status == Status.TEMPORARY_REDIRECT_307
+                || status == Status.PERMANENT_REDIRECT_308) {
+            return true;
+        }
+        return method == Method.QUERY && status != Status.SEE_OTHER_303;
     }
 
     static void validateEntityRedirect(Http2ClientRequestImpl request,
                                        Status status,
                                        ClientUri redirectUri,
                                        boolean hasEntity) {
-        if (keepsMethodAndEntity(status)
+        if (keepsMethodAndEntity(request.method(), status)
                 && hasEntity
                 && !request.canReplayEntityTo(redirectUri)) {
             throw new IllegalStateException("Cross-origin redirect with request entity is disabled.");
@@ -111,7 +114,7 @@ class RedirectionProcessor {
             }
             //Method and entity is required to be the same as with original request with 307 and 308 requests
             validateEntityRedirect(clientRequest, clientResponse.status(), redirectUri, clientResponse.hasRequestEntity());
-            if (keepsMethodAndEntity(clientResponse.status())) {
+            if (keepsMethodAndEntity(clientRequest.method(), clientResponse.status())) {
                 Object requestEntity = clientResponse.requestEntity();
                 if (requestEntity != null) {
                     entityToBeSent = requestEntity;

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -96,8 +96,10 @@ class Http1ClientTest {
         rules.put("/test", Http1ClientTest::responseHandler);
         rules.put("/redirectKeepMethod", Http1ClientTest::redirectKeepMethod);
         rules.put("/redirect", Http1ClientTest::redirect);
+        rules.query("/redirect", Http1ClientTest::redirect);
         rules.get("/afterRedirect", Http1ClientTest::afterRedirectGet);
         rules.put("/afterRedirect", Http1ClientTest::afterRedirectPut);
+        rules.query("/afterRedirect", Http1ClientTest::afterRedirectQuery);
         rules.put("/chunkresponse", Http1ClientTest::chunkResponseHandler);
         rules.put("/delayedEndpoint", Http1ClientTest::delayedHandler);
     }
@@ -411,6 +413,17 @@ class Http1ClientTest {
     }
 
     @Test
+    void testQueryRedirect() {
+        try (HttpClientResponse response = injectedHttp1client.method(Method.QUERY)
+                .uri("/redirect")
+                .submit("Test entity")) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.lastEndpointUri().path().path(), is("/afterRedirect"));
+            assertThat(response.as(String.class), is("QUERY after redirect endpoint reached"));
+        }
+    }
+
+    @Test
     void testReadTimeoutPerRequest() {
         String testEntity = "Test entity";
         try (HttpClientResponse response = injectedHttp1client.put("/delayedEndpoint")
@@ -504,6 +517,17 @@ class Http1ClientTest {
         }
         res.status(Status.NO_CONTENT_204)
                 .send();
+    }
+
+    private static void afterRedirectQuery(ServerRequest req, ServerResponse res) {
+        String entity = req.content().as(String.class);
+        if (!entity.equals("Test entity")) {
+            res.status(Status.BAD_REQUEST_400)
+                    .send("Entity was not kept the same after the redirect");
+            return;
+        }
+        res.status(Status.OK_200)
+                .send("QUERY after redirect endpoint reached");
     }
 
     private static void delayedHandler(ServerRequest req, ServerResponse res) throws IOException, InterruptedException {

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsConfigSupport.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsConfigSupport.java
@@ -66,6 +66,7 @@ class CorsConfigSupport {
                                         .addAllowMethod(Method.GET)
                                         .addAllowMethod(Method.HEAD)
                                         .addAllowMethod(Method.POST)
+                                        .addAllowMethod(Method.QUERY)
                                         .exclusive(false)
                                         .build());
             }

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityHandler.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityHandler.java
@@ -524,8 +524,8 @@ public final class SecurityHandler implements Handler, ProtocolUpgradeHandler, R
 
         if (audited.isEmpty()) {
             // use defaults
-            if (method == Method.GET || method == Method.HEAD) {
-                // get and head are not audited by default
+            if (method == Method.GET || method == Method.HEAD || method == Method.QUERY) {
+                // get, head, and query are not audited by default
                 return;
             }
             //do nothing - we want to audit

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
@@ -374,6 +374,22 @@ public interface HttpRouting extends Routing, Prototype.Api {
         }
 
         @Override
+        default Builder query(String pathPattern, Handler... handlers) {
+            for (Handler handler : handlers) {
+                route(Method.QUERY, pathPattern, handler);
+            }
+            return this;
+        }
+
+        @Override
+        default Builder query(Handler... handlers) {
+            for (Handler handler : handlers) {
+                route(Method.QUERY, handler);
+            }
+            return this;
+        }
+
+        @Override
         default Builder any(String pathPattern, Handler... handlers) {
             for (Handler handler : handlers) {
                 route(HttpRoute.builder()

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRules.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRules.java
@@ -543,6 +543,33 @@ public interface HttpRules {
     }
 
     /**
+     * Add a query route.
+     *
+     * @param pathPattern URI path pattern
+     * @param handlers    handlers to process HTTP request
+     * @return updated rules
+     */
+    default HttpRules query(String pathPattern, Handler... handlers) {
+        for (Handler handler : handlers) {
+            route(Method.QUERY, pathPattern, handler);
+        }
+        return this;
+    }
+
+    /**
+     * Add a query route.
+     *
+     * @param handlers handlers to process HTTP request
+     * @return updated rules
+     */
+    default HttpRules query(Handler... handlers) {
+        for (Handler handler : handlers) {
+            route(Method.QUERY, handler);
+        }
+        return this;
+    }
+
+    /**
      * Add a route that executes on any HTTP method and any path.
      *
      * @param pathPattern URI path pattern


### PR DESCRIPTION
### Description

Resolves #12174

This change adds support for [RFC 10008](https://www.rfc-editor.org/info/rfc10008), including the `Accept-Query` header and redirection handling for the QUERY method.

This addition would also enable future OpenAPi 3.2 support.