### PR TITLE
OIDC cookie compression (27.x)

### DIFF
--- a/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
@@ -99,6 +99,16 @@ These flags are temporary compatibility controls for upgrades, not steady-state 
 These flags only affect password-based OIDC cookie encryption; named Security encryption configured with
 `cookie-encryption-name` uses its own encryption configuration.
 
+For a top-level `server-type=idcs`, the access-token and ID-token cookies are GZIP-compressed by default when
+compression reduces their size. Compression is disabled by default for other server types and can be enabled explicitly
+with `cookie-compression-enabled` for the access token and `cookie-compression-id-enabled` for the ID token. Compression
+is applied before encryption when encryption is enabled, and uses a cookie-safe encoded form otherwise. During a
+rolling upgrade from a version that does not understand compressed token cookies, set both options to `false` on all
+nodes before upgrading. New nodes still read compressed cookies while these settings are disabled, but write the older
+uncompressed format. Re-enable compression after all nodes have been upgraded and the rollback window has closed.
+Older nodes cannot read compressed cookies. Rolling back after compression has been re-enabled therefore requires
+invalidating affected sessions or waiting for the compressed cookies to expire and users to authenticate again.
+
 Helidon obtains a token from request (from cookie, header, or query parameter):
 
 1. Token is parsed as a singed JWT

--- a/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
@@ -102,10 +102,12 @@ These flags only affect password-based OIDC cookie encryption; named Security en
 For a top-level `server-type=idcs`, the access-token and ID-token cookies are GZIP-compressed by default when
 compression reduces their size. Compression is disabled by default for other server types and can be enabled explicitly
 with `cookie-compression-enabled` for the access token and `cookie-compression-id-enabled` for the ID token. Compression
-is applied before encryption when encryption is enabled, and uses a cookie-safe encoded form otherwise. During a
-rolling upgrade from a version that does not understand compressed token cookies, set both options to `false` on all
-nodes before upgrading. New nodes still read compressed cookies while these settings are disabled, but write the older
-uncompressed format. Re-enable compression after all nodes have been upgraded and the rollback window has closed.
+is applied before encryption when encryption is enabled, and uses a cookie-safe encoded form otherwise. Password-based
+legacy cookie encryption disables compression while `legacy-cookie-encryption` is `true`, even if the compression
+options are enabled; named Security encryption does not have this override. During a rolling upgrade from a version
+that does not understand compressed token cookies, set both options to `false` on all nodes before upgrading. New nodes
+still read compressed cookies while these settings are disabled, but write the older uncompressed format. Re-enable
+compression after all nodes have been upgraded and the rollback window has closed.
 Older nodes cannot read compressed cookies. Rolling back after compression has been re-enabled therefore requires
 invalidating affected sessions or waiting for the compressed cookies to expire and users to authenticate again.
 

