### PR TITLE
Fix static content byte ranges

### DIFF
--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/ByteRangeRequest.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/ByteRangeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,10 +54,10 @@ record ByteRangeRequest(long fileLength, long offset, long length) {
             if (secondGroup != null) {
                 long second = Long.parseLong(secondGroup);
                 if (firstGroup == null) {
-                    from = fileLength - second;
+                    from = Math.max(0, fileLength - second);
                     last = fileLength - 1;
                 } else {
-                    last = second;
+                    last = Math.min(second, fileLength - 1);
                 }
             }
             parts.add(ByteRangeRequest.create(req, res, from, last, fileLength));

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/ByteRangeRequest.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/ByteRangeRequest.java
@@ -47,24 +47,30 @@ record ByteRangeRequest(long fileLength, long offset, long length) {
             // a-b, b-c (multipart)
             String firstGroup = matcher.group(1);
             String secondGroup = matcher.group(2);
+            if (fileLength == 0) {
+                if (firstGroup == null && secondGroup != null) {
+                    for (int i = 0; i < secondGroup.length(); i++) {
+                        if (secondGroup.charAt(i) != '0') {
+                            satisfiableEmptyRange = true;
+                            break;
+                        }
+                    }
+                }
+                continue;
+            }
             long from = 0;
             long last = fileLength - 1;
-            long second = 0;
             if (firstGroup != null) {
                 from = Long.parseLong(firstGroup);
             }
             if (secondGroup != null) {
-                second = Long.parseLong(secondGroup);
+                long second = Long.parseLong(secondGroup);
                 if (firstGroup == null) {
                     from = Math.max(0, fileLength - second);
                     last = fileLength - 1;
                 } else {
                     last = Math.min(second, fileLength - 1);
                 }
-            }
-            if (fileLength == 0) {
-                satisfiableEmptyRange |= firstGroup == null && second > 0;
-                continue;
             }
             parts.add(ByteRangeRequest.create(req, res, from, last, fileLength));
         }

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/ByteRangeRequest.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/ByteRangeRequest.java
@@ -37,6 +37,7 @@ record ByteRangeRequest(long fileLength, long offset, long length) {
 
         List<ByteRangeRequest> parts = new ArrayList<>();
         boolean found = false;
+        boolean satisfiableEmptyRange = false;
         while (matcher.find()) {
             found = true;
             //"bytes=0-1023" - 0 to 1023 (included both)
@@ -48,11 +49,12 @@ record ByteRangeRequest(long fileLength, long offset, long length) {
             String secondGroup = matcher.group(2);
             long from = 0;
             long last = fileLength - 1;
+            long second = 0;
             if (firstGroup != null) {
                 from = Long.parseLong(firstGroup);
             }
             if (secondGroup != null) {
-                long second = Long.parseLong(secondGroup);
+                second = Long.parseLong(secondGroup);
                 if (firstGroup == null) {
                     from = Math.max(0, fileLength - second);
                     last = fileLength - 1;
@@ -60,10 +62,18 @@ record ByteRangeRequest(long fileLength, long offset, long length) {
                     last = Math.min(second, fileLength - 1);
                 }
             }
+            if (fileLength == 0) {
+                satisfiableEmptyRange |= firstGroup == null && second > 0;
+                continue;
+            }
             parts.add(ByteRangeRequest.create(req, res, from, last, fileLength));
         }
         if (!found) {
             throw new BadRequestException("Invalid range header");
+        }
+        if (fileLength == 0 && !satisfiableEmptyRange) {
+            res.header(HeaderNames.CONTENT_RANGE, "*/0");
+            throw new HttpException("Wrong range", Status.REQUESTED_RANGE_NOT_SATISFIABLE_416, true);
         }
 
         return parts;

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerInMemory.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerInMemory.java
@@ -90,7 +90,9 @@ record CachedHandlerInMemory(MediaType mediaType,
                 range.setContentRange(response);
 
                 // only send a part of the file
-                response.send(Arrays.copyOfRange(bytes(), (int) range.offset(), (int) range.length()));
+                response.send(Arrays.copyOfRange(bytes(),
+                                                 (int) range.offset(),
+                                                 (int) (range.offset() + range.length())));
             } else {
                 // not supported, send full
                 send(response);

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -79,6 +79,10 @@ class StaticContentTest {
         Files.writeString(alternateRoot.resolve("resource.txt"), "Alternate content");
 
         builder.register("/classpath", createService(ClasspathHandlerConfig.create("web")))
+                .register("/classpath-memory", createService(ClasspathHandlerConfig.builder()
+                                                                      .location("web")
+                                                                      .cachedFiles(Set.of("resource.txt"))
+                                                                      .build()))
                 .register("/singleclasspath", createService(ClasspathHandlerConfig.create("web/resource.txt")))
                 .register("/path", createService(FileSystemHandlerConfig.create(staticRoot)))
                 .register("/singlepath", createService(FileSystemHandlerConfig.create(resource)));
@@ -227,6 +231,42 @@ class StaticContentTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NOT_FOUND_404));
+        }
+    }
+
+    @Test
+    void testClasspathRangeWithNonZeroOffset() {
+        try (Http1ClientResponse response = testClient.get("/classpath-memory/resource.txt")
+                .header(HeaderNames.RANGE, "bytes=2-4")
+                .request()) {
+
+            assertThat(response.status(), is(Status.PARTIAL_CONTENT_206));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_RANGE, "bytes 2-4/7"));
+            assertThat(response.as(String.class), is("nte"));
+        }
+    }
+
+    @Test
+    void testFileSystemRangeEndBeyondContent() {
+        try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                .header(HeaderNames.RANGE, "bytes=2-999")
+                .request()) {
+
+            assertThat(response.status(), is(Status.PARTIAL_CONTENT_206));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_RANGE, "bytes 2-6/7"));
+            assertThat(response.as(String.class), is("ntent"));
+        }
+    }
+
+    @Test
+    void testFileSystemSuffixRangeBeyondContent() {
+        try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                .header(HeaderNames.RANGE, "bytes=-999")
+                .request()) {
+
+            assertThat(response.status(), is(Status.PARTIAL_CONTENT_206));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_RANGE, "bytes 0-6/7"));
+            assertThat(response.as(String.class), is("Content"));
         }
     }
 

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -370,17 +370,8 @@ class StaticContentTest {
     }
 
     private void assertEmptyRanges(String path) {
-        try (Http1ClientResponse response = testClient.get(path)
-                .header(HeaderNames.RANGE, "bytes=-1")
-                .request()) {
-
-            assertThat(path + " status for bytes=-1", response.status(), is(Status.OK_200));
-            assertThat(path + " content length for bytes=-1",
-                       response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_LENGTH, "0"));
-            assertThat(path + " content range for bytes=-1",
-                       response.headers().contains(HeaderNames.CONTENT_RANGE), is(false));
-            assertThat(path + " entity for bytes=-1", response.entity().hasEntity(), is(false));
-        }
+        assertEmptyRangeIgnored(path, "bytes=-1");
+        assertEmptyRangeIgnored(path, "bytes=-1, 9223372036854775808-");
 
         try (Http1ClientResponse response = testClient.get(path)
                 .header(HeaderNames.RANGE, "bytes=-0")
@@ -396,6 +387,21 @@ class StaticContentTest {
 
             assertThat(path + " status for bytes=0-",
                        response.status(), is(Status.REQUESTED_RANGE_NOT_SATISFIABLE_416));
+        }
+    }
+
+    private void assertEmptyRangeIgnored(String path, String range) {
+        try (Http1ClientResponse response = testClient.get(path)
+                .header(HeaderNames.RANGE, range)
+                .request()) {
+
+            String description = path + " with " + range;
+            assertThat(description + " status", response.status(), is(Status.OK_200));
+            assertThat(description + " content length",
+                       response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_LENGTH, "0"));
+            assertThat(description + " content range",
+                       response.headers().contains(HeaderNames.CONTENT_RANGE), is(false));
+            assertThat(description + " entity", response.entity().hasEntity(), is(false));
         }
     }
 

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -68,9 +68,11 @@ class StaticContentTest {
         Files.createDirectories(alternateRoot);
 
         Path resource = staticRoot.resolve("resource.txt");
+        Path empty = staticRoot.resolve("empty.txt");
         Path favicon = staticRoot.resolve("favicon.ico");
 
         Files.writeString(resource, "Content");
+        Files.writeString(empty, "");
         Files.writeString(favicon, "Wrong icon text");
         Files.writeString(nested.resolve("resource.txt"), "Nested content");
         Files.writeString(staticRoot.resolve("alias-one.txt"), "Alias one");
@@ -85,6 +87,10 @@ class StaticContentTest {
                                                                       .build()))
                 .register("/singleclasspath", createService(ClasspathHandlerConfig.create("web/resource.txt")))
                 .register("/path", createService(FileSystemHandlerConfig.create(staticRoot)))
