### PR TITLE
4.x: Fix configuration schemas for custom factories

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -349,7 +349,9 @@ public final class Prototype {
 
     /**
      * Factory method that creates an option from a config instance.
-     * The config (the only parameter) must be of type {@code io.helidon.config.Config}.
+     * The method must have exactly one parameter. If the parameter is {@code io.helidon.config.Config}, the method
+     * receives the raw config node. Otherwise the config node is first mapped to the parameter type and then passed to
+     * the factory method.
      * <p>
      * The return type of the method must match the type of the option.
      * <p>

--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -353,7 +353,9 @@ public final class Prototype {
      * receives the raw config node. Otherwise the config node is first mapped to the parameter type and then passed to
      * the factory method.
      * <p>
-     * The return type of the method must match the type of the option.
+     * The return type of the method must match the type of the option. For list and set options, including when wrapped
+     * in {@link java.util.Optional}, the return type may instead match the element type. For map options, including when
+     * wrapped in {@link java.util.Optional}, the return type may instead match the value type.
      * <p>
      * This annotation MUST be on a static method that is part of a type referenced from blueprint through
      * {@link io.helidon.builder.api.Prototype.CustomMethods}.
@@ -575,4 +577,3 @@ public final class Prototype {
         Extension[] value();
     }
 }
-

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
@@ -832,9 +832,13 @@ final class FactoryOption {
             return;
         }
 
-        // check if a runtime type without an explicit factory is a configured prototype
+        // check if a runtime type prototype is a configured prototype
+        // Whole-option runtime factories are applied by a generated prototype setter and still need this config factory.
         var runtimeType = option.runtimeType();
-        if (runtimeType.isPresent() && runtimeType.get().factoryMethod().isEmpty()) {
+        if (runtimeType.isPresent()
+                && runtimeType.get().factoryMethod()
+                        .map(it -> resolvedTypesEqual(it.returnType(), optionType))
+                        .orElse(true)) {
             var rt = runtimeType.get();
             var expectedPrototypeType = rt.optionBuilder()
                     .builderMethodType();

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
@@ -832,9 +832,10 @@ final class FactoryOption {
             return;
         }
 
-        // check if a runtime type prototype is a configured prototype
-        if (option.runtimeType().isPresent()) {
-            var rt = option.runtimeType().get();
+        // check if a runtime type without an explicit factory is a configured prototype
+        var runtimeType = option.runtimeType();
+        if (runtimeType.isPresent() && runtimeType.get().factoryMethod().isEmpty()) {
+            var rt = runtimeType.get();
             var expectedPrototypeType = rt.optionBuilder()
                     .builderMethodType();
             var builderType = TypeName.builder(expectedPrototypeType)

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
@@ -749,9 +749,11 @@ final class FactoryOption {
                                             OptionConfigured.Builder configured) {
 
         TypeName actualType = Utils.realType(optionType);
+        TypeName valueType = realType(optionType);
         // first check config factories
         for (FactoryMethod configFactory : prototypeInfo.configFactories()) {
-            if (typesEqual(configFactory.returnType(), actualType)) {
+            if (typesEqual(configFactory.returnType(), actualType)
+                    || typesEqual(configFactory.returnType(), valueType)) {
                 if (configFactory.optionName().orElse(optionName).equals(optionName)) {
                     configured.factoryMethod(configFactory);
                     return;

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
@@ -382,15 +382,6 @@ class SchemaGenerator {
         var configuredFactory = optionInfo.configured()
                 .flatMap(OptionConfigured::factoryMethod)
                 .orElse(null);
-        // check runtime factory method
-        var runtimeParamTypeName = optionInfo.runtimeType()
-                .flatMap(RuntimeTypeInfo::factoryMethod)
-                .flatMap(FactoryMethod::parameterType)
-                .orElse(null);
-        if (runtimeParamTypeName != null) {
-            return runtimeParamTypeName;
-        }
-
         // check configured factory method
         var configuredParamTypeName = optionInfo.configured()
                 .flatMap(OptionConfigured::factoryMethod)
@@ -399,6 +390,15 @@ class SchemaGenerator {
         if (configuredParamTypeName != null
                 && !(configuredParamTypeName.equals(Types.CONFIG) || configuredParamTypeName.equals(Types.COMMON_CONFIG))) {
             return configuredParamTypeName;
+        }
+
+        // check runtime factory method
+        var runtimeParamTypeName = optionInfo.runtimeType()
+                .flatMap(RuntimeTypeInfo::factoryMethod)
+                .flatMap(FactoryMethod::parameterType)
+                .orElse(null);
+        if (runtimeParamTypeName != null) {
+            return runtimeParamTypeName;
         }
 
         // check configured factory method return type for raw Config factories

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
@@ -370,32 +370,18 @@ class SchemaGenerator {
     }
 
     private TypeName optionTypeName(OptionInfo optionInfo) {
-        var typeName = optionInfo.declaredType();
-        if (typeName.isOptional()) {
-            typeName = typeName.typeArguments().getFirst();
-        }
+        var typeName = optionValueType(optionInfo.declaredType());
         if (typeName.equals(Types.CHAR_ARRAY)) {
             return TypeNames.STRING;
-        }
-        if (typeName.isSet() || typeName.isList()) {
-            typeName = typeName.typeArguments().getFirst();
-        } else if (typeName.isMap()) {
-            typeName = typeName.typeArguments().get(1);
         }
 
         if (optionInfo.prototypedBy().isPresent()) {
             return optionInfo.prototypedBy().get();
         }
 
-        // check configured factory method
-        var configuredDeclaredTypeName = optionInfo.configured()
+        var configuredFactory = optionInfo.configured()
                 .flatMap(OptionConfigured::factoryMethod)
-                .map(FactoryMethod::declaringType)
                 .orElse(null);
-        if (configuredDeclaredTypeName != null) {
-            return configuredDeclaredTypeName;
-        }
-
         // check runtime factory method
         var runtimeParamTypeName = optionInfo.runtimeType()
                 .flatMap(RuntimeTypeInfo::factoryMethod)
@@ -405,7 +391,56 @@ class SchemaGenerator {
             return runtimeParamTypeName;
         }
 
+        // check configured factory method
+        var configuredParamTypeName = optionInfo.configured()
+                .flatMap(OptionConfigured::factoryMethod)
+                .flatMap(FactoryMethod::parameterType)
+                .orElse(null);
+        if (configuredParamTypeName != null
+                && !(configuredParamTypeName.equals(Types.CONFIG) || configuredParamTypeName.equals(Types.COMMON_CONFIG))) {
+            return configuredParamTypeName;
+        }
+
+        // check configured factory method return type for raw Config factories
+        var configuredReturnTypeName = optionInfo.configured()
+                .flatMap(OptionConfigured::factoryMethod)
+                .map(FactoryMethod::returnType)
+                .map(this::optionValueType)
+                .orElse(null);
+        if (configuredReturnTypeName != null) {
+            if (configuredFactory != null) {
+                var paramType = configuredFactory.parameterType().orElse(null);
+                if (paramType != null && (paramType.equals(Types.CONFIG) || paramType.equals(Types.COMMON_CONFIG))) {
+                    if (configuredFactory.declaringType().className().endsWith("CustomMethods")) {
+                        var methodInfo = optionInfo.interfaceMethod().orElse(null);
+                        logger.log(Level.WARNING, "Raw Config option", methodInfo);
+                    }
+                }
+            }
+            return configuredReturnTypeName;
+        }
+
+        var configuredDeclaredTypeName = optionInfo.configured()
+                .flatMap(OptionConfigured::factoryMethod)
+                .map(FactoryMethod::declaringType)
+                .orElse(null);
+        if (configuredDeclaredTypeName != null) {
+            return configuredDeclaredTypeName;
+        }
+
         return typeName.boxed();
+    }
+
+    private TypeName optionValueType(TypeName typeName) {
+        if (typeName.isOptional()) {
+            typeName = typeName.typeArguments().getFirst();
+        }
+        if (typeName.isSet() || typeName.isList()) {
+            typeName = typeName.typeArguments().getFirst();
+        } else if (typeName.isMap()) {
+            typeName = typeName.typeArguments().get(1);
+        }
+        return typeName;
     }
 
     private String optionKind(OptionInfo optionInfo) {

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerBasic.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerBasic.java
@@ -806,6 +806,13 @@ class TypeHandlerBasic implements TypeHandler {
             return;
         }
 
+        var parameterType = factoryMethod.parameterType().orElse(null);
+        if (parameterType != null && !(parameterType.equals(CONFIG) || parameterType.equals(COMMON_CONFIG))) {
+            content.addContent(".as(")
+                    .addContent(parameterType.boxed().genericTypeName())
+                    .addContent(".class)");
+        }
+
         content.addContent(".as(")
                 .addContent(factoryMethod.declaringType().genericTypeName())
                 .addContent("::");

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -183,6 +183,25 @@ abstract class TypeHandlerCollection extends TypeHandlerContainer {
                 // maybe we should add @SuppressWarnings("unchecked")
             }
 
+        } else if (option().runtimeType().isPresent()
+                && option().runtimeType().get().factoryMethod().isPresent()) {
+            RuntimeTypeInfo runtimeTypeInfo = option().runtimeType().get();
+            FactoryMethod fm = runtimeTypeInfo.factoryMethod().get();
+            TypeName configType = fm.parameterType()
+                    .orElse(runtimeTypeInfo.optionBuilder().builderMethodType());
+            method.addContent(configGet(optionConfigured)
+                                      + ".asNodeList()"
+                                      + ".map(nodeList -> nodeList.stream()"
+                                      + ".map(cfg -> cfg.as(")
+                    .addContent(configType.genericTypeName())
+                    .addContent("::create).as(")
+                    .addContent(fm.declaringType().genericTypeName())
+                    .addContent("::")
+                    .addContent(fm.methodName())
+                    .addContent(").get()).");
+            collector.accept(method);
+            method.addContentLine(").ifPresent(this::" + setterName + ");");
+
         } else {
             method.addContent(configGet(optionConfigured)
                                       + ".asNodeList()"
@@ -198,10 +217,21 @@ abstract class TypeHandlerCollection extends TypeHandlerContainer {
     void generateMapListFromConfig(ContentBuilder<?> content, FactoryMethod factoryMethod) {
         var declaringType = factoryMethod.declaringType();
         var methodName = factoryMethod.methodName();
+        var parameterType = factoryMethod.parameterType().orElse(null);
 
-        content.addContent(declaringType.genericTypeName())
-                .addContent("::")
-                .addContent(methodName);
+        if (parameterType != null && !(parameterType.equals(Types.CONFIG) || parameterType.equals(Types.COMMON_CONFIG))) {
+            content.addContent("cfg -> cfg.as(")
+                    .addContent(parameterType.boxed().genericTypeName())
+                    .addContent(".class).as(")
+                    .addContent(declaringType.genericTypeName())
+                    .addContent("::")
+                    .addContent(methodName)
+                    .addContent(").get()");
+        } else {
+            content.addContent(declaringType.genericTypeName())
+                    .addContent("::")
+                    .addContent(methodName);
+        }
     }
 
     protected abstract String decoratorSetMethodName();

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerOptional.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerOptional.java
@@ -422,6 +422,13 @@ class TypeHandlerOptional extends TypeHandlerBasic {
                                     Optional<FactoryMethod> factoryMethod) {
         if (factoryMethod.isPresent()) {
             FactoryMethod fm = factoryMethod.get();
+            var parameterType = fm.parameterType().orElse(null);
+            if (parameterType != null
+                    && !(parameterType.equals(Types.CONFIG) || parameterType.equals(Types.COMMON_CONFIG))) {
+                content.addContent(".as(")
+                        .addContent(parameterType.boxed().genericTypeName())
+                        .addContent(".class)");
+            }
             content.addContent(".as(")
                     .addContent(fm.declaringType().genericTypeName())
                     .addContent("::");
@@ -481,10 +488,21 @@ class TypeHandlerOptional extends TypeHandlerBasic {
     private void generateMapListFromConfig(ContentBuilder<?> content, FactoryMethod factoryMethod) {
         var declaringType = factoryMethod.declaringType();
         var methodName = factoryMethod.methodName();
+        var parameterType = factoryMethod.parameterType().orElse(null);
 
-        content.addContent(declaringType.genericTypeName())
-                .addContent("::")
-                .addContent(methodName);
+        if (parameterType != null && !(parameterType.equals(Types.CONFIG) || parameterType.equals(Types.COMMON_CONFIG))) {
+            content.addContent("cfg -> cfg.as(")
+                    .addContent(parameterType.boxed().genericTypeName())
+                    .addContent(".class).as(")
+                    .addContent(declaringType.genericTypeName())
+                    .addContent("::")
+                    .addContent(methodName)
+                    .addContent(").get()");
+        } else {
+            content.addContent(declaringType.genericTypeName())
+                    .addContent("::")
+                    .addContent(methodName);
+        }
     }
 
     private boolean optionalContainer() {

--- a/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
+++ b/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
@@ -2657,8 +2657,13 @@ class SchemaGeneratorTest {
                         import io.helidon.builder.api.Prototype;
 
                         class AcmeConfigMethods {
-                            @Prototype.RuntimeTypeFactoryMethod
+                            @Prototype.RuntimeTypeFactoryMethod("views")
                             static ViewRegistration createViewRegistration(ViewRegistrationConfig config) {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Prototype.RuntimeTypeFactoryMethod("viewGroups")
+                            static java.util.List<ViewRegistration> createViewRegistrations(ViewRegistrationConfig config) {
                                 throw new UnsupportedOperationException();
                             }
                         }
@@ -2683,6 +2688,12 @@ class SchemaGeneratorTest {
                              */
                             @Option.Configured
                             List<ViewRegistration> views();
+
+                            /**
+                             * View groups.
+                             */
+                            @Option.Configured
+                            List<ViewRegistration> viewGroups();
                         }
                         """)
                 .build()
@@ -2695,6 +2706,8 @@ class SchemaGeneratorTest {
                                                   + ".map(cfg -> cfg.as(ViewRegistrationConfig::create)"
                                                   + ".as(AcmeConfigMethods::createViewRegistration).get())"
                                                   + ".toList()).ifPresent(this::views);"));
+        assertThat(actual, containsString("config.get(\"view-groups\").as(ViewRegistrationConfig::create)"
+                                                  + ".ifPresent(this::viewGroups);"));
     }
 
     @Test

--- a/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
+++ b/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
@@ -2222,6 +2222,105 @@ class SchemaGeneratorTest {
     }
 
     @Test
+    void testConfigFactoryPrecedesRuntimeFactory() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .addProcessor(AptProcessor::new)
+                .addSource("AcmePrivateKey.java", """
+                        package com.acme;
+
+                        interface AcmePrivateKey {
+                        }
+                        """)
+                .addSource("AcmePrivateKeyConfigBlueprint.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME private key config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        interface AcmePrivateKeyConfigBlueprint {
+                        }
+                        """)
+                .addSource("AcmeConfigMethods.java", """
+                        package com.acme;
+
+                        import java.util.Optional;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        class AcmeConfigMethods {
+                            @Prototype.RuntimeTypeFactoryMethod("privatekey")
+                            static Optional<AcmePrivateKey> createPrivateKey(AcmePrivateKeyConfig config) {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Prototype.ConfigFactoryMethod("privatekey")
+                            static AcmePrivateKey parsePrivateKey(String config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import java.util.Optional;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeConfigMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Private key.
+                             */
+                            @Option.Configured
+                            Optional<AcmePrivateKey> privatekey();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(String.join(System.lineSeparator(), result.diagnostics()), result.success(), is(true));
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        assertThat(actual, matches("""
+                //...
+                @Configured(
+                    //...
+                    options = {
+                        @ConfiguredOption(key = "privatekey", description = "Private key", type = String.class)
+                    })
+                //...
+                public interface AcmeConfig extends AcmeConfigBlueprint, Prototype.Api {
+                        //...
+                        @Override
+                        public BUILDER config(Config config) {
+                            //...
+                            config.get("privatekey").as(String.class).as(AcmeConfigMethods::parsePrivateKey).ifPresent(this::privatekey);
+                            return self();
+                        }
+                        //...
+                        public BUILDER privatekey(AcmePrivateKeyConfig privatekey) {
+                            Objects.requireNonNull(privatekey);
+                            privatekey(AcmeConfigMethods.createPrivateKey(privatekey));
+                            return self();
+                        }
+                        //...
+                }
+                """));
+    }
+
+    @Test
     void testRawConfigFactory() throws IOException {
         var result = TestCompiler.builder()
                 .currentRelease()
@@ -2426,6 +2525,135 @@ class SchemaGeneratorTest {
                 .compile();
 
         assertThat(result.success(), is(true));
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        assertThat(actual, matches("""
+                //...
+                        @ConfiguredOption(
+                            key = "customs",
+                            description = "Custom options",
+                            type = String.class,
+                            kind = ConfiguredOption.Kind.LIST)
+                //...
+                """));
+        assertThat(actual, containsString("config.get(\"customs\")"
+                                                  + ".asList(cfg -> cfg.as(String.class)"
+                                                  + ".as(AcmeCustomMethods::custom).get())"
+                                                  + ".ifPresent(this::customs);"));
+    }
+
+    @Test
+    void testConfigFactoryOptionalCollection() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .addProcessor(AptProcessor::new)
+                .addSource("AcmeCustomType.java", """
+                        package com.acme;
+
+                        interface AcmeCustomType {
+                        }
+                        """)
+                .addSource("AcmeCustomMethods.java", """
+                        package com.acme;
+
+                        import java.util.List;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        class AcmeCustomMethods {
+                            @Prototype.ConfigFactoryMethod("customs")
+                            static List<AcmeCustomType> customs(String config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import java.util.List;
+                        import java.util.Optional;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeCustomMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Custom options.
+                             */
+                            @Option.Configured
+                            Optional<List<AcmeCustomType>> customs();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(String.join(System.lineSeparator(), result.diagnostics()), result.success(), is(true));
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        assertThat(actual, containsString("config.get(\"customs\")"
+                                                  + ".as(String.class)"
+                                                  + ".as(AcmeCustomMethods::<AcmeCustomType>customs)"
+                                                  + ".ifPresent(this::customs);"));
+    }
+
+    @Test
+    void testConfigFactoryOptionalCollectionItems() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .addProcessor(AptProcessor::new)
+                .addSource("AcmeCustomType.java", """
+                        package com.acme;
+
+                        interface AcmeCustomType {
+                        }
+                        """)
+                .addSource("AcmeCustomMethods.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        class AcmeCustomMethods {
+                            @Prototype.ConfigFactoryMethod("customs")
+                            static AcmeCustomType custom(String config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import java.util.List;
+                        import java.util.Optional;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeCustomMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Custom options.
+                             */
+                            @Option.Configured
+                            Optional<List<AcmeCustomType>> customs();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(String.join(System.lineSeparator(), result.diagnostics()), result.success(), is(true));
         var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
         assertThat(actual, matches("""
                 //...

--- a/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
+++ b/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
@@ -2609,6 +2609,95 @@ class SchemaGeneratorTest {
     }
 
     @Test
+    void testPrecompiledRuntimeTypeCollectionItems() throws IOException {
+        var compiler = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .addProcessor(AptProcessor::new)
+                .build();
+
+        var configResult = TestCompiler.builder()
+                .from(compiler)
+                .addSource("ViewRegistrationConfigBlueprint.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * View registration config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        interface ViewRegistrationConfigBlueprint {
+                            /**
+                             * View name.
+                             */
+                            @Option.Configured
+                            String name();
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(configResult.success(), is(true));
+
+        var result = TestCompiler.builder()
+                .from(compiler)
+                .addClasspathEntry(configResult.classOutput())
+                .addSource("ViewRegistration.java", """
+                        package com.acme;
+
+                        interface ViewRegistration {
+                        }
+                        """)
+                .addSource("AcmeConfigMethods.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        class AcmeConfigMethods {
+                            @Prototype.RuntimeTypeFactoryMethod
+                            static ViewRegistration createViewRegistration(ViewRegistrationConfig config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import java.util.List;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeConfigMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Views.
+                             */
+                            @Option.Configured
+                            List<ViewRegistration> views();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(result.success(), is(true));
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        assertThat(actual, containsString("config.get(\"views\").asNodeList()"
+                                                  + ".map(nodeList -> nodeList.stream()"
+                                                  + ".map(cfg -> cfg.as(ViewRegistrationConfig::create)"
+                                                  + ".as(AcmeConfigMethods::createViewRegistration).get())"
+                                                  + ".toList()).ifPresent(this::views);"));
+    }
+
+    @Test
     void testMerge() throws IOException {
         var result = TestCompiler.builder()
                 .currentRelease()

--- a/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
+++ b/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
 
 import static io.helidon.codegen.testing.CodegenMatchers.matches;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 
@@ -2189,6 +2191,7 @@ class SchemaGeneratorTest {
         assertThat(Files.exists(schema), is(true));
 
         var actual = Files.readString(schema);
+        //noinspection UnnecessaryModifier
         assertThat(actual, matches("""
                 //...
                 package com.acme;
@@ -2200,9 +2203,409 @@ class SchemaGeneratorTest {
                     })
                 //...
                 public interface AcmeConfig extends AcmeConfigBlueprint, Prototype.Api {
-                //...
+                        //...
+                        @Override
+                        public BUILDER config(Config config) {
+                            //...
+                            config.get("privatekey").as(AcmePrivateKeyConfig::create).ifPresent(this::privatekey);
+                            return self();
+                        }
+                        //...
+                        public BUILDER privatekey(AcmePrivateKeyConfig privatekey) {
+                            Objects.requireNonNull(privatekey);
+                            privatekey(AcmeConfigMethods.createPrivateKey(privatekey));
+                            return self();
+                        }
+                        //...
                 }
                 """));
+    }
+
+    @Test
+    void testRawConfigFactory() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .printDiagnostics(false)
+                .addProcessor(AptProcessor::new)
+                .addSource("AcmeCustomType.java", """
+                        package com.acme;
+
+                        interface AcmeCustomType {
+                        }
+                        """)
+                .addSource("AcmeCustomMethods.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+                        import io.helidon.config.Config;
+
+                        class AcmeCustomMethods {
+                            @Prototype.ConfigFactoryMethod("custom")
+                            static AcmeCustomType custom(Config config) {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Prototype.ConfigFactoryMethod("customs")
+                            static java.util.List<AcmeCustomType> customs(Config config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeCustomMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Custom option.
+                             */
+                            @Option.Configured
+                            AcmeCustomType custom();
+
+                            /**
+                             * Custom options.
+                             */
+                            @Option.Configured
+                            java.util.List<AcmeCustomType> customs();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(result.success(), is(true));
+        assertThat(result.diagnostics(), is(hasItems("""
+                /AcmeConfigBlueprint.java:17: warning: Raw Config option
+                    AcmeCustomType custom();
+                                   ^""")));
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        assertThat(actual, matches("""
+                //...
+                        @ConfiguredOption(
+                            key = "customs",
+                            description = "Custom options",
+                            type = AcmeCustomType.class,
+                            kind = ConfiguredOption.Kind.LIST)
+                //...
+                """));
+        assertThat(actual, containsString("config.get(\"customs\").as(AcmeCustomMethods::customs)"
+                                                  + ".ifPresent(this::customs);"));
+    }
+
+    @Test
+    void testConfigFactoryScalar() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .printDiagnostics(false)
+                .addProcessor(AptProcessor::new)
+                .addSource("AcmeCustomType.java", """
+                        package com.acme;
+
+                        interface AcmeCustomType {
+                        }
+                        """)
+                .addSource("AcmeCustomMethods.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+                        class AcmeCustomMethods {
+                            @Prototype.ConfigFactoryMethod("custom")
+                            static AcmeCustomType custom(String config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeCustomMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Custom option.
+                             */
+                            @Option.Configured
+                            AcmeCustomType custom();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(result.success(), is(true));
+        assertThat(result.diagnostics(), is(empty()));
+
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        //noinspection UnnecessaryModifier
+        assertThat(actual, matches("""
+                //...
+                @Configured(
+                    //...
+                    options = {
+                        @ConfiguredOption(key = "custom", description = "Custom option", type = String.class, required = true)
+                    })
+                //...
+                public interface AcmeConfig extends AcmeConfigBlueprint, Prototype.Api {
+                        //...
+                        @Override
+                        public BUILDER config(Config config) {
+                            //...
+                            config.get("custom").as(String.class).as(AcmeCustomMethods::custom).ifPresent(this::custom);
+                            return self();
+                        }
+                        //...
+                }
+                """));
+    }
+
+    @Test
+    void testConfigFactoryCollectionItems() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .addProcessor(AptProcessor::new)
+                .addSource("AcmeCustomType.java", """
+                        package com.acme;
+
+                        interface AcmeCustomType {
+                        }
+                        """)
+                .addSource("AcmeCustomMethods.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        class AcmeCustomMethods {
+                            @Prototype.ConfigFactoryMethod("customs")
+                            static AcmeCustomType custom(String config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import java.util.List;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeCustomMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Custom options.
+                             */
+                            @Option.Configured
+                            List<AcmeCustomType> customs();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(result.success(), is(true));
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        assertThat(actual, matches("""
+                //...
+                        @ConfiguredOption(
+                            key = "customs",
+                            description = "Custom options",
+                            type = String.class,
+                            kind = ConfiguredOption.Kind.LIST)
+                //...
+                """));
+        assertThat(actual, containsString("config.get(\"customs\")"
+                                                  + ".asList(cfg -> cfg.as(String.class)"
+                                                  + ".as(AcmeCustomMethods::custom).get())"
+                                                  + ".ifPresent(this::customs);"));
+    }
+
+    @Test
+    void testConfigFactoryAdapter() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .addProcessor(AptProcessor::new)
+                .addSource("AcmeNestedConfigBlueprint.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * Nested config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        interface AcmeNestedConfigBlueprint {
+                        }
+                        """)
+                .addSource("AcmeCustomMethods.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+                        import io.helidon.config.Config;
+
+                        class AcmeCustomMethods {
+                            @Prototype.ConfigFactoryMethod("nested")
+                            static AcmeNestedConfig nested(Config config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeCustomMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Nested option.
+                             */
+                            @Option.Configured
+                            AcmeNestedConfig nested();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(result.success(), is(true));
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        assertThat(actual, matches("""
+                //...
+                @Configured(
+                    //...
+                    options = {
+                        @ConfiguredOption(key = "nested", description = "Nested option", type = AcmeNestedConfig.class, required = true)
+                    })
+                //...
+                public interface AcmeConfig extends AcmeConfigBlueprint, Prototype.Api {
+                        //...
+                        @Override
+                        public BUILDER config(Config config) {
+                            //...
+                            config.get("nested").as(AcmeCustomMethods::nested).ifPresent(this::nested);
+                            return self();
+                        }
+                        //...
+                }
+                """));
+    }
+
+    @Test
+    void testRuntimeTypeCollectionItems() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .options(OPTS)
+                .addProcessor(AptProcessor::new)
+                .addSource("AcmeListener.java", """
+                        package com.acme;
+
+                        interface AcmeListener {
+                        }
+                        """)
+                .addSource("AcmeListenerConfigBlueprint.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME listener config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        interface AcmeListenerConfigBlueprint {
+                            /**
+                             * Port.
+                             */
+                            @Option.Configured
+                            int port();
+                        }
+                        """)
+                .addSource("AcmeConfigMethods.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        class AcmeConfigMethods {
+                            @Prototype.RuntimeTypeFactoryMethod("listeners")
+                            static AcmeListener createListener(AcmeListenerConfig config) {
+                                throw new UnsupportedOperationException();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import java.util.List;
+
+                        import io.helidon.builder.api.Option;
+                        import io.helidon.builder.api.Prototype;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeConfigMethods.class)
+                        interface AcmeConfigBlueprint {
+                            /**
+                             * Listeners.
+                             */
+                            @Option.Configured
+                            List<AcmeListener> listeners();
+                        }
+                        """)
+                .build()
+                .compile();
+
+        assertThat(result.success(), is(true));
+        var actual = Files.readString(result.sourceOutput().resolve("com/acme/AcmeConfig.java"));
+        assertThat(actual, matches("""
+                //...
+                        @ConfiguredOption(
+                            key = "listeners",
+                            description = "Listeners",
+                            type = AcmeListenerConfig.class,
+                            kind = ConfiguredOption.Kind.LIST)
+                //...
+                """));
+        assertThat(actual, containsString("config.get(\"listeners\").asNodeList()"
+                                                  + ".map(nodeList -> nodeList.stream()"
+                                                  + ".map(cfg -> cfg.as(AcmeListenerConfig::create)"
+                                                  + ".as(AcmeConfigMethods::createListener).get())"
+                                                  + ".toList()).ifPresent(this::listeners);"));
     }
 
     @Test

--- a/common/context/http/src/main/java/io/helidon/common/context/http/ContextRecordConfigSupport.java
+++ b/common/context/http/src/main/java/io/helidon/common/context/http/ContextRecordConfigSupport.java
@@ -17,7 +17,6 @@
 package io.helidon.common.context.http;
 
 import io.helidon.builder.api.Prototype;
-import io.helidon.config.Config;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 
@@ -33,10 +32,8 @@ final class ContextRecordConfigSupport {
           Factory method to read HeaderName directly from configuration
         */
         @Prototype.ConfigFactoryMethod("header")
-        static HeaderName createHeader(Config config) {
-            return config.asString()
-                    .map(HeaderNames::create)
-                    .orElseThrow(() -> new IllegalStateException("Config node did not contain a header name"));
+        static HeaderName createHeader(String header) {
+            return HeaderNames.create(header);
         }
     }
 }

--- a/config/metadata/docs/src/test/java/io/helidon/config/metadata/docs/CmResolverValueTypesTest.java
+++ b/config/metadata/docs/src/test/java/io/helidon/config/metadata/docs/CmResolverValueTypesTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.metadata.docs;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.config.metadata.model.CmModel;
+import io.helidon.config.metadata.model.CmModel.CmModule;
+import io.helidon.config.metadata.model.CmModel.CmOption;
+import io.helidon.config.metadata.model.CmModel.CmType;
+import io.helidon.config.metadata.model.CmResolver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+class CmResolverValueTypesTest {
+
+    @Test
+    void testSupportedValueTypesDoNotProduceWarnings() {
+        var options = new ArrayList<>(List.of(
+                        "io.helidon.common.Size",
+                        "java.io.File",
+                        "java.lang.Class",
+                        "java.net.URL",
+                        "java.nio.charset.Charset",
+                        "java.nio.file.Path",
+                        "java.time.LocalTime",
+                        "java.time.OffsetTime",
+                        "java.time.Period",
+                        "java.time.YearMonth",
+                        "java.time.ZoneId",
+                        "java.time.ZoneOffset",
+                        "java.util.UUID",
+                        "java.util.regex.Pattern")
+                .stream()
+                .map(typeName -> CmOption.builder()
+                        .key(CmType.simpleTypeName(typeName))
+                        .type(typeName)
+                        .build())
+                .toList());
+        options.add(CmOption.builder()
+                .key("unsupported")
+                .type("com.acme.Unsupported")
+                .build());
+        var model = CmModel.of(List.of(CmModule.of("com.acme", List.of(CmType.builder()
+                .type("com.acme.AcmeConfig")
+                .options(options)
+                .build()))));
+        var warnings = new ArrayList<String>();
+        var logger = Logger.getLogger(CmResolver.class.getPackageName());
+        var previousLevel = logger.getLevel();
+        var previousUseParentHandlers = logger.getUseParentHandlers();
+        var handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                var parameters = record.getParameters();
+                if (parameters == null) {
+                    warnings.add(record.getMessage());
+                } else {
+                    warnings.add(MessageFormat.format(record.getMessage(), parameters));
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        handler.setLevel(Level.WARNING);
+
+        try {
+            logger.addHandler(handler);
+            logger.setUseParentHandlers(false);
+            logger.setLevel(Level.WARNING);
+
+            CmResolver.create(model);
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(previousLevel);
+            logger.setUseParentHandlers(previousUseParentHandlers);
+        }
+
+        assertThat(warnings, contains(
+                "Unresolved config metadata option type: com.acme.AcmeConfig.unsupported uses com.acme.Unsupported"));
+    }
+}

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmResolverImpl.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmResolverImpl.java
@@ -51,6 +51,34 @@ final class CmResolverImpl implements CmResolver {
 
     private static final System.Logger LOGGER =
             System.getLogger(CmResolverImpl.class.getName());
+    private static final Set<String> VALUE_TYPES = Set.of(
+            DEFAULT_TYPE,
+            "String",
+            "Boolean",
+            "Byte",
+            "Short",
+            "Integer",
+            "Long",
+            "Float",
+            "Double",
+            "Character",
+            "java.lang.Boolean",
+            "java.lang.Byte",
+            "java.lang.Short",
+            "java.lang.Integer",
+            "java.lang.Long",
+            "java.lang.Float",
+            "java.lang.Double",
+            "java.lang.Character",
+            "java.math.BigDecimal",
+            "java.math.BigInteger",
+            "java.net.URI",
+            "java.time.Duration",
+            "java.time.Instant",
+            "java.time.LocalDate",
+            "java.time.LocalDateTime",
+            "java.time.OffsetDateTime",
+            "java.time.ZonedDateTime");
 
     private final CmModel metadata;
     private final Map<String, List<CmType>> prefixes = new TreeMap<>();
@@ -67,6 +95,7 @@ final class CmResolverImpl implements CmResolver {
         this.metadata = metadata;
         initTypes();
         resolveTypes();
+        warnUnresolvedOptionTypes();
         initTree();
     }
 
@@ -176,6 +205,28 @@ final class CmResolverImpl implements CmResolver {
             }
             providers.put(entry.getKey(), Collections.unmodifiableMap(sorted));
         }
+    }
+
+    private void warnUnresolvedOptionTypes() {
+        for (var type : resolvedTypes.values()) {
+            for (var option : type.options()) {
+                if (!isResolvedOptionType(option)) {
+                    LOGGER.log(Level.WARNING,
+                            "Unresolved config metadata option type: {0}.{1} uses {2}",
+                            type.typeName(),
+                            option.key().orElse("<merge>"),
+                            option.typeName());
+                }
+            }
+        }
+    }
+
+    private boolean isResolvedOptionType(CmOption option) {
+        var typeName = option.typeName();
+        return VALUE_TYPES.contains(typeName)
+                || resolvedTypes.containsKey(typeName)
+                || enums.containsKey(typeName)
+                || option.provider() && contracts.contains(typeName);
     }
 
     private void initTree() {

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmResolverImpl.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmResolverImpl.java
@@ -62,8 +62,11 @@ final class CmResolverImpl implements CmResolver {
             "Float",
             "Double",
             "Character",
+            "io.helidon.common.Size",
+            "java.io.File",
             "java.lang.Boolean",
             "java.lang.Byte",
+            "java.lang.Class",
             "java.lang.Short",
             "java.lang.Integer",
             "java.lang.Long",
@@ -73,12 +76,23 @@ final class CmResolverImpl implements CmResolver {
             "java.math.BigDecimal",
             "java.math.BigInteger",
             "java.net.URI",
+            "java.net.URL",
+            "java.nio.charset.Charset",
+            "java.nio.file.Path",
             "java.time.Duration",
             "java.time.Instant",
             "java.time.LocalDate",
             "java.time.LocalDateTime",
+            "java.time.LocalTime",
             "java.time.OffsetDateTime",
-            "java.time.ZonedDateTime");
+            "java.time.OffsetTime",
+            "java.time.Period",
+            "java.time.YearMonth",
+            "java.time.ZoneId",
+            "java.time.ZoneOffset",
+            "java.time.ZonedDateTime",
+            "java.util.UUID",
+            "java.util.regex.Pattern");
 
     private final CmModel metadata;
     private final Map<String, List<CmType>> prefixes = new TreeMap<>();

--- a/http/media/media/src/main/java/io/helidon/http/media/MediaConfigSupport.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/MediaConfigSupport.java
@@ -19,7 +19,6 @@ package io.helidon.http.media;
 import io.helidon.builder.api.Prototype;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
-import io.helidon.config.Config;
 import io.helidon.http.HttpMediaType;
 
 final class MediaConfigSupport {
@@ -31,17 +30,13 @@ final class MediaConfigSupport {
         }
 
         @Prototype.ConfigFactoryMethod("contentType")
-        static HttpMediaType createContentType(Config config) {
-            return config.asString()
-                    .as(HttpMediaType::create)
-                    .get();
+        static HttpMediaType createContentType(String contentType) {
+            return HttpMediaType.create(contentType);
         }
 
         @Prototype.ConfigFactoryMethod("acceptedMediaTypes")
-        static MediaType createAcceptedType(Config config) {
-            return config.asString()
-                    .as(MediaTypes::create)
-                    .get();
+        static MediaType createAcceptedType(String acceptedMediaType) {
+            return MediaTypes.create(acceptedMediaType);
         }
     }
 }

--- a/integrations/langchain4j/providers/oracle-genai/src/main/java/io/helidon/integrations/langchain4j/providers/oci/genai/OciFactoryMethods.java
+++ b/integrations/langchain4j/providers/oracle-genai/src/main/java/io/helidon/integrations/langchain4j/providers/oci/genai/OciFactoryMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,16 +30,12 @@ final class OciFactoryMethods {
     }
 
     @Prototype.ConfigFactoryMethod("region")
-    static Region createRegion(io.helidon.common.config.Config config) {
-        return config.asString()
-                .map(Region::fromRegionCodeOrId)
-                .get();
+    static Region createRegion(String region) {
+        return Region.fromRegionCodeOrId(region);
     }
 
     @Prototype.ConfigFactoryMethod("servingType")
-    static ServingMode.ServingType createServingType(io.helidon.common.config.Config config) {
-        return config.asString()
-                .map(ServingMode.ServingType::create)
-                .get();
+    static ServingMode.ServingType createServingType(String servingType) {
+        return ServingMode.ServingType.create(servingType);
     }
 }

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigSupport.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigSupport.java
@@ -19,7 +19,6 @@ package io.helidon.integrations.oci;
 import java.net.URI;
 
 import io.helidon.builder.api.Prototype;
-import io.helidon.config.Config;
 
 import com.oracle.bmc.Region;
 
@@ -37,9 +36,7 @@ final class OciConfigSupport {
     }
 
     @Prototype.ConfigFactoryMethod("region")
-    static Region createRegion(Config config) {
-        return config.asString()
-                .map(Region::fromRegionCodeOrId)
-                .get();
+    static Region createRegion(String region) {
+        return Region.fromRegionCodeOrId(region);
     }
 }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigSupport.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigSupport.java
@@ -66,10 +66,6 @@ class MetricsConfigSupport {
     }
 
     @Prototype.ConfigFactoryMethod("tags")
-    static List<Tag> createTags(Config globalTagExpression) {
-        return createTags(globalTagExpression.asString().get());
-    }
-
     static List<Tag> createTags(String pairs) {
         // Use a TreeMap to order by tag name.
         Map<String, Tag> result = new TreeMap<>();

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/MetricExporterConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/MetricExporterConfigSupport.java
@@ -16,20 +16,14 @@
 
 package io.helidon.telemetry.otelconfig;
 
-import java.util.function.Function;
-
 import io.helidon.builder.api.Prototype;
 import io.helidon.config.Config;
-import io.helidon.config.EnumMapperProvider;
 
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 
 class MetricExporterConfigSupport {
-
-    private static final Function<Config, MetricTemporalityPreferenceType> TEMPORALITY_PREFERENCE_MAPPER =
-            new EnumMapperProvider().mapper(MetricTemporalityPreferenceType.class).orElseThrow();
 
     private MetricExporterConfigSupport() {
     }
@@ -40,8 +34,7 @@ class MetricExporterConfigSupport {
         }
 
         @Prototype.ConfigFactoryMethod
-        static AggregationTemporalitySelector createTemporalityPreference(Config config) {
-            var preference = TEMPORALITY_PREFERENCE_MAPPER.apply(config);
+        static AggregationTemporalitySelector createTemporalityPreference(MetricTemporalityPreferenceType preference) {
             return preference.selector();
         }
 

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigSupport.java
@@ -85,10 +85,9 @@ class OpenTelemetryLoggingConfigSupport {
             return OtelConfigSupport.createProcessorConfig(config);
         }
 
-        @Prototype.ConfigFactoryMethod("logLimits")
-        static LogLimits createLogLimits(Config config) {
+        @Prototype.RuntimeTypeFactoryMethod("logLimits")
+        static LogLimits createLogLimits(LogLimitsConfig logLimitsConfig) {
             var builder = LogLimits.builder();
-            var logLimitsConfig = LogLimitsConfig.create(config);
 
             logLimitsConfig.maxAttributeValueLength().ifPresent(builder::setMaxAttributeValueLength);
             logLimitsConfig.maxNumberOfAttributes().ifPresent(builder::setMaxNumberOfAttributes);
@@ -96,8 +95,8 @@ class OpenTelemetryLoggingConfigSupport {
             return builder.build();
         }
 
-        @Prototype.ConfigFactoryMethod("attributes")
-        static AttributesBuilder createAttributesBuilder(Config config) {
+        @Prototype.RuntimeTypeFactoryMethod("attributes")
+        static AttributesBuilder createAttributesBuilder(TypedAttributes config) {
             return OtelConfigSupport.createAttributesBuilder(config);
         }
     }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryMetricsConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryMetricsConfigSupport.java
@@ -250,9 +250,8 @@ class OpenTelemetryMetricsConfigSupport {
         }
 
 
-        @Prototype.ConfigFactoryMethod
-        static ViewRegistration createViewRegistration(Config config) {
-            var viewRegistrationConfig = ViewRegistrationConfig.create(config);
+        @Prototype.RuntimeTypeFactoryMethod
+        static ViewRegistration createViewRegistration(ViewRegistrationConfig viewRegistrationConfig) {
             var viewBuilder = View.builder();
 
             viewRegistrationConfig.name().ifPresent(viewBuilder::setName);
@@ -263,8 +262,8 @@ class OpenTelemetryMetricsConfigSupport {
             return new ViewRegistration(viewRegistrationConfig.instrumentSelector(), viewBuilder.build());
         }
 
-        @Prototype.ConfigFactoryMethod("attributes")
-        static AttributesBuilder createAttributesBuilder(Config config) {
+        @Prototype.RuntimeTypeFactoryMethod("attributes")
+        static AttributesBuilder createAttributesBuilder(TypedAttributes config) {
             return OtelConfigSupport.createAttributesBuilder(config);
         }
     }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryTracingConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryTracingConfigSupport.java
@@ -73,13 +73,13 @@ class OpenTelemetryTracingConfigSupport {
             return OtelConfigSupport.createProcessorConfig(config);
         }
 
-        @Prototype.ConfigFactoryMethod("sampler")
-        static Sampler createSampler(Config config) {
+        @Prototype.RuntimeTypeFactoryMethod("sampler")
+        static Sampler createSampler(SamplerConfig config) {
             return OtelConfigSupport.createSampler(config);
         }
 
-        @Prototype.ConfigFactoryMethod("spanLimits")
-        static SpanLimits createSpanLimits(Config config) {
+        @Prototype.RuntimeTypeFactoryMethod("spanLimits")
+        static SpanLimits createSpanLimits(SpanLimitsConfig config) {
             return OtelConfigSupport.createSpanLimits(config);
         }
 
@@ -88,8 +88,8 @@ class OpenTelemetryTracingConfigSupport {
             return OtlpExporterConfigSupport.CustomMethods.createSpanExporter(config);
         }
 
-        @Prototype.ConfigFactoryMethod("attributes")
-        static AttributesBuilder createAttributesBuilder(Config config) {
+        @Prototype.RuntimeTypeFactoryMethod("attributes")
+        static AttributesBuilder createAttributesBuilder(TypedAttributes config) {
             return OtelConfigSupport.createAttributesBuilder(config);
         }
 

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtelConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtelConfigSupport.java
@@ -184,8 +184,7 @@ class OtelConfigSupport {
         return builder.build();
     }
 
-    static AttributesBuilder createAttributesBuilder(Config config) {
-        var typedAttributes = TypedAttributes.create(config);
+    static AttributesBuilder createAttributesBuilder(TypedAttributes typedAttributes) {
         var builder = Attributes.builder();
 
         typedAttributes.booleanAttributes().forEach(builder::put);

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigSupport.java
@@ -54,8 +54,8 @@ class OtlpExporterConfigSupport {
         }
 
         @Prototype.ConfigFactoryMethod("protocol")
-        static OtlpExporterProtocolType createProtocol(Config config) {
-            return OtlpExporterProtocolType.from(config);
+        static OtlpExporterProtocolType createProtocol(String protocol) {
+            return OtlpExporterProtocolType.from(protocol);
         }
 
         @Prototype.ConfigFactoryMethod
@@ -81,12 +81,10 @@ class OtlpExporterConfigSupport {
             };
         }
 
-        @Prototype.ConfigFactoryMethod("retryPolicy")
-        static RetryPolicy createRetryPolicy(Config config) {
+        @Prototype.RuntimeTypeFactoryMethod("retryPolicy")
+        static RetryPolicy createRetryPolicy(RetryPolicyConfig policyConfig) {
 
             RetryPolicy.RetryPolicyBuilder builder = RetryPolicy.builder();
-
-            RetryPolicyConfig policyConfig = RetryPolicyConfig.builder().config(config).build();
 
             policyConfig.initialBackoff().ifPresent(builder::setInitialBackoff);
             policyConfig.maxBackoff().ifPresent(builder::setMaxBackoff);

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ViewRegistrationConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ViewRegistrationConfigSupport.java
@@ -78,9 +78,8 @@ class ViewRegistrationConfigSupport {
             return attributeName -> attributePattern.matcher(attributeName).matches();
         }
 
-        @Prototype.ConfigFactoryMethod
-        static InstrumentSelector createInstrumentSelector(Config config) {
-            var instrumentSelectorConfig = InstrumentSelectorConfig.create(config);
+        @Prototype.RuntimeTypeFactoryMethod
+        static InstrumentSelector createInstrumentSelector(InstrumentSelectorConfig instrumentSelectorConfig) {
             var builder = InstrumentSelector.builder();
 
             instrumentSelectorConfig.meterName().ifPresent(builder::setMeterName);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
@@ -188,8 +188,7 @@ class HttpClientConfigSupport {
         }
 
         @Prototype.ConfigFactoryMethod("baseAddress")
-        static SocketAddress createBaseAddress(Config config) {
-            String address = config.asString().get();
+        static SocketAddress createBaseAddress(String address) {
             // unix:/path/to/socket
             if (address.startsWith(UNIX_DOMAIN_SOCKET_PREFIX)) {
                 String path = address.substring(UNIX_DOMAIN_SOCKET_PREFIX.length());

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsConfigSupport.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsConfigSupport.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import io.helidon.builder.api.Prototype;
-import io.helidon.config.Config;
 import io.helidon.http.HeaderName;
 import io.helidon.http.Method;
 
@@ -101,9 +100,7 @@ class CorsConfigSupport {
         }
 
         @Prototype.ConfigFactoryMethod("maxAge")
-        static Duration maxAgeFromConfig(Config config) {
-            String value = config.asString().get();
-
+        static Duration maxAgeFromConfig(String value) {
             try {
                 int seconds = Integer.parseInt(value);
                 return Duration.ofSeconds(seconds);

--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserverConfigSupport.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserverConfigSupport.java
@@ -17,7 +17,6 @@
 package io.helidon.webserver.observe.log;
 
 import io.helidon.builder.api.Prototype;
-import io.helidon.config.Config;
 import io.helidon.http.HttpMediaType;
 
 final class LogObserverConfigSupport {
@@ -35,8 +34,8 @@ final class LogObserverConfigSupport {
          * @return media type parsed from the config
          */
         @Prototype.ConfigFactoryMethod("contentType")
-        static HttpMediaType createContentType(Config config) {
-            return config.asString().map(HttpMediaType::create).orElseThrow();
+        static HttpMediaType createContentType(String contentType) {
+            return HttpMediaType.create(contentType);
         }
     }
 }

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityConfigSupport.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityConfigSupport.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import io.helidon.builder.api.Prototype;
 import io.helidon.common.context.Contexts;
-import io.helidon.config.Config;
 import io.helidon.config.ConfigException;
 import io.helidon.http.Method;
 import io.helidon.security.ClassToInstanceStore;
@@ -171,8 +170,8 @@ class SecurityConfigSupport {
         }
 
         @Prototype.ConfigFactoryMethod("methods")
-        static Method createMethods(Config config) {
-            return config.asString().map(Method::create).orElseThrow();
+        static Method createMethods(String method) {
+            return Method.create(method);
         }
 
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
@@ -33,7 +33,6 @@ import java.util.function.Consumer;
 import io.helidon.builder.api.Prototype;
 import io.helidon.common.Builder;
 import io.helidon.common.socket.SocketOptions;
-import io.helidon.config.Config;
 import io.helidon.config.ConfigException;
 import io.helidon.http.RequestedUriDiscoveryContext;
 import io.helidon.webserver.http.HttpRouting;
@@ -185,8 +184,7 @@ class WebServerConfigSupport {
         }
 
         @Prototype.ConfigFactoryMethod("bindAddress")
-        static SocketAddress createBindAddress(Config config) {
-            String address = config.asString().get();
+        static SocketAddress createBindAddress(String address) {
             // unix:/path/to/socket
             if (address.startsWith(UNIX_DOMAIN_SOCKET_PREFIX)) {
                 String path = address.substring(UNIX_DOMAIN_SOCKET_PREFIX.length());


### PR DESCRIPTION
### Description

Generate configuration schemas that describe the values users provide, not
the runtime objects produced from them.

#### Problem

A blueprint option declares the Java type stored by the generated builder.
A custom factory may accept a different value from configuration and convert
it to that runtime type.

The processor previously lost that distinction, exposing internal support
classes or runtime types in the schema.

#### Before: invalid schemas

##### Scalar values

The blueprint stores `HeaderName`, but configuration supplies a string:

```java
@Prototype.CustomMethods(
        ContextRecordConfigSupport.RecordCustomMethods.class)
interface ContextRecordConfigBlueprint {
    @Option.Configured
    HeaderName header();
}

@Prototype.ConfigFactoryMethod("header")
static HeaderName createHeader(Config config) {
    return config.asString()
            .map(HeaderNames::create)
            .orElseThrow(() -> new IllegalStateException(
                    "Config node did not contain a header name"));
}
```

The old schema exposes the internal helper class:

```java
@ConfiguredOption(
        key = "header",
        type = ContextRecordConfigSupport.RecordCustomMethods.class,
        required = true)
```

##### Structured collections

OpenTelemetry stores runtime objects, but each configured `views` item
follows a Helidon blueprint:

```java
interface OpenTelemetryMetricsConfigBlueprint {
    @Option.Configured("views")
    List<OpenTelemetryMetricsConfigSupport.ViewRegistration>
            viewRegistrations();
}

@Prototype.ConfigFactoryMethod
static ViewRegistration createViewRegistration(Config config) {
    var viewConfig = ViewRegistrationConfig.create(config);
    // Create the OpenTelemetry runtime objects from viewConfig.
}
```

The old schema again exposes an internal helper class:

```java
@ConfiguredOption(
        key = "views",
        type = OpenTelemetryMetricsConfigSupport.CustomMethods.class,
        kind = ConfiguredOption.Kind.LIST)
```

#### After: schemas match configuration

##### Scalar adapters

The blueprint remains unchanged. The factory parameter now declares the
value supplied by configuration:

```java
@Prototype.ConfigFactoryMethod("header")
static HeaderName createHeader(String header) {
    return HeaderNames.create(header);
}
```

The generated schema now describes a string:

```java
@ConfiguredOption(
        key = "header",
        type = String.class,
        required = true)
```

##### Structured collections

The runtime factory now receives the configured prototype explicitly:

```java
@Prototype.RuntimeTypeFactoryMethod
static ViewRegistration createViewRegistration(
        ViewRegistrationConfig config) {
    // Create the OpenTelemetry runtime objects from config.
}
```

The schema points to the configured type:

```java
@ConfiguredOption(
        key = "views",
        type = ViewRegistrationConfig.class,
        kind = ConfiguredOption.Kind.LIST)
```

Factories that genuinely need raw `Config` remain unchanged. Their return
type supplies the schema type, and unresolved types produce a warning.

No public Java API signatures change.

#### Incremental builds

In incremental builds, a precompiled configured prototype could override an
explicit collection-item factory. The processor now preserves explicit item
factories while retaining the existing mapping for whole-option factories.

### Documentation

None

### Validation

- `SchemaGeneratorTest`: 44 tests passed
- config metadata model: 21 tests passed
- JDK 21 full reactor install, checkstyle, copyright, and `git diff --check`
  passed
