### PR TITLE
4.x: Force upgrade opennlp-tools to 2.5.11, bump dependency check version

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -112,7 +112,7 @@
         <version.lib.langchain4j>1.12.1</version.lib.langchain4j>
         <version.lib.langchain4j-community>1.12.1-beta21</version.lib.langchain4j-community>
         <!-- Force upgrade opennlp-tools transitive dependency of langchain4j. Remove once langchain4j upgrades -->
-        <version.lib.opennlp-tools>2.5.9</version.lib.opennlp-tools>
+        <version.lib.opennlp-tools>2.5.11</version.lib.opennlp-tools>
         <version.lib.log4j>2.25.5</version.lib.log4j>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -502,6 +502,13 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
     <packageUrl regex="true">^pkg:maven/io\.netty/netty-.*@.*$</packageUrl>
     <cve>CVE-2026-42582</cve>
 </suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: netty-transport-4.1.136.Final.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty-.*@.*$</packageUrl>
+    <cve>CVE-2026-56816</cve>
+</suppress>
 
 <!-- False Positive
      These CVEs are against GraphQL, not dataloader.

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.2.2</version.plugin.dependency-check>
+        <version.plugin.dependency-check>13.0.0</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

1. Upgrade opennlp-tools to 2.5.11 (transitive dependency of langchain4j)
2. Upgrade dependency check plugin to 13.0.0
3. Add suppress for Netty 4.2 false positive