+                .register("/path-memory", createService(FileSystemHandlerConfig.builder()
+                                                                .location(staticRoot)
+                                                                .cachedFiles(Set.of("empty.txt"))
+                                                                .build()))
                 .register("/singlepath", createService(FileSystemHandlerConfig.create(resource)));
 
         builder.register("/welcome-path", createService(FileSystemHandlerConfig.builder()
@@ -271,6 +277,16 @@ class StaticContentTest {
     }
 
     @Test
+    void testFileSystemEmptyRange() {
+        assertEmptyRanges("/path/empty.txt");
+    }
+
+    @Test
+    void testCachedEmptyRange() {
+        assertEmptyRanges("/path-memory/empty.txt");
+    }
+
+    @Test
     void testFileSystemWelcomeFileSymlinkOutsideRoot() throws Exception {
         Path link = staticRoot.resolve("welcome").resolve("index.html");
         assumeTrue(createSymbolicLink(link, externalDir.resolve("resource.txt")), "Symbolic links cannot be created");
@@ -350,6 +366,36 @@ class StaticContentTest {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_TYPE, "text/plain"));
             assertThat(response.as(String.class), is("Content"));
+        }
+    }
+
+    private void assertEmptyRanges(String path) {
+        try (Http1ClientResponse response = testClient.get(path)
+                .header(HeaderNames.RANGE, "bytes=-1")
+                .request()) {
+
+            assertThat(path + " status for bytes=-1", response.status(), is(Status.OK_200));
+            assertThat(path + " content length for bytes=-1",
+                       response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_LENGTH, "0"));
+            assertThat(path + " content range for bytes=-1",
+                       response.headers().contains(HeaderNames.CONTENT_RANGE), is(false));
+            assertThat(path + " entity for bytes=-1", response.entity().hasEntity(), is(false));
+        }
+
+        try (Http1ClientResponse response = testClient.get(path)
+                .header(HeaderNames.RANGE, "bytes=-0")
+                .request()) {
+
+            assertThat(path + " status for bytes=-0",
+                       response.status(), is(Status.REQUESTED_RANGE_NOT_SATISFIABLE_416));
+        }
+
+        try (Http1ClientResponse response = testClient.get(path)
+                .header(HeaderNames.RANGE, "bytes=0-")
+                .request()) {
+
+            assertThat(path + " status for bytes=0-",
+                       response.status(), is(Status.REQUESTED_RANGE_NOT_SATISFIABLE_416));
         }
     }
 


### PR DESCRIPTION
Pre-requisite for #12058

Correct static-content byte-range responses for ordinary cached and file-backed resources.

- Clamp an oversized suffix range to the full representation.
- Clamp an explicit range end to the representation length.
- Use the correct exclusive array end when slicing cached content at a non-zero offset.

This keeps `Content-Range`, `Content-Length`, and the emitted payload consistent.