### PR TITLE
Add class-level declarative media types

### DIFF
--- a/declarative/README.md
+++ b/declarative/README.md
@@ -126,6 +126,8 @@ Annotations on type:
 - `@RestServer.Header` - a header to be sent with every response from the server, defined either on the endpoint class, or on a
   method (repeatable)
 - `@RestServer.ComputedHeader` - a header to be sent with every response computed from a service
+- `@Http.Produces` - default media types produced by endpoint methods, individually overridable on a method
+- `@Http.Consumes` - default media types consumed by endpoint methods, individually overridable on a method
 - `@Http.Path` - the path this endpoint will be available on
 
 Annotations on method(s), may be defined on the endpoint type, or on an interface the endpoint type implements:
@@ -134,9 +136,9 @@ Annotations on method(s), may be defined on the endpoint type, or on an interfac
 - `@Http.GET`, `@Http.POST` etc., or `@Http.Method("LIST")` - mutually exclusive, to define the HTTP method that the endpoint
   method will be available on
 - `@Http.Produces` - the media type produced by this method (returned in the `Content-Type` header), also used when matching the
-  `Accept` header of the request
+  `Accept` header of the request; overrides the endpoint type default
 - `@Http.Consumes` - the media type expected by this method, when the request has an entity, matched against `Content-Type` of
-  the request
+  the request; overrides the endpoint type default
 - `@Http.Path` - the path this method will be available on, nested within the endpoint path, may contain path parameters (same as
   we can do when setting up routing)
 
@@ -169,8 +171,9 @@ designed later.
 A `__HttpFeature` class is code generated for each `@RestServer.Endpoint`.
 This type creates entry point interceptors for each method.
 The feature is a "usual" `HttpFeature` picked up by WebServer starter service.
-In case a `Http.Produces` or `Http.Consumes` is defined on a method, the route tests the Content-Type/Accept headers respectively,
-and only invokes the method if both match.
+In case a `Http.Produces` or `Http.Consumes` is defined on an endpoint type or method, the route tests the
+Content-Type/Accept headers respectively, and only invokes the method if both match. Method annotations override endpoint type
+defaults.
 
 For each qualified parameter, the parameter is obtained from the request using generated code that uses constants wherever
 possible (for header names, header values, media types etc.).
@@ -191,6 +194,8 @@ Annotations on type:
 - `@RestClient.Endpoint` - required annotation to generate a typed rest client
 - `@RestClient.Header` - a header to be sent with every request (repeatable)
 - `@RestClient.ComputedHeader` - a header to be sent with every request computed from a service
+- `@Http.Produces` - default media types produced by the server, individually overridable on a method
+- `@Http.Consumes` - default media types consumed by the server, individually overridable on a method
 - `@Http.Path` - base path of every request from this client
 
 Annotations on the interface method(s):
@@ -200,8 +205,8 @@ Annotations on the interface method(s):
 - `@RestClient.ComputedHeader` - a header to be sent with every request computed from a
 - `@Http.GET`, `@Http.POST` etc., or `@Http.Method("LIST")` - mutually exclusive, to define the HTTP method that the client will
   invoke
-- `@Http.Produces` - the media type produced by the server (client response)
-- `@Http.Consumes` - the media type expected by the server (client request)
+- `@Http.Produces` - the media type produced by the server (client response); overrides the client type default
+- `@Http.Consumes` - the media type expected by the server (client request); overrides the client type default
 
 Parameters defined by qualifiers (may be an `Optional`, supports `Mappers`):
 

--- a/declarative/README.md
+++ b/declarative/README.md
@@ -126,8 +126,8 @@ Annotations on type:
 - `@RestServer.Header` - a header to be sent with every response from the server, defined either on the endpoint class, or on a
   method (repeatable)
 - `@RestServer.ComputedHeader` - a header to be sent with every response computed from a service
-- `@Http.Produces` - default media types produced by endpoint methods, individually overridable on a method
-- `@Http.Consumes` - default media types consumed by endpoint methods, individually overridable on a method
+- `@Http.Produces` - default media types produced by endpoint methods, individually replaceable on a method
+- `@Http.Consumes` - default media types consumed by endpoint methods with request entities, individually replaceable on a method
 - `@Http.Path` - the path this endpoint will be available on
 
 Annotations on method(s), may be defined on the endpoint type, or on an interface the endpoint type implements:
