### PR TITLE
Reject HTTP/2 status changes after requesting output stream

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -69,6 +69,14 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     }
 
     @Override
+    public Http2ServerResponse status(Status status) {
+        if (outputStream != null) {
+            throw new IllegalStateException("Cannot set response status after requesting output stream.");
+        }
+        return super.status(status);
+    }
+
+    @Override
     public Http2ServerResponse header(Header header) {
         if (streamingEntity) {
             throw new IllegalStateException("Cannot set response header after requesting output stream.");

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,6 +124,31 @@ class Http2ErrorHandlingWithOutputStreamTest {
                     os.flush();
                     throw new CustomException();
                 }))
+                .route(Http2Route.route(GET, "get-outputStream-changeStatus", (req, res) -> {
+                    try (OutputStream os = res.outputStream()) {
+                        String statusResult;
+                        try {
+                            res.status(Status.INTERNAL_SERVER_ERROR_500);
+                            statusResult = "status accepted";
+                        } catch (IllegalStateException e) {
+                            statusResult = e.getMessage();
+                        }
+                        String statusCodeResult;
+                        try {
+                            res.status(500);
+                            statusCodeResult = "status code accepted";
+                        } catch (IllegalStateException e) {
+                            statusCodeResult = e.getMessage();
+                        }
+                        os.write((statusResult + '|' + statusCodeResult).getBytes(StandardCharsets.UTF_8));
+                    }
+                }))
+                .route(Http2Route.route(GET, "get-outputStream-beforeSend-changeStatus", (req, res) -> {
+                    res.beforeSend(() -> res.status(Status.ACCEPTED_202));
+                    try (OutputStream os = res.outputStream()) {
+                        os.write("before send status accepted".getBytes(StandardCharsets.UTF_8));
+                    }
+                }))
                 .get("get-outputStream-tryWithResources", (req, res) -> {
                     res.header(MAIN_HEADER_NAME, "x");
                     try (OutputStream os = res.outputStream()) {
@@ -178,6 +203,23 @@ class Http2ErrorHandlingWithOutputStreamTest {
         assertThat(r.getCause(), instanceOf(IOException.class));
         // stream should have been reset during processing
         assertThat(r.getMessage(), containsString("RST_STREAM"));
+    }
+
+    @Test
+    void testGetOutputStreamThenChangeStatusExpectFailure() {
+        var response = request("/get-outputStream-changeStatus");
+
+        assertThat(response.statusCode(), is(200));
+        assertThat(response.body(), is("Cannot set response status after requesting output stream."
+                                               + "|Cannot set response status after requesting output stream."));
+    }
+
+    @Test
+    void testGetOutputStreamBeforeSendChangeStatus() {
+        var response = request("/get-outputStream-beforeSend-changeStatus");
+
+        assertThat(response.statusCode(), is(202));
+        assertThat(response.body(), is("before send status accepted"));
     }
 
     @Test


### PR DESCRIPTION
Pre-requisite for #3686

Reject HTTP/2 response status changes after the output stream has captured the response status, while preserving status changes from beforeSend callbacks.