### PR TITLE
Fixes an unresolved AsciiDoc attribute in the Helidon SE Metrics Guide

### DIFF
--- a/docs/src/main/asciidoc/includes/guides/metrics.adoc
+++ b/docs/src/main/asciidoc/includes/guides/metrics.adoc
@@ -20,7 +20,7 @@ ifndef::rootdir[:rootdir: {docdir}/../..]
 
 // tag::intro[]
 
-This guide describes how to create a sample Helidon {intro-project-name} project
+This guide describes how to create a sample Helidon {h1-prefix} project
 that can be used to run some basic examples using both built-in and custom {metrics} with Helidon.
 
 == What You Need


### PR DESCRIPTION
### Description
The intro-project-name attribute was assigned from {h1-prefix} before h1-prefix was defined, leaving an unresolved attribute in the generated documentation. This change references {h1-prefix} directly, consistent with the rest of metrics.adoc.

### Documentation
None
