### PR TITLE
Add stuck thread detection

### DIFF
--- a/common/uri/src/main/java/io/helidon/common/uri/UriPath.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriPath.java
@@ -59,11 +59,11 @@ public interface UriPath {
      */
     static UriPath createFromDecoded(String decodedPath) {
         String pathNoParams = UriPathHelper.stripMatrixParams(decodedPath);
+        String encodedPath = encodeDecodedPath(decodedPath);
         if (pathNoParams.length() == decodedPath.length()) {
-            return new UriPathNoParam(UriEncoding.encode(decodedPath, UriEncoding.Type.PATH));
+            return new UriPathNoParam(encodedPath);
         }
-        return new UriPathMatrix(UriEncoding.encode(decodedPath, UriEncoding.Type.PATH),
-                                 UriEncoding.encode(pathNoParams, UriEncoding.Type.PATH));
+        return new UriPathMatrix(encodedPath, encodeDecodedPath(pathNoParams));
     }
 
     /**
@@ -141,4 +141,19 @@ public interface UriPath {
      * Validate if the raw path is valid.
      */
     void validate();
+
+    private static String encodeDecodedPath(String decodedPath) {
+        String encodedPath = UriEncoding.encode(decodedPath, UriEncoding.Type.PATH);
+        int firstSlash = encodedPath.indexOf('/');
+        if (firstSlash == 0) {
+            return encodedPath;
+        }
+
+        int firstSegmentEnd = firstSlash == -1 ? encodedPath.length() : firstSlash;
+        String firstSegment = encodedPath.substring(0, firstSegmentEnd);
+        if (firstSegment.indexOf(':') == -1) {
+            return encodedPath;
+        }
+        return firstSegment.replace(":", "%3A") + encodedPath.substring(firstSegmentEnd);
+    }
 }

--- a/common/uri/src/main/java/io/helidon/common/uri/UriPath.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public interface UriPath {
     /**
      * Decoded path without matrix parameters.
      *
-     * @return path without matrix parameters
+     * @return path without matrix parameters, never {@code null}; an empty string if the URI has no path
      * @see #matrixParameters()
      */
     String path();

--- a/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,6 +133,7 @@ class UriPathNoParam implements UriPath {
             rawPath = rawPath.substring(1);
         }
 
-        return URI.create(rawPath).normalize().getPath();
+        String path = URI.create(rawPath).normalize().getPath();
+        return path == null ? "" : path;
     }
 }

