### PR TITLE
Support protocol-owned SSE entity streams

### DIFF
--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -73,6 +73,8 @@ class DataWriterSseSink implements SseSink {
     private final Runnable closeRunnable;
     private final ConnectionContext ctx;
     private final OutputStream outputStream;
+    private final boolean closeServerSocket;
+    private final boolean closeOutputStreamBeforeCommit;
 
     DataWriterSseSink(SinkProviderContext context) {
         this.response = context.serverResponse();
@@ -80,23 +82,29 @@ class DataWriterSseSink implements SseSink {
         this.mediaContext = ctx.listenerContext().mediaContext();
         this.closeRunnable = context.closeRunnable();
 
-        // output stream to write headers
-        OutputStream headersOutputStream = new DataWriterOutputStream(ctx.dataWriter());
+        prepareResponseHeaders(true);
+        Optional<OutputStream> entityOutputStream = context.entityOutputStream(() -> prepareResponseHeaders(false));
+        if (entityOutputStream.isPresent()) {
+            this.outputStream = entityOutputStream.orElseThrow();
+            this.closeServerSocket = false;
+            this.closeOutputStreamBeforeCommit = true;
+        } else {
+            // check for content encoding
+            ContentEncoder encoder = null;
+            ServerRequestHeaders requestHeaders = context.serverRequest().headers();
+            ContentEncodingContext encodingContext = ctx.listenerContext().contentEncodingContext();
+            if (encodingContext.contentEncodingEnabled() && requestHeaders.contains(HeaderNames.ACCEPT_ENCODING)) {
+                encoder = encodingContext.encoder(requestHeaders);
+                encoder.headers(response.headers());        // adds Content-Encoding
+            }
 
-        // check for content encoding
-        ContentEncoder encoder = null;
-        ServerRequestHeaders requestHeaders = context.serverRequest().headers();
-        ContentEncodingContext encodingContext = ctx.listenerContext().contentEncodingContext();
-        if (encodingContext.contentEncodingEnabled() && requestHeaders.contains(HeaderNames.ACCEPT_ENCODING)) {
-            encoder = encodingContext.encoder(requestHeaders);
-            encoder.headers(response.headers());        // adds Content-Encoding
+            // output stream to write headers
+            OutputStream headersOutputStream = new DataWriterOutputStream(ctx.dataWriter());
+            writeStatusAndHeaders(headersOutputStream);
+            this.outputStream = (encoder != null) ? encoder.apply(headersOutputStream) : headersOutputStream;
+            this.closeServerSocket = true;
+            this.closeOutputStreamBeforeCommit = false;
         }
-
-        // write status and headers before encoding stream
-        writeStatusAndHeaders(headersOutputStream);
-
-        // set the final output stream
-        this.outputStream = (encoder != null) ? encoder.apply(headersOutputStream) : headersOutputStream;
     }
 
     @Override
@@ -132,10 +140,19 @@ class DataWriterSseSink implements SseSink {
 
     @Override
     public void close() {
-        closeRunnable.run();
         try {
+            if (closeOutputStreamBeforeCommit) {
+                // Protocol responses commit after stream wrappers finish so final bytes are sent before FIN/trailers.
+                outputStream.close();
+                closeRunnable.run();
+                return;
+            }
+
+            closeRunnable.run();
             outputStream.close();
-            ctx.serverSocket().close();
+            if (closeServerSocket) {
+                ctx.serverSocket().close();
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -143,14 +160,7 @@ class DataWriterSseSink implements SseSink {
 
     void writeStatusAndHeaders(OutputStream headersOutputStream) {
         try {
-            ServerResponseHeaders headers = response.headers();
-
-            // verify response has no status or content type
-            HttpMediaType ct = headers.contentType().orElse(null);
-            if (response.status().code() != Status.OK_200.code()
-                    || ct != null && !CONTENT_TYPE_EVENT_STREAM.values().equals(ct.mediaType().text())) {
-                throw new IllegalStateException("ServerResponse instance cannot be used to create SseSink");
-            }
+            ServerResponseHeaders headers = prepareResponseHeaders(false);
 
             // start writing status line
             headersOutputStream.write(OK_200);
@@ -163,10 +173,6 @@ class DataWriterSseSink implements SseSink {
             }
 
             // set up and write headers
-            if (ct == null) {
-                headers.add(CONTENT_TYPE_EVENT_STREAM);
-            }
-            headers.set(CACHE_NO_CACHE_ONLY);
             BufferData buffer = BufferData.growing(512);
             for (Header header : headers) {
                 header.writeHttp1Header(buffer);
@@ -182,6 +188,26 @@ class DataWriterSseSink implements SseSink {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private ServerResponseHeaders prepareResponseHeaders(boolean addDateHeader) {
+        ServerResponseHeaders headers = response.headers();
+
+        // verify response has no status or content type
+        HttpMediaType ct = headers.contentType().orElse(null);
+        if (response.status().code() != Status.OK_200.code()
+                || ct != null && !CONTENT_TYPE_EVENT_STREAM.values().equals(ct.mediaType().text())) {
+            throw new IllegalStateException("ServerResponse instance cannot be used to create SseSink");
+        }
+
+        if (ct == null) {
+            headers.add(CONTENT_TYPE_EVENT_STREAM);
+        }
+        headers.set(CACHE_NO_CACHE_ONLY);
+        if (addDateHeader && !headers.contains(HeaderNames.DATE)) {
+            headers.set(create(HeaderNames.DATE, DateTime.rfc1123String()));
+        }
+        return headers;
     }
 
     private byte[] serializeData(Object object, MediaType mediaType) {

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -206,7 +206,7 @@ class DataWriterSseSink implements SseSink {
         }
         headers.set(CACHE_NO_CACHE_ONLY);
         if (addDateHeader && !headers.contains(HeaderNames.DATE)) {
-            headers.set(create(HeaderNames.DATE, DateTime.rfc1123String()));
+            headers.set(create(HeaderNames.DATE, true, false, DateTime.rfc1123String()));
         }
         return headers;
     }

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -88,6 +88,7 @@ class DataWriterSseSink implements SseSink {
             this.outputStream = entityOutputStream.orElseThrow();
             this.closeServerSocket = false;
             this.closeOutputStreamBeforeCommit = true;
+            context.flushHeaders();
         } else {
             // check for content encoding
             ContentEncoder encoder = null;

--- a/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
+++ b/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
@@ -151,6 +151,7 @@ class DataWriterSseSinkTest {
         }
 
         assertThat("SSE headers when requesting the protocol stream", headersPrepared.get(), is(true));
+        assertThat("SSE Date header is changing", responseHeaders.get(HeaderNames.DATE).changing(), is(true));
     }
 
     @Test

--- a/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
+++ b/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -150,6 +151,40 @@ class DataWriterSseSinkTest {
         }
 
         assertThat("SSE headers when requesting the protocol stream", headersPrepared.get(), is(true));
+    }
+
+    @Test
+    void shouldFlushProtocolHeadersBeforeFirstEvent() {
+        AtomicBoolean entityStreamCreated = new AtomicBoolean();
+        AtomicBoolean headersFlushedAfterStreamCreation = new AtomicBoolean();
+        ByteArrayOutputStream entityOutputStream = new ByteArrayOutputStream();
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            entityStreamCreated.set(true);
+            return Optional.of(entityOutputStream);
+        });
+        doAnswer(_ -> {
+            headersFlushedAfterStreamCreation.set(entityStreamCreated.get());
+            return null;
+        }).when(context).flushHeaders();
+        when(context.closeRunnable()).thenReturn(() -> { });
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(ServerResponseHeaders.create());
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+
+        try (DataWriterSseSink _ = new DataWriterSseSink(context)) {
+            assertThat("protocol headers flushed after entity stream creation",
+                       headersFlushedAfterStreamCreation.get(),
+                       is(true));
+            assertThat("entity bytes before first event", entityOutputStream.size(), is(0));
+        }
     }
 
     @Test

--- a/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
+++ b/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.sse;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.Status;
+import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.http.sse.SseEvent;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http.spi.SinkProviderContext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+class DataWriterSseSinkTest {
+
+    @Test
+    void shouldCloseEntityOutputStreamBeforeCommit() {
+        AtomicBoolean outputStreamClosed = new AtomicBoolean();
+        AtomicBoolean committedAfterFinalBytes = new AtomicBoolean();
+        ByteArrayOutputStream entityOutputStream = new ByteArrayOutputStream() {
+            @Override
+            public void close() {
+                writeBytes("[final]".getBytes(StandardCharsets.UTF_8));
+                outputStreamClosed.set(true);
+            }
+        };
+
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ServerRequest request = mock(ServerRequest.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.serverRequest()).thenReturn(request);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return Optional.of(entityOutputStream);
+        });
+        when(context.closeRunnable()).thenReturn(() -> {
+            String entity = entityOutputStream.toString(StandardCharsets.UTF_8);
+            committedAfterFinalBytes.set(outputStreamClosed.get() && entity.endsWith("[final]"));
+        });
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(ServerResponseHeaders.create());
+        when(request.headers()).thenReturn(ServerRequestHeaders.create());
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
+
+        try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
+            sink.emit(SseEvent.create("hello".getBytes(StandardCharsets.UTF_8)));
+        }
+
+        assertThat(committedAfterFinalBytes.get(), is(true));
+        assertThat(entityOutputStream.toString(StandardCharsets.UTF_8), equalTo("data:hello\n\n[final]"));
+    }
+
+    @Test
+    void shouldNotApplyContentEncodingToProtocolEntityOutputStream() {
+        ByteArrayOutputStream entityOutputStream = new ByteArrayOutputStream();
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ServerRequest request = mock(ServerRequest.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.serverRequest()).thenReturn(request);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return Optional.of(entityOutputStream);
+        });
+        when(context.closeRunnable()).thenReturn(() -> { });
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(ServerResponseHeaders.create());
+        when(request.headers()).thenReturn(ServerRequestHeaders.create());
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
+
+        try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
+            sink.emit(SseEvent.create("hello".getBytes(StandardCharsets.UTF_8)));
+        }
+
+        verifyZeroInteractions(contentEncodingContext);
+        assertThat(entityOutputStream.toString(StandardCharsets.UTF_8), equalTo("data:hello\n\n"));
+    }
+
+    @Test
+    void shouldPrepareResponseHeadersBeforeRequestingProtocolStream() {
+        AtomicBoolean headersPrepared = new AtomicBoolean();
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            headersPrepared.set(responseHeaders.contains(HeaderNames.CONTENT_TYPE)
+                                        && responseHeaders.contains(HeaderNames.CACHE_CONTROL)
+                                        && responseHeaders.contains(HeaderNames.DATE));
+            invocation.<Runnable>getArgument(0).run();
+            return Optional.of(new ByteArrayOutputStream());
+        });
+        when(context.closeRunnable()).thenReturn(() -> { });
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+
+        try (DataWriterSseSink _ = new DataWriterSseSink(context)) {
+            // Close the protocol stream before committing the response.
+        }
+
+        assertThat("SSE headers when requesting the protocol stream", headersPrepared.get(), is(true));
+    }
+
+    @Test
+    void shouldValidateResponseBeforeCreatingProtocolStream() {
+        AtomicBoolean entityStreamCreated = new AtomicBoolean();
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            when(response.status()).thenReturn(Status.UNAUTHORIZED_401);
+            invocation.<Runnable>getArgument(0).run();
+            entityStreamCreated.set(true);
+            return Optional.of(new ByteArrayOutputStream());
+        });
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(ServerResponseHeaders.create());
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+
+        assertThrows(IllegalStateException.class, () -> new DataWriterSseSink(context));
+        assertThat("entity stream created after invalid response", entityStreamCreated.get(), is(false));
+    }
+}

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SimpleSseClient.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SimpleSseClient.java
@@ -93,6 +93,11 @@ class SimpleSseClient implements AutoCloseable {
         }
     }
 
