### PR TITLE
4.x: Upgrade Netty to 4.1.136.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -143,7 +143,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.135.Final</version.lib.netty>
+        <version.lib.netty>4.1.136.Final</version.lib.netty>
         <version.lib.oci>3.86.2</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>


### PR DESCRIPTION
### Description

Upgrade Netty to 4.1.136.Final

Why does Helidon 4 still manage Netty version? See https://github.com/helidon-io/helidon/issues/9645
