### PR TITLE
3.x: Upgrade Netty to 4.1.137.Final. postgresql driver to 42.7.13

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -128,7 +128,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.136.Final</version.lib.netty>
+        <version.lib.netty>4.1.137.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.76.0</version.lib.oci>
         <version.lib.ojdbc8>21.15.0.0</version.lib.ojdbc8>
@@ -145,7 +145,7 @@
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.perfmark-api>0.25.0</version.lib.perfmark-api>
         <version.lib.parsson>1.0.5</version.lib.parsson>
-        <version.lib.postgresql>42.7.11</version.lib.postgresql>
+        <version.lib.postgresql>42.7.13</version.lib.postgresql>
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>2.0.17</version.lib.slf4j>
         <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -544,6 +544,43 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
     <cve>CVE-2026-42582</cve>
 </suppress>
 
+<!-- Under dispute
+     These CVEs are being disputed. For details see:
+     https://github.com/HdrHistogram/HdrHistogram/issues/222
+     https://github.com/HdrHistogram/HdrHistogram/issues/221
+     https://github.com/HdrHistogram/HdrHistogram/issues/220
+     https://github.com/HdrHistogram/HdrHistogram/issues/218
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: HdrHistogram-2.2.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.hdrhistogram/HdrHistogram@.*$</packageUrl>
+    <vulnerabilityName>CVE-2026-14683</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: HdrHistogram-2.2.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.hdrhistogram/HdrHistogram@.*$</packageUrl>
+    <vulnerabilityName>CVE-2026-14685</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: HdrHistogram-2.2.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.hdrhistogram/HdrHistogram@.*$</packageUrl>
+    <vulnerabilityName>CVE-2026-14686</vulnerabilityName>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: HdrHistogram-2.2.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.hdrhistogram/HdrHistogram@.*$</packageUrl>
+    <vulnerabilityName>CVE-2026-14684</vulnerabilityName>
+</suppress>
+
+
 
 
 </suppressions>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -580,7 +580,19 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
     <vulnerabilityName>CVE-2026-14684</vulnerabilityName>
 </suppress>
 
-
+<!--
+  This CVE only applies when using the KAPT incremental build cache (typically with Gradle).
+  We do not use Kotlin nor the Kotlin Compiler or KAPT at build time. Kotlin would only be
+  present as a transitive runtime dependencies in the form of kotlin-stdlib,
+  kotlin-stdlib-common or kotlin-stdlib-jdk8.
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: kotlin-stdlib-1.9.10.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib.*@.*$</packageUrl>
+    <cve>CVE-2026-53914</cve>
+</suppress>
 
 
 </suppressions>


### PR DESCRIPTION
### Description

- Upgrade Netty to 4.1.137.Final
- Upgrade Postgresql Driver to 42.7.13
-  Add suppression for disputed HdrHistogram 