### PR TITLE
Support char[] in @Configuration.Value injection

### DIFF
--- a/common/mapper/src/main/java/io/helidon/common/mapper/BuiltInMappers.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/BuiltInMappers.java
@@ -75,6 +75,7 @@ class BuiltInMappers implements MapperProvider {
         addStringMapper(mappers, double.class, BuiltInMappers::asDouble);
         addStringMapper(mappers, Character.class, BuiltInMappers::asChar);
         addStringMapper(mappers, char.class, BuiltInMappers::asChar);
+        addStringMapper(mappers, char[].class, String::toCharArray);
         addStringMapper(mappers, Class.class, BuiltInMappers::asClass);
         //javax.math
         addStringMapper(mappers, BigDecimal.class, BigDecimal::new);

--- a/common/mapper/src/test/java/io/helidon/common/mapper/MappersTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/MappersTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -65,6 +67,22 @@ class MappersTest {
         assertThat(shortResult, is((short) 10));
 
         assertThrows(MapperException.class, () -> mm.map(source, String.class, Object.class, "default"));
+    }
+
+    @Test
+    void testStringToCharArray() {
+        Mappers mappers = Mappers.builder()
+                .mapperProvidersDiscoverServices(false)
+                .mappersDiscoverServices(false)
+                .build();
+        GenericType<char[]> charArrayType = GenericType.create(char[].class);
+
+        char[] first = mappers.map("secret", GenericType.STRING, charArrayType, "defaults");
+        first[0] = '\0';
+        char[] second = mappers.map("secret", GenericType.STRING, charArrayType, "defaults");
+
+        assertNotSame(first, second);
+        assertArrayEquals("secret".toCharArray(), second);
     }
 
     @Test

--- a/config/config/src/main/java/io/helidon/config/ConfigMappers.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigMappers.java
@@ -128,6 +128,7 @@ public final class ConfigMappers {
                              Map.entry(Double.class, wrap(ConfigMappers::toDouble)),
                              Map.entry(Boolean.class, wrap(ConfigMappers::toBoolean)),
                              Map.entry(Character.class, wrap(ConfigMappers::toChar)),
+                             Map.entry(char[].class, wrap(String::toCharArray)),
                              //java.lang
                              Map.entry(Class.class, wrap(ConfigMappers::toClass)),
                              //javax.math

--- a/config/config/src/test/java/io/helidon/config/ConfigMappersFailingTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigMappersFailingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ public class ConfigMappersFailingTest {
         return ConfigMappers.BUILT_IN_MAPPERS.keySet()
                 .stream()
                 .filter(cls -> !Boolean.class.equals(cls)) //'Boolean.parseBoolean' does NOT fail
+                .filter(cls -> !char[].class.equals(cls)) //'String.toCharArray' does NOT fail
                 .filter(cls -> !File.class.equals(cls)) //'new File' does NOT fail
                 .filter(cls -> !Path.class.equals(cls)) //'Paths.get' does NOT fail
                 .filter(cls -> !Map.class.equals(cls)) //'Map' can bew created from any value

--- a/config/config/src/test/java/io/helidon/config/ConfigurationValueFactoryTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigurationValueFactoryTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConfigurationValueFactoryTest {
@@ -57,6 +58,39 @@ class ConfigurationValueFactoryTest {
 
         assertThat(values, hasSize(1));
         assertThat(values.getFirst().get(), is("Ahoj"));
+    }
+
+    @Test
+    void literalKeyMapsScalarToCharArray() {
+        ConfigurationValueFactory factory = factory(Map.of("app.password", "secret-value"));
+
+        List<Service.QualifiedInstance<Object>> values = factory.list(Qualifier.create(Configuration.Value.class,
+                                                                                      "app.password"),
+                                                                      Lookup.create(char[].class),
+                                                                      asObjectType(GenericType.create(char[].class)));
+
+        assertThat(values, hasSize(1));
+        assertArrayEquals("secret-value".toCharArray(), (char[]) values.getFirst().get());
+    }
+
+    @Test
+    void literalKeyUsesCustomCharArrayMapper() {
+        Config config = Config.builder()
+                .sources(ConfigSources.create(Map.of("app.password", "secret-value")))
+                .addMapper(char[].class, it -> "custom-value".toCharArray())
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .disableFilterServices()
+                .build();
+        ConfigurationValueFactory factory = new ConfigurationValueFactory(() -> defaultsResolver(config), () -> config);
+
+        List<Service.QualifiedInstance<Object>> values = factory.list(Qualifier.create(Configuration.Value.class,
+                                                                                      "app.password"),
+                                                                      Lookup.create(char[].class),
+                                                                      asObjectType(GenericType.create(char[].class)));
+
+        assertThat(values, hasSize(1));
+        assertArrayEquals("custom-value".toCharArray(), (char[]) values.getFirst().get());
     }
 
     @Test

--- a/config/config/src/test/java/io/helidon/config/ConfigurationValueFactoryTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigurationValueFactoryTest.java
@@ -77,7 +77,7 @@ class ConfigurationValueFactoryTest {
     void literalKeyUsesCustomCharArrayMapper() {
         Config config = Config.builder()
                 .sources(ConfigSources.create(Map.of("app.password", "secret-value")))
-                .addMapper(char[].class, it -> "custom-value".toCharArray())
+                .addMapper(char[].class, _ -> "custom-value".toCharArray())
                 .disableEnvironmentVariablesSource()
                 .disableSystemPropertiesSource()
                 .disableFilterServices()

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigurationValueInjectionTest.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigurationValueInjectionTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.config.tests.service.registry;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -25,6 +26,7 @@ import io.helidon.config.ConfigSources;
 import io.helidon.config.Configuration;
 import io.helidon.config.spi.ConfigNode;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInstance;
 import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
 
@@ -32,12 +34,17 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testing.Test(perMethod = true)
 class ConfigurationValueInjectionTest {
     private static final String PASSWORD = "secret-value";
     private static final List<String> PASSWORDS = List.of("first-secret", "second-secret");
+    private static final String INLINE_DEFAULT_PASSWORD = "inline-secret";
+    private static final String COMPOSITE_PASSWORD = "prefix-" + PASSWORD + "-suffix";
+    private static final String INFERRED_PASSWORD_KEY =
+            CharArrayResolutionService.class.getCanonicalName() + ".inferredPassword";
 
     @Test
     void charArrayInjectionVariantsAreSupported() {
@@ -54,12 +61,84 @@ class ConfigurationValueInjectionTest {
         assertPasswords(supplierService.passwords());
     }
 
+    @Test
+    void supplierCharArrayValuesAreIndependent() {
+        Services.set(Config.class, config());
+        CharArraySupplierService service = Services.get(CharArraySupplierService.class);
+
+        char[] password = service.password();
+        char[] optionalPassword = service.optionalPassword().orElseThrow();
+        List<char[]> passwords = service.passwords();
+
+        Arrays.fill(password, '\0');
+        Arrays.fill(optionalPassword, '\0');
+        passwords.forEach(value -> Arrays.fill(value, '\0'));
+
+        char[] nextPassword = service.password();
+        char[] nextOptionalPassword = service.optionalPassword().orElseThrow();
+        List<char[]> nextPasswords = service.passwords();
+
+        assertNotSame(password, nextPassword);
+        assertArrayEquals(PASSWORD.toCharArray(), nextPassword);
+        assertNotSame(optionalPassword, nextOptionalPassword);
+        assertArrayEquals(PASSWORD.toCharArray(), nextOptionalPassword);
+        assertEquals(passwords.size(), nextPasswords.size());
+        for (int i = 0; i < passwords.size(); i++) {
+            assertNotSame(passwords.get(i), nextPasswords.get(i));
+            assertArrayEquals(PASSWORDS.get(i).toCharArray(), nextPasswords.get(i));
+        }
+    }
+
+    @Test
+    void serviceInstanceCharArrayInjectionVariantsAreSupported() {
+        CharArrayServiceInstanceSupplierService supplierService =
+                Services.get(CharArrayServiceInstanceSupplierService.class);
+
+        Services.set(Config.class, config());
+        CharArrayServiceInstanceService service = Services.get(CharArrayServiceInstanceService.class);
+
+        assertServiceInstancePassword(service.password());
+        assertOptionalServiceInstancePassword(service.optionalPassword());
+        assertServiceInstancePasswords(service.passwords());
+        assertServiceInstancePassword(supplierService.password());
+        assertOptionalServiceInstancePassword(supplierService.optionalPassword());
+        assertServiceInstancePasswords(supplierService.passwords());
+    }
+
+    @Test
+    void charArrayResolutionVariantsAreSupported() {
+        Services.set(Config.class, config());
+        CharArrayResolutionService service = Services.get(CharArrayResolutionService.class);
+
+        assertArrayEquals(PASSWORD.toCharArray(), service.inferredPassword());
+        assertArrayEquals(new char[0], service.emptyPassword());
+        assertArrayEquals(INLINE_DEFAULT_PASSWORD.toCharArray(), service.inlineDefaultPassword());
+        assertArrayEquals(COMPOSITE_PASSWORD.toCharArray(), service.compositePassword());
+    }
+
+    @Test
+    void missingOptionalAndListCharArrayInjectionVariantsAreEmpty() {
+        Services.set(Config.class, Config.empty());
+        MissingCharArrayService service = Services.get(MissingCharArrayService.class);
+
+        assertTrue(service.optionalPassword().isEmpty());
+        assertTrue(service.passwords().isEmpty());
+        assertTrue(service.suppliedOptionalPassword().isEmpty());
+        assertTrue(service.suppliedPasswords().isEmpty());
+        assertTrue(service.optionalServiceInstancePassword().isEmpty());
+        assertTrue(service.serviceInstancePasswords().isEmpty());
+        assertTrue(service.suppliedOptionalServiceInstancePassword().isEmpty());
+        assertTrue(service.suppliedServiceInstancePasswords().isEmpty());
+    }
+
     private static Config config() {
         ConfigNode.ListNode.Builder passwords = ConfigNode.ListNode.builder();
         PASSWORDS.forEach(passwords::addValue);
         ConfigNode.ObjectNode root = ConfigNode.ObjectNode.builder()
                 .addValue("app.password", PASSWORD)
                 .addList("app.passwords", passwords.build())
+                .addValue("app.empty", "")
+                .addValue(INFERRED_PASSWORD_KEY, PASSWORD)
                 .build();
         return Config.just(ConfigSources.create(root));
     }
@@ -73,6 +152,22 @@ class ConfigurationValueInjectionTest {
         assertEquals(PASSWORDS.size(), passwords.size());
         for (int i = 0; i < PASSWORDS.size(); i++) {
             assertArrayEquals(PASSWORDS.get(i).toCharArray(), passwords.get(i));
+        }
+    }
+
+    private static void assertServiceInstancePassword(ServiceInstance<char[]> password) {
+        assertArrayEquals(PASSWORD.toCharArray(), password.get());
+    }
+
+    private static void assertOptionalServiceInstancePassword(Optional<ServiceInstance<char[]>> password) {
+        assertTrue(password.isPresent());
+        assertServiceInstancePassword(password.orElseThrow());
+    }
+
+    private static void assertServiceInstancePasswords(List<ServiceInstance<char[]>> passwords) {
+        assertEquals(PASSWORDS.size(), passwords.size());
+        for (int i = 0; i < PASSWORDS.size(); i++) {
+            assertArrayEquals(PASSWORDS.get(i).toCharArray(), passwords.get(i).get());
         }
     }
 
@@ -129,6 +224,170 @@ class ConfigurationValueInjectionTest {
 
         List<char[]> passwords() {
             return passwords.get();
+        }
+    }
+
+    @Service.Singleton
+    static class CharArrayServiceInstanceService {
+        private final ServiceInstance<char[]> password;
+        private final Optional<ServiceInstance<char[]>> optionalPassword;
+        private final List<ServiceInstance<char[]>> passwords;
+
+        @Service.Inject
+        CharArrayServiceInstanceService(
+                @Configuration.Value("app.password") ServiceInstance<char[]> password,
+                @Configuration.Value("app.password") Optional<ServiceInstance<char[]>> optionalPassword,
+                @Configuration.Value("app.passwords") List<ServiceInstance<char[]>> passwords) {
+            this.password = password;
+            this.optionalPassword = optionalPassword;
+            this.passwords = passwords;
+        }
+
+        ServiceInstance<char[]> password() {
+            return password;
+        }
+
+        Optional<ServiceInstance<char[]>> optionalPassword() {
+            return optionalPassword;
+        }
+
+        List<ServiceInstance<char[]>> passwords() {
+            return passwords;
+        }
+    }
+
+    @Service.Singleton
+    static class CharArrayServiceInstanceSupplierService {
+        private final Supplier<ServiceInstance<char[]>> password;
+        private final Supplier<Optional<ServiceInstance<char[]>>> optionalPassword;
+        private final Supplier<List<ServiceInstance<char[]>>> passwords;
+
+        @Service.Inject
+        CharArrayServiceInstanceSupplierService(
+                @Configuration.Value("app.password") Supplier<ServiceInstance<char[]>> password,
+                @Configuration.Value("app.password") Supplier<Optional<ServiceInstance<char[]>>> optionalPassword,
+                @Configuration.Value("app.passwords") Supplier<List<ServiceInstance<char[]>>> passwords) {
+            this.password = password;
+            this.optionalPassword = optionalPassword;
+            this.passwords = passwords;
+        }
+
+        ServiceInstance<char[]> password() {
+            return password.get();
+        }
+
+        Optional<ServiceInstance<char[]>> optionalPassword() {
+            return optionalPassword.get();
+        }
+
+        List<ServiceInstance<char[]>> passwords() {
+            return passwords.get();
+        }
+    }
+
+    @Service.Singleton
+    static class CharArrayResolutionService {
+        private final char[] inferredPassword;
+        private char[] emptyPassword;
+        private char[] inlineDefaultPassword;
+        private char[] compositePassword;
+
+        @Service.Inject
+        CharArrayResolutionService(@Configuration.Value char[] inferredPassword) {
+            this.inferredPassword = inferredPassword;
+        }
+
+        @Service.Inject
+        void configure(@Configuration.Value("app.empty") char[] emptyPassword,
+                       @Configuration.Value("${app.missing:inline-secret}") char[] inlineDefaultPassword,
+                       @Configuration.Value("prefix-${app.password}-suffix") char[] compositePassword) {
+            this.emptyPassword = emptyPassword;
+            this.inlineDefaultPassword = inlineDefaultPassword;
+            this.compositePassword = compositePassword;
+        }
+
+        char[] inferredPassword() {
+            return inferredPassword;
+        }
+
+        char[] emptyPassword() {
+            return emptyPassword;
+        }
+
+        char[] inlineDefaultPassword() {
+            return inlineDefaultPassword;
+        }
+
+        char[] compositePassword() {
+            return compositePassword;
+        }
+    }
+
+    @Service.Singleton
+    static class MissingCharArrayService {
+        private final Optional<char[]> optionalPassword;
+        private final List<char[]> passwords;
+        private final Supplier<Optional<char[]>> suppliedOptionalPassword;
+        private final Supplier<List<char[]>> suppliedPasswords;
+        private final Optional<ServiceInstance<char[]>> optionalServiceInstancePassword;
+        private final List<ServiceInstance<char[]>> serviceInstancePasswords;
+        private final Supplier<Optional<ServiceInstance<char[]>>> suppliedOptionalServiceInstancePassword;
+        private final Supplier<List<ServiceInstance<char[]>>> suppliedServiceInstancePasswords;
+
+        @Service.Inject
+        MissingCharArrayService(
+                @Configuration.Value("app.missing.password") Optional<char[]> optionalPassword,
+                @Configuration.Value("app.missing.passwords") List<char[]> passwords,
+                @Configuration.Value("app.missing.password") Supplier<Optional<char[]>> suppliedOptionalPassword,
+                @Configuration.Value("app.missing.passwords") Supplier<List<char[]>> suppliedPasswords,
+                @Configuration.Value("app.missing.password")
+                Optional<ServiceInstance<char[]>> optionalServiceInstancePassword,
+                @Configuration.Value("app.missing.passwords")
+                List<ServiceInstance<char[]>> serviceInstancePasswords,
+                @Configuration.Value("app.missing.password")
+                Supplier<Optional<ServiceInstance<char[]>>> suppliedOptionalServiceInstancePassword,
+                @Configuration.Value("app.missing.passwords")
+                Supplier<List<ServiceInstance<char[]>>> suppliedServiceInstancePasswords) {
+            this.optionalPassword = optionalPassword;
+            this.passwords = passwords;
+            this.suppliedOptionalPassword = suppliedOptionalPassword;
+            this.suppliedPasswords = suppliedPasswords;
+            this.optionalServiceInstancePassword = optionalServiceInstancePassword;
+            this.serviceInstancePasswords = serviceInstancePasswords;
+            this.suppliedOptionalServiceInstancePassword = suppliedOptionalServiceInstancePassword;
+            this.suppliedServiceInstancePasswords = suppliedServiceInstancePasswords;
+        }
+
+        Optional<char[]> optionalPassword() {
+            return optionalPassword;
+        }
+
+        List<char[]> passwords() {
+            return passwords;
+        }
+
+        Optional<char[]> suppliedOptionalPassword() {
+            return suppliedOptionalPassword.get();
+        }
+
+        List<char[]> suppliedPasswords() {
+            return suppliedPasswords.get();
+        }
+
+        Optional<ServiceInstance<char[]>> optionalServiceInstancePassword() {
+            return optionalServiceInstancePassword;
+        }
+
+        List<ServiceInstance<char[]>> serviceInstancePasswords() {
+            return serviceInstancePasswords;
+        }
+
+        Optional<ServiceInstance<char[]>> suppliedOptionalServiceInstancePassword() {
+            return suppliedOptionalServiceInstancePassword.get();
+        }
+
+        List<ServiceInstance<char[]>> suppliedServiceInstancePasswords() {
+            return suppliedServiceInstancePasswords.get();
         }
     }
 }

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigurationValueInjectionTest.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigurationValueInjectionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.service.registry;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.helidon.config.Config;
+import io.helidon.config.Configuration;
+import io.helidon.config.MapConfigSource;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+@Testing.Test(perMethod = true)
+class ConfigurationValueInjectionTest {
+
+    @Test
+    void charArraySupplierIsResolvedWhenRequested() {
+        CharArraySupplierService service = Services.get(CharArraySupplierService.class);
+
+        Services.set(Config.class,
+                     Config.just(MapConfigSource.create(Map.of("app.password", "secret-value"))));
+
+        assertArrayEquals("secret-value".toCharArray(), service.password());
+    }
+
+    @Service.Singleton
+    static class CharArraySupplierService {
+        private final Supplier<char[]> password;
+
+        @Service.Inject
+        CharArraySupplierService(@Configuration.Value("app.password") Supplier<char[]> password) {
+            this.password = password;
+        }
+
+        char[] password() {
+            return password.get();
+        }
+    }
+}

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigurationValueInjectionTest.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigurationValueInjectionTest.java
@@ -16,12 +16,14 @@
 
 package io.helidon.config.tests.service.registry;
 
-import java.util.Map;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 import io.helidon.config.Configuration;
-import io.helidon.config.MapConfigSource;
+import io.helidon.config.spi.ConfigNode;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
@@ -29,31 +31,104 @@ import io.helidon.testing.junit5.Testing;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testing.Test(perMethod = true)
 class ConfigurationValueInjectionTest {
+    private static final String PASSWORD = "secret-value";
+    private static final List<String> PASSWORDS = List.of("first-secret", "second-secret");
 
     @Test
-    void charArraySupplierIsResolvedWhenRequested() {
-        CharArraySupplierService service = Services.get(CharArraySupplierService.class);
+    void charArrayInjectionVariantsAreSupported() {
+        CharArraySupplierService supplierService = Services.get(CharArraySupplierService.class);
 
-        Services.set(Config.class,
-                     Config.just(MapConfigSource.create(Map.of("app.password", "secret-value"))));
+        Services.set(Config.class, config());
+        CharArrayService service = Services.get(CharArrayService.class);
 
-        assertArrayEquals("secret-value".toCharArray(), service.password());
+        assertArrayEquals(PASSWORD.toCharArray(), service.password());
+        assertOptionalPassword(service.optionalPassword());
+        assertPasswords(service.passwords());
+        assertArrayEquals(PASSWORD.toCharArray(), supplierService.password());
+        assertOptionalPassword(supplierService.optionalPassword());
+        assertPasswords(supplierService.passwords());
+    }
+
+    private static Config config() {
+        ConfigNode.ListNode.Builder passwords = ConfigNode.ListNode.builder();
+        PASSWORDS.forEach(passwords::addValue);
+        ConfigNode.ObjectNode root = ConfigNode.ObjectNode.builder()
+                .addValue("app.password", PASSWORD)
+                .addList("app.passwords", passwords.build())
+                .build();
+        return Config.just(ConfigSources.create(root));
+    }
+
+    private static void assertOptionalPassword(Optional<char[]> password) {
+        assertTrue(password.isPresent());
+        assertArrayEquals(PASSWORD.toCharArray(), password.orElseThrow());
+    }
+
+    private static void assertPasswords(List<char[]> passwords) {
+        assertEquals(PASSWORDS.size(), passwords.size());
+        for (int i = 0; i < PASSWORDS.size(); i++) {
+            assertArrayEquals(PASSWORDS.get(i).toCharArray(), passwords.get(i));
+        }
+    }
+
+    @Service.Singleton
+    static class CharArrayService {
+        private final char[] password;
+        private final Optional<char[]> optionalPassword;
+        private final List<char[]> passwords;
+
+        @Service.Inject
+        CharArrayService(@Configuration.Value("app.password") char[] password,
+                         @Configuration.Value("app.password") Optional<char[]> optionalPassword,
+                         @Configuration.Value("app.passwords") List<char[]> passwords) {
+            this.password = password;
+            this.optionalPassword = optionalPassword;
+            this.passwords = passwords;
+        }
+
+        char[] password() {
+            return password;
+        }
+
+        Optional<char[]> optionalPassword() {
+            return optionalPassword;
+        }
+
+        List<char[]> passwords() {
+            return passwords;
+        }
     }
 
     @Service.Singleton
     static class CharArraySupplierService {
         private final Supplier<char[]> password;
+        private final Supplier<Optional<char[]>> optionalPassword;
+        private final Supplier<List<char[]>> passwords;
 
         @Service.Inject
-        CharArraySupplierService(@Configuration.Value("app.password") Supplier<char[]> password) {
+        CharArraySupplierService(@Configuration.Value("app.password") Supplier<char[]> password,
+                                 @Configuration.Value("app.password") Supplier<Optional<char[]>> optionalPassword,
+                                 @Configuration.Value("app.passwords") Supplier<List<char[]>> passwords) {
             this.password = password;
+            this.optionalPassword = optionalPassword;
+            this.passwords = passwords;
         }
 
         char[] password() {
             return password.get();
+        }
+
+        Optional<char[]> optionalPassword() {
+            return optionalPassword.get();
+        }
+
+        List<char[]> passwords() {
+            return passwords.get();
         }
     }
 }

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigurationValueInjectionTest.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigurationValueInjectionTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import io.helidon.common.Default;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.config.Configuration;
@@ -42,6 +43,7 @@ class ConfigurationValueInjectionTest {
     private static final String PASSWORD = "secret-value";
     private static final List<String> PASSWORDS = List.of("first-secret", "second-secret");
     private static final String INLINE_DEFAULT_PASSWORD = "inline-secret";
+    private static final String ANNOTATION_DEFAULT_PASSWORD = "annotation-default-secret";
     private static final String COMPOSITE_PASSWORD = "prefix-" + PASSWORD + "-suffix";
     private static final String INFERRED_PASSWORD_KEY =
             CharArrayResolutionService.class.getCanonicalName() + ".inferredPassword";
@@ -113,6 +115,7 @@ class ConfigurationValueInjectionTest {
         assertArrayEquals(PASSWORD.toCharArray(), service.inferredPassword());
         assertArrayEquals(new char[0], service.emptyPassword());
         assertArrayEquals(INLINE_DEFAULT_PASSWORD.toCharArray(), service.inlineDefaultPassword());
+        assertArrayEquals(ANNOTATION_DEFAULT_PASSWORD.toCharArray(), service.annotationDefaultPassword());
         assertArrayEquals(COMPOSITE_PASSWORD.toCharArray(), service.compositePassword());
     }
 
@@ -290,6 +293,7 @@ class ConfigurationValueInjectionTest {
         private final char[] inferredPassword;
         private char[] emptyPassword;
         private char[] inlineDefaultPassword;
+        private char[] annotationDefaultPassword;
         private char[] compositePassword;
 
         @Service.Inject
@@ -300,9 +304,12 @@ class ConfigurationValueInjectionTest {
         @Service.Inject
         void configure(@Configuration.Value("app.empty") char[] emptyPassword,
                        @Configuration.Value("${app.missing:inline-secret}") char[] inlineDefaultPassword,
+                       @Configuration.Value("app.missing.password")
+                       @Default.Value(ANNOTATION_DEFAULT_PASSWORD) char[] annotationDefaultPassword,
                        @Configuration.Value("prefix-${app.password}-suffix") char[] compositePassword) {
             this.emptyPassword = emptyPassword;
             this.inlineDefaultPassword = inlineDefaultPassword;
+            this.annotationDefaultPassword = annotationDefaultPassword;
             this.compositePassword = compositePassword;
         }
 
@@ -316,6 +323,10 @@ class ConfigurationValueInjectionTest {
 
         char[] inlineDefaultPassword() {
             return inlineDefaultPassword;
+        }
+
+        char[] annotationDefaultPassword() {
+            return annotationDefaultPassword;
         }
 
         char[] compositePassword() {


### PR DESCRIPTION
### Description

Fixes #12267

Adds a built-in scalar `char[]` configuration mapper so direct `@Configuration.Value` and `Supplier<char[]>` injection work without requiring a custom mapper.

Supplier resolution remains deferred, and user-provided `char[]` mappers continue to take precedence.

### Documentation

None

### Testing

- `mvn -Ptests -pl config/config,config/tests/service-registry -am -Dtest=ConfigurationValueFactoryTest,ConfigurationValueInjectionTest,ConfigMappersTest,ConfigMappersFailingTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl config/config -am test`
- `mvn -Ptests -pl config/tests/service-registry -am test`
- `bash ./etc/scripts/copyright.sh`
- `bash ./etc/scripts/checkstyle.sh`
- `git diff --check`
