### PR TITLE
Validate explicit SSLContext configuration

### DIFF
--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
@@ -35,8 +35,9 @@ import io.helidon.common.tls.spi.TlsManagerProvider;
 @Prototype.CustomMethods(TlsConfigSupport.CustomMethods.class)
 interface TlsConfigBlueprint extends TlsMaterialBlueprint, Prototype.Factory<Tls> {
     /**
-     * Provide a fully configured {@link javax.net.ssl.SSLContext}. If defined, context creation and key or trust
-     * material options cannot be configured, and reload of Tls is not supported and will throw an exception.
+     * Provide a fully configured {@link javax.net.ssl.SSLContext}. If defined, a custom TLS manager and options for
+     * context creation, key or trust material, session cache size, and session timeout cannot be configured, and reload
+     * of Tls is not supported and will throw an exception.
      * Engine-level options such as enabled protocols, cipher suites, client authentication, and application protocols
      * are supported and are applied to engines created by the context.
      *

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
@@ -35,8 +35,10 @@ import io.helidon.common.tls.spi.TlsManagerProvider;
 @Prototype.CustomMethods(TlsConfigSupport.CustomMethods.class)
 interface TlsConfigBlueprint extends TlsMaterialBlueprint, Prototype.Factory<Tls> {
     /**
-     * Provide a fully configured {@link javax.net.ssl.SSLContext}. If defined, context related configuration
-     * is ignored, and reload of Tls is not supported, and will throw an exception.
+     * Provide a fully configured {@link javax.net.ssl.SSLContext}. If defined, context creation and key or trust
+     * material options cannot be configured, and reload of Tls is not supported and will throw an exception.
+     * Engine-level options such as enabled protocols, cipher suites, client authentication, and application protocols
+     * are supported and are applied to engines created by the context.
      *
      * @return SSL context to use
      */

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigDecorator.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
 
 package io.helidon.common.tls;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.net.ssl.SSLParameters;
 
 import io.helidon.builder.api.Prototype;
@@ -24,9 +28,62 @@ class TlsConfigDecorator implements Prototype.BuilderDecorator<TlsConfig.Builder
 
     @Override
     public void decorate(TlsConfig.BuilderBase<?, ?> target) {
+        if (target.enabled() && target.sslContext().isPresent()) {
+            var sslContext = target.sslContext().orElseThrow();
+            List<String> incompatibleOptions = new ArrayList<>();
+            target.manager()
+                    .filter(manager -> !(manager instanceof ExplicitContextTlsManager)
+                            && manager.getClass() != ConfiguredTlsManager.class)
+                    .ifPresent(_ -> incompatibleOptions.add("manager"));
+            target.privateKey().ifPresent(_ -> incompatibleOptions.add("private-key"));
+            if (!target.privateKeyCertChain().isEmpty()) {
+                incompatibleOptions.add("private-key-cert-chain");
+            }
+            if (!target.trust().isEmpty()) {
+                incompatibleOptions.add("trust");
+            }
+            target.secureRandom().ifPresent(_ -> incompatibleOptions.add("secure-random"));
+            target.secureRandomProvider().ifPresent(_ -> incompatibleOptions.add("secure-random-provider"));
+            target.secureRandomAlgorithm().ifPresent(_ -> incompatibleOptions.add("secure-random-algorithm"));
+            target.keyManagerFactoryAlgorithm().ifPresent(_ -> incompatibleOptions.add("key-manager-factory-algorithm"));
+            target.keyManagerFactoryProvider().ifPresent(_ -> incompatibleOptions.add("key-manager-factory-provider"));
+            target.trustManagerFactoryAlgorithm().ifPresent(_ -> incompatibleOptions.add("trust-manager-factory-algorithm"));
+            target.trustManagerFactoryProvider().ifPresent(_ -> incompatibleOptions.add("trust-manager-factory-provider"));
+            if (target.trustAll()) {
+                incompatibleOptions.add("trust-all");
+            }
+            target.internalKeystoreType().ifPresent(_ -> incompatibleOptions.add("internal-keystore-type"));
+            target.internalKeystoreProvider().ifPresent(_ -> incompatibleOptions.add("internal-keystore-provider"));
+            target.revocation().ifPresent(_ -> incompatibleOptions.add("revocation"));
+            if (!TlsConfigSupport.CustomMethods.DEFAULT_PROTOCOL.equals(target.protocol())) {
+                incompatibleOptions.add("protocol");
+            }
+            target.provider().ifPresent(_ -> incompatibleOptions.add("provider"));
+            if (target.sessionCacheSize() != TlsConfigSupport.CustomMethods.DEFAULT_SESSION_CACHE_SIZE) {
+                incompatibleOptions.add("session-cache-size");
+            }
+            if (!target.sessionTimeout()
+                    .equals(Duration.parse(TlsConfigSupport.CustomMethods.DEFAULT_SESSION_TIMEOUT))) {
+                incompatibleOptions.add("session-timeout");
+            }
+            if (!incompatibleOptions.isEmpty()) {
+                throw new IllegalArgumentException("Explicit SSLContext cannot be combined with TLS options: "
+                                                           + String.join(", ", incompatibleOptions));
+            }
+            target.manager()
+                    .filter(ExplicitContextTlsManager.class::isInstance)
+                    .map(ExplicitContextTlsManager.class::cast)
+                    .filter(manager -> manager.sslContext() == sslContext)
+                    .orElseGet(() -> {
+                        var manager = new ExplicitContextTlsManager(sslContext);
+                        target.manager(manager);
+                        return manager;
+                    });
+        }
         sslParameters(target);
         TlsManager theManager = target.manager().orElse(null);
-        if (theManager == null) {
+        if (theManager == null
+                || (target.sslContext().isEmpty() && theManager instanceof ExplicitContextTlsManager)) {
             theManager = new ConfiguredTlsManager();
             target.manager(theManager);
         }

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
@@ -129,10 +129,59 @@ public class TlsTest {
         SSLContext sslContext = createSslContext();
 
         Tls tls = Tls.create(it -> it.sslContext(sslContext)
-                .manager(new FailingTlsManager()));
+                .addApplicationProtocol("h3"));
 
         assertThat(tls.sslContext(), sameInstance(sslContext));
         assertThat(tls.prototype().manager(), instanceOf(ExplicitContextTlsManager.class));
+        assertThat(tls.newEngine().getSSLParameters().getApplicationProtocols(), arrayContaining("h3"));
+    }
+
+    @Test
+    public void explicitSslContextRejectsIncompatibleOptions() {
+        SSLContext sslContext = createSslContext();
+
+        IllegalArgumentException managerException = assertThrows(IllegalArgumentException.class,
+                                                                  () -> Tls.create(it -> it.sslContext(sslContext)
+                                                                          .manager(new FailingTlsManager())));
+        assertThat(managerException.getMessage(), is("Explicit SSLContext cannot be combined with TLS options: manager"));
+
+        IllegalArgumentException materialException = assertThrows(IllegalArgumentException.class,
+                                                                   () -> Tls.create(it -> it.sslContext(sslContext)
+                                                                           .trustAll(true)
+                                                                           .sessionCacheSize(1)));
+        assertThat(materialException.getMessage(),
+                   is("Explicit SSLContext cannot be combined with TLS options: trust-all, session-cache-size"));
+    }
+
+    @Test
+    public void explicitSslContextSupportsBuilderReuseAndPrototypeCopy() {
+        SSLContext sslContext = createSslContext();
+        TlsConfig.Builder builder = Tls.builder().sslContext(sslContext);
+
+        TlsConfig prototype = builder.buildPrototype();
+        TlsConfig repeatedBuild = builder.buildPrototype();
+        assertThat(repeatedBuild.manager(), sameInstance(prototype.manager()));
+
+        Tls first = Tls.create(prototype);
+        Tls second = Tls.create(repeatedBuild);
+        assertThat(first.sslContext(), sameInstance(sslContext));
+        assertThat(second.sslContext(), sameInstance(sslContext));
+
+        TlsConfig copy = TlsConfig.builder(prototype).buildPrototype();
+        assertThat(copy.sslContext().orElseThrow(), sameInstance(sslContext));
+        assertThat(copy.manager(), sameInstance(prototype.manager()));
+        assertThat(copy, is(prototype));
+
+        TlsConfig defaultPrototype = Tls.builder().buildPrototype();
+        TlsConfig contextCopy = TlsConfig.builder(defaultPrototype)
+                .sslContext(sslContext)
+                .buildPrototype();
+        assertThat(contextCopy.sslContext().orElseThrow(), sameInstance(sslContext));
+        assertThat(contextCopy.manager(), instanceOf(ExplicitContextTlsManager.class));
+
+        Tls withoutContext = builder.clearSslContext().build();
+        assertThat(withoutContext.prototype().sslContext().isEmpty(), is(true));
+        assertThat(withoutContext.prototype().manager(), instanceOf(ConfiguredTlsManager.class));
     }
 
     @Test


### PR DESCRIPTION
Pre-requisite for #3686

Rejects TLS material, custom manager, and context-owned session options when a fully configured `SSLContext` is supplied, while preserving engine-level TLS options and safe builder reuse.