@@ -136,9 +136,9 @@ Annotations on method(s), may be defined on the endpoint type, or on an interfac
 - `@Http.GET`, `@Http.POST` etc., or `@Http.Method("LIST")` - mutually exclusive, to define the HTTP method that the endpoint
   method will be available on
 - `@Http.Produces` - the media type produced by this method (returned in the `Content-Type` header), also used when matching the
-  `Accept` header of the request; overrides the endpoint type default
+  `Accept` header of the request; replaces the endpoint type default (an empty array clears it)
 - `@Http.Consumes` - the media type expected by this method, when the request has an entity, matched against `Content-Type` of
-  the request; overrides the endpoint type default
+  the request; replaces the endpoint type default (an empty array clears it)
 - `@Http.Path` - the path this method will be available on, nested within the endpoint path, may contain path parameters (same as
   we can do when setting up routing)
 
@@ -172,8 +172,9 @@ A `__HttpFeature` class is code generated for each `@RestServer.Endpoint`.
 This type creates entry point interceptors for each method.
 The feature is a "usual" `HttpFeature` picked up by WebServer starter service.
 In case a `Http.Produces` or `Http.Consumes` is defined on an endpoint type or method, the route tests the
-Content-Type/Accept headers respectively, and only invokes the method if both match. Method annotations override endpoint type
-defaults.
+Accept/Content-Type headers respectively, and only invokes the method if both match. Method annotations replace endpoint type
+defaults; an empty method annotation clears the corresponding default. Type-level `Http.Consumes` applies only to endpoint
+methods with request entities.
 
 For each qualified parameter, the parameter is obtained from the request using generated code that uses constants wherever
 possible (for header names, header values, media types etc.).
@@ -194,8 +195,8 @@ Annotations on type:
 - `@RestClient.Endpoint` - required annotation to generate a typed rest client
 - `@RestClient.Header` - a header to be sent with every request (repeatable)
 - `@RestClient.ComputedHeader` - a header to be sent with every request computed from a service
-- `@Http.Produces` - default media types produced by the server, individually overridable on a method
-- `@Http.Consumes` - default media types consumed by the server, individually overridable on a method
+- `@Http.Produces` - default media types produced by the server, individually replaceable on a method
+- `@Http.Consumes` - default media types consumed by the server for methods with request entities, individually replaceable on a method
 - `@Http.Path` - base path of every request from this client
 
 Annotations on the interface method(s):
@@ -205,8 +206,8 @@ Annotations on the interface method(s):
 - `@RestClient.ComputedHeader` - a header to be sent with every request computed from a
 - `@Http.GET`, `@Http.POST` etc., or `@Http.Method("LIST")` - mutually exclusive, to define the HTTP method that the client will
   invoke
-- `@Http.Produces` - the media type produced by the server (client response); overrides the client type default
-- `@Http.Consumes` - the media type expected by the server (client request); overrides the client type default
+- `@Http.Produces` - the media type produced by the server (client response); replaces the client type default (an empty array clears it)
+- `@Http.Consumes` - the media type expected by the server (client request); replaces the client type default (an empty array clears it)
 
 Parameters defined by qualifiers (may be an `Optional`, supports `Mappers`):
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
@@ -63,6 +63,7 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 
 import static io.helidon.declarative.codegen.DeclarativeTypes.CONFIG;
 import static io.helidon.declarative.codegen.DeclarativeTypes.SINGLETON_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_CONSUMES_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_COOKIE_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_ENTITY_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
@@ -70,6 +71,7 @@ import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_NAMES;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PATH_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PRODUCES_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_QUERY_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_REQUEST_PARAMS_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_SUPPORT;
@@ -178,13 +180,6 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         produces(annotations, builder);
         headers(annotations, builder, REST_CLIENT_HEADERS, REST_CLIENT_HEADER);
         computedHeaders(annotations, builder, REST_CLIENT_COMPUTED_HEADERS, REST_CLIENT_COMPUTED_HEADER);
-
-        if (builder.consumes().isEmpty()) {
-            builder.consumes(endpointBuilder.consumes());
-        }
-        if (builder.produces().isEmpty()) {
-            builder.produces(endpointBuilder.produces());
-        }
         builder.addHeaders(endpointBuilder.headers());
         builder.addComputedHeaders(endpointBuilder.computedHeaders());
 
