### PR TITLE
27.x: Preserve OIDC authorization and logout endpoint query parameters

### DIFF
--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcFeature.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcFeature.java
@@ -338,10 +338,18 @@ public final class OidcFeature implements HttpFeature {
                                   String stateQuery) {
         try {
             String idToken = idTokenCookieHandler.decrypt(encryptedIdToken);
-            StringBuilder sb = new StringBuilder(tenant.logoutEndpointUri()
-                                                         + "?id_token_hint="
-                                                         + idToken
-                                                         + "&post_logout_redirect_uri=" + postLogoutUri(req));
+            URI logoutEndpoint = tenant.logoutEndpointUri();
+            String logoutQuery = logoutEndpoint.getRawQuery();
+            String querySeparator = "?";
+            if (logoutQuery != null) {
+                querySeparator = logoutQuery.isEmpty() || logoutQuery.endsWith("&") ? "" : "&";
+            }
+            StringBuilder sb = new StringBuilder(logoutEndpoint.toString())
+                    .append(querySeparator)
+                    .append("id_token_hint=")
+                    .append(idToken)
+                    .append("&post_logout_redirect_uri=")
+                    .append(postLogoutUri(req));
 
             if (stateQuery != null) {
                 sb.append(stateQuery);

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -410,6 +410,11 @@ class TenantAuthenticationHandler {
             scopeString = URLEncoder.encode(scopes.toString(), StandardCharsets.UTF_8);
 
             String authorizationEndpoint = tenant.authorizationEndpointUri();
+            String authorizationQuery = URI.create(authorizationEndpoint).getRawQuery();
+            String querySeparator = "?";
+            if (authorizationQuery != null) {
+                querySeparator = authorizationQuery.isEmpty() || authorizationQuery.endsWith("&") ? "" : "&";
+            }
             String nonce = UUID.randomUUID().toString();
             String redirectUri;
             if (DEFAULT_TENANT_ID.equals(tenantId)) {
@@ -419,7 +424,7 @@ class TenantAuthenticationHandler {
                                              + encode(oidcConfig.tenantParamName()) + "=" + encode(tenantId));
             }
 
-            String queryString = "?" + "client_id=" + tenantConfig.clientId() + "&"
+            String queryString = querySeparator + "client_id=" + tenantConfig.clientId() + "&"
                     + "response_type=code&"
                     + "redirect_uri=" + redirectUri + "&"
                     + "scope=" + scopeString + "&"

--- a/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/OidcFeatureTest.java
+++ b/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/OidcFeatureTest.java
@@ -150,14 +150,28 @@ class OidcFeatureTest {
         assertThat(response, not(containsString("&state=ok&post_logout_redirect_uri=https://example.test/alternate")));
     }
 
+    @Test
+    void testLogoutAppendsParametersToEndpointQuery() throws Exception {
+        String logoutEndpoint = "http://idp.example.test/logout?domain=identity%2Fdomain";
+        String response = logoutResponse("ok", URI.create(logoutEndpoint));
+
+        assertThat(response,
+                   containsString("Location: " + logoutEndpoint
+                                          + "&id_token_hint=dummy-id-token&post_logout_redirect_uri=http://127.0.0.1:"));
+    }
+
     private static String logoutResponse(String state) throws Exception {
+        return logoutResponse(state, URI.create("http://idp.example.test/logout"));
+    }
+
+    private static String logoutResponse(String state, URI logoutEndpoint) throws Exception {
         OidcConfig oidcConfig = OidcConfig.builder()
                 .clientId("id")
                 .clientSecret("secret")
                 .identityUri(URI.create("http://idp.example.test/identity"))
                 .tokenEndpointUri(URI.create("http://idp.example.test/token"))
                 .authorizationEndpointUri(URI.create("http://idp.example.test/authorize"))
-                .logoutEndpointUri(URI.create("http://idp.example.test/logout"))
+                .logoutEndpointUri(logoutEndpoint)
                 .signJwk(JwkKeys.builder().build())
                 .oidcMetadataWellKnown(false)
                 .logoutEnabled(true)

--- a/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/TenantAuthenticationHandlerTest.java
+++ b/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/TenantAuthenticationHandlerTest.java
@@ -492,6 +492,31 @@ class TenantAuthenticationHandlerTest {
     }
 
     @Test
+    public void testRedirectAppendsAuthorizationParametersToEndpoint() {
+        OidcConfig oidcConfig = oidcConfig(NONE);
+        String authorizationEndpoint = "http://localhost:1234/authorize";
+        Map<String, String> expectedLocationPrefixes = Map.of(
+                authorizationEndpoint, authorizationEndpoint + "?client_id=test&",
+                authorizationEndpoint + "?", authorizationEndpoint + "?client_id=test&",
+                authorizationEndpoint + "?domain=identity%2Fdomain",
+                authorizationEndpoint + "?domain=identity%2Fdomain&client_id=test&",
+                authorizationEndpoint + "?domain=identity-domain&",
+                authorizationEndpoint + "?domain=identity-domain&client_id=test&");
+
+        for (Map.Entry<String, String> expected : expectedLocationPrefixes.entrySet()) {
+            TenantAuthenticationHandler authenticationHandler = authenticationHandler(oidcConfig, expected.getKey());
+            AuthenticationResponse response = authenticationHandler.authenticate(DEFAULT_TENANT_ID, requestWithCookies());
+            String location = response.responseHeaders()
+                    .get(HeaderNames.LOCATION.defaultCase())
+                    .getFirst();
+
+            assertThat("Authorization endpoint: " + expected.getKey(),
+                       location,
+                       startsWith(expected.getValue()));
+        }
+    }
+
+    @Test
     public void testRedirectSetsCookieCounter() {
         OidcConfig oidcConfig = OidcConfig.builder()
                 .clientId("test")
@@ -545,9 +570,13 @@ class TenantAuthenticationHandlerTest {
     }
 
     private static TenantAuthenticationHandler authenticationHandler(OidcConfig oidcConfig) {
+        return authenticationHandler(oidcConfig, "http://localhost:1234/authorize");
+    }
+
+    private static TenantAuthenticationHandler authenticationHandler(OidcConfig oidcConfig, String authorizationEndpoint) {
         Tenant tenant = mock(Tenant.class);
         when(tenant.tenantConfig()).thenReturn(oidcConfig);
-        when(tenant.authorizationEndpointUri()).thenReturn("http://localhost:1234/authorize");
+        when(tenant.authorizationEndpointUri()).thenReturn(authorizationEndpoint);
         return new TenantAuthenticationHandler(oidcConfig, tenant, false, true);
     }
 


### PR DESCRIPTION
Fixes #12208

Preserves existing query parameters when Helidon constructs OIDC authorization and logout redirects.

The change:

- Selects the correct separator when the endpoint has no query, an empty query, existing parameters, or a trailing &.
- Preserves the raw configured query, including percent-encoded values.
- Covers both authorization and end-session endpoint construction.
- Adds regression tests for endpoints containing existing query parameters.