### PR TITLE
Fix resolved URI query parameters (4.x)

### DIFF
--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
@@ -18,6 +18,7 @@ package io.helidon.common.uri;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -34,6 +35,8 @@ import io.helidon.common.mapper.Value;
 final class UriQueryWriteableImpl implements UriQueryWriteable {
     private final Map<String, List<String>> rawQueryParams = new HashMap<>();
     private final Map<String, List<String>> decodedQueryParams = new HashMap<>();
+
+    private Map<String, Set<String>> rawNamesByDecodedName;
 
     UriQueryWriteableImpl() {
     }
@@ -84,6 +87,13 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
                         .addAll(decoded);
             }
         }
+        Map<String, Set<String>> rawNames = rawNamesByDecodedName;
+        if (rawNames != null) {
+            rawNames.clear();
+            rawQueryParams.keySet().forEach(rawName -> rawNames
+                    .computeIfAbsent(UriEncoding.decodeUri(rawName), it -> new HashSet<>())
+                    .add(rawName));
+        }
 
         return this;
     }
@@ -92,6 +102,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
     public void clear() {
         this.rawQueryParams.clear();
         this.decodedQueryParams.clear();
+        this.rawNamesByDecodedName = null;
     }
 
     @Override
@@ -227,10 +238,11 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
         List<String> existingRawValues = rawQueryParams.get(encodedName);
         if (existingDecodedValues != null
                 && (existingRawValues == null || existingRawValues.size() != existingDecodedValues.size())) {
-            rawQueryParams.keySet().removeIf(rawName -> name.equals(UriEncoding.decodeUri(rawName)));
+            removeRawAliases(name);
         }
         rawQueryParams.put(encodedName, encodedValues);
         decodedQueryParams.put(name, decodedValues);
+        indexRawName(name, encodedName);
 
         return this;
     }
@@ -244,6 +256,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
                 .add(encodedValue);
         decodedQueryParams.computeIfAbsent(name, it -> new ArrayList<>(1))
                 .add(value);
+        indexRawName(name, encodedName);
 
         return this;
     }
@@ -260,6 +273,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
     public UriQueryWriteable remove(String name) {
         rawQueryParams.remove(name);
         decodedQueryParams.remove(name);
+        unindexRawName(name);
         return this;
     }
 
@@ -267,6 +281,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
     public UriQueryWriteable remove(String name, Consumer<List<String>> removedConsumer) {
         rawQueryParams.remove(name);
         List<String> removed = decodedQueryParams.remove(name);
+        unindexRawName(name);
         if (removed != null) {
             removedConsumer.accept(removed);
         }
@@ -314,5 +329,45 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
                 .add(encodedValue);
         decodedQueryParams.computeIfAbsent(decodedName, it -> new ArrayList<>(1))
                 .add(decodedValue);
+        indexRawName(decodedName, encodedName);
+    }
+
+    private void removeRawAliases(String name) {
+        Map<String, Set<String>> rawNames = rawNamesByDecodedName;
+        if (rawNames == null) {
+            rawNames = new HashMap<>();
+            for (String rawName : rawQueryParams.keySet()) {
+                rawNames.computeIfAbsent(UriEncoding.decodeUri(rawName), it -> new HashSet<>())
+                        .add(rawName);
+            }
+            rawNamesByDecodedName = rawNames;
+        }
+        Set<String> aliases = rawNames.remove(name);
+        if (aliases != null) {
+            aliases.forEach(rawQueryParams::remove);
+        }
+    }
+
+    private void indexRawName(String decodedName, String rawName) {
+        Map<String, Set<String>> rawNames = rawNamesByDecodedName;
+        if (rawNames != null) {
+            rawNames.computeIfAbsent(decodedName, it -> new HashSet<>())
+                    .add(rawName);
+        }
+    }
+
+    private void unindexRawName(String rawName) {
+        Map<String, Set<String>> rawNames = rawNamesByDecodedName;
+        if (rawNames == null) {
+            return;
+        }
+        String decodedName = UriEncoding.decodeUri(rawName);
+        Set<String> aliases = rawNames.get(decodedName);
+        if (aliases != null) {
+            aliases.remove(rawName);
+            if (aliases.isEmpty()) {
+                rawNames.remove(decodedName);
+            }
+        }
     }
 }

--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
@@ -223,7 +223,12 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
             encodedValues.add(UriEncoding.encode(value, UriEncoding.Type.QUERY_PARAM_SPACE_ENCODED));
         }
 
-        rawQueryParams.keySet().removeIf(rawName -> name.equals(UriEncoding.decodeUri(rawName)));
+        List<String> existingDecodedValues = decodedQueryParams.get(name);
+        List<String> existingRawValues = rawQueryParams.get(encodedName);
+        if (existingDecodedValues != null
+                && (existingRawValues == null || existingRawValues.size() != existingDecodedValues.size())) {
+            rawQueryParams.keySet().removeIf(rawName -> name.equals(UriEncoding.decodeUri(rawName)));
+        }
         rawQueryParams.put(encodedName, encodedValues);
         decodedQueryParams.put(name, decodedValues);
 

--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,6 +223,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
             encodedValues.add(UriEncoding.encode(value, UriEncoding.Type.QUERY_PARAM_SPACE_ENCODED));
         }
 
+        rawQueryParams.keySet().removeIf(rawName -> name.equals(UriEncoding.decodeUri(rawName)));
         rawQueryParams.put(encodedName, encodedValues);
         decodedQueryParams.put(name, decodedValues);
 

--- a/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
@@ -18,6 +18,7 @@ package io.helidon.common.uri;
 
 import java.net.URI;
 import java.net.URLEncoder;
+import java.util.List;
 
 import io.helidon.common.mapper.OptionalValue;
 
