### PR TITLE
Fix HTTP/2 duplex flow-control liveness

### DIFF
--- a/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
@@ -16,6 +16,7 @@
 
 package io.helidon.http.http2;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,7 @@ import io.helidon.common.socket.SocketContext;
  */
 public class Http2ConnectionWriter implements Http2StreamWriter {
     private static final Runnable NO_OP = () -> { };
+    private static final int NO_RESET_STREAM = -1;
 
     private final DataWriter writer;
 
@@ -48,6 +50,9 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
     private final Http2Headers.DynamicTable outboundDynamicTable;
     private final Http2HuffmanEncoder responseHuffman;
     private final BufferData headerBuffer = BufferData.growing(512);
+    // Guarded by windowUpdateLock. The generation prevents an older reset from clearing a newer reset's fence.
+    private int resetStreamId = NO_RESET_STREAM;
+    private long resetGeneration;
 
     /**
      * A new writer.
@@ -77,14 +82,17 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
         // The common path stays synchronous. Only hand off when another frame is holding the serialization lock
         // during a blocking transport write, otherwise an inbound flow-control callback could stop duplex progress.
         boolean locked = false;
+        int streamId = frame.header().streamId();
         try {
             windowUpdateLock.lock();
             try {
                 throwIfWindowUpdateFailed();
+                if (streamId != 0 && streamId == resetStreamId) {
+                    return;
+                }
                 locked = streamLock.tryLock(0, TimeUnit.NANOSECONDS);
                 if (!locked) {
                     Http2WindowUpdate windowUpdate = Http2WindowUpdate.create(frame.data());
-                    int streamId = frame.header().streamId();
                     pendingWindowUpdates.merge(streamId, (long) windowUpdate.windowSizeIncrement(), Long::sum);
                 }
             } finally {
@@ -295,23 +303,47 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
     }
 
     private void lockedWrite(Http2FrameData frame) {
+        boolean reset = frame.header().type() == Http2FrameType.RST_STREAM;
+        long fenceGeneration = -1;
         lock();
         try {
             throwIfWindowUpdateFailed();
-            if (frame.header().type() == Http2FrameType.RST_STREAM) {
-                Http2FrameData windowUpdate;
-                while ((windowUpdate = pollWindowUpdate(frame.header().streamId())) != null) {
+            if (reset) {
+                List<Http2FrameData> windowUpdates = new ArrayList<>();
+                windowUpdateLock.lock();
+                try {
+                    int streamId = frame.header().streamId();
+                    resetStreamId = streamId;
+                    fenceGeneration = ++resetGeneration;
+                    Http2FrameData windowUpdate;
+                    while ((windowUpdate = pollWindowUpdateNoLock(streamId)) != null) {
+                        windowUpdates.add(windowUpdate);
+                    }
+                } finally {
+                    windowUpdateLock.unlock();
+                }
+                for (Http2FrameData windowUpdate : windowUpdates) {
                     noLockWrite(windowUpdate);
                 }
             }
             noLockWrite(frame);
         } catch (Throwable t) {
-            if (frame.header().type() == Http2FrameType.RST_STREAM) {
+            if (reset) {
                 failWindowUpdates(t);
             }
             throw t;
         } finally {
             streamLock.unlock();
+            if (reset) {
+                windowUpdateLock.lock();
+                try {
+                    if (resetGeneration == fenceGeneration) {
+                        resetStreamId = NO_RESET_STREAM;
+                    }
+                } finally {
+                    windowUpdateLock.unlock();
+                }
+            }
         }
     }
 
@@ -364,15 +396,6 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
                 return null;
             }
             int streamId = pendingWindowUpdates.keySet().iterator().next();
-            return pollWindowUpdateNoLock(streamId);
-        } finally {
-            windowUpdateLock.unlock();
-        }
-    }
-
-    private Http2FrameData pollWindowUpdate(int streamId) {
-        windowUpdateLock.lock();
-        try {
             return pollWindowUpdateNoLock(streamId);
         } finally {
             windowUpdateLock.unlock();

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
@@ -111,7 +111,7 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
                 }
                 noLockWrite(frame);
             } catch (Throwable t) {
-                failWindowUpdates(t);
+                failWindowUpdatesAndClose(t);
                 throw t;
             } finally {
                 streamLock.unlock();
@@ -329,7 +329,7 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
             noLockWrite(frame);
         } catch (Throwable t) {
             if (reset) {
-                failWindowUpdates(t);
+                failWindowUpdatesAndClose(t);
             }
             throw t;
         } finally {
@@ -357,7 +357,7 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
                     .start(this::drainWindowUpdates);
         } catch (RuntimeException | Error e) {
             windowUpdateWriteScheduled.set(false);
-            failWindowUpdates(e);
+            failWindowUpdatesAndClose(e);
             throw e;
         }
     }
@@ -375,12 +375,7 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
                 streamLock.unlock();
             }
         } catch (Throwable t) {
-            failWindowUpdates(t);
-            try {
-                writer.close();
-            } catch (Throwable closeFailure) {
-                t.addSuppressed(closeFailure);
-            }
+            failWindowUpdatesAndClose(t);
         } finally {
             windowUpdateWriteScheduled.set(false);
             if (hasPendingWindowUpdates()) {
@@ -438,9 +433,16 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
         }
     }
 
-    private void failWindowUpdates(Throwable failure) {
-        windowUpdateFailure.compareAndSet(null, failure);
+    private void failWindowUpdatesAndClose(Throwable failure) {
+        if (!windowUpdateFailure.compareAndSet(null, failure)) {
+            return;
+        }
         clearWindowUpdates();
+        try {
+            writer.close();
+        } catch (Throwable closeFailure) {
+            failure.addSuppressed(closeFailure);
+        }
     }
 
     private void clearWindowUpdates() {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
@@ -16,16 +16,15 @@
 
 package io.helidon.http.http2;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
@@ -40,9 +39,10 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
     private final DataWriter writer;
 
     private final Lock streamLock = new ReentrantLock(true);
-    private final Queue<AsyncWrite> asyncWrites = new ConcurrentLinkedQueue<>();
-    private final AtomicBoolean asyncWriteScheduled = new AtomicBoolean();
-    private final AtomicReference<Throwable> asyncWriteFailure = new AtomicReference<>();
+    private final Lock windowUpdateLock = new ReentrantLock();
+    private final Map<Integer, Long> pendingWindowUpdates = new LinkedHashMap<>();
+    private final AtomicBoolean windowUpdateWriteScheduled = new AtomicBoolean();
+    private final AtomicReference<Throwable> windowUpdateFailure = new AtomicReference<>();
     private final SocketContext ctx;
     private final Http2FrameListener listener;
     private final Http2Headers.DynamicTable outboundDynamicTable;
@@ -68,37 +68,49 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
 
     @Override
     public void write(Http2FrameData frame) {
-        lockedWrite(frame);
-    }
-
-    /**
-     * Queue a frame for a serialized asynchronous write. This allows an inbound consumer to continue reading while
-     * another stream is blocked in a socket write on the same connection. The frame data is copied before this method
-     * returns.
-     *
-     * @param frame frame to write
-     * @param executor executor used to drain queued writes
-     * @param onFailure action invoked if a queued write fails
-     */
-    public void writeAsync(Http2FrameData frame, Executor executor, Consumer<Throwable> onFailure) {
         Objects.requireNonNull(frame);
-        Objects.requireNonNull(executor);
-        Objects.requireNonNull(onFailure);
-        Throwable failure = asyncWriteFailure.get();
-        if (failure != null) {
-            onFailure.accept(failure);
+        if (frame.header().type() != Http2FrameType.WINDOW_UPDATE) {
+            lockedWrite(frame);
             return;
         }
-        Http2FrameData frameCopy = new Http2FrameData(frame.header(), frame.data().copy());
-        AsyncWrite asyncWrite = new AsyncWrite(frameCopy, executor, onFailure);
-        asyncWrites.add(asyncWrite);
-        failure = asyncWriteFailure.get();
-        if (failure != null) {
-            asyncWrites.remove(asyncWrite);
-            onFailure.accept(failure);
+
+        // The common path stays synchronous. Only hand off when another frame is holding the serialization lock
+        // during a blocking transport write, otherwise an inbound flow-control callback could stop duplex progress.
+        boolean locked = false;
+        try {
+            windowUpdateLock.lock();
+            try {
+                throwIfWindowUpdateFailed();
+                locked = streamLock.tryLock(0, TimeUnit.NANOSECONDS);
+                if (!locked) {
+                    Http2WindowUpdate windowUpdate = Http2WindowUpdate.create(frame.data());
+                    int streamId = frame.header().streamId();
+                    pendingWindowUpdates.merge(streamId, (long) windowUpdate.windowSizeIncrement(), Long::sum);
+                }
+            } finally {
+                windowUpdateLock.unlock();
+            }
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Interrupted", e);
+        }
+        if (locked) {
+            try {
+                throwIfWindowUpdateFailed();
+                int count = pendingWindowUpdateCount();
+                Http2FrameData pending;
+                for (int i = 0; i < count && (pending = pollWindowUpdate()) != null; i++) {
+                    noLockWrite(pending);
+                }
+                noLockWrite(frame);
+            } catch (Throwable t) {
+                failWindowUpdates(t);
+                throw t;
+            } finally {
+                streamLock.unlock();
+            }
             return;
         }
-        scheduleAsyncWrite();
+        scheduleWindowUpdateWrite();
     }
 
     @Override
@@ -285,45 +297,142 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
     private void lockedWrite(Http2FrameData frame) {
         lock();
         try {
+            throwIfWindowUpdateFailed();
+            if (frame.header().type() == Http2FrameType.RST_STREAM) {
+                Http2FrameData windowUpdate;
+                while ((windowUpdate = pollWindowUpdate(frame.header().streamId())) != null) {
+                    noLockWrite(windowUpdate);
+                }
+            }
             noLockWrite(frame);
+        } catch (Throwable t) {
+            if (frame.header().type() == Http2FrameType.RST_STREAM) {
+                failWindowUpdates(t);
+            }
+            throw t;
         } finally {
             streamLock.unlock();
         }
     }
 
-    private void scheduleAsyncWrite() {
-        AsyncWrite next = asyncWrites.peek();
-        if (next == null || asyncWriteFailure.get() != null || !asyncWriteScheduled.compareAndSet(false, true)) {
+    private void scheduleWindowUpdateWrite() {
+        if (!hasPendingWindowUpdates() || !windowUpdateWriteScheduled.compareAndSet(false, true)) {
             return;
         }
         try {
-            next.executor().execute(this::drainAsyncWrites);
+            Thread.ofVirtual()
+                    .name("helidon-http2-window-update-" + ctx.socketId())
+                    .start(this::drainWindowUpdates);
         } catch (RuntimeException | Error e) {
-            asyncWriteScheduled.set(false);
-            failAsyncWrites(next, e);
+            windowUpdateWriteScheduled.set(false);
+            failWindowUpdates(e);
+            throw e;
         }
     }
 
-    private void drainAsyncWrites() {
-        AsyncWrite asyncWrite = null;
+    private void drainWindowUpdates() {
         try {
-            while ((asyncWrite = asyncWrites.poll()) != null) {
-                lockedWrite(asyncWrite.frame());
+            lock();
+            try {
+                int count = pendingWindowUpdateCount();
+                Http2FrameData frame;
+                for (int i = 0; i < count && (frame = pollWindowUpdate()) != null; i++) {
+                    noLockWrite(frame);
+                }
+            } finally {
+                streamLock.unlock();
             }
         } catch (Throwable t) {
-            failAsyncWrites(asyncWrite, t);
+            failWindowUpdates(t);
+            try {
+                writer.close();
+            } catch (Throwable closeFailure) {
+                t.addSuppressed(closeFailure);
+            }
         } finally {
-            asyncWriteScheduled.set(false);
-            if (asyncWriteFailure.get() == null && !asyncWrites.isEmpty()) {
-                scheduleAsyncWrite();
+            windowUpdateWriteScheduled.set(false);
+            if (hasPendingWindowUpdates()) {
+                scheduleWindowUpdateWrite();
             }
         }
     }
 
-    private void failAsyncWrites(AsyncWrite asyncWrite, Throwable failure) {
-        if (asyncWriteFailure.compareAndSet(null, failure)) {
-            asyncWrites.clear();
-            asyncWrite.onFailure().accept(failure);
+    private Http2FrameData pollWindowUpdate() {
+        windowUpdateLock.lock();
+        try {
+            if (pendingWindowUpdates.isEmpty()) {
+                return null;
+            }
+            int streamId = pendingWindowUpdates.keySet().iterator().next();
+            return pollWindowUpdateNoLock(streamId);
+        } finally {
+            windowUpdateLock.unlock();
+        }
+    }
+
+    private Http2FrameData pollWindowUpdate(int streamId) {
+        windowUpdateLock.lock();
+        try {
+            return pollWindowUpdateNoLock(streamId);
+        } finally {
+            windowUpdateLock.unlock();
+        }
+    }
+
+    private Http2FrameData pollWindowUpdateNoLock(int streamId) {
+        Long increment = pendingWindowUpdates.remove(streamId);
+        if (increment == null) {
+            return null;
+        }
+        int writeIncrement = (int) Math.min(increment, Integer.MAX_VALUE);
+        if (increment > Integer.MAX_VALUE) {
+            pendingWindowUpdates.put(streamId, increment - Integer.MAX_VALUE);
+        }
+        BufferData data = BufferData.create(4);
+        data.writeInt32(writeIncrement);
+        Http2FrameHeader header = Http2FrameHeader.create(4,
+                                                           Http2FrameTypes.WINDOW_UPDATE,
+                                                           Http2Flag.NoFlags.create(),
+                                                           streamId);
+        return new Http2FrameData(header, data);
+    }
+
+    private boolean hasPendingWindowUpdates() {
+        windowUpdateLock.lock();
+        try {
+            return !pendingWindowUpdates.isEmpty();
+        } finally {
+            windowUpdateLock.unlock();
+        }
+    }
+
+    private int pendingWindowUpdateCount() {
+        windowUpdateLock.lock();
+        try {
+            return pendingWindowUpdates.size();
+        } finally {
+            windowUpdateLock.unlock();
+        }
+    }
+
+    private void failWindowUpdates(Throwable failure) {
+        windowUpdateFailure.compareAndSet(null, failure);
+        clearWindowUpdates();
+    }
+
+    private void clearWindowUpdates() {
+        windowUpdateLock.lock();
+        try {
+            pendingWindowUpdates.clear();
+        } finally {
+            windowUpdateLock.unlock();
+        }
+    }
+
+    private void throwIfWindowUpdateFailed() {
+        Throwable failure = windowUpdateFailure.get();
+        if (failure != null) {
+            throw new IllegalStateException("Failed to write HTTP/2 window update", failure);
         }
     }
 
@@ -400,6 +509,4 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
         return frame.header().length() + Http2FrameHeader.LENGTH;
     }
 
-    private record AsyncWrite(Http2FrameData frame, Executor executor, Consumer<Throwable> onFailure) {
-    }
 }

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2ConnectionWriter.java
@@ -18,8 +18,14 @@ package io.helidon.http.http2;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
@@ -34,6 +40,9 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
     private final DataWriter writer;
 
     private final Lock streamLock = new ReentrantLock(true);
+    private final Queue<AsyncWrite> asyncWrites = new ConcurrentLinkedQueue<>();
+    private final AtomicBoolean asyncWriteScheduled = new AtomicBoolean();
+    private final AtomicReference<Throwable> asyncWriteFailure = new AtomicReference<>();
     private final SocketContext ctx;
     private final Http2FrameListener listener;
     private final Http2Headers.DynamicTable outboundDynamicTable;
@@ -60,6 +69,36 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
     @Override
     public void write(Http2FrameData frame) {
         lockedWrite(frame);
+    }
+
+    /**
+     * Queue a frame for a serialized asynchronous write. This allows an inbound consumer to continue reading while
+     * another stream is blocked in a socket write on the same connection. The frame data is copied before this method
+     * returns.
+     *
+     * @param frame frame to write
+     * @param executor executor used to drain queued writes
+     * @param onFailure action invoked if a queued write fails
+     */
+    public void writeAsync(Http2FrameData frame, Executor executor, Consumer<Throwable> onFailure) {
+        Objects.requireNonNull(frame);
+        Objects.requireNonNull(executor);
+        Objects.requireNonNull(onFailure);
+        Throwable failure = asyncWriteFailure.get();
+        if (failure != null) {
+            onFailure.accept(failure);
+            return;
+        }
+        Http2FrameData frameCopy = new Http2FrameData(frame.header(), frame.data().copy());
+        AsyncWrite asyncWrite = new AsyncWrite(frameCopy, executor, onFailure);
+        asyncWrites.add(asyncWrite);
+        failure = asyncWriteFailure.get();
+        if (failure != null) {
+            asyncWrites.remove(asyncWrite);
+            onFailure.accept(failure);
+            return;
+        }
+        scheduleAsyncWrite();
     }
 
     @Override
@@ -252,6 +291,42 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
         }
     }
 
+    private void scheduleAsyncWrite() {
+        AsyncWrite next = asyncWrites.peek();
+        if (next == null || asyncWriteFailure.get() != null || !asyncWriteScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            next.executor().execute(this::drainAsyncWrites);
+        } catch (RuntimeException | Error e) {
+            asyncWriteScheduled.set(false);
+            failAsyncWrites(next, e);
+        }
+    }
+
+    private void drainAsyncWrites() {
+        AsyncWrite asyncWrite = null;
+        try {
+            while ((asyncWrite = asyncWrites.poll()) != null) {
+                lockedWrite(asyncWrite.frame());
+            }
+        } catch (Throwable t) {
+            failAsyncWrites(asyncWrite, t);
+        } finally {
+            asyncWriteScheduled.set(false);
+            if (asyncWriteFailure.get() == null && !asyncWrites.isEmpty()) {
+                scheduleAsyncWrite();
+            }
+        }
+    }
+
+    private void failAsyncWrites(AsyncWrite asyncWrite, Throwable failure) {
+        if (asyncWriteFailure.compareAndSet(null, failure)) {
+            asyncWrites.clear();
+            asyncWrite.onFailure().accept(failure);
+        }
+    }
+
     private void lock() {
         try {
             streamLock.lockInterruptibly();
@@ -323,5 +398,8 @@ public class Http2ConnectionWriter implements Http2StreamWriter {
 
     private static int frameBytes(Http2FrameData frame) {
         return frame.header().length() + Http2FrameHeader.LENGTH;
+    }
+
+    private record AsyncWrite(Http2FrameData frame, Executor executor, Consumer<Throwable> onFailure) {
     }
 }

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
@@ -18,10 +18,9 @@ package io.helidon.http.http2;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,63 +50,135 @@ import static org.mockito.Mockito.when;
 class Http2ConnectionWriterTest {
 
     @Test
-    void asyncWriteDoesNotBlockInboundProgressBehindDataWrite() throws InterruptedException {
+    void writesPendingWindowUpdatesBeforeResetWhileDataWriteBlocked() throws InterruptedException {
         AtomicInteger writes = new AtomicInteger();
-        AtomicReference<Throwable> writeFailure = new AtomicReference<>();
-        AtomicReference<Throwable> asyncFailure = new AtomicReference<>();
+        AtomicInteger windowIncrement = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
         CountDownLatch dataWriteStarted = new CountDownLatch(1);
         CountDownLatch releaseDataWrite = new CountDownLatch(1);
-        CountDownLatch asyncWriteReturned = new CountDownLatch(1);
-        CountDownLatch asyncWriteCompleted = new CountDownLatch(1);
         DataWriter dataWriter = mock(DataWriter.class);
         doAnswer(_ -> {
             if (writes.incrementAndGet() == 1) {
                 dataWriteStarted.countDown();
                 releaseDataWrite.await();
-            } else {
-                asyncWriteCompleted.countDown();
             }
             return null;
         }).when(dataWriter).writeNow(any(BufferData.class));
+        List<Http2FrameType> frameTypes = new ArrayList<>();
+        AtomicReference<Http2FrameType> frameType = new AtomicReference<>();
+        Http2FrameListener listener = new Http2FrameListener() {
+            @Override
+            public void frameHeader(SocketContext ctx, int streamId, Http2FrameHeader header) {
+                frameTypes.add(header.type());
+                frameType.set(header.type());
+            }
 
-        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of());
-        Thread dataWriterThread = Thread.startVirtualThread(() -> {
+            @Override
+            public void frame(SocketContext ctx, int streamId, BufferData data) {
+                if (frameType.get() == Http2FrameType.WINDOW_UPDATE) {
+                    windowIncrement.set(data.copy().readInt32() & Integer.MAX_VALUE);
+                }
+            }
+        };
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of(listener));
+        Thread dataWriterThread = Thread.ofVirtual().start(() -> {
             try {
                 writer.write(dataFrame(1, 1024));
             } catch (Throwable t) {
-                writeFailure.set(t);
+                failure.compareAndSet(null, t);
             }
         });
 
         assertThat("DATA write must start", dataWriteStarted.await(1, TimeUnit.SECONDS), is(true));
-        try (ExecutorService executor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory())) {
-            Http2WindowUpdate windowUpdate = new Http2WindowUpdate(1024);
-            Thread asyncCaller = Thread.startVirtualThread(() -> {
-                writer.writeAsync(windowUpdate.toFrameData(null, 1, Http2Flag.NoFlags.create()),
-                                  executor,
-                                  asyncFailure::set);
-                asyncWriteReturned.countDown();
-            });
+        for (int i = 0; i < 2; i++) {
+            Http2WindowUpdate windowUpdate = new Http2WindowUpdate(1);
+            writer.write(windowUpdate.toFrameData(null, 1, Http2Flag.NoFlags.create()));
+        }
+        Http2RstStream reset = new Http2RstStream(Http2ErrorCode.CANCEL);
+        Thread resetWriterThread = Thread.ofVirtual().start(() -> {
+            try {
+                writer.write(reset.toFrameData(null, 1, Http2Flag.NoFlags.create()));
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        });
 
-            assertThat("queueing WINDOW_UPDATE must not block behind DATA",
-                       asyncWriteReturned.await(1, TimeUnit.SECONDS),
-                       is(true));
-            assertThat("asynchronous write must wait for the active DATA frame",
-                       asyncWriteCompleted.await(100, TimeUnit.MILLISECONDS),
-                       is(false));
+        try {
             releaseDataWrite.countDown();
-            assertThat("queued WINDOW_UPDATE must be written after DATA",
-                       asyncWriteCompleted.await(1, TimeUnit.SECONDS),
-                       is(true));
-            asyncCaller.join();
+            dataWriterThread.join(TimeUnit.SECONDS.toMillis(2));
+            resetWriterThread.join(TimeUnit.SECONDS.toMillis(2));
         } finally {
             releaseDataWrite.countDown();
-            dataWriterThread.join();
         }
 
+        assertThat("DATA writer must terminate", dataWriterThread.isAlive(), is(false));
+        assertThat("reset writer must terminate", resetWriterThread.isAlive(), is(false));
+        assertThat(writes.get(), is(3));
+        assertThat(frameTypes, is(List.of(Http2FrameType.DATA,
+                                          Http2FrameType.WINDOW_UPDATE,
+                                          Http2FrameType.RST_STREAM)));
+        assertThat(windowIncrement.get(), is(2));
+        assertThat(failure.get(), is(nullValue()));
+    }
+
+    @Test
+    void coalescesWindowUpdateBacklogWhileWriterIsBlocked() throws InterruptedException {
+        AtomicInteger writes = new AtomicInteger();
+        AtomicInteger windowIncrement = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch dataWriteStarted = new CountDownLatch(1);
+        CountDownLatch releaseDataWrite = new CountDownLatch(1);
+        CountDownLatch windowUpdateWritten = new CountDownLatch(1);
+        DataWriter dataWriter = mock(DataWriter.class);
+        doAnswer(_ -> {
+            int write = writes.incrementAndGet();
+            if (write == 1) {
+                dataWriteStarted.countDown();
+                releaseDataWrite.await();
+            } else {
+                windowUpdateWritten.countDown();
+            }
+            return null;
+        }).when(dataWriter).writeNow(any(BufferData.class));
+        AtomicReference<Http2FrameType> frameType = new AtomicReference<>();
+        Http2FrameListener listener = new Http2FrameListener() {
+            @Override
+            public void frameHeader(SocketContext ctx, int streamId, Http2FrameHeader header) {
+                frameType.set(header.type());
+            }
+
+            @Override
+            public void frame(SocketContext ctx, int streamId, BufferData data) {
+                if (frameType.get() == Http2FrameType.WINDOW_UPDATE) {
+                    windowIncrement.set(data.copy().readInt32() & Integer.MAX_VALUE);
+                }
+            }
+        };
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of(listener));
+        Thread dataWriterThread = Thread.ofVirtual().start(() -> {
+            try {
+                writer.write(dataFrame(1, 1024));
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        });
+
+        assertThat("DATA write must start", dataWriteStarted.await(1, TimeUnit.SECONDS), is(true));
+        try {
+            for (int i = 0; i < 5000; i++) {
+                Http2WindowUpdate windowUpdate = new Http2WindowUpdate(1);
+                writer.write(windowUpdate.toFrameData(null, 1, Http2Flag.NoFlags.create()));
+            }
+        } finally {
+            releaseDataWrite.countDown();
+        }
+
+        dataWriterThread.join(TimeUnit.SECONDS.toMillis(2));
+        assertThat("DATA writer must terminate", dataWriterThread.isAlive(), is(false));
+        assertThat("WINDOW_UPDATE must be written", windowUpdateWritten.await(2, TimeUnit.SECONDS), is(true));
         assertThat(writes.get(), is(2));
-        assertThat(writeFailure.get(), is(nullValue()));
-        assertThat(asyncFailure.get(), is(nullValue()));
+        assertThat(windowIncrement.get(), is(5000));
+        assertThat(failure.get(), is(nullValue()));
     }
 
     @Test

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
@@ -122,6 +122,60 @@ class Http2ConnectionWriterTest {
     }
 
     @Test
+    void doesNotWriteWindowUpdateAfterReset() {
+        AtomicReference<Http2ConnectionWriter> writerRef = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        List<Http2FrameType> frameTypes = new ArrayList<>();
+        List<Integer> windowUpdateStreamIds = new ArrayList<>();
+        Http2FrameListener listener = new Http2FrameListener() {
+            @Override
+            public void frameHeader(SocketContext ctx, int streamId, Http2FrameHeader header) {
+                frameTypes.add(header.type());
+                if (header.type() == Http2FrameType.WINDOW_UPDATE) {
+                    windowUpdateStreamIds.add(streamId);
+                }
+                if (header.type() == Http2FrameType.RST_STREAM) {
+                    Thread lateWindowUpdateWriter = Thread.ofVirtual().start(() -> {
+                        try {
+                            Http2WindowUpdate windowUpdate = new Http2WindowUpdate(1);
+                            writerRef.get().write(windowUpdate.toFrameData(null,
+                                                                          streamId,
+                                                                          Http2Flag.NoFlags.create()));
+                        } catch (Throwable t) {
+                            failure.compareAndSet(null, t);
+                        }
+                    });
+                    try {
+                        lateWindowUpdateWriter.join(TimeUnit.SECONDS.toMillis(2));
+                        if (lateWindowUpdateWriter.isAlive()) {
+                            failure.compareAndSet(null, new AssertionError("WINDOW_UPDATE writer did not terminate"));
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException("Interrupted", e);
+                    }
+                }
+            }
+        };
+        DataWriter dataWriter = mock(DataWriter.class);
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of(listener));
+        writerRef.set(writer);
+
+        Http2RstStream reset = new Http2RstStream(Http2ErrorCode.CANCEL);
+        writer.write(reset.toFrameData(null, 1, Http2Flag.NoFlags.create()));
+        Http2WindowUpdate windowUpdate = new Http2WindowUpdate(1);
+        writer.write(windowUpdate.toFrameData(null, 0, Http2Flag.NoFlags.create()));
+        writer.write(Http2Ping.create().toFrameData());
+
+        assertThat(frameTypes, is(List.of(Http2FrameType.RST_STREAM,
+                                          Http2FrameType.WINDOW_UPDATE,
+                                          Http2FrameType.PING)));
+        assertThat(windowUpdateStreamIds, is(List.of(0)));
+        assertThat(failure.get(), is(nullValue()));
+        verify(dataWriter, times(3)).writeNow(any(BufferData.class));
+    }
+
+    @Test
     void coalescesWindowUpdateBacklogWhileWriterIsBlocked() throws InterruptedException {
         AtomicInteger writes = new AtomicInteger();
         AtomicInteger windowIncrement = new AtomicInteger();

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketContext;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 
@@ -48,6 +49,88 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Http2ConnectionWriterTest {
+
+    @Test
+    void closesWriterWhenSynchronousWindowUpdateWriteFails() {
+        SocketWriterException writeFailure = new SocketWriterException();
+        DataWriter dataWriter = mock(DataWriter.class);
+        doAnswer(_ -> {
+            throw writeFailure;
+        }).when(dataWriter).writeNow(any(BufferData.class));
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of());
+        Http2WindowUpdate windowUpdate = new Http2WindowUpdate(1);
+
+        SocketWriterException thrown = assertThrows(SocketWriterException.class,
+                                                     () -> writer.write(windowUpdate.toFrameData(null,
+                                                                                                1,
+                                                                                                Http2Flag.NoFlags.create())));
+
+        assertThat(thrown, is(writeFailure));
+        verify(dataWriter).close();
+    }
+
+    @Test
+    void closesWriterWhenPendingWindowUpdateFailsBeforeReset() throws InterruptedException {
+        AtomicInteger writes = new AtomicInteger();
+        AtomicReference<Throwable> dataFailure = new AtomicReference<>();
+        AtomicReference<Throwable> resetFailure = new AtomicReference<>();
+        CountDownLatch dataWriteStarted = new CountDownLatch(1);
+        CountDownLatch releaseDataWrite = new CountDownLatch(1);
+        CountDownLatch resetWriteStarted = new CountDownLatch(1);
+        SocketWriterException writeFailure = new SocketWriterException();
+        DataWriter dataWriter = mock(DataWriter.class);
+        doAnswer(_ -> {
+            if (writes.incrementAndGet() == 1) {
+                dataWriteStarted.countDown();
+                releaseDataWrite.await();
+                return null;
+            }
+            throw writeFailure;
+        }).when(dataWriter).writeNow(any(BufferData.class));
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of());
+        Thread dataWriterThread = Thread.ofVirtual().start(() -> {
+            try {
+                writer.write(dataFrame(1, 1024));
+            } catch (Throwable t) {
+                dataFailure.set(t);
+            }
+        });
+
+        assertThat("DATA write must start", dataWriteStarted.await(1, TimeUnit.SECONDS), is(true));
+        Http2RstStream reset = new Http2RstStream(Http2ErrorCode.CANCEL);
+        Thread resetWriterThread = Thread.ofVirtual().start(() -> {
+            resetWriteStarted.countDown();
+            try {
+                writer.write(reset.toFrameData(null, 1, Http2Flag.NoFlags.create()));
+            } catch (Throwable t) {
+                resetFailure.set(t);
+            }
+        });
+
+        try {
+            assertThat("reset write must start", resetWriteStarted.await(1, TimeUnit.SECONDS), is(true));
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+            while (resetWriterThread.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+                Thread.onSpinWait();
+            }
+            assertThat("reset writer must wait for the DATA write",
+                       resetWriterThread.getState(),
+                       is(Thread.State.WAITING));
+            Http2WindowUpdate windowUpdate = new Http2WindowUpdate(1);
+            writer.write(windowUpdate.toFrameData(null, 1, Http2Flag.NoFlags.create()));
+        } finally {
+            releaseDataWrite.countDown();
+        }
+
+        dataWriterThread.join(TimeUnit.SECONDS.toMillis(2));
+        resetWriterThread.join(TimeUnit.SECONDS.toMillis(2));
+        assertThat("DATA writer must terminate", dataWriterThread.isAlive(), is(false));
+        assertThat("reset writer must terminate", resetWriterThread.isAlive(), is(false));
+        assertThat(dataFailure.get(), is(nullValue()));
+        assertThat(resetFailure.get(), is(writeFailure));
+        assertThat(writes.get(), is(2));
+        verify(dataWriter).close();
+    }
 
     @Test
     void writesPendingWindowUpdatesBeforeResetWhileDataWriteBlocked() throws InterruptedException {

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2ConnectionWriterTest.java
@@ -20,6 +20,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,6 +49,66 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Http2ConnectionWriterTest {
+
+    @Test
+    void asyncWriteDoesNotBlockInboundProgressBehindDataWrite() throws InterruptedException {
+        AtomicInteger writes = new AtomicInteger();
+        AtomicReference<Throwable> writeFailure = new AtomicReference<>();
+        AtomicReference<Throwable> asyncFailure = new AtomicReference<>();
+        CountDownLatch dataWriteStarted = new CountDownLatch(1);
+        CountDownLatch releaseDataWrite = new CountDownLatch(1);
+        CountDownLatch asyncWriteReturned = new CountDownLatch(1);
+        CountDownLatch asyncWriteCompleted = new CountDownLatch(1);
+        DataWriter dataWriter = mock(DataWriter.class);
+        doAnswer(_ -> {
+            if (writes.incrementAndGet() == 1) {
+                dataWriteStarted.countDown();
+                releaseDataWrite.await();
+            } else {
+                asyncWriteCompleted.countDown();
+            }
+            return null;
+        }).when(dataWriter).writeNow(any(BufferData.class));
+
+        Http2ConnectionWriter writer = new Http2ConnectionWriter(mock(SocketContext.class), dataWriter, List.of());
+        Thread dataWriterThread = Thread.startVirtualThread(() -> {
+            try {
+                writer.write(dataFrame(1, 1024));
+            } catch (Throwable t) {
+                writeFailure.set(t);
+            }
+        });
+
+        assertThat("DATA write must start", dataWriteStarted.await(1, TimeUnit.SECONDS), is(true));
+        try (ExecutorService executor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory())) {
+            Http2WindowUpdate windowUpdate = new Http2WindowUpdate(1024);
+            Thread asyncCaller = Thread.startVirtualThread(() -> {
+                writer.writeAsync(windowUpdate.toFrameData(null, 1, Http2Flag.NoFlags.create()),
+                                  executor,
+                                  asyncFailure::set);
+                asyncWriteReturned.countDown();
+            });
+
+            assertThat("queueing WINDOW_UPDATE must not block behind DATA",
+                       asyncWriteReturned.await(1, TimeUnit.SECONDS),
+                       is(true));
+            assertThat("asynchronous write must wait for the active DATA frame",
+                       asyncWriteCompleted.await(100, TimeUnit.MILLISECONDS),
+                       is(false));
+            releaseDataWrite.countDown();
+            assertThat("queued WINDOW_UPDATE must be written after DATA",
+                       asyncWriteCompleted.await(1, TimeUnit.SECONDS),
+                       is(true));
+            asyncCaller.join();
+        } finally {
+            releaseDataWrite.countDown();
+            dataWriterThread.join();
+        }
+
+        assertThat(writes.get(), is(2));
+        assertThat(writeFailure.get(), is(nullValue()));
+        assertThat(asyncFailure.get(), is(nullValue()));
+    }
 
     @Test
     void concurrentWritersDoNotReuseConnectionWindowCredit() throws InterruptedException {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
@@ -70,7 +70,7 @@ class Http2CallEntityChain extends Http2CallChainBase {
         Http2Headers http2Headers = prepareHeaders(serviceRequest.method(), headers, uri);
 
         stream.writeHeaders(http2Headers, !clientRequest().outputStreamRedirect() && entityBytes.length == 0);
-        stream.flowControl().inbound().incrementWindowSize(clientRequest().requestPrefetch());
+        stream.incrementInboundWindowSize(clientRequest().requestPrefetch());
         whenSent.complete(serviceRequest);
 
         waitFor100Continue(stream);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -106,6 +106,7 @@ public class Http2ClientConnection {
     private final ReentrantLock reservedStreamsLock = new ReentrantLock();
     private final CountDownLatch initialSettingsLatch = new CountDownLatch(1);
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
+    private volatile ExecutorService executor;
     private volatile int lastStreamId;
     private volatile long expectedPingAck = NO_PING_ACK;
     private volatile long peerMaxConcurrentStreams = Http2Setting.MAX_CONCURRENT_STREAMS.defaultValue();
@@ -492,6 +493,7 @@ public class Http2ClientConnection {
                        ExecutorService executor,
                        boolean sendSettings) {
         CountDownLatch cdl = new CountDownLatch(1);
+        this.executor = executor;
 
         handleTask = executor.submit(() -> {
             ctx.log(LOGGER, TRACE, "Starting HTTP/2 connection, thread: %s", Thread.currentThread().getName());
@@ -573,7 +575,7 @@ public class Http2ClientConnection {
 
     private void writeWindowsUpdate(int streamId, Http2WindowUpdate windowUpdateFrame) {
         if (streamId == 0) {
-            writer.write(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            writeWindowUpdate(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
             return;
         }
         if (streamId < lastStreamId) {
@@ -593,8 +595,17 @@ public class Http2ClientConnection {
         }
         Http2ClientStream stream = stream(streamId);
         if (stream != null && !stream.streamState().equals(Http2StreamState.CLOSED)) {
-            writer.write(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            writeWindowUpdate(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
         }
+    }
+
+    private void writeWindowUpdate(Http2FrameData frame) {
+        writer.writeAsync(frame, executor, this::windowUpdateWriteFailed);
+    }
+
+    private void windowUpdateWriteFailed(Throwable failure) {
+        ctx.log(LOGGER, DEBUG, "Failed to write HTTP/2 window update", failure);
+        closeNow();
     }
 
     private boolean handle() {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -106,7 +106,6 @@ public class Http2ClientConnection {
     private final ReentrantLock reservedStreamsLock = new ReentrantLock();
     private final CountDownLatch initialSettingsLatch = new CountDownLatch(1);
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
-    private volatile ExecutorService executor;
     private volatile int lastStreamId;
     private volatile long expectedPingAck = NO_PING_ACK;
     private volatile long peerMaxConcurrentStreams = Http2Setting.MAX_CONCURRENT_STREAMS.defaultValue();
@@ -140,7 +139,7 @@ public class Http2ClientConnection {
         this.ctx = connection.helidonSocket();
         this.dataWriter = connection.writer();
         this.reader = connection.reader();
-        this.writer = new Http2ConnectionWriter(connection.helidonSocket(), connection.writer(), List.of());
+        this.writer = new Http2ConnectionWriter(connection.helidonSocket(), new ConnectionDataWriter(), List.of());
         this.closeListener = closeListener;
     }
 
@@ -493,7 +492,6 @@ public class Http2ClientConnection {
                        ExecutorService executor,
                        boolean sendSettings) {
         CountDownLatch cdl = new CountDownLatch(1);
-        this.executor = executor;
 
         handleTask = executor.submit(() -> {
             ctx.log(LOGGER, TRACE, "Starting HTTP/2 connection, thread: %s", Thread.currentThread().getName());
@@ -575,7 +573,7 @@ public class Http2ClientConnection {
 
     private void writeWindowsUpdate(int streamId, Http2WindowUpdate windowUpdateFrame) {
         if (streamId == 0) {
-            writeWindowUpdate(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            writer.write(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
             return;
         }
         if (streamId < lastStreamId) {
@@ -595,17 +593,8 @@ public class Http2ClientConnection {
         }
         Http2ClientStream stream = stream(streamId);
         if (stream != null && !stream.streamState().equals(Http2StreamState.CLOSED)) {
-            writeWindowUpdate(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            writer.write(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
         }
-    }
-
-    private void writeWindowUpdate(Http2FrameData frame) {
-        writer.writeAsync(frame, executor, this::windowUpdateWriteFailed);
-    }
-
-    private void windowUpdateWriteFailed(Throwable failure) {
-        ctx.log(LOGGER, DEBUG, "Failed to write HTTP/2 window update", failure);
-        closeNow();
     }
 
     private boolean handle() {
@@ -1097,6 +1086,38 @@ public class Http2ClientConnection {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL,
                                          "Response Header Fields Too Large");
             }
+        }
+    }
+
+    private final class ConnectionDataWriter implements DataWriter {
+        @Override
+        public void write(BufferData... buffers) {
+            dataWriter.write(buffers);
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+            dataWriter.write(buffer);
+        }
+
+        @Override
+        public void writeNow(BufferData... buffers) {
+            dataWriter.writeNow(buffers);
+        }
+
+        @Override
+        public void writeNow(BufferData buffer) {
+            dataWriter.writeNow(buffer);
+        }
+
+        @Override
+        public void flush() {
+            dataWriter.flush();
+        }
+
+        @Override
+        public void close() {
+            closeNow();
         }
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -190,31 +190,40 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
     @Override
     public void windowUpdate(Http2WindowUpdate windowUpdate) {
-        this.state = Http2StreamState.checkAndGetState(this.state,
-                                                       Http2FrameType.WINDOW_UPDATE,
-                                                       false,
-                                                       false,
-                                                       false);
+        inboundStateLock.lock();
+        try {
+            this.state = Http2StreamState.checkAndGetState(this.state,
+                                                           Http2FrameType.WINDOW_UPDATE,
+                                                           false,
+                                                           false,
+                                                           false);
+        } finally {
+            inboundStateLock.unlock();
+        }
 
         int increment = windowUpdate.windowSizeIncrement();
 
         //6.9/2
         if (increment == 0) {
-            Http2RstStream frame = new Http2RstStream(Http2ErrorCode.PROTOCOL);
-            connection.writer().write(frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            reset(Http2ErrorCode.PROTOCOL);
+            return;
         }
         //6.9.1/3
         if (flowControl.outbound().incrementStreamWindowSize(increment) > WindowSize.MAX_WIN_SIZE) {
-            Http2RstStream frame = new Http2RstStream(Http2ErrorCode.FLOW_CONTROL);
-            connection.writer().write(frame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+            reset(Http2ErrorCode.FLOW_CONTROL);
         }
     }
 
     @Override
     public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
-        updateState(Http2StreamState.checkAndGetState(this.state, header.type(), false, endOfStream, false));
-        readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
-        flowControl.inbound().incrementWindowSize(header.length());
+        inboundStateLock.lock();
+        try {
+            updateState(Http2StreamState.checkAndGetState(this.state, header.type(), false, endOfStream, false));
+            readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
+            incrementInboundWindowSizeLocked(header.length());
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     @Override
@@ -278,25 +287,51 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @param errorCode HTTP/2 error code to send
      */
     void reset(Http2ErrorCode errorCode) {
-        if (NON_CANCELABLE.contains(state)) {
-            return;
+        Http2StreamState nextState;
+        inboundStateLock.lock();
+        try {
+            if (NON_CANCELABLE.contains(state)) {
+                return;
+            }
+            nextState = Http2StreamState.checkAndGetState(this.state,
+                                                          Http2FrameType.RST_STREAM,
+                                                          true,
+                                                          false,
+                                                          false);
+            this.state = nextState;
+        } finally {
+            inboundStateLock.unlock();
         }
         Http2RstStream rstStream = new Http2RstStream(errorCode);
         Http2FrameData frameData = rstStream.toFrameData(settings, streamId, Http2Flag.NoFlags.create());
-        Http2StreamState nextState = Http2StreamState.checkAndGetState(this.state,
-                                                                       Http2FrameType.RST_STREAM,
-                                                                       true,
-                                                                       false,
-                                                                       false);
-        sendListener.frameHeader(ctx, streamId, frameData.header());
-        sendListener.frame(ctx, streamId, rstStream);
         try {
+            sendListener.frameHeader(ctx, streamId, frameData.header());
+            sendListener.frame(ctx, streamId, rstStream);
             connection.writer().write(frameData);
         } catch (UncheckedIOException e) {
             // we consider this to be a marker that the connection is already close
             ctx.log(LOGGER, DEBUG, "Exception during stream cancel", e);
         } finally {
-            updateState(nextState);
+            if (nextState == Http2StreamState.CLOSED) {
+                releaseReservation();
+            }
+        }
+    }
+
+    void incrementInboundWindowSize(int increment) {
+        inboundStateLock.lock();
+        try {
+            incrementInboundWindowSizeLocked(increment);
+        } finally {
+            inboundStateLock.unlock();
+        }
+    }
+
+    private void incrementInboundWindowSizeLocked(int increment) {
+        if (state == Http2StreamState.CLOSED || closed) {
+            connection.flowControl().incrementInboundConnectionWindowSize(increment);
+        } else {
+            flowControl.inbound().incrementWindowSize(increment);
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionPingTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -37,6 +38,7 @@ import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.mapper.MapperException;
 import io.helidon.common.mapper.Value;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.SocketContext;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -50,6 +52,7 @@ import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameListener;
+import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanEncoder;
@@ -124,6 +127,44 @@ class Http2ClientConnectionPingTest {
         stream.windowUpdate(new Http2WindowUpdate(1024));
 
         assertThat(stream.flowControl().outbound().getRemainingWindowSize(), is(before + 1024));
+    }
+
+    @Test
+    void resetClosesStreamWindowUpdateProducerBeforeWritingReset() {
+        MockedConnectionTestContext test = new MockedConnectionTestContext(Duration.ofMillis(100));
+        AtomicReference<Http2ClientStream> streamRef = new AtomicReference<>();
+        Http2FrameListener sendListener = new Http2FrameListener() {
+            @Override
+            public void frameHeader(SocketContext ctx, int streamId, Http2FrameHeader header) {
+                if (header.type() == Http2FrameType.RST_STREAM) {
+                    streamRef.get().incrementInboundWindowSize(1);
+                }
+            }
+        };
+        Http2ClientStream stream = new Http2ClientStream(test.connection,
+                                                         Http2Settings.create(),
+                                                         test.socket,
+                                                         STREAM_CONFIG,
+                                                         test.clientConfig,
+                                                         test.streamIdSequence,
+                                                         sendListener,
+                                                         Http2FrameListener.create(List.of()));
+        streamRef.set(stream);
+        stream.writeHeaders(requestHeaders(VALID_REGULAR_HEADER), false);
+        stream.flowControl().inbound().decrementWindowSize(1);
+        test.writes().clear();
+
+        stream.cancel();
+
+        List<Http2FrameType> frameTypes = new ArrayList<>();
+        List<Integer> streamIds = new ArrayList<>();
+        for (BufferData write : test.writes()) {
+            Http2FrameHeader header = Http2FrameHeader.create(write.copy());
+            frameTypes.add(header.type());
+            streamIds.add(header.streamId());
+        }
+        assertThat(frameTypes, is(List.of(Http2FrameType.WINDOW_UPDATE, Http2FrameType.RST_STREAM)));
+        assertThat(streamIds, is(List.of(0, stream.streamId())));
     }
 
     @Test

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -44,6 +44,7 @@ import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameListener;
+import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanEncoder;
@@ -64,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
@@ -447,6 +449,70 @@ class Http2ClientConnectionTest {
             }
             cancel.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             stream.close();
+        }
+    }
+
+    @Test
+    void windowUpdateWriterDoesNotDependOnConnectionExecutor() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            try {
+                Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+                stream.writeHeaders(requestHeaders(), true);
+                Http2Headers.DynamicTable inboundTable =
+                        Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+                Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+                byte[] responseData = "response".getBytes(StandardCharsets.UTF_8);
+                test.offerInbound(encodedHeaderFrame(stream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+                                  dataFrame(stream.streamId(), responseData, false));
+                assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+                clearInvocations(test.dataWriter);
+                MockedConnectionTestContext.BlockedWrite blockedWrite = test.blockNextWriteNow();
+                CompletableFuture<Void> activeWrite = CompletableFuture.runAsync(
+                        () -> connection.writer().write(windowUpdateFrame(0)));
+
+                assertTrue(blockedWrite.awaitEntered());
+                try {
+                    CompletableFuture<Http2FrameData> read = CompletableFuture.supplyAsync(
+                            () -> stream.readOne(Duration.ofSeconds(1)));
+                    Http2FrameData frame = read.get(2, TimeUnit.SECONDS);
+                    assertThat(frame.header().type(), is(Http2FrameType.DATA));
+                    assertThat(frame.data().readBytes(), is(responseData));
+                } finally {
+                    blockedWrite.release();
+                }
+                activeWrite.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+                verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).atLeast(2))
+                        .writeNow(any(BufferData.class));
+            } finally {
+                connection.closeNow();
+            }
+        }
+    }
+
+    @Test
+    void deferredWindowUpdateFailureClosesConnection() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            MockedConnectionTestContext.BlockedWrite blockedWrite = test.blockNextWriteNow();
+            CompletableFuture<Void> activeWrite = CompletableFuture.runAsync(
+                    () -> connection.writer().write(dataFrame(1, new byte[1024], false)));
+
+            assertTrue(blockedWrite.awaitEntered());
+            try {
+                test.failWrites();
+                connection.writer().write(windowUpdateFrame(0));
+            } finally {
+                blockedWrite.release();
+            }
+
+            activeWrite.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            test.assertConnectionClosed();
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -499,6 +499,7 @@ class Http2ClientConnectionTest {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.offerInbound(settingsFrame(1));
             Http2ClientConnection connection = test.createConnection(false);
+            assertTrue(test.initialWriteNowCallsCompleted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
             MockedConnectionTestContext.BlockedWrite blockedWrite = test.blockNextWriteNow();
             CompletableFuture<Void> activeWrite = CompletableFuture.runAsync(
                     () -> connection.writer().write(dataFrame(1, new byte[1024], false)));
@@ -880,6 +881,8 @@ class Http2ClientConnectionTest {
 
         private final ExecutorService connectionExecutor = Executors.newSingleThreadExecutor();
         private final LinkedBlockingQueue<byte[]> inboundFrames = new LinkedBlockingQueue<>();
+        // The client preface is the first writeNow call; the initial SETTINGS ACK is the second.
+        private final CountDownLatch initialWriteNowCallsCompleted = new CountDownLatch(2);
         private final AtomicBoolean failWrites = new AtomicBoolean();
         private final AtomicReference<BlockedWrite> blockedWrite = new AtomicReference<>();
         private final DataWriter dataWriter = mock(DataWriter.class);
@@ -913,11 +916,13 @@ class Http2ClientConnectionTest {
             doAnswer(invocation -> {
                 maybeFailWrites();
                 maybeBlockWriteNow();
+                initialWriteNowCallsCompleted.countDown();
                 return null;
             }).when(dataWriter).writeNow(any(BufferData.class));
             doAnswer(invocation -> {
                 maybeFailWrites();
                 maybeBlockWriteNow();
+                initialWriteNowCallsCompleted.countDown();
                 return null;
             }).when(dataWriter).writeNow(any(BufferData[].class));
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -638,7 +638,13 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
 
     // Used in inbound flow control instance to write WINDOW_UPDATE frame.
     private void writeWindowUpdateFrame(int streamId, Http2WindowUpdate windowUpdateFrame) {
-        writeConnectionFrame(windowUpdateFrame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+        Http2FrameData frame = windowUpdateFrame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create());
+        connectionWriter.writeAsync(frame, ctx.executor(), this::windowUpdateWriteFailed);
+    }
+
+    private void windowUpdateWriteFailed(Throwable failure) {
+        LOGGER.log(DEBUG, "Failed to write HTTP/2 window update", failure);
+        close(true);
     }
 
     private void doSettings() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -31,6 +31,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.concurrency.limits.Limit;
 import io.helidon.common.socket.SocketWriterException;
 import io.helidon.common.task.InterruptableTask;
@@ -157,7 +158,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                 ? Http2FrameListener.create(List.of(Http2LoggingFrameListener.create(log, "recv")))
                 : Http2FrameListener.create(List.of());
         this.connectionWriter = new Http2ConnectionWriter(ctx,
-                                                          ctx.dataWriter(),
+                                                          new ConnectionDataWriter(ctx.dataWriter()),
                                                           log.sendLog()
                                                                   ? List.of(Http2LoggingFrameListener.create(log, "send"))
                                                                   : List.of());
@@ -638,13 +639,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
 
     // Used in inbound flow control instance to write WINDOW_UPDATE frame.
     private void writeWindowUpdateFrame(int streamId, Http2WindowUpdate windowUpdateFrame) {
-        Http2FrameData frame = windowUpdateFrame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create());
-        connectionWriter.writeAsync(frame, ctx.executor(), this::windowUpdateWriteFailed);
-    }
-
-    private void windowUpdateWriteFailed(Throwable failure) {
-        LOGGER.log(DEBUG, "Failed to write HTTP/2 window update", failure);
-        close(true);
+        writeConnectionFrame(windowUpdateFrame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
     }
 
     private void doSettings() {
@@ -1509,6 +1504,44 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         @Override
         public StreamFlowControl flowControl() {
             return FLOW_CONTROL;
+        }
+    }
+
+    private final class ConnectionDataWriter implements DataWriter {
+        private final DataWriter delegate;
+
+        private ConnectionDataWriter(DataWriter delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void write(BufferData... buffers) {
+            delegate.write(buffers);
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+            delegate.write(buffer);
+        }
+
+        @Override
+        public void writeNow(BufferData... buffers) {
+            delegate.writeNow(buffers);
+        }
+
+        @Override
+        public void writeNow(BufferData buffer) {
+            delegate.writeNow(buffer);
+        }
+
+        @Override
+        public void flush() {
+            delegate.flush();
+        }
+
+        @Override
+        public void close() {
+            Http2Connection.this.close(true);
         }
     }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -124,6 +124,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private volatile boolean resetStreamSent;
     private volatile boolean remoteCompleteAfterReset;
     private volatile boolean ignoreInboundDataAfterReset;
+    private boolean windowUpdatesClosed;
     private volatile boolean connectionAborted;
     // used from this instance and from connection
     private volatile Http2StreamState state = Http2StreamState.IDLE;
@@ -337,14 +338,14 @@ class Http2ServerStream implements Runnable, Http2Stream {
             //6.9/2
             if (windowUpdate.windowSizeIncrement() == 0) {
                 Http2RstStream frame = new Http2RstStream(Http2ErrorCode.PROTOCOL);
-                writer.write(frame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+                writeResetStream(frame, clientSettings);
                 connectionAttackVectorMetrics.madeYouResetCheck();
             }
             //6.9.1/3
             long size = flowControl.outbound().incrementStreamWindowSize(windowUpdate.windowSizeIncrement());
             if (size > WindowSize.MAX_WIN_SIZE || size < 0L) {
                 Http2RstStream frame = new Http2RstStream(Http2ErrorCode.FLOW_CONTROL);
-                writer.write(frame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+                writeResetStream(frame, clientSettings);
                 connectionAttackVectorMetrics.madeYouResetCheck();
             }
         } catch (UncheckedIOException e) {
@@ -386,7 +387,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
             if (state == Http2StreamState.CLOSED) {
                 restoreDiscardedConnectionCredit(header.length());
             } else {
-                flowControl.inbound().incrementWindowSize(header.length());
+                incrementInboundWindowSize(header.length());
             }
             return;
         }
@@ -402,7 +403,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
             }
         }
         if (dataLength == 0) {
-            flowControl.inbound().incrementWindowSize(header.length());
+            incrementInboundWindowSize(header.length());
             if (endOfStream) {
                 closeFromRemote();
             }
@@ -569,7 +570,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                     : Http2ErrorCode.STREAM_CLOSED;
             Http2RstStream rst = new Http2RstStream(errorCode);
             try {
-                writer.write(rst.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+                writeResetStream(rst, serverSettings);
                 resetSent = true;
             } catch (SocketWriterException | UncheckedIOException writeFailure) {
                 connectionFailed = true;
@@ -593,7 +594,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                     if (!connectionFailed && !resetSent) {
                         Http2RstStream rst = new Http2RstStream(Http2ErrorCode.INTERNAL);
                         try {
-                            writer.write(rst.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
+                            writeResetStream(rst, serverSettings);
                             resetSent = true;
                         } catch (SocketWriterException | UncheckedIOException writeFailure) {
                             ctx.log(LOGGER, DEBUG, "Failed to reset stream %d after handler failure", streamId);
@@ -911,7 +912,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 discardDataAfterReset(currentFrameLength);
             }
             if (sendReset) {
-                writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+                writeResetStream(rst, clientSettings);
                 connectionAttackVectorMetrics.madeYouResetCheck();
             }
         } finally {
@@ -970,7 +971,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 }
                 return BufferData.empty();
             }
-            inboundData.complete(frame, () -> flowControl.inbound().incrementStreamWindowSize(frame.flowControlLength()));
+            inboundData.complete(frame, () -> incrementInboundStreamWindowSize(frame.flowControlLength()));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new ServerConnectionException("Interrupted while waiting for request data", e);
@@ -1083,11 +1084,21 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private void writeResetStream(Http2ErrorCode resetCode) {
         Http2RstStream rst = new Http2RstStream(resetCode);
         try {
-            writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+            writeResetStream(rst, clientSettings);
         } catch (SocketWriterException | UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write reset stream", e);
         }
         connectionAttackVectorMetrics.madeYouResetCheck();
+    }
+
+    private void writeResetStream(Http2RstStream reset, Http2Settings settings) {
+        resetCompletionLock.lock();
+        try {
+            windowUpdatesClosed = true;
+        } finally {
+            resetCompletionLock.unlock();
+        }
+        writer.write(reset.toFrameData(settings, streamId, Http2Flag.NoFlags.create()));
     }
 
     private void remoteCompleteAfterReset() {
@@ -1114,6 +1125,30 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private void restoreDiscardedConnectionCredit(int bytes) {
         if (bytes > 0) {
             connectionFlowControl.incrementInboundConnectionWindowSize(bytes);
+        }
+    }
+
+    private void incrementInboundWindowSize(int increment) {
+        resetCompletionLock.lock();
+        try {
+            if (windowUpdatesClosed) {
+                connectionFlowControl.incrementInboundConnectionWindowSize(increment);
+            } else {
+                flowControl.inbound().incrementWindowSize(increment);
+            }
+        } finally {
+            resetCompletionLock.unlock();
+        }
+    }
+
+    private void incrementInboundStreamWindowSize(int increment) {
+        resetCompletionLock.lock();
+        try {
+            if (!windowUpdatesClosed) {
+                flowControl.inbound().incrementStreamWindowSize(increment);
+            }
+        } finally {
+            resetCompletionLock.unlock();
         }
     }
 
@@ -1307,7 +1342,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                     abortInboundData();
                 } else {
                     inboundData.complete(frame,
-                                         () -> flowControl.inbound().incrementStreamWindowSize(frame.flowControlLength()));
+                                         () -> incrementInboundStreamWindowSize(frame.flowControlLength()));
                 }
             }
         }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -198,6 +198,27 @@ class Http2ServerStreamSniTest {
     }
 
     @Test
+    void localResetClosesStreamWindowUpdateProducer() {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        List<WindowUpdate> windowUpdates = new ArrayList<>();
+        Http2ServerStream stream = stream(streams, writer, windowUpdates);
+        stream.headers(headersWithAuthority("api.example.com"), false);
+        stream.flowControl().inbound().decrementWindowSize(1);
+
+        stream.windowUpdate(new Http2WindowUpdate(0));
+        stream.data(Http2FrameHeader.create(1,
+                                            Http2FrameTypes.DATA,
+                                            Http2Flag.DataFlags.create(0),
+                                            STREAM_ID),
+                    BufferData.empty(),
+                    false);
+
+        assertThat(writer.rstStreamCodes, is(List.of(Http2ErrorCode.PROTOCOL)));
+        assertThat(windowUpdates, is(List.of(new WindowUpdate(0, 1))));
+    }
+
+    @Test
     void rejectedStreamRestoresQueuedDataConnectionFlowControl() {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingStreamWriter writer = new RecordingStreamWriter();


### PR DESCRIPTION
### Summary

- prevent inbound HTTP/2 `WINDOW_UPDATE` callbacks from blocking behind an unrelated transport write
- keep the uncontended write path synchronous and coalesce only contended flow-control credit
- preserve queued update ordering before `RST_STREAM` and close the owning connection if a deferred write fails
- keep the change behind the existing writer contract, with no public API additions

### Background

The gRPC failure observed in #12123 exposed a pre-existing duplex liveness cycle. A request writer could hold the HTTP/2 serialization lock while blocked in the transport, while the response reader needed that lock to return flow-control credit. The blocked reader then stopped the server from consuming more request data, so neither side could make progress.

The handoff is specific to contended `WINDOW_UPDATE` frames. Normal updates still use the existing synchronous write path. Contended increments are coalesced per stream and drained through the same serialized writer, independently of the configured connection executor.

### Performance

A three-fork bidirectional gRPC JMH comparison covered payloads of 65,530, 65,531, and 131,072 bytes with GC profiling. Throughput deltas were -0.60%, -0.47%, and +5.20%; normalized allocation deltas were +292, +438, and +278 bytes per operation. All throughput and allocation confidence intervals overlapped the `main` baseline.