--- a/security/jwt/src/main/java/io/helidon/security/jwt/EncryptedJwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/EncryptedJwt.java
@@ -69,8 +69,9 @@ public final class EncryptedJwt {
 
     private static final LazyValue<SecureRandom> RANDOM = LazyValue.create(SecureRandom::new);
 
+    // Delimiter-exclusive possessive groups keep rejection of malformed input linear.
     private static final Pattern JWE_PATTERN = Pattern
-            .compile("(^[\\S]+)\\.([\\S]+)\\.([\\S]+)\\.([\\S]+)\\.([\\S]+$)");
+            .compile("([^\\s.]++)\\.([^\\s.]++)\\.([^\\s.]++)\\.([^\\s.]++)\\.([^\\s.]++)");
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
 

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -264,6 +264,18 @@ import io.helidon.webclient.tracing.WebClientTracing;
  *     <td>Whether the access token cookie should be encrypted.</td>
  * </tr>
  * <tr>
+ *     <td>{@code cookie-compression-enabled}</td>
+ *     <td>{@code true} when the top-level server type is IDCS, {@code false} otherwise</td>
+ *     <td>Whether the access token cookie should be GZIP-compressed when this reduces its size.
+ *     Compression is applied before encryption when encryption is enabled.</td>
+ * </tr>
+ * <tr>
+ *     <td>{@code cookie-compression-id-enabled}</td>
+ *     <td>{@code true} when the top-level server type is IDCS, {@code false} otherwise</td>
+ *     <td>Whether the ID token cookie should be GZIP-compressed when this reduces its size.
+ *     Compression is applied before encryption when encryption is enabled.</td>
+ * </tr>
+ * <tr>
  *     <td>{@code cookie-encryption-password}</td>
  *     <td>Generated for this service (as a file)</td>
  *     <td>Encryption password to be used for symmetric cipher. Must be the same for all services that are intended
@@ -1004,6 +1016,8 @@ public final class OidcConfig extends TenantConfigImpl {
                 .build();
         private boolean useCookie = DEFAULT_COOKIE_USE;
         private boolean cookieSameSiteDefault = true;
+        private boolean cookieCompressionConfigured;
+        private boolean cookieCompressionIdConfigured;
         private boolean tokenSignatureValidation = true;
         private boolean idTokenSignatureValidation = true;
         private boolean accessTokenIpCheck = true;
@@ -1025,6 +1039,12 @@ public final class OidcConfig extends TenantConfigImpl {
         @Override
         public OidcConfig build() {
             buildConfiguration();
+            if (!cookieCompressionConfigured) {
+                tokenCookieBuilder.compressionEnabled("idcs".equals(serverType()));
+            }
+            if (!cookieCompressionIdConfigured) {
+                idTokenCookieBuilder.compressionEnabled("idcs".equals(serverType()));
+            }
 
             Errors.Collector collector = Errors.collector();
             if (useCookie && logoutEnabled) {
@@ -1120,7 +1140,9 @@ public final class OidcConfig extends TenantConfigImpl {
             config.get("cookie-same-site").asString().ifPresent(this::cookieSameSite);
             // encryption of cookies
             config.get("cookie-encryption-enabled").asBoolean().ifPresent(this::cookieEncryptionEnabled);
+            config.get("cookie-compression-enabled").asBoolean().ifPresent(this::cookieCompressionEnabled);
             config.get("cookie-encryption-id-enabled").asBoolean().ifPresent(this::cookieEncryptionEnabledIdToken);
+            config.get("cookie-compression-id-enabled").asBoolean().ifPresent(this::cookieCompressionEnabledIdToken);
             config.get("cookie-encryption-tenant-enabled").asBoolean().ifPresent(this::cookieEncryptionEnabledTenantName);
             config.get("cookie-encryption-refresh-enabled").asBoolean().ifPresent(this::cookieEncryptionEnabledRefreshToken);
             config.get("cookie-encryption-state-enabled").asBoolean().ifPresent(this::cookieEncryptionEnabledState);
@@ -1509,6 +1531,24 @@ public final class OidcConfig extends TenantConfigImpl {
         }
 
         /**
+         * Whether to GZIP-compress the access token cookie when this reduces its size.
+         * When encryption is enabled, compression is applied before encryption.
+         * Defaults to {@code true} when the top-level {@code server-type} is {@code idcs}, and to {@code false}
+         * otherwise. Disabling compression affects newly written cookies only; compressed cookies remain readable.
+         *
+         * @param cookieCompressionEnabled whether the access token cookie should be compressed
+         * @return updated builder instance
+         */
+        @ConfiguredOption(value = "true if server-type is idcs; false otherwise",
+                          description = "Whether to GZIP-compress the access token cookie when this "
+                                  + "reduces its size.")
+        public Builder cookieCompressionEnabled(boolean cookieCompressionEnabled) {
+            this.tokenCookieBuilder.compressionEnabled(cookieCompressionEnabled);
+            this.cookieCompressionConfigured = true;
+            return this;
+        }
+
+        /**
          * Whether to encrypt id token cookie created by this microservice.
          * Defaults to {@code true}.
          *
@@ -1519,6 +1559,25 @@ public final class OidcConfig extends TenantConfigImpl {
         @ConfiguredOption(key = "cookie-encryption-id-enabled", value = "true")
         public Builder cookieEncryptionEnabledIdToken(boolean cookieEncryptionEnabled) {
             this.idTokenCookieBuilder.encryptionEnabled(cookieEncryptionEnabled);
+            return this;
+        }
+
+        /**
+         * Whether to GZIP-compress the ID token cookie when this reduces its size.
+         * When encryption is enabled, compression is applied before encryption.
+         * Defaults to {@code true} when the top-level {@code server-type} is {@code idcs}, and to {@code false}
+         * otherwise. Disabling compression affects newly written cookies only; compressed cookies remain readable.
+         *
+         * @param cookieCompressionEnabled whether the ID token cookie should be compressed
+         * @return updated builder instance
+         */
+        @ConfiguredOption(key = "cookie-compression-id-enabled",
+                          value = "true if server-type is idcs; false otherwise",
+                          description = "Whether to GZIP-compress the ID token cookie when this "
+                                  + "reduces its size.")
+        public Builder cookieCompressionEnabledIdToken(boolean cookieCompressionEnabled) {
+            this.idTokenCookieBuilder.compressionEnabled(cookieCompressionEnabled);
+            this.cookieCompressionIdConfigured = true;
             return this;
         }
 

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -1535,13 +1535,14 @@ public final class OidcConfig extends TenantConfigImpl {
          * When encryption is enabled, compression is applied before encryption.
          * Defaults to {@code true} when the top-level {@code server-type} is {@code idcs}, and to {@code false}
          * otherwise. Disabling compression affects newly written cookies only; compressed cookies remain readable.
+         * Password-based legacy cookie encryption disables compression while {@code legacy-cookie-encryption} is enabled.
          *
          * @param cookieCompressionEnabled whether the access token cookie should be compressed
          * @return updated builder instance
          */
         @ConfiguredOption(value = "true if server-type is idcs; false otherwise",
                           description = "Whether to GZIP-compress the access token cookie when this "
-                                  + "reduces its size.")
+                                  + "reduces its size, unless password-based legacy cookie encryption is enabled.")
         public Builder cookieCompressionEnabled(boolean cookieCompressionEnabled) {
             this.tokenCookieBuilder.compressionEnabled(cookieCompressionEnabled);
             this.cookieCompressionConfigured = true;
@@ -1567,6 +1568,7 @@ public final class OidcConfig extends TenantConfigImpl {
          * When encryption is enabled, compression is applied before encryption.
          * Defaults to {@code true} when the top-level {@code server-type} is {@code idcs}, and to {@code false}
          * otherwise. Disabling compression affects newly written cookies only; compressed cookies remain readable.
+         * Password-based legacy cookie encryption disables compression while {@code legacy-cookie-encryption} is enabled.
          *
          * @param cookieCompressionEnabled whether the ID token cookie should be compressed
          * @return updated builder instance
@@ -1574,7 +1576,7 @@ public final class OidcConfig extends TenantConfigImpl {
         @ConfiguredOption(key = "cookie-compression-id-enabled",
                           value = "true if server-type is idcs; false otherwise",
                           description = "Whether to GZIP-compress the ID token cookie when this "
-                                  + "reduces its size.")
+                                  + "reduces its size, unless password-based legacy cookie encryption is enabled.")
         public Builder cookieCompressionEnabledIdToken(boolean cookieCompressionEnabled) {
             this.idTokenCookieBuilder.compressionEnabled(cookieCompressionEnabled);
             this.cookieCompressionIdConfigured = true;

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcCookieHandler.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcCookieHandler.java
@@ -51,6 +51,8 @@ public class OidcCookieHandler {
     private static final int COMPRESSION_BUFFER_SIZE = 1024;
     private static final int MAX_COOKIE_VALUE_SIZE = 64 * 1024;
     private static final int MAX_DECOMPRESSED_BASE64_VALUE_SIZE = MAX_COOKIE_VALUE_SIZE / 4 * 3;
+    private static final int MAX_ENCODED_COMPRESSED_VALUE_SIZE = COMPRESSED_VALUE_PREFIX.length()
+            + ((MAX_COOKIE_VALUE_SIZE + 2) / 3) * 4;
 
     private final String createCookieOptions;
     private final List<Consumer<SetCookie.Builder>> removeCookieUpdaters = new LinkedList<>();
@@ -138,6 +140,9 @@ public class OidcCookieHandler {
                 this.decryptFunction = it -> {
                     if (!it.startsWith(COMPRESSED_VALUE_PREFIX)) {
                         return it;
+                    }
+                    if (it.length() > MAX_ENCODED_COMPRESSED_VALUE_SIZE) {
+                        throw new CryptoException("OIDC encoded compressed cookie exceeds the maximum supported size");
                     }
                     try {
                         byte[] compressed = Base64.getDecoder().decode(it.substring(COMPRESSED_VALUE_PREFIX.length()));

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcCookieHandler.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcCookieHandler.java
@@ -16,10 +16,16 @@
 
 package io.helidon.security.providers.oidc.common;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +33,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.zip.Deflater;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
+import io.helidon.common.crypto.CryptoException;
 import io.helidon.http.SetCookie;
 
 /**
@@ -35,6 +45,12 @@ import io.helidon.http.SetCookie;
  */
 public class OidcCookieHandler {
     private static final System.Logger LOGGER = System.getLogger(OidcCookieHandler.class.getName());
+    private static final byte COMPRESSED_BASE64_VALUE = 0;
+    private static final byte COMPRESSED_RAW_VALUE = 1;
+    private static final String COMPRESSED_VALUE_PREFIX = "~";
+    private static final int COMPRESSION_BUFFER_SIZE = 1024;
+    private static final int MAX_COOKIE_VALUE_SIZE = 64 * 1024;
+    private static final int MAX_DECOMPRESSED_BASE64_VALUE_SIZE = MAX_COOKIE_VALUE_SIZE / 4 * 3;
 
     private final String createCookieOptions;
     private final List<Consumer<SetCookie.Builder>> removeCookieUpdaters = new LinkedList<>();
@@ -92,11 +108,51 @@ public class OidcCookieHandler {
                                                          builder.encryptionPassword,
                                                          builder.legacyCookieEncryption,
                                                          builder.legacyCookieFallback);
-            this.encryptFunction = it -> cookieEncryption.encrypt(it.getBytes(StandardCharsets.UTF_8));
-            this.decryptFunction = it -> new String(cookieEncryption.decrypt(it), StandardCharsets.UTF_8);
+            // Older instances can decrypt legacy password-encrypted cookies, but cannot decompress their payload.
+            // Named encryption ignores the legacy flag; rolling upgrades using it must control compression explicitly.
+            boolean legacyPasswordEncryption = builder.legacyCookieEncryption && builder.encryptionName == null;
+            boolean compressionEnabled = builder.compressionEnabled && !legacyPasswordEncryption;
+            this.encryptFunction = it -> {
+                byte[] valueBytes = it.getBytes(StandardCharsets.UTF_8);
+                return cookieEncryption.encrypt(compressionEnabled ? compress(valueBytes) : valueBytes);
+            };
+            // Marker-aware decompression also accepts uncompressed cookies created by older instances.
+            this.decryptFunction = it -> new String(decompress(cookieEncryption.decrypt(it)),
+                                                    StandardCharsets.UTF_8);
         } else {
-            this.encryptFunction = Function.identity();
-            this.decryptFunction = Function.identity();
+            if (builder.compressionEnabled) {
+                this.encryptFunction = it -> {
+                    byte[] valueBytes = it.getBytes(StandardCharsets.UTF_8);
+                    byte[] compressed = compress(valueBytes);
+                    if (compressed == valueBytes) {
+                        return it;
+                    }
+                    String encoded = COMPRESSED_VALUE_PREFIX + Base64.getEncoder().encodeToString(compressed);
+                    return encoded.length() < valueBytes.length ? encoded : it;
+                };
+            } else {
+                this.encryptFunction = Function.identity();
+            }
+            if (builder.compressionConfigured) {
+                // OIDC token values use Base64 or Base64URL, neither of which contains the compression prefix.
+                this.decryptFunction = it -> {
+                    if (!it.startsWith(COMPRESSED_VALUE_PREFIX)) {
+                        return it;
+                    }
+                    try {
+                        byte[] compressed = Base64.getDecoder().decode(it.substring(COMPRESSED_VALUE_PREFIX.length()));
+                        byte[] decompressed = decompress(compressed);
+                        if (decompressed == compressed) {
+                            throw new CryptoException("OIDC compressed cookie has an unsupported format");
+                        }
+                        return new String(decompressed, StandardCharsets.UTF_8);
+                    } catch (IllegalArgumentException e) {
+                        throw new CryptoException("OIDC cookie decompression failed", e);
+                    }
+                };
+            } else {
+                this.decryptFunction = Function.identity();
+            }
         }
 
         if (LOGGER.isLoggable(Level.TRACE)) {
@@ -143,7 +199,7 @@ public class OidcCookieHandler {
 
     /**
      * Locate cookie in a map of headers and return its value.
-     * If the cookie is encrypted, decrypts the cookie value.
+     * If the cookie is encrypted or compressed, restores the original cookie value.
      *
      * @param headers headers to process
      * @return cookie value, or empty if the cookie could not be found
@@ -171,13 +227,13 @@ public class OidcCookieHandler {
     }
 
     /**
-     * Decrypt a cipher text into clear text (if encryption is enabled).
+     * Restore an encrypted or compressed cookie value.
      *
-     * @param cipherText cipher text to decrypt
-     * @return secret
+     * @param value stored cookie value
+     * @return original cookie value
      */
-    public String decrypt(String cipherText) {
-        return decryptFunction.apply(cipherText);
+    public String decrypt(String value) {
+        return decryptFunction.apply(value);
     }
 
     String createCookieOptions() {
@@ -186,6 +242,75 @@ public class OidcCookieHandler {
 
     String cookieValuePrefix() {
         return valuePrefix;
+    }
+
+    private static byte[] compress(byte[] value) {
+        if (value.length <= 1 || value.length > MAX_COOKIE_VALUE_SIZE) {
+            return value;
+        }
+
+        byte compressionMarker = COMPRESSED_RAW_VALUE;
+        byte[] uncompressed = value;
+        try {
+            byte[] decoded = Base64.getDecoder().decode(value);
+            // Access-token cookies contain Base64-encoded JSON. Decoding canonical Base64 before compression removes
+            // its roughly one-third expansion, which can be necessary to fit the encrypted value within browser cookie
+            // limits and leaves fewer bytes for GZIP and encryption to process. The exact decode/encode round trip
+            // ensures that the marker can be used to restore the original representation byte for byte.
+            if (Arrays.equals(value, Base64.getEncoder().encode(decoded))) {
+                compressionMarker = COMPRESSED_BASE64_VALUE;
+                uncompressed = decoded;
+            }
+        } catch (IllegalArgumentException e) {
+            // Compress the raw value.
+        }
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream(value.length);
+        // Compressed values use [format marker][GZIP stream]. The marker is a control byte that cannot begin the
+        // textual token and URL values handled here. GZIPOutputStream writes the fixed RFC 1952 magic bytes
+        // 0x1f, 0x8b immediately after it.
+        result.write(compressionMarker);
+        try (GZIPOutputStream gzip = new BestCompressionGzipOutputStream(result)) {
+            gzip.write(uncompressed);
+        } catch (IOException e) {
+            throw new CryptoException("OIDC cookie compression failed", e);
+        }
+        byte[] compressed = result.toByteArray();
+        return compressed.length < value.length ? compressed : value;
+    }
+
+    private static byte[] decompress(byte[] value) {
+        if (value.length == 0) {
+            return value;
+        }
+
+        boolean base64Value;
+        int maxDecompressedValueSize;
+        // The leading marker identifies both compression and the original representation. GZIPInputStream below
+        // validates the following 0x1f, 0x8b magic bytes; no marker means this is an uncompressed value.
+        if (value[0] == COMPRESSED_BASE64_VALUE) {
+            base64Value = true;
+            maxDecompressedValueSize = MAX_DECOMPRESSED_BASE64_VALUE_SIZE;
+        } else if (value[0] == COMPRESSED_RAW_VALUE) {
+            base64Value = false;
+            maxDecompressedValueSize = MAX_COOKIE_VALUE_SIZE;
+        } else {
+            return value;
+        }
+        if (value.length > MAX_COOKIE_VALUE_SIZE) {
+            throw new CryptoException("OIDC compressed cookie exceeds the maximum supported size");
+        }
+
+        try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(value, 1, value.length - 1),
+                                                        COMPRESSION_BUFFER_SIZE)) {
+            byte[] decompressed = gzip.readNBytes(maxDecompressedValueSize + 1);
+            if (decompressed.length > maxDecompressedValueSize) {
+                throw new CryptoException("OIDC decompressed cookie exceeds the maximum supported size");
+            }
+            return base64Value ? Base64.getEncoder().encode(decompressed) : decompressed;
+        } catch (IOException e) {
+            throw new CryptoException("OIDC cookie decompression failed", e);
+        }
     }
 
     private SetCookie.Builder createCookieDirectValue(String value) {
@@ -210,6 +335,8 @@ public class OidcCookieHandler {
         private String encryptionName;
         private char[] encryptionPassword;
         private boolean encryptionEnabled;
+        private boolean compressionEnabled;
+        private boolean compressionConfigured;
         private boolean legacyCookieEncryption;
         private boolean legacyCookieFallback;
 
@@ -271,6 +398,12 @@ public class OidcCookieHandler {
             return this;
         }
 
+        Builder compressionEnabled(boolean compressionEnabled) {
+            this.compressionEnabled = compressionEnabled;
+            this.compressionConfigured = true;
+            return this;
+        }
+
         Builder legacyCookieEncryption(boolean legacyCookieEncryption) {
             this.legacyCookieEncryption = legacyCookieEncryption;
             return this;
@@ -279,6 +412,13 @@ public class OidcCookieHandler {
         Builder legacyCookieFallback(boolean legacyCookieFallback) {
             this.legacyCookieFallback = legacyCookieFallback;
             return this;
+        }
+    }
+
+    private static final class BestCompressionGzipOutputStream extends GZIPOutputStream {
+        private BestCompressionGzipOutputStream(OutputStream out) throws IOException {
+            super(out, COMPRESSION_BUFFER_SIZE);
+            def.setLevel(Deflater.BEST_COMPRESSION);
         }
     }
 }

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
@@ -304,6 +304,150 @@ class OidcConfigFromBuilderTest extends OidcConfigAbstractTest {
     }
 
     @Test
+    void testTokenCookieCompressionDefaultsAndOverrides() {
+        String largeCookieValue =
+                "eyJhY2Nlc3NUb2tlbiI6ImV5SnliMnhsY3lJNld5SmhaRzFwYmlJc0luVnpaWElpWFgwPSJ9".repeat(45);
+        OidcConfig idcsDefault = cookieCompressionConfigBuilder()
+                .config(Config.builder()
+                                .sources(ConfigSources.create(Map.of("server-type", "idcs")))
+                                .build())
+                .build();
+        OidcConfig defaultServerDefault = cookieCompressionConfigBuilder()
+                .build();
+        OidcConfig idcsDisabled = cookieCompressionConfigBuilder()
+                .config(Config.builder()
+                                .sources(ConfigSources.create(Map.of("server-type", "idcs",
+                                                                     "cookie-compression-enabled", "false")))
+                                .build())
+                .build();
+        OidcConfig defaultServerEnabled = cookieCompressionConfigBuilder()
+                .config(Config.builder()
+                                .sources(ConfigSources.create(Map.of("cookie-compression-enabled", "true")))
+                                .build())
+                .build();
+        String idcsDefaultCookie = idcsDefault.tokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+        String defaultServerDefaultCookie = defaultServerDefault.tokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+        String idcsDisabledCookie = idcsDisabled.tokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+        String defaultServerEnabledCookie = defaultServerEnabled.tokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+
+        assertAll("token cookie compression defaults and overrides",
+                  () -> assertThat("IDCS should enable compression by default",
+                                   idcsDefaultCookie.length() < 4096,
+                                   is(true)),
+                  () -> assertThat("The default server type should disable compression by default",
+                                   defaultServerDefaultCookie.length() > 4096,
+                                   is(true)),
+                  () -> assertThat("IDCS should honor an explicit compression opt-out",
+                                   idcsDisabledCookie.length() > 4096,
+                                   is(true)),
+                  () -> assertThat("The default server type should honor explicit compression",
+                                   defaultServerEnabledCookie.length() < 4096,
+                                   is(true)));
+    }
+
+    @Test
+    void testIdTokenCookieCompressionDefaultsAndOverrides() {
+        String largeCookieValue = largeIdTokenValue();
+        String largeAccessCookieValue =
+                "eyJhY2Nlc3NUb2tlbiI6ImV5SnliMnhsY3lJNld5SmhaRzFwYmlJc0luVnpaWElpWFgwPSJ9".repeat(45);
+        OidcConfig idcsDefault = cookieCompressionConfigBuilder()
+                .config(Config.builder()
+                                .sources(ConfigSources.create(Map.of("server-type", "idcs")))
+                                .build())
+                .build();
+        OidcConfig defaultServerDefault = cookieCompressionConfigBuilder()
+                .build();
+        OidcConfig idcsDisabled = cookieCompressionConfigBuilder()
+                .config(Config.builder()
+                                .sources(ConfigSources.create(Map.of("server-type", "idcs",
+                                                                     "cookie-compression-id-enabled", "false")))
+                                .build())
+                .build();
+        OidcConfig defaultServerEnabled = cookieCompressionConfigBuilder()
+                .config(Config.builder()
+                                .sources(ConfigSources.create(Map.of("cookie-compression-id-enabled", "true")))
+                                .build())
+                .build();
+        OidcConfig idcsAccessCompressionDisabled = cookieCompressionConfigBuilder()
+                .cookieCompressionEnabled(false)
+                .serverType("idcs")
+                .build();
+        OidcConfig idcsIdEncryptionDisabled = cookieCompressionConfigBuilder()
+                .cookieEncryptionEnabledIdToken(false)
+                .serverType("idcs")
+                .build();
+        String idcsDefaultCookie = idcsDefault.idTokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+        String defaultServerDefaultCookie = defaultServerDefault.idTokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+        String idcsDisabledCookie = idcsDisabled.idTokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+        String defaultServerEnabledCookie = defaultServerEnabled.idTokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+        String idcsAccessCompressionDisabledCookie = idcsAccessCompressionDisabled.idTokenCookieHandler()
+                .createCookie(largeCookieValue)
+                .build()
+                .toString();
+        String idcsIdCompressionDisabledAccessCookie = idcsDisabled.tokenCookieHandler()
+                .createCookie(largeAccessCookieValue)
+                .build()
+                .toString();
+        OidcCookieHandler idcsIdEncryptionDisabledHandler = idcsIdEncryptionDisabled.idTokenCookieHandler();
+        String idcsIdEncryptionDisabledCookie = idcsIdEncryptionDisabledHandler
+                .createCookie(largeCookieValue)
+                .build()
+                .value();
+
+        assertAll("ID token cookie compression defaults and overrides",
+                  () -> assertThat("IDCS should enable ID token compression by default",
+                                   idcsDefaultCookie.length() < 4096,
+                                   is(true)),
+                  () -> assertThat("The default server type should disable ID token compression by default",
+                                   defaultServerDefaultCookie.length() > 4096,
+                                   is(true)),
+                  () -> assertThat("IDCS should honor an explicit ID token compression opt-out",
+                                   idcsDisabledCookie.length() > 4096,
+                                   is(true)),
+                  () -> assertThat("The default server type should honor explicit ID token compression",
+                                   defaultServerEnabledCookie.length() < 4096,
+                                   is(true)),
+                  () -> assertThat("Access token compression should not control ID token compression",
+                                   idcsAccessCompressionDisabledCookie.length() < 4096,
+                                   is(true)),
+                  () -> assertThat("ID token compression should not control access token compression",
+                                   idcsIdCompressionDisabledAccessCookie.length() < 4096,
+                                   is(true)),
+                  () -> assertThat("ID token compression should work when ID token encryption is disabled",
+                                   idcsIdEncryptionDisabledCookie.length() < 4096,
+                                   is(true)),
+                  () -> assertThat(idcsIdEncryptionDisabledHandler
+                                           .findCookie(Map.of("Cookie",
+                                                              List.of(idcsIdEncryptionDisabledHandler.cookieName()
+                                                                              + "=" + idcsIdEncryptionDisabledCookie))),
+                                   is(Optional.of(largeCookieValue))));
+    }
+
+    @Test
     void testTokenCookieEncryptionCanBeDisabled() {
         OidcConfig config = OidcConfig.builder()
                 .identityUri(URI.create("https://identity.oracle.com"))
@@ -604,6 +748,23 @@ class OidcConfigFromBuilderTest extends OidcConfigAbstractTest {
                        config.tenantCookieHandler(),
                        config.refreshTokenCookieHandler(),
                        config.stateCookieHandler());
+    }
+
+    private static OidcConfig.Builder cookieCompressionConfigBuilder() {
+        return OidcConfig.builder()
+                .identityUri(URI.create("https://identity.oracle.com"))
+                .clientId("client-id-value")
+                .clientSecret("client-secret-value")
+                .oidcMetadataWellKnown(false)
+                .cookieEncryptionPassword(COOKIE_ENCRYPTION_PASSWORD.toCharArray());
+    }
+
+    private static String largeIdTokenValue() {
+        return "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
+                + "eyJhdWQiOiJjbGllbnQtaWQiLCJpc3MiOiJodHRwczovL2lkZW50aXR5Lm9yYWNsZS5jb20iLCJzdWIiOiJ1c2VyIn0"
+                .repeat(40)
+                + "."
+                + "c2lnbmF0dXJlLWJ5dGVz".repeat(20);
     }
 
     private static SymmetricCipher currentCipher() {

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
@@ -359,7 +359,11 @@ class OidcConfigFromBuilderTest extends OidcConfigAbstractTest {
 
     @Test
     void testIdTokenCookieCompressionDefaultsAndOverrides() {
-        String largeCookieValue = largeIdTokenValue();
+        String largeCookieValue = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
+                + "eyJhdWQiOiJjbGllbnQtaWQiLCJpc3MiOiJodHRwczovL2lkZW50aXR5Lm9yYWNsZS5jb20iLCJzdWIiOiJ1c2VyIn0"
+                .repeat(40)
+                + "."
+                + "c2lnbmF0dXJlLWJ5dGVz".repeat(20);
         String largeAccessCookieValue =
                 "eyJhY2Nlc3NUb2tlbiI6ImV5SnliMnhsY3lJNld5SmhaRzFwYmlJc0luVnpaWElpWFgwPSJ9".repeat(45);
         OidcConfig idcsDefault = cookieCompressionConfigBuilder()
@@ -757,14 +761,6 @@ class OidcConfigFromBuilderTest extends OidcConfigAbstractTest {
                 .clientSecret("client-secret-value")
                 .oidcMetadataWellKnown(false)
                 .cookieEncryptionPassword(COOKIE_ENCRYPTION_PASSWORD.toCharArray());
-    }
-
-    private static String largeIdTokenValue() {
-        return "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
-                + "eyJhdWQiOiJjbGllbnQtaWQiLCJpc3MiOiJodHRwczovL2lkZW50aXR5Lm9yYWNsZS5jb20iLCJzdWIiOiJ1c2VyIn0"
-                .repeat(40)
-                + "."
-                + "c2lnbmF0dXJlLWJ5dGVz".repeat(20);
     }
 
     private static SymmetricCipher currentCipher() {

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcCookieHandlerTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcCookieHandlerTest.java
@@ -16,14 +16,20 @@
 
 package io.helidon.security.providers.oidc.common;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.zip.GZIPOutputStream;
 
 import io.helidon.common.Base64Value;
 import io.helidon.common.crypto.CryptoException;
 import io.helidon.common.crypto.SymmetricCipher;
+import io.helidon.http.SetCookie;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -95,6 +101,15 @@ class OidcCookieHandlerTest {
         assertThat(cookie, not(Optional.empty()));
         cookieValue = cookie.get();
         assertThat(cookieValue, is(expectedValue));
+    }
+
+    @Test
+    void testUncompressedHandlerPreservesCompressionPrefix() {
+        String expectedValue = "~tenant";
+
+        Optional<String> cookie = handler.findCookie(Map.of("Cookie", List.of("COOKIE=" + expectedValue)));
+
+        assertThat(cookie, is(Optional.of(expectedValue)));
     }
 
     @Test
@@ -177,6 +192,252 @@ class OidcCookieHandlerTest {
     }
 
     @Test
+    void testCompressedEncryptedCookieRoundTripAndSize() {
+        String expectedValue =
+                "eyJhY2Nlc3NUb2tlbiI6ImV5SnliMnhsY3lJNld5SmhaRzFwYmlJc0luVnpaWElpWFgwPSJ9".repeat(45);
+        OidcCookieHandler compressedHandler = compressedHandler();
+        SetCookie compressedCookie = compressedHandler.createCookie(expectedValue).build();
+        SetCookie uncompressedCookie = encryptedHandler().createCookie(expectedValue).build();
+        String compressed = compressedCookie.value();
+        String uncompressed = uncompressedCookie.value();
+        byte[] compressedPayload = currentCipher(ENCRYPTION_PASSWORD)
+                .decrypt(versionedPayload(compressed))
+                .toBytes();
+
+        assertAll(() -> assertThat(compressedHandler
+                                           .findCookie(Map.of("Cookie", List.of("COOKIE=" + compressed))),
+                                   is(Optional.of(expectedValue))),
+                  () -> assertThat("Compression must reduce the encrypted cookie size",
+                                   compressed.length() < uncompressed.length(),
+                                   is(true)),
+                  () -> assertThat("Compressed cookie must fit into the browser cookie limit",
+                                   compressedCookie.toString().length() < 4096,
+                                   is(true)),
+                  () -> assertThat("The equivalent uncompressed cookie must demonstrate the size regression",
+                                   uncompressedCookie.toString().length() > 4096,
+                                   is(true)),
+                  () -> assertThat(compressedPayload[0], is((byte) 0)),
+                  () -> assertThat(compressedPayload[1], is((byte) 0x1f)),
+                  () -> assertThat(compressedPayload[2], is((byte) 0x8b)));
+    }
+
+    @Test
+    void testCompressedRawEncryptedCookieRoundTripAndSize() {
+        String expectedValue = largeIdTokenValue();
+        OidcCookieHandler compressedHandler = compressedHandler();
+        SetCookie compressedCookie = compressedHandler.createCookie(expectedValue).build();
+        SetCookie uncompressedCookie = encryptedHandler().createCookie(expectedValue).build();
+        String compressed = compressedCookie.value();
+        String uncompressed = uncompressedCookie.value();
+        byte[] compressedPayload = currentCipher(ENCRYPTION_PASSWORD)
+                .decrypt(versionedPayload(compressed))
+                .toBytes();
+
+        assertAll(() -> assertThat(compressedHandler
+                                           .findCookie(Map.of("Cookie", List.of("COOKIE=" + compressed))),
+                                   is(Optional.of(expectedValue))),
+                  () -> assertThat("Compression must reduce the encrypted cookie size",
+                                   compressed.length() < uncompressed.length(),
+                                   is(true)),
+                  () -> assertThat("Compressed cookie must fit into the browser cookie limit",
+                                   compressedCookie.toString().length() < 4096,
+                                   is(true)),
+                  () -> assertThat("The equivalent uncompressed cookie must demonstrate the size regression",
+                                   uncompressedCookie.toString().length() > 4096,
+                                   is(true)),
+                  () -> assertThat(compressedPayload[0], is((byte) 1)),
+                  () -> assertThat(compressedPayload[1], is((byte) 0x1f)),
+                  () -> assertThat(compressedPayload[2], is((byte) 0x8b)));
+    }
+
+    @Test
+    void testCompressedUnencryptedCookieRoundTripAndSize() {
+        String expectedValue =
+                "eyJhY2Nlc3NUb2tlbiI6ImV5SnliMnhsY3lJNld5SmhaRzFwYmlJc0luVnpaWElpWFgwPSJ9".repeat(65);
+        OidcCookieHandler compressedHandler = unencryptedHandler(true);
+        SetCookie compressedCookie = compressedHandler.createCookie(expectedValue).build();
+        SetCookie uncompressedCookie = unencryptedHandler(false).createCookie(expectedValue).build();
+        String compressed = compressedCookie.value();
+
+        assertAll(() -> assertThat(compressedHandler
+                                           .findCookie(Map.of("Cookie", List.of("COOKIE=" + compressed))),
+                                   is(Optional.of(expectedValue))),
+                  () -> assertThat("Compressed value must use the cookie-safe format",
+                                   compressed.startsWith("~"),
+                                   is(true)),
+                  () -> assertThat("Compression must reduce the unencrypted cookie size",
+                                   compressed.length() < uncompressedCookie.value().length(),
+                                   is(true)),
+                  () -> assertThat("Compressed cookie must fit into the browser cookie limit",
+                                   compressedCookie.toString().length() < 4096,
+                                   is(true)),
+                  () -> assertThat("The equivalent uncompressed cookie must demonstrate the size regression",
+                                   uncompressedCookie.toString().length() > 4096,
+                                   is(true)));
+    }
+
+    @Test
+    void testCompressedHandlerReadsExistingUncompressedCookie() {
+        String expectedValue = "existingCookieValue";
+        String encrypted = encryptedHandler().createCookie(expectedValue).build().value();
+
+        Optional<String> cookie = compressedHandler()
+                .findCookie(Map.of("Cookie", List.of("COOKIE=" + encrypted)));
+
+        assertThat(cookie, is(Optional.of(expectedValue)));
+    }
+
+    @Test
+    void testCompressionDisabledHandlerReadsCompressedCookie() {
+        String expectedValue =
+                "eyJhY2Nlc3NUb2tlbiI6ImV5SnliMnhsY3lJNld5SmhaRzFwYmlJc0luVnpaWElpWFgwPSJ9".repeat(45);
+        String encrypted = compressedHandler().createCookie(expectedValue).build().value();
+
+        Optional<String> cookie = encryptedHandler()
+                .findCookie(Map.of("Cookie", List.of("COOKIE=" + encrypted)));
+
+        assertThat(cookie, is(Optional.of(expectedValue)));
+    }
+
+    @Test
+    void testCompressionDisabledHandlerReadsCompressedRawCookie() {
+        String expectedValue = largeIdTokenValue();
+        String encrypted = compressedHandler().createCookie(expectedValue).build().value();
+
+        Optional<String> cookie = encryptedHandler()
+                .findCookie(Map.of("Cookie", List.of("COOKIE=" + encrypted)));
+
+        assertThat(cookie, is(Optional.of(expectedValue)));
+    }
+
+    @Test
+    void testCompressionDisabledUnencryptedHandlerReadsCompressedCookie() {
+        String expectedValue = largeIdTokenValue();
+        String compressed = unencryptedHandler(true).createCookie(expectedValue).build().value();
+
+        Optional<String> cookie = unencryptedHandler(false)
+                .findCookie(Map.of("Cookie", List.of("COOKIE=" + compressed)));
+
+        assertAll(() -> assertThat(compressed.startsWith("~"), is(true)),
+                  () -> assertThat(cookie, is(Optional.of(expectedValue))));
+    }
+
+    @Test
+    void testMaximumSizeCompressedRawCookieRoundTrip() {
+        String expectedValue = "a.".repeat(32 * 1024);
+        String encrypted = compressedHandler().createCookie(expectedValue).build().value();
+
+        Optional<String> cookie = compressedHandler()
+                .findCookie(Map.of("Cookie", List.of("COOKIE=" + encrypted)));
+
+        assertThat(cookie, is(Optional.of(expectedValue)));
+    }
+
+    @Test
+    void testLegacyEncryptionDoesNotWriteCompressedCookie() {
+        String expectedValue =
+                "eyJhY2Nlc3NUb2tlbiI6ImV5SnliMnhsY3lJNld5SmhaRzFwYmlJc0luVnpaWElpWFgwPSJ9".repeat(45);
+        String encrypted = encryptedHandler(true, false, true).createCookie(expectedValue).build().value();
+        String decrypted = legacyCipher(ENCRYPTION_PASSWORD)
+                .decrypt(Base64Value.createFromEncoded(encrypted))
+                .toDecodedString();
+
+        assertThat(decrypted, is(expectedValue));
+    }
+
+    @Test
+    void testLegacyEncryptionFallbackReadsCurrentCompressedRawCookie() {
+        String expectedValue = largeIdTokenValue();
+        String currentEncrypted = compressedHandler().createCookie(expectedValue).build().value();
+
+        assertAll(() -> assertThrows(CryptoException.class,
+                                     () -> encryptedHandler(true, false)
+                                             .findCookie(Map.of("Cookie", List.of("COOKIE=" + currentEncrypted)))),
+                  () -> assertThat(encryptedHandler(true, true)
+                                           .findCookie(Map.of("Cookie", List.of("COOKIE=" + currentEncrypted))),
+                                   is(Optional.of(expectedValue))));
+    }
+
+    @Test
+    void testCompressionDoesNotExpandShortCookie() {
+        String expectedValue = "cookieValue";
+        String encrypted = compressedHandler().createCookie(expectedValue).build().value();
+        String decrypted = currentCipher(ENCRYPTION_PASSWORD)
+                .decrypt(versionedPayload(encrypted))
+                .toDecodedString();
+        String unencrypted = unencryptedHandler(true).createCookie(expectedValue).build().value();
+
+        assertAll(() -> assertThat(decrypted, is(expectedValue)),
+                  () -> assertThat(unencrypted, is(expectedValue)));
+    }
+
+    @Test
+    void testUnencryptedCompressionDoesNotExpandEncodedCookie() {
+        String expectedValue = "a".repeat(25);
+        String unencrypted = unencryptedHandler(true).createCookie(expectedValue).build().value();
+        String encrypted = compressedHandler().createCookie(expectedValue).build().value();
+        byte[] compressedPayload = currentCipher(ENCRYPTION_PASSWORD)
+                .decrypt(versionedPayload(encrypted))
+                .toBytes();
+
+        assertAll(() -> assertThat(compressedPayload[0], is((byte) 1)),
+                  () -> assertThat(unencrypted, is(expectedValue)));
+    }
+
+    @Test
+    void testMalformedUnencryptedCompressedCookieRejected() {
+        assertAll(() -> assertThrows(CryptoException.class,
+                                     () -> unencryptedHandler(false)
+                                             .findCookie(Map.of("Cookie", List.of("COOKIE=~not-base64")))),
+                  () -> assertThrows(CryptoException.class,
+                                     () -> unencryptedHandler(false)
+                                             .findCookie(Map.of("Cookie", List.of("COOKIE=~Y29va2llVmFsdWU=")))));
+    }
+
+    @Test
+    void testMalformedCompressedCookieRejected() {
+        String compressedBase64 = encryptCurrent(new byte[] {0, 1, 2, 3});
+        String compressedRaw = encryptCurrent(new byte[] {1, 1, 2, 3});
+
+        assertAll(() -> assertThrows(CryptoException.class,
+                                     () -> compressedHandler()
+                                             .findCookie(Map.of("Cookie", List.of("COOKIE=" + compressedBase64)))),
+                  () -> assertThrows(CryptoException.class,
+                                     () -> compressedHandler()
+                                             .findCookie(Map.of("Cookie", List.of("COOKIE=" + compressedRaw)))));
+    }
+
+    @Test
+    void testOversizedCompressedCookieRejected() throws IOException {
+        byte[] oversized = "a".repeat(48 * 1024 + 1).getBytes(StandardCharsets.UTF_8);
+        String encrypted = encryptCurrent(compress(oversized));
+
+        assertThrows(CryptoException.class,
+                     () -> compressedHandler().findCookie(Map.of("Cookie", List.of("COOKIE=" + encrypted))));
+    }
+
+    @Test
+    void testMaximumSizeCompressedBase64CookieAccepted() throws IOException {
+        byte[] maximum = "a".repeat(48 * 1024).getBytes(StandardCharsets.UTF_8);
+        String encrypted = encryptCurrent(compress(maximum));
+        String expectedValue = Base64.getEncoder().encodeToString(maximum);
+
+        Optional<String> cookie = compressedHandler()
+                .findCookie(Map.of("Cookie", List.of("COOKIE=" + encrypted)));
+
+        assertThat(cookie, is(Optional.of(expectedValue)));
+    }
+
+    @Test
+    void testOversizedCompressedRawCookieRejected() throws IOException {
+        byte[] oversized = "a".repeat(64 * 1024 + 1).getBytes(StandardCharsets.UTF_8);
+        String encrypted = encryptCurrent(compress(oversized, (byte) 1));
+
+        assertThrows(CryptoException.class,
+                     () -> compressedHandler().findCookie(Map.of("Cookie", List.of("COOKIE=" + encrypted))));
+    }
+
+    @Test
     void testCurrentEncryptedCookieRejectsTamperedPayload() {
         String encrypted = encryptedHandler().createCookie("cookieValue").build().value();
         byte[] versioned = Base64Value.createFromEncoded(encrypted).toBytes();
@@ -231,13 +492,63 @@ class OidcCookieHandlerTest {
     }
 
     private static OidcCookieHandler encryptedHandler(boolean legacyCookieEncryption, boolean legacyCookieFallback) {
+        return encryptedHandler(legacyCookieEncryption, legacyCookieFallback, false);
+    }
+
+    private static OidcCookieHandler compressedHandler() {
+        return encryptedHandler(false, false, true);
+    }
+
+    private static OidcCookieHandler unencryptedHandler(boolean compressionEnabled) {
+        return OidcCookieHandler.builder()
+                .encryptionEnabled(false)
+                .compressionEnabled(compressionEnabled)
+                .cookieName("COOKIE")
+                .build();
+    }
+
+    private static OidcCookieHandler encryptedHandler(boolean legacyCookieEncryption,
+                                                      boolean legacyCookieFallback,
+                                                      boolean compressionEnabled) {
         return OidcCookieHandler.builder()
                 .encryptionEnabled(true)
                 .encryptionPassword(ENCRYPTION_PASSWORD)
+                .compressionEnabled(compressionEnabled)
                 .legacyCookieEncryption(legacyCookieEncryption)
                 .legacyCookieFallback(legacyCookieFallback)
                 .cookieName("COOKIE")
                 .build();
+    }
+
+    private static String encryptCurrent(byte[] value) {
+        byte[] encrypted = currentCipher(ENCRYPTION_PASSWORD)
+                .encrypt(Base64Value.create(value))
+                .toBytes();
+        byte[] versioned = new byte[encrypted.length + 1];
+        versioned[0] = CURRENT_VERSION;
+        System.arraycopy(encrypted, 0, versioned, 1, encrypted.length);
+        return Base64Value.create(versioned).toBase64();
+    }
+
+    private static byte[] compress(byte[] value) throws IOException {
+        return compress(value, (byte) 0);
+    }
+
+    private static byte[] compress(byte[] value, byte marker) throws IOException {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        result.write(marker);
+        try (GZIPOutputStream gzip = new GZIPOutputStream(result)) {
+            gzip.write(value);
+        }
+        return result.toByteArray();
+    }
+
+    private static String largeIdTokenValue() {
+        return "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
+                + "eyJhdWQiOiJjbGllbnQtaWQiLCJpc3MiOiJodHRwczovL2lkZW50aXR5Lm9yYWNsZS5jb20iLCJzdWIiOiJ1c2VyIn0"
+                .repeat(40)
+                + "."
+                + "c2lnbmF0dXJlLWJ5dGVz".repeat(20);
     }
 
     private static Base64Value versionedPayload(String encrypted) {

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcCookieHandlerTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcCookieHandlerTest.java
@@ -395,6 +395,17 @@ class OidcCookieHandlerTest {
     }
 
     @Test
+    void testOversizedEncodedCompressedCookieRejectedBeforeDecoding() {
+        int maxEncodedLength = ((64 * 1024 + 2) / 3) * 4;
+
+        CryptoException exception = assertThrows(CryptoException.class,
+                                                  () -> unencryptedHandler(false)
+                                                          .decrypt("~" + "A".repeat(maxEncodedLength + 1)));
+
+        assertThat(exception.getMessage(), is("OIDC encoded compressed cookie exceeds the maximum supported size"));
+    }
+
+    @Test
     void testMalformedCompressedCookieRejected() {
         String compressedBase64 = encryptCurrent(new byte[] {0, 1, 2, 3});
         String compressedRaw = encryptCurrent(new byte[] {1, 1, 2, 3});

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcEncryptionTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcEncryptionTest.java
@@ -179,6 +179,41 @@ class OidcEncryptionTest {
 
     @Test
     void namedEncryptionDoesNotAddOidcVersionEnvelope() {
+        Context context = namedEncryptionContext();
+
+        Contexts.runInContext(context, () -> {
+            assertNamedEncryptionDoesNotAddOidcVersionEnvelope(OidcEncryption.create("test", "test-name", null));
+            assertNamedEncryptionDoesNotAddOidcVersionEnvelope(OidcEncryption.create("test", "test-name", null, true, false));
+            assertNamedEncryptionDoesNotAddOidcVersionEnvelope(OidcEncryption.create("test", "test-name", null, false, true));
+            assertNamedEncryptionDoesNotAddOidcVersionEnvelope(OidcEncryption.create("test", "test-name", null, true, true));
+        });
+    }
+
+    @Test
+    void legacyPasswordEncryptionFlagDoesNotDisableNamedEncryptionCompression() {
+        String expectedValue =
+                "eyJhY2Nlc3NUb2tlbiI6ImV5SnliMnhsY3lJNld5SmhaRzFwYmlJc0luVnpaWElpWFgwPSJ9".repeat(45);
+        Context context = namedEncryptionContext();
+
+        Contexts.runInContext(context, () -> {
+            OidcCookieHandler handler = OidcCookieHandler.builder()
+                    .encryptionEnabled(true)
+                    .encryptionName("test-name")
+                    .compressionEnabled(true)
+                    .legacyCookieEncryption(true)
+                    .cookieName("COOKIE")
+                    .build();
+            String encrypted = handler.createCookie(expectedValue).build().value();
+            byte[] compressed = Base64.getDecoder().decode(encrypted);
+
+            assertThat(compressed[0], is((byte) 0));
+            assertThat(compressed[1], is((byte) 0x1f));
+            assertThat(compressed[2], is((byte) 0x8b));
+            assertThat(handler.decrypt(encrypted), is(expectedValue));
+        });
+    }
+
+    private static Context namedEncryptionContext() {
         EncryptionProvider<ProviderConfig> provider = new EncryptionProvider<>() {
             @Override
             public EncryptionSupport encryption(Config config) {
@@ -196,13 +231,7 @@ class OidcEncryptionTest {
                 .build();
         Context context = Context.create();
         context.register(security);
-
-        Contexts.runInContext(context, () -> {
-            assertNamedEncryptionDoesNotAddOidcVersionEnvelope(OidcEncryption.create("test", "test-name", null));
-            assertNamedEncryptionDoesNotAddOidcVersionEnvelope(OidcEncryption.create("test", "test-name", null, true, false));
-            assertNamedEncryptionDoesNotAddOidcVersionEnvelope(OidcEncryption.create("test", "test-name", null, false, true));
-            assertNamedEncryptionDoesNotAddOidcVersionEnvelope(OidcEncryption.create("test", "test-name", null, true, true));
-        });
+        return context;
     }
 
     private static boolean posixSupported(Path path) {

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcFeature.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcFeature.java
@@ -31,11 +31,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.helidon.common.Errors;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LruCache;
 import io.helidon.common.Weight;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
+import io.helidon.common.crypto.CryptoException;
 import io.helidon.common.mapper.OptionalValue;
 import io.helidon.common.parameters.Parameters;
 import io.helidon.config.Config;
@@ -50,6 +52,7 @@ import io.helidon.security.Security;
 import io.helidon.security.SecurityException;
 import io.helidon.security.jwt.EncryptedJwt;
 import io.helidon.security.jwt.Jwt;
+import io.helidon.security.jwt.JwtException;
 import io.helidon.security.jwt.JwtHeaders;
 import io.helidon.security.jwt.SignedJwt;
 import io.helidon.security.jwt.jwk.JwkKeys;
@@ -337,7 +340,28 @@ public final class OidcFeature implements HttpFeature {
                                   String encryptedIdToken,
                                   String stateQuery) {
         try {
-            String idToken = idTokenCookieHandler.decrypt(encryptedIdToken);
+            String idToken;
+            try {
+                idToken = idTokenCookieHandler.decrypt(encryptedIdToken);
+                JwtHeaders jwtHeaders = JwtHeaders.parseToken(idToken);
+                if (jwtHeaders.encryption().isPresent()) {
+                    EncryptedJwt.parseToken(jwtHeaders, idToken);
+                } else {
+                    SignedJwt.parseToken(jwtHeaders, idToken);
+                }
+            } catch (CryptoException
+                     | IllegalArgumentException
+                     | JwtException
+                     | Errors.ErrorMessagesException e) {
+                if (LOGGER.isLoggable(Level.TRACE)) {
+                    LOGGER.log(Level.TRACE, "Invalid OIDC logout ID token cookie", e);
+                }
+                clearLocalOidcCookies(res.headers());
+                res.status(Status.BAD_REQUEST_400)
+                        .send();
+                return;
+            }
+
             URI logoutEndpoint = tenant.logoutEndpointUri();
             String logoutQuery = logoutEndpoint.getRawQuery();
             String querySeparator = "?";
@@ -347,7 +371,7 @@ public final class OidcFeature implements HttpFeature {
             StringBuilder sb = new StringBuilder(logoutEndpoint.toString())
                     .append(querySeparator)
                     .append("id_token_hint=")
-                    .append(idToken)
+                    .append(encode(idToken))
                     .append("&post_logout_redirect_uri=")
                     .append(postLogoutUri(req));
 

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -218,23 +218,23 @@ class TenantAuthenticationHandler {
                 }
             }
             if (oidcConfig.useCookie() && idToken.isEmpty()) {
-                // only do this for cookies
-                Optional<String> cookie = oidcConfig.idTokenCookieHandler()
-                        .findCookie(providerRequest.env().headers());
-                if (cookie.isPresent()) {
-                    try {
+                try {
+                    // only do this for cookies
+                    Optional<String> cookie = oidcConfig.idTokenCookieHandler()
+                            .findCookie(providerRequest.env().headers());
+                    if (cookie.isPresent()) {
                         String idTokenValue = cookie.get();
                         return validateIdToken(tenantId, providerRequest, idTokenValue);
-                    } catch (Exception e) {
-                        if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-                            LOGGER.log(System.Logger.Level.DEBUG, "Invalid id token in cookie", e);
-                        }
-                        return errorResponse(providerRequest,
-                                             Status.UNAUTHORIZED_401,
-                                             null,
-                                             "Invalid id token",
-                                             tenantId);
                     }
+                } catch (Exception e) {
+                    if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+                        LOGGER.log(System.Logger.Level.DEBUG, "Invalid id token in cookie", e);
+                    }
+                    return errorResponse(providerRequest,
+                                         Status.UNAUTHORIZED_401,
+                                         null,
+                                         "Invalid id token",
+                                         tenantId);
                 }
             }
         } catch (SecurityException e) {

--- a/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/OidcFeatureTest.java
+++ b/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/OidcFeatureTest.java
@@ -41,6 +41,9 @@ import io.helidon.security.ProviderRequest;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.SecurityEnvironment;
 import io.helidon.security.Subject;
+import io.helidon.security.jwt.Jwt;
+import io.helidon.security.jwt.SignedJwt;
+import io.helidon.security.jwt.jwk.Jwk;
 import io.helidon.security.jwt.jwk.JwkKeys;
 import io.helidon.security.providers.common.OutboundConfig;
 import io.helidon.security.providers.common.OutboundTarget;
@@ -50,6 +53,8 @@ import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http1.Http1Config;
+import io.helidon.webserver.http1.Http1ConnectionSelector;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -72,6 +77,14 @@ import static org.mockito.Mockito.when;
  */
 class OidcFeatureTest {
     private static final String PARAM_NAME = "my-param-attempts";
+    private static final URI DEFAULT_LOGOUT_ENDPOINT = URI.create("http://idp.example.test/logout");
+    private static final String ID_TOKEN = SignedJwt.sign(
+            Jwt.builder()
+                    .algorithm("none")
+                    .addPayloadClaim("padding", "a".repeat(512))
+                    .build(),
+            Jwk.NONE_JWK)
+            .tokenContent();
 
     private final OidcConfig oidcConfig = OidcConfig.builder()
             .clientId("id")
@@ -157,14 +170,59 @@ class OidcFeatureTest {
 
         assertThat(response,
                    containsString("Location: " + logoutEndpoint
-                                          + "&id_token_hint=dummy-id-token&post_logout_redirect_uri=http://127.0.0.1:"));
+                                          + "&id_token_hint=" + ID_TOKEN
+                                          + "&post_logout_redirect_uri=http://127.0.0.1:"));
+    }
+
+    @Test
+    void testLogoutRejectsInvalidCompressedIdToken() throws Exception {
+        String injectedHeader = "X-Reproducer: injected";
+        String invalidIdToken = ID_TOKEN + "\r\n" + injectedHeader + "\r\n";
+        String response = logoutResponse("ok", DEFAULT_LOGOUT_ENDPOINT, invalidIdToken, false);
+
+        assertThat(response, startsWith("HTTP/1.1 400"));
+        assertLocalOidcCookiesRemoved(response);
+        assertThat(response, not(containsString("\r\n" + injectedHeader + "\r\n")));
+        assertThat(response, not(containsString("\r\nLocation:")));
+    }
+
+    @Test
+    void testLogoutRejectsCompressedJweWithTooManySegments() throws Exception {
+        String header = Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString("{\"alg\":\"RSA-OAEP\",\"enc\":\"A256GCM\"}"
+                                        .getBytes(StandardCharsets.UTF_8));
+        String invalidJwe = header + ".AA".repeat(20_000);
+        String response = logoutResponse("ok", DEFAULT_LOGOUT_ENDPOINT, invalidJwe, true);
+
+        assertThat(response, startsWith("HTTP/1.1 400"));
+        assertLocalOidcCookiesRemoved(response);
+        assertThat(response, not(containsString("\r\nLocation:")));
+    }
+
+    private static void assertLocalOidcCookiesRemoved(String response) {
+        for (String cookieName : List.of(OidcConfig.DEFAULT_COOKIE_NAME,
+                                         OidcConfig.DEFAULT_ID_COOKIE_NAME,
+                                         OidcConfig.DEFAULT_TENANT_COOKIE_NAME,
+                                         OidcConfig.DEFAULT_REFRESH_COOKIE_NAME)) {
+            assertThat(response,
+                       containsString("\r\nSet-Cookie: " + cookieName
+                                              + "=; Expires="));
+        }
     }
 
     private static String logoutResponse(String state) throws Exception {
-        return logoutResponse(state, URI.create("http://idp.example.test/logout"));
+        return logoutResponse(state, DEFAULT_LOGOUT_ENDPOINT);
     }
 
     private static String logoutResponse(String state, URI logoutEndpoint) throws Exception {
+        return logoutResponse(state, logoutEndpoint, ID_TOKEN, true);
+    }
+
+    private static String logoutResponse(String state,
+                                         URI logoutEndpoint,
+                                         String idToken,
+                                         boolean validateResponseHeaders) throws Exception {
         OidcConfig oidcConfig = OidcConfig.builder()
                 .clientId("id")
                 .clientSecret("secret")
@@ -179,13 +237,24 @@ class OidcFeatureTest {
                 .postLogoutUri(URI.create("/logged-out"))
                 .cookieEncryptionEnabled(false)
                 .cookieEncryptionEnabledIdToken(false)
+                .cookieCompressionEnabledIdToken(true)
                 .cookieEncryptionEnabledTenantName(false)
                 .cookieEncryptionEnabledRefreshToken(false)
                 .cookieEncryptionEnabledState(false)
                 .build();
+        String idTokenCookie = oidcConfig.idTokenCookieHandler()
+                .createCookie(idToken)
+                .build()
+                .value();
+        assertThat("ID token test cookie should be compressed", idTokenCookie, startsWith("~"));
 
         WebServer server = WebServer.builder()
                 .port(0)
+                .addConnectionSelector(Http1ConnectionSelector.builder()
+                                               .config(Http1Config.builder()
+                                                               .validateResponseHeaders(validateResponseHeaders)
+                                                               .build())
+                                               .build())
                 .addRouting(HttpRouting.builder()
                                     .addFeature(OidcFeature.create(oidcConfig)))
                 .build()
@@ -196,7 +265,7 @@ class OidcFeatureTest {
             OutputStream output = socket.getOutputStream();
             output.write(("GET /oidc/logout?state=" + state + " HTTP/1.1\r\n"
                     + "Host: 127.0.0.1:" + server.port() + "\r\n"
-                    + "Cookie: " + oidcConfig.idTokenCookieHandler().cookieName() + "=dummy-id-token\r\n"
+                    + "Cookie: " + oidcConfig.idTokenCookieHandler().cookieName() + "=" + idTokenCookie + "\r\n"
                     + "Connection: close\r\n"
                     + "\r\n").getBytes(StandardCharsets.US_ASCII));
             output.flush();

--- a/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/TenantAuthenticationHandlerTest.java
+++ b/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/TenantAuthenticationHandlerTest.java
@@ -153,6 +153,32 @@ class TenantAuthenticationHandlerTest {
     }
 
     @Test
+    public void testMalformedCompressedIdTokenCookieFailsAuthentication() {
+        OidcConfig oidcConfig = OidcConfig.builder()
+                .clientId("test")
+                .clientSecret("123")
+                .identityUri(URI.create("http://localhost:1234"))
+                .oidcMetadataWellKnown(false)
+                .useCookie(true)
+                .useHeader(false)
+                .redirect(false)
+                .cookieEncryptionEnabledIdToken(false)
+                .cookieCompressionEnabledIdToken(true)
+                .build();
+        Tenant tenant = mock(Tenant.class);
+        when(tenant.tenantConfig()).thenReturn(oidcConfig);
+        TenantAuthenticationHandler authenticationHandler = new TenantAuthenticationHandler(oidcConfig, tenant, false, false);
+        String malformedCookie = oidcConfig.idTokenCookieHandler().cookieName() + "=~not-base64";
+
+        AuthenticationResponse response = authenticationHandler.authenticate(DEFAULT_TENANT_ID,
+                                                                             requestWithCookies(malformedCookie));
+
+        assertThat(response.status(), is(SecurityResponse.SecurityStatus.FAILURE));
+        assertThat(response.statusCode().orElseThrow(), is(401));
+        assertThat(response.description().orElseThrow(), is("Invalid id token"));
+    }
+
+    @Test
     public void testOriginalUri() {
         OidcConfig oidcConfig = OidcConfig.builder()
                 .clientId("test")


### PR DESCRIPTION
Resolves #12224

Carries forward #12218 to `main`, adding optional compression for OIDC access-token and ID-token cookies, rolling-upgrade compatibility, bounded decompression, and handling for malformed compressed cookies.
