### PR TITLE
4.x: Balance Javadoc HTML in config schema descriptions

### DIFF
--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
@@ -19,6 +19,7 @@ package io.helidon.codegen;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -199,7 +200,7 @@ public final class JavadocWriter {
 
     private void writeRawEndElement(String tag) {
         buf.append("</");
-        buf.append(tag.toLowerCase());
+        buf.append(tag.toLowerCase(Locale.ROOT));
         buf.append(">");
     }
 
@@ -271,18 +272,19 @@ public final class JavadocWriter {
     }
 
     private static boolean isClosedBy(String openTag, String startTag) {
-        return switch (openTag) {
+        return switch (openTag.toLowerCase(Locale.ROOT)) {
             case "li" -> isElement(startTag, "li");
-            case "optgroup" -> isElement(startTag, "optgroup");
+            case "optgroup" -> isElement(startTag, "optgroup", "hr");
             case "tfoot" -> isElement(startTag, "tbody");
             case "colgroup" -> !isElement(startTag, "col");
+            case "caption" -> isElement(startTag, "colgroup", "thead", "tbody", "tfoot", "tr");
             case "dt", "dd" -> isElement(startTag, "dt", "dd");
-            case "p" -> isElement(startTag, "address", "article", "aside", "blockquote", "dir", "div", "dl",
-                    "fieldset", "footer", "form", "h1", "h2", "h3", "h4", "h5",
-                    "h6", "header", "hgroup", "hr", "menu", "nav", "ol", "p",
-                    "pre", "section", "table", "ul");
+            case "p" -> isElement(startTag, "address", "article", "aside", "blockquote", "details", "dialog",
+                    "dir", "div", "dl", "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3",
+                    "h4", "h5", "h6", "header", "hgroup", "hr", "main", "menu", "nav", "ol", "p", "pre", "search",
+                    "section", "table", "ul");
             case "rt", "rp" -> isElement(startTag, "rt", "rp");
-            case "option" -> isElement(startTag, "option", "optgroup");
+            case "option" -> isElement(startTag, "option", "optgroup", "hr");
             case "thead", "tbody" -> isElement(startTag, "tbody", "tfoot");
             case "tr" -> isElement(startTag, "tr", "tbody", "tfoot");
             case "td", "th" -> isElement(startTag, "td", "th", "tr", "tbody", "tfoot");

--- a/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/JavadocWriter.java
@@ -16,6 +16,8 @@
 
 package io.helidon.codegen;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -56,6 +58,7 @@ import io.helidon.common.Api;
 public final class JavadocWriter {
 
     private final StringBuilder buf;
+    private final Deque<String> stack = new ArrayDeque<>();
 
     private JavadocWriter(StringBuilder buf) {
         this.buf = buf;
@@ -85,6 +88,7 @@ public final class JavadocWriter {
         for (var e : elements) {
             write(e);
         }
+        closeElements();
     }
 
     /**
@@ -125,6 +129,7 @@ public final class JavadocWriter {
     }
 
     private void writeStartElement(String tag, boolean selfClosing, Map<String, AttrValue> attrs) {
+        closeElements(tag);
         buf.append("<");
         buf.append(tag);
         attrs.forEach(this::writeAttribute);
@@ -132,6 +137,9 @@ public final class JavadocWriter {
             buf.append("/");
         }
         buf.append(">");
+        if (!selfClosing && !isVoidElement(tag)) {
+            stack.push(tag);
+        }
     }
 
     private void writeAttribute(String name, AttrValue value) {
@@ -159,8 +167,39 @@ public final class JavadocWriter {
     }
 
     private void writeEndElement(String tag) {
+        if (hasOpenElement(tag)) {
+            while (!tag.equalsIgnoreCase(stack.peek())) {
+                writeRawEndElement(stack.pop());
+            }
+            stack.pop();
+            writeRawEndElement(tag);
+        }
+    }
+
+    private void closeElements(String startTag) {
+        while (!stack.isEmpty() && isClosedBy(stack.peek(), startTag)) {
+            writeRawEndElement(stack.pop());
+        }
+    }
+
+    private void closeElements() {
+        while (!stack.isEmpty()) {
+            writeRawEndElement(stack.pop());
+        }
+    }
+
+    private boolean hasOpenElement(String tag) {
+        for (var elt : stack) {
+            if (elt.equalsIgnoreCase(tag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void writeRawEndElement(String tag) {
         buf.append("</");
-        buf.append(tag);
+        buf.append(tag.toLowerCase());
         buf.append(">");
     }
 
@@ -222,5 +261,41 @@ public final class JavadocWriter {
 
     private static boolean isValidHexChar(char c) {
         return Character.digit(c, 16) != -1;
+    }
+
+    private static boolean isVoidElement(String elt) {
+        return isElement(elt,
+                "area", "base", "br", "col", "command",
+                "embed", "hr", "img", "input", "keygen", "link", "meta",
+                "param", "source", "track", "wbr");
+    }
+
+    private static boolean isClosedBy(String openTag, String startTag) {
+        return switch (openTag) {
+            case "li" -> isElement(startTag, "li");
+            case "optgroup" -> isElement(startTag, "optgroup");
+            case "tfoot" -> isElement(startTag, "tbody");
+            case "colgroup" -> !isElement(startTag, "col");
+            case "dt", "dd" -> isElement(startTag, "dt", "dd");
+            case "p" -> isElement(startTag, "address", "article", "aside", "blockquote", "dir", "div", "dl",
+                    "fieldset", "footer", "form", "h1", "h2", "h3", "h4", "h5",
+                    "h6", "header", "hgroup", "hr", "menu", "nav", "ol", "p",
+                    "pre", "section", "table", "ul");
+            case "rt", "rp" -> isElement(startTag, "rt", "rp");
+            case "option" -> isElement(startTag, "option", "optgroup");
+            case "thead", "tbody" -> isElement(startTag, "tbody", "tfoot");
+            case "tr" -> isElement(startTag, "tr", "tbody", "tfoot");
+            case "td", "th" -> isElement(startTag, "td", "th", "tr", "tbody", "tfoot");
+            default -> false;
+        };
+    }
+
+    private static boolean isElement(String elt, String... elements) {
+        for (var e : elements) {
+            if (e.equalsIgnoreCase(elt)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/codegen/codegen/src/test/java/io/helidon/codegen/JavadocWriterTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/JavadocWriterTest.java
@@ -15,6 +15,9 @@
  */
 package io.helidon.codegen;
 
+import java.util.List;
+import java.util.Locale;
+
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -132,9 +135,37 @@ class JavadocWriterTest {
     }
 
     @Test
+    void testOptionalParagraphCloseBeforeModernBlockElements() {
+        for (var tag : List.of("details", "dialog", "figcaption", "figure", "main", "search")) {
+            var actual = html("<p>Intro<" + tag + ">Content");
+            assertThat(actual, is("<p>Intro</p><" + tag + ">Content</" + tag + ">"));
+        }
+    }
+
+    @Test
+    void testOptionalOptionCloseBeforeHorizontalRule() {
+        var actual = html("<select><option>One<hr><option>Two");
+        assertThat(actual, is("<select><option>One</option><hr><option>Two</option></select>"));
+    }
+
+    @Test
+    void testOptionalOptgroupCloseBeforeHorizontalRule() {
+        var actual = html("<select><optgroup>One<hr><optgroup>Two");
+        assertThat(actual, is("<select><optgroup>One</optgroup><hr><optgroup>Two</optgroup></select>"));
+    }
+
+    @Test
     void testOptionalTableElementClose() {
         var actual = html("<table><tr><td>A<td>B<tr><td>C");
         assertThat(actual, is("<table><tr><td>A</td><td>B</td></tr><tr><td>C</td></tr></table>"));
+    }
+
+    @Test
+    void testOptionalCaptionCloseBeforeTableStructure() {
+        for (var tag : List.of("colgroup", "thead", "tbody", "tfoot", "tr")) {
+            var actual = html("<table><caption>Title<" + tag + ">");
+            assertThat(actual, is("<table><caption>Title</caption><" + tag + "></" + tag + "></table>"));
+        }
     }
 
     @Test
@@ -142,6 +173,18 @@ class JavadocWriterTest {
         var actual = html("<table><tbody><tr><td>A<tbody><tr><td>B");
         assertThat(actual,
                    is("<table><tbody><tr><td>A</td></tr></tbody><tbody><tr><td>B</td></tr></tbody></table>"));
+    }
+
+    @Test
+    void testMixedCaseElementsUnderTurkishLocale() {
+        var defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+            var actual = html("<UL><LI>One<LI>Two");
+            assertThat(actual, is("<UL><LI>One</li><LI>Two</li></ul>"));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     @Test

--- a/codegen/codegen/src/test/java/io/helidon/codegen/JavadocWriterTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/JavadocWriterTest.java
@@ -107,6 +107,67 @@ class JavadocWriterTest {
         assertThat(actual, is("Start &#x0FA; end"));
     }
 
+    @Test
+    void testUnclosedElement() {
+        var actual = html("<p>Text");
+        assertThat(actual, is("<p>Text</p>"));
+    }
+
+    @Test
+    void testUnclosedNestedElements() {
+        var actual = html("<ul><li>One");
+        assertThat(actual, is("<ul><li>One</li></ul>"));
+    }
+
+    @Test
+    void testOptionalListItemClose() {
+        var actual = html("<ul><li>One<li>Two");
+        assertThat(actual, is("<ul><li>One</li><li>Two</li></ul>"));
+    }
+
+    @Test
+    void testOptionalParagraphCloseBeforeBlock() {
+        var actual = html("<p>Intro<ul><li>One");
+        assertThat(actual, is("<p>Intro</p><ul><li>One</li></ul>"));
+    }
+
+    @Test
+    void testOptionalTableElementClose() {
+        var actual = html("<table><tr><td>A<td>B<tr><td>C");
+        assertThat(actual, is("<table><tr><td>A</td><td>B</td></tr><tr><td>C</td></tr></table>"));
+    }
+
+    @Test
+    void testOptionalTbodyClose() {
+        var actual = html("<table><tbody><tr><td>A<tbody><tr><td>B");
+        assertThat(actual,
+                   is("<table><tbody><tr><td>A</td></tr></tbody><tbody><tr><td>B</td></tr></tbody></table>"));
+    }
+
+    @Test
+    void testVoidElement() {
+        var actual = html("Break<br>after");
+        assertThat(actual, is("Break<br>after"));
+    }
+
+    @Test
+    void testBalancedElements() {
+        var actual = html("<b><i>x</i></b>");
+        assertThat(actual, is("<b><i>x</i></b>"));
+    }
+
+    @Test
+    void testMisorderedCloseElement() {
+        var actual = html("<b><i>x</b></i>");
+        assertThat(actual, is("<b><i>x</i></b>"));
+    }
+
+    @Test
+    void testUnmatchedCloseElement() {
+        var actual = html("Text</p>");
+        assertThat(actual, is("Text"));
+    }
+
     static String html(String javadoc) {
         var reader = JavadocReader.create(javadoc);
         var document = reader.read();


### PR DESCRIPTION
### Description

Keep generated configuration descriptions structurally sound.

Configuration schema descriptions embed simplified HTML rendered from
Javadoc. Javadoc commonly relies on optional HTML end tags, and incomplete
or irregular fragments can become unbalanced when reused outside the
original Javadoc page.

Unbalanced fragments can distort the surrounding generated documentation.
This change keeps embedded descriptions balanced and consistent across tag
casing and host locales, including common list, paragraph, selection, and
table structures.

### Documentation

None

### Validation

Run under JDK 21:

```text
mvn -pl codegen/codegen -Dtest=JavadocWriterTest test
mvn -pl codegen/codegen,config/metadata/codegen,config/metadata/docs \
  -am test
mvn -pl codegen/codegen -DskipTests -Pcheckstyle validate
mvn -pl codegen/codegen -DskipTests -Pcopyright validate
git diff --check
```
