### PR TITLE
Fix listener and provider configuration compatibility

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
@@ -423,6 +423,9 @@ class SchemaGenerator {
             if (configForm == Option.Provider.ConfigForm.LIST) {
                 return "LIST";
             }
+            if (configForm == Option.Provider.ConfigForm.OBJECT_OR_LIST) {
+                return "MAP_OR_LIST";
+            }
         }
 
         var typeName = optionInfo.declaredType();

--- a/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
+++ b/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
@@ -1237,7 +1237,7 @@ class SchemaGeneratorTest {
     }
 
     @Test
-    void testProviderList() throws IOException {
+    void testObjectOrListProviderMetadata() throws IOException {
         var result = TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(CLASSPATH)
@@ -1277,7 +1277,8 @@ class SchemaGeneratorTest {
                              * @return option1
                              */
                             @Option.Configured
-                            @Option.Provider(AcmeServiceProvider.class)
+                            @Option.Provider(value = AcmeServiceProvider.class,
+                                             configForm = Option.Provider.ConfigForm.OBJECT_OR_LIST)
                             List<AcmeService> option1();
                         }
                         """)
@@ -1299,7 +1300,7 @@ class SchemaGeneratorTest {
                             key = "option1",
                             description = "Option1",
                             type = AcmeService.class,
-                            kind = ConfiguredOption.Kind.LIST,
+                            kind = ConfiguredOption.Kind.MAP_OR_LIST,
                             provider = true),
                         @ConfiguredOption(
                             key = "option1-discover-services",
@@ -1474,7 +1475,12 @@ class SchemaGeneratorTest {
                 @Configured(
                     description = "ACME config",
                     options = {
-                        @ConfiguredOption(key = "option1", description = "Option1", type = AcmeService.class, provider = true),
+                        @ConfiguredOption(
+                            key = "option1",
+                            description = "Option1",
+                            type = AcmeService.class,
+                            kind = ConfiguredOption.Kind.MAP_OR_LIST,
+                            provider = true),
                         @ConfiguredOption(
                             key = "option1-discover-services",
                             description = "Whether to enable automatic service discovery for <code>option1</code>",

--- a/config/metadata/README.md
+++ b/config/metadata/README.md
@@ -169,7 +169,7 @@ defined by another type (nested types).
      "key": "key in configuration (may be missing, if this merges with parent)",
      "type": "fully qualified type of the configuration option, defaults to java.lang.String",
      "description": "description of this configuration node (expected to be non-empty)",
-     "kind": "LIST|MAP|VALUE",
+     "kind": "LIST|MAP|MAP_OR_LIST|VALUE",
      "method": "annotated method",
      "merge": true,
      "experimental": true,
@@ -194,6 +194,7 @@ defined by another type (nested types).
   * `Kind.LIST` - this is a list of values (either simple values, or objects)
   * `Kind.MAP` - this is a map of values, using keys of the map as keys, and values of the map as values, `type` defines 
      the value type (must be a simple value), key is expected to be `java.lang.String`
+  * `Kind.MAP_OR_LIST` - either the `Kind.MAP` or `Kind.LIST` configuration shape is accepted
   * `Kind.VALUE` - either a simple value (String, Long etc.) or a nested object (this is the default)
 * method - method to be called to configure this option (may be a static factory method, such as `create(Config)`, or a builder method)
 * merge - if set to `true` (default is `false`) this option's key is ignored and all its nested keys are inserted

--- a/config/metadata/docs/src/main/java/io/helidon/config/metadata/docs/CmPageResolver.java
+++ b/config/metadata/docs/src/main/java/io/helidon/config/metadata/docs/CmPageResolver.java
@@ -551,6 +551,7 @@ final class CmPageResolver {
             case VALUE -> typeName;
             case LIST -> "List<" + typeName + ">";
             case MAP -> "Map<String, " + typeName + ">";
+            case MAP_OR_LIST -> "Map<String, " + typeName + "> or List<" + typeName + ">";
         };
     }
 

--- a/config/metadata/docs/src/test/resources/java-type-notation/config-metadata.json
+++ b/config/metadata/docs/src/test/resources/java-type-notation/config-metadata.json
@@ -64,6 +64,12 @@
             "description": "Handlers"
           },
           {
+            "key": "external-handler-alternatives",
+            "kind": "MAP_OR_LIST",
+            "type": "com.acme.ExternalHandler",
+            "description": "Handler alternatives"
+          },
+          {
             "key": "modes",
             "kind": "LIST",
             "type": "com.acme.AcmeMode",

--- a/config/metadata/docs/src/test/resources/java-type-notation/expected/com_acme_AcmeServerConfig.adoc
+++ b/config/metadata/docs/src/test/resources/java-type-notation/expected/com_acme_AcmeServerConfig.adoc
@@ -42,6 +42,10 @@ ACME server configuration.
 |`List<ExternalListener>`
 |pass:[Listeners]
 
+| `external-handler-alternatives`
+|`Map<String, ExternalHandler> or List<ExternalHandler>`
+|pass:[Handler alternatives]
+
 | `host`
 |`String`
 |pass:[Host]

--- a/config/metadata/metadata/src/main/java/io/helidon/config/metadata/ConfiguredOption.java
+++ b/config/metadata/metadata/src/main/java/io/helidon/config/metadata/ConfiguredOption.java
@@ -194,6 +194,10 @@ public @interface ConfiguredOption {
         /**
          * Option is a map keyed by strings.
          */
-        MAP
+        MAP,
+        /**
+         * Option accepts either a map keyed by strings or a list of values.
+         */
+        MAP_OR_LIST
     }
 }

--- a/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmModel.java
+++ b/config/metadata/model/src/main/java/io/helidon/config/metadata/model/CmModel.java
@@ -335,7 +335,11 @@ public sealed interface CmModel permits CmModelImpl {
             /**
              * Map tree node.
              */
-            MAP
+            MAP,
+            /**
+             * Map or list tree node.
+             */
+            MAP_OR_LIST
         }
 
         /**

--- a/config/metadata/tests/test-codegen/src/test/java/io/helidon/config/metadata/test/codegen/TypeHandlerTest.java
+++ b/config/metadata/tests/test-codegen/src/test/java/io/helidon/config/metadata/test/codegen/TypeHandlerTest.java
@@ -2206,7 +2206,7 @@ class TypeHandlerTest {
     }
 
     @Test
-    void testExplicitKind() throws IOException {
+    void testExplicitMapOrListKind() throws IOException {
         var result = TestCompiler.builder()
                 .currentRelease()
                 .addClasspath(Configured.class)
@@ -2234,7 +2234,7 @@ class TypeHandlerTest {
                                  * @param option1 option1
                                  * @return this builder
                                  */
-                                @ConfiguredOption(kind = Kind.LIST)
+                                @ConfiguredOption(kind = Kind.MAP_OR_LIST)
                                 Builder option1(Map<String, String> option1);
                             }
                         }
@@ -2259,7 +2259,7 @@ class TypeHandlerTest {
                                     {
                                         "key": "option1",
                                         "description": "Option1",
-                                        "kind": "LIST"
+                                        "kind": "MAP_OR_LIST"
                                     }
                                 ]
                             }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
@@ -157,7 +157,9 @@ class WebServerConfigSupport {
 
     static class ListenerConfigDecorator implements Prototype.BuilderDecorator<ListenerConfig.BuilderBase<?, ?>> {
         @Override
+        @SuppressWarnings("removal")
         public void decorate(ListenerConfig.BuilderBase<?, ?> target) {
+            target.maxTcpConnections(target.maxConnections());
             if (target.bindAddress().isPresent()) {
                 if (target.address().isEmpty()) {
                     target.address(InetAddress.getLoopbackAddress());

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
@@ -111,6 +111,7 @@ public class ListenerConfigTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     void testDeprecatedMaxTcpConnectionsConfiguresMaxConnections() {
         Config config = Config.just("""
                 server:
@@ -122,6 +123,7 @@ public class ListenerConfigTest {
                 .buildPrototype();
 
         assertThat(listenerConfig.maxConnections(), is(23));
+        assertThat(listenerConfig.maxTcpConnections(), is(23));
     }
 
     @Test
@@ -162,6 +164,31 @@ public class ListenerConfigTest {
                 .buildPrototype();
 
         assertThat(listenerConfig.maxConnections(), is(23));
+        assertThat(listenerConfig.maxTcpConnections(), is(23));
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void testMaxConnectionsBuilderConfiguresDeprecatedMaxTcpConnections() {
+        ListenerConfig listenerConfig = ListenerConfig.builder()
+                .maxConnections(23)
+                .buildPrototype();
+
+        assertThat(listenerConfig.maxTcpConnections(), is(23));
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void testConnectionLimitAliasesProduceEqualConfigs() {
+        ListenerConfig listenerConfig = ListenerConfig.builder()
+                .maxConnections(23)
+                .buildPrototype();
+        ListenerConfig legacyListenerConfig = ListenerConfig.builder(listenerConfig)
+                .maxTcpConnections(23)
+                .buildPrototype();
+
+        assertThat(listenerConfig, is(legacyListenerConfig));
+        assertThat(listenerConfig.hashCode(), is(legacyListenerConfig.hashCode()));
     }
 
     @Test
@@ -184,6 +211,7 @@ public class ListenerConfigTest {
                 .buildPrototype();
 
         assertThat(listenerConfig.maxConnections(), is(-1));
+        assertThat(listenerConfig.maxTcpConnections(), is(-1));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #12092.

Keeps the deprecated listener connection-limit accessor synchronized with `maxConnections`, and represents provider configurations that accept either object or list form in generated configuration metadata.
