### PR TITLE
Skip unknown HTTP/2 SETTINGS identifiers when parsing frames

### DIFF
--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Settings.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,10 @@ public final class Http2Settings implements Http2Frame<Http2Flag.SettingsFlags> 
             Http2Setting<?> http2Setting = Http2Setting.BY_ID.get(identifier);
             if (http2Setting != null) {
                 values.put(identifier, new SettingValue(http2Setting, http2Setting.read(frame)));
+            } else {
+                // RFC 9113 §6.5.2: ignore unknown/unsupported identifiers, but still consume the value
+                // so subsequent settings stay aligned (each setting is 2-byte id + 4-byte value).
+                frame.skip(4);
             }
         }
         return new Http2Settings(values);

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2SettingsTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2SettingsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.http2;
+
+import io.helidon.common.buffers.BufferData;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class Http2SettingsTest {
+
+    private static final int UNKNOWN_ID = 0x8; // SETTINGS_ENABLE_CONNECT_PROTOCOL (RFC 8441)
+    private static final long BIG_WINDOW = 64L * 1024 * 1024;
+
+    @Test
+    void knownSettingsAreParsed() {
+        BufferData frame = settingsBuffer(
+                setting(Http2Setting.INITIAL_WINDOW_SIZE.identifier(), BIG_WINDOW),
+                setting(Http2Setting.MAX_FRAME_SIZE.identifier(), 32_768L));
+
+        Http2Settings settings = Http2Settings.create(frame);
+
+        assertThat(settings.value(Http2Setting.INITIAL_WINDOW_SIZE), is(BIG_WINDOW));
+        assertThat(settings.value(Http2Setting.MAX_FRAME_SIZE), is(32_768L));
+        assertThat(settings.hasValue(Http2Setting.INITIAL_WINDOW_SIZE), is(true));
+    }
+
+    @Test
+    void unknownSettingBeforeInitialWindowSizeIsSkipped() {
+        // #12196: unknown id before INITIAL_WINDOW_SIZE must not drop the window setting
+        BufferData frame = settingsBuffer(
+                setting(UNKNOWN_ID, 0L),
+                setting(Http2Setting.INITIAL_WINDOW_SIZE.identifier(), BIG_WINDOW));
+
+        Http2Settings settings = Http2Settings.create(frame);
+
+        assertThat(settings.hasValue(Http2Setting.INITIAL_WINDOW_SIZE), is(true));
+        assertThat(settings.value(Http2Setting.INITIAL_WINDOW_SIZE), is(BIG_WINDOW));
+    }
+
+    @Test
+    void unknownSettingAfterInitialWindowSizeIsSkipped() {
+        BufferData frame = settingsBuffer(
+                setting(Http2Setting.INITIAL_WINDOW_SIZE.identifier(), BIG_WINDOW),
+                setting(UNKNOWN_ID, 0L));
+
+        Http2Settings settings = Http2Settings.create(frame);
+
+        assertThat(settings.value(Http2Setting.INITIAL_WINDOW_SIZE), is(BIG_WINDOW));
+    }
+
+    @Test
+    void multipleUnknownSettingsDoNotCorruptLaterKnownSettings() {
+        BufferData frame = settingsBuffer(
+                setting(0x7, 1L),
+                setting(UNKNOWN_ID, 0L),
+                setting(0x63, 99L),
+                setting(Http2Setting.MAX_CONCURRENT_STREAMS.identifier(), 100L),
+                setting(Http2Setting.INITIAL_WINDOW_SIZE.identifier(), BIG_WINDOW));
+
+        Http2Settings settings = Http2Settings.create(frame);
+
+        assertThat(settings.value(Http2Setting.MAX_CONCURRENT_STREAMS), is(100L));
+        assertThat(settings.value(Http2Setting.INITIAL_WINDOW_SIZE), is(BIG_WINDOW));
+    }
+
+    @Test
+    void onlyUnknownSettingsYieldsEmptyPresentValues() {
+        BufferData frame = settingsBuffer(
+                setting(UNKNOWN_ID, 1L),
+                setting(0x63, 2L));
+
+        Http2Settings settings = Http2Settings.create(frame);
+
+        assertThat(settings.hasValue(Http2Setting.INITIAL_WINDOW_SIZE), is(false));
+        assertThat(settings.value(Http2Setting.INITIAL_WINDOW_SIZE),
+                   is((long) WindowSize.DEFAULT_WIN_SIZE));
+        assertThat(settings.presentValue(Http2Setting.ENABLE_PUSH).isEmpty(), is(true));
+    }
+
+    private static byte[] setting(int identifier, long value) {
+        BufferData tmp = BufferData.create(6);
+        tmp.writeInt16(identifier);
+        tmp.writeUnsignedInt32(value);
+        byte[] bytes = new byte[6];
+        tmp.read(bytes);
+        return bytes;
+    }
+
+    private static BufferData settingsBuffer(byte[]... settings) {
+        int size = settings.length * 6;
+        byte[] all = new byte[size];
+        int offset = 0;
+        for (byte[] setting : settings) {
+            System.arraycopy(setting, 0, all, offset, setting.length);
+            offset += setting.length;
+        }
+        return BufferData.create(all);
+    }
+}


### PR DESCRIPTION
### Description

Fixes #12196.

HTTP/2 SETTINGS parsing in `Http2Settings.create(BufferData)` did not consume the 4-byte value of an unknown/unsupported setting identifier. Because each setting is 6 bytes (2-byte id + 4-byte value) and the loop is bounded by `available / 6`, the read cursor became misaligned and **every setting after the unknown one was parsed from the wrong offset** and lost.

In particular, when a peer sent an unknown setting (e.g. Envoy’s `SETTINGS_ENABLE_CONNECT_PROTOCOL` / `0x8`) **before** `SETTINGS_INITIAL_WINDOW_SIZE`, Helidon dropped the peer’s larger initial window and kept the default **65535**. Outbound responses larger than 65535 bytes then stalled forever waiting for a `WINDOW_UPDATE` the peer had no reason to send.

**Fix:** per [RFC 9113 §6.5.2](https://www.rfc-editor.org/rfc/rfc9113.html#section-6.5.2) — *“An endpoint that receives a SETTINGS frame with any unknown or unsupported identifier MUST ignore that setting.”* — skip the 4-byte value for unknown identifiers so subsequent settings stay aligned and are applied.

```java
if (http2Setting != null) {
    values.put(identifier, new SettingValue(http2Setting, http2Setting.read(frame)));
} else {
    frame.skip(4); // ignore unknown setting, still consume its value
}
```

Unit tests cover:
- known settings only
- unknown **before** `INITIAL_WINDOW_SIZE` (regression for #12196)
- unknown **after** `INITIAL_WINDOW_SIZE`
- multiple unknown ids before known settings
- only-unknown frames leave defaults in place

### Documentation

None