+    public void awaitHeaders() {
+        ensureConnected();
+        ensureHeadersRead();
+    }
+
     @Override
     public void close() throws Exception {
         client.close();

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBaseTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBaseTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class SseBaseTest {
+    private static volatile CountDownLatch delayedLatch = new CountDownLatch(0);
     private static volatile CountDownLatch flushLatch = new CountDownLatch(0);
 
     private final WebServer webServer;
@@ -50,6 +51,10 @@ class SseBaseTest {
 
     protected WebServer webServer() {
         return webServer;
+    }
+
+    static void delayedLatch(CountDownLatch latch) {
+        delayedLatch = latch;
     }
 
     static void flushLatch(CountDownLatch latch) {
@@ -70,6 +75,13 @@ class SseBaseTest {
             Thread.sleep(50);      // simulates messages over time
         }
         sseSink.close();
+    }
+
+    static void sseDelayed(ServerRequest req, ServerResponse res) throws InterruptedException {
+        try (SseSink sseSink = res.sink(SseSink.TYPE)) {
+            delayedLatch.await(10, TimeUnit.SECONDS);
+            sseSink.emit(SseEvent.create("delayed"));
+        }
     }
 
     static void sseFlush(ServerRequest req, ServerResponse res) throws InterruptedException {

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBaseTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBaseTest.java
@@ -79,7 +79,7 @@ class SseBaseTest {
 
     static void sseDelayed(ServerRequest req, ServerResponse res) throws InterruptedException {
         try (SseSink sseSink = res.sink(SseSink.TYPE)) {
-            delayedLatch.await(10, TimeUnit.SECONDS);
+            delayedLatch.await();
             sseSink.emit(SseEvent.create("delayed"));
         }
     }

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
@@ -46,6 +46,7 @@ class SseServerTest extends SseBaseTest {
     static void routing(HttpRules rules) {
         rules.get("/sseString1", SseServerTest::sseString1);
         rules.get("/sseString2", SseServerTest::sseString2);
+        rules.get("/sseDelayed", SseServerTest::sseDelayed);
         rules.get("/sseFlush", SseServerTest::sseFlush);
         rules.get("/sseJson1", SseServerTest::sseJson1);
         rules.get("/sseJson2", SseServerTest::sseJson2);
@@ -70,6 +71,24 @@ class SseServerTest extends SseBaseTest {
     @Test
     void testSseString2() throws Exception {
         testSse("/sseString2", "data:1", "data:2", "data:3");
+    }
+
+    @Test
+    void testSseHeadersAreSentBeforeFirstEvent() throws Exception {
+        CountDownLatch delayedLatch = new CountDownLatch(1);
+        SseBaseTest.delayedLatch(delayedLatch);
+        try (SimpleSseClient sseClient = SimpleSseClient.create("localhost",
+                                                                webServer().port(),
+                                                                "/sseDelayed",
+                                                                Duration.ofSeconds(10))) {
+            sseClient.awaitHeaders();
+
+            delayedLatch.countDown();
+            assertThat(sseClient.nextEvent(), is("data:delayed"));
+        } finally {
+            delayedLatch.countDown();
+            SseBaseTest.delayedLatch(new CountDownLatch(0));
+        }
     }
 
     @Test

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/SinkProviderContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/SinkProviderContext.java
@@ -15,6 +15,10 @@
  */
 package io.helidon.webserver.http.spi;
 
+import java.io.OutputStream;
+import java.util.Objects;
+import java.util.Optional;
+
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
@@ -47,6 +51,31 @@ public interface SinkProviderContext {
      * @return the connection context
      */
     ConnectionContext connectionContext();
+
+    /**
+     * Entity output stream supplied by protocols that cannot expose the connection data writer directly to a sink provider.
+     * <p>
+     * An empty result indicates that the sink provider must use the connection data writer. When present, the protocol
+     * supplies the fully decorated response entity stream, including response filters and content encoding, and the sink
+     * provider is responsible for closing it. The sink provider must write unencoded entity bytes and must not apply these
+     * transformations again.
+     * <p>
+     * A protocol that supplies an entity stream invokes {@code responsePreparation} exactly once, after
+     * {@link io.helidon.webserver.http.ServerResponse#beforeSend(Runnable)} listeners and before constructing response filters
+     * or content encoding. If response preparation fails, the protocol must not construct or return an entity stream. An
+     * implementation that returns an empty result does not invoke {@code responsePreparation}.
+     * <p>
+     * The sink provider must close the stream before invoking
+     * {@link io.helidon.webserver.http.spi.SinkProviderContext#closeRunnable()} so stream wrappers can write their final bytes
+     * before the protocol response is committed.
+     *
+     * @param responsePreparation final response preparation
+     * @return entity output stream, or an empty optional if the protocol does not provide one
+     */
+    default Optional<OutputStream> entityOutputStream(Runnable responsePreparation) {
+        Objects.requireNonNull(responsePreparation);
+        return Optional.empty();
+    }
 
     /**
      * Runnable to execute to close the response.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/SinkProviderContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/SinkProviderContext.java
@@ -78,6 +78,16 @@ public interface SinkProviderContext {
     }
 
     /**
+     * Flushes final response headers while keeping the entity output stream open.
+     * <p>
+     * Protocols returning a stream from
+     * {@link io.helidon.webserver.http.spi.SinkProviderContext#entityOutputStream(Runnable)} must override this method so
+     * headers can be sent before the first entity byte.
+     */
+    default void flushHeaders() {
+    }
+
+    /**
      * Runnable to execute to close the response.
      *
      * @return the close runnable


### PR DESCRIPTION
Pre-requisite for #3686

Allow SSE sinks to use a protocol-supplied entity output stream when the protocol cannot expose its connection data writer directly.

Let the protocol run final response preparation immediately before constructing response filters and content encoding.

Close the entity stream before committing the response so encoding wrappers can emit their final bytes, while preserving the existing HTTP/1 behavior.
