### PR TITLE
Support disabled protocol configurations

### DIFF
--- a/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/DisabledWsConfigTest.java
+++ b/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/DisabledWsConfigTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.websocket;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http1.Http1Config;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.websocket.WsConfig;
+import io.helidon.webserver.websocket.WsRouting;
+import io.helidon.websocket.WsCloseCodes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class DisabledWsConfigTest {
+    private final int port;
+
+    DisabledWsConfigTest(WebServer server) {
+        this.port = server.port();
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.protocolsDiscoverServices(false)
+                .addProtocol(Http1Config.create())
+                .addProtocol(new TestWsConfig("disabled", 1024, false))
+                .addProtocol(new TestWsConfig("enabled", 5, true));
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(WsRouting.builder().endpoint("/echo", new EchoService()));
+    }
+
+    @Test
+    void disabledConfigurationDoesNotSetFrameLimit() throws Exception {
+        CloseListener listener = new CloseListener();
+        WebSocket webSocket = HttpClient.newHttpClient()
+                .newWebSocketBuilder()
+                .buildAsync(URI.create("ws://localhost:" + port + "/echo"), listener)
+                .get(5, TimeUnit.SECONDS);
+
+        webSocket.sendText("too-large", true).get(5, TimeUnit.SECONDS);
+
+        assertThat(listener.closeCode().get(5, TimeUnit.SECONDS), is(WsCloseCodes.TOO_BIG));
+    }
+
+    private record TestWsConfig(String name, int maxFrameLength, boolean enabled) implements WsConfig {
+        @Override
+        public Set<String> origins() {
+            return Set.of();
+        }
+    }
+
+    private static final class CloseListener implements WebSocket.Listener {
+        private final CompletableFuture<Integer> closeCode = new CompletableFuture<>();
+
+        @Override
+        public void onOpen(WebSocket webSocket) {
+            webSocket.request(1);
+        }
+
+        @Override
+        public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            closeCode.completeExceptionally(new AssertionError("Oversized WebSocket frame was accepted"));
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            closeCode.complete(statusCode);
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket webSocket, Throwable error) {
+            closeCode.completeExceptionally(error);
+        }
+
+        CompletableFuture<Integer> closeCode() {
+            return closeCode;
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -437,6 +437,9 @@ class ServerListener implements TransportBindingContext, ListenerContext {
             activeTypes.add(binding.type());
         }
         for (ProtocolConfig protocolConfig : protocolConfigs) {
+            if (!protocolConfig.enabled()) {
+                continue;
+            }
             Set<String> requiredTypes = protocolConfig.transportBindingTypes();
             if (requiredTypes.isEmpty()) {
                 continue;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SocketTransportBinding.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SocketTransportBinding.java
@@ -129,6 +129,9 @@ abstract class SocketTransportBinding implements TransportBinding {
     }
 
     private static boolean supportsTransportBinding(String type, ProtocolConfig config) {
+        if (!config.enabled()) {
+            return false;
+        }
         Set<String> transportBindingTypes = config.transportBindingTypes();
         return transportBindingTypes.isEmpty() || transportBindingTypes.contains(type);
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/spi/ProtocolConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/spi/ProtocolConfig.java
@@ -27,6 +27,15 @@ import io.helidon.webserver.TransportBindingTypes;
  */
 public interface ProtocolConfig extends NamedService {
     /**
+     * Whether this protocol configuration is enabled.
+     *
+     * @return whether this protocol is enabled
+     */
+    default boolean enabled() {
+        return true;
+    }
+
+    /**
      * Transport binding provider keys compatible with this protocol.
      * <p>
      * An empty set means this protocol has no transport preference and can use the listener default binding.

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ServerListenerLifecycleTest.java
@@ -1833,6 +1833,31 @@ class ServerListenerLifecycleTest {
     }
 
     @Test
+    void disabledProtocolsDoNotParticipateInListenerBinding() {
+        TestRequiredTransportConnectionSelectorProvider.reset();
+        WebServer server = WebServer.builder()
+                .shutdownHook(false)
+                .port(0)
+                .protocolsDiscoverServices(false)
+                .addConnectionSelectorProvider(new TestRequiredTransportConnectionSelectorProvider())
+                .addProtocol(new TestRequiredTransportProtocolConfig("disabled-required-transport",
+                                                                     Set.of(TestTransportBindingConfig.TYPE),
+                                                                     false))
+                .addProtocol(new TestRequiredTransportProtocolConfig("disabled-transport-neutral",
+                                                                     Set.of(),
+                                                                     false))
+                .build()
+                .start();
+
+        try {
+            assertThat(server.port(), greaterThan(0));
+            assertThat(TestRequiredTransportConnectionSelectorProvider.creates(), is(0));
+        } finally {
+            stopUntilStopped(server);
+        }
+    }
+
+    @Test
     void tcpTransportSkipsProtocolsForOtherTransports() {
         TestRequiredTransportConnectionSelectorProvider.reset();
         WebServer server = WebServer.builder()

--- a/webserver/webserver/src/test/java/io/helidon/webserver/TestRequiredTransportProtocolConfig.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/TestRequiredTransportProtocolConfig.java
@@ -21,8 +21,13 @@ import java.util.Set;
 import io.helidon.webserver.spi.ProtocolConfig;
 
 record TestRequiredTransportProtocolConfig(String name,
-                                           Set<String> transportBindingTypes) implements ProtocolConfig {
+                                           Set<String> transportBindingTypes,
+                                           boolean enabled) implements ProtocolConfig {
     static final String TYPE = "required-transport-test";
+
+    TestRequiredTransportProtocolConfig(String name, Set<String> transportBindingTypes) {
+        this(name, transportBindingTypes, true);
+    }
 
     @Override
     public String type() {

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
@@ -91,7 +91,7 @@ public class WsConnection implements ServerConnection, WsSession {
                                       .config()
                                       .protocols()
                                       .stream()
-                                      .filter(p -> p instanceof WsConfig)
+                                      .filter(p -> p instanceof WsConfig && p.enabled())
                                       .findFirst()
                                       .orElseThrow(() -> new InternalError("Unable to find WebSocket config"));
     }


### PR DESCRIPTION
Add a common protocol enablement contract that preserves the enabled behavior of existing configurations. Disabled protocols no longer participate in transport binding validation or selector construction, and disabled WebSocket configurations are ignored when selecting connection settings.

Pre-requisite for #3686.
