### PR TITLE
Stabilize HTTP/2 cache upgrade test

### DIFF
--- a/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
+++ b/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
+++ b/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
@@ -70,39 +70,45 @@ class SharedHttp2CacheTest {
             int port = webServer.port();
 
             Http2Client webClient = Http2Client.builder()
+                    // Keep each parameterized case independent of the process-wide cache and recycled local ports.
+                    .shareConnectionCache(false)
                     .protocolConfig(Http2ClientProtocolConfig.builder()
                                             .priorKnowledge(param.priorKnowledge())
                                             .ping(param.usePing())
                                             .build())
                     .baseUri("http://localhost:" + port + "/versionspecific")
                     .build();
+            try {
 
-            Integer firstReqClientPort;
-            try (var res = webClient.post().submit("WHATEVER")) {
-                firstReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
-                assertThat(res.status(), is(Status.OK_200));
-            }
+                Integer firstReqClientPort;
+                try (var res = webClient.post().submit("WHATEVER")) {
+                    firstReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
+                    assertThat(res.status(), is(Status.OK_200));
+                }
 
-            if (param.restart()) {
-                // Test severing cached connections
-                webServer.stop();
-                webServer = WebServer.builder()
-                        .port(port)
-                        .routing(routing)
-                        .build()
-                        .start();
-            }
+                if (param.restart()) {
+                    // Test severing cached connections
+                    webServer.stop();
+                    webServer = WebServer.builder()
+                            .port(port)
+                            .routing(routing)
+                            .build()
+                            .start();
+                }
 
-            Integer secondReqClientPort;
-            try (var res = webClient.post().submit("WHATEVER")) {
-                secondReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
-                assertThat(res.status(), is(Status.OK_200));
-            }
+                Integer secondReqClientPort;
+                try (var res = webClient.post().submit("WHATEVER")) {
+                    secondReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
+                    assertThat(res.status(), is(Status.OK_200));
+                }
 
-            if (!param.restart()) {
-                assertThat("In case of cached connection client port must be the same.",
-                           secondReqClientPort,
-                           is(firstReqClientPort));
+                if (!param.restart()) {
+                    assertThat("In case of cached connection client port must be the same.",
+                               secondReqClientPort,
+                               is(firstReqClientPort));
+                }
+            } finally {
+                webClient.closeResource();
             }
 
         } finally {


### PR DESCRIPTION
Make the HTTP/2 upgrade cache test client-scoped and close its cache after each parameterized case, preventing stopped-server entries and recycled local ports from affecting later cases.
