### PR TITLE
4.x: Fix unresolved placeholder in metrics guide

### DIFF
--- a/docs/se/guides/metrics.md
+++ b/docs/se/guides/metrics.md
@@ -5,9 +5,8 @@ navigation:
 -->
 # Metrics
 
-This guide describes how to create a sample Helidon {h1-prefix} project that can
-be used to run some basic examples using both built-in and custom meters with
-Helidon.
+This guide describes how to create a sample Helidon SE project that can be used
+to run some basic examples using both built-in and custom meters with Helidon.
 
 ## What You Need
 


### PR DESCRIPTION
Fixes #12226

Replaces the unresolved AsciiDoc attribute in the converted Helidon SE metrics
guide with the intended `SE` text.

## Validation

- Checked `docs/` for remaining `{h1-prefix}` references; none remain.
