### PR TITLE
Fix resolved URI query parameters (27.x)

### DIFF
--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
@@ -18,6 +18,7 @@ package io.helidon.common.uri;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -33,6 +34,8 @@ import io.helidon.common.mapper.Value;
 final class UriQueryWriteableImpl implements UriQueryWriteable {
     private final Map<String, List<String>> rawQueryParams = new HashMap<>();
     private final Map<String, List<String>> decodedQueryParams = new HashMap<>();
+
+    private Map<String, Set<String>> rawNamesByDecodedName;
 
     UriQueryWriteableImpl() {
     }
@@ -83,6 +86,13 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
                         .addAll(decoded);
             }
         }
+        Map<String, Set<String>> rawNames = rawNamesByDecodedName;
+        if (rawNames != null) {
+            rawNames.clear();
+            rawQueryParams.keySet().forEach(rawName -> rawNames
+                    .computeIfAbsent(UriEncoding.decodeUri(rawName), it -> new HashSet<>())
+                    .add(rawName));
+        }
 
         return this;
     }
@@ -91,6 +101,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
     public void clear() {
         this.rawQueryParams.clear();
         this.decodedQueryParams.clear();
+        this.rawNamesByDecodedName = null;
     }
 
     @Override
@@ -222,8 +233,15 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
             encodedValues.add(UriEncoding.encode(value, UriEncoding.Type.QUERY_PARAM_SPACE_ENCODED));
         }
 
+        List<String> existingDecodedValues = decodedQueryParams.get(name);
+        List<String> existingRawValues = rawQueryParams.get(encodedName);
+        if (existingDecodedValues != null
+                && (existingRawValues == null || existingRawValues.size() != existingDecodedValues.size())) {
+            removeRawAliases(name);
+        }
         rawQueryParams.put(encodedName, encodedValues);
         decodedQueryParams.put(name, decodedValues);
+        indexRawName(name, encodedName);
 
         return this;
     }
@@ -237,6 +255,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
                 .add(encodedValue);
         decodedQueryParams.computeIfAbsent(name, it -> new ArrayList<>(1))
                 .add(value);
+        indexRawName(name, encodedName);
 
         return this;
     }
@@ -253,6 +272,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
     public UriQueryWriteable remove(String name) {
         rawQueryParams.remove(name);
         decodedQueryParams.remove(name);
+        unindexRawName(name);
         return this;
     }
 
@@ -260,6 +280,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
     public UriQueryWriteable remove(String name, Consumer<List<String>> removedConsumer) {
         rawQueryParams.remove(name);
         List<String> removed = decodedQueryParams.remove(name);
+        unindexRawName(name);
         if (removed != null) {
             removedConsumer.accept(removed);
         }
@@ -307,5 +328,45 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
                 .add(encodedValue);
         decodedQueryParams.computeIfAbsent(decodedName, it -> new ArrayList<>(1))
                 .add(decodedValue);
+        indexRawName(decodedName, encodedName);
+    }
+
+    private void removeRawAliases(String name) {
+        Map<String, Set<String>> rawNames = rawNamesByDecodedName;
+        if (rawNames == null) {
+            rawNames = new HashMap<>();
+            for (String rawName : rawQueryParams.keySet()) {
+                rawNames.computeIfAbsent(UriEncoding.decodeUri(rawName), it -> new HashSet<>())
+                        .add(rawName);
+            }
+            rawNamesByDecodedName = rawNames;
+        }
+        Set<String> aliases = rawNames.remove(name);
+        if (aliases != null) {
+            aliases.forEach(rawQueryParams::remove);
+        }
+    }
+
+    private void indexRawName(String decodedName, String rawName) {
+        Map<String, Set<String>> rawNames = rawNamesByDecodedName;
+        if (rawNames != null) {
+            rawNames.computeIfAbsent(decodedName, it -> new HashSet<>())
+                    .add(rawName);
+        }
+    }
+
+    private void unindexRawName(String rawName) {
+        Map<String, Set<String>> rawNames = rawNamesByDecodedName;
+        if (rawNames == null) {
+            return;
+        }
+        String decodedName = UriEncoding.decodeUri(rawName);
+        Set<String> aliases = rawNames.get(decodedName);
+        if (aliases != null) {
+            aliases.remove(rawName);
+            if (aliases.isEmpty()) {
+                rawNames.remove(decodedName);
+            }
+        }
     }
 }

--- a/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
@@ -18,6 +18,7 @@ package io.helidon.common.uri;
 
 import java.net.URI;
 import java.net.URLEncoder;
+import java.util.List;
 
 import io.helidon.common.mapper.OptionalValue;
 
