### PR TITLE
Add Vary for automatic content encoding

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -41,6 +41,8 @@ import io.helidon.webserver.http.ServerResponseBase;
 
 class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     private static final System.Logger LOGGER = System.getLogger(Http2ServerResponse.class.getName());
+    private static final Header VARY_ACCEPT_ENCODING =
+            HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
 
     private final ConnectionContext ctx;
     private final ServerResponseHeaders headers;
@@ -123,7 +125,8 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             int actualLength = length;
             int actualPosition = position;
             byte[] actualBytes = entityBytes(entityBytes, position, length);
-            if (entityBytes != actualBytes) {       // encoding happened, new byte array
+            boolean automaticContentEncoding = entityBytes != actualBytes;
+            if (automaticContentEncoding) {       // encoding happened, new byte array
                 actualPosition = 0;
                 actualLength = actualBytes.length;
             }
@@ -138,6 +141,9 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
 
             int initialStatusCode = status().code();
             prepareResponse();
+            if (automaticContentEncoding && !headers.containsToken(VARY_ACCEPT_ENCODING)) {
+                headers.add(VARY_ACCEPT_ENCODING);
+            }
 
             Status responseStatus = status();
             int statusCode = responseStatus.code();

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -47,6 +47,7 @@ import io.helidon.webserver.http.spi.SinkProviderContext;
 
 import static io.helidon.http.HeaderValues.CONTENT_TYPE_EVENT_STREAM;
 import static io.helidon.http.HeaderValues.create;
+import static io.helidon.http.HeaderValues.createCached;
 
 /**
  * Implementation of an SSE sink. Emits {@link SseEvent}s.
@@ -59,6 +60,8 @@ class DataWriterSseSink implements SseSink {
     public static final GenericType<DataWriterSseSink> TYPE = GenericType.create(DataWriterSseSink.class);
 
     private static final Header CACHE_NO_CACHE_ONLY = create(HeaderNames.CACHE_CONTROL, "no-cache");
+    private static final Header VARY_ACCEPT_ENCODING =
+            createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
     private static final byte[] SSE_NL = "\n".getBytes(StandardCharsets.UTF_8);
     private static final byte[] SSE_ID = "id:".getBytes(StandardCharsets.UTF_8);
     private static final byte[] SSE_DATA = "data:".getBytes(StandardCharsets.UTF_8);
@@ -94,9 +97,12 @@ class DataWriterSseSink implements SseSink {
             ContentEncoder encoder = null;
             ServerRequestHeaders requestHeaders = context.serverRequest().headers();
             ContentEncodingContext encodingContext = ctx.listenerContext().contentEncodingContext();
-            if (encodingContext.contentEncodingEnabled() && requestHeaders.contains(HeaderNames.ACCEPT_ENCODING)) {
-                encoder = encodingContext.encoder(requestHeaders);
-                encoder.headers(response.headers());        // adds Content-Encoding
+            if (encodingContext.contentEncodingEnabled()) {
+                response.headers().add(VARY_ACCEPT_ENCODING);
+                if (requestHeaders.contains(HeaderNames.ACCEPT_ENCODING)) {
+                    encoder = encodingContext.encoder(requestHeaders);
+                    encoder.headers(response.headers());        // adds Content-Encoding
+                }
             }
 
             // output stream to write headers

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentEncodingVaryTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentEncodingVaryTest.java
@@ -33,6 +33,7 @@ import io.helidon.webserver.testing.junit5.SetUpServer;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeaderValue;
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.noHeader;
 import static io.helidon.http.Method.GET;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,6 +42,7 @@ import static org.hamcrest.Matchers.equalToIgnoringCase;
 @ServerTest
 class ContentEncodingVaryTest {
     private static final String ENTITY = "hello webserver";
+    private static final String ETAG = "\"content-encoding\"";
     private static final Header VARY_ACCEPT_ENCODING =
             HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
     private static final Header VARY_ORIGIN =
@@ -64,6 +66,13 @@ class ContentEncodingVaryTest {
         rules.route(Http2Route.route(GET, "/before-send-vary", (_, res) -> {
             res.beforeSend(() -> res.headers().set(VARY_ORIGIN));
             res.send(ENTITY);
+        })).route(Http2Route.route(GET, "/not-modified", (req, res) -> {
+            res.header(HeaderNames.ETAG, ETAG);
+            if (req.headers().contains(HeaderValues.create(HeaderNames.IF_NONE_MATCH, ETAG))) {
+                res.status(Status.NOT_MODIFIED_304).send();
+            } else {
+                res.send(ENTITY);
+            }
         }));
     }
 
@@ -79,6 +88,35 @@ class ContentEncodingVaryTest {
             var varyValues = response.headers().values(HeaderNames.VARY);
             assertThat("Vary response header " + varyValues,
                        response.headers().containsToken(VARY_ORIGIN), is(true));
+            assertThat("Vary response header " + varyValues,
+                       response.headers().containsToken(VARY_ACCEPT_ENCODING), is(true));
+        }
+    }
+
+    @Test
+    void testAutomaticEncodingAddsVaryToNotModified() {
+        try (var response = client.get("/not-modified")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers(),
+                       hasHeaderValue(HeaderNames.CONTENT_ENCODING, equalToIgnoringCase("gzip")));
+
+            var varyValues = response.headers().values(HeaderNames.VARY);
+            assertThat("Vary response header " + varyValues,
+                       response.headers().containsToken(VARY_ACCEPT_ENCODING), is(true));
+        }
+
+        try (var response = client.get("/not-modified")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .header(HeaderNames.IF_NONE_MATCH, ETAG)
+                .followRedirects(false)
+                .request()) {
+            assertThat(response.status(), is(Status.NOT_MODIFIED_304));
+            assertThat(response.headers(), noHeader(HeaderNames.CONTENT_ENCODING));
+            assertThat(response.entity().as(byte[].class).length, is(0));
+
+            var varyValues = response.headers().values(HeaderNames.VARY);
             assertThat("Vary response header " + varyValues,
                        response.headers().containsToken(VARY_ACCEPT_ENCODING), is(true));
         }

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentEncodingVaryTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentEncodingVaryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Status;
+import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.http.encoding.gzip.GzipEncoding;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeaderValue;
+import static io.helidon.http.Method.GET;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+
+@ServerTest
+class ContentEncodingVaryTest {
+    private static final String ENTITY = "hello webserver";
+    private static final Header VARY_ACCEPT_ENCODING =
+            HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
+    private static final Header VARY_ORIGIN =
+            HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ORIGIN.defaultCase());
+
+    private final Http2Client client;
+
+    ContentEncodingVaryTest(Http2Client client) {
+        this.client = client;
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.contentEncoding(ContentEncodingContext.builder()
+                                       .addContentEncoding(GzipEncoding.create())
+                                       .build());
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder rules) {
+        rules.route(Http2Route.route(GET, "/before-send-vary", (_, res) -> {
+            res.beforeSend(() -> res.headers().set(VARY_ORIGIN));
+            res.send(ENTITY);
+        }));
+    }
+
+    @Test
+    void testAutomaticEncodingPreservesBeforeSendVary() {
+        try (var response = client.get("/before-send-vary")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers(),
+                       hasHeaderValue(HeaderNames.CONTENT_ENCODING, equalToIgnoringCase("gzip")));
+
+            var varyValues = response.headers().values(HeaderNames.VARY);
+            assertThat("Vary response header " + varyValues,
+                       response.headers().containsToken(VARY_ORIGIN), is(true));
+            assertThat("Vary response header " + varyValues,
+                       response.headers().containsToken(VARY_ACCEPT_ENCODING), is(true));
+        }
+    }
+}

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SimpleSseClient.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SimpleSseClient.java
@@ -25,7 +25,10 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Headers;
 import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
 
 class SimpleSseClient implements AutoCloseable {
 
@@ -39,6 +42,7 @@ class SimpleSseClient implements AutoCloseable {
     private State state = State.DISCONNECTED;
     private final String path;
     private final SocketHttpClient client;
+    private final WritableHeaders<?> responseHeaders = WritableHeaders.create();
     private String contentEncoding;
     private boolean chunked;
     private InputStream inputStream;
@@ -98,6 +102,12 @@ class SimpleSseClient implements AutoCloseable {
         ensureHeadersRead();
     }
 
+    public Headers responseHeaders() {
+        ensureConnected();
+        ensureHeadersRead();
+        return responseHeaders;
+    }
+
     @Override
     public void close() throws Exception {
         client.close();
@@ -143,6 +153,12 @@ class SimpleSseClient implements AutoCloseable {
                         }
                         return;
                     }
+                    int colonIndex = line.indexOf(':');
+                    if (colonIndex > 0) {
+                        responseHeaders.add(HeaderValues.create(line.substring(0, colonIndex),
+                                                                line.substring(colonIndex + 1).trim()));
+                    }
+
                     line = line.toLowerCase(Locale.ROOT);
                     if (line.contains("http/1.1") && !line.contains("200")) {
                         throw new RuntimeException("Invalid status code in response");

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseCompressionTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseCompressionTest.java
@@ -16,14 +16,25 @@
 
 package io.helidon.webserver.tests.sse;
 
+import java.time.Duration;
 import java.util.List;
 
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Headers;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeaderValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.hasItem;
 
 @ServerTest
 class SseCompressionTest extends SseBaseTest {
@@ -45,7 +56,22 @@ class SseCompressionTest extends SseBaseTest {
 
     @Test
     void testSseString1() throws Exception {
-        testSse("/sseString1", GZIP_HEADER, "data:hello", "data:world");
+        try (SimpleSseClient sseClient = SimpleSseClient.create("localhost",
+                                                                webServer().port(),
+                                                                "/sseString1",
+                                                                GZIP_HEADER,
+                                                                Duration.ofSeconds(10))) {
+            Headers responseHeaders = sseClient.responseHeaders();
+
+            assertThat(sseClient.nextEvent(), is("data:hello"));
+            assertThat(sseClient.nextEvent(), is("data:world"));
+            assertThat(sseClient.nextEvent(), is(nullValue()));
+            assertThat(responseHeaders,
+                       hasHeaderValue(HeaderNames.CONTENT_ENCODING, equalToIgnoringCase("gzip")));
+            assertThat(responseHeaders, hasHeader(HeaderNames.VARY));
+            assertThat(responseHeaders.values(HeaderNames.VARY),
+                       hasItem(equalToIgnoringCase(HeaderNames.ACCEPT_ENCODING.defaultCase())));
+        }
     }
 
     @Test

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingContextTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingContextTest.java
@@ -53,6 +53,7 @@ import static org.hamcrest.Matchers.is;
 @ServerTest
 class ContentEncodingContextTest {
 
+    private static final String ETAG = "\"content-encoding\"";
     private static final Header VARY_ACCEPT_ENCODING =
             HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
     private static final Header VARY_ORIGIN =
@@ -83,6 +84,14 @@ class ContentEncodingContextTest {
                 .get("/vary", (_, res) -> {
                     res.headers().add(HeaderValues.create(HeaderNames.VARY, HeaderNames.ORIGIN.defaultCase()));
                     res.send("hello webserver");
+                })
+                .get("/not-modified", (req, res) -> {
+                    res.header(HeaderNames.ETAG, ETAG);
+                    if (req.headers().contains(HeaderValues.create(HeaderNames.IF_NONE_MATCH, ETAG))) {
+                        res.status(Status.NOT_MODIFIED_304).send();
+                    } else {
+                        res.send("hello webserver");
+                    }
                 });
     }
 
@@ -143,6 +152,35 @@ class ContentEncodingContextTest {
             assertThat(response.headers().values(HeaderNames.VARY), hasSize(2));
             assertThat(response.headers().containsToken(VARY_ORIGIN), is(true));
             assertThat(response.headers().containsToken(VARY_ACCEPT_ENCODING), is(true));
+        }
+    }
+
+    @Test
+    void testAutomaticContentEncodingAddsVaryToNotModified() {
+        try (Http1ClientResponse response = client.method(Method.GET)
+                .uri("/not-modified")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_ENCODING, "gzip"));
+
+            var varyValues = response.headers().values(HeaderNames.VARY);
+            assertThat("Vary response header " + varyValues,
+                       response.headers().containsToken(VARY_ACCEPT_ENCODING), is(true));
+        }
+
+        try (Http1ClientResponse response = client.method(Method.GET)
+                .uri("/not-modified")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .header(HeaderNames.IF_NONE_MATCH, ETAG)
+                .request()) {
+            assertThat(response.status(), is(Status.NOT_MODIFIED_304));
+            assertThat(response.headers(), HttpHeaderMatcher.noHeader(HeaderNames.CONTENT_ENCODING));
+            assertThat(response.entity().hasEntity(), is(false));
+
+            var varyValues = response.headers().values(HeaderNames.VARY);
+            assertThat("Vary response header " + varyValues,
+                       response.headers().containsToken(VARY_ACCEPT_ENCODING), is(true));
         }
     }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingContextTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,24 @@
 
 package io.helidon.webserver.tests;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.NoSuchElementException;
 
+import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
+import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.Method;
+import io.helidon.http.Status;
 import io.helidon.http.encoding.ContentDecoder;
 import io.helidon.http.encoding.ContentEncoder;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.encoding.ContentEncodingContextConfig;
+import io.helidon.http.encoding.gzip.GzipEncoding;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServerConfig;
@@ -38,10 +47,16 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 @ServerTest
 class ContentEncodingContextTest {
 
+    private static final Header VARY_ACCEPT_ENCODING =
+            HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
+    private static final Header VARY_ORIGIN =
+            HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ORIGIN.defaultCase());
     private static final CustomizedEncodingContext encodingContext = new CustomizedEncodingContext();
 
     private final Http1Client client;
@@ -57,24 +72,88 @@ class ContentEncodingContextTest {
 
     @SetUpRoute
     static void routing(HttpRules rules) {
-        rules.get("/hello", (req, res) -> res.send("hello webserver"));
+        rules.get("/hello", (_, res) -> res.send("hello webserver"))
+                .get("/stream", (_, res) -> {
+                    try (OutputStream out = res.outputStream()) {
+                        out.write("hello webserver".getBytes(StandardCharsets.UTF_8));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                })
+                .get("/vary", (_, res) -> {
+                    res.headers().add(HeaderValues.create(HeaderNames.VARY, HeaderNames.ORIGIN.defaultCase()));
+                    res.send("hello webserver");
+                });
     }
 
     @Test
-    void testCustomizeContentEncodingContext() {
+    void testAutomaticContentEncodingAddsVaryWithoutRequestHeader() {
         try (Http1ClientResponse response = client.method(Method.GET).uri("/hello").request()) {
+            assertThat(response.status(), equalTo(Status.OK_200));
+            assertThat(response.headers(), HttpHeaderMatcher.noHeader(HeaderNames.CONTENT_ENCODING));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.VARY,
+                                                                       HeaderNames.ACCEPT_ENCODING_NAME));
             assertThat(response.entity().as(String.class), equalTo("hello webserver"));
             assertThat(encodingContext.NO_ACCEPT_ENCODING_COUNT, greaterThan(0));
         }
     }
 
+    @Test
+    void testAutomaticContentEncodingAddsVaryWithoutRequestHeaderForOutputStream() {
+        try (Http1ClientResponse response = client.method(Method.GET).uri("/stream").request()) {
+            assertThat(response.status(), equalTo(Status.OK_200));
+            assertThat(response.headers(), HttpHeaderMatcher.noHeader(HeaderNames.CONTENT_ENCODING));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.VARY,
+                                                                       HeaderNames.ACCEPT_ENCODING_NAME));
+            assertThat(response.entity().as(String.class), equalTo("hello webserver"));
+        }
+    }
+
+    @Test
+    void testAutomaticContentEncodingAddsVaryAcceptEncoding() {
+        try (Http1ClientResponse response = client.method(Method.GET)
+                .uri("/hello")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .request()) {
+
+            assertThat(response.status(), equalTo(Status.OK_200));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_ENCODING, "gzip"));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.VARY,
+                                                                       HeaderNames.ACCEPT_ENCODING_NAME));
+        }
+    }
+
+    @Test
+    void testAutomaticContentEncodingAddsVaryAcceptEncodingForOutputStream() {
+        try (Http1ClientResponse response = client.method(Method.GET)
+                .uri("/stream")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .request()) {
+
+            assertThat(response.status(), equalTo(Status.OK_200));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.CONTENT_ENCODING, "gzip"));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(HeaderNames.VARY,
+                                                                       HeaderNames.ACCEPT_ENCODING_NAME));
+        }
+    }
+
+    @Test
+    void testAutomaticContentEncodingPreservesVary() {
+        try (Http1ClientResponse response = client.method(Method.GET).uri("/vary").request()) {
+            assertThat(response.headers().values(HeaderNames.VARY), hasSize(2));
+            assertThat(response.headers().containsToken(VARY_ORIGIN), is(true));
+            assertThat(response.headers().containsToken(VARY_ACCEPT_ENCODING), is(true));
+        }
+    }
 
     private static class CustomizedEncodingContext implements ContentEncodingContext {
         int ACCEPT_ENCODING_COUNT = 0;
 
         int NO_ACCEPT_ENCODING_COUNT = 0;
 
-        ContentEncodingContext contentEncodingContext = ContentEncodingContext.create();
+        ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()
+                .addContentEncoding(GzipEncoding.create())
+                .build();
 
         @Override
         public ContentEncodingContextConfig prototype() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -301,6 +301,12 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      */
     protected void beforeSend() {
         beforeSend.forEach(Runnable::run);
+        if (status().code() == Status.NOT_MODIFIED_304.code()
+                && contentEncodingContext.contentEncodingEnabled()
+                && !headers().contains(HeaderNames.CONTENT_ENCODING)
+                && !headers().containsToken(VARY_ACCEPT_ENCODING)) {
+            headers().add(VARY_ACCEPT_ENCODING);
+        }
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -67,6 +67,8 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      */
     protected static final Header STREAM_TRAILERS =
             HeaderValues.create(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
+    private static final Header VARY_ACCEPT_ENCODING =
+            HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
     private final ContentEncodingContext contentEncodingContext;
     private final MediaContext mediaContext;
     private final ServerRequestHeaders requestHeaders;
@@ -272,6 +274,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
             }
             entity = baos.toByteArray();
             encoder.headers(headers());
+            headers().add(VARY_ACCEPT_ENCODING);
         }
         return entity;
     }
@@ -286,6 +289,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         if (contentEncodingContext.contentEncodingEnabled() && !headers().contains(HeaderNames.CONTENT_ENCODING)) {
             ContentEncoder encoder = contentEncodingContext.encoder(requestHeaders);
             encoder.headers(headers());
+            headers().add(VARY_ACCEPT_ENCODING);
 
             return encoder.apply(outputStream);
         }


### PR DESCRIPTION
Pre-requisite for #12058

Automatic WebServer content encoding selects a response representation using `Accept-Encoding`, but the response does not currently advertise that selection to shared caches.

Add `Vary: Accept-Encoding` for both buffered and streaming automatic encoding paths. Append the value so dimensions configured by other components remain intact.