--- a/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
@@ -117,15 +117,15 @@ class UriPathNoParam implements UriPath {
 
          we use decoded and normalized path to match routing, so we need to resolve all of that
          */
-        if (rawPath.indexOf('/') == -1 && rawPath.indexOf(':') > 0) {
-            return "";
-        }
-
         int percent = rawPath.indexOf('%');
         int dot = rawPath.indexOf(".");
         int doubleSlash = rawPath.indexOf("//");
 
-        if (!validate && percent == -1 && doubleSlash == -1 && dot == -1) {
+        if (!validate
+                && percent == -1
+                && doubleSlash == -1
+                && dot == -1
+                && (rawPath.isEmpty() || rawPath.charAt(0) == '/' || rawPath.indexOf(':') == -1)) {
             return rawPath;
         }
 

--- a/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
@@ -117,6 +117,10 @@ class UriPathNoParam implements UriPath {
 
          we use decoded and normalized path to match routing, so we need to resolve all of that
          */
+        if (rawPath.indexOf('/') == -1 && rawPath.indexOf(':') > 0) {
+            return "";
+        }
+
         int percent = rawPath.indexOf('%');
         int dot = rawPath.indexOf(".");
         int doubleSlash = rawPath.indexOf("//");

--- a/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
@@ -240,7 +240,7 @@ public final class UriValidator {
 
         String host = ipLiteral.substring(1, ipLiteral.length() - 1);
         checkNotBlank(Segment.HOST, "Host", ipLiteral, host);
-        if (host.charAt(0) == 'v') {
+        if (host.charAt(0) == 'v' || host.charAt(0) == 'V') {
             // IP future - starts with version `v1` etc.
             validateIpFuture(ipLiteral, host);
             return;

--- a/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
@@ -309,6 +309,7 @@ public final class UriValidator {
                         validateIpOctet("Host IPv6 dual address contains invalid IPv4 address", ipLiteral, matcher.group(2));
                         validateIpOctet("Host IPv6 dual address contains invalid IPv4 address", ipLiteral, matcher.group(3));
                         validateIpOctet("Host IPv6 dual address contains invalid IPv4 address", ipLiteral, matcher.group(4));
+                        segments += 2;
                     } else {
                         throw new UriValidationException(Segment.HOST,
                                                          ipLiteral.toCharArray(),
@@ -337,6 +338,11 @@ public final class UriValidator {
             throw new UriValidationException(Segment.HOST,
                                              ipLiteral.toCharArray(),
                                              "Host IPv6 address contains too many segments");
+        }
+        if (!skipped && segments < 8) {
+            throw new UriValidationException(Segment.HOST,
+                                             ipLiteral.toCharArray(),
+                                             "Host IPv6 address contains too few segments");
         }
     }
 

--- a/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
@@ -272,6 +272,11 @@ public final class UriValidator {
         int segments = 0; // max segments is 8 (full IPv6 address)
         String inProgress = host;
         while (!inProgress.isEmpty()) {
+            if (segments >= 8) {
+                throw new UriValidationException(Segment.HOST,
+                                                 ipLiteral.toCharArray(),
+                                                 "Host IPv6 address contains too many segments");
+            }
             if (inProgress.length() == 1) {
                 segments++;
                 validateH16(ipLiteral, inProgress);
@@ -310,6 +315,11 @@ public final class UriValidator {
                         validateIpOctet("Host IPv6 dual address contains invalid IPv4 address", ipLiteral, matcher.group(3));
                         validateIpOctet("Host IPv6 dual address contains invalid IPv4 address", ipLiteral, matcher.group(4));
                         segments += 2;
+                        if (segments > 8) {
+                            throw new UriValidationException(Segment.HOST,
+                                                             ipLiteral.toCharArray(),
+                                                             "Host IPv6 address contains too many segments");
+                        }
                     } else {
                         throw new UriValidationException(Segment.HOST,
                                                          ipLiteral.toCharArray(),

--- a/common/uri/src/test/java/io/helidon/common/uri/UriPathTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriPathTest.java
@@ -52,11 +52,29 @@ class UriPathTest {
         assertThat(path.path(), is("/foo/bar"));
     }
 
-    @Test
-    void opaqueUriHasEmptyPath() {
-        UriPath path = UriPath.create("example.com:443");
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "example.com:443",
+            "localhost:443",
+            "[::1]:443",
+            "service%2Dname:443"
+    })
+    void authorityFormHasEmptyPath(String rawPath) {
+        UriPath path = UriPath.create(rawPath);
 
-        assertThat(path.rawPath(), is("example.com:443"));
+        assertThat(path.rawPath(), is(rawPath));
         assertThat(path.path(), is(""));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/first:second",
+            "first/second:third"
+    })
+    void colonInPath(String rawPath) {
+        UriPath path = UriPath.create(rawPath);
+
+        assertThat(path.rawPath(), is(rawPath));
+        assertThat(path.path(), is(rawPath));
     }
 }

--- a/common/uri/src/test/java/io/helidon/common/uri/UriPathTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,5 +50,13 @@ class UriPathTest {
     void testDoubleSlash(String rawPath) {
         UriPath path = UriPath.create(rawPath);
         assertThat(path.path(), is("/foo/bar"));
+    }
+
+    @Test
+    void opaqueUriHasEmptyPath() {
+        UriPath path = UriPath.create("example.com:443");
+
+        assertThat(path.rawPath(), is("example.com:443"));
+        assertThat(path.path(), is(""));
     }
 }

--- a/common/uri/src/test/java/io/helidon/common/uri/UriPathTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriPathTest.java
@@ -18,10 +18,12 @@ package io.helidon.common.uri;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UriPathTest {
     @Test
@@ -55,11 +57,9 @@ class UriPathTest {
     @ParameterizedTest
     @ValueSource(strings = {
             "example.com:443",
-            "localhost:443",
-            "[::1]:443",
-            "service%2Dname:443"
+            "localhost:443"
     })
-    void authorityFormHasEmptyPath(String rawPath) {
+    void opaqueUriHasEmptyPath(String rawPath) {
         UriPath path = UriPath.create(rawPath);
 
         assertThat(path.rawPath(), is(rawPath));
@@ -76,5 +76,24 @@ class UriPathTest {
 
         assertThat(path.rawPath(), is(rawPath));
         assertThat(path.path(), is(rawPath));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "first:second, first%3Asecond, first:second",
+            "first:second;key=value, first%3Asecond;key=value, first:second"
+    })
+    void decodedColonInPath(String decodedPath, String expectedRawPath, String expectedPath) {
+        UriPath path = UriPath.createFromDecoded(decodedPath);
+
+        assertThat(path.rawPath(), is(expectedRawPath));
+        assertThat(path.path(), is(expectedPath));
+    }
+
+    @Test
+    void malformedAuthorityLikePathFailsValidation() {
+        UriPath path = UriPath.create("service%2Gname:443");
+
+        assertThrows(IllegalArgumentException.class, path::validate);
     }
 }

--- a/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
@@ -177,6 +177,7 @@ class UriValidatorTest {
         // IPvFuture
         validateHost("[v9.abc:def]");
         validateHost("[v9.abc:def*]");
+        validateHost("[Vf.foo-bar]");
     }
 
     @Test

--- a/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
@@ -159,6 +159,7 @@ class UriValidatorTest {
         validateHost("[::1234:5678:1]");
         validateHost("[2001:db8::1234:5678]");
         validateHost("[2001:db8:1::ab9:C0A8:102]");
+        validateHost("[1:2:3:4:5:6:7::]");
     }
 
     @Test
@@ -170,6 +171,7 @@ class UriValidatorTest {
         validateHost("[::1234:5678:91.123.4.56]");
         validateHost("[::1234:5678:1.2.3.4]");
         validateHost("[2001:db8::1234:5678:5.6.7.8]");
+        validateHost("[1:2:3:4:5::192.0.2.1]");
     }
 
     @Test
@@ -233,6 +235,18 @@ class UriValidatorTest {
         invokeExpectFailure("Host IPv6 address contains too many segments: "
                                     + "[0000:0000:0000:0000:0000:0000:0000:0000:0000:0000]",
                             "[0000:0000:0000:0000:0000:0000:0000:0000:0000:0000]");
+        invokeExpectFailure("Host IPv6 address contains too few segments: [1:2:3]",
+                            "[1:2:3]");
+        invokeExpectFailure("Host IPv6 address contains too few segments: [1.2.3.4]",
+                            "[1.2.3.4]");
+        invokeExpectFailure("Host IPv6 address contains too few segments: [1:2:3:4:5:6:7]",
+                            "[1:2:3:4:5:6:7]");
+        invokeExpectFailure("Host IPv6 address contains too few segments: [1:2:3:4:5:192.0.2.1]",
+                            "[1:2:3:4:5:192.0.2.1]");
+        invokeExpectFailure("Host IPv6 address contains too many segments: [1:2:3:4:5:6:7:8::]",
+                            "[1:2:3:4:5:6:7:8::]");
+        invokeExpectFailure("Host IPv6 address contains too many segments: [1:2:3:4:5:6::192.0.2.1]",
+                            "[1:2:3:4:5:6::192.0.2.1]");
         // missing everything
         invokeExpectFailure("Host cannot be blank. Value: []",
                             "[]");

--- a/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
@@ -235,6 +235,9 @@ class UriValidatorTest {
         invokeExpectFailure("Host IPv6 address contains too many segments: "
                                     + "[0000:0000:0000:0000:0000:0000:0000:0000:0000:0000]",
                             "[0000:0000:0000:0000:0000:0000:0000:0000:0000:0000]");
+        String overlongLiteral = "[" + "1:".repeat(500) + "1]";
+        invokeExpectFailure("Host IPv6 address contains too many segments: " + overlongLiteral,
+                            overlongLiteral);
         invokeExpectFailure("Host IPv6 address contains too few segments: [1:2:3]",
                             "[1:2:3]");
         invokeExpectFailure("Host IPv6 address contains too few segments: [1.2.3.4]",

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -38,6 +38,7 @@ include::{rootdir}/includes/se.adoc[]
 ** <<Request Handling, Request Handling>>
 ** <<Error Handling, Error Handling>>
 - <<Server Features, Server Features>>
+** <<Stuck Thread Detection, Stuck Thread Detection>>
 ** <<Access Log, Access Log>>
 ** <<Context, Context>>
 ** <<HSTS, HSTS>>
@@ -724,6 +725,9 @@ first.
 |<<Context, Context>>
 |1100
 
+|<<Stuck Thread Detection, Stuck Thread Detection>>
+|1050
+
 |<<Access Log, Access Log>>
 |1000
 
@@ -772,6 +776,47 @@ Context feature can be configured, all options shown below are also available bo
 when using builder.
 
 include::{rootdir}/config/io_helidon_webserver_context_ContextFeature.adoc[leveloffset=+1]
+
+=== Stuck Thread Detection
+
+Stuck thread detection is an opt-in WebServer feature that reports HTTP request threads which have been executing longer
+than a configured threshold. The feature starts one monitoring virtual thread for each selected server socket. Each monitor
+periodically scans only ordinary HTTP requests while they execute within the routing and filter chain; it does not enumerate
+JVM threads.
+
+The first scan after a request crosses the threshold logs a warning with the request method, path without query or matrix
+parameters, socket and request identifiers, thread state, and stack trace. If that request later completes, the feature logs
+an informational recovery message. Detection is diagnostic only and never interrupts a request thread.
+
+For HTTP/1.1, only the connection thread while it is processing a request is a candidate; idle keep-alive time is excluded.
+For HTTP/2, only ordinary HTTP stream threads are candidates; the connection reader and subprotocol processing such as gRPC
+streams are excluded. Post-routing transport cleanup and connections handed to an upgraded protocol are also excluded.
+Legitimately long-running handlers, such as server-sent events or long polling, can still be reported.
+
+==== Configuring Stuck Thread Detection in Your Code
+
+[source,java]
+----
+include::{sourcedir}/se/WebServerSnippets.java[tag=snippet_44, indent=0]
+----
+
+==== Configuring Stuck Thread Detection in a Configuration File
+
+[source,yaml]
+.Stuck thread detection configuration file
+----
+server:
+  features:
+    stuck-thread-detection:
+      threshold: PT10M
+      check-period: PT1M
+----
+
+With this configuration, a request becomes eligible after 10 minutes and is normally detected on the next scan, within the
+following minute. Both `threshold` and `check-period` must be positive durations representable in nanoseconds. The feature
+can be limited to named server sockets using the `sockets` option; an empty list selects all sockets.
+
+include::{rootdir}/config/io_helidon_webserver_StuckThreadDetectionFeature.adoc[leveloffset=+1]
 
 === Access Log
 

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -785,8 +785,10 @@ periodically scans only ordinary HTTP requests while they execute within the rou
 JVM threads.
 
 The first scan after a request crosses the threshold logs a warning with the request method, path without query or matrix
-parameters, socket and request identifiers, thread state, and stack trace. If that request later completes, the feature logs
-an informational recovery message. Detection is diagnostic only and never interrupts a request thread.
+parameters, socket and request identifiers, thread state, and stack trace. If that request later completes, the feature
+normally logs an informational recovery message. Recovery logging is bounded and best effort; when a burst exceeds the
+recovery queue capacity, the monitor logs an informational summary with the number of omitted individual recovery messages.
+Detection is diagnostic only and never interrupts a request thread.
 
 For HTTP/1.1, only the connection thread while it is processing a request is a candidate; idle keep-alive time is excluded.
 For HTTP/2, only ordinary HTTP stream threads are candidates; the connection reader and subprotocol processing such as gRPC

--- a/docs/src/main/java/io/helidon/docs/se/WebServerSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/WebServerSnippets.java
@@ -44,6 +44,7 @@ import io.helidon.http.encoding.gzip.GzipEncoding;
 import io.helidon.http.media.jsonp.JsonpSupport;
 import io.helidon.webserver.ProxyProtocolData;
 import io.helidon.webserver.ProxyProtocolV2Data;
+import io.helidon.webserver.StuckThreadDetectionFeature;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.accesslog.AccessLogFeature;
@@ -380,6 +381,15 @@ class WebServerSnippets {
                                     .commonLogFormat()
                                     .build());
         // end::snippet_29[]
+    }
+
+    void snippet_44() {
+        // tag::snippet_44[]
+        WebServer.builder()
+                .addFeature(StuckThreadDetectionFeature.create(config -> config
+                        .threshold(Duration.ofMinutes(10))
+                        .checkPeriod(Duration.ofMinutes(1))));
+        // end::snippet_44[]
     }
 
     void snippet_30() {

--- a/http/http/src/main/java/io/helidon/http/PathMatchers.java
+++ b/http/http/src/main/java/io/helidon/http/PathMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.http;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -28,6 +29,7 @@ import java.util.regex.Pattern;
 import io.helidon.common.parameters.Parameters;
 import io.helidon.common.uri.UriEncoding;
 import io.helidon.common.uri.UriPath;
+import io.helidon.common.uri.UriPathSegment;
 
 /**
  * Utility methods to create path matchers.
@@ -571,6 +573,11 @@ public final class PathMatchers {
         @Override
         public String path() {
             return path.path();
+        }
+
+        @Override
+        public List<UriPathSegment> segments() {
+            return path.segments();
         }
 
         @Override

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/HttpPrologueParsingJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/HttpPrologueParsingJmhTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,9 @@ import io.helidon.http.HttpPrologue;
 import io.helidon.webserver.http1.Http1Prologue;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -46,5 +48,24 @@ public class HttpPrologueParsingJmhTest {
         HttpPrologue prologue = new Http1Prologue(DataReader.create(() -> ENCODED_PROLOGUE), 1024, false)
                 .readPrologue();
         bh.consume(prologue);
+    }
+
+    @Benchmark
+    public void connectAuthority(ConnectAuthorityState state, Blackhole bh) {
+        HttpPrologue prologue = new Http1Prologue(DataReader.create(() -> state.prologue), 1024, false)
+                .readPrologue();
+        bh.consume(prologue);
+    }
+
+    @State(Scope.Benchmark)
+    public static class ConnectAuthorityState {
+        @Param({"example.com:443", "[2001:db8::1]:9443"})
+        private String authority;
+        private byte[] prologue;
+
+        @Setup
+        public void setup() {
+            prologue = ("CONNECT " + authority + " HTTP/1.1\r\n").getBytes(StandardCharsets.UTF_8);
+        }
     }
 }

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/StuckThreadDetectionJmhTest.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/StuckThreadDetectionJmhTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webserver.StuckThreadDetectionFeature;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.Handler;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+public class StuckThreadDetectionJmhTest {
+    private static final String SERVER_HOST = "127.0.0.1";
+    private static final Header CONTENT_TYPE = HeaderValues.createCached(HeaderNames.CONTENT_TYPE,
+                                                                         "text/plain; charset=UTF-8");
+    private static final Header CONTENT_LENGTH = HeaderValues.createCached(HeaderNames.CONTENT_LENGTH, "2");
+    private static final Header SERVER = HeaderValues.createCached(HeaderNames.SERVER, "Helidon");
+    private static final byte[] RESPONSE_BYTES = "OK".getBytes(StandardCharsets.UTF_8);
+
+    private WebServer disabledServer;
+    private WebServer enabledServer;
+    private HttpClient httpClient;
+    private HttpRequest disabledRequest;
+    private HttpRequest enabledRequest;
+
+    @Setup
+    public void setup() {
+        LogConfig.configureRuntime();
+
+        disabledServer = serverBuilder()
+                .build()
+                .start();
+        enabledServer = serverBuilder()
+                .addFeature(StuckThreadDetectionFeature.create(builder -> builder
+                        .threshold(Duration.ofDays(1))
+                        .checkPeriod(Duration.ofDays(1))))
+                .build()
+                .start();
+
+        httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+        disabledRequest = request(disabledServer.port());
+        enabledRequest = request(enabledServer.port());
+    }
+
+    @TearDown
+    public void tearDown() {
+        disabledServer.stop();
+        enabledServer.stop();
+    }
+
+    @Benchmark
+    public void disabled(Blackhole bh) throws IOException, InterruptedException {
+        bh.consume(send(disabledRequest));
+    }
+
+    @Benchmark
+    public void enabled(Blackhole bh) throws IOException, InterruptedException {
+        bh.consume(send(enabledRequest));
+    }
+
+    private HttpResponse<byte[]> send(HttpRequest request) throws IOException, InterruptedException {
+        HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        if (response.statusCode() != 200) {
+            throw new IOException("Unexpected status: " + response.statusCode());
+        }
+        return response;
+    }
+
+    private static HttpRequest request(int serverPort) {
+        return HttpRequest.newBuilder()
+                .GET()
+                .uri(URI.create("http://" + SERVER_HOST + ":" + serverPort + "/direct/42"))
+                .build();
+    }
+
+    private static WebServerConfig.Builder serverBuilder() {
+        return WebServer.builder()
+                .connectionOptions(builder -> builder
+                        .readTimeout(Duration.ZERO)
+                        .connectTimeout(Duration.ZERO)
+                        .socketSendBufferSize(64000)
+                        .socketReceiveBufferSize(64000))
+                .writeQueueLength(4000)
+                .host(SERVER_HOST)
+                .backlog(8192)
+                .routing(router -> router.get("/direct/{id}", new OkHandler()));
+    }
+
+    private static class OkHandler implements Handler {
+        @Override
+        public void handle(ServerRequest req, ServerResponse res) {
+            res.header(CONTENT_LENGTH);
+            res.header(CONTENT_TYPE);
+            res.header(SERVER);
+            res.send(RESPONSE_BYTES);
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/UriPathJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/UriPathJmhBenchmark.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import io.helidon.common.uri.UriPath;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class UriPathJmhBenchmark {
+    @Param({
+            "/routing/path",
+            "example.com:443",
+            "localhost:443"
+    })
+    private String rawPath;
+
+    @Benchmark
+    public String decode() {
+        return UriPath.create(rawPath).path();
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/UriPathJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/UriPathJmhRunnerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class UriPathJmhRunnerTest {
+    @Test
+    void run() throws RunnerException {
+        String result = System.getProperty("uri.path.jmh.result", "./target/uri-path-jmh-result.json");
+        Options options = new OptionsBuilder()
+                .include(".*UriPathJmhBenchmark.decode.*")
+                .forks(3)
+                .threads(1)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .warmupIterations(5)
+                .warmupTime(TimeValue.milliseconds(500))
+                .measurementIterations(8)
+                .measurementTime(TimeValue.seconds(1))
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/StuckThreadDetectionTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/StuckThreadDetectionTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.webserver.StuckThreadDetectionFeature;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http1.Http1Route;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpFeatures;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.http.Method.GET;
+import static io.helidon.http.Method.PUT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class StuckThreadDetectionTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    private static final String PATH = "/stuck-thread-detection";
+    private static final CountDownLatch REQUEST_STARTED = new CountDownLatch(1);
+    private static final CountDownLatch RELEASE_REQUEST = new CountDownLatch(1);
+
+    private final URI uri;
+
+    StuckThreadDetectionTest(URI uri) {
+        this.uri = uri;
+    }
+
+    @SetUpFeatures
+    static List<ServerFeature> features() {
+        return List.of(StuckThreadDetectionFeature.create(config -> config
+                .threshold(Duration.ofMillis(20))
+                .checkPeriod(Duration.ofMillis(5))));
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder router) {
+        router.route(Http1Route.route(GET, PATH, (req, res) -> res.send()))
+                .route(Http2Route.route(PUT, PATH, (req, res) -> {
+                    REQUEST_STARTED.countDown();
+                    try {
+                        RELEASE_REQUEST.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException(e);
+                    }
+                    res.send();
+                }));
+    }
+
+    @Test
+    void tracksHttp2BusinessLogic() throws Exception {
+        var client = HttpClient.newBuilder()
+                .connectTimeout(TIMEOUT)
+                .build();
+        URI resource = uri.resolve(PATH);
+        client.send(HttpRequest.newBuilder()
+                            .GET()
+                            .version(HttpClient.Version.HTTP_2)
+                            .uri(resource)
+                            .build(),
+                    HttpResponse.BodyHandlers.discarding());
+
+        try (TestLogHandler logs = new TestLogHandler()) {
+            var response = client.sendAsync(HttpRequest.newBuilder()
+                                                     .version(HttpClient.Version.HTTP_2)
+                                                     .uri(resource)
+                                                     .PUT(HttpRequest.BodyPublishers.noBody())
+                                                     .build(),
+                                             HttpResponse.BodyHandlers.discarding());
+            try {
+                assertThat("HTTP/2 request handler did not start",
+                           REQUEST_STARTED.await(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                           is(true));
+
+                LogRecord warning = logs.await(Level.WARNING);
+                assertThat(warning.getMessage(), containsString("PUT " + PATH + " HTTP/2.0"));
+
+                RELEASE_REQUEST.countDown();
+                assertThat(response.get(TIMEOUT.toSeconds(), TimeUnit.SECONDS).statusCode(), is(200));
+
+                LogRecord recovery = logs.await(Level.INFO);
+                assertThat(recovery.getMessage(), containsString("PUT " + PATH + " HTTP/2.0"));
+            } finally {
+                RELEASE_REQUEST.countDown();
+            }
+        }
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final LinkedBlockingQueue<LogRecord> records = new LinkedBlockingQueue<>();
+        private final Logger logger = Logger.getLogger("io.helidon.webserver.StuckThreadDetectionFilter");
+        private final Level originalLevel = logger.getLevel();
+        private final boolean originalUseParentHandlers = logger.getUseParentHandlers();
+
+        private TestLogHandler() {
+            setLevel(Level.ALL);
+            logger.setLevel(Level.ALL);
+            logger.setUseParentHandlers(false);
+            logger.addHandler(this);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (isLoggable(record)) {
+                records.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setUseParentHandlers(originalUseParentHandlers);
+            logger.setLevel(originalLevel);
+        }
+
+        private LogRecord await(Level level) throws InterruptedException {
+            long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+            while (true) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    throw new AssertionError("No " + level + " log record received");
+                }
+                LogRecord record = records.poll(remaining, TimeUnit.NANOSECONDS);
+                if (record == null) {
+                    throw new AssertionError("No " + level + " log record received");
+                }
+                if (record.getLevel().equals(level)) {
+                    return record;
+                }
+            }
+        }
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/StuckThreadDetectionConnectTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/StuckThreadDetectionConnectTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests;
+
+import java.util.List;
+
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webserver.StuckThreadDetectionFeature;
+import io.helidon.webserver.http.HttpRoute;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpFeatures;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.http.junit5.SocketHttpClient.statusFromResponse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class StuckThreadDetectionConnectTest {
+    private final SocketHttpClient client;
+
+    StuckThreadDetectionConnectTest(SocketHttpClient client) {
+        this.client = client;
+    }
+
+    @SetUpFeatures
+    static List<ServerFeature> features() {
+        return List.of(StuckThreadDetectionFeature.create());
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
+        builder.route(HttpRoute.builder()
+                              .methods(Method.CONNECT)
+                              .handler((req, res) -> res.header(HeaderValues.CONNECTION_CLOSE)
+                                      .status(Status.OK_200)
+                                      .send())
+                              .build());
+    }
+
+    @Test
+    void validAuthorityFormReachesHandler() {
+        String response = client.sendAndReceive(Method.CONNECT,
+                                                "example.com:443",
+                                                null,
+                                                List.of("Connection: close"));
+
+        assertThat(statusFromResponse(response), is(Status.OK_200));
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/StuckThreadDetectionConnectTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/StuckThreadDetectionConnectTest.java
@@ -51,7 +51,11 @@ class StuckThreadDetectionConnectTest {
 
     @SetUpRoute
     static void routing(HttpRouting.Builder builder) {
-        builder.route(HttpRoute.builder()
+        builder.addFilter((chain, req, res) -> {
+            assertThat(req.path().segments(), is(List.of()));
+            chain.proceed();
+        })
+                .route(HttpRoute.builder()
                               .methods(Method.CONNECT)
                               .handler((req, res) -> {
                                   assertThat(req.path().segments(), is(List.of()));

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/StuckThreadDetectionConnectTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/StuckThreadDetectionConnectTest.java
@@ -53,9 +53,12 @@ class StuckThreadDetectionConnectTest {
     static void routing(HttpRouting.Builder builder) {
         builder.route(HttpRoute.builder()
                               .methods(Method.CONNECT)
-                              .handler((req, res) -> res.header(HeaderValues.CONNECTION_CLOSE)
-                                      .status(Status.OK_200)
-                                      .send())
+                              .handler((req, res) -> {
+                                  assertThat(req.path().segments(), is(List.of()));
+                                  res.header(HeaderValues.CONNECTION_CLOSE)
+                                          .status(Status.OK_200)
+                                          .send();
+                              })
                               .build());
     }
 

--- a/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/StuckThreadDetectionUpgradeTest.java
+++ b/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/StuckThreadDetectionUpgradeTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.websocket;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.http.Headers;
+import io.helidon.http.HttpPrologue;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.StuckThreadDetectionFeature;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpFeatures;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.websocket.WsRouting;
+import io.helidon.websocket.WsCloseCodes;
+import io.helidon.websocket.WsListener;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class StuckThreadDetectionUpgradeTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final CountDownLatch UPGRADE_STARTED = new CountDownLatch(1);
+    private static final CountDownLatch RELEASE_UPGRADE = new CountDownLatch(1);
+
+    private final int port;
+
+    StuckThreadDetectionUpgradeTest(WebServer server) {
+        this.port = server.port();
+    }
+
+    @SetUpFeatures
+    static List<ServerFeature> features() {
+        return List.of(StuckThreadDetectionFeature.create(config -> config
+                .threshold(Duration.ofMillis(20))
+                .checkPeriod(Duration.ofMillis(5))));
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(WsRouting.builder().endpoint("/upgrade", new WsListener() {
+            @Override
+            public Optional<Headers> onHttpUpgrade(HttpPrologue prologue, Headers headers) {
+                UPGRADE_STARTED.countDown();
+                try {
+                    RELEASE_UPGRADE.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+                return Optional.empty();
+            }
+        }));
+    }
+
+    @Test
+    void completesDetectionWhenRequestUpgrades() throws Exception {
+        var client = HttpClient.newBuilder()
+                .connectTimeout(TIMEOUT)
+                .build();
+
+        try (TestLogHandler logs = new TestLogHandler()) {
+            var webSocketFuture = client.newWebSocketBuilder()
+                    .buildAsync(URI.create("ws://localhost:" + port + "/upgrade"), new WebSocket.Listener() { });
+            try {
+                assertThat("WebSocket upgrade did not start",
+                           UPGRADE_STARTED.await(TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                           is(true));
+
+                LogRecord warning = logs.await(Level.WARNING);
+                assertThat(warning.getMessage(), containsString("GET /upgrade HTTP/1.1"));
+
+                RELEASE_UPGRADE.countDown();
+                WebSocket webSocket = webSocketFuture.get(TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+
+                LogRecord recovery = logs.await(Level.INFO);
+                assertThat(recovery.getMessage(), containsString("GET /upgrade HTTP/1.1"));
+
+                webSocket.sendClose(WsCloseCodes.NORMAL_CLOSE, "normal")
+                        .get(TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            } finally {
+                RELEASE_UPGRADE.countDown();
+            }
+        }
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final LinkedBlockingQueue<LogRecord> records = new LinkedBlockingQueue<>();
+        private final Logger logger = Logger.getLogger("io.helidon.webserver.StuckThreadDetectionFilter");
+        private final Level originalLevel = logger.getLevel();
+        private final boolean originalUseParentHandlers = logger.getUseParentHandlers();
+
+        private TestLogHandler() {
+            setLevel(Level.ALL);
+            logger.setLevel(Level.ALL);
+            logger.setUseParentHandlers(false);
+            logger.addHandler(this);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (isLoggable(record)) {
+                records.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setUseParentHandlers(originalUseParentHandlers);
+            logger.setLevel(originalLevel);
+        }
+
+        private LogRecord await(Level level) throws InterruptedException {
+            long deadline = System.nanoTime() + TIMEOUT.toNanos();
+            while (true) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    throw new AssertionError("No " + level + " log record received");
+                }
+                LogRecord record = records.poll(remaining, TimeUnit.NANOSECONDS);
+                if (record == null) {
+                    throw new AssertionError("No " + level + " log record received");
+                }
+                if (record.getLevel().equals(level)) {
+                    return record;
+                }
+            }
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionConfigBlueprint.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.time.Duration;
+import java.util.Set;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+/**
+ * Configuration of the stuck thread detection feature.
+ */
+@Prototype.Blueprint(decorator = StuckThreadDetectionConfigSupport.BuilderDecorator.class)
+@Prototype.Configured(value = StuckThreadDetectionFeature.FEATURE_ID, root = false)
+@Prototype.Provides(ServerFeatureProvider.class)
+interface StuckThreadDetectionConfigBlueprint extends Prototype.Factory<StuckThreadDetectionFeature> {
+    /**
+     * Whether this feature is enabled.
+     *
+     * @return whether enabled, defaults to {@code true}
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(true)
+    boolean enabled();
+
+    /**
+     * Minimum time a request must be executing before its thread is reported as stuck.
+     * The duration must be positive and representable in nanoseconds.
+     *
+     * @return stuck request threshold, defaults to 10 minutes
+     */
+    @Option.Configured
+    @Option.Default("PT10M")
+    Duration threshold();
+
+    /**
+     * Period between scans of executing request threads.
+     * A request becomes eligible after {@link #threshold()} and is reported on the next scan.
+     * The duration must be positive and representable in nanoseconds.
+     *
+     * @return check period, defaults to 1 minute
+     */
+    @Option.Configured
+    @Option.Default("PT1M")
+    Duration checkPeriod();
+
+    /**
+     * Weight of the feature.
+     *
+     * @return feature weight
+     */
+    @Option.Configured
+    @Option.DefaultDouble(StuckThreadDetectionFeature.WEIGHT)
+    double weight();
+
+    /**
+     * List of sockets to register this feature on. If empty, the feature is registered on all sockets.
+     *
+     * @return socket names to register on, defaults to empty (all available sockets)
+     */
+    @Option.Configured
+    Set<String> sockets();
+
+    /**
+     * Name of this feature instance.
+     *
+     * @return instance name
+     */
+    @Option.Default(StuckThreadDetectionFeature.FEATURE_ID)
+    String name();
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionConfigSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionConfigSupport.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.time.Duration;
+
+import io.helidon.builder.api.Prototype;
+
+final class StuckThreadDetectionConfigSupport {
+    private StuckThreadDetectionConfigSupport() {
+    }
+
+    static final class BuilderDecorator
+            implements Prototype.BuilderDecorator<StuckThreadDetectionConfig.BuilderBase<?, ?>> {
+        @Override
+        public void decorate(StuckThreadDetectionConfig.BuilderBase<?, ?> target) {
+            validateDuration(target.threshold(), "threshold");
+            validateDuration(target.checkPeriod(), "check-period");
+        }
+
+        private static void validateDuration(Duration duration, String option) {
+            if (duration.isZero() || duration.isNegative()) {
+                throw new IllegalArgumentException("Stuck thread detection " + option + " must be positive");
+            }
+            try {
+                duration.toNanos();
+            } catch (ArithmeticException e) {
+                throw new IllegalArgumentException("Stuck thread detection " + option + " is too large", e);
+            }
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFeature.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFeature.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Weighted;
+import io.helidon.config.Config;
+import io.helidon.webserver.spi.ServerFeature;
+
+/**
+ * Reports HTTP request threads that have been executing for longer than a configured threshold.
+ * <p>
+ * Detection covers ordinary HTTP routing and handler processing. It does not include post-routing transport cleanup, idle
+ * HTTP/1 connections, connections handed to an upgraded protocol, HTTP/2 connection readers, or HTTP/2 subprotocol
+ * processing such as gRPC streams. A long-running request is not necessarily stuck, so this feature reports diagnostics but
+ * never interrupts a request thread.
+ */
+public final class StuckThreadDetectionFeature
+        implements Weighted, ServerFeature, RuntimeType.Api<StuckThreadDetectionConfig> {
+    /**
+     * Default feature weight. The detector runs within request context and after concurrency admission, but before
+     * access logging, security, observability, and application routing.
+     */
+    static final double WEIGHT = Weighted.DEFAULT_WEIGHT + 950;
+
+    static final String FEATURE_ID = "stuck-thread-detection";
+
+    private final StuckThreadDetectionConfig config;
+
+    StuckThreadDetectionFeature(StuckThreadDetectionConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * Create a stuck thread detection feature with default configuration.
+     *
+     * @return a new feature
+     */
+    public static StuckThreadDetectionFeature create() {
+        return builder().build();
+    }
+
+    /**
+     * Create a stuck thread detection feature from configuration.
+     *
+     * @param config configuration
+     * @return a new feature
+     */
+    public static StuckThreadDetectionFeature create(Config config) {
+        return builder()
+                .config(Objects.requireNonNull(config))
+                .build();
+    }
+
+    /**
+     * Create a stuck thread detection feature from its configuration prototype.
+     *
+     * @param config configuration prototype
+     * @return a new feature
+     */
+    public static StuckThreadDetectionFeature create(StuckThreadDetectionConfig config) {
+        return new StuckThreadDetectionFeature(Objects.requireNonNull(config));
+    }
+
+    /**
+     * Create a stuck thread detection feature, customizing its configuration.
+     *
+     * @param builderConsumer consumer of the configuration builder
+     * @return a new feature
+     */
+    public static StuckThreadDetectionFeature create(Consumer<StuckThreadDetectionConfig.Builder> builderConsumer) {
+        return builder()
+                .update(Objects.requireNonNull(builderConsumer))
+                .build();
+    }
+
+    /**
+     * Create a fluent configuration builder.
+     *
+     * @return a new builder
+     */
+    public static StuckThreadDetectionConfig.Builder builder() {
+        return StuckThreadDetectionConfig.builder();
+    }
+
+    @Override
+    public void setup(ServerFeatureContext featureContext) {
+        if (!config.enabled()) {
+            return;
+        }
+
+        Set<String> sockets = new HashSet<>(config.sockets());
+        if (sockets.isEmpty()) {
+            sockets.addAll(featureContext.sockets());
+            sockets.add(WebServer.DEFAULT_SOCKET_NAME);
+        }
+
+        for (String socket : sockets) {
+            featureContext.socket(socket)
+                    .httpRouting()
+                    .addFilter(new StuckThreadDetectionFilter(config, socket));
+        }
+    }
+
+    @Override
+    public String name() {
+        return config.name();
+    }
+
+    @Override
+    public String type() {
+        return FEATURE_ID;
+    }
+
+    @Override
+    public double weight() {
+        return config.weight();
+    }
+
+    @Override
+    public StuckThreadDetectionConfig prototype() {
+        return config;
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFeatureProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFeatureProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import io.helidon.common.Api;
+import io.helidon.common.Weight;
+import io.helidon.config.Config;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+/**
+ * {@link java.util.ServiceLoader} provider for {@link StuckThreadDetectionFeature}.
+ */
+@Weight(StuckThreadDetectionFeature.WEIGHT)
+public final class StuckThreadDetectionFeatureProvider
+        implements ServerFeatureProvider<StuckThreadDetectionFeature> {
+    /**
+     * Required public constructor for {@link java.util.ServiceLoader}.
+     */
+    @Api.Internal
+    public StuckThreadDetectionFeatureProvider() {
+    }
+
+    @Override
+    public String configKey() {
+        return StuckThreadDetectionFeature.FEATURE_ID;
+    }
+
+    @Override
+    public StuckThreadDetectionFeature create(Config config, String name) {
+        var builder = StuckThreadDetectionConfig.builder()
+                .config(config)
+                .name(name);
+        if (!config.exists()) {
+            builder.enabled(false);
+        }
+        return new StuckThreadDetectionFeature(builder.buildPrototype());
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
@@ -120,7 +120,7 @@ final class StuckThreadDetectionFilter implements Filter {
                                        System.nanoTime(),
                                        prologue.rawProtocol(),
                                        prologue.method().text(),
-                                       LogFormatter.escape(prologue.uriPath().rawPathNoParams()),
+                                       LogFormatter.escape(prologue.uriPath().path()),
                                        req.id(),
                                        req.serverSocketId(),
                                        req.socketId());

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+
+import io.helidon.http.LogFormatter;
+import io.helidon.webserver.http.Filter;
+import io.helidon.webserver.http.FilterChain;
+import io.helidon.webserver.http.RoutingRequest;
+import io.helidon.webserver.http.RoutingResponse;
+
+/**
+ * Tracks active HTTP requests on one listener socket.
+ */
+final class StuckThreadDetectionFilter implements Filter {
+    private static final System.Logger LOGGER = System.getLogger(StuckThreadDetectionFilter.class.getName());
+    private static final long STOP_WAIT_NANOS = Duration.ofSeconds(1).toNanos();
+
+    private final Set<ActiveRequest> activeRequests = ConcurrentHashMap.newKeySet();
+    private final ConcurrentLinkedQueue<ActiveRequest> completedRequests = new ConcurrentLinkedQueue<>();
+    private final AtomicBoolean running = new AtomicBoolean();
+    private final AtomicReference<Thread> monitorThread = new AtomicReference<>();
+    private final long checkPeriodNanos;
+    private final long thresholdNanos;
+    private final String socketName;
+
+    StuckThreadDetectionFilter(StuckThreadDetectionConfig config, String socketName) {
+        this.checkPeriodNanos = config.checkPeriod().toNanos();
+        this.thresholdNanos = config.threshold().toNanos();
+        this.socketName = socketName;
+    }
+
+    @Override
+    public void afterStart(WebServer webServer) {
+        Thread thread = Thread.ofVirtual()
+                .name("stuck-thread-detection-" + socketName)
+                .inheritInheritableThreadLocals(false)
+                .unstarted(this::monitorRequests);
+        if (!monitorThread.compareAndSet(null, thread)) {
+            return;
+        }
+        activeRequests.clear();
+        completedRequests.clear();
+        running.set(true);
+        try {
+            thread.start();
+        } catch (RuntimeException | Error e) {
+            running.set(false);
+            monitorThread.compareAndSet(thread, null);
+            activeRequests.forEach(ActiveRequest::stop);
+            activeRequests.clear();
+            throw e;
+        }
+    }
+
+    @Override
+    public void afterStop() {
+        running.set(false);
+        activeRequests.forEach(ActiveRequest::stop);
+        activeRequests.clear();
+
+        Thread thread = monitorThread.getAndSet(null);
+        if (thread == null) {
+            completedRequests.clear();
+            return;
+        }
+        thread.interrupt();
+        boolean interrupted = Thread.interrupted();
+        long deadline = System.nanoTime() + STOP_WAIT_NANOS;
+        while (thread.isAlive()) {
+            long remainingNanos = deadline - System.nanoTime();
+            if (remainingNanos <= 0) {
+                break;
+            }
+            try {
+                thread.join(Duration.ofNanos(remainingNanos));
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        completedRequests.clear();
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void filter(FilterChain chain, RoutingRequest req, RoutingResponse res) {
+        if (!running.get()) {
+            chain.proceed();
+            return;
+        }
+
+        Thread thread = Thread.currentThread();
+        var prologue = req.prologue();
+        var active = new ActiveRequest(thread,
+                                       System.nanoTime(),
+                                       prologue.rawProtocol(),
+                                       prologue.method().text(),
+                                       LogFormatter.escape(prologue.uriPath().rawPathNoParams()),
+                                       req.id(),
+                                       req.serverSocketId(),
+                                       req.socketId());
+        activeRequests.add(active);
+        if (!running.get()) {
+            activeRequests.remove(active);
+            active.stop();
+            chain.proceed();
+            return;
+        }
+
+        try {
+            chain.proceed();
+        } finally {
+            complete(active);
+        }
+    }
+
+    private void complete(ActiveRequest active) {
+        activeRequests.remove(active);
+        if (active.complete(System.nanoTime())) {
+            completedRequests.offer(active);
+            if (!running.get()) {
+                completedRequests.remove(active);
+                return;
+            }
+            Thread thread = monitorThread.get();
+            if (thread != null) {
+                LockSupport.unpark(thread);
+            }
+        }
+    }
+
+    private void monitorRequests() {
+        long nextScan = System.nanoTime() + checkPeriodNanos;
+        while (running.get()) {
+            ActiveRequest completed;
+            while ((completed = completedRequests.poll()) != null) {
+                if (running.get()) {
+                    logRecovery(completed);
+                }
+            }
+
+            long nanosUntilScan = nextScan - System.nanoTime();
+            if (nanosUntilScan > 0) {
+                LockSupport.parkNanos(this, nanosUntilScan);
+                if (Thread.interrupted()) {
+                    return;
+                }
+                continue;
+            }
+            nextScan = System.nanoTime() + checkPeriodNanos;
+
+            if (!LOGGER.isLoggable(System.Logger.Level.WARNING)) {
+                continue;
+            }
+
+            try {
+                long now = System.nanoTime();
+                for (ActiveRequest active : activeRequests) {
+                    long elapsedNanos = now - active.startNanos;
+                    if (elapsedNanos < thresholdNanos || !active.beginReport()) {
+                        continue;
+                    }
+
+                    StackTraceElement[] stackTrace = active.thread.getStackTrace();
+                    if (!activeRequests.contains(active) || !active.reporting()) {
+                        active.cancelReport();
+                        continue;
+                    }
+
+                    var message = new StringBuilder()
+                            .append("Request has been running for ")
+                            .append(Duration.ofNanos(elapsedNanos))
+                            .append(" and may be stuck. Request: ")
+                            .append(active.method)
+                            .append(' ')
+                            .append(active.path)
+                            .append(' ')
+                            .append(active.protocol)
+                            .append(", request id: ")
+                            .append(active.requestId)
+                            .append(", server socket: ")
+                            .append(active.serverSocketId)
+                            .append(", connection: ")
+                            .append(active.connectionId)
+                            .append(", thread: \"")
+                            .append(active.threadName)
+                            .append("\" (id: ")
+                            .append(active.thread.threadId())
+                            .append(", virtual: ")
+                            .append(active.thread.isVirtual())
+                            .append(", state: ")
+                            .append(active.thread.getState())
+                            .append(')');
+                    for (StackTraceElement stackTraceElement : stackTrace) {
+                        message.append(System.lineSeparator())
+                                .append("\tat ")
+                                .append(stackTraceElement);
+                    }
+                    boolean reported = false;
+                    try {
+                        LOGGER.log(System.Logger.Level.WARNING, message.toString());
+                        reported = true;
+                    } finally {
+                        if (reported) {
+                            if (active.finishReport() && running.get()) {
+                                logRecovery(active);
+                            }
+                        } else {
+                            active.abortReport();
+                        }
+                    }
+                }
+            } catch (RuntimeException e) {
+                LOGGER.log(System.Logger.Level.ERROR,
+                           "Failed to inspect request threads for socket " + socketName,
+                           e);
+            }
+        }
+    }
+
+    private void logRecovery(ActiveRequest active) {
+        if (!LOGGER.isLoggable(System.Logger.Level.INFO)) {
+            return;
+        }
+        long elapsedNanos = active.completionNanos - active.startNanos;
+        LOGGER.log(System.Logger.Level.INFO,
+                   "Request previously reported as stuck completed after " + Duration.ofNanos(elapsedNanos)
+                           + ". Request: " + active.method + " " + active.path + " " + active.protocol
+                           + ", request id: " + active.requestId
+                           + ", server socket: " + active.serverSocketId
+                           + ", connection: " + active.connectionId
+                           + ", thread: \"" + active.threadName + "\" (id: "
+                           + active.thread.threadId() + ", virtual: " + active.thread.isVirtual() + ")");
+    }
+
+    private static final class ActiveRequest {
+        private static final int ACTIVE = 0;
+        private static final int REPORTING = 1;
+        private static final int REPORTED = 2;
+        private static final int COMPLETED = 3;
+        private static final int COMPLETED_DURING_REPORT = 4;
+        private static final int STOPPED = 5;
+
+        private final AtomicInteger state = new AtomicInteger();
+        private final Thread thread;
+        private final String threadName;
+        private final long startNanos;
+        private final String protocol;
+        private final String method;
+        private final String path;
+        private final int requestId;
+        private final String serverSocketId;
+        private final String connectionId;
+
+        private volatile long completionNanos;
+
+        private ActiveRequest(Thread thread,
+                              long startNanos,
+                              String protocol,
+                              String method,
+                              String path,
+                              int requestId,
+                              String serverSocketId,
+                              String connectionId) {
+            this.thread = thread;
+            this.threadName = LogFormatter.escape(Objects.toString(thread.getName(), ""));
+            this.startNanos = startNanos;
+            this.protocol = protocol;
+            this.method = method;
+            this.path = path;
+            this.requestId = requestId;
+            this.serverSocketId = serverSocketId;
+            this.connectionId = connectionId;
+        }
+
+        private boolean beginReport() {
+            return state.compareAndSet(ACTIVE, REPORTING);
+        }
+
+        private boolean reporting() {
+            return state.get() == REPORTING;
+        }
+
+        private void cancelReport() {
+            if (!state.compareAndSet(REPORTING, ACTIVE)) {
+                state.compareAndSet(COMPLETED_DURING_REPORT, COMPLETED);
+            }
+        }
+
+        private boolean finishReport() {
+            if (state.compareAndSet(REPORTING, REPORTED)) {
+                return false;
+            }
+            return state.compareAndSet(COMPLETED_DURING_REPORT, COMPLETED);
+        }
+
+        private void abortReport() {
+            if (!state.compareAndSet(REPORTING, ACTIVE)) {
+                state.compareAndSet(COMPLETED_DURING_REPORT, COMPLETED);
+            }
+        }
+
+        private boolean complete(long completionNanos) {
+            this.completionNanos = completionNanos;
+            while (true) {
+                int currentState = state.get();
+                switch (currentState) {
+                case ACTIVE:
+                    if (state.compareAndSet(ACTIVE, COMPLETED)) {
+                        return false;
+                    }
+                    break;
+                case REPORTING:
+                    if (state.compareAndSet(REPORTING, COMPLETED_DURING_REPORT)) {
+                        return false;
+                    }
+                    break;
+                case REPORTED:
+                    if (state.compareAndSet(REPORTED, COMPLETED)) {
+                        return true;
+                    }
+                    break;
+                default:
+                    return false;
+                }
+            }
+        }
+
+        private void stop() {
+            state.set(STOPPED);
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
@@ -142,21 +142,17 @@ final class StuckThreadDetectionFilter implements Filter {
         try {
             chain.proceed();
         } finally {
-            complete(active);
-        }
-    }
-
-    private void complete(ActiveRequest active) {
-        activeRequests.remove(active);
-        if (active.complete(System.nanoTime())) {
-            completedRequests.offer(active);
-            if (!running.get()) {
-                completedRequests.remove(active);
-                return;
-            }
-            Thread thread = monitorThread.get();
-            if (thread != null) {
-                LockSupport.unpark(thread);
+            activeRequests.remove(active);
+            if (active.complete(System.nanoTime())) {
+                completedRequests.offer(active);
+                if (!running.get()) {
+                    completedRequests.remove(active);
+                    return;
+                }
+                Thread monitor = monitorThread.get();
+                if (monitor != null) {
+                    LockSupport.unpark(monitor);
+                }
             }
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
@@ -59,6 +59,14 @@ final class StuckThreadDetectionFilter implements Filter {
     }
 
     @Override
+    public void beforeStart() {
+        activeRequests.clear();
+        completedRequests.clear();
+        omittedRecoveries.set(0);
+        running.set(true);
+    }
+
+    @Override
     public void afterStart(WebServer webServer) {
         Thread thread = Thread.ofVirtual()
                 .name("stuck-thread-detection-" + socketName)
@@ -67,10 +75,6 @@ final class StuckThreadDetectionFilter implements Filter {
         if (!monitorThread.compareAndSet(null, thread)) {
             return;
         }
-        activeRequests.clear();
-        completedRequests.clear();
-        omittedRecoveries.set(0);
-        running.set(true);
         try {
             thread.start();
         } catch (RuntimeException | Error e) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
@@ -118,7 +118,9 @@ final class StuckThreadDetectionFilter implements Filter {
         Thread thread = Thread.currentThread();
         var prologue = req.prologue();
         String path = prologue.uriPath().path();
-        if (Method.CONNECT.equals(prologue.method()) && path.isEmpty()) {
+        if (Method.CONNECT.equals(prologue.method())
+                && path.isEmpty()
+                && prologue.uriPath().segments().isEmpty()) {
             path = prologue.uriPath().rawPathNoParams();
         }
         var active = new ActiveRequest(thread,

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
@@ -19,10 +19,11 @@ package io.helidon.webserver;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
@@ -39,10 +40,13 @@ import io.helidon.webserver.http.RoutingResponse;
 final class StuckThreadDetectionFilter implements Filter {
     private static final System.Logger LOGGER = System.getLogger(StuckThreadDetectionFilter.class.getName());
     private static final long STOP_WAIT_NANOS = Duration.ofSeconds(1).toNanos();
+    static final int MAX_QUEUED_RECOVERIES = 32;
+    static final int MAX_RECOVERY_LOGS_PER_CYCLE = 8;
 
     private final Set<ActiveRequest> activeRequests = ConcurrentHashMap.newKeySet();
-    private final ConcurrentLinkedQueue<ActiveRequest> completedRequests = new ConcurrentLinkedQueue<>();
+    private final ArrayBlockingQueue<ActiveRequest> completedRequests = new ArrayBlockingQueue<>(MAX_QUEUED_RECOVERIES);
     private final AtomicBoolean running = new AtomicBoolean();
+    private final AtomicLong omittedRecoveries = new AtomicLong();
     private final AtomicReference<Thread> monitorThread = new AtomicReference<>();
     private final long checkPeriodNanos;
     private final long thresholdNanos;
@@ -65,6 +69,7 @@ final class StuckThreadDetectionFilter implements Filter {
         }
         activeRequests.clear();
         completedRequests.clear();
+        omittedRecoveries.set(0);
         running.set(true);
         try {
             thread.start();
@@ -86,6 +91,7 @@ final class StuckThreadDetectionFilter implements Filter {
         Thread thread = monitorThread.getAndSet(null);
         if (thread == null) {
             completedRequests.clear();
+            omittedRecoveries.set(0);
             return;
         }
         thread.interrupt();
@@ -103,6 +109,7 @@ final class StuckThreadDetectionFilter implements Filter {
             }
         }
         completedRequests.clear();
+        omittedRecoveries.set(0);
         if (interrupted) {
             Thread.currentThread().interrupt();
         }
@@ -144,31 +151,61 @@ final class StuckThreadDetectionFilter implements Filter {
         } finally {
             activeRequests.remove(active);
             if (active.complete(System.nanoTime())) {
-                completedRequests.offer(active);
-                if (!running.get()) {
-                    completedRequests.remove(active);
-                    return;
-                }
-                Thread monitor = monitorThread.get();
-                if (monitor != null) {
-                    LockSupport.unpark(monitor);
-                }
+                enqueueRecovery(active);
             }
+        }
+    }
+
+    private void enqueueRecovery(ActiveRequest active) {
+        if (!running.get()) {
+            return;
+        }
+        if (!completedRequests.offer(active)) {
+            omittedRecoveries.incrementAndGet();
+        }
+        if (!running.get()) {
+            completedRequests.remove(active);
+            return;
+        }
+        Thread monitor = monitorThread.get();
+        if (monitor != null) {
+            LockSupport.unpark(monitor);
         }
     }
 
     private void monitorRequests() {
         long nextScan = System.nanoTime() + checkPeriodNanos;
         while (running.get()) {
-            ActiveRequest completed;
-            while ((completed = completedRequests.poll()) != null) {
-                if (running.get()) {
-                    logRecovery(completed);
+            int loggedRecoveries = 0;
+            try {
+                long omitted = omittedRecoveries.getAndSet(0);
+                if (omitted != 0 && running.get() && LOGGER.isLoggable(System.Logger.Level.INFO)) {
+                    LOGGER.log(System.Logger.Level.INFO,
+                               omitted + (omitted == 1
+                                       ? " request recovery log message was omitted for socket "
+                                       : " request recovery log messages were omitted for socket ") + socketName
+                                       + " because the bounded recovery queue was full");
+                    loggedRecoveries++;
                 }
+                ActiveRequest completed;
+                while (loggedRecoveries < MAX_RECOVERY_LOGS_PER_CYCLE
+                        && (completed = completedRequests.poll()) != null) {
+                    if (running.get()) {
+                        logRecovery(completed);
+                    }
+                    loggedRecoveries++;
+                }
+            } catch (RuntimeException e) {
+                LOGGER.log(System.Logger.Level.ERROR,
+                           "Failed to report recovered requests for socket " + socketName,
+                           e);
             }
 
             long nanosUntilScan = nextScan - System.nanoTime();
             if (nanosUntilScan > 0) {
+                if (!completedRequests.isEmpty() || omittedRecoveries.get() != 0) {
+                    continue;
+                }
                 LockSupport.parkNanos(this, nanosUntilScan);
                 if (Thread.interrupted()) {
                     return;
@@ -231,7 +268,7 @@ final class StuckThreadDetectionFilter implements Filter {
                     } finally {
                         if (reported) {
                             if (active.finishReport() && running.get()) {
-                                logRecovery(active);
+                                enqueueRecovery(active);
                             }
                         } else {
                             active.abortReport();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StuckThreadDetectionFilter.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
 import io.helidon.http.LogFormatter;
+import io.helidon.http.Method;
 import io.helidon.webserver.http.Filter;
 import io.helidon.webserver.http.FilterChain;
 import io.helidon.webserver.http.RoutingRequest;
@@ -116,11 +117,15 @@ final class StuckThreadDetectionFilter implements Filter {
 
         Thread thread = Thread.currentThread();
         var prologue = req.prologue();
+        String path = prologue.uriPath().path();
+        if (Method.CONNECT.equals(prologue.method()) && path.isEmpty()) {
+            path = prologue.uriPath().rawPathNoParams();
+        }
         var active = new ActiveRequest(thread,
                                        System.nanoTime(),
                                        prologue.rawProtocol(),
                                        prologue.method().text(),
-                                       LogFormatter.escape(prologue.uriPath().path()),
+                                       LogFormatter.escape(path),
                                        req.id(),
                                        req.serverSocketId(),
                                        req.socketId());

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/Filters.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/Filters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/Filters.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/Filters.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 
 import io.helidon.common.parameters.Parameters;
 import io.helidon.common.uri.UriPath;
+import io.helidon.common.uri.UriPathSegment;
 import io.helidon.http.HttpException;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.Status;
@@ -186,6 +187,11 @@ public final class Filters implements ServerLifecycle {
         @Override
         public Parameters matrixParameters() {
             return uriPath.matrixParameters();
+        }
+
+        @Override
+        public List<UriPathSegment> segments() {
+            return uriPath.segments();
         }
 
         @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RouteCrawler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RouteCrawler.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import io.helidon.common.parameters.Parameters;
 import io.helidon.common.uri.UriPath;
+import io.helidon.common.uri.UriPathSegment;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
@@ -243,6 +244,11 @@ class RouteCrawler {
             @Override
             public String path() {
                 return path.path();
+            }
+
+            @Override
+            public List<UriPathSegment> segments() {
+                return path.segments();
             }
 
             @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
@@ -257,27 +257,7 @@ public final class Http1Prologue {
                     }
 
                     String host = path.substring(0, portSeparator);
-                    for (int i = 0; i < host.length(); i++) {
-                        char c = host.charAt(i);
-                        if ((c >= 'a' && c <= 'z')
-                                || (c >= 'A' && c <= 'Z')
-                                || (c >= '0' && c <= '9')
-                                || switch (c) {
-                                    case '-', '.', '_', '~', '!', '$', '&', '\'', '(', ')', '*', '+',
-                                         ',', ';', '=' -> true;
-                                    default -> false;
-                                }) {
-                            continue;
-                        }
-                        if (c == '%'
-                                && i + 2 < host.length()
-                                && Character.digit(host.charAt(i + 1), 16) >= 0
-                                && Character.digit(host.charAt(i + 2), 16) >= 0) {
-                            i += 2;
-                            continue;
-                        }
-                        throw new IllegalArgumentException("CONNECT authority contains an invalid host");
-                    }
+                    UriValidator.validateNonIpLiteral(host);
                 }
 
                 if (portSeparator == path.length() - 1) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
@@ -17,9 +17,16 @@
 package io.helidon.webserver.http1;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import io.helidon.common.buffers.Bytes;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.parameters.Parameters;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriFragment;
+import io.helidon.common.uri.UriPath;
+import io.helidon.common.uri.UriPathSegment;
+import io.helidon.common.uri.UriQuery;
 import io.helidon.http.DirectHandler;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
@@ -231,6 +238,19 @@ public final class Http1Prologue {
         }
 
         try {
+            if (Method.CONNECT.equals(method)) {
+                UriAuthority authority = UriAuthority.create(path);
+                if (!authority.hasPort()) {
+                    throw new IllegalArgumentException("CONNECT authority must include a port");
+                }
+                return HttpPrologue.create(protocol,
+                                           "HTTP",
+                                           "1.1",
+                                           method,
+                                           new AuthorityFormPath(path),
+                                           UriQuery.empty(),
+                                           UriFragment.empty());
+            }
             return HttpPrologue.create(protocol,
                                        "HTTP",
                                        "1.1",
@@ -259,5 +279,43 @@ public final class Http1Prologue {
         }
 
         return new String(bytes, StandardCharsets.US_ASCII);
+    }
+
+    private record AuthorityFormPath(String rawPath) implements UriPath {
+        private static final Parameters EMPTY_PARAMETERS = Parameters.empty("uri/authority");
+
+        @Override
+        public String rawPathNoParams() {
+            return rawPath;
+        }
+
+        @Override
+        public String path() {
+            return "";
+        }
+
+        @Override
+        public Parameters matrixParameters() {
+            return EMPTY_PARAMETERS;
+        }
+
+        @Override
+        public UriPath absolute() {
+            return this;
+        }
+
+        @Override
+        public List<UriPathSegment> segments() {
+            return List.of();
+        }
+
+        @Override
+        public void validate() {
+        }
+
+        @Override
+        public String toString() {
+            return rawPath;
+        }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
@@ -239,9 +239,54 @@ public final class Http1Prologue {
 
         try {
             if (Method.CONNECT.equals(method)) {
-                UriAuthority authority = UriAuthority.create(path);
-                if (!authority.hasPort()) {
-                    throw new IllegalArgumentException("CONNECT authority must include a port");
+                if (path.charAt(0) == '[') {
+                    UriAuthority authority = UriAuthority.create(path);
+                    if (!authority.hasPort()) {
+                        throw new IllegalArgumentException("CONNECT authority must include a port");
+                    }
+                } else {
+                    int portSeparator = path.lastIndexOf(':');
+                    if (portSeparator <= 0 || path.indexOf(':') != portSeparator) {
+                        throw new IllegalArgumentException("CONNECT authority must contain a host and port");
+                    }
+
+                    String host = path.substring(0, portSeparator);
+                    for (int i = 0; i < host.length(); i++) {
+                        char c = host.charAt(i);
+                        if ((c >= 'a' && c <= 'z')
+                                || (c >= 'A' && c <= 'Z')
+                                || (c >= '0' && c <= '9')
+                                || switch (c) {
+                                    case '-', '.', '_', '~', '!', '$', '&', '\'', '(', ')', '*', '+',
+                                         ',', ';', '=' -> true;
+                                    default -> false;
+                                }) {
+                            continue;
+                        }
+                        if (c == '%'
+                                && i + 2 < host.length()
+                                && Character.digit(host.charAt(i + 1), 16) >= 0
+                                && Character.digit(host.charAt(i + 2), 16) >= 0) {
+                            i += 2;
+                            continue;
+                        }
+                        throw new IllegalArgumentException("CONNECT authority contains an invalid host");
+                    }
+
+                    if (portSeparator == path.length() - 1) {
+                        throw new IllegalArgumentException("CONNECT authority port cannot be blank");
+                    }
+                    int port = 0;
+                    for (int i = portSeparator + 1; i < path.length(); i++) {
+                        char c = path.charAt(i);
+                        if (c < '0' || c > '9') {
+                            throw new IllegalArgumentException("CONNECT authority port must contain only digits");
+                        }
+                        port = port * 10 + c - '0';
+                        if (port > 65535) {
+                            throw new IllegalArgumentException("CONNECT authority port must be between 0 and 65535");
+                        }
+                    }
                 }
                 return HttpPrologue.create(protocol,
                                            "HTTP",

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
@@ -22,11 +22,11 @@ import java.util.List;
 import io.helidon.common.buffers.Bytes;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.parameters.Parameters;
-import io.helidon.common.uri.UriAuthority;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriPath;
 import io.helidon.common.uri.UriPathSegment;
 import io.helidon.common.uri.UriQuery;
+import io.helidon.common.uri.UriValidator;
 import io.helidon.http.DirectHandler;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
@@ -239,13 +239,19 @@ public final class Http1Prologue {
 
         try {
             if (Method.CONNECT.equals(method)) {
+                int portSeparator;
                 if (path.charAt(0) == '[') {
-                    UriAuthority authority = UriAuthority.create(path);
-                    if (!authority.hasPort()) {
+                    int closingBracket = path.indexOf(']');
+                    if (closingBracket == -1) {
+                        throw new IllegalArgumentException("CONNECT authority is missing a closing bracket");
+                    }
+                    UriValidator.validateIpLiteral(path.substring(0, closingBracket + 1));
+                    portSeparator = closingBracket + 1;
+                    if (portSeparator == path.length() || path.charAt(portSeparator) != ':') {
                         throw new IllegalArgumentException("CONNECT authority must include a port");
                     }
                 } else {
-                    int portSeparator = path.lastIndexOf(':');
+                    portSeparator = path.lastIndexOf(':');
                     if (portSeparator <= 0 || path.indexOf(':') != portSeparator) {
                         throw new IllegalArgumentException("CONNECT authority must contain a host and port");
                     }
@@ -272,20 +278,20 @@ public final class Http1Prologue {
                         }
                         throw new IllegalArgumentException("CONNECT authority contains an invalid host");
                     }
+                }
 
-                    if (portSeparator == path.length() - 1) {
-                        throw new IllegalArgumentException("CONNECT authority port cannot be blank");
+                if (portSeparator == path.length() - 1) {
+                    throw new IllegalArgumentException("CONNECT authority port cannot be blank");
+                }
+                int port = 0;
+                for (int i = portSeparator + 1; i < path.length(); i++) {
+                    char c = path.charAt(i);
+                    if (c < '0' || c > '9') {
+                        throw new IllegalArgumentException("CONNECT authority port must contain only digits");
                     }
-                    int port = 0;
-                    for (int i = portSeparator + 1; i < path.length(); i++) {
-                        char c = path.charAt(i);
-                        if (c < '0' || c > '9') {
-                            throw new IllegalArgumentException("CONNECT authority port must contain only digits");
-                        }
-                        port = port * 10 + c - '0';
-                        if (port > 65535) {
-                            throw new IllegalArgumentException("CONNECT authority port must be between 0 and 65535");
-                        }
+                    port = port * 10 + c - '0';
+                    if (port > 65535) {
+                        throw new IllegalArgumentException("CONNECT authority port must be between 0 and 65535");
                     }
                 }
                 return HttpPrologue.create(protocol,

--- a/webserver/webserver/src/main/java/io/helidon/webserver/spi/ServerFeatureProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/spi/ServerFeatureProvider.java
@@ -36,10 +36,12 @@ import io.helidon.config.ConfiguredProvider;
  * </ol>
  * The following weights are used by features of Helidon:
  * <ul>
+ *     <li>Concurrency limits: 2000</li>
  *     <li>Context: 1100</li>
+ *     <li>Stuck thread detection: 1050</li>
  *     <li>Access Log: 1000</li>
  *     <li>Tracing: 900</li>
- *     <li>CORS: 950</li>
+ *     <li>CORS: 850</li>
  *     <li>Security: 800</li>
  *     <li>User routing (all handlers): 100</li>
  *     <li>OpenAPI: 90</li>

--- a/webserver/webserver/src/main/java/module-info.java
+++ b/webserver/webserver/src/main/java/module-info.java
@@ -69,5 +69,7 @@ module io.helidon.webserver {
     provides io.helidon.webserver.spi.ProtocolConfigProvider
             with io.helidon.webserver.http1.Http1ProtocolConfigProvider;
     provides io.helidon.webserver.spi.ServerConnectionSelectorProvider with io.helidon.webserver.http1.Http1ConnectionProvider;
+    provides io.helidon.webserver.spi.ServerFeatureProvider
+            with io.helidon.webserver.StuckThreadDetectionFeatureProvider;
 
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.webserver.http.FilterChain;
+import io.helidon.webserver.http.RoutingRequest;
+import io.helidon.webserver.http.RoutingResponse;
+import io.helidon.webserver.spi.ServerFeature.ServerFeatureContext;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StuckThreadDetectionFeatureTest {
+    @Test
+    void defaultConfiguration() {
+        StuckThreadDetectionConfig config = StuckThreadDetectionFeature.create().prototype();
+
+        assertThat(config.enabled(), is(true));
+        assertThat(config.threshold(), is(Duration.ofMinutes(10)));
+        assertThat(config.checkPeriod(), is(Duration.ofMinutes(1)));
+        assertThat(config.weight(), is(StuckThreadDetectionFeature.WEIGHT));
+        assertThat(config.sockets().isEmpty(), is(true));
+    }
+
+    @Test
+    void durationsMustBePositive() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> StuckThreadDetectionConfig.builder()
+                             .threshold(Duration.ZERO)
+                             .buildPrototype());
+        assertThrows(IllegalArgumentException.class,
+                     () -> StuckThreadDetectionConfig.builder()
+                             .checkPeriod(Duration.ofSeconds(-1))
+                             .buildPrototype());
+    }
+
+    @Test
+    void automaticDiscoveryDoesNotEnableDetectionWithoutConfiguration() {
+        var feature = new StuckThreadDetectionFeatureProvider()
+                .create(Config.empty(), StuckThreadDetectionFeature.FEATURE_ID);
+        var context = mock(ServerFeatureContext.class);
+
+        feature.setup(context);
+
+        assertThat(feature.prototype().enabled(), is(false));
+        verify(context, never()).sockets();
+    }
+
+    @Test
+    void explicitlyDisabledFeatureDoesNotEnableDetection() {
+        Config config = Config.just(ConfigSources.create(Map.of("enabled", "false")));
+        var feature = StuckThreadDetectionFeature.create(config);
+        var context = mock(ServerFeatureContext.class);
+
+        feature.setup(context);
+
+        verify(context, never()).sockets();
+    }
+
+    @Test
+    void configuredFeatureIsDiscovered() {
+        Config config = Config.just(ConfigSources.create(Map.of(
+                "features.stuck-thread-detection.threshold", "PT2M",
+                "features.stuck-thread-detection.check-period", "PT10S")));
+
+        var webServerConfig = WebServer.builder()
+                .config(config)
+                .buildPrototype();
+        var feature = webServerConfig.features()
+                .stream()
+                .filter(StuckThreadDetectionFeature.class::isInstance)
+                .map(StuckThreadDetectionFeature.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(feature.prototype().enabled(), is(true));
+        assertThat(feature.prototype().threshold(), is(Duration.ofMinutes(2)));
+        assertThat(feature.prototype().checkPeriod(), is(Duration.ofSeconds(10)));
+    }
+
+    @Test
+    void reportsStuckRequestAndRecovery() throws Exception {
+        var config = StuckThreadDetectionConfig.builder()
+                .threshold(Duration.ofMillis(20))
+                .checkPeriod(Duration.ofMillis(5))
+                .buildPrototype();
+        var filter = new StuckThreadDetectionFilter(config, WebServer.DEFAULT_SOCKET_NAME);
+        var started = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var failure = new AtomicReference<Throwable>();
+        FilterChain chain = () -> {
+            started.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            }
+        };
+
+        RoutingRequest request = mock(RoutingRequest.class);
+        when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
+                                                               "HTTP",
+                                                               "1.1",
+                                                               Method.GET,
+                                                               "/slow?secret=value",
+                                                               true));
+        when(request.id()).thenReturn(7);
+        when(request.serverSocketId()).thenReturn("server-socket");
+        when(request.socketId()).thenReturn("connection-socket");
+        try (TestLogHandler logs = new TestLogHandler()) {
+            filter.afterStart(mock(WebServer.class));
+            Thread requestThread = Thread.ofVirtual().start(() -> {
+                try {
+                    filter.filter(chain, request, mock(RoutingResponse.class));
+                } catch (Throwable t) {
+                    failure.set(t);
+                }
+            });
+            try {
+                assertThat("Request handler did not start", started.await(5, TimeUnit.SECONDS), is(true));
+
+                LogRecord warning = logs.await(Level.WARNING);
+                assertThat(warning.getMessage(), containsString("Request has been running for"));
+                assertThat(warning.getMessage(), containsString("GET /slow HTTP/1.1"));
+                assertThat(warning.getMessage(), containsString("request id: 7"));
+                assertThat(warning.getMessage(), containsString("server socket: server-socket"));
+                assertThat(warning.getMessage(), containsString("connection: connection-socket"));
+                assertThat(warning.getMessage(), containsString("virtual: true"));
+                assertThat(warning.getMessage(), containsString("\tat "));
+                assertThat(warning.getMessage(), not(containsString("secret=value")));
+                assertThat("Request was reported more than once",
+                           logs.records.poll(50, TimeUnit.MILLISECONDS),
+                           is((LogRecord) null));
+
+                release.countDown();
+                requestThread.join(5000);
+                assertThat("Request handler did not finish", requestThread.isAlive(), is(false));
+                assertThat("Request handler failed", failure.get(), is((Throwable) null));
+
+                LogRecord recovery = logs.await(Level.INFO);
+                assertThat(recovery.getMessage(), containsString("Request previously reported as stuck completed after"));
+                assertThat(recovery.getMessage(), containsString("GET /slow HTTP/1.1"));
+            } finally {
+                release.countDown();
+                requestThread.join(5000);
+                filter.afterStop();
+            }
+        }
+    }
+
+    @Test
+    void warningLoggingDoesNotBlockRequestCompletion() throws Exception {
+        var config = StuckThreadDetectionConfig.builder()
+                .threshold(Duration.ofMillis(20))
+                .checkPeriod(Duration.ofMillis(5))
+                .buildPrototype();
+        var filter = new StuckThreadDetectionFilter(config, WebServer.DEFAULT_SOCKET_NAME);
+        var releaseRequest = new CountDownLatch(1);
+        var warningStarted = new CountDownLatch(1);
+        var releaseWarning = new CountDownLatch(1);
+        var requestCompleted = new CountDownLatch(1);
+        var failure = new AtomicReference<Throwable>();
+        RoutingRequest request = mock(RoutingRequest.class);
+        when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
+                                                               "HTTP",
+                                                               "1.1",
+                                                               Method.GET,
+                                                               "/logging",
+                                                               true));
+        when(request.id()).thenReturn(8);
+        when(request.serverSocketId()).thenReturn("server-socket");
+        when(request.socketId()).thenReturn("connection-socket");
+        try (TestLogHandler logs = new TestLogHandler(warningStarted, releaseWarning)) {
+            filter.afterStart(mock(WebServer.class));
+            Thread requestThread = Thread.ofVirtual().start(() -> {
+                try {
+                    filter.filter(() -> {
+                        try {
+                            releaseRequest.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException(e);
+                        }
+                    }, request, mock(RoutingResponse.class));
+                } catch (Throwable t) {
+                    failure.set(t);
+                } finally {
+                    requestCompleted.countDown();
+                }
+            });
+            try {
+                assertThat("Warning logger was not entered", warningStarted.await(5, TimeUnit.SECONDS), is(true));
+                releaseRequest.countDown();
+                assertThat("Warning logging blocked request completion",
+                           requestCompleted.await(5, TimeUnit.SECONDS),
+                           is(true));
+                assertThat("Request handler failed", failure.get(), is((Throwable) null));
+
+                releaseWarning.countDown();
+                LogRecord warning = logs.await(Level.WARNING);
+                assertThat(warning.getMessage(), containsString("GET /logging HTTP/1.1"));
+                LogRecord recovery = logs.await(Level.INFO);
+                assertThat(recovery.getMessage(), containsString("GET /logging HTTP/1.1"));
+            } finally {
+                releaseRequest.countDown();
+                releaseWarning.countDown();
+                requestThread.join(5000);
+                filter.afterStop();
+            }
+        }
+    }
+
+    @Test
+    void stopPreservesCallerInterruptAndWaitsForMonitor() throws Exception {
+        var filter = new StuckThreadDetectionFilter(StuckThreadDetectionFeature.create().prototype(),
+                                                    WebServer.DEFAULT_SOCKET_NAME);
+        var interrupted = new AtomicReference<Boolean>();
+        filter.afterStart(mock(WebServer.class));
+
+        Thread stopThread = Thread.ofVirtual().start(() -> {
+            Thread.currentThread().interrupt();
+            filter.afterStop();
+            interrupted.set(Thread.currentThread().isInterrupted());
+        });
+
+        stopThread.join(5000);
+        assertThat("Feature stop did not finish", stopThread.isAlive(), is(false));
+        assertThat("Feature stop did not restore caller interrupt", interrupted.get(), is(true));
+    }
+
+    @Test
+    void stopDoesNotWaitIndefinitelyForBlockedLogger() throws Exception {
+        var config = StuckThreadDetectionConfig.builder()
+                .threshold(Duration.ofMillis(20))
+                .checkPeriod(Duration.ofMillis(5))
+                .buildPrototype();
+        var filter = new StuckThreadDetectionFilter(config, WebServer.DEFAULT_SOCKET_NAME);
+        var releaseRequest = new CountDownLatch(1);
+        var warningStarted = new CountDownLatch(1);
+        var releaseWarning = new CountDownLatch(1);
+        RoutingRequest request = mock(RoutingRequest.class);
+        when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
+                                                               "HTTP",
+                                                               "1.1",
+                                                               Method.GET,
+                                                               "/blocked-logger",
+                                                               true));
+        when(request.id()).thenReturn(9);
+        when(request.serverSocketId()).thenReturn("server-socket");
+        when(request.socketId()).thenReturn("connection-socket");
+        try (TestLogHandler ignored = new TestLogHandler(warningStarted, releaseWarning, true)) {
+            filter.afterStart(mock(WebServer.class));
+            Thread requestThread = Thread.ofVirtual().start(() -> {
+                filter.filter(() -> {
+                    try {
+                        releaseRequest.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException(e);
+                    }
+                }, request, mock(RoutingResponse.class));
+            });
+            assertThat("Warning logger was not entered", warningStarted.await(5, TimeUnit.SECONDS), is(true));
+
+            Thread stopThread = Thread.ofVirtual().start(filter::afterStop);
+            stopThread.join(3000);
+            boolean stopped = !stopThread.isAlive();
+
+            releaseWarning.countDown();
+            releaseRequest.countDown();
+            stopThread.join(5000);
+            requestThread.join(5000);
+            assertThat("Feature stop waited indefinitely for blocked logging", stopped, is(true));
+        }
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final LinkedBlockingQueue<LogRecord> records = new LinkedBlockingQueue<>();
+        private final Logger logger = Logger.getLogger(StuckThreadDetectionFilter.class.getName());
+        private final Level originalLevel = logger.getLevel();
+        private final boolean originalUseParentHandlers = logger.getUseParentHandlers();
+        private final CountDownLatch warningStarted;
+        private final CountDownLatch releaseWarning;
+        private final boolean ignoreWarningInterrupt;
+
+        private TestLogHandler() {
+            this(null, null, false);
+        }
+
+        private TestLogHandler(CountDownLatch warningStarted, CountDownLatch releaseWarning) {
+            this(warningStarted, releaseWarning, false);
+        }
+
+        private TestLogHandler(CountDownLatch warningStarted,
+                               CountDownLatch releaseWarning,
+                               boolean ignoreWarningInterrupt) {
+            this.warningStarted = warningStarted;
+            this.releaseWarning = releaseWarning;
+            this.ignoreWarningInterrupt = ignoreWarningInterrupt;
+            setLevel(Level.ALL);
+            logger.setLevel(Level.ALL);
+            logger.setUseParentHandlers(false);
+            logger.addHandler(this);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (warningStarted != null && record.getLevel().equals(Level.WARNING)) {
+                warningStarted.countDown();
+                boolean interrupted = false;
+                while (true) {
+                    try {
+                        releaseWarning.await();
+                        break;
+                    } catch (InterruptedException e) {
+                        if (!ignoreWarningInterrupt) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                        interrupted = true;
+                    }
+                }
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (isLoggable(record)) {
+                records.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setUseParentHandlers(originalUseParentHandlers);
+            logger.setLevel(originalLevel);
+        }
+
+        private LogRecord await(Level level) throws InterruptedException {
+            long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+            while (true) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    throw new AssertionError("No " + level + " log record received");
+                }
+                LogRecord record = records.poll(remaining, TimeUnit.NANOSECONDS);
+                if (record == null) {
+                    throw new AssertionError("No " + level + " log record received");
+                }
+                if (record.getLevel().equals(level)) {
+                    return record;
+                }
+            }
+        }
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
@@ -140,7 +140,7 @@ class StuckThreadDetectionFeatureTest {
                                                                "HTTP",
                                                                "1.1",
                                                                Method.GET,
-                                                               "/slow?secret=value",
+                                                               "http://alice:s3cr3t@localhost/slow?secret=value",
                                                                true));
         when(request.id()).thenReturn(7);
         when(request.serverSocketId()).thenReturn("server-socket");
@@ -166,6 +166,8 @@ class StuckThreadDetectionFeatureTest {
                 assertThat(warning.getMessage(), containsString("virtual: true"));
                 assertThat(warning.getMessage(), containsString("\tat "));
                 assertThat(warning.getMessage(), not(containsString("secret=value")));
+                assertThat(warning.getMessage(), not(containsString("alice")));
+                assertThat(warning.getMessage(), not(containsString("s3cr3t")));
                 assertThat("Request was reported more than once",
                            logs.records.poll(50, TimeUnit.MILLISECONDS),
                            is((LogRecord) null));
@@ -178,6 +180,9 @@ class StuckThreadDetectionFeatureTest {
                 LogRecord recovery = logs.await(Level.INFO);
                 assertThat(recovery.getMessage(), containsString("Request previously reported as stuck completed after"));
                 assertThat(recovery.getMessage(), containsString("GET /slow HTTP/1.1"));
+                assertThat(recovery.getMessage(), not(containsString("secret=value")));
+                assertThat(recovery.getMessage(), not(containsString("alice")));
+                assertThat(recovery.getMessage(), not(containsString("s3cr3t")));
             } finally {
                 release.countDown();
                 requestThread.join(5000);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
@@ -192,6 +192,57 @@ class StuckThreadDetectionFeatureTest {
     }
 
     @Test
+    void reportsConnectAuthority() throws Exception {
+        var config = StuckThreadDetectionConfig.builder()
+                .threshold(Duration.ofMillis(20))
+                .checkPeriod(Duration.ofMillis(5))
+                .buildPrototype();
+        var filter = new StuckThreadDetectionFilter(config, WebServer.DEFAULT_SOCKET_NAME);
+        var started = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var failure = new AtomicReference<Throwable>();
+        RoutingRequest request = mock(RoutingRequest.class);
+        when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
+                                                               "HTTP",
+                                                               "1.1",
+                                                               Method.CONNECT,
+                                                               "example.com:443",
+                                                               true));
+        when(request.id()).thenReturn(10);
+        when(request.serverSocketId()).thenReturn("server-socket");
+        when(request.socketId()).thenReturn("connection-socket");
+        try (TestLogHandler logs = new TestLogHandler()) {
+            filter.afterStart(mock(WebServer.class));
+            Thread requestThread = Thread.ofVirtual().start(() -> {
+                try {
+                    filter.filter(() -> {
+                        started.countDown();
+                        try {
+                            release.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException(e);
+                        }
+                    }, request, mock(RoutingResponse.class));
+                } catch (Throwable t) {
+                    failure.set(t);
+                }
+            });
+            try {
+                assertThat("Request handler did not start", started.await(5, TimeUnit.SECONDS), is(true));
+
+                LogRecord warning = logs.await(Level.WARNING);
+                assertThat(warning.getMessage(), containsString("CONNECT example.com:443 HTTP/1.1"));
+            } finally {
+                release.countDown();
+                requestThread.join(5000);
+                filter.afterStop();
+            }
+        }
+        assertThat("Request handler failed", failure.get(), is((Throwable) null));
+    }
+
+    @Test
     void warningLoggingDoesNotBlockRequestCompletion() throws Exception {
         var config = StuckThreadDetectionConfig.builder()
                 .threshold(Duration.ofMillis(20))

--- a/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
@@ -120,6 +120,60 @@ class StuckThreadDetectionFeatureTest {
     }
 
     @Test
+    void tracksRequestAcceptedBeforeAfterStart() throws Exception {
+        var config = StuckThreadDetectionConfig.builder()
+                .threshold(Duration.ofMillis(20))
+                .checkPeriod(Duration.ofMillis(5))
+                .buildPrototype();
+        var filter = new StuckThreadDetectionFilter(config, WebServer.DEFAULT_SOCKET_NAME);
+        var started = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var failure = new AtomicReference<Throwable>();
+        RoutingRequest request = mock(RoutingRequest.class);
+        when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
+                                                               "HTTP",
+                                                               "1.1",
+                                                               Method.GET,
+                                                               "/during-startup",
+                                                               true));
+        when(request.id()).thenReturn(13);
+        when(request.serverSocketId()).thenReturn("server-socket");
+        when(request.socketId()).thenReturn("connection-socket");
+
+        filter.beforeStart();
+        try (TestLogHandler logs = new TestLogHandler()) {
+            Thread requestThread = Thread.ofVirtual().start(() -> {
+                try {
+                    filter.filter(() -> {
+                        started.countDown();
+                        try {
+                            release.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException(e);
+                        }
+                    }, request, mock(RoutingResponse.class));
+                } catch (Throwable t) {
+                    failure.set(t);
+                }
+            });
+            try {
+                assertThat("Request handler did not start", started.await(5, TimeUnit.SECONDS), is(true));
+
+                filter.afterStart(mock(WebServer.class));
+
+                LogRecord warning = logs.await(Level.WARNING);
+                assertThat(warning.getMessage(), containsString("GET /during-startup HTTP/1.1"));
+            } finally {
+                release.countDown();
+                requestThread.join(5000);
+                filter.afterStop();
+            }
+        }
+        assertThat("Request handler failed", failure.get(), is((Throwable) null));
+    }
+
+    @Test
     void reportsStuckRequestAndRecovery() throws Exception {
         var config = StuckThreadDetectionConfig.builder()
                 .threshold(Duration.ofMillis(20))
@@ -150,6 +204,7 @@ class StuckThreadDetectionFeatureTest {
         when(request.serverSocketId()).thenReturn("server-socket");
         when(request.socketId()).thenReturn("connection-socket");
         try (TestLogHandler logs = new TestLogHandler()) {
+            filter.beforeStart();
             filter.afterStart(mock(WebServer.class));
             Thread requestThread = Thread.ofVirtual().start(() -> {
                 try {
@@ -231,6 +286,7 @@ class StuckThreadDetectionFeatureTest {
         when(request.serverSocketId()).thenReturn("server-socket");
         when(request.socketId()).thenReturn("connection-socket");
         try (TestLogHandler logs = new TestLogHandler()) {
+            filter.beforeStart();
             filter.afterStart(mock(WebServer.class));
             Thread requestThread = Thread.ofVirtual().start(() -> {
                 try {
@@ -293,6 +349,7 @@ class StuckThreadDetectionFeatureTest {
         when(request.serverSocketId()).thenReturn("server-socket");
         when(request.socketId()).thenReturn("connection-socket");
         try (TestLogHandler logs = new TestLogHandler(warningStarted, releaseWarning)) {
+            filter.beforeStart();
             filter.afterStart(mock(WebServer.class));
             Thread requestThread = Thread.ofVirtual().start(() -> {
                 try {
@@ -371,6 +428,7 @@ class StuckThreadDetectionFeatureTest {
         when(probeRequest.serverSocketId()).thenReturn("server-socket");
         when(probeRequest.socketId()).thenReturn("connection-socket");
         try (TestLogHandler logs = new TestLogHandler(Level.INFO, infoStarted, releaseInfo)) {
+            filter.beforeStart();
             filter.afterStart(mock(WebServer.class));
             for (int i = 0; i < requestCount; i++) {
                 CountDownLatch releaseRequest = i == 0 ? releaseFirstRequest : releaseRequests;
@@ -485,6 +543,7 @@ class StuckThreadDetectionFeatureTest {
         var filter = new StuckThreadDetectionFilter(StuckThreadDetectionFeature.create().prototype(),
                                                     WebServer.DEFAULT_SOCKET_NAME);
         var interrupted = new AtomicReference<Boolean>();
+        filter.beforeStart();
         filter.afterStart(mock(WebServer.class));
 
         Thread stopThread = Thread.ofVirtual().start(() -> {
@@ -519,6 +578,7 @@ class StuckThreadDetectionFeatureTest {
         when(request.serverSocketId()).thenReturn("server-socket");
         when(request.socketId()).thenReturn("connection-socket");
         try (TestLogHandler ignored = new TestLogHandler(warningStarted, releaseWarning, true)) {
+            filter.beforeStart();
             filter.afterStart(mock(WebServer.class));
             Thread requestThread = Thread.ofVirtual().start(() -> {
                 filter.filter(() -> {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
@@ -18,6 +18,7 @@ package io.helidon.webserver;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -332,6 +333,154 @@ class StuckThreadDetectionFeatureTest {
     }
 
     @Test
+    void boundsRecoveryBacklogWhenInfoLoggingBlocks() throws Exception {
+        var config = StuckThreadDetectionConfig.builder()
+                .threshold(Duration.ofNanos(1))
+                .checkPeriod(Duration.ofNanos(1))
+                .buildPrototype();
+        var filter = new StuckThreadDetectionFilter(config, WebServer.DEFAULT_SOCKET_NAME);
+        int requestCount = StuckThreadDetectionFilter.MAX_QUEUED_RECOVERIES + 2;
+        var handlersStarted = new CountDownLatch(requestCount);
+        var releaseFirstRequest = new CountDownLatch(1);
+        var releaseRequests = new CountDownLatch(1);
+        var probeStarted = new CountDownLatch(1);
+        var releaseProbe = new CountDownLatch(1);
+        var infoStarted = new CountDownLatch(1);
+        var releaseInfo = new CountDownLatch(1);
+        var failure = new AtomicReference<Throwable>();
+        var requestThreads = new ArrayList<Thread>(requestCount);
+        var probeThread = new AtomicReference<Thread>();
+        RoutingRequest request = mock(RoutingRequest.class);
+        when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
+                                                               "HTTP",
+                                                               "1.1",
+                                                               Method.GET,
+                                                               "/recovery-backlog",
+                                                               true));
+        when(request.id()).thenReturn(11);
+        when(request.serverSocketId()).thenReturn("server-socket");
+        when(request.socketId()).thenReturn("connection-socket");
+        RoutingRequest probeRequest = mock(RoutingRequest.class);
+        when(probeRequest.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
+                                                                    "HTTP",
+                                                                    "1.1",
+                                                                    Method.GET,
+                                                                    "/recovery-probe",
+                                                                    true));
+        when(probeRequest.id()).thenReturn(12);
+        when(probeRequest.serverSocketId()).thenReturn("server-socket");
+        when(probeRequest.socketId()).thenReturn("connection-socket");
+        try (TestLogHandler logs = new TestLogHandler(Level.INFO, infoStarted, releaseInfo)) {
+            filter.afterStart(mock(WebServer.class));
+            for (int i = 0; i < requestCount; i++) {
+                CountDownLatch releaseRequest = i == 0 ? releaseFirstRequest : releaseRequests;
+                requestThreads.add(Thread.ofVirtual().start(() -> {
+                    try {
+                        filter.filter(() -> {
+                            handlersStarted.countDown();
+                            try {
+                                releaseRequest.await();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new IllegalStateException(e);
+                            }
+                        }, request, mock(RoutingResponse.class));
+                    } catch (Throwable t) {
+                        failure.compareAndSet(null, t);
+                    }
+                }));
+            }
+            try {
+                assertThat("Request handlers did not start", handlersStarted.await(5, TimeUnit.SECONDS), is(true));
+                for (int i = 0; i < requestCount; i++) {
+                    logs.await(Level.WARNING);
+                }
+
+                releaseFirstRequest.countDown();
+                assertThat("Recovery logger was not entered", infoStarted.await(5, TimeUnit.SECONDS), is(true));
+                releaseRequests.countDown();
+                for (Thread requestThread : requestThreads) {
+                    requestThread.join(5000);
+                    assertThat("Blocked recovery logging blocked request completion", requestThread.isAlive(), is(false));
+                }
+                assertThat("Request handler failed", failure.get(), is((Throwable) null));
+
+                probeThread.set(Thread.ofVirtual().start(() -> {
+                    try {
+                        filter.filter(() -> {
+                            probeStarted.countDown();
+                            try {
+                                releaseProbe.await();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new IllegalStateException(e);
+                            }
+                        }, probeRequest, mock(RoutingResponse.class));
+                    } catch (Throwable t) {
+                        failure.compareAndSet(null, t);
+                    }
+                }));
+                assertThat("Probe request handler did not start", probeStarted.await(5, TimeUnit.SECONDS), is(true));
+
+                releaseInfo.countDown();
+                int recoveryLogsBeforeScan = 0;
+                boolean sawOmittedSummary = false;
+                while (true) {
+                    LogRecord record = logs.records.poll(10, TimeUnit.SECONDS);
+                    if (record == null) {
+                        throw new AssertionError("Probe request was not reported");
+                    }
+                    if (record.getLevel().equals(Level.WARNING)
+                            && record.getMessage().contains("/recovery-probe")) {
+                        break;
+                    }
+                    if (record.getLevel().equals(Level.INFO)) {
+                        recoveryLogsBeforeScan++;
+                        if (record.getMessage().contains("bounded recovery queue was full")) {
+                            assertThat(record.getMessage(), containsString("1 request recovery log message was omitted"));
+                            sawOmittedSummary = true;
+                        }
+                    }
+                }
+                assertThat("Recovery backlog delayed the next stuck-request scan",
+                           recoveryLogsBeforeScan <= StuckThreadDetectionFilter.MAX_RECOVERY_LOGS_PER_CYCLE,
+                           is(true));
+
+                releaseProbe.countDown();
+                probeThread.get().join(5000);
+                assertThat("Probe request did not finish", probeThread.get().isAlive(), is(false));
+                boolean sawProbeRecovery = false;
+                while (!sawOmittedSummary || !sawProbeRecovery) {
+                    LogRecord record = logs.records.poll(10, TimeUnit.SECONDS);
+                    if (record == null) {
+                        throw new AssertionError("Recovery backlog was not fully reported");
+                    }
+                    if (record.getLevel().equals(Level.INFO)) {
+                        if (record.getMessage().contains("bounded recovery queue was full")) {
+                            assertThat(record.getMessage(), containsString("1 request recovery log message was omitted"));
+                            sawOmittedSummary = true;
+                        }
+                        sawProbeRecovery |= record.getMessage().contains("/recovery-probe");
+                    }
+                }
+                assertThat("Request handler failed", failure.get(), is((Throwable) null));
+            } finally {
+                releaseFirstRequest.countDown();
+                releaseRequests.countDown();
+                releaseProbe.countDown();
+                releaseInfo.countDown();
+                for (Thread requestThread : requestThreads) {
+                    requestThread.join(5000);
+                }
+                if (probeThread.get() != null) {
+                    probeThread.get().join(5000);
+                }
+                filter.afterStop();
+            }
+        }
+    }
+
+    @Test
     void stopPreservesCallerInterruptAndWaitsForMonitor() throws Exception {
         var filter = new StuckThreadDetectionFilter(StuckThreadDetectionFeature.create().prototype(),
                                                     WebServer.DEFAULT_SOCKET_NAME);
@@ -403,21 +552,36 @@ class StuckThreadDetectionFeatureTest {
         private final CountDownLatch warningStarted;
         private final CountDownLatch releaseWarning;
         private final boolean ignoreWarningInterrupt;
+        private final Level blockedLevel;
 
         private TestLogHandler() {
-            this(null, null, false);
+            this(Level.WARNING, null, null, false);
         }
 
         private TestLogHandler(CountDownLatch warningStarted, CountDownLatch releaseWarning) {
-            this(warningStarted, releaseWarning, false);
+            this(Level.WARNING, warningStarted, releaseWarning, false);
         }
 
         private TestLogHandler(CountDownLatch warningStarted,
                                CountDownLatch releaseWarning,
                                boolean ignoreWarningInterrupt) {
+            this(Level.WARNING, warningStarted, releaseWarning, ignoreWarningInterrupt);
+        }
+
+        private TestLogHandler(Level blockedLevel,
+                               CountDownLatch warningStarted,
+                               CountDownLatch releaseWarning) {
+            this(blockedLevel, warningStarted, releaseWarning, false);
+        }
+
+        private TestLogHandler(Level blockedLevel,
+                               CountDownLatch warningStarted,
+                               CountDownLatch releaseWarning,
+                               boolean ignoreWarningInterrupt) {
             this.warningStarted = warningStarted;
             this.releaseWarning = releaseWarning;
             this.ignoreWarningInterrupt = ignoreWarningInterrupt;
+            this.blockedLevel = blockedLevel;
             setLevel(Level.ALL);
             logger.setLevel(Level.ALL);
             logger.setUseParentHandlers(false);
@@ -426,7 +590,7 @@ class StuckThreadDetectionFeatureTest {
 
         @Override
         public void publish(LogRecord record) {
-            if (warningStarted != null && record.getLevel().equals(Level.WARNING)) {
+            if (warningStarted != null && record.getLevel().equals(blockedLevel)) {
                 warningStarted.countDown();
                 boolean interrupted = false;
                 while (true) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/StuckThreadDetectionFeatureTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -27,6 +28,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import io.helidon.common.buffers.DataReader;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.http.HttpPrologue;
@@ -34,6 +36,7 @@ import io.helidon.http.Method;
 import io.helidon.webserver.http.FilterChain;
 import io.helidon.webserver.http.RoutingRequest;
 import io.helidon.webserver.http.RoutingResponse;
+import io.helidon.webserver.http1.Http1Prologue;
 import io.helidon.webserver.spi.ServerFeature.ServerFeatureContext;
 import org.junit.jupiter.api.Test;
 
@@ -193,6 +196,26 @@ class StuckThreadDetectionFeatureTest {
 
     @Test
     void reportsConnectAuthority() throws Exception {
+        DataReader reader = DataReader.create(() -> "CONNECT example.com:443 HTTP/1.1\r\n"
+                .getBytes(StandardCharsets.US_ASCII));
+        HttpPrologue prologue = new Http1Prologue(reader, 100, true).readPrologue();
+
+        assertConnectLog(prologue, "example.com:443", null);
+    }
+
+    @Test
+    void doesNotReportUnverifiedConnectAuthority() throws Exception {
+        HttpPrologue prologue = HttpPrologue.create("HTTP/1.1",
+                                                    "HTTP",
+                                                    "1.1",
+                                                    Method.CONNECT,
+                                                    "alice:s3cr3t@example.com:443",
+                                                    true);
+
+        assertConnectLog(prologue, null, "alice:s3cr3t");
+    }
+
+    private void assertConnectLog(HttpPrologue prologue, String expected, String unexpected) throws Exception {
         var config = StuckThreadDetectionConfig.builder()
                 .threshold(Duration.ofMillis(20))
                 .checkPeriod(Duration.ofMillis(5))
@@ -202,12 +225,7 @@ class StuckThreadDetectionFeatureTest {
         var release = new CountDownLatch(1);
         var failure = new AtomicReference<Throwable>();
         RoutingRequest request = mock(RoutingRequest.class);
-        when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
-                                                               "HTTP",
-                                                               "1.1",
-                                                               Method.CONNECT,
-                                                               "example.com:443",
-                                                               true));
+        when(request.prologue()).thenReturn(prologue);
         when(request.id()).thenReturn(10);
         when(request.serverSocketId()).thenReturn("server-socket");
         when(request.socketId()).thenReturn("connection-socket");
@@ -229,10 +247,19 @@ class StuckThreadDetectionFeatureTest {
                 }
             });
             try {
-                assertThat("Request handler did not start", started.await(5, TimeUnit.SECONDS), is(true));
+                boolean handlerStarted = started.await(5, TimeUnit.SECONDS);
+                if (!handlerStarted) {
+                    assertThat("Request handler failed before it started", failure.get(), is((Throwable) null));
+                }
+                assertThat("Request handler did not start", handlerStarted, is(true));
 
                 LogRecord warning = logs.await(Level.WARNING);
-                assertThat(warning.getMessage(), containsString("CONNECT example.com:443 HTTP/1.1"));
+                if (expected != null) {
+                    assertThat(warning.getMessage(), containsString("CONNECT " + expected + " HTTP/1.1"));
+                }
+                if (unexpected != null) {
+                    assertThat(warning.getMessage(), not(containsString(unexpected)));
+                }
             } finally {
                 release.countDown();
                 requestThread.join(5000);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
@@ -81,7 +81,9 @@ class Http1PrologueTest {
             "service+name:443",
             "service%2Dname:443",
             "192.0.2.10:8443",
-            "[2001:db8::1]:9443"
+            "[2001:db8::1]:9443",
+            "[v1.fe80]:443",
+            "[Vf.foo-bar]:443"
     })
     void testConnectAuthorityForm(String authority) {
         DataReader reader = DataReader.create(() -> ("CONNECT " + authority + " HTTP/1.1\r\n")
@@ -105,6 +107,9 @@ class Http1PrologueTest {
             "service/name:443",
             "service%2Gname:443",
             "[2001:db8::1]",
+            "[v1.]:443",
+            "[vG.fe80]:443",
+            "[v1.fe80]x:443",
             "2001:db8::1:443",
             "example.com:not-a-port",
             "example.com:65536"

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
@@ -78,6 +78,8 @@ class Http1PrologueTest {
     @ParameterizedTest
     @ValueSource(strings = {
             "example.com:443",
+            "service+name:443",
+            "service%2Dname:443",
             "192.0.2.10:8443",
             "[2001:db8::1]:9443"
     })
@@ -95,10 +97,13 @@ class Http1PrologueTest {
     @ParameterizedTest
     @ValueSource(strings = {
             "example.com",
+            ":443",
             "user@example.com:443",
             "http://example.com:443",
             "example.com:443?query=value",
             "example.com:443#fragment",
+            "service/name:443",
+            "service%2Gname:443",
             "[2001:db8::1]",
             "2001:db8::1:443",
             "example.com:not-a-port",

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import io.helidon.http.RequestException;
 import io.helidon.http.Status;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -71,5 +73,45 @@ class Http1PrologueTest {
             assertThat(e.safeMessage(), is(true));
             assertThat(e.getMessage(), containsString("HTTP 1.0 is not supported"));
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "example.com:443",
+            "192.0.2.10:8443",
+            "[2001:db8::1]:9443"
+    })
+    void testConnectAuthorityForm(String authority) {
+        DataReader reader = DataReader.create(() -> ("CONNECT " + authority + " HTTP/1.1\r\n")
+                .getBytes(StandardCharsets.US_ASCII));
+
+        HttpPrologue prologue = new Http1Prologue(reader, 100, true).readPrologue();
+
+        assertThat(prologue.method(), is(Method.CONNECT));
+        assertThat(prologue.uriPath().rawPath(), is(authority));
+        assertThat(prologue.uriPath().path(), is(""));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "example.com",
+            "user@example.com:443",
+            "http://example.com:443",
+            "example.com:443?query=value",
+            "example.com:443#fragment",
+            "[2001:db8::1]",
+            "2001:db8::1:443",
+            "example.com:not-a-port",
+            "example.com:65536"
+    })
+    void testInvalidConnectAuthorityForm(String authority) {
+        DataReader reader = DataReader.create(() -> ("CONNECT " + authority + " HTTP/1.1\r\n")
+                .getBytes(StandardCharsets.US_ASCII));
+
+        RequestException exception = assertThrows(RequestException.class,
+                                                  () -> new Http1Prologue(reader, 100, true).readPrologue());
+
+        assertThat(exception.status(), is(Status.BAD_REQUEST_400));
+        assertThat(exception.eventType(), is(DirectHandler.EventType.BAD_REQUEST));
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
@@ -107,6 +107,8 @@ class Http1PrologueTest {
             "service/name:443",
             "service%2Gname:443",
             "[2001:db8::1]",
+            "[1:2:3]:443",
+            "[1.2.3.4]:443",
             "[v1.]:443",
             "[vG.fe80]:443",
             "[v1.fe80]x:443",


### PR DESCRIPTION
Resolves #5727

Adds an opt-in WebServer feature that reports request threads which remain in HTTP routing and business logic beyond a configured threshold.

The feature:

- monitors HTTP/1 request processing and HTTP/2 stream request processing using an independent filter;
- reports a request once with request and thread diagnostics, then logs recovery when the handler returns;
- remains disabled unless configured under `server.features.stuck-thread-detection` or added programmatically; and
- excludes idle connections, post-routing transport cleanup, upgraded connection lifetime, and HTTP/2 subprotocols such as gRPC.
