### PR TITLE
Fix WebServer metrics Javadoc dependencies

### DIFF
--- a/webserver/observe/metrics/pom.xml
+++ b/webserver/observe/metrics/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>io.helidon.metrics.providers</groupId>
             <artifactId>helidon-metrics-providers-micrometer</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/webserver/observe/telemetry/metrics/pom.xml
+++ b/webserver/observe/telemetry/metrics/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>helidon-webserver-observe-metrics</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>


### PR DESCRIPTION
Resolves #12184

Uses runtime scope for the Micrometer provider in WebServer metrics so Javadoc no longer creates an invalid reactor module link. Declares Micrometer Core directly in the telemetry metrics module that compiles against it.
