### PR TITLE
Use stable Eclipse URLs for Jakarta EE TCK downloads

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,7 +34,7 @@ env:
   GRAALVM_VERSION: 21.0.3
   JAVA_DISTRO: oracle
   MVN_ARGS: |
-    -B -fae -e
+    -B -fae -e -ntp
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
     -Dmaven.wagon.http.retryHandler.count=3
     -Djdk.toolchain.version=${JAVA_VERSION}

--- a/microprofile/tests/tck/tck-core-profile/pom.xml
+++ b/microprofile/tests/tck/tck-core-profile/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <tck.filename>jakarta-core-profile-tck-${version.lib.microprofile-core-profile}</tck.filename>
-        <tck.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/${tck.filename}.zip</tck.url>
+        <tck.url>https://download.eclipse.org/jakartaee/coreprofile/10.0/${tck.filename}.zip</tck.url>
         <tck.artifact>core-profile-tck-impl-${version.lib.microprofile-core-profile}</tck.artifact>
         <stage.dir>${project.build.directory}/tck</stage.dir>
     </properties>

--- a/microprofile/tests/tck/tck-jsonb/pom.xml
+++ b/microprofile/tests/tck/tck-jsonb/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <tck.filename>jakarta-jsonb-tck-${version.lib.jakarta.jsonb-tck}</tck.filename>
-        <tck.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/promoted/eftl/${tck.filename}.zip</tck.url>
+        <tck.url>https://download.eclipse.org/jakartaee/jsonb/3.0/${tck.filename}.zip</tck.url>
         <tck.artifact>jakarta.json.bind-tck-${version.lib.jakarta.jsonb-tck}</tck.artifact>
         <stage.dir>${project.build.directory}/tck</stage.dir>
     </properties>

--- a/microprofile/tests/tck/tck-restful/pom.xml
+++ b/microprofile/tests/tck/tck-restful/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <tck.filename>jakarta-restful-ws-tck-${version.lib.microprofile-restful-tck}</tck.filename>
-        <tck.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/${tck.filename}.zip</tck.url>
+        <tck.url>https://download.eclipse.org/jakartaee/restful-ws/3.1/${tck.filename}.zip</tck.url>
         <tck.artifact>${tck.filename}</tck.artifact>
         <stage.dir>${project.build.directory}/tck</stage.dir>
     </properties>


### PR DESCRIPTION
Resolves #12193

Update the Jakarta EE 10 TCK download URLs to its current Eclipse location. The former staged path now returns 404 and breaks the TCK builds.
