### PR TITLE
Add Apple Silicon support to ShellCheck script

### DIFF
--- a/etc/scripts/shellcheck.sh
+++ b/etc/scripts/shellcheck.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,25 +15,25 @@
 # limitations under the License.
 #
 
-BASE_URL="https://github.com/koalaman/shellcheck/releases/download"
-readonly BASE_URL
+set -euo pipefail
 
-VERSION=0.9.0
-readonly VERSION
+readonly BASE_URL="https://github.com/koalaman/shellcheck/releases/download"
+readonly VERSION=0.11.0
+readonly CACHE_DIR="${HOME}/.shellcheck"
 
-CACHE_DIR="${HOME}/.shellcheck"
-readonly CACHE_DIR
-
-# Caching the shellcheck
 mkdir -p "${CACHE_DIR}"
-if [ ! -e "${CACHE_DIR}/${VERSION}/shellcheck" ] ; then
-    ARCH=$(uname -m | tr "[:upper:]" "[:lower:]")
-    PLATFORM=$(uname -s | tr "[:upper:]" "[:lower:]")
-    curl -Lso "${CACHE_DIR}/sc.tar.xz" "${BASE_URL}/v${VERSION}/shellcheck-v${VERSION}.${PLATFORM}.${ARCH}.tar.xz"
-    tar -xf "${CACHE_DIR}/sc.tar.xz" -C "${CACHE_DIR}"
-    mkdir "${CACHE_DIR}/${VERSION}"
-    mv "${CACHE_DIR}/shellcheck-v${VERSION}/shellcheck" "${CACHE_DIR}/${VERSION}/shellcheck"
-    rm -rf "${CACHE_DIR}/shellcheck-v${VERSION}" "${CACHE_DIR}/sc.tar.xz"
+if [[ ! -x "${CACHE_DIR}/${VERSION}/shellcheck" ]]; then
+  arch=$(uname -m | tr '[:upper:]' '[:lower:]')
+  platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+  if [[ ${arch} == arm64 ]]; then
+    arch=aarch64
+  fi
+  curl -fsSL -o "${CACHE_DIR}/sc.tar.xz" \
+    "${BASE_URL}/v${VERSION}/shellcheck-v${VERSION}.${platform}.${arch}.tar.xz"
+  tar -xf "${CACHE_DIR}/sc.tar.xz" -C "${CACHE_DIR}"
+  mkdir -p "${CACHE_DIR}/${VERSION}"
+  mv "${CACHE_DIR}/shellcheck-v${VERSION}/shellcheck" "${CACHE_DIR}/${VERSION}/shellcheck"
+  rm -rf "${CACHE_DIR}/shellcheck-v${VERSION}" "${CACHE_DIR}/sc.tar.xz"
 fi
 export PATH="${CACHE_DIR}/${VERSION}:${PATH}"
 
@@ -41,13 +41,10 @@ echo "ShellCheck version"
 shellcheck --version
 
 status_code=0
-# shellcheck disable=SC2044
-for file in $(find . -name "*.sh") ; do
-    # only check tracked files
-    if git ls-files --error-unmatch "${file}" > /dev/null 2>&1 ; then
-      printf "\n-- Checking file:  %s --\n" "${file}"
-      shellcheck "${file}" || status_code=${?}
-    fi
-done
+while IFS= read -r -d '' file; do
+  [[ -f ${file} ]] || continue
+  printf '\n-- Checking file: %s --\n' "${file}"
+  shellcheck "${file}" || status_code=$?
+done < <(git ls-files -z -- '*.sh')
 
-exit ${status_code}
+exit "${status_code}"


### PR DESCRIPTION
### Description

Forward-ports the ShellCheck Apple Silicon support from #12233 to `main`:

- Updates ShellCheck to 0.11.0.
- Normalizes platform and architecture names and maps Darwin `arm64` to the
  release artifact name `aarch64`.
- Uses an executable cache check, robust download flags, and idempotent cache
  directory creation.
- Checks tracked `*.sh` files with NUL-delimited `git ls-files` iteration while
  preserving aggregate lint status.

### Documentation

None

### Verification

- `bash -n etc/scripts/shellcheck.sh`
- `etc/scripts/shellcheck.sh` using ShellCheck 0.11.0; all 19 tracked shell
  scripts passed
- `mvn validate -Pcopyright`
- `git diff --check`
