### PR TITLE
Expose active WebClient TCP protocols

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
@@ -159,7 +159,10 @@ class LoomClient implements WebClient {
     @Override
     public List<String> tcpProtocolIds() {
         List<String> protocolIds = tcpProtocolIds;
-        return protocolIds == null ? List.of() : protocolIds;
+        if (protocolIds == null) {
+            throw new IllegalStateException("TCP protocol IDs are not available during WebClient construction");
+        }
+        return protocolIds;
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
@@ -157,6 +157,12 @@ class LoomClient implements WebClient {
     }
 
     @Override
+    public List<String> tcpProtocolIds() {
+        List<String> protocolIds = tcpProtocolIds;
+        return protocolIds == null ? List.of() : protocolIds;
+    }
+
+    @Override
     public <T, C extends ProtocolConfig> T client(Protocol<T, C> protocol, C protocolConfig) {
         return protocol.provider().protocol(this, protocolConfig);
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 
 package io.helidon.webclient.api;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Api;
 import io.helidon.webclient.spi.Protocol;
 import io.helidon.webclient.spi.ProtocolConfig;
 
@@ -96,6 +98,18 @@ public interface WebClient extends RuntimeType.Api<WebClientConfig>, HttpClient<
      * @return a new protocol client instance
      */
     <T, C extends ProtocolConfig> T client(Protocol<T, C> protocol);
+
+    /**
+     * Active TCP protocol IDs in preference order.
+     * Implementations that do not expose their active protocols return an empty list.
+     * The returned list is an immutable snapshot.
+     *
+     * @return unmodifiable list of active TCP protocol IDs
+     */
+    @Api.Internal
+    default List<String> tcpProtocolIds() {
+        return List.of();
+    }
 
     /**
      * Executor services, uses virtual threads.

--- a/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 
 import io.helidon.builder.api.RuntimeType;
 import io.helidon.common.Api;
+import io.helidon.webclient.spi.HttpClientSpiProvider;
 import io.helidon.webclient.spi.Protocol;
 import io.helidon.webclient.spi.ProtocolConfig;
 
@@ -105,7 +106,7 @@ public interface WebClient extends RuntimeType.Api<WebClientConfig>, HttpClient<
      * The returned list is an immutable snapshot.
      * <p>
      * This method must not be called from
-     * {@link io.helidon.webclient.spi.HttpClientSpiProvider#protocol(WebClient, Object)} while this client is being
+     * {@link HttpClientSpiProvider#protocol(WebClient, Object)} while this client is being
      * constructed. Protocol clients should retain the {@link WebClient} instance and obtain the protocol IDs after
      * construction completes.
      *

--- a/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
@@ -103,8 +103,14 @@ public interface WebClient extends RuntimeType.Api<WebClientConfig>, HttpClient<
      * Active TCP protocol IDs in preference order.
      * Implementations that do not expose their active protocols return an empty list.
      * The returned list is an immutable snapshot.
+     * <p>
+     * This method must not be called from
+     * {@link io.helidon.webclient.spi.HttpClientSpiProvider#protocol(WebClient, Object)} while this client is being
+     * constructed. Protocol clients should retain the {@link WebClient} instance and obtain the protocol IDs after
+     * construction completes.
      *
      * @return unmodifiable list of active TCP protocol IDs
+     * @throws IllegalStateException if the protocol inventory is not yet available
      */
     @Api.Internal
     default List<String> tcpProtocolIds() {

--- a/webclient/api/src/test/java/io/helidon/webclient/api/TestHttpClientSpiProvider.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/TestHttpClientSpiProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.api;
+
+import io.helidon.webclient.spi.HttpClientSpi;
+import io.helidon.webclient.spi.HttpClientSpiProvider;
+import io.helidon.webclient.spi.ProtocolConfig;
+
+public class TestHttpClientSpiProvider implements HttpClientSpiProvider<ProtocolConfig> {
+    static final String PROTOCOL_ID = "test-protocol";
+
+    private static final HttpClientSpi CLIENT_SPI = new HttpClientSpi() {
+        @Override
+        public SupportLevel supports(FullClientRequest<?> clientRequest, ClientUri clientUri) {
+            return SupportLevel.NOT_SUPPORTED;
+        }
+
+        @Override
+        public ClientRequest<?> clientRequest(FullClientRequest<?> clientRequest, ClientUri clientUri) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isTcp() {
+            return false;
+        }
+
+        @Override
+        public void closeResource() {
+        }
+    };
+
+    private static volatile IllegalStateException constructionFailure;
+
+    @Override
+    public String protocolId() {
+        return PROTOCOL_ID;
+    }
+
+    @Override
+    public Class<ProtocolConfig> configType() {
+        return ProtocolConfig.class;
+    }
+
+    @Override
+    public ProtocolConfig defaultConfig() {
+        return new ProtocolConfig() {
+            @Override
+            public String name() {
+                return PROTOCOL_ID;
+            }
+
+            @Override
+            public String type() {
+                return PROTOCOL_ID;
+            }
+        };
+    }
+
+    @Override
+    public HttpClientSpi protocol(WebClient client, ProtocolConfig config) {
+        try {
+            client.tcpProtocolIds();
+        } catch (IllegalStateException e) {
+            constructionFailure = e;
+        }
+        return CLIENT_SPI;
+    }
+
+    static void reset() {
+        constructionFailure = null;
+    }
+
+    static IllegalStateException constructionFailure() {
+        return constructionFailure;
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/WebClientProtocolInventoryTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/WebClientProtocolInventoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.api;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+class WebClientProtocolInventoryTest {
+
+    @Test
+    void rejectsProtocolInventoryAccessDuringConstruction() {
+        TestHttpClientSpiProvider.reset();
+
+        WebClient client = WebClient.builder()
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(TestHttpClientSpiProvider.PROTOCOL_ID))
+                .build();
+        try {
+            IllegalStateException failure = TestHttpClientSpiProvider.constructionFailure();
+            assertThat(failure, is(notNullValue()));
+            assertThat(failure.getMessage(), is("TCP protocol IDs are not available during WebClient construction"));
+        } finally {
+            client.closeResource();
+        }
+    }
+}

--- a/webclient/api/src/test/resources/META-INF/services/io.helidon.webclient.spi.HttpClientSpiProvider
+++ b/webclient/api/src/test/resources/META-INF/services/io.helidon.webclient.spi.HttpClientSpiProvider
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.webclient.api.TestHttpClientSpiProvider

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/WebClientProtocolInventoryTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/WebClientProtocolInventoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.http2;
+
+import java.util.List;
+
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http1.Http1Client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WebClientProtocolInventoryTest {
+
+    @Test
+    void exposesActiveTcpProtocolsInPreferenceOrder() {
+        WebClient client = WebClient.builder()
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .protocolPreference(List.of(Http1Client.PROTOCOL_ID, Http2Client.PROTOCOL_ID))
+                .build();
+        try {
+            List<String> protocolIds = client.tcpProtocolIds();
+            assertThat(protocolIds, contains(Http1Client.PROTOCOL_ID, Http2Client.PROTOCOL_ID));
+            assertThrows(UnsupportedOperationException.class, () -> protocolIds.add("test"));
+        } finally {
+            client.closeResource();
+        }
+    }
+}


### PR DESCRIPTION
Expose the active TCP protocol IDs in configured preference order through the WebClient contract, allowing protocol clients to preserve TCP fallback without an implementation-specific downcast. Existing implementations default to an empty immutable list.

Pre-requisite for #3686.
