### PR TITLE
4.x: Update TCK download URLs to not use staged/eftl

### DIFF
--- a/microprofile/tests/tck/tck-core-profile/pom.xml
+++ b/microprofile/tests/tck/tck-core-profile/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <tck.filename>jakarta-core-profile-tck-${version.lib.microprofile-core-profile}</tck.filename>
-        <tck.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/${tck.filename}.zip</tck.url>
+        <tck.url>https://download.eclipse.org/jakartaee/coreprofile/10.0/${tck.filename}.zip</tck.url>
         <tck.artifact>core-profile-tck-impl-${version.lib.microprofile-core-profile}</tck.artifact>
         <stage.dir>${project.build.directory}/tck</stage.dir>
     </properties>

--- a/microprofile/tests/tck/tck-restful/pom.xml
+++ b/microprofile/tests/tck/tck-restful/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <tck.filename>jakarta-restful-ws-tck-${version.lib.microprofile-restful-tck}</tck.filename>
-        <tck.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/${tck.filename}.zip</tck.url>
+        <tck.url>https://download.eclipse.org/jakartaee/restful-ws/3.1/${tck.filename}.zip</tck.url>
         <tck.artifact>${tck.filename}</tck.artifact>
         <stage.dir>${project.build.directory}/tck</stage.dir>
     </properties>


### PR DESCRIPTION
### Description

Update the eclipse download URLs for coreprofile and jax-rs.  The original URL, `ee4j/jakartaee-tck/jakartaee10/staged/eftl/`, is now empty.  So I switched to an alternative that seems more legit and is working.

This is a quick fix. I assume these downloads were work-arounds for missing maven artifacts. It is possible they are no longer needed.  

