### PR TITLE
Fix static content conditional requests

### DIFF
--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-static-content</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.graphql</groupId>
             <artifactId>helidon-graphql-server</artifactId>
         </dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/staticcontent/StaticContentPreconditionsBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/staticcontent/StaticContentPreconditionsBenchmark.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.staticcontent;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.HttpException;
+import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode({Mode.AverageTime, Mode.SampleTime})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class StaticContentPreconditionsBenchmark {
+    private static final Instant LAST_MODIFIED = Instant.parse("2026-08-11T12:34:56.123Z");
+    private static final String ETAG = String.valueOf(LAST_MODIFIED.toEpochMilli());
+    private static final Header LAST_MODIFIED_HEADER = HeaderValues.create(HeaderNames.LAST_MODIFIED,
+                                                                            true,
+                                                                            false,
+                                                                            "Tue, 11 Aug 2026 12:34:56 GMT");
+    private static final BiConsumer<ServerResponseHeaders, Instant> SET_MODIFIED =
+            (headers, _) -> headers.set(LAST_MODIFIED_HEADER);
+
+    private ServerRequestHeaders noConditionalHeader;
+    private ServerRequestHeaders matchingIfNoneMatch;
+    private ServerRequestHeaders nonMatchingIfNoneMatch;
+    private ServerRequestHeaders quotedCommaList;
+    private ServerRequestHeaders largeNonMatchingList;
+
+    @Setup
+    public void setup() {
+        noConditionalHeader = ServerRequestHeaders.create();
+        matchingIfNoneMatch = requestHeaders('"' + ETAG + '"');
+        nonMatchingIfNoneMatch = requestHeaders("\"different-etag\"");
+        quotedCommaList = requestHeaders("\"tag,with,commas\", \"different-etag\"");
+
+        StringBuilder largeValue = new StringBuilder(8_000);
+        for (int i = 0; i < 800; i++) {
+            if (!largeValue.isEmpty()) {
+                largeValue.append(", ");
+            }
+            largeValue.append('"').append("tag").append(i).append('"');
+        }
+        largeNonMatchingList = requestHeaders(largeValue.toString());
+    }
+
+    @Benchmark
+    public ServerResponseHeaders noConditionalHeader200() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        process(noConditionalHeader, responseHeaders);
+        return responseHeaders;
+    }
+
+    @Benchmark
+    public void matchingIfNoneMatch304(Blackhole blackhole) {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        try {
+            process(matchingIfNoneMatch, responseHeaders);
+            throw new AssertionError("Expected 304 response");
+        } catch (HttpException e) {
+            if (e.status() != Status.NOT_MODIFIED_304) {
+                throw e;
+            }
+            blackhole.consume(responseHeaders);
+            blackhole.consume(e);
+        }
+    }
+
+    @Benchmark
+    public ServerResponseHeaders nonMatchingIfNoneMatch200() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        process(nonMatchingIfNoneMatch, responseHeaders);
+        return responseHeaders;
+    }
+
+    @Benchmark
+    public ServerResponseHeaders quotedCommaShortList200() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        process(quotedCommaList, responseHeaders);
+        return responseHeaders;
+    }
+
+    @Benchmark
+    public ServerResponseHeaders nearLimitIfNoneMatch200() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        process(largeNonMatchingList, responseHeaders);
+        return responseHeaders;
+    }
+
+    private static void process(ServerRequestHeaders requestHeaders, ServerResponseHeaders responseHeaders) {
+        StaticContentHandler.processPreconditions(ETAG,
+                                                  LAST_MODIFIED,
+                                                  requestHeaders,
+                                                  responseHeaders,
+                                                  SET_MODIFIED);
+    }
+
+    private static ServerRequestHeaders requestHeaders(String value) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.set(HeaderValues.create(HeaderNames.IF_NONE_MATCH, value));
+        return ServerRequestHeaders.create(headers);
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/staticcontent/StaticContentPreconditionsBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/staticcontent/StaticContentPreconditionsBenchmark.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpException;
@@ -56,13 +57,15 @@ public class StaticContentPreconditionsBenchmark {
     private ServerRequestHeaders nonMatchingIfNoneMatch;
     private ServerRequestHeaders quotedCommaList;
     private ServerRequestHeaders largeNonMatchingList;
+    private ServerRequestHeaders largeMatchingIfNoneMatch;
+    private ServerRequestHeaders largeMatchingIfMatch;
 
     @Setup
     public void setup() {
         noConditionalHeader = ServerRequestHeaders.create();
-        matchingIfNoneMatch = requestHeaders('"' + ETAG + '"');
-        nonMatchingIfNoneMatch = requestHeaders("\"different-etag\"");
-        quotedCommaList = requestHeaders("\"tag,with,commas\", \"different-etag\"");
+        matchingIfNoneMatch = requestHeaders(HeaderNames.IF_NONE_MATCH, '"' + ETAG + '"');
+        nonMatchingIfNoneMatch = requestHeaders(HeaderNames.IF_NONE_MATCH, "\"different-etag\"");
+        quotedCommaList = requestHeaders(HeaderNames.IF_NONE_MATCH, "\"tag,with,commas\", \"different-etag\"");
 
         StringBuilder largeValue = new StringBuilder(8_000);
         for (int i = 0; i < 800; i++) {
@@ -71,7 +74,10 @@ public class StaticContentPreconditionsBenchmark {
             }
             largeValue.append('"').append("tag").append(i).append('"');
         }
-        largeNonMatchingList = requestHeaders(largeValue.toString());
+        largeNonMatchingList = requestHeaders(HeaderNames.IF_NONE_MATCH, largeValue.toString());
+        String largeMatchingValue = '"' + ETAG + "\", " + largeValue;
+        largeMatchingIfNoneMatch = requestHeaders(HeaderNames.IF_NONE_MATCH, largeMatchingValue);
+        largeMatchingIfMatch = requestHeaders(HeaderNames.IF_MATCH, largeMatchingValue);
     }
 
     @Benchmark
@@ -117,6 +123,28 @@ public class StaticContentPreconditionsBenchmark {
         return responseHeaders;
     }
 
+    @Benchmark
+    public void nearLimitMatchingIfNoneMatch304(Blackhole blackhole) {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        try {
+            process(largeMatchingIfNoneMatch, responseHeaders);
+            throw new AssertionError("Expected 304 response");
+        } catch (HttpException e) {
+            if (e.status() != Status.NOT_MODIFIED_304) {
+                throw e;
+            }
+            blackhole.consume(responseHeaders);
+            blackhole.consume(e);
+        }
+    }
+
+    @Benchmark
+    public ServerResponseHeaders nearLimitMatchingIfMatch200() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        process(largeMatchingIfMatch, responseHeaders);
+        return responseHeaders;
+    }
+
     private static void process(ServerRequestHeaders requestHeaders, ServerResponseHeaders responseHeaders) {
         StaticContentHandler.processPreconditions(ETAG,
                                                   LAST_MODIFIED,
@@ -125,9 +153,9 @@ public class StaticContentPreconditionsBenchmark {
                                                   SET_MODIFIED);
     }
 
-    private static ServerRequestHeaders requestHeaders(String value) {
+    private static ServerRequestHeaders requestHeaders(HeaderName headerName, String value) {
         WritableHeaders<?> headers = WritableHeaders.create();
-        headers.set(HeaderValues.create(HeaderNames.IF_NONE_MATCH, value));
+        headers.set(HeaderValues.create(headerName, value));
         return ServerRequestHeaders.create(headers);
     }
 }

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/staticcontent/StaticContentPreconditionsJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/staticcontent/StaticContentPreconditionsJmhRunnerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.staticcontent;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class StaticContentPreconditionsJmhRunnerTest {
+    @Test
+    void runExactBenchmark() throws RunnerException {
+        String result = System.getProperty("static.content.preconditions.jmh.result",
+                                           "target/static-content-preconditions-jmh.json");
+        Options options = new OptionsBuilder()
+                .include("^" + Pattern.quote(StaticContentPreconditionsBenchmark.class.getName())
+                                 + "\\.(noConditionalHeader200"
+                                 + "|matchingIfNoneMatch304"
+                                 + "|nonMatchingIfNoneMatch200"
+                                 + "|quotedCommaShortList200"
+                                 + "|nearLimitIfNoneMatch200)$")
+                .forks(Integer.getInteger("static.content.preconditions.jmh.forks", 3))
+                .threads(1)
+                .warmupIterations(Integer.getInteger("static.content.preconditions.jmh.warmupIterations", 5))
+                .warmupTime(TimeValue.milliseconds(Long.getLong("static.content.preconditions.jmh.warmupMillis", 1_000)))
+                .measurementIterations(Integer.getInteger("static.content.preconditions.jmh.measurementIterations", 8))
+                .measurementTime(TimeValue.milliseconds(
+                        Long.getLong("static.content.preconditions.jmh.measurementMillis", 1_000)))
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/staticcontent/StaticContentPreconditionsJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/staticcontent/StaticContentPreconditionsJmhRunnerTest.java
@@ -38,7 +38,9 @@ class StaticContentPreconditionsJmhRunnerTest {
                                  + "|matchingIfNoneMatch304"
                                  + "|nonMatchingIfNoneMatch200"
                                  + "|quotedCommaShortList200"
-                                 + "|nearLimitIfNoneMatch200)$")
+                                 + "|nearLimitIfNoneMatch200"
+                                 + "|nearLimitMatchingIfNoneMatch304"
+                                 + "|nearLimitMatchingIfMatch200)$")
                 .forks(Integer.getInteger("static.content.preconditions.jmh.forks", 3))
                 .threads(1)
                 .warmupIterations(Integer.getInteger("static.content.preconditions.jmh.warmupIterations", 5))

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerInMemory.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerInMemory.java
@@ -49,13 +49,11 @@ record CachedHandlerInMemory(MediaType mediaType,
                           ServerResponse response,
                           String requestedResource) {
         // etag etc.
-        if (lastModified != null) {
-            processPreconditions(String.valueOf(lastModified.toEpochMilli()),
-                                 lastModified,
-                                 request.headers(),
-                                 response.headers(),
-                                 setLastModifiedHeader);
-        }
+        processPreconditions(lastModified == null ? null : String.valueOf(lastModified.toEpochMilli()),
+                             lastModified,
+                             request.headers(),
+                             response.headers(),
+                             setLastModifiedHeader);
 
         response.headers().contentType(mediaType);
 

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerInMemory.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerInMemory.java
@@ -33,8 +33,7 @@ import io.helidon.http.Status;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
-import static io.helidon.webserver.staticcontent.StaticContentHandler.processEtag;
-import static io.helidon.webserver.staticcontent.StaticContentHandler.processModifyHeaders;
+import static io.helidon.webserver.staticcontent.StaticContentHandler.processPreconditions;
 
 record CachedHandlerInMemory(MediaType mediaType,
                              Instant lastModified,
@@ -51,8 +50,11 @@ record CachedHandlerInMemory(MediaType mediaType,
                           String requestedResource) {
         // etag etc.
         if (lastModified != null) {
-            processEtag(String.valueOf(lastModified.toEpochMilli()), request.headers(), response.headers());
-            processModifyHeaders(lastModified, request.headers(), response.headers(), setLastModifiedHeader);
+            processPreconditions(String.valueOf(lastModified.toEpochMilli()),
+                                 lastModified,
+                                 request.headers(),
+                                 response.headers(),
+                                 setLastModifiedHeader);
         }
 
         response.headers().contentType(mediaType);

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerJar.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerJar.java
@@ -104,13 +104,11 @@ class CachedHandlerJar implements CachedHandler {
         }
 
         // etag etc.
-        if (lastModified != null) {
-            processPreconditions(String.valueOf(lastModified.toEpochMilli()),
-                                 lastModified,
-                                 request.headers(),
-                                 response.headers(),
-                                 setLastModifiedHeader);
-        }
+        processPreconditions(lastModified == null ? null : String.valueOf(lastModified.toEpochMilli()),
+                             lastModified,
+                             request.headers(),
+                             response.headers(),
+                             setLastModifiedHeader);
 
         response.headers().contentType(mediaType);
 

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerJar.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerJar.java
@@ -38,8 +38,7 @@ import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
 import static io.helidon.webserver.staticcontent.StaticContentHandler.formatLastModified;
-import static io.helidon.webserver.staticcontent.StaticContentHandler.processEtag;
-import static io.helidon.webserver.staticcontent.StaticContentHandler.processModifyHeaders;
+import static io.helidon.webserver.staticcontent.StaticContentHandler.processPreconditions;
 
 /**
  * Handles a jar file entry.
@@ -106,8 +105,11 @@ class CachedHandlerJar implements CachedHandler {
 
         // etag etc.
         if (lastModified != null) {
-            processEtag(String.valueOf(lastModified.toEpochMilli()), request.headers(), response.headers());
-            processModifyHeaders(lastModified, request.headers(), response.headers(), setLastModifiedHeader);
+            processPreconditions(String.valueOf(lastModified.toEpochMilli()),
+                                 lastModified,
+                                 request.headers(),
+                                 response.headers(),
+                                 setLastModifiedHeader);
         }
 
         response.headers().contentType(mediaType);

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerPath.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerPath.java
@@ -97,13 +97,11 @@ record CachedHandlerPath(Path path,
         }
 
         // etag etc.
-        if (lastModified != null) {
-            processPreconditions(String.valueOf(lastModified.toEpochMilli()),
-                                 lastModified,
-                                 request.headers(),
-                                 response.headers(),
-                                 setLastModifiedHeader());
-        }
+        processPreconditions(lastModified == null ? null : String.valueOf(lastModified.toEpochMilli()),
+                             lastModified,
+                             request.headers(),
+                             response.headers(),
+                             setLastModifiedHeader());
 
         response.headers().contentType(mediaType);
 

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerPath.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerPath.java
@@ -36,8 +36,7 @@ import io.helidon.http.ServerResponseHeaders;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
-import static io.helidon.webserver.staticcontent.StaticContentHandler.processEtag;
-import static io.helidon.webserver.staticcontent.StaticContentHandler.processModifyHeaders;
+import static io.helidon.webserver.staticcontent.StaticContentHandler.processPreconditions;
 
 record CachedHandlerPath(Path path,
                          MediaType mediaType,
@@ -99,8 +98,11 @@ record CachedHandlerPath(Path path,
 
         // etag etc.
         if (lastModified != null) {
-            processEtag(String.valueOf(lastModified.toEpochMilli()), request.headers(), response.headers());
-            processModifyHeaders(lastModified, request.headers(), response.headers(), setLastModifiedHeader());
+            processPreconditions(String.valueOf(lastModified.toEpochMilli()),
+                                 lastModified,
+                                 request.headers(),
+                                 response.headers(),
+                                 setLastModifiedHeader());
         }
 
         response.headers().contentType(mediaType);

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerUrlStream.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerUrlStream.java
@@ -45,13 +45,12 @@ record CachedHandlerUrlStream(MediaType mediaType, URL url) implements CachedHan
 
         URLConnection urlConnection = url.openConnection();
         long lastModified = urlConnection.getLastModified();
+        Instant modified = lastModified == 0 ? null : Instant.ofEpochMilli(lastModified);
 
-        if (lastModified != 0) {
-            StaticContentHandler.processPreconditions(String.valueOf(lastModified),
-                                                      Instant.ofEpochMilli(lastModified),
-                                                      request.headers(),
-                                                      response.headers());
-        }
+        StaticContentHandler.processPreconditions(modified == null ? null : String.valueOf(lastModified),
+                                                  modified,
+                                                  request.headers(),
+                                                  response.headers());
 
         response.headers().contentType(mediaType);
 

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerUrlStream.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/CachedHandlerUrlStream.java
@@ -47,8 +47,10 @@ record CachedHandlerUrlStream(MediaType mediaType, URL url) implements CachedHan
         long lastModified = urlConnection.getLastModified();
 
         if (lastModified != 0) {
-            StaticContentHandler.processEtag(String.valueOf(lastModified), request.headers(), response.headers());
-            StaticContentHandler.processModifyHeaders(Instant.ofEpochMilli(lastModified), request.headers(), response.headers());
+            StaticContentHandler.processPreconditions(String.valueOf(lastModified),
+                                                      Instant.ofEpochMilli(lastModified),
+                                                      request.headers(),
+                                                      response.headers());
         }
 
         response.headers().contentType(mediaType);

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -114,6 +115,7 @@ abstract class StaticContentHandler implements HttpService {
         }
 
         if (modified != null) {
+            modified = modified.truncatedTo(ChronoUnit.SECONDS);
             // Last-Modified
             setModified.accept(responseHeaders, modified);
             // If-Unmodified-Since

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -93,10 +93,11 @@ abstract class StaticContentHandler implements HttpService {
         boolean ifMatchPresent = requestHeaders.contains(HeaderNames.IF_MATCH);
         if (newEtag != null && ifMatchPresent) {
             // Process If-Match header
-            List<String> ifMatches = requestHeaders.get(HeaderNames.IF_MATCH).allValues();
+            List<String> ifMatches = requestHeaders.values(HeaderNames.IF_MATCH);
             if (!ifMatches.isEmpty()) {
                 boolean ifMatchChecked = false;
                 for (String ifMatch : ifMatches) {
+                    ifMatch = ifMatch.trim();
                     boolean wildcard = "*".equals(ifMatch);
                     boolean weak = ifMatch.startsWith("W/") || ifMatch.startsWith("w/");
                     ifMatch = unquoteETag(ifMatch);
@@ -131,8 +132,9 @@ abstract class StaticContentHandler implements HttpService {
         // Process If-None-Match header
         boolean ifNoneMatchPresent = requestHeaders.contains(HeaderNames.IF_NONE_MATCH);
         if (newEtag != null && ifNoneMatchPresent) {
-            List<String> ifNoneMatches = requestHeaders.get(HeaderNames.IF_NONE_MATCH).allValues();
+            List<String> ifNoneMatches = requestHeaders.values(HeaderNames.IF_NONE_MATCH);
             for (String ifNoneMatch : ifNoneMatches) {
+                ifNoneMatch = ifNoneMatch.trim();
                 ifNoneMatch = unquoteETag(ifNoneMatch);
                 if ("*".equals(ifNoneMatch) || ifNoneMatch.equals(etag)) {
                     // using exception to handle normal flow (same as in reactive static content)

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -166,10 +166,6 @@ abstract class StaticContentHandler implements HttpService {
                 if (entityStart < fieldLength && fieldValue.charAt(entityStart) == '"') {
                     int entityEnd = fieldValue.indexOf('"', entityStart + 1);
                     if (entityEnd < 0) {
-                        if (fieldLength - entityStart == 1) {
-                            // Preserve the existing malformed-tag failure until invalid entity tags are handled separately.
-                            unquoteETag(fieldValue.substring(entityStart));
-                        }
                         break;
                     }
 

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -150,6 +150,8 @@ abstract class StaticContentHandler implements HttpService {
     }
 
     private static boolean matchesEntityTag(Header header, String etag, boolean strongComparison) {
+        boolean matched = false;
+        boolean singleValue = header.valueCount() == 1;
         for (String fieldValue : header.allValues()) {
             int tokenStart = 0;
             int fieldLength = fieldValue.length();
@@ -179,7 +181,7 @@ abstract class StaticContentHandler implements HttpService {
                                 && (!strongComparison || !weak)
                                 && length == etag.length()
                                 && fieldValue.regionMatches(entityStart + 1, etag, 0, length)) {
-                            return true;
+                            matched = true;
                         }
                     } else {
                         separator = fieldValue.indexOf(',', separator);
@@ -198,7 +200,7 @@ abstract class StaticContentHandler implements HttpService {
                         end--;
                     }
                     if (end - start == 1 && fieldValue.charAt(start) == '*') {
-                        return true;
+                        return singleValue && tokenStart == 0 && separator < 0;
                     }
                     if (weak) {
                         start += 2;
@@ -208,7 +210,7 @@ abstract class StaticContentHandler implements HttpService {
                             && (!strongComparison || !weak)
                             && length == etag.length()
                             && fieldValue.regionMatches(start, etag, 0, length)) {
-                        return true;
+                        matched = true;
                     }
                     if (separator < 0) {
                         break;
@@ -217,7 +219,7 @@ abstract class StaticContentHandler implements HttpService {
                 }
             }
         }
-        return false;
+        return matched;
     }
 
     private static Optional<Instant> conditionalDate(ServerRequestHeaders requestHeaders,

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -25,7 +25,6 @@ import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -95,23 +94,9 @@ abstract class StaticContentHandler implements HttpService {
         boolean ifMatchPresent = requestHeaders.contains(HeaderNames.IF_MATCH);
         if (newEtag != null && ifMatchPresent) {
             // Process If-Match header
-            List<String> ifMatches = requestHeaders.values(HeaderNames.IF_MATCH);
-            if (!ifMatches.isEmpty()) {
-                boolean ifMatchChecked = false;
-                for (String ifMatch : ifMatches) {
-                    ifMatch = ifMatch.trim();
-                    boolean wildcard = "*".equals(ifMatch);
-                    boolean weak = ifMatch.startsWith("W/") || ifMatch.startsWith("w/");
-                    ifMatch = unquoteETag(ifMatch);
-                    if (wildcard || (!weak && ifMatch.equals(etag))) {
-                        ifMatchChecked = true;
-                        break;
-                    }
-                }
-                if (!ifMatchChecked) {
-                    throw new HttpException("Not accepted by If-Match header", Status.PRECONDITION_FAILED_412, true)
-                            .header(newEtag);
-                }
+            if (!matchesEntityTag(requestHeaders.get(HeaderNames.IF_MATCH), etag, true)) {
+                throw new HttpException("Not accepted by If-Match header", Status.PRECONDITION_FAILED_412, true)
+                        .header(newEtag);
             }
         }
 
@@ -133,16 +118,10 @@ abstract class StaticContentHandler implements HttpService {
         // Process If-None-Match header
         boolean ifNoneMatchPresent = requestHeaders.contains(HeaderNames.IF_NONE_MATCH);
         if (newEtag != null && ifNoneMatchPresent) {
-            List<String> ifNoneMatches = requestHeaders.values(HeaderNames.IF_NONE_MATCH);
-            for (String ifNoneMatch : ifNoneMatches) {
-                ifNoneMatch = ifNoneMatch.trim();
-                boolean wildcard = "*".equals(ifNoneMatch);
-                ifNoneMatch = unquoteETag(ifNoneMatch);
-                if (wildcard || ifNoneMatch.equals(etag)) {
-                    // using exception to handle normal flow (same as in reactive static content)
-                    throw new HttpException("Accepted by If-None-Match header", Status.NOT_MODIFIED_304, true)
-                            .header(newEtag);
-                }
+            if (matchesEntityTag(requestHeaders.get(HeaderNames.IF_NONE_MATCH), etag, false)) {
+                // using exception to handle normal flow (same as in reactive static content)
+                throw new HttpException("Accepted by If-None-Match header", Status.NOT_MODIFIED_304, true)
+                        .header(newEtag);
             }
         }
 
@@ -153,6 +132,79 @@ abstract class StaticContentHandler implements HttpService {
                 throw new HttpException("Not valid for If-Modified-Since header", Status.NOT_MODIFIED_304, true);
             }
         }
+    }
+
+    private static boolean matchesEntityTag(Header header, String etag, boolean strongComparison) {
+        for (String fieldValue : header.allValues()) {
+            int tokenStart = 0;
+            int fieldLength = fieldValue.length();
+            while (tokenStart <= fieldLength) {
+                int start = tokenStart;
+                while (start < fieldLength && fieldValue.charAt(start) <= ' ') {
+                    start++;
+                }
+
+                boolean weak = fieldLength - start >= 2
+                        && (fieldValue.charAt(start) == 'W' || fieldValue.charAt(start) == 'w')
+                        && fieldValue.charAt(start + 1) == '/';
+                int entityStart = weak ? start + 2 : start;
+                if (entityStart < fieldLength && fieldValue.charAt(entityStart) == '"') {
+                    int entityEnd = fieldValue.indexOf('"', entityStart + 1);
+                    if (entityEnd < 0) {
+                        if (fieldLength - entityStart == 1) {
+                            // Preserve the existing malformed-tag failure until invalid entity tags are handled separately.
+                            unquoteETag(fieldValue.substring(entityStart));
+                        }
+                        break;
+                    }
+
+                    int separator = entityEnd + 1;
+                    while (separator < fieldLength && fieldValue.charAt(separator) <= ' ') {
+                        separator++;
+                    }
+                    if (separator == fieldLength || fieldValue.charAt(separator) == ',') {
+                        int length = entityEnd - entityStart - 1;
+                        if ((!strongComparison || !weak)
+                                && length == etag.length()
+                                && fieldValue.regionMatches(entityStart + 1, etag, 0, length)) {
+                            return true;
+                        }
+                    } else {
+                        separator = fieldValue.indexOf(',', separator);
+                        if (separator < 0) {
+                            break;
+                        }
+                    }
+                    if (separator == fieldLength) {
+                        break;
+                    }
+                    tokenStart = separator + 1;
+                } else {
+                    int separator = fieldValue.indexOf(',', start);
+                    int end = separator < 0 ? fieldLength : separator;
+                    while (start < end && fieldValue.charAt(end - 1) <= ' ') {
+                        end--;
+                    }
+                    if (end - start == 1 && fieldValue.charAt(start) == '*') {
+                        return true;
+                    }
+                    if (weak) {
+                        start += 2;
+                    }
+                    int length = end - start;
+                    if ((!strongComparison || !weak)
+                            && length == etag.length()
+                            && fieldValue.regionMatches(start, etag, 0, length)) {
+                        return true;
+                    }
+                    if (separator < 0) {
+                        break;
+                    }
+                    tokenStart = separator + 1;
+                }
+            }
+        }
+        return false;
     }
 
     private static Optional<Instant> conditionalDate(Supplier<Optional<ZonedDateTime>> dateSupplier) {

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -120,9 +121,7 @@ abstract class StaticContentHandler implements HttpService {
             setModified.accept(responseHeaders, modified);
             // If-Unmodified-Since
             if (!ifMatchPresent) {
-                Optional<Instant> ifUnmodSince = requestHeaders
-                        .ifUnmodifiedSince()
-                        .map(ChronoZonedDateTime::toInstant);
+                Optional<Instant> ifUnmodSince = conditionalDate(requestHeaders::ifUnmodifiedSince);
                 if (ifUnmodSince.isPresent() && ifUnmodSince.get().isBefore(modified)) {
                     throw new HttpException("Not valid for If-Unmodified-Since header",
                                             Status.PRECONDITION_FAILED_412,
@@ -149,12 +148,18 @@ abstract class StaticContentHandler implements HttpService {
 
         if (modified != null && !ifNoneMatchPresent) {
             // If-Modified-Since
-            Optional<Instant> ifModSince = requestHeaders
-                    .ifModifiedSince()
-                    .map(ChronoZonedDateTime::toInstant);
+            Optional<Instant> ifModSince = conditionalDate(requestHeaders::ifModifiedSince);
             if (ifModSince.isPresent() && !ifModSince.get().isBefore(modified)) {
                 throw new HttpException("Not valid for If-Modified-Since header", Status.NOT_MODIFIED_304, true);
             }
+        }
+    }
+
+    private static Optional<Instant> conditionalDate(Supplier<Optional<ZonedDateTime>> dateSupplier) {
+        try {
+            return dateSupplier.get().map(ChronoZonedDateTime::toInstant);
+        } catch (DateTimeParseException _) {
+            return Optional.empty();
         }
     }
 

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -90,6 +90,27 @@ abstract class StaticContentHandler implements HttpService {
         // Put ETag into the response
         responseHeaders.set(newEtag);
 
+        if (requestHeaders.contains(HeaderNames.IF_MATCH)) {
+            // Process If-Match header
+            List<String> ifMatches = requestHeaders.get(HeaderNames.IF_MATCH).allValues();
+            if (!ifMatches.isEmpty()) {
+                boolean ifMatchChecked = false;
+                for (String ifMatch : ifMatches) {
+                    boolean wildcard = "*".equals(ifMatch);
+                    boolean weak = ifMatch.startsWith("W/") || ifMatch.startsWith("w/");
+                    ifMatch = unquoteETag(ifMatch);
+                    if (wildcard || (!weak && ifMatch.equals(etag))) {
+                        ifMatchChecked = true;
+                        break;
+                    }
+                }
+                if (!ifMatchChecked) {
+                    throw new HttpException("Not accepted by If-Match header", Status.PRECONDITION_FAILED_412, true)
+                            .header(newEtag);
+                }
+            }
+        }
+
         // Process If-None-Match header
         if (requestHeaders.contains(HeaderNames.IF_NONE_MATCH)) {
             List<String> ifNoneMatches = requestHeaders.get(HeaderNames.IF_NONE_MATCH).allValues();
@@ -98,25 +119,6 @@ abstract class StaticContentHandler implements HttpService {
                 if ("*".equals(ifNoneMatch) || ifNoneMatch.equals(etag)) {
                     // using exception to handle normal flow (same as in reactive static content)
                     throw new HttpException("Accepted by If-None-Match header", Status.NOT_MODIFIED_304, true)
-                            .header(newEtag);
-                }
-            }
-        }
-
-        if (requestHeaders.contains(HeaderNames.IF_MATCH)) {
-            // Process If-Match header
-            List<String> ifMatches = requestHeaders.get(HeaderNames.IF_MATCH).allValues();
-            if (!ifMatches.isEmpty()) {
-                boolean ifMatchChecked = false;
-                for (String ifMatch : ifMatches) {
-                    ifMatch = unquoteETag(ifMatch);
-                    if ("*".equals(ifMatch) || ifMatch.equals(etag)) {
-                        ifMatchChecked = true;
-                        break;
-                    }
-                }
-                if (!ifMatchChecked) {
-                    throw new HttpException("Not accepted by If-Match header", Status.PRECONDITION_FAILED_412, true)
                             .header(newEtag);
                 }
             }
@@ -134,11 +136,13 @@ abstract class StaticContentHandler implements HttpService {
         // Last-Modified
         setModified.accept(responseHeaders, modified);
         // If-Modified-Since
-        Optional<Instant> ifModSince = requestHeaders
-                .ifModifiedSince()
-                .map(ChronoZonedDateTime::toInstant);
-        if (ifModSince.isPresent() && !ifModSince.get().isBefore(modified)) {
-            throw new HttpException("Not valid for If-Modified-Since header", Status.NOT_MODIFIED_304, true);
+        if (!requestHeaders.contains(HeaderNames.IF_NONE_MATCH)) {
+            Optional<Instant> ifModSince = requestHeaders
+                    .ifModifiedSince()
+                    .map(ChronoZonedDateTime::toInstant);
+            if (ifModSince.isPresent() && !ifModSince.get().isBefore(modified)) {
+                throw new HttpException("Not valid for If-Modified-Since header", Status.NOT_MODIFIED_304, true);
+            }
         }
         // If-Unmodified-Since
         Optional<Instant> ifUnmodSince = requestHeaders

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -35,6 +35,7 @@ import io.helidon.common.LruCache;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.http.DateTime;
 import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpException;
@@ -106,7 +107,9 @@ abstract class StaticContentHandler implements HttpService {
             setModified.accept(responseHeaders, modified);
             // If-Unmodified-Since
             if (!ifMatchPresent) {
-                Optional<Instant> ifUnmodSince = conditionalDate(requestHeaders::ifUnmodifiedSince);
+                Optional<Instant> ifUnmodSince = conditionalDate(requestHeaders,
+                                                                 HeaderNames.IF_UNMODIFIED_SINCE,
+                                                                 requestHeaders::ifUnmodifiedSince);
                 if (ifUnmodSince.isPresent() && ifUnmodSince.get().isBefore(modified)) {
                     throw new HttpException("Not valid for If-Unmodified-Since header",
                                             Status.PRECONDITION_FAILED_412,
@@ -127,7 +130,9 @@ abstract class StaticContentHandler implements HttpService {
 
         if (modified != null && !ifNoneMatchPresent) {
             // If-Modified-Since
-            Optional<Instant> ifModSince = conditionalDate(requestHeaders::ifModifiedSince);
+            Optional<Instant> ifModSince = conditionalDate(requestHeaders,
+                                                           HeaderNames.IF_MODIFIED_SINCE,
+                                                           requestHeaders::ifModifiedSince);
             if (ifModSince.isPresent() && !ifModSince.get().isBefore(modified)) {
                 throw new HttpException("Not valid for If-Modified-Since header", Status.NOT_MODIFIED_304, true);
             }
@@ -207,7 +212,12 @@ abstract class StaticContentHandler implements HttpService {
         return false;
     }
 
-    private static Optional<Instant> conditionalDate(Supplier<Optional<ZonedDateTime>> dateSupplier) {
+    private static Optional<Instant> conditionalDate(ServerRequestHeaders requestHeaders,
+                                                     HeaderName headerName,
+                                                     Supplier<Optional<ZonedDateTime>> dateSupplier) {
+        if (requestHeaders.contains(headerName) && requestHeaders.get(headerName).valueCount() != 1) {
+            return Optional.empty();
+        }
         try {
             return dateSupplier.get().map(ChronoZonedDateTime::toInstant);
         } catch (DateTimeParseException _) {

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -135,8 +135,9 @@ abstract class StaticContentHandler implements HttpService {
             List<String> ifNoneMatches = requestHeaders.values(HeaderNames.IF_NONE_MATCH);
             for (String ifNoneMatch : ifNoneMatches) {
                 ifNoneMatch = ifNoneMatch.trim();
+                boolean wildcard = "*".equals(ifNoneMatch);
                 ifNoneMatch = unquoteETag(ifNoneMatch);
-                if ("*".equals(ifNoneMatch) || ifNoneMatch.equals(etag)) {
+                if (wildcard || ifNoneMatch.equals(etag)) {
                     // using exception to handle normal flow (same as in reactive static content)
                     throw new HttpException("Accepted by If-None-Match header", Status.NOT_MODIFIED_304, true)
                             .header(newEtag);

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -93,11 +93,16 @@ abstract class StaticContentHandler implements HttpService {
         }
 
         boolean ifMatchPresent = requestHeaders.contains(HeaderNames.IF_MATCH);
-        if (newEtag != null && ifMatchPresent) {
+        if (ifMatchPresent) {
             // Process If-Match header
             if (!matchesEntityTag(requestHeaders.get(HeaderNames.IF_MATCH), etag, true)) {
-                throw new HttpException("Not accepted by If-Match header", Status.PRECONDITION_FAILED_412, true)
-                        .header(newEtag);
+                HttpException exception = new HttpException("Not accepted by If-Match header",
+                                                            Status.PRECONDITION_FAILED_412,
+                                                            true);
+                if (newEtag != null) {
+                    exception.header(newEtag);
+                }
+                throw exception;
             }
         }
 
@@ -120,11 +125,16 @@ abstract class StaticContentHandler implements HttpService {
 
         // Process If-None-Match header
         boolean ifNoneMatchPresent = requestHeaders.contains(HeaderNames.IF_NONE_MATCH);
-        if (newEtag != null && ifNoneMatchPresent) {
+        if (ifNoneMatchPresent) {
             if (matchesEntityTag(requestHeaders.get(HeaderNames.IF_NONE_MATCH), etag, false)) {
                 // using exception to handle normal flow (same as in reactive static content)
-                throw new HttpException("Accepted by If-None-Match header", Status.NOT_MODIFIED_304, true)
-                        .header(newEtag);
+                HttpException exception = new HttpException("Accepted by If-None-Match header",
+                                                            Status.NOT_MODIFIED_304,
+                                                            true);
+                if (newEtag != null) {
+                    exception.header(newEtag);
+                }
+                throw exception;
             }
         }
 
@@ -169,7 +179,8 @@ abstract class StaticContentHandler implements HttpService {
                     }
                     if (separator == fieldLength || fieldValue.charAt(separator) == ',') {
                         int length = entityEnd - entityStart - 1;
-                        if ((!strongComparison || !weak)
+                        if (etag != null
+                                && (!strongComparison || !weak)
                                 && length == etag.length()
                                 && fieldValue.regionMatches(entityStart + 1, etag, 0, length)) {
                             return true;
@@ -197,7 +208,8 @@ abstract class StaticContentHandler implements HttpService {
                         start += 2;
                     }
                     int length = end - start;
-                    if ((!strongComparison || !weak)
+                    if (etag != null
+                            && (!strongComparison || !weak)
                             && length == etag.length()
                             && fieldValue.regionMatches(start, etag, 0, length)) {
                         return true;

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -71,26 +71,27 @@ abstract class StaticContentHandler implements HttpService {
         this.memoryCache = config.memoryCache().orElseGet(MemoryCache::create);
     }
 
-    /**
-     * Put {@code etag} parameter (if provided ) into the response headers, than validates {@code If-Match} and
-     * {@code If-None-Match} headers and react accordingly.
-     *
-     * @param etag            the proposed ETag. If {@code null} then method returns false
-     * @param requestHeaders  an HTTP request headers
-     * @param responseHeaders an HTTP response headers
-     * @throws io.helidon.http.RequestException if ETag is checked
-     */
-    static void processEtag(String etag, ServerRequestHeaders requestHeaders, ServerResponseHeaders responseHeaders) {
-        if (etag == null || etag.isEmpty()) {
-            return;
+    static void processPreconditions(String etag,
+                                     Instant modified,
+                                     ServerRequestHeaders requestHeaders,
+                                     ServerResponseHeaders responseHeaders) {
+        processPreconditions(etag, modified, requestHeaders, responseHeaders, ServerResponseHeaders::lastModified);
+    }
+
+    static void processPreconditions(String etag,
+                                     Instant modified,
+                                     ServerRequestHeaders requestHeaders,
+                                     ServerResponseHeaders responseHeaders,
+                                     BiConsumer<ServerResponseHeaders, Instant> setModified) {
+        Header newEtag = null;
+        if (etag != null && !etag.isEmpty()) {
+            etag = unquoteETag(etag);
+            newEtag = HeaderValues.create(HeaderNames.ETAG, true, false, '"' + etag + '"');
+            responseHeaders.set(newEtag);
         }
-        etag = unquoteETag(etag);
 
-        Header newEtag = HeaderValues.create(HeaderNames.ETAG, true, false, '"' + etag + '"');
-        // Put ETag into the response
-        responseHeaders.set(newEtag);
-
-        if (requestHeaders.contains(HeaderNames.IF_MATCH)) {
+        boolean ifMatchPresent = requestHeaders.contains(HeaderNames.IF_MATCH);
+        if (newEtag != null && ifMatchPresent) {
             // Process If-Match header
             List<String> ifMatches = requestHeaders.get(HeaderNames.IF_MATCH).allValues();
             if (!ifMatches.isEmpty()) {
@@ -111,8 +112,25 @@ abstract class StaticContentHandler implements HttpService {
             }
         }
 
+        if (modified != null) {
+            // Last-Modified
+            setModified.accept(responseHeaders, modified);
+            // If-Unmodified-Since
+            if (!ifMatchPresent) {
+                Optional<Instant> ifUnmodSince = requestHeaders
+                        .ifUnmodifiedSince()
+                        .map(ChronoZonedDateTime::toInstant);
+                if (ifUnmodSince.isPresent() && ifUnmodSince.get().isBefore(modified)) {
+                    throw new HttpException("Not valid for If-Unmodified-Since header",
+                                            Status.PRECONDITION_FAILED_412,
+                                            true);
+                }
+            }
+        }
+
         // Process If-None-Match header
-        if (requestHeaders.contains(HeaderNames.IF_NONE_MATCH)) {
+        boolean ifNoneMatchPresent = requestHeaders.contains(HeaderNames.IF_NONE_MATCH);
+        if (newEtag != null && ifNoneMatchPresent) {
             List<String> ifNoneMatches = requestHeaders.get(HeaderNames.IF_NONE_MATCH).allValues();
             for (String ifNoneMatch : ifNoneMatches) {
                 ifNoneMatch = unquoteETag(ifNoneMatch);
@@ -123,20 +141,9 @@ abstract class StaticContentHandler implements HttpService {
                 }
             }
         }
-    }
 
-    static void processModifyHeaders(Instant modified,
-                                     ServerRequestHeaders requestHeaders,
-                                     ServerResponseHeaders responseHeaders,
-                                     BiConsumer<ServerResponseHeaders, Instant> setModified) {
-        if (modified == null) {
-            return;
-        }
-
-        // Last-Modified
-        setModified.accept(responseHeaders, modified);
-        // If-Modified-Since
-        if (!requestHeaders.contains(HeaderNames.IF_NONE_MATCH)) {
+        if (modified != null && !ifNoneMatchPresent) {
+            // If-Modified-Since
             Optional<Instant> ifModSince = requestHeaders
                     .ifModifiedSince()
                     .map(ChronoZonedDateTime::toInstant);
@@ -144,28 +151,6 @@ abstract class StaticContentHandler implements HttpService {
                 throw new HttpException("Not valid for If-Modified-Since header", Status.NOT_MODIFIED_304, true);
             }
         }
-        // If-Unmodified-Since
-        Optional<Instant> ifUnmodSince = requestHeaders
-                .ifUnmodifiedSince()
-                .map(ChronoZonedDateTime::toInstant);
-        if (ifUnmodSince.isPresent() && ifUnmodSince.get().isBefore(modified)) {
-            throw new HttpException("Not valid for If-Unmodified-Since header", Status.PRECONDITION_FAILED_412, true);
-        }
-    }
-
-    /**
-     * Validates {@code If-Modify-Since} and {@code If-Unmodify-Since} headers and react accordingly.
-     * Returns {@code true} only if response was sent.
-     *
-     * @param modified        the last modification instance. If {@code null} then method just returns {@code false}.
-     * @param requestHeaders  an HTTP request headers
-     * @param responseHeaders an HTTP response headers
-     * @throws io.helidon.http.RequestException if (un)modify since header is checked
-     */
-    static void processModifyHeaders(Instant modified,
-                                     ServerRequestHeaders requestHeaders,
-                                     ServerResponseHeaders responseHeaders) {
-        processModifyHeaders(modified, requestHeaders, responseHeaders, ServerResponseHeaders::lastModified);
     }
 
     /**

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/CachedHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/CachedHandlerTest.java
@@ -22,6 +22,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
@@ -38,6 +40,7 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import io.helidon.common.LruCache;
 import io.helidon.common.Size;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.media.type.MediaType;
@@ -47,10 +50,12 @@ import io.helidon.http.ForbiddenException;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.HttpException;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.Status;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
@@ -166,6 +171,48 @@ class CachedHandlerTest {
         assertThat("Last modified function", pathHandler.lastModified(), notNullValue());
         assertThat("Last modified", pathHandler.lastModified().apply(pathHandler.path()), notNullValue());
         assertThat("Media type", pathHandler.mediaType(), is(MediaTypes.TEXT_PLAIN));
+    }
+
+    @Test
+    void testUrlStreamPreconditionsWithoutLastModified() throws IOException {
+        URL url = URL.of(URI.create("test:/resource.txt"), new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL url) {
+                return new URLConnection(url) {
+                    @Override
+                    public void connect() {
+                    }
+
+                    @Override
+                    public long getLastModified() {
+                        return 0;
+                    }
+                };
+            }
+        });
+
+        ServerRequestHeaders requestHeaders = mock(ServerRequestHeaders.class);
+        when(requestHeaders.contains(HeaderNames.IF_NONE_MATCH)).thenReturn(true);
+        when(requestHeaders.get(HeaderNames.IF_NONE_MATCH))
+                .thenReturn(HeaderValues.create(HeaderNames.IF_NONE_MATCH, "*"));
+        ServerRequest request = mock(ServerRequest.class);
+        when(request.headers()).thenReturn(requestHeaders);
+
+        ServerResponse response = mock(ServerResponse.class);
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        when(response.headers()).thenReturn(responseHeaders);
+
+        CachedHandlerUrlStream handler = new CachedHandlerUrlStream(MediaTypes.TEXT_PLAIN, url);
+        HttpException exception = assertThrows(HttpException.class,
+                                               () -> handler.handle(LruCache.create(),
+                                                                    Method.HEAD,
+                                                                    request,
+                                                                    response,
+                                                                    "resource.txt"));
+
+        assertThat(exception.status(), is(Status.NOT_MODIFIED_304));
+        assertThat(responseHeaders.contains(HeaderNames.ETAG), is(false));
+        assertThat(exception.headers().contains(HeaderNames.ETAG), is(false));
     }
 
     @Test

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -22,6 +22,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -68,7 +69,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"ccc\"", "\"ddd\""));
+        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processPreconditions("aaa", null, req, res);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
@@ -79,7 +80,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"ccc\"", "W/\"aaa\""));
+        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("\"ccc\"", "W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.NOT_MODIFIED_304);
@@ -91,7 +92,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"ccc\"", "\"ddd\""));
+        when(req.values(IF_MATCH)).thenReturn(List.of("\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.PRECONDITION_FAILED_412);
@@ -103,7 +104,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"ccc\"", "\"aaa\""));
+        when(req.values(IF_MATCH)).thenReturn(List.of("\"ccc\"", "\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processPreconditions("aaa", null, req, res);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
@@ -114,7 +115,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"aaa\""));
+        when(req.values(IF_MATCH)).thenReturn(List.of("W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.PRECONDITION_FAILED_412);
@@ -126,7 +127,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"*\""));
+        when(req.values(IF_MATCH)).thenReturn(List.of("W/\"*\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.PRECONDITION_FAILED_412);
@@ -137,9 +138,9 @@ class StaticContentHandlerTest {
     void etag_IfMatchTakesPrecedenceOverIfNoneMatch() {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
-        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"aaa\""));
+        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("\"aaa\""));
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"aaa\""));
+        when(req.values(IF_MATCH)).thenReturn(List.of("W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.PRECONDITION_FAILED_412);
@@ -151,7 +152,7 @@ class StaticContentHandlerTest {
         ZonedDateTime modified = ZonedDateTime.now();
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, ETAG_VALUE));
+        when(req.values(IF_MATCH)).thenReturn(List.of(ETAG_VALUE));
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
@@ -166,7 +167,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_MATCH)).thenReturn(false);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
-        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, ETAG_VALUE));
+        when(req.values(IF_NONE_MATCH)).thenReturn(List.of(ETAG_VALUE));
         Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -232,10 +232,31 @@ class StaticContentHandlerTest {
     }
 
     @Test
+    void ifModifiedSinceUsesHttpDatePrecision() {
+        ZonedDateTime modified = ZonedDateTime.parse("2026-08-11T12:34:56.123Z");
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        Mockito.doReturn(Optional.of(modified.withNano(0))).when(req).ifModifiedSince();
+        Mockito.doReturn(Optional.empty()).when(req).ifUnmodifiedSince();
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+        assertHttpException(() -> StaticContentHandler.processPreconditions(null, modified.toInstant(), req, res),
+                            Status.NOT_MODIFIED_304);
+    }
+
+    @Test
     void ifUnmodifySince_Accept() {
         ZonedDateTime modified = ZonedDateTime.now();
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         Mockito.doReturn(Optional.of(modified)).when(req).ifUnmodifiedSince();
+        Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+        StaticContentHandler.processPreconditions(null, modified.toInstant(), req, res);
+    }
+
+    @Test
+    void ifUnmodifiedSinceUsesHttpDatePrecision() {
+        ZonedDateTime modified = ZonedDateTime.parse("2026-08-11T12:34:56.123Z");
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        Mockito.doReturn(Optional.of(modified.withNano(0))).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processPreconditions(null, modified.toInstant(), req, res);

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -22,7 +22,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -69,7 +68,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("\"ccc\"", "\"ddd\""));
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processPreconditions("aaa", null, req, res);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
@@ -80,7 +79,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("\"ccc\"", "W/\"aaa\""));
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"ccc\"", " W/\"aaa\" "));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.NOT_MODIFIED_304);
@@ -92,7 +91,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("*"));
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, " * "));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.NOT_MODIFIED_304);
@@ -104,7 +103,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("\"*\""));
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, " \"*\" "));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processPreconditions("aaa", null, req, res);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
@@ -115,7 +114,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("W/\"*\""));
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, " W/\"*\" "));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processPreconditions("aaa", null, req, res);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
@@ -126,7 +125,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.values(IF_MATCH)).thenReturn(List.of("\"ccc\"", "\"ddd\""));
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.PRECONDITION_FAILED_412);
@@ -138,7 +137,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.values(IF_MATCH)).thenReturn(List.of("\"ccc\"", "\"aaa\""));
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"ccc\"", " \"aaa\" "));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processPreconditions("aaa", null, req, res);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
@@ -149,7 +148,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.values(IF_MATCH)).thenReturn(List.of("W/\"aaa\""));
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, " W/\"aaa\" "));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.PRECONDITION_FAILED_412);
@@ -161,7 +160,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.values(IF_MATCH)).thenReturn(List.of("W/\"*\""));
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, " W/\"*\" "));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.PRECONDITION_FAILED_412);
@@ -172,9 +171,9 @@ class StaticContentHandlerTest {
     void etag_IfMatchTakesPrecedenceOverIfNoneMatch() {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
-        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("\"aaa\""));
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"aaa\""));
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.values(IF_MATCH)).thenReturn(List.of("W/\"aaa\""));
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
                             Status.PRECONDITION_FAILED_412);
@@ -186,7 +185,7 @@ class StaticContentHandlerTest {
         ZonedDateTime modified = ZonedDateTime.now();
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.values(IF_MATCH)).thenReturn(List.of(ETAG_VALUE));
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, ETAG_VALUE));
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
@@ -201,7 +200,7 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_MATCH)).thenReturn(false);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
-        when(req.values(IF_NONE_MATCH)).thenReturn(List.of(ETAG_VALUE));
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, ETAG_VALUE));
         Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -181,6 +181,48 @@ class StaticContentHandlerTest {
     }
 
     @Test
+    void etag_NoValidatorBareWildcardInMatch_Accept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_MATCH)).thenReturn(true);
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "*"));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+
+        StaticContentHandler.processPreconditions(null, null, req, res);
+    }
+
+    @Test
+    void etag_NoValidatorInMatch_NotAccept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_MATCH)).thenReturn(true);
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"other\""));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+
+        assertHttpException(() -> StaticContentHandler.processPreconditions(null, null, req, res),
+                            Status.PRECONDITION_FAILED_412);
+    }
+
+    @Test
+    void etag_NoValidatorBareWildcardInNoneMatch_Accept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(true);
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "*"));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+
+        assertHttpException(() -> StaticContentHandler.processPreconditions(null, null, req, res),
+                            Status.NOT_MODIFIED_304);
+    }
+
+    @Test
+    void etag_NoValidatorInNoneMatch_NotAccept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(true);
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"other\""));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+
+        StaticContentHandler.processPreconditions(null, null, req, res);
+    }
+
+    @Test
     void ifMatchTakesPrecedenceOverIfUnmodifiedSince() {
         ZonedDateTime modified = ZonedDateTime.now();
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -108,6 +108,40 @@ class StaticContentHandlerTest {
     }
 
     @Test
+    void etag_WeakInMatch_NotAccept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(false);
+        when(req.contains(IF_MATCH)).thenReturn(true);
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"aaa\""));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+        assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.PRECONDITION_FAILED_412);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
+    }
+
+    @Test
+    void etag_WeakQuotedWildcardInMatch_NotAccept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(false);
+        when(req.contains(IF_MATCH)).thenReturn(true);
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"*\""));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+        assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.PRECONDITION_FAILED_412);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
+    }
+
+    @Test
+    void etag_IfMatchTakesPrecedenceOverIfNoneMatch() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(true);
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"aaa\""));
+        when(req.contains(IF_MATCH)).thenReturn(true);
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"aaa\""));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+        assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.PRECONDITION_FAILED_412);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
+    }
+
+    @Test
     void ifModifySince_Accept() {
         ZonedDateTime modified = ZonedDateTime.now();
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -88,6 +88,40 @@ class StaticContentHandlerTest {
     }
 
     @Test
+    void etag_BareWildcardInNoneMatch_Accept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(true);
+        when(req.contains(IF_MATCH)).thenReturn(false);
+        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("*"));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+        assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
+                            Status.NOT_MODIFIED_304);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
+    }
+
+    @Test
+    void etag_StrongQuotedWildcardInNoneMatch_NotAccept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(true);
+        when(req.contains(IF_MATCH)).thenReturn(false);
+        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("\"*\""));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+        StaticContentHandler.processPreconditions("aaa", null, req, res);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
+    }
+
+    @Test
+    void etag_WeakQuotedWildcardInNoneMatch_NotAccept() {
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(true);
+        when(req.contains(IF_MATCH)).thenReturn(false);
+        when(req.values(IF_NONE_MATCH)).thenReturn(List.of("W/\"*\""));
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+        StaticContentHandler.processPreconditions("aaa", null, req, res);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
+    }
+
+    @Test
     void etag_InMatch_NotAccept() {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -70,7 +70,7 @@ class StaticContentHandlerTest {
         when(req.contains(IF_MATCH)).thenReturn(false);
         when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        StaticContentHandler.processEtag("aaa", req, res);
+        StaticContentHandler.processPreconditions("aaa", null, req, res);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
@@ -81,7 +81,8 @@ class StaticContentHandlerTest {
         when(req.contains(IF_MATCH)).thenReturn(false);
         when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"ccc\"", "W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.NOT_MODIFIED_304);
+        assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
+                            Status.NOT_MODIFIED_304);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
@@ -92,7 +93,8 @@ class StaticContentHandlerTest {
         when(req.contains(IF_MATCH)).thenReturn(true);
         when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.PRECONDITION_FAILED_412);
+        assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
+                            Status.PRECONDITION_FAILED_412);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
@@ -103,7 +105,7 @@ class StaticContentHandlerTest {
         when(req.contains(IF_MATCH)).thenReturn(true);
         when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"ccc\"", "\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        StaticContentHandler.processEtag("aaa", req, res);
+        StaticContentHandler.processPreconditions("aaa", null, req, res);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
@@ -114,7 +116,8 @@ class StaticContentHandlerTest {
         when(req.contains(IF_MATCH)).thenReturn(true);
         when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.PRECONDITION_FAILED_412);
+        assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
+                            Status.PRECONDITION_FAILED_412);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
@@ -125,7 +128,8 @@ class StaticContentHandlerTest {
         when(req.contains(IF_MATCH)).thenReturn(true);
         when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"*\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.PRECONDITION_FAILED_412);
+        assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
+                            Status.PRECONDITION_FAILED_412);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
@@ -137,8 +141,38 @@ class StaticContentHandlerTest {
         when(req.contains(IF_MATCH)).thenReturn(true);
         when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.PRECONDITION_FAILED_412);
+        assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", null, req, res),
+                            Status.PRECONDITION_FAILED_412);
         verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
+    }
+
+    @Test
+    void ifMatchTakesPrecedenceOverIfUnmodifiedSince() {
+        ZonedDateTime modified = ZonedDateTime.now();
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_MATCH)).thenReturn(true);
+        when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, ETAG_VALUE));
+        when(req.contains(IF_NONE_MATCH)).thenReturn(false);
+        Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifUnmodifiedSince();
+        Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+
+        StaticContentHandler.processPreconditions("aaa", modified.toInstant(), req, res);
+    }
+
+    @Test
+    void ifUnmodifiedSinceTakesPrecedenceOverIfNoneMatch() {
+        ZonedDateTime modified = ZonedDateTime.now();
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
+        when(req.contains(IF_MATCH)).thenReturn(false);
+        when(req.contains(IF_NONE_MATCH)).thenReturn(true);
+        when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, ETAG_VALUE));
+        Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifUnmodifiedSince();
+        Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
+
+        assertHttpException(() -> StaticContentHandler.processPreconditions("aaa", modified.toInstant(), req, res),
+                            Status.PRECONDITION_FAILED_412);
     }
 
     @Test
@@ -148,7 +182,7 @@ class StaticContentHandlerTest {
         Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifModifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifUnmodifiedSince();
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        StaticContentHandler.processModifyHeaders(modified.toInstant(), req, res);
+        StaticContentHandler.processPreconditions(null, modified.toInstant(), req, res);
     }
 
     @Test
@@ -158,7 +192,7 @@ class StaticContentHandlerTest {
         Mockito.doReturn(Optional.of(modified)).when(req).ifModifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifUnmodifiedSince();
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        assertHttpException(() -> StaticContentHandler.processModifyHeaders(modified.toInstant(), req, res),
+        assertHttpException(() -> StaticContentHandler.processPreconditions(null, modified.toInstant(), req, res),
                             Status.NOT_MODIFIED_304);
     }
 
@@ -169,7 +203,7 @@ class StaticContentHandlerTest {
         Mockito.doReturn(Optional.of(modified)).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        StaticContentHandler.processModifyHeaders(modified.toInstant(), req, res);
+        StaticContentHandler.processPreconditions(null, modified.toInstant(), req, res);
     }
 
     @Test
@@ -179,7 +213,7 @@ class StaticContentHandlerTest {
         Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
-        assertHttpException(() -> StaticContentHandler.processModifyHeaders(modified.toInstant(), req, res),
+        assertHttpException(() -> StaticContentHandler.processPreconditions(null, modified.toInstant(), req, res),
                             Status.PRECONDITION_FAILED_412);
     }
 

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -165,6 +165,18 @@ class StaticContentTest {
     }
 
     @Test
+    void testIfNoneMatchTakesPrecedenceOverIfModifiedSince() {
+        try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                .header(HeaderNames.IF_NONE_MATCH, "\"different\"")
+                .header(HeaderNames.IF_MODIFIED_SINCE, "Wed, 21 Oct 2099 07:28:00 GMT")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("Content"));
+        }
+    }
+
+    @Test
     void testFileSystemSymlinkOutsideRoot() throws Exception {
         Path link = staticRoot.resolve("external");
         assumeTrue(createSymbolicLink(link, externalDir), "Symbolic links cannot be created");

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -177,6 +177,28 @@ class StaticContentTest {
     }
 
     @Test
+    void testInvalidIfModifiedSinceIsIgnored() {
+        try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                .header(HeaderNames.IF_MODIFIED_SINCE, "nope")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("Content"));
+        }
+    }
+
+    @Test
+    void testInvalidIfUnmodifiedSinceIsIgnored() {
+        try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                .header(HeaderNames.IF_UNMODIFIED_SINCE, "nope")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("Content"));
+        }
+    }
+
+    @Test
     void testFileSystemSymlinkOutsideRoot() throws Exception {
         Path link = staticRoot.resolve("external");
         assumeTrue(createSymbolicLink(link, externalDir), "Symbolic links cannot be created");

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -188,9 +188,35 @@ class StaticContentTest {
     }
 
     @Test
+    void testMultipleIfModifiedSinceValuesAreIgnored() {
+        try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                .header(HeaderNames.IF_MODIFIED_SINCE,
+                        "Wed, 21 Oct 2099 07:28:00 GMT",
+                        "Wed, 21 Oct 2015 07:28:00 GMT")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("Content"));
+        }
+    }
+
+    @Test
     void testInvalidIfUnmodifiedSinceIsIgnored() {
         try (Http1ClientResponse response = testClient.get("/path/resource.txt")
                 .header(HeaderNames.IF_UNMODIFIED_SINCE, "nope")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("Content"));
+        }
+    }
+
+    @Test
+    void testMultipleIfUnmodifiedSinceValuesAreIgnored() {
+        try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                .header(HeaderNames.IF_UNMODIFIED_SINCE,
+                        "Wed, 21 Oct 2015 07:28:00 GMT",
+                        "Wed, 21 Oct 2099 07:28:00 GMT")
                 .request()) {
 
             assertThat(response.status(), is(Status.OK_200));

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -203,6 +203,32 @@ class StaticContentTest {
     }
 
     @Test
+    void testWildcardMustBeSoleConditionalEntityTagValue() {
+        String etag;
+        try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                .request()) {
+            etag = response.headers().get(HeaderNames.ETAG).get();
+        }
+
+        for (String value : List.of(etag + ", *", "*, " + etag)) {
+            try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                    .header(HeaderNames.IF_NONE_MATCH, value)
+                    .request()) {
+
+                assertThat("If-None-Match: " + value, response.status(), is(Status.OK_200));
+                assertThat("If-None-Match body for: " + value, response.as(String.class), is("Content"));
+            }
+
+            try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                    .header(HeaderNames.IF_MATCH, value)
+                    .request()) {
+
+                assertThat("If-Match: " + value, response.status(), is(Status.PRECONDITION_FAILED_412));
+            }
+        }
+    }
+
+    @Test
     void testInvalidIfModifiedSinceIsIgnored() {
         try (Http1ClientResponse response = testClient.get("/path/resource.txt")
                 .header(HeaderNames.IF_MODIFIED_SINCE, "nope")

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentTest.java
@@ -19,6 +19,7 @@ package io.helidon.webserver.staticcontent;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
@@ -173,6 +174,31 @@ class StaticContentTest {
 
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.as(String.class), is("Content"));
+        }
+    }
+
+    @Test
+    void testMalformedIfNoneMatchIsIgnored() {
+        for (String value : List.of("\"", "W/\"")) {
+            try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                    .header(HeaderNames.IF_NONE_MATCH, value)
+                    .request()) {
+
+                assertThat("If-None-Match: " + value, response.status(), is(Status.OK_200));
+                assertThat("If-None-Match body for: " + value, response.as(String.class), is("Content"));
+            }
+        }
+    }
+
+    @Test
+    void testMalformedIfMatchFailsPrecondition() {
+        for (String value : List.of("\"", "W/\"")) {
+            try (Http1ClientResponse response = testClient.get("/path/resource.txt")
+                    .header(HeaderNames.IF_MATCH, value)
+                    .request()) {
+
+                assertThat("If-Match: " + value, response.status(), is(Status.PRECONDITION_FAILED_412));
+            }
         }
     }
 

--- a/webserver/tests/static-content/src/test/java/io/helidon/webserver/tests/staticcontent/StaticContentTest.java
+++ b/webserver/tests/static-content/src/test/java/io/helidon/webserver/tests/staticcontent/StaticContentTest.java
@@ -106,6 +106,13 @@ class StaticContentTest {
 
         assertThat(response.status(), is(Status.NOT_MODIFIED_304));
         assertThat(response.headers(), hasHeader(HeaderNames.ETAG));
+
+        response = client.get("/files/static-content.txt")
+                .header(HeaderNames.IF_NONE_MATCH, "\"wrong,tag\", " + header.get())
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.NOT_MODIFIED_304));
+        assertThat(response.headers(), hasHeader(HeaderNames.ETAG));
     }
 
     @Test
@@ -116,11 +123,21 @@ class StaticContentTest {
         assertThat(response.status(), is(Status.OK_200));
         assertThat(response.headers(), hasHeader(HeaderNames.ETAG));
 
+        Header header = response.headers()
+                .get(HeaderNames.ETAG);
+
         response = client.get("/files/static-content.txt")
                 .header(HeaderNames.IF_MATCH, "\"wrong\"")
                 .request(String.class);
 
         assertThat(response.status(), is(Status.PRECONDITION_FAILED_412));
+        assertThat(response.headers(), hasHeader(HeaderNames.ETAG));
+
+        response = client.get("/files/static-content.txt")
+                .header(HeaderNames.IF_MATCH, "\"wrong,tag\", " + header.get())
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
         assertThat(response.headers(), hasHeader(HeaderNames.ETAG));
     }
 }


### PR DESCRIPTION
Pre-requisite for #12058

Correct static-content conditional request handling:

- require strong validator comparison for If-Match
- evaluate If-Match before If-None-Match
- ignore If-Modified-Since whenever If-None-Match is present

Add regression coverage for weak validators, wildcard handling, and conditional-header precedence.