@@ -192,6 +187,19 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         for (TypedElementInfo parameterInfo : method.parameterArguments()) {
             processEndpointParameter(typeInfo, method, parameterInfo, builder, index);
             index++;
+        }
+
+        if (Annotations.findFirst(HTTP_CONSUMES_ANNOTATION, annotations).isEmpty()) {
+            boolean hasEntity = clientParameters(builder.build())
+                    .stream()
+                    .anyMatch(parameter -> Annotations.findFirst(HTTP_ENTITY_ANNOTATION, parameter.annotations()).isPresent()
+                            || Annotations.findFirst(HTTP_FORM_PARAM_ANNOTATION, parameter.annotations()).isPresent());
+            if (hasEntity) {
+                builder.consumes(endpointBuilder.consumes());
+            }
+        }
+        if (Annotations.findFirst(HTTP_PRODUCES_ANNOTATION, annotations).isEmpty()) {
+            builder.produces(endpointBuilder.produces());
         }
 
         return builder.build();

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
@@ -65,12 +65,14 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 
 import static io.helidon.codegen.CodegenUtil.toConstantName;
 import static io.helidon.declarative.codegen.DeclarativeTypes.SINGLETON_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_CONSUMES_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_ENTITY_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PATH_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PRODUCES_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_QUERY_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_REQUEST_PARAMS_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_SUPPORT;
@@ -293,13 +295,6 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
         produces(annotations, builder);
         headers(annotations, builder, REST_SERVER_HEADERS, REST_SERVER_HEADER);
         computedHeaders(annotations, builder, REST_SERVER_COMPUTED_HEADERS, REST_SERVER_COMPUTED_HEADER);
-
-        if (builder.consumes().isEmpty()) {
-            builder.consumes(endpointBuilder.consumes());
-        }
-        if (builder.produces().isEmpty()) {
-            builder.produces(endpointBuilder.produces());
-        }
         builder.addHeaders(endpointBuilder.headers());
         builder.addComputedHeaders(endpointBuilder.computedHeaders());
 
