### PR TITLE
Enforce read-only buffer logical bounds

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.Objects;
 
 class ReadOnlyArrayData extends ReadOnlyBufferData {
     private final byte[] bytes;
@@ -84,6 +85,7 @@ class ReadOnlyArrayData extends ReadOnlyBufferData {
 
     @Override
     public String readString(int length, Charset charset) {
+        Objects.checkFromIndexSize(position, length, this.length);
         String result = new String(bytes, offset + position, length, charset);
         position += length;
         return result;
@@ -129,7 +131,9 @@ class ReadOnlyArrayData extends ReadOnlyBufferData {
 
     @Override
     public void skip(int length) {
-        position = Math.min(this.length, position + length);
+        int actualLength = Math.min(length, available());
+        Objects.checkFromIndexSize(position, actualLength, this.length);
+        position += actualLength;
     }
 
     @Override
@@ -165,6 +169,7 @@ class ReadOnlyArrayData extends ReadOnlyBufferData {
 
     @Override
     public int get(int index) {
+        Objects.checkIndex(index, available());
         return bytes[offset + position + index] & 0xFF;
     }
 }

--- a/common/buffers/src/test/java/io/helidon/common/buffers/ReadOnlyArrayDataTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/ReadOnlyArrayDataTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ReadOnlyArrayDataTest {
     @Test
@@ -71,6 +72,49 @@ class ReadOnlyArrayDataTest {
         ReadOnlyArrayData buf = new ReadOnlyArrayData(data, 0, data.length);
 
         assertThat(buf.lastIndexOf((byte) 'a', Integer.MIN_VALUE), is(-1));
+    }
+
+    @Test
+    void getHonorsLogicalRangeAndReadPosition() {
+        byte[] data = "prefixABsuffix".getBytes(StandardCharsets.UTF_8);
+        ReadOnlyArrayData buf = new ReadOnlyArrayData(data, 6, 2);
+
+        assertThat(buf.get(0), is((int) 'A'));
+        assertThat(buf.get(1), is((int) 'B'));
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.get(2));
+
+        buf.skip(1);
+
+        assertThat(buf.get(0), is((int) 'B'));
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.get(1));
+    }
+
+    @Test
+    void readStringHonorsLogicalRangeAndPreservesPositionOnFailure() {
+        byte[] data = "prefixABsuffix".getBytes(StandardCharsets.UTF_8);
+        ReadOnlyArrayData buf = new ReadOnlyArrayData(data, 6, 2);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.readString(3, StandardCharsets.UTF_8));
+        assertThat(buf.available(), is(2));
+        assertThat(buf.readString(2, StandardCharsets.UTF_8), is("AB"));
+        assertThat(buf.available(), is(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.readString(1, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void skipHonorsLogicalRange() {
+        byte[] data = "prefixABsuffix".getBytes(StandardCharsets.UTF_8);
+        ReadOnlyArrayData buf = new ReadOnlyArrayData(data, 6, 2);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.skip(-1));
+        assertThat(buf.available(), is(2));
+        assertThat(buf.get(0), is((int) 'A'));
+
+        buf.skip(Integer.MAX_VALUE);
+
+        assertThat(buf.available(), is(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> buf.get(0));
     }
 
     @Test


### PR DESCRIPTION
Pre-requisite for #3686

Enforces logical view bounds for read-only array-backed buffers so reads and cursor movement cannot access bytes outside the configured view.
