### PR TITLE
Clear HTTP/1 read timeout after h2c upgrade

### DIFF
--- a/declarative/tests/grpc/src/test/java/io/helidon/declarative/tests/grpc/DeclarativeGrpcTest.java
+++ b/declarative/tests/grpc/src/test/java/io/helidon/declarative/tests/grpc/DeclarativeGrpcTest.java
@@ -229,11 +229,12 @@ class DeclarativeGrpcTest {
     @Test
     void testUnaryMethodTracing() {
         exporter.clear();
+        long startEpochMillis = System.currentTimeMillis();
 
         var response = blockingStub.greet(request("Tracing"));
 
         assertThat(response.getMessage(), is("Hello Tracing"));
-        var spans = exporter.spanData(2);
+        var spans = exporter.spanData(startEpochMillis, grpcGreetMethod(), "grpc-greet-method");
         exporter.clear();
         SpanData grpcSpan = span(spans, grpcGreetMethod());
         SpanData methodSpan = span(spans, "grpc-greet-method");

--- a/declarative/tests/grpc/src/test/java/io/helidon/declarative/tests/grpc/TestSpanExporter.java
+++ b/declarative/tests/grpc/src/test/java/io/helidon/declarative/tests/grpc/TestSpanExporter.java
@@ -16,10 +16,10 @@
 
 package io.helidon.declarative.tests.grpc;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.testing.junit5.MatcherWithRetry;
 
@@ -56,10 +56,15 @@ class TestSpanExporter implements SpanExporter {
         return CompletableResultCode.ofSuccess();
     }
 
-    List<SpanData> spanData(int expectedCount) {
+    List<SpanData> spanData(long startEpochMillis, String... spanNames) {
+        List<String> expectedSpanNames = List.of(spanNames);
         return MatcherWithRetry.assertThatWithRetry("Expected span count",
-                                                    () -> new ArrayList<>(spanData),
-                                                    iterableWithSize(expectedCount),
+                                                    () -> spanData.stream()
+                                                            .filter(span -> span.getStartEpochNanos()
+                                                                    >= TimeUnit.MILLISECONDS.toNanos(startEpochMillis))
+                                                            .filter(span -> expectedSpanNames.contains(span.getName()))
+                                                            .toList(),
+                                                    iterableWithSize(spanNames.length),
                                                     retryCount,
                                                     retryDelayMs);
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.http2;
 
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -165,7 +166,15 @@ public class Http2ClientConnection {
                                         Consumer<Http2ClientConnection> closeListener) {
 
         Http2ClientConnection h2conn = new Http2ClientConnection(http2Client, connection, closeListener);
-        return create(h2conn, http2Client, sendSettings);
+        return create(h2conn, http2Client, sendSettings, false);
+    }
+
+    static Http2ClientConnection createUpgraded(Http2ClientImpl http2Client,
+                                                ClientConnection connection,
+                                                Consumer<Http2ClientConnection> closeListener) {
+
+        Http2ClientConnection h2conn = new Http2ClientConnection(http2Client, connection, closeListener);
+        return create(h2conn, http2Client, false, true);
     }
 
     /**
@@ -183,9 +192,22 @@ public class Http2ClientConnection {
     static <T extends Http2ClientConnection> T create(T connection,
                                                       Http2ClientImpl http2Client,
                                                       boolean sendSettings) {
+        return create(connection, http2Client, sendSettings, false);
+    }
+
+    private static <T extends Http2ClientConnection> T create(T connection,
+                                                              Http2ClientImpl http2Client,
+                                                              boolean sendSettings,
+                                                              boolean clearReadTimeout) {
         Http2ClientConnection rawConnection = connection;
         boolean success = false;
         try {
+            if (clearReadTimeout) {
+                // HTTP/1.1 installs a request-scoped socket timeout. HTTP/2 owns a permanent connection reader and
+                // applies read timeouts to individual streams, so the inherited socket timeout must not close an idle
+                // upgraded connection.
+                rawConnection.connection.readTimeout(Duration.ZERO);
+            }
             rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
             rawConnection.awaitInitialSettings();
             success = true;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -202,14 +202,14 @@ public class Http2ClientConnection {
         Http2ClientConnection rawConnection = connection;
         boolean success = false;
         try {
-            if (clearReadTimeout) {
-                // HTTP/1.1 installs a request-scoped socket timeout. HTTP/2 owns a permanent connection reader and
-                // applies read timeouts to individual streams, so the inherited socket timeout must not close an idle
-                // upgraded connection.
-                rawConnection.connection.readTimeout(Duration.ZERO);
-            }
             rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
             rawConnection.awaitInitialSettings();
+            if (clearReadTimeout) {
+                // Preserve the HTTP/1.1 request timeout through the upgrade handshake. Once the peer's initial
+                // SETTINGS arrive, HTTP/2 owns a permanent connection reader and applies timeouts to individual
+                // streams, so the inherited socket timeout must not close an idle upgraded connection.
+                rawConnection.connection.readTimeout(Duration.ZERO);
+            }
             success = true;
         } finally {
             if (!success) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -180,10 +180,11 @@ public class Http2ClientConnection {
 
     static Http2ClientConnection createUpgraded(Http2ClientImpl http2Client,
                                                 ClientConnection connection,
-                                                Consumer<Http2ClientConnection> closeListener) {
+                                                Consumer<Http2ClientConnection> closeListener,
+                                                Consumer<Http2ClientConnection> beforeStart) {
 
         Http2ClientConnection h2conn = new Http2ClientConnection(http2Client, connection, closeListener, true);
-        return create(h2conn, http2Client, false);
+        return create(h2conn, http2Client, false, beforeStart);
     }
 
     /**
@@ -201,9 +202,17 @@ public class Http2ClientConnection {
     static <T extends Http2ClientConnection> T create(T connection,
                                                       Http2ClientImpl http2Client,
                                                       boolean sendSettings) {
+        return create(connection, http2Client, sendSettings, _ -> { });
+    }
+
+    private static <T extends Http2ClientConnection> T create(T connection,
+                                                              Http2ClientImpl http2Client,
+                                                              boolean sendSettings,
+                                                              Consumer<T> beforeStart) {
         Http2ClientConnection rawConnection = connection;
         boolean success = false;
         try {
+            beforeStart.accept(connection);
             rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
             rawConnection.awaitInitialSettings();
             success = true;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -111,6 +111,7 @@ public class Http2ClientConnection {
     private volatile int lastStreamId;
     private volatile long expectedPingAck = NO_PING_ACK;
     private volatile long peerMaxConcurrentStreams = Http2Setting.MAX_CONCURRENT_STREAMS.defaultValue();
+    private volatile boolean clientPrefaceSent;
     private volatile boolean initialSettingsReceived;
     private int reservedStreams;
 
@@ -458,6 +459,10 @@ public class Http2ClientConnection {
      */
     public void close() {
         initialSettingsLatch.countDown();
+        if (!clientPrefaceSent) {
+            closeConnection();
+            return;
+        }
         try {
             this.goAway(0, Http2ErrorCode.NO_ERROR, "Closing connection");
         } catch (Throwable e) {
@@ -524,6 +529,7 @@ public class Http2ClientConnection {
             ctx.log(LOGGER, TRACE, "Starting HTTP/2 connection, thread: %s", Thread.currentThread().getName());
             try {
                 sendPreface(protocolConfig, sendSettings);
+                clientPrefaceSent = true;
             } catch (Throwable e) {
                 ctx.log(LOGGER, WARNING, "Failed to send preface.", e);
             } finally {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -104,6 +104,7 @@ public class Http2ClientConnection {
     private final Semaphore pingPongSemaphore = new Semaphore(0);
     private final AtomicLong pingIdSequence = new AtomicLong();
     private final Http2ClientConfig clientConfig;
+    private final boolean clearReadTimeoutAfterInitialSettings;
     private final ReentrantLock reservedStreamsLock = new ReentrantLock();
     private final CountDownLatch initialSettingsLatch = new CountDownLatch(1);
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
@@ -120,14 +121,22 @@ public class Http2ClientConnection {
 
     Http2ClientConnection(Http2ClientImpl http2Client, ClientConnection connection) {
         this(http2Client, connection, it -> {
-        });
+        }, false);
     }
 
     Http2ClientConnection(Http2ClientImpl http2Client,
                           ClientConnection connection,
                           Consumer<Http2ClientConnection> closeListener) {
+        this(http2Client, connection, closeListener, false);
+    }
+
+    private Http2ClientConnection(Http2ClientImpl http2Client,
+                                  ClientConnection connection,
+                                  Consumer<Http2ClientConnection> closeListener,
+                                  boolean clearReadTimeoutAfterInitialSettings) {
         this.protocolConfig = http2Client.protocolConfig();
         this.clientConfig = http2Client.clientConfig();
+        this.clearReadTimeoutAfterInitialSettings = clearReadTimeoutAfterInitialSettings;
         this.pendingInboundHeaders = new PendingInboundHeaders(protocolConfig.maxHeaderListSize());
         this.sendListener = http2Client.sendListener();
         this.recvListener = http2Client.recvListener();
@@ -166,15 +175,15 @@ public class Http2ClientConnection {
                                         Consumer<Http2ClientConnection> closeListener) {
 
         Http2ClientConnection h2conn = new Http2ClientConnection(http2Client, connection, closeListener);
-        return create(h2conn, http2Client, sendSettings, false);
+        return create(h2conn, http2Client, sendSettings);
     }
 
     static Http2ClientConnection createUpgraded(Http2ClientImpl http2Client,
                                                 ClientConnection connection,
                                                 Consumer<Http2ClientConnection> closeListener) {
 
-        Http2ClientConnection h2conn = new Http2ClientConnection(http2Client, connection, closeListener);
-        return create(h2conn, http2Client, false, true);
+        Http2ClientConnection h2conn = new Http2ClientConnection(http2Client, connection, closeListener, true);
+        return create(h2conn, http2Client, false);
     }
 
     /**
@@ -192,24 +201,11 @@ public class Http2ClientConnection {
     static <T extends Http2ClientConnection> T create(T connection,
                                                       Http2ClientImpl http2Client,
                                                       boolean sendSettings) {
-        return create(connection, http2Client, sendSettings, false);
-    }
-
-    private static <T extends Http2ClientConnection> T create(T connection,
-                                                              Http2ClientImpl http2Client,
-                                                              boolean sendSettings,
-                                                              boolean clearReadTimeout) {
         Http2ClientConnection rawConnection = connection;
         boolean success = false;
         try {
             rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
             rawConnection.awaitInitialSettings();
-            if (clearReadTimeout) {
-                // Preserve the HTTP/1.1 request timeout through the upgrade handshake. Once the peer's initial
-                // SETTINGS arrive, HTTP/2 owns a permanent connection reader and applies timeouts to individual
-                // streams, so the inherited socket timeout must not close an idle upgraded connection.
-                rawConnection.connection.readTimeout(Duration.ZERO);
-            }
             success = true;
         } finally {
             if (!success) {
@@ -775,6 +771,12 @@ public class Http2ClientConnection {
         recvListener.frame(ctx, streamId, receivedSettings);
         serverSettings = mergeSettings(serverSettings, receivedSettings);
         updatePeerSettings(receivedSettings);
+        if (!initialSettingsReceived && clearReadTimeoutAfterInitialSettings) {
+            // Preserve the HTTP/1.1 request timeout through the upgrade handshake. Once the peer's initial
+            // SETTINGS arrive, HTTP/2 owns a permanent connection reader and applies timeouts to individual
+            // streams, so the inherited socket timeout must be cleared before the next connection read.
+            connection.readTimeout(Duration.ZERO);
+        }
         initialSettingsReceived = true;
         initialSettingsLatch.countDown();
         ackSettings();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -252,9 +252,7 @@ class Http2ClientConnectionHandler {
                                                       http2Client.protocolConfig());
             if (upgradeResponse.isUpgraded()) {
                 result.set(Result.HTTP_2);
-                Http2ClientConnection conn = createHttp2Connection(http2Client,
-                                                                   upgradeResponse.connection(),
-                                                                   false);
+                Http2ClientConnection conn = createUpgradedHttp2Connection(http2Client, upgradeResponse.connection());
                 activeConnection.set(conn);
                 return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
             } else {
@@ -463,7 +461,7 @@ class Http2ClientConnectionHandler {
                     if (upgradeResponse.isUpgraded()) {
                         result.set(Result.HTTP_2);
                         connection = upgradeResponse.connection();
-                        usedConnection = createHttp2Connection(http2Client, connection, false);
+                        usedConnection = createUpgradedHttp2Connection(http2Client, connection);
                     } else {
                         HttpClientResponse response = upgradeResponse.response();
                         if (request.followRedirects() && RedirectionProcessor.redirectionStatusCode(response.status())) {
@@ -518,6 +516,11 @@ class Http2ClientConnectionHandler {
                                                         ClientConnection clientConnection,
                                                         boolean sendSettings) {
         return Http2ClientConnection.create(http2Client, clientConnection, sendSettings, this::removeConnection);
+    }
+
+    private Http2ClientConnection createUpgradedHttp2Connection(Http2ClientImpl http2Client,
+                                                                ClientConnection clientConnection) {
+        return Http2ClientConnection.createUpgraded(http2Client, clientConnection, this::removeConnection);
     }
 
     private void removeConnection(Http2ClientConnection connection) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -66,10 +66,14 @@ class Http2ClientConnectionHandler {
             Collections.synchronizedMap(new IdentityHashMap<>());
 
     private final Map<Http2ClientConnection, Boolean> allConnections = Collections.synchronizedMap(new IdentityHashMap<>());
+    private final Set<Http2ClientConnection> pendingUpgradedConnections =
+            Collections.newSetFromMap(new IdentityHashMap<>());
     private final ConnectionKey connectionKey;
     private final AtomicReference<Http2ClientConnection> activeConnection = new AtomicReference<>();
     private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
     private final AtomicReference<Result> result = new AtomicReference<>(Result.UNKNOWN);
+    private boolean closed;
 
     Http2ClientConnectionHandler(ConnectionKey connectionKey) {
         this.connectionKey = connectionKey;
@@ -77,17 +81,26 @@ class Http2ClientConnectionHandler {
 
     void close() {
         // this is to prevent concurrent modification (connections remove themselves from the map)
-        Set<Http2ClientConnection> toClose;
-        synchronized (allConnections) {
-            toClose = new HashSet<>(allConnections.keySet());
+        Set<Http2ClientConnection> toClose = new HashSet<>();
+        lifecycleLock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            toClose.addAll(pendingUpgradedConnections);
+            toClose.addAll(allConnections.keySet());
+            pendingUpgradedConnections.clear();
+            allConnections.clear();
+            h2ConnByConn.clear();
+            Http2ClientConnection active = activeConnection.getAndSet(null);
+            if (active != null) {
+                toClose.add(active);
+            }
+        } finally {
+            lifecycleLock.unlock();
         }
         toClose.forEach(Http2ClientConnection::close);
-        Http2ClientConnection active = this.activeConnection.getAndSet(null);
-        if (active != null) {
-            active.close();
-        }
-        this.allConnections.clear();
-        this.h2ConnByConn.clear();
     }
 
     Http2ConnectionAttemptResult newStream(Http2ClientImpl http2Client,
@@ -193,9 +206,7 @@ class Http2ClientConnectionHandler {
                         Http2ClientConnection connection = createHttp2Connection(http2Client,
                                                                                  clientConnection,
                                                                                  true);
-                        allConnections.put(connection, true);
-                        h2ConnByConn.put(clientConnection, connection);
-                        this.activeConnection.set(connection);
+                        activateConnection(clientConnection, connection);
                         return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
                     } else {
                         if (!http1FallbackAllowed(request)) {
@@ -228,9 +239,7 @@ class Http2ClientConnectionHandler {
                     Http2ClientConnection connection = createHttp2Connection(http2Client,
                                                                              clientConnection,
                                                                              true);
-                    allConnections.put(connection, true);
-                    h2ConnByConn.put(clientConnection, connection);
-                    this.activeConnection.set(connection);
+                    activateConnection(clientConnection, connection);
                     return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
                 }
             }
@@ -254,9 +263,7 @@ class Http2ClientConnectionHandler {
                 result.set(Result.HTTP_2);
                 ClientConnection connection = upgradeResponse.connection();
                 Http2ClientConnection conn = createUpgradedHttp2Connection(http2Client, connection);
-                allConnections.put(conn, true);
-                h2ConnByConn.put(connection, conn);
-                activeConnection.set(conn);
+                activateConnection(connection, conn);
                 return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
             } else {
                 HttpClientResponse response = upgradeResponse.response();
@@ -357,14 +364,10 @@ class Http2ClientConnectionHandler {
                     }
                     throw e;
                 }
-                if (ownsExplicitConnection) {
-                    h2ConnByConn.put(clientConnection, connection);
-                }
             }
             if (ownsExplicitConnection) {
                 result.set(Result.HTTP_2);
-                allConnections.put(connection, true);
-                activeConnection.set(connection);
+                activateConnection(clientConnection, connection);
             }
 
             return new Http2ConnectionAttemptResult(Result.HTTP_2,
@@ -486,9 +489,7 @@ class Http2ClientConnectionHandler {
             }
 
             // only set these for requests that do not have an explicit connection defined
-            activeConnection.set(usedConnection);
-            allConnections.put(usedConnection, true);
-            h2ConnByConn.put(connection, usedConnection);
+            activateConnection(connection, usedConnection);
         }
 
         return usedConnection;
@@ -509,9 +510,7 @@ class Http2ClientConnectionHandler {
     }
 
     private void discardConnection(Http2ClientConnection connection) {
-        activeConnection.compareAndSet(connection, null);
-        allConnections.remove(connection);
-        h2ConnByConn.values().remove(connection);
+        removeConnection(connection);
         connection.close();
     }
 
@@ -523,15 +522,54 @@ class Http2ClientConnectionHandler {
 
     private Http2ClientConnection createUpgradedHttp2Connection(Http2ClientImpl http2Client,
                                                                 ClientConnection clientConnection) {
-        return Http2ClientConnection.createUpgraded(http2Client, clientConnection, this::removeConnection);
+        return Http2ClientConnection.createUpgraded(http2Client,
+                                                    clientConnection,
+                                                    this::removeConnection,
+                                                    this::registerPendingUpgradedConnection);
+    }
+
+    private void registerPendingUpgradedConnection(Http2ClientConnection connection) {
+        lifecycleLock.lock();
+        try {
+            if (closed) {
+                throw new IllegalStateException("HTTP/2 connection handler is closed");
+            }
+            pendingUpgradedConnections.add(connection);
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private void activateConnection(ClientConnection clientConnection, Http2ClientConnection connection) {
+        boolean closeConnection;
+        lifecycleLock.lock();
+        try {
+            pendingUpgradedConnections.remove(connection);
+            closeConnection = closed;
+            if (!closeConnection) {
+                allConnections.put(connection, true);
+                h2ConnByConn.put(clientConnection, connection);
+                activeConnection.set(connection);
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+        if (closeConnection) {
+            connection.close();
+            throw new IllegalStateException("HTTP/2 connection handler is closed");
+        }
     }
 
     private void removeConnection(Http2ClientConnection connection) {
-        synchronized (h2ConnByConn) {
+        lifecycleLock.lock();
+        try {
+            pendingUpgradedConnections.remove(connection);
             h2ConnByConn.values().removeIf(it -> it == connection);
+            allConnections.remove(connection);
+            activeConnection.compareAndSet(connection, null);
+        } finally {
+            lifecycleLock.unlock();
         }
-        allConnections.remove(connection);
-        activeConnection.compareAndSet(connection, null);
     }
 
     private static void closeClientConnection(ClientConnection clientConnection) {
@@ -583,27 +621,29 @@ class Http2ClientConnectionHandler {
                                                           alpn,
                                                           udsAddress,
                                                           connection -> false,
-                                                          connection -> {
-                                                              Http2ClientConnection h2conn = h2ConnByConn.remove(
-                                                                      connection);
-                                                              if (h2conn != null) {
-                                                                  allConnections.remove(h2conn);
-                                                              }
-                                                          })
+                                                          this::removeClientConnection)
                     .connect();
         }
         return TcpClientConnection.create(webClient,
                                           connectionKey,
                                           alpn,
                                           connection -> false,
-                                          connection -> {
-                                              Http2ClientConnection h2conn = h2ConnByConn.remove(
-                                                      connection);
-                                              if (h2conn != null) {
-                                                  allConnections.remove(h2conn);
-                                              }
-                                          })
+                                          this::removeClientConnection)
                 .connect();
+    }
+
+    private void removeClientConnection(ClientConnection clientConnection) {
+        lifecycleLock.lock();
+        try {
+            Http2ClientConnection connection = h2ConnByConn.remove(clientConnection);
+            if (connection != null) {
+                pendingUpgradedConnections.remove(connection);
+                allConnections.remove(connection);
+                activeConnection.compareAndSet(connection, null);
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
     }
 
     private static class Http1FallbackResponse extends RuntimeException {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -252,7 +252,10 @@ class Http2ClientConnectionHandler {
                                                       http2Client.protocolConfig());
             if (upgradeResponse.isUpgraded()) {
                 result.set(Result.HTTP_2);
-                Http2ClientConnection conn = createUpgradedHttp2Connection(http2Client, upgradeResponse.connection());
+                ClientConnection connection = upgradeResponse.connection();
+                Http2ClientConnection conn = createUpgradedHttp2Connection(http2Client, connection);
+                allConnections.put(conn, true);
+                h2ConnByConn.put(connection, conn);
                 activeConnection.set(conn);
                 return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
             } else {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -348,7 +348,7 @@ class Http2ClientConnectionTest {
 
             Http2ClientConnection connection = Http2ClientConnection.createUpgraded(test.client,
                                                                                      test.clientConnection,
-                                                                                     ignored -> { },
+                                                                                     _ -> { },
                                                                                      ignored -> { });
 
             assertThat(http2ReadTimeouts.poll(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
@@ -490,7 +490,7 @@ class Http2ClientConnectionTest {
             CompletableFuture<Http2ClientConnection> connectionFuture = CompletableFuture.supplyAsync(
                     () -> Http2ClientConnection.createUpgraded(test.client,
                                                                test.clientConnection,
-                                                               ignored -> { },
+                                                               _ -> { },
                                                                connectionRef::set));
 
             assertTrue(blockedWrite.awaitEntered());

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -331,16 +331,16 @@ class Http2ClientConnectionTest {
     }
 
     @Test
-    void upgradedConnectionClearsSocketReadTimeoutAfterInitialSettings() {
+    void upgradedConnectionClearsSocketReadTimeoutAfterInitialSettings() throws InterruptedException {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             AtomicReference<Duration> socketReadTimeout = new AtomicReference<>(Duration.ofSeconds(30));
-            AtomicReference<Duration> firstHttp2ReadTimeout = new AtomicReference<>();
+            LinkedBlockingQueue<Duration> http2ReadTimeouts = new LinkedBlockingQueue<>();
             doAnswer(invocation -> {
                 socketReadTimeout.set(invocation.getArgument(0));
                 return null;
             }).when(test.clientConnection).readTimeout(any(Duration.class));
             when(test.clientConnection.reader()).thenReturn(DataReader.create(() -> {
-                firstHttp2ReadTimeout.compareAndSet(null, socketReadTimeout.get());
+                http2ReadTimeouts.add(socketReadTimeout.get());
                 return test.nextInboundFrame();
             }));
             test.offerInbound(settingsFrame(10));
@@ -349,7 +349,10 @@ class Http2ClientConnectionTest {
                                                                                      test.clientConnection,
                                                                                      ignored -> { });
 
-            assertThat(firstHttp2ReadTimeout.get(), is(Duration.ofSeconds(30)));
+            assertThat(http2ReadTimeouts.poll(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                       is(Duration.ofSeconds(30)));
+            assertThat(http2ReadTimeouts.poll(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                       is(Duration.ZERO));
             assertThat(socketReadTimeout.get(), is(Duration.ZERO));
             connection.close();
         }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -331,6 +331,30 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void upgradedConnectionClearsSocketReadTimeout() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            AtomicReference<Duration> socketReadTimeout = new AtomicReference<>(Duration.ofSeconds(30));
+            AtomicReference<Duration> firstHttp2ReadTimeout = new AtomicReference<>();
+            doAnswer(invocation -> {
+                socketReadTimeout.set(invocation.getArgument(0));
+                return null;
+            }).when(test.clientConnection).readTimeout(any(Duration.class));
+            when(test.clientConnection.reader()).thenReturn(DataReader.create(() -> {
+                firstHttp2ReadTimeout.compareAndSet(null, socketReadTimeout.get());
+                return test.nextInboundFrame();
+            }));
+            test.offerInbound(settingsFrame(10));
+
+            Http2ClientConnection connection = Http2ClientConnection.createUpgraded(test.client,
+                                                                                     test.clientConnection,
+                                                                                     ignored -> { });
+
+            assertThat(firstHttp2ReadTimeout.get(), is(Duration.ZERO));
+            connection.close();
+        }
+    }
+
+    @Test
     void initialSettingsFailureClosesConnection() {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.closeInbound();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -331,7 +331,7 @@ class Http2ClientConnectionTest {
     }
 
     @Test
-    void upgradedConnectionClearsSocketReadTimeout() {
+    void upgradedConnectionClearsSocketReadTimeoutAfterInitialSettings() {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             AtomicReference<Duration> socketReadTimeout = new AtomicReference<>(Duration.ofSeconds(30));
             AtomicReference<Duration> firstHttp2ReadTimeout = new AtomicReference<>();
@@ -349,7 +349,8 @@ class Http2ClientConnectionTest {
                                                                                      test.clientConnection,
                                                                                      ignored -> { });
 
-            assertThat(firstHttp2ReadTimeout.get(), is(Duration.ZERO));
+            assertThat(firstHttp2ReadTimeout.get(), is(Duration.ofSeconds(30)));
+            assertThat(socketReadTimeout.get(), is(Duration.ZERO));
             connection.close();
         }
     }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -478,6 +479,35 @@ class Http2ClientConnectionTest {
             }
             cancel.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             stream.close();
+        }
+    }
+
+    @Test
+    void closeBeforePrefaceDoesNotSendGoAway() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            AtomicReference<Http2ClientConnection> connectionRef = new AtomicReference<>();
+            MockedConnectionTestContext.BlockedWrite blockedWrite = test.blockNextWriteNow();
+            CompletableFuture<Http2ClientConnection> connectionFuture = CompletableFuture.supplyAsync(
+                    () -> Http2ClientConnection.createUpgraded(test.client,
+                                                               test.clientConnection,
+                                                               ignored -> { },
+                                                               connectionRef::set));
+
+            assertTrue(blockedWrite.awaitEntered());
+            Http2ClientConnection connection = connectionRef.get();
+            assertNotNull(connection);
+            try {
+                connection.close();
+                test.assertConnectionClosed();
+                verify(test.dataWriter).writeNow(any(BufferData.class));
+            } finally {
+                blockedWrite.release();
+            }
+            ExecutionException connectionFailure = assertThrows(ExecutionException.class,
+                                                                () -> connectionFuture.get(
+                                                                        TEST_WAIT_TIMEOUT.toMillis(),
+                                                                        TimeUnit.MILLISECONDS));
+            assertNotNull(connectionFailure.getCause());
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -347,6 +347,7 @@ class Http2ClientConnectionTest {
 
             Http2ClientConnection connection = Http2ClientConnection.createUpgraded(test.client,
                                                                                      test.clientConnection,
+                                                                                     ignored -> { },
                                                                                      ignored -> { });
 
             assertThat(http2ReadTimeouts.poll(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
@@ -231,14 +231,14 @@ class H2cShutdownTest {
                 assertArrayEquals(clientPreface, input.readNBytes(clientPreface.length));
 
                 http2Client.closeResource();
+                while (input.read() != -1) {
+                    // Drain any final HTTP/2 frames until the client closes its socket.
+                }
                 try {
                     output.write(new byte[] {0, 0, 0, 4, 0, 0, 0, 0, 0});
                     output.flush();
                 } catch (IOException ignored) {
                     // The client may close before the peer sends its initial settings.
-                }
-                while (input.read() != -1) {
-                    // Drain any final HTTP/2 frames until the client closes its socket.
                 }
 
                 ExecutionException requestFailure = assertThrows(ExecutionException.class,

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.tests.http2;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.http.Method;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webclient.http2.Http2ClientProtocolConfig;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http1.Http1Config;
+import io.helidon.webserver.http1.Http1ConnectionSelector;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2ConnectionSelector;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.http2.Http2Upgrader;
+import io.helidon.webserver.spi.ServerConnection;
+import io.helidon.webserver.spi.ServerConnectionSelector;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ServerTest
+class H2cShutdownTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration HOLD_TIMEOUT = Duration.ofSeconds(30);
+
+    private static final ConcurrentMap<Integer, CompletableFuture<Void>> connectionClosed = new ConcurrentHashMap<>();
+
+    private static volatile CompletableFuture<Integer> heldRequestReceived = new CompletableFuture<>();
+    private static volatile CompletableFuture<Void> releaseHeldRequest = new CompletableFuture<>();
+
+    private final int serverPort;
+
+    H2cShutdownTest(WebServer server) {
+        serverPort = server.port();
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder server) {
+        Http2Config http2Config = Http2Config.builder()
+                .maxConcurrentStreams(1)
+                .build();
+        server.protocolsDiscoverServices(false)
+                .addConnectionSelector(recordingSelector(Http2ConnectionSelector.builder()
+                                                                 .http2Config(http2Config)
+                                                                 .build()))
+                .addConnectionSelector(recordingSelector(Http1ConnectionSelector.builder()
+                                                                 .config(Http1Config.create())
+                                                                 .addUpgrader(Http2Upgrader.create(http2Config))
+                                                                 .build()));
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder routing) {
+        routing.route(Http2Route.route(Method.GET, "/held", (req, res) -> {
+            int clientPort = req.remotePeer().port();
+            heldRequestReceived.complete(clientPort);
+            try {
+                releaseHeldRequest.get(HOLD_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while holding request A", e);
+            } catch (ExecutionException | TimeoutException e) {
+                throw new IllegalStateException("Failed while holding request A", e);
+            }
+            res.send(String.valueOf(clientPort));
+        }));
+        routing.route(Http2Route.route(Method.GET,
+                                       "/second",
+                                       (req, res) -> res.send(String.valueOf(req.remotePeer().port()))));
+    }
+
+    @BeforeEach
+    void resetRequests() {
+        connectionClosed.clear();
+        heldRequestReceived = new CompletableFuture<>();
+        releaseHeldRequest = new CompletableFuture<>();
+    }
+
+    @Test
+    void closesDisplacedUpgradedConnection() {
+        Http2Client http2Client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .protocolConfig(Http2ClientProtocolConfig.builder().priorKnowledge(false))
+                .connectTimeout(TIMEOUT)
+                .baseUri("http://127.0.0.1:" + serverPort)
+                .build();
+        var executor = Executors.newVirtualThreadPerTaskExecutor();
+        CompletableFuture<Integer> heldResponse = CompletableFuture.supplyAsync(() -> {
+            try (var response = http2Client.get("/held")
+                    .readTimeout(TIMEOUT)
+                    .request()) {
+                return Integer.parseInt(response.entity().as(String.class));
+            }
+        }, executor);
+        try {
+            int heldClientPort = await(heldRequestReceived, "request A to reach the server");
+            int secondClientPort;
+            try (var response = http2Client.get("/second")
+                    .readTimeout(TIMEOUT)
+                    .request()) {
+                secondClientPort = Integer.parseInt(response.entity().as(String.class));
+            }
+            assertThat("request B should use a new connection while request A occupies the only stream",
+                       secondClientPort,
+                       not(is(heldClientPort)));
+
+            releaseHeldRequest.complete(null);
+            assertThat(await(heldResponse, "request A to complete"), is(heldClientPort));
+
+            CompletableFuture<Void> heldConnectionClosed =
+                    connectionClosed.computeIfAbsent(heldClientPort, ignored -> new CompletableFuture<>());
+            CompletableFuture<Void> secondConnectionClosed =
+                    connectionClosed.computeIfAbsent(secondClientPort, ignored -> new CompletableFuture<>());
+            assertThat("request A connection should remain open before client shutdown",
+                       heldConnectionClosed.isDone(),
+                       is(false));
+            assertThat("request B connection should remain open before client shutdown",
+                       secondConnectionClosed.isDone(),
+                       is(false));
+
+            http2Client.closeResource();
+            await(secondConnectionClosed, "connection from client port " + secondClientPort + " to close");
+            await(heldConnectionClosed, "connection from client port " + heldClientPort + " to close");
+        } finally {
+            releaseHeldRequest.complete(null);
+            http2Client.closeResource();
+            heldResponse.cancel(true);
+            executor.shutdownNow();
+        }
+    }
+
+    private static ServerConnectionSelector recordingSelector(ServerConnectionSelector delegate) {
+        return new ServerConnectionSelector() {
+            @Override
+            public int bytesToIdentifyConnection() {
+                return delegate.bytesToIdentifyConnection();
+            }
+
+            @Override
+            public Support supports(BufferData data) {
+                return delegate.supports(data);
+            }
+
+            @Override
+            public Set<String> supportedApplicationProtocols() {
+                return delegate.supportedApplicationProtocols();
+            }
+
+            @Override
+            public ServerConnection connection(ConnectionContext ctx) {
+                ServerConnection connection = delegate.connection(ctx);
+                int clientPort = ctx.remotePeer().port();
+                return new ServerConnection() {
+                    @Override
+                    public void handle(Limit limit) throws InterruptedException {
+                        try {
+                            connection.handle(limit);
+                        } finally {
+                            connectionClosed.computeIfAbsent(clientPort, ignored -> new CompletableFuture<>())
+                                    .complete(null);
+                        }
+                    }
+
+                    @Override
+                    public Duration idleTime() {
+                        return connection.idleTime();
+                    }
+
+                    @Override
+                    public void close(boolean interrupt) {
+                        connection.close(interrupt);
+                    }
+                };
+            }
+        };
+    }
+
+    private static <T> T await(CompletableFuture<T> future, String description) {
+        try {
+            return future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return fail("Interrupted while waiting for " + description, e);
+        } catch (ExecutionException | TimeoutException e) {
+            return fail("Failed while waiting for " + description, e);
+        }
+    }
+}

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.tests.http2;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -230,8 +231,12 @@ class H2cShutdownTest {
                 assertArrayEquals(clientPreface, input.readNBytes(clientPreface.length));
 
                 http2Client.closeResource();
-                output.write(new byte[] {0, 0, 0, 4, 0, 0, 0, 0, 0});
-                output.flush();
+                try {
+                    output.write(new byte[] {0, 0, 0, 4, 0, 0, 0, 0, 0});
+                    output.flush();
+                } catch (IOException ignored) {
+                    // The client may close before the peer sends its initial settings.
+                }
                 while (input.read() != -1) {
                     // Drain any final HTTP/2 frames until the client closes its socket.
                 }

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
@@ -16,7 +16,14 @@
 
 package io.helidon.webclient.tests.http2;
 
+import java.io.ByteArrayOutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,8 +58,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ServerTest
@@ -164,6 +175,76 @@ class H2cShutdownTest {
             http2Client.closeResource();
             heldResponse.cancel(true);
             executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void closesUpgradedConnectionWaitingForInitialSettings() throws Exception {
+        byte[] clientPreface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+        byte[] headerTerminator = "\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+        try (ServerSocket serverSocket = new ServerSocket()) {
+            serverSocket.bind(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0));
+            serverSocket.setSoTimeout((int) TIMEOUT.toMillis());
+            Http2Client http2Client = Http2Client.builder()
+                    .shareConnectionCache(false)
+                    .protocolConfig(Http2ClientProtocolConfig.builder().priorKnowledge(false))
+                    .connectTimeout(TIMEOUT)
+                    .baseUri("http://127.0.0.1:" + serverSocket.getLocalPort())
+                    .build();
+            var executor = Executors.newVirtualThreadPerTaskExecutor();
+            CompletableFuture<Void> request = CompletableFuture.runAsync(() -> {
+                try (var response = http2Client.get("/")
+                        .readTimeout(HOLD_TIMEOUT)
+                        .request()) {
+                    response.entity().as(String.class);
+                }
+            }, executor);
+            try (Socket socket = serverSocket.accept()) {
+                socket.setSoTimeout((int) TIMEOUT.toMillis());
+                var input = socket.getInputStream();
+                var requestBytes = new ByteArrayOutputStream();
+                int terminatorIndex = 0;
+                while (terminatorIndex < headerTerminator.length) {
+                    int next = input.read();
+                    if (next == -1) {
+                        fail("Client closed before sending the h2c upgrade request");
+                    }
+                    requestBytes.write(next);
+                    if (next == headerTerminator[terminatorIndex]) {
+                        terminatorIndex++;
+                    } else {
+                        terminatorIndex = next == headerTerminator[0] ? 1 : 0;
+                    }
+                }
+                String requestHeaders = requestBytes.toString(StandardCharsets.US_ASCII).toLowerCase(Locale.ROOT);
+                assertThat(requestHeaders, containsString("\r\nupgrade: h2c\r\n"));
+                assertThat(requestHeaders, containsString("\r\nhttp2-settings:"));
+
+                var output = socket.getOutputStream();
+                output.write(("HTTP/1.1 101 Switching Protocols\r\n"
+                                      + "Connection: Upgrade\r\n"
+                                      + "Upgrade: h2c\r\n"
+                                      + "\r\n")
+                                     .getBytes(StandardCharsets.US_ASCII));
+                output.flush();
+                assertArrayEquals(clientPreface, input.readNBytes(clientPreface.length));
+
+                http2Client.closeResource();
+                output.write(new byte[] {0, 0, 0, 4, 0, 0, 0, 0, 0});
+                output.flush();
+                while (input.read() != -1) {
+                    // Drain any final HTTP/2 frames until the client closes its socket.
+                }
+
+                ExecutionException requestFailure = assertThrows(ExecutionException.class,
+                                                                  () -> request.get(TIMEOUT.toMillis(),
+                                                                                    TimeUnit.MILLISECONDS));
+                assertThat(requestFailure.getCause(), notNullValue());
+            } finally {
+                http2Client.closeResource();
+                request.cancel(true);
+                executor.shutdownNow();
+            }
         }
     }
 

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
@@ -237,7 +237,7 @@ class H2cShutdownTest {
                 try {
                     output.write(new byte[] {0, 0, 0, 4, 0, 0, 0, 0, 0});
                     output.flush();
-                } catch (IOException ignored) {
+                } catch (IOException _) {
                     // The client may close before the peer sends its initial settings.
                 }
 


### PR DESCRIPTION
Clear the HTTP/1 request-scoped socket read timeout when an upgraded connection is handed to the HTTP/2 client, before its permanent reader starts. HTTP/2 continues to apply response deadlines per stream, while normal, ALPN, and prior-knowledge connection setup remains unchanged.

This is an intermittently failing test, and this change should remove the failures, this time caused by a production code.

I have added a fix for a flaky grpc test as well, as it failed on this PR directly.