@@ -316,6 +311,16 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
         for (TypedElementInfo parameterInfo : method.parameterArguments()) {
             processEndpointParameter(endpoint, method, parameterInfo, builder, index);
             index++;
+        }
+
+        if (Annotations.findFirst(HTTP_CONSUMES_ANNOTATION, annotations).isEmpty()) {
+            BodyParameters bodyParameters = bodyParameters(builder.build());
+            if (bodyParameters.entityCount() > 0 || bodyParameters.formCount() > 0) {
+                builder.consumes(endpointBuilder.consumes());
+            }
+        }
+        if (Annotations.findFirst(HTTP_PRODUCES_ANNOTATION, annotations).isEmpty()) {
+            builder.produces(endpointBuilder.produces());
         }
 
         endpointBuilder.addMethod(builder.build());

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/MediaTypeDefaultsClient.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/MediaTypeDefaultsClient.java
@@ -35,4 +35,14 @@ interface MediaTypeDefaultsClient {
     @Http.Consumes(MediaTypes.TEXT_PLAIN_VALUE)
     @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
     String override(@Http.Entity String entity);
+
+    @Http.GET
+    @Http.Path("/no-entity")
+    JsonObject noEntity();
+
+    @Http.POST
+    @Http.Path("/clear")
+    @Http.Consumes({})
+    @Http.Produces({})
+    String clear(@Http.Entity String entity);
 }

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/MediaTypeDefaultsClient.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/MediaTypeDefaultsClient.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.Http;
+import io.helidon.json.JsonObject;
+import io.helidon.webclient.api.RestClient;
+
+@RestClient.Endpoint("${greet-service.client.uri:http://localhost:8080}")
+@Http.Path("/media-type-defaults")
+@Http.Consumes(MediaTypes.APPLICATION_JSON_VALUE)
+@Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+interface MediaTypeDefaultsClient {
+
+    @Http.POST
+    JsonObject defaults(@Http.Entity JsonObject entity);
+
+    @Http.POST
+    @Http.Path("/override")
+    @Http.Consumes(MediaTypes.TEXT_PLAIN_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String override(@Http.Entity String entity);
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/MediaTypeDefaultsEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/MediaTypeDefaultsEndpoint.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.Http;
+import io.helidon.json.JsonObject;
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@Http.Path("/media-type-defaults")
+@Http.Consumes(MediaTypes.APPLICATION_JSON_VALUE)
+@Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+@RestServer.Listener("@default")
+@RestServer.Endpoint
+@Service.Singleton
+class MediaTypeDefaultsEndpoint {
+
+    @Http.POST
+    JsonObject defaults(@Http.Entity JsonObject entity) {
+        return entity;
+    }
+
+    @Http.POST
+    @Http.Path("/override")
+    @Http.Consumes(MediaTypes.TEXT_PLAIN_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String override(@Http.Entity String entity) {
+        return entity;
+    }
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/MediaTypeDefaultsEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/MediaTypeDefaultsEndpoint.java
@@ -16,11 +16,15 @@
 
 package io.helidon.declarative.tests.http;
 
+import java.util.function.Supplier;
+
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.Http;
 import io.helidon.json.JsonObject;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
+import io.helidon.webserver.http.ServerRequest;
 
 @Http.Path("/media-type-defaults")
 @Http.Consumes(MediaTypes.APPLICATION_JSON_VALUE)
@@ -29,6 +33,12 @@ import io.helidon.webserver.http.RestServer;
 @RestServer.Endpoint
 @Service.Singleton
 class MediaTypeDefaultsEndpoint {
+    private final Supplier<ServerRequest> requestSupplier;
+
+    @Service.Inject
+    MediaTypeDefaultsEndpoint(Supplier<ServerRequest> requestSupplier) {
+        this.requestSupplier = requestSupplier;
+    }
 
     @Http.POST
     JsonObject defaults(@Http.Entity JsonObject entity) {
@@ -41,5 +51,27 @@ class MediaTypeDefaultsEndpoint {
     @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
     String override(@Http.Entity String entity) {
         return entity;
+    }
+
+    @Http.GET
+    @Http.Path("/no-entity")
+    JsonObject noEntity() {
+        return JsonObject.builder()
+                .set("contentTypePresent", requestSupplier.get().headers().contentType().isPresent())
+                .build();
+    }
+
+    @Http.POST
+    @Http.Path("/clear")
+    @Http.Consumes({})
+    @Http.Produces({})
+    String clear(@Http.Entity String entity) {
+        var headers = requestSupplier.get().headers();
+        boolean textPlain = headers.contentType()
+                .map(it -> it.mediaType().equals(MediaTypes.TEXT_PLAIN))
+                .orElse(false);
+        boolean acceptsJson = headers.contains(HeaderNames.ACCEPT)
+                && headers.get(HeaderNames.ACCEPT).values().contains(MediaTypes.APPLICATION_JSON_VALUE);
+        return entity + "|" + textPlain + "|" + acceptsJson;
     }
 }

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -689,6 +689,27 @@ class DeclarativeHttpTest {
         assertThat(overrideResponse.headers().contentType().orElseThrow().mediaType(), is(MediaTypes.TEXT_PLAIN));
         assertThat(overrideResponse.entity(), is("override"));
 
+        try (var inheritedMediaResponse = client.post("/media-type-defaults/override")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit(expected)) {
+            assertThat(inheritedMediaResponse.status(), is(Status.NOT_FOUND_404));
+        }
+
+        var noEntityResponse = client.get("/media-type-defaults/no-entity")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .request(JsonObject.class);
+        assertThat(noEntityResponse.status(), is(Status.OK_200));
+        assertThat(noEntityResponse.entity().booleanValue("contentTypePresent").orElseThrow(), is(false));
+
+        var clearResponse = client.post("/media-type-defaults/clear")
+                .accept(MediaTypes.TEXT_PLAIN)
+                .contentType(MediaTypes.TEXT_PLAIN)
+                .submit("clear", String.class);
+        assertThat(clearResponse.status(), is(Status.OK_200));
+        assertThat(clearResponse.headers().contentType().orElseThrow().mediaType(), is(MediaTypes.TEXT_PLAIN));
+        assertThat(clearResponse.entity(), is("clear|true|false"));
+
         MediaTypeDefaultsClient typedClient = registry.get(Lookup.builder()
                                                                    .addContract(MediaTypeDefaultsClient.class)
                                                                    .addQualifier(Qualifier.create(RestClient.Client.class))
@@ -696,6 +717,9 @@ class DeclarativeHttpTest {
 
         assertThat(typedClient.defaults(expected), is(expected));
         assertThat(typedClient.override("override"), is("override"));
+        assertThat(typedClient.noEntity().booleanValue("contentTypePresent").orElseThrow(), is(false));
+
+        assertThat(typedClient.clear("clear"), is("clear|true|false"));
     }
 
     @Test

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -668,6 +668,37 @@ class DeclarativeHttpTest {
     }
 
     @Test
+    void testClassLevelMediaTypes() {
+        JsonObject expected = JsonObject.builder()
+                .set("message", "default")
+                .build();
+
+        var defaultResponse = client.post("/media-type-defaults")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit(expected, JsonObject.class);
+        assertThat(defaultResponse.status(), is(Status.OK_200));
+        assertThat(defaultResponse.headers().contentType().orElseThrow().mediaType(), is(MediaTypes.APPLICATION_JSON));
+        assertThat(defaultResponse.entity(), is(expected));
+
+        var overrideResponse = client.post("/media-type-defaults/override")
+                .accept(MediaTypes.TEXT_PLAIN)
+                .contentType(MediaTypes.TEXT_PLAIN)
+                .submit("override", String.class);
+        assertThat(overrideResponse.status(), is(Status.OK_200));
+        assertThat(overrideResponse.headers().contentType().orElseThrow().mediaType(), is(MediaTypes.TEXT_PLAIN));
+        assertThat(overrideResponse.entity(), is("override"));
+
+        MediaTypeDefaultsClient typedClient = registry.get(Lookup.builder()
+                                                                   .addContract(MediaTypeDefaultsClient.class)
+                                                                   .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                                   .build());
+
+        assertThat(typedClient.defaults(expected), is(expected));
+        assertThat(typedClient.override("override"), is("override"));
+    }
+
+    @Test
     void testTypedClientNullParams() {
         GreetServiceClient typedClient = registry.get(Lookup.builder()
                                                               .addContract(GreetServiceClient.class)

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -160,6 +160,8 @@ Annotations on endpoint type:
 - link:{webserver-javadoc-base-url}/io/helidon/webserver/http/RestServer.Listener.html[`io.helidon.webserver.http.RestServer.Listener`] - to define the named listener this should be served on (named port/socket)
 - link:{webserver-javadoc-base-url}/io/helidon/webserver/http/RestServer.Header.html[`io.helidon.webserver.http.RestServer.Header`] - header to return with each response from this endpoint
 - link:{webserver-javadoc-base-url}/io/helidon/webserver/http/RestServer.ComputedHeader.html[`io.helidon.webserver.http.RestServer.ComputedHeader`] - computed header to return with each response from this endpoint
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - default media types produced by endpoint methods
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - default media types consumed by endpoint methods
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Path.html[`io.helidon.http.Http.Path`] - path (context) this endpoint will be available on
 
 Annotations on endpoint methods:
@@ -170,8 +172,8 @@ Annotations on endpoint methods:
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Path.html[`io.helidon.http.Http.Path`] - path (context) this method will be available on (subpath of the endpoint path)
 - link:{http-javadoc-base-url}/io/helidon/http/Http.GET.html[`io.helidon.http.Http.GET`] (and other methods) - definition of HTTP method this method will serve
 - link:{http-javadoc-base-url}/io/helidon/http/Http.HttpMethod.html[`io.helidon.http.Http.HttpMethod`] - for custom HTTP method names (mutually exclusive with above)
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - what media type this method produces (return entity content type)
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - what media type this method accepts (request entity content type)
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - what media type this method produces (return entity content type), overriding the endpoint default
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - what media type this method accepts (request entity content type), overriding the endpoint default
 
 Annotations on method parameters:
 
@@ -226,6 +228,8 @@ Annotations on endpoint type:
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Path.html[`io.helidon.http.Http.Path`] - path (context) the server listens on
 - link:{webclient-api-javadoc-base-url}/io/helidon/webclient/api/RestClient.Header.html[`io.helidon.webclient.api.RestClient.Header`] - header to include in every request to the server
 - link:{webclient-api-javadoc-base-url}/io/helidon/webclient/api/RestClient.ComputedHeader.html[`io.helidon.webclient.api.RestClient.ComputedHeader`] - header to compute and include in every request to the server
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - default media types produced by the server
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - default media types consumed by the server
 
 Annotations on endpoint methods:
 
@@ -234,8 +238,8 @@ Annotations on endpoint methods:
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Path.html[`io.helidon.http.Http.Path`] - path (context) the server serves this endpoint method on
 - link:{http-javadoc-base-url}/io/helidon/http/Http.GET.html[`io.helidon.http.Http.GET`] (and other methods) - definition of HTTP method this method will invoke
 - link:{http-javadoc-base-url}/io/helidon/http/Http.HttpMethod.html[`io.helidon.http.Http.HttpMethod`] - for custom HTTP method names (mutually exclusive with above)
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - what media type this method produces (content type of entity from the server)
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - what media type this method accepts (request entity content type)
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - what media type this method produces (content type of entity from the server), overriding the client type default
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - what media type this method accepts (request entity content type), overriding the client type default
 
 Annotations on method parameters:
 

--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -161,7 +161,7 @@ Annotations on endpoint type:
 - link:{webserver-javadoc-base-url}/io/helidon/webserver/http/RestServer.Header.html[`io.helidon.webserver.http.RestServer.Header`] - header to return with each response from this endpoint
 - link:{webserver-javadoc-base-url}/io/helidon/webserver/http/RestServer.ComputedHeader.html[`io.helidon.webserver.http.RestServer.ComputedHeader`] - computed header to return with each response from this endpoint
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - default media types produced by endpoint methods
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - default media types consumed by endpoint methods
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - default media types consumed by endpoint methods with request entities
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Path.html[`io.helidon.http.Http.Path`] - path (context) this endpoint will be available on
 
 Annotations on endpoint methods:
@@ -172,8 +172,8 @@ Annotations on endpoint methods:
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Path.html[`io.helidon.http.Http.Path`] - path (context) this method will be available on (subpath of the endpoint path)
 - link:{http-javadoc-base-url}/io/helidon/http/Http.GET.html[`io.helidon.http.Http.GET`] (and other methods) - definition of HTTP method this method will serve
 - link:{http-javadoc-base-url}/io/helidon/http/Http.HttpMethod.html[`io.helidon.http.Http.HttpMethod`] - for custom HTTP method names (mutually exclusive with above)
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - what media type this method produces (return entity content type), overriding the endpoint default
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - what media type this method accepts (request entity content type), overriding the endpoint default
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - what media type this method produces (return entity content type), replacing the endpoint default; an empty array clears it
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - what media type this method accepts (request entity content type), replacing the endpoint default; an empty array clears it
 
 Annotations on method parameters:
 
@@ -229,7 +229,7 @@ Annotations on endpoint type:
 - link:{webclient-api-javadoc-base-url}/io/helidon/webclient/api/RestClient.Header.html[`io.helidon.webclient.api.RestClient.Header`] - header to include in every request to the server
 - link:{webclient-api-javadoc-base-url}/io/helidon/webclient/api/RestClient.ComputedHeader.html[`io.helidon.webclient.api.RestClient.ComputedHeader`] - header to compute and include in every request to the server
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - default media types produced by the server
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - default media types consumed by the server
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - default media types consumed by the server for methods with request entities
 
 Annotations on endpoint methods:
 
@@ -238,8 +238,8 @@ Annotations on endpoint methods:
 - link:{http-javadoc-base-url}/io/helidon/http/Http.Path.html[`io.helidon.http.Http.Path`] - path (context) the server serves this endpoint method on
 - link:{http-javadoc-base-url}/io/helidon/http/Http.GET.html[`io.helidon.http.Http.GET`] (and other methods) - definition of HTTP method this method will invoke
 - link:{http-javadoc-base-url}/io/helidon/http/Http.HttpMethod.html[`io.helidon.http.Http.HttpMethod`] - for custom HTTP method names (mutually exclusive with above)
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - what media type this method produces (content type of entity from the server), overriding the client type default
-- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - what media type this method accepts (request entity content type), overriding the client type default
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Produces.html[`io.helidon.http.Http.Produces`] - what media type this method produces (content type of entity from the server), replacing the client type default; an empty array clears it
+- link:{http-javadoc-base-url}/io/helidon/http/Http.Consumes.html[`io.helidon.http.Http.Consumes`] - what media type this method accepts (request entity content type), replacing the client type default; an empty array clears it
 
 Annotations on method parameters:
 

--- a/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
+++ b/docs/src/main/java/io/helidon/docs/se/inject/DeclarativeExample.java
@@ -59,9 +59,9 @@ public class DeclarativeExample {
     // tag::snippet_3[]
     @RestClient.Endpoint("${greet-service.client.uri:http://localhost:8080}")
     @RestClient.Header(name = HeaderNames.USER_AGENT_NAME, value = "my-client")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
     interface GreetClient {
         @Http.GET
-        @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
         JsonObject getDefaultMessageHandler();
     }
     // end::snippet_3[]
@@ -106,6 +106,7 @@ public class DeclarativeExample {
     // tag::snippet_2[]
     @RestServer.Endpoint // identifies this class as a server endpoint
     @Http.Path("/greet") // serve this endpoint on /greet context root (path)
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE) // default response media type for all endpoint methods
     @Service.Singleton   // a singleton service (single instance within a service registry)
     static class GreetEndpoint {
         private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
@@ -117,7 +118,6 @@ public class DeclarativeExample {
         }
 
         @Http.GET   // HTTP GET endpoint
-        @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE) // produces entity of application/json media type
         public JsonObject getDefaultMessageHandler() {
             // build the JSON object (requires `helidon-http-media-jsonp` on classpath)
             return JSON.createObjectBuilder()

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -346,7 +346,7 @@ public final class Http {
      * exactly one type, that type will be set by Helidon on response.
      * <p>
      * When declared on an endpoint type, the media types are used as defaults for every endpoint method. An annotation
-     * declared on a method overrides the endpoint type defaults for that method.
+     * declared on a method replaces the endpoint type defaults for that method; an empty method annotation clears them.
      * <p>
      * When used by Helidon declarative server code on an endpoint method that accepts the server response, generated
      * routing code configures the content type before invoking the method, so it is available to output-stream response
@@ -368,8 +368,9 @@ public final class Http {
     /**
      * What media type(s) an endpoint or method can consume.
      * <p>
-     * When declared on an endpoint type, the media types are used as defaults for every endpoint method. An annotation
-     * declared on a method overrides the endpoint type defaults for that method.
+     * When declared on an endpoint type, the media types are used as defaults for endpoint methods that accept a request
+     * entity. An annotation declared on a method replaces the endpoint type defaults for that method; an empty method
+     * annotation clears them.
      */
     @Retention(RetentionPolicy.CLASS)
     @Target({ElementType.TYPE, ElementType.METHOD})

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -340,10 +340,13 @@ public final class Http {
     }
 
     /**
-     * What media type(s) this method produces.
+     * What media type(s) an endpoint or method produces.
      * <p>
      * If the method may produce more than one type, the response headers must be crafted by hand. If it produces
      * exactly one type, that type will be set by Helidon on response.
+     * <p>
+     * When declared on an endpoint type, the media types are used as defaults for every endpoint method. An annotation
+     * declared on a method overrides the endpoint type defaults for that method.
      * <p>
      * When used by Helidon declarative server code on an endpoint method that accepts the server response, generated
      * routing code configures the content type before invoking the method, so it is available to output-stream response
@@ -351,11 +354,11 @@ public final class Http {
      * after the method returns and before the generated response is sent.
      */
     @Retention(RetentionPolicy.CLASS)
-    @Target(ElementType.METHOD)
+    @Target({ElementType.TYPE, ElementType.METHOD})
     @Documented
     public @interface Produces {
         /**
-         * Media types produced by this method.
+         * Media types produced by this endpoint or method.
          *
          * @return produced media types, such as {@code application/json}
          */
@@ -363,13 +366,17 @@ public final class Http {
     }
 
     /**
-     * What media type(s) this method can consume.
+     * What media type(s) an endpoint or method can consume.
+     * <p>
+     * When declared on an endpoint type, the media types are used as defaults for every endpoint method. An annotation
+     * declared on a method overrides the endpoint type defaults for that method.
      */
     @Retention(RetentionPolicy.CLASS)
+    @Target({ElementType.TYPE, ElementType.METHOD})
     @Documented
     public @interface Consumes {
         /**
-         * Media types acceptable by this method.
+         * Media types acceptable by this endpoint or method.
          *
          * @return consumed media types, such as {@code application/json}
          */


### PR DESCRIPTION
Resolves #12091

Allows `@Http.Consumes` and `@Http.Produces` to define type-level defaults for declarative server and client APIs. Method annotations replace those defaults, including explicit clearing, and type-level `Consumes` applies only to entity-bearing methods.
