### PR TITLE
Accept parsed authority for SNI validation

### DIFF
--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcConnectionContextImplTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcConnectionContextImplTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.PeerInfo;
+import io.helidon.common.uri.UriAuthority;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
@@ -69,7 +70,7 @@ class GrpcConnectionContextImplTest {
             }
 
             @Override
-            public AuthorityCheck checkAuthority(String authority) {
+            public AuthorityCheck checkAuthority(UriAuthority authority) {
                 return AuthorityCheck.ALLOWED;
             }
         };

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -37,6 +37,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.PeerInfo;
+import io.helidon.common.uri.UriAuthority;
 import io.helidon.grpc.core.WeightedBag;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -793,7 +794,7 @@ class GrpcProtocolHandlerTest {
             }
 
             @Override
-            public AuthorityCheck checkAuthority(String authority) {
+            public AuthorityCheck checkAuthority(UriAuthority authority) {
                 return AuthorityCheck.ALLOWED;
             }
         };

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -1319,7 +1319,7 @@ class Http2ServerStreamSniTest {
             }
 
             @Override
-            public AuthorityCheck checkAuthority(String authority) {
+            public AuthorityCheck checkAuthority(UriAuthority authority) {
                 return AuthorityCheck.ALLOWED;
             }
         };
@@ -1343,8 +1343,8 @@ class Http2ServerStreamSniTest {
             }
 
             @Override
-            public AuthorityCheck checkAuthority(String authority) {
-                UriAuthority.create(authority).host();
+            public AuthorityCheck checkAuthority(UriAuthority authority) {
+                authority.host();
                 return AuthorityCheck.ALLOWED;
             }
         };

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-uri</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon</groupId>
             <artifactId>helidon</artifactId>
         </dependency>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SniContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SniContext.java
@@ -19,6 +19,7 @@ package io.helidon.webserver;
 import java.util.Optional;
 
 import io.helidon.common.Api;
+import io.helidon.common.uri.UriAuthority;
 
 /**
  * Listener SNI decision attached to a connection after TLS virtual-host selection.
@@ -50,12 +51,13 @@ public interface SniContext {
     SniMatchType matchType();
 
     /**
-     * Check whether an HTTP authority is allowed by the listener SNI policy.
+     * Check whether an already parsed {@link io.helidon.common.uri.UriAuthority HTTP authority} is allowed by the listener
+     * SNI policy.
      *
-     * @param authority HTTP authority
+     * @param authority parsed HTTP authority
      * @return authority check result
      */
