### PR TITLE
Validate HTTP tokens using ASCII grammar

### DIFF
--- a/http/http/src/main/java/io/helidon/http/HttpToken.java
+++ b/http/http/src/main/java/io/helidon/http/HttpToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,28 +17,32 @@
 package io.helidon.http;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import io.helidon.common.buffers.BufferData;
 
 /**
  * HTTP Token utility.
- * Token is defined by the HTTP specification and must not contain a set of characters.
+ * A token is defined by the HTTP specification as one or more ASCII {@code tchar} characters.
  */
 public final class HttpToken {
     private HttpToken() {
     }
 
     /**
-     * Validate if this is a good HTTP token.
+     * Validate an HTTP token.
      *
      * @param token token to validate
      * @throws IllegalArgumentException in case the token is not valid
      */
     public static void validate(String token) throws IllegalArgumentException {
-        char[] chars = token.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            char aChar = chars[i];
-            if (aChar > 254) {
+        Objects.requireNonNull(token);
+        if (token.isEmpty()) {
+            throw new IllegalArgumentException("Token must not be empty");
+        }
+        for (int i = 0; i < token.length(); i++) {
+            char aChar = token.charAt(i);
+            if (aChar > 127) {
                 throw new IllegalArgumentException("Token contains non-ASCII character at position "
                                                            + hex(i)
                                                            + " \n"
@@ -56,16 +60,18 @@ public final class HttpToken {
                                                            + "\n"
                                                            + debugToken(token));
             }
-            switch (aChar) {
-            case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}' -> {
+            boolean valid = (aChar >= '0' && aChar <= '9')
+                    || (aChar >= 'A' && aChar <= 'Z')
+                    || (aChar >= 'a' && aChar <= 'z')
+                    || switch (aChar) {
+                        case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' -> true;
+                        default -> false;
+                    };
+            if (!valid) {
                 throw new IllegalArgumentException("Token contains illegal character at position "
                                                            + hex(i)
                                                            + "\n"
                                                            + debugToken(token));
-            }
-            default -> {
-                // this is a valid character
-            }
             }
         }
     }

--- a/http/http/src/test/java/io/helidon/http/HttpTokenTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpTokenTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HttpTokenTest {
+
+    @Test
+    void testValidTokens() {
+        assertValid("*");
+        assertValid("gzip");
+        assertValid("x-gzip_1");
+        assertValid("!#$%&'*+-.^_`|~");
+    }
+
+    @Test
+    void testInvalidTokens() {
+        assertInvalid("");
+        assertInvalid("g zip");
+        assertInvalid("gzip;level=1");
+        assertInvalid("x/gzip");
+        assertInvalid("\u00e9");
+        assertInvalid("\u0100");
+    }
+
+    private static void assertValid(String token) {
+        assertDoesNotThrow(() -> HttpToken.validate(token));
+    }
+
+    private static void assertInvalid(String token) {
+        assertThrows(IllegalArgumentException.class, () -> HttpToken.validate(token));
+    }
+}


### PR DESCRIPTION
Pre-requisite for #12058

Validate HTTP tokens as non-empty sequences of ASCII `tchar` characters.

Reject empty and non-ASCII tokens that the previous delimiter-based validation accepted, while retaining all valid token punctuation. Add focused regression coverage for valid and invalid token forms.
