### PR TITLE
Restore CI build-cache fast-forwarding

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -86,17 +86,16 @@ runs:
       with:
         path: .tools/apache-maven-*/**
         enableCrossOsArchive: true
-        key: tools-maven-${{ hashFiles('.tools/apache-maven-*/**') }}
-        restore-keys: |
-          tools-maven-
+        key: tools-maven-${{ env.MVN_VERSION }}
     - if: ${{ inputs.setup-maven == 'true' && runner.os != 'Windows' }}
       name: Set up Maven
       shell: bash
       run: |
         if [ -z "${MVN_VERSION}" ] ; then echo "MVN_VERSION not set"; exit 1 ; fi
         if [ ! -d .tools/apache-maven-${MVN_VERSION}/bin ] ; then
-          curl -O https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.zip
-          unzip apache-maven-${MVN_VERSION}-bin.zip -d .tools
+          curl -o "${RUNNER_TEMP}/apache-maven-${MVN_VERSION}-bin.zip" \
+            https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.zip
+          unzip "${RUNNER_TEMP}/apache-maven-${MVN_VERSION}-bin.zip" -d .tools
         fi
         echo ${PWD}/.tools/apache-maven-${MVN_VERSION}/bin >> "${GITHUB_PATH}"
     - name: Set up JDK


### PR DESCRIPTION
### Description

Forward port PR #12216 to main.

Restore CI build-cache fast-forwarding so downstream jobs reuse the prime
build instead of rebuilding the reactor.

On a cold Maven installation cache miss, the leftover Maven ZIP in the
checkout invalidates the entire build cache.

Use a new version-based key to start with a fresh Maven installation cache,
and store the installation ZIP under `RUNNER_TEMP` so it no longer modifies
the checkout.

### Documentation

None

### Validation

- parsed the composite action as YAML and verified its structure
- verified the embedded Maven setup script with `bash -n`
- ran `etc/scripts/copyright.sh` with JDK 21
- ran `git diff --check`
- validated the cold miss, exact downstream restore, and Maven build-cache
  fast-forward behavior in the fork's GitHub Actions Validate workflow:
  https://github.com/romain-grecourt/helidon/actions/runs/30597823041
