### PR TITLE
Fix static content cache accounting

### DIFF
--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/MemoryCache.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/MemoryCache.java
@@ -37,6 +37,8 @@ public class MemoryCache implements RuntimeType.Api<MemoryCacheConfig> {
     private final long maxSize;
     // cache is Map<instance of handler -> Map<resource path -> CachedHandlerInMemory>>
     private final Map<StaticContentHandler, Map<String, CachedHandlerInMemory>> cache = new IdentityHashMap<>();
+    // A cached handler may have multiple path aliases, but its byte array consumes capacity only once.
+    private final Map<CachedHandlerInMemory, Integer> cachedHandlerReferences = new IdentityHashMap<>();
     private final ReadWriteLock cacheLock = new ReentrantReadWriteLock();
 
     // Mutations that affect currentSize take sizeLock before cacheLock to keep currentSize in sync with cache entries.
@@ -105,11 +107,9 @@ public class MemoryCache implements RuntimeType.Api<MemoryCacheConfig> {
             cacheLock.writeLock().lock();
             Map<String, CachedHandlerInMemory> removed = cache.remove(staticContentHandler);
             if (removed != null) {
-                long removedSize = removed.values()
-                        .stream()
-                        .mapToLong(CachedHandlerInMemory::contentLength)
-                        .sum();
-                adjustSize(-removedSize);
+                for (CachedHandlerInMemory cached : removed.values()) {
+                    removeReference(cached);
+                }
             }
         } finally {
             cacheLock.writeLock().unlock();
@@ -141,37 +141,43 @@ public class MemoryCache implements RuntimeType.Api<MemoryCacheConfig> {
             // either we are not enabled, or the size would be bigger than maximal size
             return Optional.empty();
         }
-        long oldSize;
         try {
             sizeLock.lock();
+            CachedHandlerInMemory oldValue;
             try {
                 cacheLock.readLock().lock();
                 Map<String, CachedHandlerInMemory> resourceCache = cache.get(handler);
-                oldSize = contentLength(resourceCache == null ? null : resourceCache.get(resource));
+                oldValue = resourceCache == null ? null : resourceCache.get(resource);
             } finally {
                 cacheLock.readLock().unlock();
             }
-            if (currentSize - oldSize + size > maxSize) {
+            long releasableSize = oldValue != null && cachedHandlerReferences.getOrDefault(oldValue, 0) == 1
+                    ? oldValue.contentLength()
+                    : 0;
+            if (currentSize - releasableSize + size > maxSize) {
                 return Optional.empty();
             }
-            adjustSize(size - oldSize);
-            CachedHandlerInMemory cachedHandlerInMemory;
-            try {
-                cachedHandlerInMemory = handlerSupplier.get();
-            } catch (RuntimeException | Error e) {
-                adjustSize(oldSize - size);
-                throw e;
-            }
-            long newSize = cachedHandlerInMemory.contentLength();
-            if (currentSize - size + newSize > maxSize) {
-                adjustSize(oldSize - size);
-                return Optional.empty();
-            }
+            CachedHandlerInMemory cachedHandlerInMemory = handlerSupplier.get();
             cacheLock.writeLock().lock();
             try {
-                cache.computeIfAbsent(handler, k -> new HashMap<>())
-                        .put(resource, cachedHandlerInMemory);
-                adjustSize(newSize - size);
+                Map<String, CachedHandlerInMemory> resourceCache = cache.computeIfAbsent(handler,
+                                                                                          k -> new HashMap<>());
+                CachedHandlerInMemory previous = resourceCache.put(resource, cachedHandlerInMemory);
+                removeReference(previous);
+                addReference(cachedHandlerInMemory);
+                if (currentSize > maxSize) {
+                    removeReference(cachedHandlerInMemory);
+                    if (previous == null) {
+                        resourceCache.remove(resource);
+                        if (resourceCache.isEmpty()) {
+                            cache.remove(handler);
+                        }
+                    } else {
+                        resourceCache.put(resource, previous);
+                        addReference(previous);
+                    }
+                    return Optional.empty();
+                }
                 return Optional.of(cachedHandlerInMemory);
             } finally {
                 cacheLock.writeLock().unlock();
@@ -188,7 +194,8 @@ public class MemoryCache implements RuntimeType.Api<MemoryCacheConfig> {
             cacheLock.writeLock().lock();
             Map<String, CachedHandlerInMemory> resourceCache = cache.computeIfAbsent(handler, k -> new HashMap<>());
             CachedHandlerInMemory oldValue = resourceCache.put(resource, inMemoryHandler);
-            adjustSize(inMemoryHandler.contentLength() - contentLength(oldValue));
+            removeReference(oldValue);
+            addReference(inMemoryHandler);
         } finally {
             cacheLock.writeLock().unlock();
             sizeLock.unlock();
@@ -214,7 +221,32 @@ public class MemoryCache implements RuntimeType.Api<MemoryCacheConfig> {
         }
     }
 
-    private static long contentLength(CachedHandlerInMemory handler) {
-        return handler == null ? 0 : handler.contentLength();
+    private void addReference(CachedHandlerInMemory handler) {
+        if (maxSize == 0) {
+            return;
+        }
+        Integer references = cachedHandlerReferences.get(handler);
+        if (references == null) {
+            cachedHandlerReferences.put(handler, 1);
+            adjustSize(handler.contentLength());
+        } else {
+            cachedHandlerReferences.put(handler, references + 1);
+        }
+    }
+
+    private void removeReference(CachedHandlerInMemory handler) {
+        if (maxSize == 0 || handler == null) {
+            return;
+        }
+        Integer references = cachedHandlerReferences.get(handler);
+        if (references == null) {
+            return;
+        }
+        if (references == 1) {
+            cachedHandlerReferences.remove(handler);
+            adjustSize(-handler.contentLength());
+        } else {
+            cachedHandlerReferences.put(handler, references - 1);
+        }
     }
 }

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/CachedHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/CachedHandlerTest.java
@@ -503,6 +503,62 @@ class CachedHandlerTest {
     }
 
     @Test
+    void testMemoryCacheCountsAliasedHandlerOnce(@TempDir Path tempDir) throws IOException {
+        Path root = tempDir.resolve("root");
+        Files.createDirectories(root);
+
+        MemoryCache memoryCache = MemoryCache.create(it -> it.capacity(Size.create(10)));
+        FileSystemContentHandler handler = (FileSystemContentHandler) StaticContentFeature.createService(
+                FileSystemHandlerConfig.builder()
+                        .location(root)
+                        .memoryCache(memoryCache)
+                        .build());
+        handler.cacheInMemory("resource.txt",
+                              MediaTypes.TEXT_PLAIN,
+                              "12345".getBytes(StandardCharsets.UTF_8),
+                              Optional.empty());
+        CachedHandlerInMemory cached = handler.cacheInMemory("resource.txt").orElseThrow();
+
+        handler.cacheInMemory("alias.txt", cached);
+
+        assertThat("Aliased cache keys should share the payload capacity",
+                   memoryCache.available(5),
+                   is(true));
+        assertThat("The shared payload should still consume its capacity",
+                   memoryCache.available(6),
+                   is(false));
+
+        byte[] replacementBytes = "1".getBytes(StandardCharsets.UTF_8);
+        CachedHandlerInMemory replacement = new CachedHandlerInMemory(MediaTypes.TEXT_PLAIN,
+                                                                       null,
+                                                                       null,
+                                                                       replacementBytes,
+                                                                       replacementBytes.length,
+                                                                       HeaderValues.create(HeaderNames.CONTENT_LENGTH,
+                                                                                           replacementBytes.length));
+        handler.cacheInMemory("alias.txt", replacement);
+
+        assertThat("Replacing one alias should retain both distinct payloads",
+                   memoryCache.available(4),
+                   is(true));
+        assertThat("Both distinct payloads should consume capacity",
+                   memoryCache.available(5),
+                   is(false));
+
+        handler.cacheInMemory("resource.txt", replacement);
+
+        assertThat("Replacing the last original alias should release its payload",
+                   memoryCache.available(9),
+                   is(true));
+
+        handler.releaseCache();
+
+        assertThat("Clearing aliases should release their shared capacity",
+                   memoryCache.available(10),
+                   is(true));
+    }
+
+    @Test
     void testSingleFileSymlinkRetargetingAfterStart(@TempDir Path tempDir) throws IOException {
         Path root = tempDir.resolve("root");
         Path externalDir = tempDir.resolve("external");


### PR DESCRIPTION
Pre-requisite for #12058

Count an in-memory static-content payload only once when the same cached handler is stored under multiple path aliases.

Track alias references by identity so replacements and cache clearing release capacity only when the final reference is removed. Add regression coverage for aliasing, replacement, last-reference release, and clear.