@@ -137,6 +138,16 @@ class UriQueryTest {
         assertThat(query.getRaw("p3"), is("%2F%2Fv3%2F%2F"));
         assertThat(query.get("p4"), is("a b c"));
         assertThat(query.getRaw("p4"), is("a%20b%20c"));
+    }
+
+    @Test
+    void setReplacesEquivalentEncodedName() {
+        UriQueryWriteable query = writeableQuery("%61=template");
+
+        query.set("a", "request");
+
+        assertThat(query.all("a"), is(List.of("request")));
+        assertThat(query.rawValue(), is("a=request"));
     }
 
     private static UriQueryWriteable writeableQuery(String queryString) {

--- a/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
@@ -26,8 +26,10 @@ import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -148,6 +150,44 @@ class UriQueryTest {
 
         assertThat(query.all("a"), is(List.of("request")));
         assertThat(query.rawValue(), is("a=request"));
+    }
+
+    @Test
+    void setReplacesMultipleEquivalentEncodedNames() {
+        StringBuilder queryString = new StringBuilder();
+        for (int i = 0; i < 32; i++) {
+            if (!queryString.isEmpty()) {
+                queryString.append('&');
+            }
+            queryString.append("%61").append(i).append("=template");
+        }
+        UriQueryWriteable query = writeableQuery(queryString.toString());
+
+        for (int i = 0; i < 32; i++) {
+            query.set("a" + i, "request" + i);
+        }
+
+        assertThat(query.size(), is(32));
+        for (int i = 0; i < 32; i++) {
+            assertThat(query.getAllRaw("a" + i), is(List.of("request" + i)));
+        }
+        assertThat(query.rawValue(), not(containsString("%61")));
+    }
+
+    @Test
+    void aliasIndexTracksLaterRawUpdates() {
+        UriQueryWriteable query = writeableQuery("%61=template");
+        query.set("a", "request");
+
+        query.fromQueryString("%62=template");
+        query.set("b", "request");
+        query.from(writeableQuery("%63=template"));
+        query.set("c", "request");
+
+        assertThat(query.getAllRaw("a"), is(List.of("request")));
+        assertThat(query.getAllRaw("b"), is(List.of("request")));
+        assertThat(query.getAllRaw("c"), is(List.of("request")));
+        assertThat(query.rawValue(), not(containsString("%")));
     }
 
     private static UriQueryWriteable writeableQuery(String queryString) {

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -29,6 +29,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryAliasBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryAliasBenchmark.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.http.Method;
+import io.helidon.webclient.api.ClientRequest.OutputStreamHandler;
+import io.helidon.webclient.api.ClientRequestBase;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.WebClientConfig;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(3)
+@Threads(1)
+@State(Scope.Thread)
+public class ClientRequestQueryAliasBenchmark {
+    private static final URI BASE_URI = URI.create("https://base.example/root");
+    private static final WebClientConfig CLIENT_CONFIG = WebClientConfig.create();
+
+    @Param({"4", "32"})
+    public int queryParamCount;
+
+    @Benchmark
+    public String encodedAliasReplay() {
+        StringBuilder template = new StringBuilder("https://{host}/items/{id}?");
+        for (int i = 0; i < queryParamCount; i++) {
+            if (i > 0) {
+                template.append('&');
+            }
+            template.append("%61").append(i).append("=template");
+        }
+        FakeClientRequest request = new FakeClientRequest(ClientUri.create(BASE_URI));
+        request.uri(template.toString())
+                .pathParam("host", "other.example")
+                .pathParam("id", "one")
+                .skipUriEncoding(true);
+        for (int i = 0; i < queryParamCount; i++) {
+            request.queryParam("a" + i, "request" + i);
+        }
+        return request
+                .resolvedUri()
+                .pathWithQueryAndFragment();
+    }
+
+    private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
+        private FakeClientRequest(ClientUri clientUri) {
+            super(CLIENT_CONFIG, null, "jmh", Method.GET, clientUri, Collections.emptyMap());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            return null;
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            return null;
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryBenchmark.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.http.Method;
+import io.helidon.webclient.api.ClientRequest.OutputStreamHandler;
+import io.helidon.webclient.api.ClientRequestBase;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.WebClientConfig;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(3)
+@Threads(1)
+@State(Scope.Thread)
+public class ClientRequestQueryBenchmark {
+    private static final URI BASE_URI = URI.create("https://base.example/root?inherited=base");
+    private static final WebClientConfig CLIENT_CONFIG = WebClientConfig.create();
+
+    @Param({"1", "4"})
+    public int queryParamCount;
+
+    @Benchmark
+    public String nonTemplate() {
+        FakeClientRequest request = newRequest();
+        request.uri(URI.create("https://base.example/items"));
+        addQueryParams(request);
+        return request.resolvedUri().pathWithQueryAndFragment();
+    }
+
+    @Benchmark
+    public String relativeTemplate() {
+        FakeClientRequest request = newRequest();
+        request.uri("/items/{id}");
+        request.pathParam("id", "one");
+        addQueryParams(request);
+        return request.resolvedUri().pathWithQueryAndFragment();
+    }
+
+    @Benchmark
+    public String relativeTemplateSkipEncoding() {
+        FakeClientRequest request = newRequest();
+        request.uri("/items/{id}");
+        request.pathParam("id", "one");
+        request.skipUriEncoding(true);
+        addQueryParams(request);
+        return request.resolvedUri().pathWithQueryAndFragment();
+    }
+
+    @Benchmark
+    public String absoluteTemplate() {
+        FakeClientRequest request = newRequest();
+        request.uri("https://{host}/items/{id}?template=value");
+        request.pathParam("host", "other.example");
+        request.pathParam("id", "one");
+        addQueryParams(request);
+        return request.resolvedUri().pathWithQueryAndFragment();
+    }
+
+    private FakeClientRequest newRequest() {
+        return new FakeClientRequest(ClientUri.create(BASE_URI));
+    }
+
+    private void addQueryParams(FakeClientRequest request) {
+        for (int i = 0; i < queryParamCount; i++) {
+            request.queryParam("request" + i, "value" + i);
+        }
+    }
+
+    private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
+        private FakeClientRequest(ClientUri clientUri) {
+            super(CLIENT_CONFIG, null, "jmh", Method.GET, clientUri, Collections.emptyMap());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            return null;
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            return null;
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientSecurityQueryBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientSecurityQueryBenchmark.java
@@ -101,8 +101,8 @@ public class WebClientSecurityQueryBenchmark {
             uri.writeableQuery().set("four", "valueFour");
         } else {
             uri.writeableQuery().set("one", "value%2Fone");
-            uri.writeableQuery().set("two", "value#two");
-            uri.writeableQuery().set("three", "value three");
+            uri.writeableQuery().set("two", "value%23two");
+            uri.writeableQuery().set("three", "value%20three");
             uri.writeableQuery().set("four", "value+four");
         }
         environment = null;

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientSecurityQueryBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientSecurityQueryBenchmark.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.context.Context;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
+import io.helidon.security.OutboundSecurityResponse;
+import io.helidon.security.Security;
+import io.helidon.security.SecurityEnvironment;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+import io.helidon.webclient.security.WebClientSecurity;
+import io.helidon.webclient.spi.WebClientService;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(3)
+@Threads(1)
+@State(Scope.Thread)
+public class WebClientSecurityQueryBenchmark {
+    private static final URI TARGET_URI = URI.create("https://example.test/items");
+    private static final ClientRequestHeaders HEADERS = ClientRequestHeaders.create(WritableHeaders.create());
+    private static final WebClientService.Chain CHAIN = request -> null;
+
+    private WebClientSecurity service;
+    private Context context;
+    private SecurityEnvironment environment;
+
+    @Setup
+    public void setup() {
+        Security security = Security.builder()
+                .addOutboundSecurityProvider((request, environment, config) -> {
+                    this.environment = environment;
+                    return OutboundSecurityResponse.abstain();
+                })
+                .build();
+        context = Context.create();
+        context.register(security.contextBuilder("jmh").build());
+        service = WebClientSecurity.create();
+    }
+
+    @Benchmark
+    public String defaultEncoding() {
+        return applySecurity(false, false);
+    }
+
+    @Benchmark
+    public String skipEncoding() {
+        return applySecurity(true, false);
+    }
+
+    @Benchmark
+    public String skipEncodingPlain() {
+        return applySecurity(true, true);
+    }
+
+    private String applySecurity(boolean skipEncoding, boolean plainValues) {
+        ClientUri uri = ClientUri.create(TARGET_URI);
+        uri.skipUriEncoding(skipEncoding);
+        if (plainValues) {
+            uri.writeableQuery().set("one", "valueOne");
+            uri.writeableQuery().set("two", "valueTwo");
+            uri.writeableQuery().set("three", "valueThree");
+            uri.writeableQuery().set("four", "valueFour");
+        } else {
+            uri.writeableQuery().set("one", "value%2Fone");
+            uri.writeableQuery().set("two", "value#two");
+            uri.writeableQuery().set("three", "value three");
+            uri.writeableQuery().set("four", "value+four");
+        }
+        environment = null;
+        service.handle(CHAIN, new BenchmarkServiceRequest(uri, context));
+        return environment.requestedQuery().orElseThrow().rawValue();
+    }
+
+    private static final class BenchmarkServiceRequest implements WebClientServiceRequest {
+        private final ClientUri uri;
+        private final Context context;
+        private String requestId = "jmh";
+
+        private BenchmarkServiceRequest(ClientUri uri, Context context) {
+            this.uri = uri;
+            this.context = context;
+        }
+
+        @Override
+        public ClientUri uri() {
+            return uri;
+        }
+
+        @Override
+        public Method method() {
+            return Method.GET;
+        }
+
+        @Override
+        public String protocolId() {
+            return "http/1.1";
+        }
+
+        @Override
+        public ClientRequestHeaders headers() {
+            return HEADERS;
+        }
+
+        @Override
+        public Context context() {
+            return context;
+        }
+
+        @Override
+        public String requestId() {
+            return requestId;
+        }
+
+        @Override
+        public void requestId(String requestId) {
+            this.requestId = requestId;
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceRequest> whenSent() {
+            return CompletableFuture.completedStage(this);
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceResponse> whenComplete() {
+            return CompletableFuture.completedStage(null);
+        }
+
+        @Override
+        public Map<String, String> properties() {
+            return Map.of();
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryJmhRunnerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+class ClientRequestQueryJmhRunnerTest {
+    @Test
+    void runExactBenchmark() throws RunnerException {
+        Options options = new OptionsBuilder()
+                .include("^" + Pattern.quote(ClientRequestQueryBenchmark.class.getName())
+                                 + "\\.(nonTemplate|relativeTemplate|relativeTemplateSkipEncoding|absoluteTemplate)$")
+                .include("^" + Pattern.quote(WebClientSecurityQueryBenchmark.class.getName())
+                                 + "\\.(defaultEncoding|skipEncoding|skipEncodingPlain)$")
+                .include("^" + Pattern.quote(ClientRequestQueryAliasBenchmark.class.getName())
+                                 + "\\.encodedAliasReplay$")
+                .forks(1)
+                .warmupIterations(3)
+                .measurementIterations(5)
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .result("target/client-request-query-jmh.json")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryJmhRunnerTest.java
@@ -28,6 +28,15 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 class ClientRequestQueryJmhRunnerTest {
     @Test
+    void securityBenchmarksAreExecutable() {
+        WebClientSecurityQueryBenchmark benchmark = new WebClientSecurityQueryBenchmark();
+        benchmark.setup();
+        benchmark.defaultEncoding();
+        benchmark.skipEncoding();
+        benchmark.skipEncodingPlain();
+    }
+
+    @Test
     void runExactBenchmark() throws RunnerException {
         Options options = new OptionsBuilder()
                 .include("^" + Pattern.quote(ClientRequestQueryBenchmark.class.getName())

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -295,14 +295,17 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
 
     @Override
     public T queryParam(String name, String... values) {
-        if (uriTemplate != null) {
-            if (uriTemplateQueryParamNames == null) {
-                uriTemplateQueryParamNames = new HashSet<>();
-                uriTemplateQuerySnapshot = UriQueryWriteable.create().from(clientUri.query());
-            }
+        UriQueryWriteable querySnapshot = uriTemplate != null && uriTemplateQueryParamNames == null
+                ? UriQueryWriteable.create().from(clientUri.query())
+                : null;
+        clientUri.writeableQuery().set(name, values);
+        if (querySnapshot != null) {
+            uriTemplateQueryParamNames = new HashSet<>();
+            uriTemplateQuerySnapshot = querySnapshot;
+        }
+        if (uriTemplateQueryParamNames != null) {
             uriTemplateQueryParamNames.add(name);
         }
-        clientUri.writeableQuery().set(name, values);
         return identity();
     }
 

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -293,9 +293,6 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                 uriTemplateQueryParamNames = new HashSet<>();
             }
             uriTemplateQueryParamNames.add(name);
-            if (uriTemplateQueryParamNames.size() > clientUri.query().size()) {
-                uriTemplateQueryParamNames.retainAll(clientUri.query().names());
-            }
         }
         return identity();
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -291,10 +291,11 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         if (uriTemplate != null) {
             if (uriTemplateQueryParamNames == null) {
                 uriTemplateQueryParamNames = new HashSet<>();
-            } else {
-                uriTemplateQueryParamNames.retainAll(clientUri.query().names());
             }
             uriTemplateQueryParamNames.add(name);
+            if (uriTemplateQueryParamNames.size() > clientUri.query().size()) {
+                uriTemplateQueryParamNames.retainAll(clientUri.query().names());
+            }
         }
         return identity();
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -91,6 +91,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private SocketAddress socketAddress;
     private String uriTemplate;
     private Set<String> uriTemplateQueryParamNames;
+    private UriQueryWriteable uriTemplateQuerySnapshot;
     private boolean crossOriginRedirect;
     private boolean skipUriEncoding;
     private boolean followRedirects;
@@ -195,6 +196,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     public T uri(URI uri) {
         this.uriTemplate = null;
         this.uriTemplateQueryParamNames = null;
+        this.uriTemplateQuerySnapshot = null;
         this.clientUri.resolve(uri);
         return identity();
     }
@@ -219,6 +221,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     public T uri(ClientUri uri) {
         this.uriTemplate = null;
         this.uriTemplateQueryParamNames = null;
+        this.uriTemplateQuerySnapshot = null;
         this.clientUri.resolve(uri);
         return identity();
     }
@@ -232,8 +235,13 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T uri(String uri) {
         if (uri.indexOf('{') > -1) {
+            if (this.uriTemplate != null && uriTemplateQuerySnapshot != null) {
+                this.clientUri.writeableQuery().clear();
+                this.clientUri.writeableQuery().from(uriTemplateQuerySnapshot);
+            }
             this.uriTemplate = uri;
             this.uriTemplateQueryParamNames = null;
+            this.uriTemplateQuerySnapshot = null;
         } else {
             uri(URI.create(UriEncoding.encodeUri(uri)));
         }
@@ -287,13 +295,14 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
 
     @Override
     public T queryParam(String name, String... values) {
-        clientUri.writeableQuery().set(name, values);
         if (uriTemplate != null) {
             if (uriTemplateQueryParamNames == null) {
                 uriTemplateQueryParamNames = new HashSet<>();
+                uriTemplateQuerySnapshot = UriQueryWriteable.create().from(clientUri.query());
             }
             uriTemplateQueryParamNames.add(name);
         }
+        clientUri.writeableQuery().set(name, values);
         return identity();
     }
 

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -40,7 +41,7 @@ import io.helidon.common.context.Contexts;
 import io.helidon.common.tls.Tls;
 import io.helidon.common.uri.UriEncoding;
 import io.helidon.common.uri.UriFragment;
-import io.helidon.common.uri.UriQuery;
+import io.helidon.common.uri.UriQueryWriteable;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
@@ -89,6 +90,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
 
     private SocketAddress socketAddress;
     private String uriTemplate;
+    private Set<String> uriTemplateQueryParamNames;
     private boolean crossOriginRedirect;
     private boolean skipUriEncoding;
     private boolean followRedirects;
@@ -192,6 +194,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T uri(URI uri) {
         this.uriTemplate = null;
+        this.uriTemplateQueryParamNames = null;
         this.clientUri.resolve(uri);
         return identity();
     }
@@ -215,6 +218,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T uri(ClientUri uri) {
         this.uriTemplate = null;
+        this.uriTemplateQueryParamNames = null;
         this.clientUri.resolve(uri);
         return identity();
     }
@@ -229,6 +233,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     public T uri(String uri) {
         if (uri.indexOf('{') > -1) {
             this.uriTemplate = uri;
+            this.uriTemplateQueryParamNames = null;
         } else {
             uri(URI.create(UriEncoding.encodeUri(uri)));
         }
@@ -283,6 +288,14 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T queryParam(String name, String... values) {
         clientUri.writeableQuery().set(name, values);
+        if (uriTemplate != null) {
+            if (uriTemplateQueryParamNames == null) {
+                uriTemplateQueryParamNames = new HashSet<>();
+            } else {
+                uriTemplateQueryParamNames.retainAll(clientUri.query().names());
+            }
+            uriTemplateQueryParamNames.add(name);
+        }
         return identity();
     }
 
@@ -574,6 +587,15 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
      */
     protected ClientUri resolveUri(ClientUri toResolve) {
         if (uriTemplate != null) {
+            Map<String, String[]> requestQueryParams = null;
+            if (uriTemplateQueryParamNames != null) {
+                requestQueryParams = new HashMap<>();
+                Set<String> queryNames = clientUri.query().names();
+                uriTemplateQueryParamNames.retainAll(queryNames);
+                for (String name : uriTemplateQueryParamNames) {
+                    requestQueryParams.put(name, clientUri.query().all(name).toArray(String[]::new));
+                }
+            }
             String resolved = resolvePathParams(uriTemplate);
             URI uri;
             if (skipUriEncoding) {
@@ -583,11 +605,9 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
             }
             toResolve.resolve(uri);
 
-            if (uri.isAbsolute()) { // query parameters are cleared when resolving against absolute URIs
-                UriQuery query = clientUri.query();
-                if (!query.isEmpty()) {
-                    toResolve.writeableQuery().from(query);
-                }
+            if (requestQueryParams != null) {
+                UriQueryWriteable query = toResolve.writeableQuery();
+                requestQueryParams.forEach(query::set);
             }
         }
         return toResolve;

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -41,7 +40,6 @@ import io.helidon.common.context.Contexts;
 import io.helidon.common.tls.Tls;
 import io.helidon.common.uri.UriEncoding;
 import io.helidon.common.uri.UriFragment;
-import io.helidon.common.uri.UriQueryWriteable;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
@@ -89,9 +87,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private final boolean filterRedirectHeaders;
 
     private SocketAddress socketAddress;
-    private String uriTemplate;
-    private Set<String> uriTemplateQueryParamNames;
-    private UriQueryWriteable uriTemplateQuerySnapshot;
+    private UriTemplateQuery uriTemplate;
     private boolean crossOriginRedirect;
     private boolean skipUriEncoding;
     private boolean followRedirects;
@@ -195,8 +191,6 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T uri(URI uri) {
         this.uriTemplate = null;
-        this.uriTemplateQueryParamNames = null;
-        this.uriTemplateQuerySnapshot = null;
         this.clientUri.resolve(uri);
         return identity();
     }
@@ -220,8 +214,6 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T uri(ClientUri uri) {
         this.uriTemplate = null;
-        this.uriTemplateQueryParamNames = null;
-        this.uriTemplateQuerySnapshot = null;
         this.clientUri.resolve(uri);
         return identity();
     }
@@ -235,13 +227,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T uri(String uri) {
         if (uri.indexOf('{') > -1) {
-            if (this.uriTemplate != null && uriTemplateQuerySnapshot != null) {
-                this.clientUri.writeableQuery().clear();
-                this.clientUri.writeableQuery().from(uriTemplateQuerySnapshot);
-            }
-            this.uriTemplate = uri;
-            this.uriTemplateQueryParamNames = null;
-            this.uriTemplateQuerySnapshot = null;
+            this.uriTemplate = new UriTemplateQuery(uri);
         } else {
             uri(URI.create(UriEncoding.encodeUri(uri)));
         }
@@ -295,16 +281,10 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
 
     @Override
     public T queryParam(String name, String... values) {
-        UriQueryWriteable querySnapshot = uriTemplate != null && uriTemplateQueryParamNames == null
-                ? UriQueryWriteable.create().from(clientUri.query())
-                : null;
         clientUri.writeableQuery().set(name, values);
-        if (querySnapshot != null) {
-            uriTemplateQueryParamNames = new HashSet<>();
-            uriTemplateQuerySnapshot = querySnapshot;
-        }
-        if (uriTemplateQueryParamNames != null) {
-            uriTemplateQueryParamNames.add(name);
+        UriTemplateQuery templateQuery = uriTemplate;
+        if (templateQuery != null) {
+            templateQuery.trackQueryParam(name);
         }
         return identity();
     }
@@ -596,29 +576,21 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
      * @return updated client uri
      */
     protected ClientUri resolveUri(ClientUri toResolve) {
-        if (uriTemplate != null) {
-            Map<String, String[]> requestQueryParams = null;
-            if (uriTemplateQueryParamNames != null) {
-                requestQueryParams = new HashMap<>();
-                Set<String> queryNames = clientUri.query().names();
-                for (String name : uriTemplateQueryParamNames) {
-                    if (queryNames.contains(name)) {
-                        requestQueryParams.put(name, clientUri.query().all(name).toArray(String[]::new));
-                    }
-                }
-            }
-            String resolved = resolvePathParams(uriTemplate);
+        UriTemplateQuery templateQuery = uriTemplate;
+        if (templateQuery != null) {
+            String resolved = resolvePathParams(templateQuery.template());
             URI uri;
             if (skipUriEncoding) {
                 uri = URI.create(resolved);
             } else {
                 uri = URI.create(UriEncoding.encodeUri(resolved));
             }
+            boolean replayQuery = skipUriEncoding || uri.isAbsolute();
+            ClientUri querySource = replayQuery && toResolve == clientUri ? ClientUri.create(clientUri) : clientUri;
             toResolve.resolve(uri);
 
-            if (requestQueryParams != null) {
-                UriQueryWriteable query = toResolve.writeableQuery();
-                requestQueryParams.forEach(query::set);
+            if (replayQuery) {
+                templateQuery.replay(querySource.query(), toResolve.writeableQuery(), uri.isAbsolute());
             }
         }
         return toResolve;
@@ -675,4 +647,5 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private T identity() {
         return (T) this;
     }
+
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -40,6 +40,7 @@ import io.helidon.common.context.Contexts;
 import io.helidon.common.tls.Tls;
 import io.helidon.common.uri.UriEncoding;
 import io.helidon.common.uri.UriFragment;
+import io.helidon.common.uri.UriQuery;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
@@ -574,10 +575,19 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     protected ClientUri resolveUri(ClientUri toResolve) {
         if (uriTemplate != null) {
             String resolved = resolvePathParams(uriTemplate);
+            URI uri;
             if (skipUriEncoding) {
-                toResolve.resolve(URI.create(resolved));
+                uri = URI.create(resolved);
             } else {
-                toResolve.resolve(URI.create(UriEncoding.encodeUri(resolved)));
+                uri = URI.create(UriEncoding.encodeUri(resolved));
+            }
+            toResolve.resolve(uri);
+
+            if (uri.isAbsolute()) { // query parameters are cleared when resolving against absolute URIs
+                UriQuery query = clientUri.query();
+                if (!query.isEmpty()) {
+                    toResolve.writeableQuery().from(query);
+                }
             }
         }
         return toResolve;

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -598,9 +598,10 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
             if (uriTemplateQueryParamNames != null) {
                 requestQueryParams = new HashMap<>();
                 Set<String> queryNames = clientUri.query().names();
-                uriTemplateQueryParamNames.retainAll(queryNames);
                 for (String name : uriTemplateQueryParamNames) {
-                    requestQueryParams.put(name, clientUri.query().all(name).toArray(String[]::new));
+                    if (queryNames.contains(name)) {
+                        requestQueryParams.put(name, clientUri.query().all(name).toArray(String[]::new));
+                    }
                 }
             }
             String resolved = resolvePathParams(uriTemplate);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientUri.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientUri.java
@@ -18,6 +18,7 @@ package io.helidon.webclient.api;
 
 import java.net.URI;
 
+import io.helidon.common.Api;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriInfo;
 import io.helidon.common.uri.UriPath;
@@ -250,6 +251,16 @@ public class ClientUri implements UriInfo {
     @Override
     public UriQuery query() {
         return query;
+    }
+
+    /**
+     * Query as serialized into the HTTP request target.
+     *
+     * @return request target query
+     */
+    @Api.Internal
+    public UriQuery requestTargetQuery() {
+        return skipUriEncoding ? UriQuery.create(query.value()) : query;
     }
 
     /**

--- a/webclient/api/src/main/java/io/helidon/webclient/api/UriTemplateQuery.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/UriTemplateQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.uri.UriQuery;
+import io.helidon.common.uri.UriQueryWriteable;
+
+final class UriTemplateQuery {
+    private final String template;
+
+    private Set<String> queryParamNames;
+
+    UriTemplateQuery(String template) {
+        this.template = template;
+    }
+
+    String template() {
+        return template;
+    }
+
+    void replay(UriQuery source, UriQueryWriteable target, boolean absolute) {
+        Set<String> names = queryParamNames;
+        if (names == null) {
+            return;
+        }
+        for (String name : names) {
+            if (!containsDecodedName(source, name)) {
+                continue;
+            }
+            List<String> sourceValues = source.all(name);
+            if (absolute
+                    || !containsDecodedName(target, name)
+                    || !target.all(name).equals(sourceValues)) {
+                target.set(name, sourceValues.toArray(String[]::new));
+            }
+        }
+    }
+
+    void trackQueryParam(String name) {
+        Set<String> names = queryParamNames;
+        if (names == null) {
+            names = new LinkedHashSet<>();
+            queryParamNames = names;
+        }
+        names.add(name);
+    }
+
+    private static boolean containsDecodedName(UriQuery query, String name) {
+        if (name.indexOf('%') >= 0 || name.indexOf('+') >= 0) {
+            return query.names().contains(name);
+        }
+        return query.contains(name) || query.names().contains(name);
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import io.helidon.common.uri.UriPath;
+import io.helidon.http.Method;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ClientRequestBaseTest {
+
+    /**
+     * Verify that query parameters are preserved when resolving URI templates (cf. issue #8566).
+     * Make sure to test both absolute and relative URIs as they are handled differently when resolving.
+     */
+    @Test
+    public void resolvedUriTest() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/")
+                .queryParam("k", "v").resolvedUri();
+        assertThat(uri.authority(), is("www.example.com:443"));
+        assertThat(uri.host(), is("www.example.com"));
+        assertThat(uri.path(), is(UriPath.root()));
+        assertThat(uri.port(), is(443));
+        assertThat(uri.scheme(), is("https"));
+        assertThat(uri.query().get("k"), is("v"));
+
+        uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("k", "v").resolvedUri();
+        assertThat(uri.authority(), is("www.example.com:443"));
+        assertThat(uri.host(), is("www.example.com"));
+        assertThat(uri.path(), is(UriPath.create("/p")));
+        assertThat(uri.port(), is(443));
+        assertThat(uri.scheme(), is("https"));
+        assertThat(uri.query().get("k"), is("v"));
+
+        uri = new FakeClientRequest()
+                .uri("example/{path}")
+                .pathParam("path", "p")
+                .queryParam("k", "v").resolvedUri();
+        assertThat(uri.authority(), is("localhost:80"));
+        assertThat(uri.host(), is("localhost"));
+        assertThat(uri.path(), is(UriPath.create("/example/p")));
+        assertThat(uri.port(), is(80));
+        assertThat(uri.scheme(), is("http"));
+        assertThat(uri.query().get("k"), is("v"));
+
+        uri = new FakeClientRequest()
+                .uri("https://www.example.com/p?k={k}")
+                .pathParam("k", "v")
+                .queryParam("k", "v").resolvedUri();
+        assertThat(uri.authority(), is("www.example.com:443"));
+        assertThat(uri.host(), is("www.example.com"));
+        assertThat(uri.path(), is(UriPath.create("/p%3Fk=v")));
+        assertThat(uri.port(), is(443));
+        assertThat(uri.scheme(), is("https"));
+        assertThat(uri.query().get("k"), is("v"));
+    }
+
+
+    private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
+        private FakeClientRequest() {
+            super(WebClientConfig.create(), null, "fake", Method.GET, ClientUri.create(), Collections.emptyMap());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            return null;
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            return null;
+        }
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -186,6 +186,20 @@ class ClientRequestBaseTest {
     }
 
     @Test
+    void rejectedQueryParamDoesNotArmInheritedQuery() {
+        ClientUri baseUri = ClientUri.create(URI.create("https://trusted.example/base?access_token=secret"));
+        FakeClientRequest request = new FakeClientRequest(baseUri)
+                .uri("https://{host}/path")
+                .pathParam("host", "other.example");
+
+        assertThrows(NullPointerException.class, () -> request.queryParam("access_token", (String) null));
+
+        ClientUri uri = request.resolvedUri();
+        assertThat(uri.authority(), is("other.example:443"));
+        assertThat(uri.query().contains("access_token"), is(false));
+    }
+
+    @Test
     void templateQueryResolutionIsRepeatableAndAliasSafe() {
         FakeClientRequest request = new FakeClientRequest()
                 .uri("https://www.example.com/{path}")

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -202,6 +202,22 @@ class ClientRequestBaseTest {
         assertThat(request.resolvedUri().query().all("access_token"), is(List.of("template")));
     }
 
+    @Test
+    void subsequentQueryParamPrunesRemovedRequestQueryParam() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?access_token=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("access_token", "secret");
+        request.uri().writeableQuery().remove("access_token");
+        request.queryParam("request", "value");
+        request.uri().writeableQuery().set("access_token", "replacement");
+
+        ClientUri resolved = request.resolvedUri();
+        assertThat(resolved.query().all("access_token"), is(List.of("template")));
+        assertThat(resolved.query().all("request"), is(List.of("value")));
+    }
+
     private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
         private FakeClientRequest() {
             this(ClientUri.create());

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -110,6 +110,20 @@ class ClientRequestBaseTest {
     }
 
     @Test
+    void requestQueryOverridesEquivalentEncodedTemplateQueryName() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?%61=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("a", "request")
+                .resolvedUri();
+
+        assertThat(uri.query().all("a"), is(List.of("request")));
+        assertThat(uri.query().rawValue(), is("a=request"));
+        assertThat(uri.pathWithQueryAndFragment(), is("/p?a=request"));
+    }
+
+    @Test
     void replacingTemplateDoesNotCarryEarlierQueryParam() {
         ClientUri uri = new FakeClientRequest()
                 .uri("https://www.example.com/{path}")

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -97,6 +97,53 @@ class ClientRequestBaseTest {
     }
 
     @Test
+    void requestQueryOverridesRelativeTemplateQueryWhenEncodingIsConfiguredLater() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("example/{path}?k=template")
+                .pathParam("path", "p")
+                .queryParam("k", "request")
+                .skipUriEncoding(true)
+                .resolvedUri();
+
+        assertThat(uri.path(), is(UriPath.create("/example/p")));
+        assertThat(uri.query().all("k"), is(List.of("request")));
+    }
+
+    @Test
+    void multipleRequestQueryParamsArePreserved() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("one", "1")
+                .queryParam("two", "2")
+                .queryParam("three", "3")
+                .queryParam("four", "4")
+                .queryParam("five", "5")
+                .queryParam("one", "replacement")
+                .resolvedUri();
+
+        assertThat(uri.query().all("one"), is(List.of("replacement")));
+        assertThat(uri.query().all("two"), is(List.of("2")));
+        assertThat(uri.query().all("three"), is(List.of("3")));
+        assertThat(uri.query().all("four"), is(List.of("4")));
+        assertThat(uri.query().all("five"), is(List.of("5")));
+    }
+
+    @Test
+    void requestQueryCoexistsWithRelativeTemplateQuery() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("example/{path}?template=value")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("request", "value")
+                .resolvedUri();
+
+        assertThat(uri.path(), is(UriPath.create("/example/p")));
+        assertThat(uri.query().all("template"), is(List.of("value")));
+        assertThat(uri.query().all("request"), is(List.of("value")));
+    }
+
+    @Test
     void requestQueryOverridesEncodedTemplateQueryName() {
         ClientUri uri = new FakeClientRequest()
                 .uri("https://www.example.com/{path}?a%20b=template")
@@ -138,7 +185,7 @@ class ClientRequestBaseTest {
     }
 
     @Test
-    void replacingRelativeTemplateRestoresBaseQuery() {
+    void replacingRelativeTemplateRetainsEarlierQueryParams() {
         ClientUri baseUri = ClientUri.create(URI.create("https://www.example.com/base?k=base&unrelated=value"));
         ClientUri uri = new FakeClientRequest(baseUri)
                 .uri("first/{path}")
@@ -150,14 +197,14 @@ class ClientRequestBaseTest {
                 .queryParam("new", "value")
                 .resolvedUri();
 
-        assertThat(uri.query().all("k"), is(List.of("base")));
+        assertThat(uri.query().all("k"), is(List.of("old")));
         assertThat(uri.query().all("unrelated"), is(List.of("value")));
-        assertThat(uri.query().contains("old"), is(false));
+        assertThat(uri.query().all("old"), is(List.of("value")));
         assertThat(uri.query().all("new"), is(List.of("value")));
     }
 
     @Test
-    void replacingRelativeTemplateRestoresEncodedBaseQueryName() {
+    void replacingRelativeTemplateRetainsReplacementForEncodedBaseQueryName() {
         ClientUri baseUri = ClientUri.create(URI.create("https://www.example.com/base?%61=base"));
         ClientUri uri = new FakeClientRequest(baseUri)
                 .uri("first/{path}")
@@ -167,8 +214,8 @@ class ClientRequestBaseTest {
                 .pathParam("replacement", "p")
                 .resolvedUri();
 
-        assertThat(uri.query().all("a"), is(List.of("base")));
-        assertThat(uri.query().rawValue(), is("%61=base"));
+        assertThat(uri.query().all("a"), is(List.of("old")));
+        assertThat(uri.query().rawValue(), is("a=old"));
     }
 
     @Test
@@ -186,6 +233,80 @@ class ClientRequestBaseTest {
     }
 
     @Test
+    void directQueryMutationIsNotPromotedToTemplateRequestParam() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p");
+        request.uri().writeableQuery().set("direct", "value");
+
+        assertThat(request.resolvedUri().query().contains("direct"), is(false));
+    }
+
+    @Test
+    void queryParamConfiguredBeforeTemplateIsNotPromoted() {
+        ClientUri uri = new FakeClientRequest()
+                .queryParam("before", "value")
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .resolvedUri();
+
+        assertThat(uri.query().contains("before"), is(false));
+    }
+
+    @Test
+    void queryParamConfiguredBeforeRelativeTemplateIsRetained() {
+        ClientUri uri = new FakeClientRequest()
+                .queryParam("before", "value")
+                .uri("example/{path}")
+                .pathParam("path", "p")
+                .resolvedUri();
+
+        assertThat(uri.query().all("before"), is(List.of("value")));
+    }
+
+    @Test
+    void directQueryMutationRetainsRelativeTemplateBehavior() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("example/{path}")
+                .pathParam("path", "p");
+        request.uri().writeableQuery().set("direct", "value");
+
+        assertThat(request.resolvedUri().query().all("direct"), is(List.of("value")));
+    }
+
+    @Test
+    void defaultEncodingKeepsTemplateQueryInPath() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?template=value")
+                .pathParam("path", "p")
+                .queryParam("request", "value")
+                .resolvedUri();
+
+        assertThat(uri.pathWithQueryAndFragment(), is("/p%3Ftemplate=value?request=value"));
+    }
+
+    @Test
+    void requestQueryCoexistsWithAbsoluteTemplateQueryForEitherEncodingOrder() {
+        ClientUri encodingFirst = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?template=value")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("request", "value")
+                .resolvedUri();
+        ClientUri encodingLast = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?template=value")
+                .pathParam("path", "p")
+                .queryParam("request", "value")
+                .skipUriEncoding(true)
+                .resolvedUri();
+
+        assertThat(encodingFirst.query().all("template"), is(List.of("value")));
+        assertThat(encodingFirst.query().all("request"), is(List.of("value")));
+        assertThat(encodingLast.query().all("template"), is(List.of("value")));
+        assertThat(encodingLast.query().all("request"), is(List.of("value")));
+    }
+
+    @Test
     void rejectedQueryParamDoesNotArmInheritedQuery() {
         ClientUri baseUri = ClientUri.create(URI.create("https://trusted.example/base?access_token=secret"));
         FakeClientRequest request = new FakeClientRequest(baseUri)
@@ -197,6 +318,20 @@ class ClientRequestBaseTest {
         ClientUri uri = request.resolvedUri();
         assertThat(uri.authority(), is("other.example:443"));
         assertThat(uri.query().contains("access_token"), is(false));
+    }
+
+    @Test
+    void rejectedQueryParamDoesNotDiscardEarlierTrackedName() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("accepted", "value");
+
+        assertThrows(NullPointerException.class, () -> request.queryParam("rejected", (String) null));
+
+        ClientUri uri = request.resolvedUri();
+        assertThat(uri.query().all("accepted"), is(List.of("value")));
+        assertThat(uri.query().contains("rejected"), is(false));
     }
 
     @Test
@@ -232,7 +367,19 @@ class ClientRequestBaseTest {
     }
 
     @Test
-    void removedRequestQueryParamCanBeAddedAgain() {
+    void rawAliasDoesNotMasqueradeAsTrackedDecodedName() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("%61", "request");
+        request.uri().writeableQuery().clear();
+        request.uri().writeableQuery().fromQueryString("%61=raw");
+
+        assertThat(request.resolvedUri().query().isEmpty(), is(true));
+    }
+
+    @Test
+    void resolvedUriDoesNotChangeTemplateQueryTracking() {
         FakeClientRequest request = new FakeClientRequest()
                 .uri("https://www.example.com/{path}?access_token=template")
                 .pathParam("path", "p")
@@ -262,6 +409,21 @@ class ClientRequestBaseTest {
         request.pathParam("path", "p");
 
         assertThat(request.resolvedUri().query().all("access_token"), is(List.of("replacement")));
+    }
+
+    @Test
+    void relativeTemplateQueryResolutionIsRepeatable() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("example/{path}?template=value")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("request", "value");
+
+        ClientUri first = request.resolvedUri();
+        ClientUri second = request.resolvedUri();
+        assertThat(second.query().rawValue(), is(first.query().rawValue()));
+        assertThat(second.query().all("template"), is(List.of("value")));
+        assertThat(second.query().all("request"), is(List.of("value")));
     }
 
     private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -218,7 +218,7 @@ class ClientRequestBaseTest {
     }
 
     @Test
-    void removedRequestQueryParamIsNoLongerTracked() {
+    void removedRequestQueryParamCanBeAddedAgain() {
         FakeClientRequest request = new FakeClientRequest()
                 .uri("https://www.example.com/{path}?access_token=template")
                 .pathParam("path", "p")
@@ -230,11 +230,11 @@ class ClientRequestBaseTest {
 
         request.uri().writeableQuery().set("access_token", "replacement");
 
-        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("template")));
+        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("replacement")));
     }
 
     @Test
-    void failedTemplateResolutionPrunesRemovedRequestQueryParam() {
+    void failedTemplateResolutionDoesNotChangeTrackedQueryParams() {
         FakeClientRequest request = new FakeClientRequest()
                 .uri("https://www.example.com/{path}?access_token=template")
                 .pathParam("path", "{invalid")
@@ -247,7 +247,7 @@ class ClientRequestBaseTest {
         request.uri().writeableQuery().set("access_token", "replacement");
         request.pathParam("path", "p");
 
-        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("template")));
+        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("replacement")));
     }
 
     private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,18 @@
 
 package io.helidon.webclient.api;
 
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
 import io.helidon.common.uri.UriPath;
 import io.helidon.http.Method;
-import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ClientRequestBaseTest {
 
@@ -32,7 +36,7 @@ class ClientRequestBaseTest {
      * Make sure to test both absolute and relative URIs as they are handled differently when resolving.
      */
     @Test
-    public void resolvedUriTest() {
+    void resolvedUriTest() {
         ClientUri uri = new FakeClientRequest()
                 .uri("https://www.example.com/")
                 .queryParam("k", "v").resolvedUri();
@@ -64,23 +68,147 @@ class ClientRequestBaseTest {
         assertThat(uri.port(), is(80));
         assertThat(uri.scheme(), is("http"));
         assertThat(uri.query().get("k"), is("v"));
-
-        uri = new FakeClientRequest()
-                .uri("https://www.example.com/p?k={k}")
-                .pathParam("k", "v")
-                .queryParam("k", "v").resolvedUri();
-        assertThat(uri.authority(), is("www.example.com:443"));
-        assertThat(uri.host(), is("www.example.com"));
-        assertThat(uri.path(), is(UriPath.create("/p%3Fk=v")));
-        assertThat(uri.port(), is(443));
-        assertThat(uri.scheme(), is("https"));
-        assertThat(uri.query().get("k"), is("v"));
     }
 
+    @Test
+    void requestQueryOverridesTemplateQuery() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?k=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("k", "request")
+                .resolvedUri();
+
+        assertThat(uri.path(), is(UriPath.create("/p")));
+        assertThat(uri.query().all("k"), is(List.of("request")));
+    }
+
+    @Test
+    void requestQueryOverridesRelativeTemplateQuery() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("example/{path}?k=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("k", "request")
+                .resolvedUri();
+
+        assertThat(uri.path(), is(UriPath.create("/example/p")));
+        assertThat(uri.query().all("k"), is(List.of("request")));
+    }
+
+    @Test
+    void requestQueryOverridesEncodedTemplateQueryName() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?a%20b=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("a b", "request")
+                .resolvedUri();
+
+        assertThat(uri.query().all("a b"), is(List.of("request")));
+        assertThat(uri.query().rawValue(), is("a%20b=request"));
+    }
+
+    @Test
+    void replacingTemplateDoesNotCarryEarlierQueryParam() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .queryParam("old", "value")
+                .uri("https://www.example.com/{replacement}")
+                .pathParam("replacement", "p")
+                .queryParam("new", "value")
+                .resolvedUri();
+
+        assertThat(uri.query().contains("old"), is(false));
+        assertThat(uri.query().all("new"), is(List.of("value")));
+    }
+
+    @Test
+    void inheritedQueryIsNotCopiedToAnotherAuthority() {
+        ClientUri baseUri = ClientUri.create(URI.create("https://trusted.example/base?access_token=secret"));
+        ClientUri uri = new FakeClientRequest(baseUri)
+                .uri("https://{host}/path")
+                .pathParam("host", "other.example")
+                .queryParam("request", "value")
+                .resolvedUri();
+
+        assertThat(uri.authority(), is("other.example:443"));
+        assertThat(uri.query().contains("access_token"), is(false));
+        assertThat(uri.query().all("request"), is(List.of("value")));
+    }
+
+    @Test
+    void templateQueryResolutionIsRepeatableAndAliasSafe() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("request", "value");
+
+        assertThat(request.resolvedUri().query().rawValue(), is("request=value"));
+        assertThat(request.resolvedUri().query().rawValue(), is("request=value"));
+        assertThat(request.resolveUri(request.uri()).query().rawValue(), is("request=value"));
+        assertThat(request.resolveUri(request.uri()).query().rawValue(), is("request=value"));
+    }
+
+    @Test
+    void mutableRequestQueryIsAuthoritative() {
+        FakeClientRequest removed = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("access_token", "secret");
+        removed.uri().writeableQuery().remove("access_token");
+
+        assertThat(removed.resolvedUri().query().contains("access_token"), is(false));
+
+        FakeClientRequest replaced = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("access_token", "secret");
+        replaced.uri().writeableQuery().set("access_token", "replacement");
+
+        assertThat(replaced.resolvedUri().query().all("access_token"), is(List.of("replacement")));
+    }
+
+    @Test
+    void removedRequestQueryParamIsNoLongerTracked() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?access_token=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("access_token", "secret");
+        request.uri().writeableQuery().remove("access_token");
+
+        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("template")));
+
+        request.uri().writeableQuery().set("access_token", "replacement");
+
+        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("template")));
+    }
+
+    @Test
+    void failedTemplateResolutionPrunesRemovedRequestQueryParam() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?access_token=template")
+                .pathParam("path", "{invalid")
+                .skipUriEncoding(true)
+                .queryParam("access_token", "secret");
+        request.uri().writeableQuery().remove("access_token");
+
+        assertThrows(IllegalArgumentException.class, request::resolvedUri);
+
+        request.uri().writeableQuery().set("access_token", "replacement");
+        request.pathParam("path", "p");
+
+        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("template")));
+    }
 
     private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
         private FakeClientRequest() {
-            super(WebClientConfig.create(), null, "fake", Method.GET, ClientUri.create(), Collections.emptyMap());
+            this(ClientUri.create());
+        }
+
+        private FakeClientRequest(ClientUri clientUri) {
+            super(WebClientConfig.create(), null, "fake", Method.GET, clientUri, Collections.emptyMap());
         }
 
         @Override

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -202,22 +202,6 @@ class ClientRequestBaseTest {
         assertThat(request.resolvedUri().query().all("access_token"), is(List.of("template")));
     }
 
-    @Test
-    void subsequentQueryParamPrunesRemovedRequestQueryParam() {
-        FakeClientRequest request = new FakeClientRequest()
-                .uri("https://www.example.com/{path}?access_token=template")
-                .pathParam("path", "p")
-                .skipUriEncoding(true)
-                .queryParam("access_token", "secret");
-        request.uri().writeableQuery().remove("access_token");
-        request.queryParam("request", "value");
-        request.uri().writeableQuery().set("access_token", "replacement");
-
-        ClientUri resolved = request.resolvedUri();
-        assertThat(resolved.query().all("access_token"), is(List.of("template")));
-        assertThat(resolved.query().all("request"), is(List.of("value")));
-    }
-
     private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
         private FakeClientRequest() {
             this(ClientUri.create());

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -138,6 +138,40 @@ class ClientRequestBaseTest {
     }
 
     @Test
+    void replacingRelativeTemplateRestoresBaseQuery() {
+        ClientUri baseUri = ClientUri.create(URI.create("https://www.example.com/base?k=base&unrelated=value"));
+        ClientUri uri = new FakeClientRequest(baseUri)
+                .uri("first/{path}")
+                .pathParam("path", "p")
+                .queryParam("k", "old")
+                .queryParam("old", "value")
+                .uri("second/{replacement}")
+                .pathParam("replacement", "p")
+                .queryParam("new", "value")
+                .resolvedUri();
+
+        assertThat(uri.query().all("k"), is(List.of("base")));
+        assertThat(uri.query().all("unrelated"), is(List.of("value")));
+        assertThat(uri.query().contains("old"), is(false));
+        assertThat(uri.query().all("new"), is(List.of("value")));
+    }
+
+    @Test
+    void replacingRelativeTemplateRestoresEncodedBaseQueryName() {
+        ClientUri baseUri = ClientUri.create(URI.create("https://www.example.com/base?%61=base"));
+        ClientUri uri = new FakeClientRequest(baseUri)
+                .uri("first/{path}")
+                .pathParam("path", "p")
+                .queryParam("a", "old")
+                .uri("second/{replacement}")
+                .pathParam("replacement", "p")
+                .resolvedUri();
+
+        assertThat(uri.query().all("a"), is(List.of("base")));
+        assertThat(uri.query().rawValue(), is("%61=base"));
+    }
+
+    @Test
     void inheritedQueryIsNotCopiedToAnotherAuthority() {
         ClientUri baseUri = ClientUri.create(URI.create("https://trusted.example/base?access_token=secret"));
         ClientUri uri = new FakeClientRequest(baseUri)

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientUriTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientUriTest.java
@@ -84,6 +84,19 @@ class ClientUriTest {
     }
 
     @Test
+    void testRequestTargetQueryUsesConfiguredEncoding() {
+        ClientUri helper = ClientUri.create(URI.create("http://localhost/path"));
+        helper.writeableQuery().set("q", "a#b");
+
+        assertThat(helper.requestTargetQuery().rawValue(), is("q=a%23b"));
+
+        helper.skipUriEncoding(true);
+
+        assertThat(helper.requestTargetQuery().rawValue(), is("q=a#b"));
+        assertThat(helper.query().rawValue(), is("q=a%23b"));
+    }
+
+    @Test
     void testEmptyQueryDelimiter() {
         ClientUri helper = ClientUri.create(URI.create("http://localhost:8080/loom/quick?"));
 

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
@@ -135,6 +135,7 @@ public class WebClientSecurity implements WebClientService {
         OutboundSecurityClientBuilder clientBuilder;
 
         try {
+            UriQuery query = request.uri().query();
             URI targetUri = request.uri().toUri();
             SecurityEnvironment.Builder outboundEnv = context.env()
                     .derive()
@@ -145,11 +146,13 @@ public class WebClientSecurity implements WebClientService {
                     .method(request.method().text())
                     .path(request.uri().path().path())
                     .targetUri(targetUri)
-                    .queryParams(request.uri().query())
+                    .queryParams(query)
                     .requestedMethod(request.method().text())
                     .requestedPath(request.uri().path())
                     .requestedQuery(request.uri().hasQuery()
-                                            ? Optional.of(UriQuery.create(targetUri))
+                                            ? Optional.of(query.rawValue().equals(targetUri.getRawQuery())
+                                                                  ? query
+                                                                  : UriQuery.create(query.value()))
                                             : Optional.empty());
 
             request.headers()

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
@@ -150,9 +150,7 @@ public class WebClientSecurity implements WebClientService {
                     .requestedMethod(request.method().text())
                     .requestedPath(request.uri().path())
                     .requestedQuery(request.uri().hasQuery()
-                                            ? Optional.of(query.rawValue().equals(targetUri.getRawQuery())
-                                                                  ? query
-                                                                  : UriQuery.create(query.value()))
+                                            ? Optional.of(request.uri().requestTargetQuery())
                                             : Optional.empty());
 
             request.headers()

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
@@ -16,6 +16,7 @@
 package io.helidon.webclient.security;
 
 import java.lang.System.Logger.Level;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,6 +24,7 @@ import java.util.UUID;
 
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
+import io.helidon.common.uri.UriQuery;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -133,6 +135,7 @@ public class WebClientSecurity implements WebClientService {
         OutboundSecurityClientBuilder clientBuilder;
 
         try {
+            URI targetUri = request.uri().toUri();
             SecurityEnvironment.Builder outboundEnv = context.env()
                     .derive()
                     .clearHeaders()
@@ -141,12 +144,12 @@ public class WebClientSecurity implements WebClientService {
             outboundEnv.transport(request.uri().scheme())
                     .method(request.method().text())
                     .path(request.uri().path().path())
-                    .targetUri(request.uri().toUri())
+                    .targetUri(targetUri)
                     .queryParams(request.uri().query())
                     .requestedMethod(request.method().text())
                     .requestedPath(request.uri().path())
                     .requestedQuery(request.uri().hasQuery()
-                                            ? Optional.of(request.uri().query())
+                                            ? Optional.of(UriQuery.create(targetUri))
                                             : Optional.empty());
 
             request.headers()

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
@@ -121,6 +121,21 @@ class WebClientSecurityTest {
         assertThat(environment.queryParams().get("q"), is("a%2Fb"));
 
         assertThrows(TestException.class, () -> client.get()
+                .uri("https://example.test/{path}")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("q", "a#b")
+                .request());
+
+        environment = outboundEnvironment.get();
+        assertThat(outboundTarget.get(), is("/p?q=a#b"));
+        assertThat(environment.targetUri().getRawQuery(), is("q=a"));
+        assertThat(environment.targetUri().getRawFragment(), is("b"));
+        assertThat(environment.requestedQuery().orElseThrow().rawValue(), is("q=a#b"));
+        assertThat(environment.queryParams().rawValue(), is("q=a%23b"));
+        assertThat(environment.queryParams().get("q"), is("a#b"));
+
+        assertThrows(TestException.class, () -> client.get()
                 .uri(URI.create("https://example.test/p?"))
                 .request());
 

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.security;
 
+import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.security.OutboundSecurityResponse;
@@ -66,7 +67,67 @@ class WebClientSecurityTest {
         SecurityEnvironment environment = outboundEnvironment.get();
         assertThat(environment.targetUri().getScheme(), is("https"));
         assertThat(environment.transport(), is("https"));
+        assertThat(environment.requestedQuery().isEmpty(), is(true));
         assertThat(outboundConfig.findTarget(environment).isPresent(), is(true));
+    }
+
+    @Test
+    void requestedQueryMatchesSerializedQueryWithoutChangingDefaultEncoding() {
+        AtomicReference<SecurityEnvironment> outboundEnvironment = new AtomicReference<>();
+        AtomicReference<String> outboundTarget = new AtomicReference<>();
+        Security security = Security.builder()
+                .addOutboundSecurityProvider((request, environment, config) -> {
+                    outboundEnvironment.set(environment);
+                    return OutboundSecurityResponse.abstain();
+                })
+                .build();
+        WebClientService stopBeforeNetwork = (chain, request) -> {
+            outboundTarget.set(request.uri().pathWithQueryAndFragment());
+            throw new TestException();
+        };
+        Http1Client client = Http1Client.builder()
+                .servicesDiscoverServices(false)
+                .addService(WebClientSecurity.create(security))
+                .addService(stopBeforeNetwork)
+                .build();
+
+        assertThrows(TestException.class, () -> client.get()
+                .uri("https://example.test/{path}")
+                .pathParam("path", "p")
+                .queryParam("q", "a%2Fb")
+                .request());
+
+        SecurityEnvironment environment = outboundEnvironment.get();
+        assertThat(outboundTarget.get(), is("/p?q=a%252Fb"));
+        assertThat(environment.targetUri().getRawQuery(), is("q=a%252Fb"));
+        assertThat(environment.requestedPath().rawPath(), is("/p"));
+        assertThat(environment.requestedQuery().orElseThrow().rawValue(), is("q=a%252Fb"));
+        assertThat(environment.queryParams().rawValue(), is("q=a%252Fb"));
+        assertThat(environment.queryParams().get("q"), is("a%2Fb"));
+
+        assertThrows(TestException.class, () -> client.get()
+                .uri("https://example.test/{path}")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("q", "a%2Fb")
+                .request());
+
+        environment = outboundEnvironment.get();
+        assertThat(outboundTarget.get(), is("/p?q=a%2Fb"));
+        assertThat(environment.targetUri().getRawQuery(), is("q=a%2Fb"));
+        assertThat(environment.requestedPath().rawPath(), is("/p"));
+        assertThat(environment.requestedQuery().orElseThrow().rawValue(), is("q=a%2Fb"));
+        assertThat(environment.queryParams().rawValue(), is("q=a%252Fb"));
+        assertThat(environment.queryParams().get("q"), is("a%2Fb"));
+
+        assertThrows(TestException.class, () -> client.get()
+                .uri(URI.create("https://example.test/p?"))
+                .request());
+
+        environment = outboundEnvironment.get();
+        assertThat(outboundTarget.get(), is("/p?"));
+        assertThat(environment.targetUri().getRawQuery(), is(""));
+        assertThat(environment.requestedQuery().orElseThrow().rawValue(), is(""));
     }
 
     private static final class TestException extends RuntimeException {


### PR DESCRIPTION
Resolves #8566

Carries forward Kay Werndli’s contribution from #8614 onto the current 4.x line and preserves request-added query parameters when resolving URI templates.