@@ -25,8 +26,10 @@ import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -137,6 +140,54 @@ class UriQueryTest {
         assertThat(query.getRaw("p3"), is("%2F%2Fv3%2F%2F"));
         assertThat(query.get("p4"), is("a b c"));
         assertThat(query.getRaw("p4"), is("a%20b%20c"));
+    }
+
+    @Test
+    void setReplacesEquivalentEncodedName() {
+        UriQueryWriteable query = writeableQuery("%61=template");
+
+        query.set("a", "request");
+
+        assertThat(query.all("a"), is(List.of("request")));
+        assertThat(query.rawValue(), is("a=request"));
+    }
+
+    @Test
+    void setReplacesMultipleEquivalentEncodedNames() {
+        StringBuilder queryString = new StringBuilder();
+        for (int i = 0; i < 32; i++) {
+            if (!queryString.isEmpty()) {
+                queryString.append('&');
+            }
+            queryString.append("%61").append(i).append("=template");
+        }
+        UriQueryWriteable query = writeableQuery(queryString.toString());
+
+        for (int i = 0; i < 32; i++) {
+            query.set("a" + i, "request" + i);
+        }
+
+        assertThat(query.size(), is(32));
+        for (int i = 0; i < 32; i++) {
+            assertThat(query.getAllRaw("a" + i), is(List.of("request" + i)));
+        }
+        assertThat(query.rawValue(), not(containsString("%61")));
+    }
+
+    @Test
+    void aliasIndexTracksLaterRawUpdates() {
+        UriQueryWriteable query = writeableQuery("%61=template");
+        query.set("a", "request");
+
+        query.fromQueryString("%62=template");
+        query.set("b", "request");
+        query.from(writeableQuery("%63=template"));
+        query.set("c", "request");
+
+        assertThat(query.getAllRaw("a"), is(List.of("request")));
+        assertThat(query.getAllRaw("b"), is(List.of("request")));
+        assertThat(query.getAllRaw("c"), is(List.of("request")));
+        assertThat(query.rawValue(), not(containsString("%")));
     }
 
     private static UriQueryWriteable writeableQuery(String queryString) {

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>helidon-common-uri</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryAliasBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryAliasBenchmark.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.http.Method;
+import io.helidon.webclient.api.ClientRequest.OutputStreamHandler;
+import io.helidon.webclient.api.ClientRequestBase;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.WebClientConfig;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(3)
+@Threads(1)
+@State(Scope.Thread)
+public class ClientRequestQueryAliasBenchmark {
+    private static final URI BASE_URI = URI.create("https://base.example/root");
+    private static final WebClientConfig CLIENT_CONFIG = WebClientConfig.create();
+
+    @Param({"4", "32"})
+    public int queryParamCount;
+
+    @Benchmark
+    public String encodedAliasReplay() {
+        StringBuilder template = new StringBuilder("https://{host}/items/{id}?");
+        for (int i = 0; i < queryParamCount; i++) {
+            if (i > 0) {
+                template.append('&');
+            }
+            template.append("%61").append(i).append("=template");
+        }
+        FakeClientRequest request = new FakeClientRequest(ClientUri.create(BASE_URI));
+        request.uri(template.toString())
+                .pathParam("host", "other.example")
+                .pathParam("id", "one")
+                .skipUriEncoding(true);
+        for (int i = 0; i < queryParamCount; i++) {
+            request.queryParam("a" + i, "request" + i);
+        }
+        return request
+                .resolvedUri()
+                .pathWithQueryAndFragment();
+    }
+
+    private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
+        private FakeClientRequest(ClientUri clientUri) {
+            super(CLIENT_CONFIG, null, "jmh", Method.GET, clientUri, Collections.emptyMap());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            return null;
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            return null;
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryBenchmark.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.http.Method;
+import io.helidon.webclient.api.ClientRequest.OutputStreamHandler;
+import io.helidon.webclient.api.ClientRequestBase;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.WebClientConfig;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(3)
+@Threads(1)
+@State(Scope.Thread)
+public class ClientRequestQueryBenchmark {
+    private static final URI BASE_URI = URI.create("https://base.example/root?inherited=base");
+    private static final WebClientConfig CLIENT_CONFIG = WebClientConfig.create();
+
+    @Param({"1", "4"})
+    public int queryParamCount;
+
+    @Benchmark
+    public String nonTemplate() {
+        FakeClientRequest request = newRequest();
+        request.uri(URI.create("https://base.example/items"));
+        addQueryParams(request);
+        return request.resolvedUri().pathWithQueryAndFragment();
+    }
+
+    @Benchmark
+    public String relativeTemplate() {
+        FakeClientRequest request = newRequest();
+        request.uri("/items/{id}");
+        request.pathParam("id", "one");
+        addQueryParams(request);
+        return request.resolvedUri().pathWithQueryAndFragment();
+    }
+
+    @Benchmark
+    public String relativeTemplateSkipEncoding() {
+        FakeClientRequest request = newRequest();
+        request.uri("/items/{id}");
+        request.pathParam("id", "one");
+        request.skipUriEncoding(true);
+        addQueryParams(request);
+        return request.resolvedUri().pathWithQueryAndFragment();
+    }
+
+    @Benchmark
+    public String absoluteTemplate() {
+        FakeClientRequest request = newRequest();
+        request.uri("https://{host}/items/{id}?template=value");
+        request.pathParam("host", "other.example");
+        request.pathParam("id", "one");
+        addQueryParams(request);
+        return request.resolvedUri().pathWithQueryAndFragment();
+    }
+
+    private FakeClientRequest newRequest() {
+        return new FakeClientRequest(ClientUri.create(BASE_URI));
+    }
+
+    private void addQueryParams(FakeClientRequest request) {
+        for (int i = 0; i < queryParamCount; i++) {
+            request.queryParam("request" + i, "value" + i);
+        }
+    }
+
+    private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
+        private FakeClientRequest(ClientUri clientUri) {
+            super(CLIENT_CONFIG, null, "jmh", Method.GET, clientUri, Collections.emptyMap());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            return null;
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            return null;
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientSecurityQueryBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientSecurityQueryBenchmark.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.context.Context;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
+import io.helidon.security.OutboundSecurityResponse;
+import io.helidon.security.Security;
+import io.helidon.security.SecurityEnvironment;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+import io.helidon.webclient.security.WebClientSecurity;
+import io.helidon.webclient.spi.WebClientService;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(3)
+@Threads(1)
+@State(Scope.Thread)
+public class WebClientSecurityQueryBenchmark {
+    private static final URI TARGET_URI = URI.create("https://example.test/items");
+    private static final ClientRequestHeaders HEADERS = ClientRequestHeaders.create(WritableHeaders.create());
+    private static final WebClientService.Chain CHAIN = request -> null;
+
+    private WebClientSecurity service;
+    private Context context;
+    private SecurityEnvironment environment;
+
+    @Setup
+    public void setup() {
+        Security security = Security.builder()
+                .addOutboundSecurityProvider((request, environment, config) -> {
+                    this.environment = environment;
+                    return OutboundSecurityResponse.abstain();
+                })
+                .build();
+        context = Context.create();
+        context.register(security.contextBuilder("jmh").build());
+        service = WebClientSecurity.create();
+    }
+
+    @Benchmark
+    public String defaultEncoding() {
+        return applySecurity(false, false);
+    }
+
+    @Benchmark
+    public String skipEncoding() {
+        return applySecurity(true, false);
+    }
+
+    @Benchmark
+    public String skipEncodingPlain() {
+        return applySecurity(true, true);
+    }
+
+    private String applySecurity(boolean skipEncoding, boolean plainValues) {
+        ClientUri uri = ClientUri.create(TARGET_URI);
+        uri.skipUriEncoding(skipEncoding);
+        if (plainValues) {
+            uri.writeableQuery().set("one", "valueOne");
+            uri.writeableQuery().set("two", "valueTwo");
+            uri.writeableQuery().set("three", "valueThree");
+            uri.writeableQuery().set("four", "valueFour");
+        } else {
+            uri.writeableQuery().set("one", "value%2Fone");
+            uri.writeableQuery().set("two", "value%23two");
+            uri.writeableQuery().set("three", "value%20three");
+            uri.writeableQuery().set("four", "value+four");
+        }
+        environment = null;
+        service.handle(CHAIN, new BenchmarkServiceRequest(uri, context));
+        return environment.requestedQuery().orElseThrow().rawValue();
+    }
+
+    private static final class BenchmarkServiceRequest implements WebClientServiceRequest {
+        private final ClientUri uri;
+        private final Context context;
+        private String requestId = "jmh";
+
+        private BenchmarkServiceRequest(ClientUri uri, Context context) {
+            this.uri = uri;
+            this.context = context;
+        }
+
+        @Override
+        public ClientUri uri() {
+            return uri;
+        }
+
+        @Override
+        public Method method() {
+            return Method.GET;
+        }
+
+        @Override
+        public String protocolId() {
+            return "http/1.1";
+        }
+
+        @Override
+        public ClientRequestHeaders headers() {
+            return HEADERS;
+        }
+
+        @Override
+        public Context context() {
+            return context;
+        }
+
+        @Override
+        public String requestId() {
+            return requestId;
+        }
+
+        @Override
+        public void requestId(String requestId) {
+            this.requestId = requestId;
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceRequest> whenSent() {
+            return CompletableFuture.completedStage(this);
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceResponse> whenComplete() {
+            return CompletableFuture.completedStage(null);
+        }
+
+        @Override
+        public Map<String, String> properties() {
+            return Map.of();
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/ClientRequestQueryJmhRunnerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+class ClientRequestQueryJmhRunnerTest {
+    @Test
+    void securityBenchmarksAreExecutable() {
+        WebClientSecurityQueryBenchmark benchmark = new WebClientSecurityQueryBenchmark();
+        benchmark.setup();
+        benchmark.defaultEncoding();
+        benchmark.skipEncoding();
+        benchmark.skipEncodingPlain();
+    }
+
+    @Test
+    void runExactBenchmark() throws RunnerException {
+        Options options = new OptionsBuilder()
+                .include("^" + Pattern.quote(ClientRequestQueryBenchmark.class.getName())
+                                 + "\\.(nonTemplate|relativeTemplate|relativeTemplateSkipEncoding|absoluteTemplate)$")
+                .include("^" + Pattern.quote(WebClientSecurityQueryBenchmark.class.getName())
+                                 + "\\.(defaultEncoding|skipEncoding|skipEncodingPlain)$")
+                .include("^" + Pattern.quote(ClientRequestQueryAliasBenchmark.class.getName())
+                                 + "\\.encodedAliasReplay$")
+                .forks(1)
+                .warmupIterations(3)
+                .measurementIterations(5)
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .result("target/client-request-query-jmh.json")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -88,7 +88,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private final boolean filterRedirectHeaders;
 
     private SocketAddress socketAddress;
-    private String uriTemplate;
+    private UriTemplateQuery uriTemplate;
     private boolean crossOriginRedirect;
     private boolean skipUriEncoding;
     private boolean followRedirects;
@@ -281,7 +281,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T uri(String uri) {
         if (uri.indexOf('{') > -1) {
-            this.uriTemplate = uri;
+            this.uriTemplate = new UriTemplateQuery(uri);
         } else {
             uri(URI.create(UriEncoding.encodeUri(uri)));
         }
@@ -336,6 +336,10 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T queryParam(String name, String... values) {
         clientUri.writeableQuery().set(name, values);
+        UriTemplateQuery templateQuery = uriTemplate;
+        if (templateQuery != null) {
+            templateQuery.trackQueryParam(name);
+        }
         return identity();
     }
 
@@ -656,12 +660,21 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
      * @return updated client uri
      */
     protected ClientUri resolveUri(ClientUri toResolve) {
-        if (uriTemplate != null) {
-            String resolved = resolvePathParams(uriTemplate);
+        UriTemplateQuery templateQuery = uriTemplate;
+        if (templateQuery != null) {
+            String resolved = resolvePathParams(templateQuery.template());
+            URI uri;
             if (skipUriEncoding) {
-                toResolve.resolve(URI.create(resolved));
+                uri = URI.create(resolved);
             } else {
-                toResolve.resolve(URI.create(UriEncoding.encodeUri(resolved)));
+                uri = URI.create(UriEncoding.encodeUri(resolved));
+            }
+            boolean replayQuery = skipUriEncoding || uri.isAbsolute();
+            ClientUri querySource = replayQuery && toResolve == clientUri ? ClientUri.create(clientUri) : clientUri;
+            toResolve.resolve(uri);
+
+            if (replayQuery) {
+                templateQuery.replay(querySource.query(), toResolve.writeableQuery(), uri.isAbsolute());
             }
         }
         return toResolve;
@@ -722,4 +735,5 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private T identity() {
         return (T) this;
     }
+
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientUri.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientUri.java
@@ -18,6 +18,7 @@ package io.helidon.webclient.api;
 
 import java.net.URI;
 
+import io.helidon.common.Api;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriInfo;
 import io.helidon.common.uri.UriPath;
@@ -251,6 +252,16 @@ public class ClientUri implements UriInfo {
     @Override
     public UriQuery query() {
         return query;
+    }
+
+    /**
+     * Query as serialized into the HTTP request target.
+     *
+     * @return request target query
+     */
+    @Api.Internal
+    public UriQuery requestTargetQuery() {
+        return skipUriEncoding ? UriQuery.create(query.value()) : query;
     }
 
     /**

--- a/webclient/api/src/main/java/io/helidon/webclient/api/UriTemplateQuery.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/UriTemplateQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.uri.UriQuery;
+import io.helidon.common.uri.UriQueryWriteable;
+
+final class UriTemplateQuery {
+    private final String template;
+
+    private Set<String> queryParamNames;
+
+    UriTemplateQuery(String template) {
+        this.template = template;
+    }
+
+    String template() {
+        return template;
+    }
+
+    void replay(UriQuery source, UriQueryWriteable target, boolean absolute) {
+        Set<String> names = queryParamNames;
+        if (names == null) {
+            return;
+        }
+        for (String name : names) {
+            if (!containsDecodedName(source, name)) {
+                continue;
+            }
+            List<String> sourceValues = source.all(name);
+            if (absolute
+                    || !containsDecodedName(target, name)
+                    || !target.all(name).equals(sourceValues)) {
+                target.set(name, sourceValues.toArray(String[]::new));
+            }
+        }
+    }
+
+    void trackQueryParam(String name) {
+        Set<String> names = queryParamNames;
+        if (names == null) {
+            names = new LinkedHashSet<>();
+            queryParamNames = names;
+        }
+        names.add(name);
+    }
+
+    private static boolean containsDecodedName(UriQuery query, String name) {
+        if (name.indexOf('%') >= 0 || name.indexOf('+') >= 0) {
+            return query.names().contains(name);
+        }
+        return query.contains(name) || query.names().contains(name);
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -17,11 +17,13 @@
 package io.helidon.webclient.api;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.uri.UriPath;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -139,6 +141,426 @@ class ClientRequestBaseTest {
 
         private int endpointCount() {
             return endpointCount.get();
+        }
+    }
+
+    /**
+     * Verify that query parameters are preserved when resolving URI templates (cf. issue #8566).
+     * Make sure to test both absolute and relative URIs as they are handled differently when resolving.
+     */
+    @Test
+    void resolvedUriTest() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/")
+                .queryParam("k", "v").resolvedUri();
+        assertThat(uri.authority(), is("www.example.com:443"));
+        assertThat(uri.host(), is("www.example.com"));
+        assertThat(uri.path(), is(UriPath.root()));
+        assertThat(uri.port(), is(443));
+        assertThat(uri.scheme(), is("https"));
+        assertThat(uri.query().get("k"), is("v"));
+
+        uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("k", "v").resolvedUri();
+        assertThat(uri.authority(), is("www.example.com:443"));
+        assertThat(uri.host(), is("www.example.com"));
+        assertThat(uri.path(), is(UriPath.create("/p")));
+        assertThat(uri.port(), is(443));
+        assertThat(uri.scheme(), is("https"));
+        assertThat(uri.query().get("k"), is("v"));
+
+        uri = new FakeClientRequest()
+                .uri("example/{path}")
+                .pathParam("path", "p")
+                .queryParam("k", "v").resolvedUri();
+        assertThat(uri.authority(), is("localhost:80"));
+        assertThat(uri.host(), is("localhost"));
+        assertThat(uri.path(), is(UriPath.create("/example/p")));
+        assertThat(uri.port(), is(80));
+        assertThat(uri.scheme(), is("http"));
+        assertThat(uri.query().get("k"), is("v"));
+    }
+
+    @Test
+    void requestQueryOverridesTemplateQuery() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?k=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("k", "request")
+                .resolvedUri();
+
+        assertThat(uri.path(), is(UriPath.create("/p")));
+        assertThat(uri.query().all("k"), is(List.of("request")));
+    }
+
+    @Test
+    void requestQueryOverridesRelativeTemplateQuery() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("example/{path}?k=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("k", "request")
+                .resolvedUri();
+
+        assertThat(uri.path(), is(UriPath.create("/example/p")));
+        assertThat(uri.query().all("k"), is(List.of("request")));
+    }
+
+    @Test
+    void requestQueryOverridesRelativeTemplateQueryWhenEncodingIsConfiguredLater() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("example/{path}?k=template")
+                .pathParam("path", "p")
+                .queryParam("k", "request")
+                .skipUriEncoding(true)
+                .resolvedUri();
+
+        assertThat(uri.path(), is(UriPath.create("/example/p")));
+        assertThat(uri.query().all("k"), is(List.of("request")));
+    }
+
+    @Test
+    void multipleRequestQueryParamsArePreserved() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("one", "1")
+                .queryParam("two", "2")
+                .queryParam("three", "3")
+                .queryParam("four", "4")
+                .queryParam("five", "5")
+                .queryParam("one", "replacement")
+                .resolvedUri();
+
+        assertThat(uri.query().all("one"), is(List.of("replacement")));
+        assertThat(uri.query().all("two"), is(List.of("2")));
+        assertThat(uri.query().all("three"), is(List.of("3")));
+        assertThat(uri.query().all("four"), is(List.of("4")));
+        assertThat(uri.query().all("five"), is(List.of("5")));
+    }
+
+    @Test
+    void requestQueryCoexistsWithRelativeTemplateQuery() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("example/{path}?template=value")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("request", "value")
+                .resolvedUri();
+
+        assertThat(uri.path(), is(UriPath.create("/example/p")));
+        assertThat(uri.query().all("template"), is(List.of("value")));
+        assertThat(uri.query().all("request"), is(List.of("value")));
+    }
+
+    @Test
+    void requestQueryOverridesEncodedTemplateQueryName() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?a%20b=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("a b", "request")
+                .resolvedUri();
+
+        assertThat(uri.query().all("a b"), is(List.of("request")));
+        assertThat(uri.query().rawValue(), is("a%20b=request"));
+    }
+
+    @Test
+    void requestQueryOverridesEquivalentEncodedTemplateQueryName() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?%61=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("a", "request")
+                .resolvedUri();
+
+        assertThat(uri.query().all("a"), is(List.of("request")));
+        assertThat(uri.query().rawValue(), is("a=request"));
+        assertThat(uri.pathWithQueryAndFragment(), is("/p?a=request"));
+    }
+
+    @Test
+    void replacingTemplateDoesNotCarryEarlierQueryParam() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .queryParam("old", "value")
+                .uri("https://www.example.com/{replacement}")
+                .pathParam("replacement", "p")
+                .queryParam("new", "value")
+                .resolvedUri();
+
+        assertThat(uri.query().contains("old"), is(false));
+        assertThat(uri.query().all("new"), is(List.of("value")));
+    }
+
+    @Test
+    void replacingRelativeTemplateRetainsEarlierQueryParams() {
+        ClientUri baseUri = ClientUri.create(URI.create("https://www.example.com/base?k=base&unrelated=value"));
+        ClientUri uri = new FakeClientRequest(baseUri)
+                .uri("first/{path}")
+                .pathParam("path", "p")
+                .queryParam("k", "old")
+                .queryParam("old", "value")
+                .uri("second/{replacement}")
+                .pathParam("replacement", "p")
+                .queryParam("new", "value")
+                .resolvedUri();
+
+        assertThat(uri.query().all("k"), is(List.of("old")));
+        assertThat(uri.query().all("unrelated"), is(List.of("value")));
+        assertThat(uri.query().all("old"), is(List.of("value")));
+        assertThat(uri.query().all("new"), is(List.of("value")));
+    }
+
+    @Test
+    void replacingRelativeTemplateRetainsReplacementForEncodedBaseQueryName() {
+        ClientUri baseUri = ClientUri.create(URI.create("https://www.example.com/base?%61=base"));
+        ClientUri uri = new FakeClientRequest(baseUri)
+                .uri("first/{path}")
+                .pathParam("path", "p")
+                .queryParam("a", "old")
+                .uri("second/{replacement}")
+                .pathParam("replacement", "p")
+                .resolvedUri();
+
+        assertThat(uri.query().all("a"), is(List.of("old")));
+        assertThat(uri.query().rawValue(), is("a=old"));
+    }
+
+    @Test
+    void inheritedQueryIsNotCopiedToAnotherAuthority() {
+        ClientUri baseUri = ClientUri.create(URI.create("https://trusted.example/base?access_token=secret"));
+        ClientUri uri = new FakeClientRequest(baseUri)
+                .uri("https://{host}/path")
+                .pathParam("host", "other.example")
+                .queryParam("request", "value")
+                .resolvedUri();
+
+        assertThat(uri.authority(), is("other.example:443"));
+        assertThat(uri.query().contains("access_token"), is(false));
+        assertThat(uri.query().all("request"), is(List.of("value")));
+    }
+
+    @Test
+    void directQueryMutationIsNotPromotedToTemplateRequestParam() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p");
+        request.uri().writeableQuery().set("direct", "value");
+
+        assertThat(request.resolvedUri().query().contains("direct"), is(false));
+    }
+
+    @Test
+    void queryParamConfiguredBeforeTemplateIsNotPromoted() {
+        ClientUri uri = new FakeClientRequest()
+                .queryParam("before", "value")
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .resolvedUri();
+
+        assertThat(uri.query().contains("before"), is(false));
+    }
+
+    @Test
+    void queryParamConfiguredBeforeRelativeTemplateIsRetained() {
+        ClientUri uri = new FakeClientRequest()
+                .queryParam("before", "value")
+                .uri("example/{path}")
+                .pathParam("path", "p")
+                .resolvedUri();
+
+        assertThat(uri.query().all("before"), is(List.of("value")));
+    }
+
+    @Test
+    void directQueryMutationRetainsRelativeTemplateBehavior() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("example/{path}")
+                .pathParam("path", "p");
+        request.uri().writeableQuery().set("direct", "value");
+
+        assertThat(request.resolvedUri().query().all("direct"), is(List.of("value")));
+    }
+
+    @Test
+    void defaultEncodingKeepsTemplateQueryInPath() {
+        ClientUri uri = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?template=value")
+                .pathParam("path", "p")
+                .queryParam("request", "value")
+                .resolvedUri();
+
+        assertThat(uri.pathWithQueryAndFragment(), is("/p%3Ftemplate=value?request=value"));
+    }
+
+    @Test
+    void requestQueryCoexistsWithAbsoluteTemplateQueryForEitherEncodingOrder() {
+        ClientUri encodingFirst = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?template=value")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("request", "value")
+                .resolvedUri();
+        ClientUri encodingLast = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?template=value")
+                .pathParam("path", "p")
+                .queryParam("request", "value")
+                .skipUriEncoding(true)
+                .resolvedUri();
+
+        assertThat(encodingFirst.query().all("template"), is(List.of("value")));
+        assertThat(encodingFirst.query().all("request"), is(List.of("value")));
+        assertThat(encodingLast.query().all("template"), is(List.of("value")));
+        assertThat(encodingLast.query().all("request"), is(List.of("value")));
+    }
+
+    @Test
+    void rejectedQueryParamDoesNotArmInheritedQuery() {
+        ClientUri baseUri = ClientUri.create(URI.create("https://trusted.example/base?access_token=secret"));
+        FakeClientRequest request = new FakeClientRequest(baseUri)
+                .uri("https://{host}/path")
+                .pathParam("host", "other.example");
+
+        assertThrows(NullPointerException.class, () -> request.queryParam("access_token", (String) null));
+
+        ClientUri uri = request.resolvedUri();
+        assertThat(uri.authority(), is("other.example:443"));
+        assertThat(uri.query().contains("access_token"), is(false));
+    }
+
+    @Test
+    void rejectedQueryParamDoesNotDiscardEarlierTrackedName() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("accepted", "value");
+
+        assertThrows(NullPointerException.class, () -> request.queryParam("rejected", (String) null));
+
+        ClientUri uri = request.resolvedUri();
+        assertThat(uri.query().all("accepted"), is(List.of("value")));
+        assertThat(uri.query().contains("rejected"), is(false));
+    }
+
+    @Test
+    void templateQueryResolutionIsRepeatableAndAliasSafe() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("request", "value");
+
+        assertThat(request.resolvedUri().query().rawValue(), is("request=value"));
+        assertThat(request.resolvedUri().query().rawValue(), is("request=value"));
+        assertThat(request.resolveUri(request.uri()).query().rawValue(), is("request=value"));
+        assertThat(request.resolveUri(request.uri()).query().rawValue(), is("request=value"));
+    }
+
+    @Test
+    void mutableRequestQueryIsAuthoritative() {
+        FakeClientRequest removed = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("access_token", "secret");
+        removed.uri().writeableQuery().remove("access_token");
+
+        assertThat(removed.resolvedUri().query().contains("access_token"), is(false));
+
+        FakeClientRequest replaced = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("access_token", "secret");
+        replaced.uri().writeableQuery().set("access_token", "replacement");
+
+        assertThat(replaced.resolvedUri().query().all("access_token"), is(List.of("replacement")));
+    }
+
+    @Test
+    void rawAliasDoesNotMasqueradeAsTrackedDecodedName() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}")
+                .pathParam("path", "p")
+                .queryParam("%61", "request");
+        request.uri().writeableQuery().clear();
+        request.uri().writeableQuery().fromQueryString("%61=raw");
+
+        assertThat(request.resolvedUri().query().isEmpty(), is(true));
+    }
+
+    @Test
+    void resolvedUriDoesNotChangeTemplateQueryTracking() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?access_token=template")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("access_token", "secret");
+        request.uri().writeableQuery().remove("access_token");
+
+        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("template")));
+
+        request.uri().writeableQuery().set("access_token", "replacement");
+
+        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("replacement")));
+    }
+
+    @Test
+    void failedTemplateResolutionDoesNotChangeTrackedQueryParams() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("https://www.example.com/{path}?access_token=template")
+                .pathParam("path", "{invalid")
+                .skipUriEncoding(true)
+                .queryParam("access_token", "secret");
+        request.uri().writeableQuery().remove("access_token");
+
+        assertThrows(IllegalArgumentException.class, request::resolvedUri);
+
+        request.uri().writeableQuery().set("access_token", "replacement");
+        request.pathParam("path", "p");
+
+        assertThat(request.resolvedUri().query().all("access_token"), is(List.of("replacement")));
+    }
+
+    @Test
+    void relativeTemplateQueryResolutionIsRepeatable() {
+        FakeClientRequest request = new FakeClientRequest()
+                .uri("example/{path}?template=value")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("request", "value");
+
+        ClientUri first = request.resolvedUri();
+        ClientUri second = request.resolvedUri();
+        assertThat(second.query().rawValue(), is(first.query().rawValue()));
+        assertThat(second.query().all("template"), is(List.of("value")));
+        assertThat(second.query().all("request"), is(List.of("value")));
+    }
+
+    private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {
+        private FakeClientRequest() {
+            this(ClientUri.create());
+        }
+
+        private FakeClientRequest(ClientUri clientUri) {
+            super(HttpClientConfig.builder().build(),
+                  WebClientCookieManager.builder().build(),
+                  "fake",
+                  Method.GET,
+                  clientUri,
+                  Map.of());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            return null;
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            return null;
         }
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -92,58 +92,6 @@ class ClientRequestBaseTest {
         assertThat(request.endpointCount(), is(0));
     }
 
-    private static final class TestRequest extends ClientRequestBase<TestRequest, HttpClientResponse> {
-        private final AtomicInteger endpointCount = new AtomicInteger();
-
-        private TestRequest(Method method, String uri) {
-            this(HttpClientConfig.builder().build(), method, uri);
-        }
-
-        private TestRequest(HttpClientConfig clientConfig, Method method, String uri) {
-            super(clientConfig,
-                  WebClientCookieManager.builder().build(),
-                  "test",
-                  method,
-                  ClientUri.create(URI.create(uri)),
-                  Map.of());
-        }
-
-        @Override
-        protected HttpClientResponse doSubmit(Object entity) {
-            invokeEndpoint();
-            return null;
-        }
-
-        @Override
-        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
-            invokeEndpoint();
-            return null;
-        }
-
-        private void invokeEndpoint() {
-            CompletableFuture<WebClientServiceRequest> whenSent = new CompletableFuture<>();
-            CompletableFuture<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
-            invokeServices(endpoint(), whenSent, whenComplete, resolvedUri());
-        }
-
-        private WebClientService.Chain endpoint() {
-            return serviceRequest -> {
-                endpointCount.incrementAndGet();
-                return WebClientServiceResponse.builder()
-                        .serviceRequest(serviceRequest)
-                        .whenComplete(new CompletableFuture<>())
-                        .connection(() -> { })
-                        .status(Status.OK_200)
-                        .headers(ClientResponseHeaders.create(WritableHeaders.create()))
-                        .build();
-            };
-        }
-
-        private int endpointCount() {
-            return endpointCount.get();
-        }
-    }
-
     /**
      * Verify that query parameters are preserved when resolving URI templates (cf. issue #8566).
      * Make sure to test both absolute and relative URIs as they are handled differently when resolving.
@@ -537,6 +485,58 @@ class ClientRequestBaseTest {
         assertThat(second.query().rawValue(), is(first.query().rawValue()));
         assertThat(second.query().all("template"), is(List.of("value")));
         assertThat(second.query().all("request"), is(List.of("value")));
+    }
+
+    private static final class TestRequest extends ClientRequestBase<TestRequest, HttpClientResponse> {
+        private final AtomicInteger endpointCount = new AtomicInteger();
+
+        private TestRequest(Method method, String uri) {
+            this(HttpClientConfig.builder().build(), method, uri);
+        }
+
+        private TestRequest(HttpClientConfig clientConfig, Method method, String uri) {
+            super(clientConfig,
+                  WebClientCookieManager.builder().build(),
+                  "test",
+                  method,
+                  ClientUri.create(URI.create(uri)),
+                  Map.of());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            invokeEndpoint();
+            return null;
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            invokeEndpoint();
+            return null;
+        }
+
+        private void invokeEndpoint() {
+            CompletableFuture<WebClientServiceRequest> whenSent = new CompletableFuture<>();
+            CompletableFuture<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
+            invokeServices(endpoint(), whenSent, whenComplete, resolvedUri());
+        }
+
+        private WebClientService.Chain endpoint() {
+            return serviceRequest -> {
+                endpointCount.incrementAndGet();
+                return WebClientServiceResponse.builder()
+                        .serviceRequest(serviceRequest)
+                        .whenComplete(new CompletableFuture<>())
+                        .connection(() -> { })
+                        .status(Status.OK_200)
+                        .headers(ClientResponseHeaders.create(WritableHeaders.create()))
+                        .build();
+            };
+        }
+
+        private int endpointCount() {
+            return endpointCount.get();
+        }
     }
 
     private static final class FakeClientRequest extends ClientRequestBase<FakeClientRequest, HttpClientResponse> {

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientUriTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientUriTest.java
@@ -84,6 +84,19 @@ class ClientUriTest {
     }
 
     @Test
+    void testRequestTargetQueryUsesConfiguredEncoding() {
+        ClientUri helper = ClientUri.create(URI.create("http://localhost/path"));
+        helper.writeableQuery().set("q", "a#b");
+
+        assertThat(helper.requestTargetQuery().rawValue(), is("q=a%23b"));
+
+        helper.skipUriEncoding(true);
+
+        assertThat(helper.requestTargetQuery().rawValue(), is("q=a#b"));
+        assertThat(helper.query().rawValue(), is("q=a%23b"));
+    }
+
+    @Test
     void testEmptyQueryDelimiter() {
         ClientUri helper = ClientUri.create(URI.create("http://localhost:8080/loom/quick?"));
 

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
@@ -16,6 +16,7 @@
 package io.helidon.webclient.security;
 
 import java.lang.System.Logger.Level;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,6 +24,7 @@ import java.util.UUID;
 
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
+import io.helidon.common.uri.UriQuery;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -133,6 +135,8 @@ public class WebClientSecurity implements WebClientService {
         OutboundSecurityClientBuilder clientBuilder;
 
         try {
+            UriQuery query = request.uri().query();
+            URI targetUri = request.uri().toUri();
             SecurityEnvironment.Builder outboundEnv = context.env()
                     .derive()
                     .clearHeaders()
@@ -141,12 +145,12 @@ public class WebClientSecurity implements WebClientService {
             outboundEnv.transport(request.uri().scheme())
                     .method(request.method().text())
                     .path(request.uri().path().path())
-                    .targetUri(request.uri().toUri())
-                    .queryParams(request.uri().query())
+                    .targetUri(targetUri)
+                    .queryParams(query)
                     .requestedMethod(request.method().text())
                     .requestedPath(request.uri().path())
                     .requestedQuery(request.uri().hasQuery()
-                                            ? Optional.of(request.uri().query())
+                                            ? Optional.of(request.uri().requestTargetQuery())
                                             : Optional.empty());
 
             request.headers()

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.security;
 
+import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.security.OutboundSecurityResponse;
@@ -66,7 +67,82 @@ class WebClientSecurityTest {
         SecurityEnvironment environment = outboundEnvironment.get();
         assertThat(environment.targetUri().getScheme(), is("https"));
         assertThat(environment.transport(), is("https"));
+        assertThat(environment.requestedQuery().isEmpty(), is(true));
         assertThat(outboundConfig.findTarget(environment).isPresent(), is(true));
+    }
+
+    @Test
+    void requestedQueryMatchesSerializedQueryWithoutChangingDefaultEncoding() {
+        AtomicReference<SecurityEnvironment> outboundEnvironment = new AtomicReference<>();
+        AtomicReference<String> outboundTarget = new AtomicReference<>();
+        Security security = Security.builder()
+                .addOutboundSecurityProvider((request, environment, config) -> {
+                    outboundEnvironment.set(environment);
+                    return OutboundSecurityResponse.abstain();
+                })
+                .build();
+        WebClientService stopBeforeNetwork = (chain, request) -> {
+            outboundTarget.set(request.uri().pathWithQueryAndFragment());
+            throw new TestException();
+        };
+        Http1Client client = Http1Client.builder()
+                .servicesDiscoverServices(false)
+                .addService(WebClientSecurity.create(security))
+                .addService(stopBeforeNetwork)
+                .build();
+
+        assertThrows(TestException.class, () -> client.get()
+                .uri("https://example.test/{path}")
+                .pathParam("path", "p")
+                .queryParam("q", "a%2Fb")
+                .request());
+
+        SecurityEnvironment environment = outboundEnvironment.get();
+        assertThat(outboundTarget.get(), is("/p?q=a%252Fb"));
+        assertThat(environment.targetUri().getRawQuery(), is("q=a%252Fb"));
+        assertThat(environment.requestedPath().rawPath(), is("/p"));
+        assertThat(environment.requestedQuery().orElseThrow().rawValue(), is("q=a%252Fb"));
+        assertThat(environment.queryParams().rawValue(), is("q=a%252Fb"));
+        assertThat(environment.queryParams().get("q"), is("a%2Fb"));
+
+        assertThrows(TestException.class, () -> client.get()
+                .uri("https://example.test/{path}")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("q", "a%2Fb")
+                .request());
+
+        environment = outboundEnvironment.get();
+        assertThat(outboundTarget.get(), is("/p?q=a%2Fb"));
+        assertThat(environment.targetUri().getRawQuery(), is("q=a%2Fb"));
+        assertThat(environment.requestedPath().rawPath(), is("/p"));
+        assertThat(environment.requestedQuery().orElseThrow().rawValue(), is("q=a%2Fb"));
+        assertThat(environment.queryParams().rawValue(), is("q=a%252Fb"));
+        assertThat(environment.queryParams().get("q"), is("a%2Fb"));
+
+        assertThrows(TestException.class, () -> client.get()
+                .uri("https://example.test/{path}")
+                .pathParam("path", "p")
+                .skipUriEncoding(true)
+                .queryParam("q", "a#b")
+                .request());
+
+        environment = outboundEnvironment.get();
+        assertThat(outboundTarget.get(), is("/p?q=a#b"));
+        assertThat(environment.targetUri().getRawQuery(), is("q=a"));
+        assertThat(environment.targetUri().getRawFragment(), is("b"));
+        assertThat(environment.requestedQuery().orElseThrow().rawValue(), is("q=a#b"));
+        assertThat(environment.queryParams().rawValue(), is("q=a%23b"));
+        assertThat(environment.queryParams().get("q"), is("a#b"));
+
+        assertThrows(TestException.class, () -> client.get()
+                .uri(URI.create("https://example.test/p?"))
+                .request());
+
+        environment = outboundEnvironment.get();
+        assertThat(outboundTarget.get(), is("/p?"));
+        assertThat(environment.targetUri().getRawQuery(), is(""));
+        assertThat(environment.requestedQuery().orElseThrow().rawValue(), is(""));
     }
 
     private static final class TestException extends RuntimeException {


### PR DESCRIPTION
Resolves #12229

Carries the query parameter resolution fix from #12228 forward to `main`, preserving request-added query parameters across URI-template resolution and aligning HTTP-signature query state with the serialized request target.
