### PR TITLE
Share HTTP prefixed integer codec

### DIFF
--- a/common/buffers/pom.xml
+++ b/common/buffers/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
@@ -490,83 +490,25 @@ public interface BufferData {
      * HPack integer value (may be 1 or more bytes).
      *
      * @param originalValue value (only bitsOfPrefix are used, bits before that are ignored)
-     * @param bitsOfPrefix number of bits significant in the value
+     * @param bitsOfPrefix number of bits significant in the value, between {@code 1} and {@code 8}
      * @return integer value
+     * @throws java.lang.IllegalArgumentException if the prefix width is outside the supported range
      */
     default int readHpackInt(int originalValue, int bitsOfPrefix) {
-        // significant bits of the value
-
-        int value = originalValue & (0b11111111 >> (8 - bitsOfPrefix));
-        /*
-        The value is computed as
-        max + (read integer from the next x 7 bits, where next 7 bits are read if the first bit of the octet is 1)
-         */
-        int max = (1 << bitsOfPrefix) - 1;
-        if (value < max) { // 31 is the max number of 5 bits
-            // value fits into the prefix, no need to read additional bytes
-            // System.out.println("Resolved original value " + Integer.toBinaryString(originalValue) + " to " + value);
-            return value;
-        }
-        //System.out.println("Original value " + Integer.toBinaryString(originalValue) + " has more than one byte, carry on: "
-        // + value);
-        int shiftBy = 0;
-        long longValue = value;
-        while (true) {
-            if (shiftBy > 28) {
-                throw new IllegalArgumentException("HPACK integer exceeds supported range");
-            }
-            if (available() == 0) {
-                throw new IllegalArgumentException("Truncated HPACK integer");
-            }
-            int next = read();
-            //System.out.println("Read additional byte " + Integer.toBinaryString(next));
-            // add all valid bits to the number and continue next cycle
-            longValue += (long) (next & 0b01111111) << shiftBy;
-            if (longValue > Integer.MAX_VALUE) {
-                throw new IllegalArgumentException("HPACK integer exceeds supported range");
-            }
-            shiftBy += 7; // the next iteration must be shifted by 7 additional bits
-
-            if ((next & 0b10000000) == 0) {
-                // last byte
-                return (int) longValue;
-            }
-        }
+        return PrefixedIntegerCodec.readInt(this, originalValue, bitsOfPrefix);
     }
 
     /**
      * Write hpack integer to this buffer.
      *
-     * @param value the full value we want to write
+     * @param value the full non-negative value we want to write
      * @param prefixedInt value to store in the other bits of the first byte
-     * @param bitPrefix bits reserved for our value in the first byte
+     * @param bitPrefix bits reserved for our value in the first byte, between {@code 1} and {@code 8}
      * @return this instance
+     * @throws java.lang.IllegalArgumentException if the value or prefix width is outside the supported range
      */
     default BufferData writeHpackInt(int value, int prefixedInt, int bitPrefix) {
-        // we do not want possible garbage from wrong value
-        int prefixedValue = prefixedInt & (~(0b11111111 >> (8 - bitPrefix)));
-
-        int max = (1 << bitPrefix) - 1;
-        if (value < max) {
-            write(value | prefixedValue);
-            return this;
-        }
-        write(max | prefixedValue);
-
-        // now encode the rest of the value
-        int remainingValue = value - max;
-        while (true) {
-            if (remainingValue < (1 << 7)) {
-                write(remainingValue);
-                return this;
-            }
-            // write the seven bits + the first bit to mark this continues
-            int toWrite = (remainingValue & 0b01111111) | 0b10000000;
-            write(toWrite);
-
-            // shift to the right by seven bits
-            remainingValue = remainingValue >> 7;
-        }
+        return PrefixedIntegerCodec.writeInt(this, value, prefixedInt, bitPrefix);
     }
 
     /**

--- a/common/buffers/src/main/java/io/helidon/common/buffers/PrefixedIntegerCodec.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/PrefixedIntegerCodec.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.buffers;
+
+import java.util.Objects;
+
+import io.helidon.common.Api;
+
+/**
+ * Shared codec for HPACK/QPACK prefixed integers.
+ */
+@Api.Internal
+public final class PrefixedIntegerCodec {
+    private static final int MAX_INT_CONTINUATION_BYTES = 5;
+    private static final int MAX_LONG_CONTINUATION_BYTES = 10;
+
+    private PrefixedIntegerCodec() {
+    }
+
+    /**
+     * Read a prefixed integer into an {@code int}.
+     *
+     * @param source source buffer positioned after the first byte
+     * @param firstByte first byte of the encoded integer
+     * @param prefixBits number of bits in the first byte reserved for the value, between {@code 1} and {@code 8}
+     * @return decoded integer value
+     * @throws java.lang.IllegalArgumentException if the prefix width is outside the supported range
+     */
+    public static int readInt(BufferData source, int firstByte, int prefixBits) {
+        long value = readLong(source, firstByte, prefixBits, Integer.MAX_VALUE, MAX_INT_CONTINUATION_BYTES);
+        if (value > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("HPACK integer value exceeds int range: " + value);
+        }
+        return (int) value;
+    }
+
+    /**
+     * Read a prefixed integer into a {@code long}.
+     *
+     * @param source source buffer positioned after the first byte
+     * @param firstByte first byte of the encoded integer
+     * @param prefixBits number of bits in the first byte reserved for the value, between {@code 1} and {@code 8}
+     * @return decoded integer value
+     * @throws java.lang.IllegalArgumentException if the prefix width is outside the supported range
+     */
+    public static long readLong(BufferData source, int firstByte, int prefixBits) {
+        return readLong(source, firstByte, prefixBits, Long.MAX_VALUE, MAX_LONG_CONTINUATION_BYTES);
+    }
+
+    /**
+     * Write an {@code int} prefixed integer.
+     *
+     * @param target target buffer
+     * @param value full non-negative value to write
+     * @param leadingBits bits stored in the first byte outside of the value prefix
+     * @param prefixBits number of bits in the first byte reserved for the value, between {@code 1} and {@code 8}
+     * @return target buffer
+     * @throws java.lang.IllegalArgumentException if the value or prefix width is outside the supported range
+     */
+    public static BufferData writeInt(BufferData target, int value, int leadingBits, int prefixBits) {
+        return write(target, value, leadingBits, prefixBits);
+    }
+
+    /**
+     * Write a {@code long} prefixed integer.
+     *
+     * @param target target buffer
+     * @param value full non-negative value to write
+     * @param leadingBits bits stored in the first byte outside of the value prefix
+     * @param prefixBits number of bits in the first byte reserved for the value, between {@code 1} and {@code 8}
+     * @return target buffer
+     * @throws java.lang.IllegalArgumentException if the value or prefix width is outside the supported range
+     */
+    public static BufferData writeLong(BufferData target, long value, int leadingBits, int prefixBits) {
+        return write(target, value, leadingBits, prefixBits);
+    }
+
+    private static long readLong(BufferData source, int firstByte, int prefixBits, long maxValue, int maxContinuationBytes) {
+        Objects.requireNonNull(source, "source");
+        int max = prefixMask(prefixBits);
+        long value = firstByte & max;
+        if (value < max) {
+            return value;
+        }
+
+        int shiftBy = 0;
+        for (int i = 0; i < maxContinuationBytes; i++) {
+            int next = readContinuation(source);
+            int addition = next & 0b0111_1111;
+            if (addition > (maxValue - value) >>> shiftBy) {
+                throw new IllegalArgumentException("Prefixed integer value exceeds supported range");
+            }
+            value += (long) addition << shiftBy;
+            if ((next & 0b1000_0000) == 0) {
+                return value;
+            }
+            shiftBy += 7;
+        }
+        throw new IllegalArgumentException("Prefixed integer is too long");
+    }
+
+    private static int readContinuation(BufferData source) {
+        if (source.available() == 0) {
+            throw new IllegalArgumentException("Prefixed integer is truncated");
+        }
+        return source.read();
+    }
+
+    private static BufferData write(BufferData target, long value, int leadingBits, int prefixBits) {
+        Objects.requireNonNull(target, "target");
+        if (value < 0) {
+            throw new IllegalArgumentException("Prefixed integer value must not be negative: " + value);
+        }
+        int max = prefixMask(prefixBits);
+        int maskedLeadingBits = leadingBits & ~max;
+
+        if (value < max) {
+            target.write(maskedLeadingBits | (int) value);
+            return target;
+        }
+
+        target.write(maskedLeadingBits | max);
+
+        long remaining = value - max;
+        while (remaining >= (1 << 7)) {
+            target.write((int) ((remaining & 0b0111_1111) | 0b1000_0000));
+            remaining >>>= 7;
+        }
+        target.write((int) remaining);
+        return target;
+    }
+
+    private static int prefixMask(int prefixBits) {
+        if (prefixBits < 1 || prefixBits > Byte.SIZE) {
+            throw new IllegalArgumentException("Prefix width must be between 1 and 8 bits: " + prefixBits);
+        }
+        return (1 << prefixBits) - 1;
+    }
+}

--- a/common/buffers/src/main/java/module-info.java
+++ b/common/buffers/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
  * Byte buffers and byte operations.
  */
 module io.helidon.common.buffers {
+    requires static io.helidon.common;
 
     exports io.helidon.common.buffers;
 

--- a/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataTest.java
@@ -22,6 +22,7 @@ import java.util.HexFormat;
 import java.util.stream.Stream;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -184,6 +185,74 @@ class BufferDataTest {
         buffer.write(0x80);
 
         assertThrows(IllegalArgumentException.class, () -> buffer.readHpackInt(0xff, 7));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void testLongPrefixedIntegerRoundTrip(TestContext context) {
+        long expected = (1L << 33) + 42;
+        BufferData buffer = context.bufferData();
+
+        PrefixedIntegerCodec.writeLong(buffer, expected, 0b1010_0000, 5);
+
+        int first = buffer.read();
+        assertThat(first & 0b1110_0000, is(0b1010_0000));
+        assertThat(PrefixedIntegerCodec.readLong(buffer, first, 5), is(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void testRejectsOverflowingLongPrefixedInteger(TestContext context) {
+        BufferData buffer = context.bufferData();
+        for (int i = 0; i < 9; i++) {
+            buffer.write(0x80);
+        }
+        buffer.write(0x02);
+
+        assertThrows(IllegalArgumentException.class, () -> PrefixedIntegerCodec.readLong(buffer, 0x1f, 5));
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void testRejectsInvalidPrefixWidthsWithoutBufferMutation(TestContext context) {
+        BufferData buffer = context.bufferData();
+        buffer.write(0x80);
+        int available = buffer.available();
+
+        for (int prefixBits : new int[] {0, 9}) {
+            assertThrows(IllegalArgumentException.class,
+                         () -> PrefixedIntegerCodec.readInt(buffer, 0xff, prefixBits));
+            assertThat(buffer.available(), is(available));
+            assertThrows(IllegalArgumentException.class,
+                         () -> PrefixedIntegerCodec.readLong(buffer, 0xff, prefixBits));
+            assertThat(buffer.available(), is(available));
+            assertThrows(IllegalArgumentException.class,
+                         () -> PrefixedIntegerCodec.writeInt(buffer, 0, 0, prefixBits));
+            assertThat(buffer.available(), is(available));
+            assertThrows(IllegalArgumentException.class,
+                         () -> PrefixedIntegerCodec.writeLong(buffer, 0, 0, prefixBits));
+            assertThat(buffer.available(), is(available));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("initParams")
+    void testRejectsNegativePrefixedIntegerWithoutBufferMutation(TestContext context) {
+        BufferData buffer = context.bufferData();
+        int available = buffer.available();
+
+        assertThrows(IllegalArgumentException.class, () -> PrefixedIntegerCodec.writeInt(buffer, -1, 0, 5));
+        assertThat(buffer.available(), is(available));
+        assertThrows(IllegalArgumentException.class, () -> PrefixedIntegerCodec.writeLong(buffer, -1, 0, 5));
+        assertThat(buffer.available(), is(available));
+    }
+
+    @Test
+    void testRejectsNullPrefixedIntegerBuffers() {
+        assertThrows(NullPointerException.class, () -> PrefixedIntegerCodec.readInt(null, 0, 5));
+        assertThrows(NullPointerException.class, () -> PrefixedIntegerCodec.readLong(null, 0, 5));
+        assertThrows(NullPointerException.class, () -> PrefixedIntegerCodec.writeInt(null, 0, 0, 5));
+        assertThrows(NullPointerException.class, () -> PrefixedIntegerCodec.writeLong(null, 0, 0, 5));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Pre-requisite for #3686

Share prefixed-integer encoding between HPACK and QPACK while preserving the existing HPACK API.
