### PR TITLE
4.x netty 4.1.137.final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -143,7 +143,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.136.Final</version.lib.netty>
+        <version.lib.netty>4.1.137.Final</version.lib.netty>
         <version.lib.oci>3.86.2</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -574,7 +574,7 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
     <notes><![CDATA[
     file name: kotlin-stdlib-1.9.10.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib.*@.*$</packageUrl>
     <cve>CVE-2026-53914</cve>
 </suppress>
 

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -564,4 +564,19 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
     <vulnerabilityName>CVE-2026-14684</vulnerabilityName>
 </suppress>
 
+<!--
+  This CVE only applies when using the KAPT incremental build cache (typically with Gradle).
+  We do not use Kotlin nor the Kotlin Compiler or KAPT at build time. Kotlin would only be
+  present as a transitive runtime dependencies in the form of kotlin-stdlib,
+  kotlin-stdlib-common or kotlin-stdlib-jdk8.
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: kotlin-stdlib-1.9.10.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib@.*$</packageUrl>
+    <cve>CVE-2026-53914</cve>
+</suppress>
+
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <version.lib.jsonp-tck>2.1.1</version.lib.jsonp-tck>
         <version.lib.microprofile-cdi-tck>4.0.13</version.lib.microprofile-cdi-tck>
         <version.lib.microprofile-restful-tck>3.1.5</version.lib.microprofile-restful-tck>
-        <version.lib.jsoup>1.15.3</version.lib.jsoup>
+        <version.lib.jsoup>1.23.1</version.lib.jsoup>
         <version.lib.junit4>4.13.1</version.lib.junit4>
         <version.lib.kafka-junit5>3.2.3</version.lib.kafka-junit5>
         <version.lib.mockito>2.23.4</version.lib.mockito>


### PR DESCRIPTION
### Description

Upgrade Netty to 4.1.137.Final
Upgrade  jsoup to 1.23.1
Suppress Kotlin build time positive

Why does Helidon 4 still manage Netty version? See [9645](https://github.com/helidon-io/helidon/issues/9645)