-    AuthorityCheck checkAuthority(String authority);
+    AuthorityCheck checkAuthority(UriAuthority authority);
 
     /**
      * Authority check result.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SniRequestSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SniRequestSupport.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 
 import io.helidon.common.Api;
+import io.helidon.common.uri.UriAuthority;
 import io.helidon.http.DirectHandler;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
@@ -51,6 +52,28 @@ public final class SniRequestSupport {
                                          HttpPrologue prologue,
                                          Headers headers,
                                          String authority) {
+        Objects.requireNonNull(prologue);
+        Objects.requireNonNull(headers);
+        try {
+            validateAuthorityCheck(checkAuthority(sniContext, authority), prologue, headers);
+        } catch (IllegalArgumentException e) {
+            throw invalidAuthority(prologue, headers, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Validate an already parsed {@link io.helidon.common.uri.UriAuthority HTTP authority} against the connection SNI
+     * context.
+     *
+     * @param sniContext SNI context
+     * @param prologue   HTTP prologue
+     * @param headers    request headers
+     * @param authority  parsed request authority
+     */
+    public static void validateAuthority(SniContext sniContext,
+                                         HttpPrologue prologue,
+                                         Headers headers,
+                                         UriAuthority authority) {
         Objects.requireNonNull(prologue);
         Objects.requireNonNull(headers);
         try {
@@ -97,6 +120,24 @@ public final class SniRequestSupport {
         if (authority.isBlank()) {
             throw new IllegalArgumentException("HTTP authority is required by SNI policy");
         }
+        try {
+            return sniContext.checkAuthority(UriAuthority.create(authority));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid HTTP authority: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Check an already parsed {@link io.helidon.common.uri.UriAuthority HTTP authority} against the connection SNI context.
+     *
+     * @param sniContext SNI context
+     * @param authority  parsed request authority
+     * @return authority check result
+     */
+    public static SniContext.AuthorityCheck checkAuthority(SniContext sniContext,
+                                                           UriAuthority authority) {
+        Objects.requireNonNull(sniContext);
+        Objects.requireNonNull(authority);
         try {
             return sniContext.checkAuthority(authority);
         } catch (IllegalArgumentException e) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostRegistry.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/VirtualHostRegistry.java
@@ -264,8 +264,8 @@ final class VirtualHostRegistry implements ListenerTlsContext {
         }
 
         @Override
-        public AuthorityCheck checkAuthority(String authority) {
-            UriHost authorityHost = UriAuthority.create(authority).host();
+        public AuthorityCheck checkAuthority(UriAuthority authority) {
+            UriHost authorityHost = Objects.requireNonNull(authority, "authority").host();
             String normalizedAuthority = authorityHost.value();
 
             if (sniConfig.authorityMismatch() == SniAuthorityPolicy.REJECT

--- a/webserver/webserver/src/main/java/module-info.java
+++ b/webserver/webserver/src/main/java/module-info.java
@@ -30,7 +30,7 @@ module io.helidon.webserver {
     requires io.helidon.common.features.api;
     requires io.helidon.common.features;
     requires io.helidon.common.task;
-    requires io.helidon.common.uri;
+    requires transitive io.helidon.common.uri;
     requires io.helidon.common.resumable;
     requires io.helidon.logging.common;
     requires io.helidon.service.registry;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/VirtualHostRegistryTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/VirtualHostRegistryTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import io.helidon.common.tls.Tls;
 import io.helidon.common.tls.TlsMaterial;
+import io.helidon.common.uri.UriAuthority;
 
 import org.junit.jupiter.api.Test;
 
@@ -97,8 +98,9 @@ class VirtualHostRegistryTest {
         assertThat(selection.tls(), is(TLS));
         assertThat(selection.sniContext().matchType(), is(SniMatchType.EXACT));
         assertThat(selection.sniContext().matchedHost(), is(Optional.of("api.example.com")));
-        assertThat(selection.sniContext().checkAuthority("api.example.com"), is(SniContext.AuthorityCheck.ALLOWED));
-        assertThat(selection.sniContext().checkAuthority("admin.example.com"),
+        assertThat(selection.sniContext().checkAuthority(UriAuthority.create("api.example.com")),
+                   is(SniContext.AuthorityCheck.ALLOWED));
+        assertThat(selection.sniContext().checkAuthority(UriAuthority.create("admin.example.com")),
                    is(SniContext.AuthorityCheck.AUTHORITY_MISMATCH));
     }
 
@@ -111,7 +113,8 @@ class VirtualHostRegistryTest {
         assertThat(context.presentedHost(), is(Optional.of("api.example.com")));
         assertThat(context.matchedHost(), is(Optional.of("api.example.com")));
         assertThat(context.matchType(), is(SniMatchType.EXACT));
-        assertThat(context.checkAuthority("API.EXAMPLE.COM"), is(SniContext.AuthorityCheck.ALLOWED));
+        assertThat(context.checkAuthority(UriAuthority.create("API.EXAMPLE.COM")),
+                   is(SniContext.AuthorityCheck.ALLOWED));
     }
 
     @Test
@@ -148,9 +151,12 @@ class VirtualHostRegistryTest {
         SniContext context = registry.selectWithoutSni().sniContext();
 
         assertThat(context.matchType(), is(SniMatchType.FALLBACK_MISSING));
-        assertThat(context.checkAuthority("api.example.com"), is(SniContext.AuthorityCheck.FALLBACK_AUTHORITY));
-        assertThat(context.checkAuthority("admin.example.org"), is(SniContext.AuthorityCheck.FALLBACK_AUTHORITY));
-        assertThat(context.checkAuthority("other.example.net"), is(SniContext.AuthorityCheck.ALLOWED));
+        assertThat(context.checkAuthority(UriAuthority.create("api.example.com")),
+                   is(SniContext.AuthorityCheck.FALLBACK_AUTHORITY));
+        assertThat(context.checkAuthority(UriAuthority.create("admin.example.org")),
+                   is(SniContext.AuthorityCheck.FALLBACK_AUTHORITY));
+        assertThat(context.checkAuthority(UriAuthority.create("other.example.net")),
+                   is(SniContext.AuthorityCheck.ALLOWED));
     }
 
     @Test
@@ -158,8 +164,10 @@ class VirtualHostRegistryTest {
         VirtualHostRegistry registry = registry("api.example.com");
         SniContext context = registry.select("unmatched.example.com").sniContext();
 
-        assertThat(context.checkAuthority("unmatched.example.com"), is(SniContext.AuthorityCheck.ALLOWED));
-        assertThat(context.checkAuthority("other.example.com"), is(SniContext.AuthorityCheck.AUTHORITY_MISMATCH));
+        assertThat(context.checkAuthority(UriAuthority.create("unmatched.example.com")),
+                   is(SniContext.AuthorityCheck.ALLOWED));
+        assertThat(context.checkAuthority(UriAuthority.create("other.example.com")),
+                   is(SniContext.AuthorityCheck.AUTHORITY_MISMATCH));
     }
 
     @Test


### PR DESCRIPTION
Pre-requisite for #3686

Use parsed `UriAuthority` values for SNI validation while retaining the string-based helper for HTTP/1 and HTTP/2. This lets protocol implementations pass parsed authority metadata without reparsing it.
