### PR TITLE
Fix declarative ServerResponse handling (27.x)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
@@ -523,6 +523,14 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
             method.addContentLine();
         }
 
+        List<RestMethodParameter> params = restMethod.parameters();
+        boolean hasServerResponse = params.stream()
+                .map(RestMethodParameter::typeName)
+                .anyMatch(WebServerCodegenTypes.SERVER_RESPONSE::equals);
+        if (hasServerResponse) {
+            responseMetadata(fieldHandler, method, restMethod, headerProducers);
+        }
+
         boolean hasResponse = false;
         if (!restMethod.returnType().boxed().equals(TypeNames.BOXED_VOID)) {
             method.addContent("var ")
@@ -531,7 +539,6 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
             hasResponse = true;
         }
 
-        List<RestMethodParameter> params = restMethod.parameters();
         if (singleton) {
             method.addContent("this.endpoint.");
         } else {
@@ -562,6 +569,33 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                     .decreaseContentPadding();
         }
 
+        if (!hasServerResponse) {
+            responseMetadata(fieldHandler, method, restMethod, headerProducers);
+        }
+        boolean guardDefaultSend = hasServerResponse && !hasResponse;
+        if (guardDefaultSend) {
+            method.addContent("if (!")
+                    .addContent(RESPONSE_PARAM_NAME)
+                    .addContentLine(".isResponseHandled()) {")
+                    .increaseContentPadding();
+        }
+        method.addContent(RESPONSE_PARAM_NAME)
+                .addContent(".send(");
+        if (hasResponse) {
+            // we consider the response to be an entity to be sent (unmodified) over the response
+            method.addContent(METHOD_RESPONSE_NAME);
+        }
+        method.addContentLine(");");
+        if (guardDefaultSend) {
+            method.decreaseContentPadding()
+                    .addContentLine("}");
+        }
+    }
+
+    private void responseMetadata(FieldHandler fieldHandler,
+                                  Method.Builder method,
+                                  RestMethod restMethod,
+                                  Map<String, String> headerProducers) {
         if (restMethod.produces().size() == 1) {
             String mediaType = restMethod.produces().getFirst();
             if (!"*/*".equals(mediaType)) {
@@ -598,14 +632,6 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                     .addContent(RESPONSE_PARAM_NAME)
                     .addContent(".header(it));");
         }
-
-        method.addContent(RESPONSE_PARAM_NAME)
-                .addContent(".send(");
-        if (hasResponse) {
-            // we consider the response to be an entity to be sent (unmodified) over the response
-            method.addContent(METHOD_RESPONSE_NAME);
-        }
-        method.addContentLine(");");
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber") // this is a private method

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/VariableNamingCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/VariableNamingCodegenTest.java
@@ -29,6 +29,7 @@ import io.helidon.common.Default;
 import io.helidon.common.Generated;
 import io.helidon.common.GenericType;
 import io.helidon.common.mapper.Mappers;
+import io.helidon.common.media.type.MediaType;
 import io.helidon.common.parameters.Parameters;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.uri.UriQuery;
@@ -71,6 +72,7 @@ class VariableNamingCodegenTest {
             HttpRoute.class,
             HttpRouting.class,
             HttpRules.class,
+            MediaType.class,
             Mappers.class,
             Parameters.class,
             Prototype.class,
@@ -152,5 +154,159 @@ class VariableNamingCodegenTest {
         assertThat(generated, containsString("u_response);"));
         assertThat(generated, containsString("res.send(response);"));
         assertThat(generated, not(containsString("helidonDeclarative__")));
+    }
+
+    @Test
+    void generatedServerResponseParameterGuardsSend() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-server-response-parameter"))
+                .addSource("OutputStreamEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+                        import io.helidon.webserver.http.ServerResponse;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/output")
+                        class OutputStreamEndpoint {
+                            @Http.GET
+                            @Http.Path("/stream")
+                            @Http.Produces("text/plain")
+                            @RestServer.Header(name = "X-Stream", value = "true")
+                            @RestServer.Status(201)
+                            void stream(ServerResponse response) {
+                                response.send();
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedSources = Files.walk(result.sourceOutput())
+                .filter(it -> it.getFileName().toString().endsWith(".java"))
+                .toList();
+
+        StringBuilder generatedContent = new StringBuilder();
+        for (Path generatedSource : generatedSources) {
+            generatedContent.append(Files.readString(generatedSource, StandardCharsets.UTF_8));
+            generatedContent.append('\n');
+        }
+
+        String generated = generatedContent.toString();
+        int contentType = generated.indexOf("res.headers().contentType(");
+        int status = generated.indexOf("res.status(");
+        int header = generated.indexOf("res.header(");
+        int invocation = generated.indexOf("this.endpoint.stream(u_response);");
+        int guard = generated.indexOf("if (!res.isResponseHandled()) {");
+        int send = generated.indexOf("res.send();", guard);
+
+        assertThat(generated, containsString("var u_response = res;"));
+        assertThat("content type must be generated", contentType, not(-1));
+        assertThat("status must be generated", status, not(-1));
+        assertThat("header must be generated", header, not(-1));
+        assertThat("endpoint invocation must be generated", invocation, not(-1));
+        assertThat("send guard must be generated", guard, not(-1));
+        assertThat("send must be generated inside the guard", send, not(-1));
+        assertThat("content type must be set before the endpoint method is invoked", contentType < invocation, is(true));
+        assertThat("status must be set before the endpoint method is invoked", status < invocation, is(true));
+        assertThat("headers must be set before the endpoint method is invoked", header < invocation, is(true));
+        assertThat("send guard must be generated after the endpoint method is invoked", invocation < guard, is(true));
+        assertThat("send must be guarded by ServerResponse.isResponseHandled()", guard < send, is(true));
+    }
+
+    @Test
+    void generatedServerResponseParameterReturnValueAlwaysSends() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-server-response-return-value"))
+                .addSource("ReturnValueEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+                        import io.helidon.webserver.http.ServerResponse;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/return")
+                        class ReturnValueEndpoint {
+                            @Http.GET
+                            @Http.Path("/entity")
+                            @Http.Produces("text/plain")
+                            @RestServer.Header(name = "X-Entity", value = "true")
+                            @RestServer.Status(202)
+                            String entity(ServerResponse response) {
+                                return "entity";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedSources = Files.walk(result.sourceOutput())
+                .filter(it -> it.getFileName().toString().endsWith(".java"))
+                .toList();
+
+        StringBuilder generatedContent = new StringBuilder();
+        for (Path generatedSource : generatedSources) {
+            generatedContent.append(Files.readString(generatedSource, StandardCharsets.UTF_8));
+            generatedContent.append('\n');
+        }
+
+        String generated = generatedContent.toString();
+        int contentType = generated.indexOf("res.headers().contentType(");
+        int status = generated.indexOf("res.status(");
+        int header = generated.indexOf("res.header(");
+        int invocation = generated.indexOf("var response = this.endpoint.entity(u_response);");
+        int send = generated.indexOf("res.send(response);", invocation);
+
+        assertThat(generated, containsString("var u_response = res;"));
+        assertThat("content type must be generated", contentType, not(-1));
+        assertThat("status must be generated", status, not(-1));
+        assertThat("header must be generated", header, not(-1));
+        assertThat("endpoint invocation must be generated", invocation, not(-1));
+        assertThat("return value send must be generated", send, not(-1));
+        assertThat("content type must be set before the endpoint method is invoked", contentType < invocation, is(true));
+        assertThat("status must be set before the endpoint method is invoked", status < invocation, is(true));
+        assertThat("headers must be set before the endpoint method is invoked", header < invocation, is(true));
+        assertThat("return value must be sent without response-handled guard",
+                   generated,
+                   not(containsString("if (!res.isResponseHandled()) {")));
+        assertThat("return value must be sent after the endpoint method is invoked", invocation < send, is(true));
     }
 }

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
@@ -16,6 +16,9 @@
 
 package io.helidon.declarative.tests.http;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
@@ -40,6 +40,7 @@ import io.helidon.security.abac.role.RoleValidator;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
 
 /**
  * A simple endpoint to greet you. Examples:
@@ -120,6 +121,28 @@ class GreetServiceEndpoint implements GreetService {
     @Http.Path("/query-int")
     String queryInt(@Http.QueryParam("param") Integer queryParam) {
         return Integer.toString(queryParam);
+    }
+
+    @Http.GET
+    @Http.Path("/output-stream")
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    @RestServer.Header(name = "X-Stream", value = "true")
+    @RestServer.Status(Status.CREATED_201_CODE)
+    void outputStream(ServerResponse response) throws IOException {
+        try (var outputStream = response.outputStream()) {
+            outputStream.write("streamed".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    @Http.POST
+    @Http.Path("/input-stream-output-stream")
+    @Http.Consumes(MediaTypes.TEXT_PLAIN_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    void inputStreamOutputStream(@Http.Entity InputStream inputStream,
+                                 ServerResponse response) throws IOException {
+        try (var outputStream = response.outputStream()) {
+            inputStream.transferTo(outputStream);
+        }
     }
 
     /**

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -252,6 +252,26 @@ class DeclarativeHttpTest {
     }
 
     @Test
+    void testServerResponseOutputStream() {
+        try (var response = client.get("/greet/output-stream").request()) {
+            assertThat(response.status(), is(Status.CREATED_201));
+            assertThat(response.headers().contentType().orElseThrow().text(), is("text/plain"));
+            assertThat(response.headers().get(HeaderNames.create("X-Stream")).get(), is("true"));
+            assertThat(response.entity().as(String.class), is("streamed"));
+        }
+    }
+
+    @Test
+    void testInputStreamServerResponseEcho() {
+        String entity = "echoed entity";
+        var response = client.post("/greet/input-stream-output-stream")
+                .submit(entity, String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is(entity));
+    }
+
+    @Test
     void testQueryParamEmptyStringPreserved() {
         try (var response = client.get("/greet/query-param")
                 .queryParam("param", "")

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -143,6 +143,16 @@ Supported method parameters (no annotation required):
 - `io.helidon.common.security.SecurityContext`
 - link:{security-javadoc-base-url}/io/helidon/security/SecurityContext.html`[`io.helidon.security.SecurityContext] - in case `helidon-security` module is on the classpath
 
+If an endpoint method uses `ServerResponse` directly, generated response metadata such as status, content type,
+and declarative response headers is configured before the method is invoked.
+This is equivalent to imperative code configuring the same `ServerResponse` with `status(...)`,
+`headers().contentType(...)`, and `header(...)` before handling the response. The metadata belongs to the current
+response and is not automatically cleared if the method later calls `next()`, calls `reroute(...)`, or throws an
+exception; later route or error handling can change it before sending the response.
+When using `ServerResponse.outputStream()`, close the returned stream before leaving the endpoint method.
+For `void` endpoint methods, the generated handler only sends the response automatically if the method did not already
+handle it. Methods that return a value still send the returned entity.
+
 Annotations on endpoint type:
 
 - link:{webserver-javadoc-base-url}/io/helidon/webserver/http/RestServer.Endpoint.html[`io.helidon.webserver.http.RestServer.Endpoint`] - required annotation

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -468,6 +468,12 @@ Each `Handler` has two parameters. `ServerRequest` and `ServerResponse`.
 headers and entity.
 * Response provides an ability to set response code, headers, and entity.
 
+Status and headers configured on `ServerResponse` are mutable response metadata.
+Configure them before calling `send()` or `outputStream()` when they should apply to the response emitted by the route.
+Once configured, this metadata remains on the current response until later handling changes it.
+Calling `next()`, calling `reroute(...)`, or throwing an exception does not clear it automatically; downstream routes and
+error handlers can replace or remove response metadata before sending the response.
+
 [[anchor-filtering]]
 === Filtering
 Filtering can be done either using a dedicated `Filter`, or through routes.

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -344,6 +344,11 @@ public final class Http {
      * <p>
      * If the method may produce more than one type, the response headers must be crafted by hand. If it produces
      * exactly one type, that type will be set by Helidon on response.
+     * <p>
+     * When used by Helidon declarative server code on an endpoint method that accepts the server response, generated
+     * routing code configures the content type before invoking the method, so it is available to output-stream response
+     * handling. For endpoint methods that do not accept the server response, generated code configures the content type
+     * after the method returns and before the generated response is sent.
      */
     @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.METHOD)

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RestServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RestServer.java
@@ -29,6 +29,16 @@ import io.helidon.service.registry.Service;
 
 /**
  * APIs to define a declarative server endpoint.
+ * <p>
+ * Declarative response metadata, such as {@link Status}, {@link Header}, {@link ComputedHeader}, and
+ * {@link io.helidon.http.Http.Produces}, is configured on {@link ServerResponse} by generated routing code.
+ * For endpoint methods that accept {@link ServerResponse}, generated code configures this metadata before invoking the
+ * method, so it is available to {@link ServerResponse#outputStream()} and other response-handling APIs.
+ * For endpoint methods that do not accept {@link ServerResponse}, generated code configures this metadata after the
+ * method returns and before the generated response is sent.
+ * <p>
+ * Declarative response metadata has the same lifecycle as metadata configured imperatively on {@link ServerResponse}:
+ * it remains on the current response unless later route or error handling changes it.
  */
 @Api.Incubating
 public final class RestServer {
@@ -47,7 +57,7 @@ public final class RestServer {
     }
 
     /**
-     * Definition of an outbound header (sent with every response).
+     * Definition of outbound response header metadata.
      */
     @Target({ElementType.TYPE, ElementType.METHOD})
     @Repeatable(Headers.class)
@@ -75,7 +85,7 @@ public final class RestServer {
     @Documented
     public @interface Headers {
         /**
-         * Headers to add to request.
+         * Headers to add to response.
          *
          * @return headers
          */
@@ -83,7 +93,7 @@ public final class RestServer {
     }
 
     /**
-     * Definition of an outbound header (sent with every request).
+     * Definition of computed outbound response header metadata.
      */
     @Target({ElementType.TYPE, ElementType.METHOD})
     @Documented
@@ -112,7 +122,7 @@ public final class RestServer {
     @Documented
     public @interface ComputedHeaders {
         /**
-         * Headers to add to request.
+         * Headers to add to response.
          *
          * @return headers
          */
@@ -137,12 +147,17 @@ public final class RestServer {
     }
 
     /**
-     * Status that should be returned. Only use when not setting it explicitly.
-     * If an exception is thrown from the method, status is determined based on
-     * error handling.
+     * HTTP status to configure for a declarative server response.
      * <p>
-     * You can use {@code _CODE} constants from {@link io.helidon.http.Status} for
-     * {@link #value()}.
+     * For endpoint methods that accept {@link ServerResponse}, generated code configures this status before invoking
+     * the method. The configured status has the same lifecycle as status set imperatively through
+     * {@link ServerResponse#status(io.helidon.http.Status)}: it remains on the response unless later route or error
+     * handling changes it.
+     * <p>
+     * For methods that do not accept {@link ServerResponse}, generated code configures this status after the method
+     * returns and before the generated response is sent.
+     * <p>
+     * You can use {@code _CODE} constants from {@link io.helidon.http.Status} for {@link #value()}.
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Documented

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,13 @@ import io.helidon.webserver.http.spi.Sink;
 public interface ServerResponse {
     /**
      * Status of the response.
+     * <p>
+     * The status is mutable response metadata. Once configured, it remains on this response unless later application
+     * code or error handling changes it. Calling {@link #next()}, calling {@link #reroute(String)}, or throwing an
+     * exception does not clear the configured status automatically.
+     * <p>
+     * Configure the status before calling {@link #send()} or {@link #outputStream()} when it should apply to the
+     * response emitted by this route.
      *
      * @param status HTTP status
      * @return this instance
@@ -94,6 +101,11 @@ public interface ServerResponse {
 
     /**
      * Set header with a value.
+     * <p>
+     * Headers are mutable response metadata. Once configured, they remain on this response unless later application
+     * code or error handling changes them. Calling {@link #next()}, calling {@link #reroute(String)}, or throwing an
+     * exception does not clear configured headers automatically.
+     * <p>
      * Headers cannot be set after {@link #outputStream()} method is called, or after the response was sent.
      *
      * @param header header value
@@ -151,8 +163,26 @@ public interface ServerResponse {
     boolean isSent();
 
     /**
+     * Whether this response has already been handled by the application.
+     * <p>
+     * This method is intended for generated or framework code that may send a default response only when user code has
+     * not already sent an entity, obtained an output stream, or selected another routing action.
+     * Header and status changes alone do not handle the response.
+     * <p>
+     * The default implementation returns {@link #isSent()}.
+     *
+     * @return whether response handling was already selected
+     */
+    default boolean isResponseHandled() {
+        return isSent();
+    }
+
+    /**
      * Alternative way to send an entity, using an output stream. This should be used for entities that are big
      * and that should not be materialized into memory.
+     * <p>
+     * Configure response status and headers before requesting the output stream. The returned stream completes the
+     * response when it is closed, so it must be closed before the handler method returns.
      *
      * @return output stream
      */
@@ -190,6 +220,7 @@ public interface ServerResponse {
 
     /**
      * Re-route using a different path.
+     * Configured response status and headers remain on this response unless later handling changes them.
      *
      * @param newPath new path to use
      * @return this instance
@@ -198,6 +229,7 @@ public interface ServerResponse {
 
     /**
      * Re-route using a different path and query.
+     * Configured response status and headers remain on this response unless later handling changes them.
      *
      * @param path  new path
      * @param query new query
@@ -211,6 +243,7 @@ public interface ServerResponse {
     /**
      * Continue processing with the next route (and if none found, return a {@link io.helidon.http.Status#NOT_FOUND_404}).
      * If any entity method was called, this method will throw an exception.
+     * Configured response status and headers remain on this response unless later handling changes them.
      *
      * @return this instance
      * @throws IllegalStateException in case the entity was already configured
@@ -219,6 +252,8 @@ public interface ServerResponse {
 
     /**
      * Response headers (mutable).
+     * <p>
+     * Changes to these headers have the same lifecycle as headers configured through {@link #header(Header)}.
      *
      * @return headers
      */

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -207,6 +207,11 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     }
 
     @Override
+    public boolean isResponseHandled() {
+        return hasEntity() || isNexted() || shouldReroute();
+    }
+
+    @Override
     public ServerResponse beforeTrailers(Consumer<ServerResponseTrailers> beforeTrailers) {
         this.beforeTrailers = beforeTrailers;
         return this;


### PR DESCRIPTION
Resolves #12146

Carries forward the declarative `ServerResponse` output-stream fix from #12145 to main. Generated routes configure response metadata before invoking methods that accept `ServerResponse`, and skip the default empty send when user code has already handled a void response.
