### PR TITLE
27.x: Use explicit Helidon SE name in metrics guide

### DIFF
--- a/docs/src/main/asciidoc/se/guides/metrics.adoc
+++ b/docs/src/main/asciidoc/se/guides/metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 = Helidon SE Metrics Guide
 :description: Helidon metrics
 :keywords: helidon, metrics, guide
-:intro-project-name: {h1-prefix}
+:intro-project-name: SE
 :rootdir: {docdir}/../..
 
 include::{rootdir}/includes/se.adoc[]
@@ -328,4 +328,3 @@ This guide demonstrated how to use metrics in a Helidon SE application using var
 Refer to the following references for additional information:
 
 * link:{javadoc-base-url}/index.html?overview-summary.html[Helidon Javadoc]
-


### PR DESCRIPTION
Fixes #12236

Carries the metrics guide correction from #12235 to `main` by setting the
SE-specific intro project name explicitly.

## Validation

- Rendered the SE metrics guide and confirmed the output contains
  `Helidon SE` with no unresolved project-name placeholders.
- `mvn -f docs/pom.xml validate -Pcopyright`
