### PR TITLE
Add read-only buffer slicing support

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
@@ -82,11 +82,11 @@ public interface BufferData {
      * Consume a range from the source and return an independently positioned read-only view of exactly that range.
      *
      * <p>Sources created with
-     * {@link io.helidon.common.buffers.BufferData#createReadOnly(byte[], int, int)} share their backing array with the
+     * {@link #createReadOnly(byte[], int, int)} share their backing array with the
      * returned view. The caller must not modify that array while either buffer is in use. All other sources use an exact
      * defensive copy on the first slice. A slice backed by such a private copy may share that copy when it is re-sliced.
      * The returned logical range never includes bytes before or after the consumed source range,
-     * including after {@link io.helidon.common.buffers.BufferData#rewind()}.
+     * including after {@link #rewind()}.
      *
      * @param source source buffer
      * @param length number of bytes to consume

--- a/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
+import io.helidon.common.Api;
+
 /**
  * Wrapper around a byte array.
  */
@@ -74,6 +76,43 @@ public interface BufferData {
      */
     static BufferData createReadOnly(byte[] bytes, int offset, int length) {
         return new ReadOnlyArrayData(bytes, offset, length);
+    }
+
+    /**
+     * Consume a range from the source and return an independently positioned read-only view of exactly that range.
+     *
+     * <p>Sources created with
+     * {@link io.helidon.common.buffers.BufferData#createReadOnly(byte[], int, int)} share their backing array with the
+     * returned view. The caller must not modify that array while either buffer is in use. Other sources use an exact
+     * defensive copy. The returned logical range never includes bytes before or after the consumed source range,
+     * including after {@link io.helidon.common.buffers.BufferData#rewind()}.
+     *
+     * @param source source buffer
+     * @param length number of bytes to consume
+     * @return independently positioned read-only range
+     * @throws IndexOutOfBoundsException if length is negative or exceeds the available source bytes
+     */
+    @Api.Internal
+    static BufferData readOnlySlice(BufferData source, int length) {
+        Objects.requireNonNull(source, "source");
+        Objects.checkFromIndexSize(0, length, source.available());
+        if (length == 0) {
+            return ReadOnlyArrayData.EMPTY;
+        }
+        if (source instanceof ReadOnlyArrayData arrayData) {
+            return arrayData.readOnlySlice(length);
+        }
+
+        byte[] copy = new byte[length];
+        int offset = 0;
+        while (offset < length) {
+            int read = source.read(copy, offset, length - offset);
+            if (read <= 0) {
+                throw new IllegalStateException("Buffer reported available data but did not provide it");
+            }
+            offset += read;
+        }
+        return BufferData.createReadOnly(copy, 0, copy.length);
     }
 
     /**

--- a/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
@@ -75,7 +75,7 @@ public interface BufferData {
      * @return new byte array buffer data that are read only
      */
     static BufferData createReadOnly(byte[] bytes, int offset, int length) {
-        return new ReadOnlyArrayData(bytes, offset, length);
+        return new ReadOnlyArrayData(bytes, offset, length, true);
     }
 
     /**
@@ -83,8 +83,9 @@ public interface BufferData {
      *
      * <p>Sources created with
      * {@link io.helidon.common.buffers.BufferData#createReadOnly(byte[], int, int)} share their backing array with the
-     * returned view. The caller must not modify that array while either buffer is in use. Other sources use an exact
-     * defensive copy. The returned logical range never includes bytes before or after the consumed source range,
+     * returned view. The caller must not modify that array while either buffer is in use. All other sources use an exact
+     * defensive copy on the first slice. A slice backed by such a private copy may share that copy when it is re-sliced.
+     * The returned logical range never includes bytes before or after the consumed source range,
      * including after {@link io.helidon.common.buffers.BufferData#rewind()}.
      *
      * @param source source buffer

--- a/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
@@ -25,6 +25,8 @@ import java.nio.charset.Charset;
 import java.util.Objects;
 
 class ReadOnlyArrayData extends ReadOnlyBufferData {
+    static final BufferData EMPTY = new ReadOnlyArrayData(BufferData.EMPTY_BYTES, 0, 0);
+
     private final byte[] bytes;
     private final int offset;
     private final int length;
@@ -35,6 +37,13 @@ class ReadOnlyArrayData extends ReadOnlyBufferData {
         this.offset = offset;
         this.length = length;
         this.position = 0;
+    }
+
+    BufferData readOnlySlice(int sliceLength) {
+        Objects.checkFromIndexSize(position, sliceLength, length);
+        BufferData result = new ReadOnlyArrayData(bytes, offset + position, sliceLength);
+        position += sliceLength;
+        return result;
     }
 
     @Override

--- a/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/ReadOnlyArrayData.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.Objects;
 
 class ReadOnlyArrayData extends ReadOnlyBufferData {
@@ -30,18 +31,31 @@ class ReadOnlyArrayData extends ReadOnlyBufferData {
     private final byte[] bytes;
     private final int offset;
     private final int length;
+    private final boolean sliceSharesBacking;
     private int position;
 
     ReadOnlyArrayData(byte[] bytes, int offset, int length) {
+        this(bytes, offset, length, false);
+    }
+
+    ReadOnlyArrayData(byte[] bytes, int offset, int length, boolean sliceSharesBacking) {
         this.bytes = bytes;
         this.offset = offset;
         this.length = length;
+        this.sliceSharesBacking = sliceSharesBacking;
         this.position = 0;
     }
 
     BufferData readOnlySlice(int sliceLength) {
         Objects.checkFromIndexSize(position, sliceLength, length);
-        BufferData result = new ReadOnlyArrayData(bytes, offset + position, sliceLength);
+        int sliceOffset = offset + position;
+        BufferData result;
+        if (sliceSharesBacking) {
+            result = new ReadOnlyArrayData(bytes, sliceOffset, sliceLength, true);
+        } else {
+            byte[] copy = Arrays.copyOfRange(bytes, sliceOffset, sliceOffset + sliceLength);
+            result = BufferData.createReadOnly(copy, 0, copy.length);
+        }
         position += sliceLength;
         return result;
     }

--- a/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataReadOnlySliceTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataReadOnlySliceTest.java
@@ -88,20 +88,22 @@ class BufferDataReadOnlySliceTest {
 
     @Test
     void dataReaderSourcesUseIndependentCopyRegardlessOfFragmentation() {
-        byte[] contiguousBytes = {1, 2, 3};
+        byte[] contiguousBytes = {0, 1, 2, 3};
         DataReader contiguousReader = DataReader.create(() -> contiguousBytes);
+        contiguousReader.skip(1);
         BufferData contiguousSlice = BufferData.readOnlySlice(contiguousReader.getBuffer(3), 3);
         BufferData contiguousReslice = BufferData.readOnlySlice(contiguousSlice, 2);
 
-        byte[] first = {4, 5};
+        byte[] first = {0, 4, 5};
         byte[] second = {6};
         Iterator<byte[]> chunks = List.of(first, second).iterator();
         DataReader fragmentedReader = DataReader.create(chunks::next);
+        fragmentedReader.skip(1);
         BufferData fragmentedSlice = BufferData.readOnlySlice(fragmentedReader.getBuffer(3), 3);
         BufferData fragmentedReslice = BufferData.readOnlySlice(fragmentedSlice, 2);
 
-        contiguousBytes[0] = 9;
-        first[0] = 9;
+        contiguousBytes[1] = 9;
+        first[1] = 9;
         second[0] = 9;
 
         assertThat(contiguousReslice.readBytes(), is(new byte[] {1, 2}));

--- a/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataReadOnlySliceTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataReadOnlySliceTest.java
@@ -17,6 +17,8 @@
 package io.helidon.common.buffers;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -63,10 +65,11 @@ class BufferDataReadOnlySliceTest {
         BufferData source = BufferData.createReadOnly(bytes, 0, bytes.length);
         source.skip(1);
 
-        BufferData slice = BufferData.readOnlySlice(source, 2);
+        BufferData slice = BufferData.readOnlySlice(source, 3);
+        BufferData resliced = BufferData.readOnlySlice(slice, 2);
         bytes[1] = 9;
 
-        assertThat(slice.readBytes(), is(new byte[] {9, 3}));
+        assertThat(resliced.readBytes(), is(new byte[] {9, 3}));
     }
 
     @Test
@@ -75,11 +78,34 @@ class BufferDataReadOnlySliceTest {
         BufferData source = BufferData.create(bytes);
 
         BufferData slice = BufferData.readOnlySlice(source, 3);
+        BufferData resliced = BufferData.readOnlySlice(slice, 2);
         bytes[0] = 9;
 
-        assertThat(slice.readBytes(), is(new byte[] {1, 2, 3}));
+        assertThat(resliced.readBytes(), is(new byte[] {1, 2}));
         assertThat(source.readBytes(), is(new byte[] {4}));
-        assertThrows(UnsupportedOperationException.class, () -> slice.write(1));
+        assertThrows(UnsupportedOperationException.class, () -> resliced.write(1));
+    }
+
+    @Test
+    void dataReaderSourcesUseIndependentCopyRegardlessOfFragmentation() {
+        byte[] contiguousBytes = {1, 2, 3};
+        DataReader contiguousReader = DataReader.create(() -> contiguousBytes);
+        BufferData contiguousSlice = BufferData.readOnlySlice(contiguousReader.getBuffer(3), 3);
+        BufferData contiguousReslice = BufferData.readOnlySlice(contiguousSlice, 2);
+
+        byte[] first = {4, 5};
+        byte[] second = {6};
+        Iterator<byte[]> chunks = List.of(first, second).iterator();
+        DataReader fragmentedReader = DataReader.create(chunks::next);
+        BufferData fragmentedSlice = BufferData.readOnlySlice(fragmentedReader.getBuffer(3), 3);
+        BufferData fragmentedReslice = BufferData.readOnlySlice(fragmentedSlice, 2);
+
+        contiguousBytes[0] = 9;
+        first[0] = 9;
+        second[0] = 9;
+
+        assertThat(contiguousReslice.readBytes(), is(new byte[] {1, 2}));
+        assertThat(fragmentedReslice.readBytes(), is(new byte[] {4, 5}));
     }
 
     @Test

--- a/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataReadOnlySliceTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataReadOnlySliceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.buffers;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BufferDataReadOnlySliceTest {
+
+    @Test
+    void readOnlySliceHasIndependentCursorAndStrictLogicalBounds() {
+        BufferData source = BufferData.createReadOnly("guardHEADbodyTAILguard".getBytes(StandardCharsets.UTF_8), 5, 12);
+        source.skip(4);
+
+        BufferData body = BufferData.readOnlySlice(source, 4);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> body.get(4));
+        assertThat(body.readString(4), is("body"));
+        assertThat(source.readString(4), is("TAIL"));
+        body.rewind();
+        assertThrows(IndexOutOfBoundsException.class, () -> body.get(4));
+        assertThat(body.readString(4), is("body"));
+        assertThrows(IndexOutOfBoundsException.class, () -> body.get(0));
+        assertThrows(UnsupportedOperationException.class, () -> body.write(1));
+    }
+
+    @Test
+    void slicesAdvanceOnlyTheSourceRangeTheyConsume() {
+        BufferData source = BufferData.createReadOnly(new byte[] {1, 2, 3, 4, 5}, 0, 5);
+
+        BufferData first = BufferData.readOnlySlice(source, 2);
+        BufferData second = BufferData.readOnlySlice(source, 2);
+
+        assertThat(first.readBytes(), is(new byte[] {1, 2}));
+        assertThat(second.readBytes(), is(new byte[] {3, 4}));
+        assertThat(source.readBytes(), is(new byte[] {5}));
+        first.rewind();
+        assertThat(first.readBytes(), is(new byte[] {1, 2}));
+    }
+
+    @Test
+    void readOnlyArraySliceSharesBackingArray() {
+        byte[] bytes = {1, 2, 3, 4};
+        BufferData source = BufferData.createReadOnly(bytes, 0, bytes.length);
+        source.skip(1);
+
+        BufferData slice = BufferData.readOnlySlice(source, 2);
+        bytes[1] = 9;
+
+        assertThat(slice.readBytes(), is(new byte[] {9, 3}));
+    }
+
+    @Test
+    void unknownMutableSourceUsesIndependentCopy() {
+        byte[] bytes = {1, 2, 3, 4};
+        BufferData source = BufferData.create(bytes);
+
+        BufferData slice = BufferData.readOnlySlice(source, 3);
+        bytes[0] = 9;
+
+        assertThat(slice.readBytes(), is(new byte[] {1, 2, 3}));
+        assertThat(source.readBytes(), is(new byte[] {4}));
+        assertThrows(UnsupportedOperationException.class, () -> slice.write(1));
+    }
+
+    @Test
+    void compositeSourceUsesIndependentCopy() {
+        byte[] first = {1, 2};
+        byte[] second = {3, 4};
+        BufferData source = BufferData.create(BufferData.createReadOnly(first, 0, first.length),
+                                              BufferData.createReadOnly(second, 0, second.length));
+
+        BufferData slice = BufferData.readOnlySlice(source, 3);
+        first[0] = 9;
+        second[0] = 9;
+
+        assertThat(slice.readBytes(), is(new byte[] {1, 2, 3}));
+        assertThat(source.readBytes(), is(new byte[] {4}));
+    }
+
+    @Test
+    void emptyAndInvalidSlicesDoNotAdvanceSource() {
+        BufferData source = BufferData.createReadOnly(new byte[] {1, 2}, 0, 2);
+
+        BufferData empty = BufferData.readOnlySlice(source, 0);
+        assertThat(empty.available(), is(0));
+        assertThrows(UnsupportedOperationException.class, () -> empty.write(1));
+        assertThat(source.available(), is(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> BufferData.readOnlySlice(source, -1));
+        assertThrows(IndexOutOfBoundsException.class, () -> BufferData.readOnlySlice(source, 3));
+        assertThat(source.readBytes(), is(new byte[] {1, 2}));
+    }
+}


### PR DESCRIPTION
Add an internal buffer operation that consumes an exact source range and returns an independently positioned read-only view. Read-only array data shares backing storage, while other buffer implementations use an exact defensive copy.

Pre-requisite for #3686.
