### PR TITLE
Expose TLS reload generation

### DIFF
--- a/common/tls/README.md
+++ b/common/tls/README.md
@@ -23,7 +23,12 @@ Intention (target solution):
 
 There is only one `Tls` instance per use (i.e. listener).
 
-There is only one `TlsManager` instance per instance of `Tls`.
+An automatically created `ConfiguredTlsManager` is owned by one `Tls` instance.
+
+An explicitly supplied or provider-created `TlsManager` may be shared by multiple `Tls` instances. A shared manager must
+keep the first successfully initialized `SSLContext` identity across repeated `init(TlsConfig)` calls, either ignoring later
+calls or rejecting incompatible configuration. Its reload state and reported generation are shared by all `Tls` instances
+using it.
 
 The method `reload(TlsMaterial)` on listener(s) will delegate the call to the currently configured `TlsManager` - this may not be supported by the chosen manager (i.e. OCI based manager may refuse or ignore calls, as it has a scheduler to read rotated information).
 

--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -118,7 +118,15 @@ public class ConfiguredTlsManager implements TlsManager {
     @SuppressWarnings("removal")
     public void reload(Tls tls) {
         Tls.validateReloadSource(tls);
-        reload(tls.keyManager(), tls.trustManager());
+        long sourceGeneration;
+        Optional<X509KeyManager> keyManager;
+        Optional<X509TrustManager> trustManager;
+        do {
+            sourceGeneration = tls.generation();
+            keyManager = tls.keyManager();
+            trustManager = tls.trustManager();
+        } while (sourceGeneration != tls.generation());
+        reload(keyManager, trustManager);
     }
 
     @Override // TlsManager

--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -50,6 +50,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
+import io.helidon.common.Api;
 import io.helidon.common.LazyValue;
 
 /**
@@ -65,6 +66,8 @@ public class ConfiguredTlsManager implements TlsManager {
     private final ReentrantLock stateLock = new ReentrantLock();
 
     private volatile TlsManagerState state = new TlsManagerState();
+    // Even values are stable. An odd value exists only while stateLock is held for material publication.
+    private volatile long generationState;
 
     ConfiguredTlsManager() {
         this("@default", "tls-manager");
@@ -99,7 +102,15 @@ public class ConfiguredTlsManager implements TlsManager {
 
     @Override // TlsManager
     public void init(TlsConfig tlsConfig) {
-        sslContext(tlsConfig);
+        Objects.requireNonNull(tlsConfig, "tlsConfig");
+        stateLock.lock();
+        try {
+            if (state.sslContext == null) {
+                sslContext(tlsConfig);
+            }
+        } finally {
+            stateLock.unlock();
+        }
     }
 
     @Override // TlsManager
@@ -122,17 +133,37 @@ public class ConfiguredTlsManager implements TlsManager {
     }
 
     @Override // TlsManager
+    @Api.Internal
+    public long generation() {
+        long current = generationState;
+        if ((current & 1L) == 0L) {
+            return current >>> 1;
+        }
+
+        stateLock.lock();
+        try {
+            return generationState >>> 1;
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    @Override // TlsManager
     public Optional<X509KeyManager> keyManager() {
-        return Optional.ofNullable(state.keyManager);
+        return Optional.ofNullable(state.reloadableKeyManager.current());
     }
 
     @Override // TlsManager
     public Optional<X509TrustManager> trustManager() {
-        return Optional.ofNullable(state.trustManager);
+        return Optional.ofNullable(state.reloadableTrustManager.current());
     }
 
     /**
      * Reload the current SSL context with the provided key manager and trust manager (if defined).
+     * <p>
+     * Subclasses must route every key and trust material publication through this method to retain the inherited
+     * {@link io.helidon.common.tls.TlsManager#generation()} tracking. A subclass that bypasses this method owns the
+     * generation contract.
      *
      * @param keyManager   key manager to use
      * @param trustManager trust manager to use
@@ -153,19 +184,19 @@ public class ConfiguredTlsManager implements TlsManager {
                 validateReload(current.reloadableTrustManager, trustManagerToReload);
             }
 
-            if (keyManagerToReload != null) {
-                current.reloadableKeyManager.reload(keyManagerToReload);
-            }
-            if (trustManagerToReload != null) {
-                current.reloadableTrustManager.reload(trustManagerToReload);
-            }
-
             if (keyManagerToReload != null || trustManagerToReload != null) {
-                state = new TlsManagerState(current.sslContext,
-                                            keyManagerToReload == null ? current.keyManager : keyManagerToReload,
-                                            current.reloadableKeyManager,
-                                            trustManagerToReload == null ? current.trustManager : trustManagerToReload,
-                                            current.reloadableTrustManager);
+                long publishingGeneration = generationState + 1;
+                generationState = publishingGeneration;
+                try {
+                    if (keyManagerToReload != null) {
+                        current.reloadableKeyManager.reload(keyManagerToReload);
+                    }
+                    if (trustManagerToReload != null) {
+                        current.reloadableTrustManager.reload(trustManagerToReload);
+                    }
+                } finally {
+                    generationState = publishingGeneration + 1;
+                }
             }
         } finally {
             stateLock.unlock();
@@ -174,6 +205,8 @@ public class ConfiguredTlsManager implements TlsManager {
 
     /**
      * Initialize and set the {@link javax.net.ssl.SSLContext} on this manager instance.
+     * The first successful initialization retains generation {@code 0}; later calls are ignored. Use
+     * {@link io.helidon.common.tls.TlsManager#reload(io.helidon.common.tls.TlsMaterial)} for later material changes.
      *
      * @param tlsConfig     the tls configuration
      * @param secureRandom  the secure random
@@ -184,9 +217,14 @@ public class ConfiguredTlsManager implements TlsManager {
                                   SecureRandom secureRandom,
                                   KeyManager[] keyManagers,
                                   TrustManager[] trustManagers) {
+        Objects.requireNonNull(tlsConfig, "tlsConfig");
+        Objects.requireNonNull(keyManagers, "keyManagers");
+        Objects.requireNonNull(trustManagers, "trustManagers");
         stateLock.lock();
         try {
-            initSslContextLocked(tlsConfig, secureRandom, keyManagers, trustManagers);
+            if (state.sslContext == null) {
+                initSslContextLocked(tlsConfig, secureRandom, keyManagers, trustManagers);
+            }
         } catch (GeneralSecurityException e) {
             throw new IllegalArgumentException("Failed to create SSLContext", e);
         } finally {
@@ -730,7 +768,7 @@ public class ConfiguredTlsManager implements TlsManager {
             if (keyManager instanceof X509KeyManager x509KeyManager) {
                 TlsReloadableX509KeyManager reloadableKeyManager = TlsReloadableX509KeyManager.create(x509KeyManager);
                 toReturn[i] = reloadableKeyManager;
-                return new KeyManagerState(toReturn, x509KeyManager, reloadableKeyManager);
+                return new KeyManagerState(toReturn, reloadableKeyManager);
             }
         }
         return noReloadableKeyManagerState(toReturn);
@@ -750,82 +788,66 @@ public class ConfiguredTlsManager implements TlsManager {
             if (trustManager instanceof X509TrustManager x509TrustManager) {
                 TlsReloadableX509TrustManager reloadableTrustManager = TlsReloadableX509TrustManager.create(x509TrustManager);
                 toReturn[i] = reloadableTrustManager;
-                return new TrustManagerState(toReturn, x509TrustManager, reloadableTrustManager);
+                return new TrustManagerState(toReturn, reloadableTrustManager);
             }
         }
         return noReloadableTrustManagerState(toReturn);
     }
 
     private KeyManagerState noReloadableKeyManagerState(KeyManager[] keyManagers) {
-        return new KeyManagerState(keyManagers, null, new TlsReloadableX509KeyManager.NotReloadableKeyManager());
+        return new KeyManagerState(keyManagers, new TlsReloadableX509KeyManager.NotReloadableKeyManager());
     }
 
     private TrustManagerState noReloadableTrustManagerState(TrustManager[] trustManagers) {
-        return new TrustManagerState(trustManagers, null, new TlsReloadableX509TrustManager.NotReloadableTrustManager());
+        return new TrustManagerState(trustManagers, new TlsReloadableX509TrustManager.NotReloadableTrustManager());
     }
 
     private void setSslContext(SSLContext sslContext,
                                KeyManagerState keyManagerState,
                                TrustManagerState trustManagerState) {
         this.state = new TlsManagerState(sslContext,
-                                         keyManagerState.keyManager,
                                          keyManagerState.reloadableKeyManager,
-                                         trustManagerState.trustManager,
                                          trustManagerState.reloadableTrustManager);
     }
 
     private static final class TlsManagerState {
         private final SSLContext sslContext;
-        private final X509KeyManager keyManager;
         private final TlsReloadableX509KeyManager reloadableKeyManager;
-        private final X509TrustManager trustManager;
         private final TlsReloadableX509TrustManager reloadableTrustManager;
 
         private TlsManagerState() {
             this(null,
-                 null,
                  new TlsReloadableX509KeyManager.NotReloadableKeyManager(),
-                 null,
                  new TlsReloadableX509TrustManager.NotReloadableTrustManager());
         }
 
         private TlsManagerState(SSLContext sslContext,
-                                X509KeyManager keyManager,
                                 TlsReloadableX509KeyManager reloadableKeyManager,
-                                X509TrustManager trustManager,
                                 TlsReloadableX509TrustManager reloadableTrustManager) {
             this.sslContext = sslContext;
-            this.keyManager = keyManager;
             this.reloadableKeyManager = reloadableKeyManager;
-            this.trustManager = trustManager;
             this.reloadableTrustManager = reloadableTrustManager;
         }
     }
 
     private static final class KeyManagerState {
         private final KeyManager[] keyManagers;
-        private final X509KeyManager keyManager;
         private final TlsReloadableX509KeyManager reloadableKeyManager;
 
         private KeyManagerState(KeyManager[] keyManagers,
-                                X509KeyManager keyManager,
                                 TlsReloadableX509KeyManager reloadableKeyManager) {
             this.keyManagers = keyManagers;
-            this.keyManager = keyManager;
             this.reloadableKeyManager = reloadableKeyManager;
         }
     }
 
     private static final class TrustManagerState {
         private final TrustManager[] trustManagers;
-        private final X509TrustManager trustManager;
         private final TlsReloadableX509TrustManager reloadableTrustManager;
 
         private TrustManagerState(TrustManager[] trustManagers,
-                                  X509TrustManager trustManager,
                                   TlsReloadableX509TrustManager reloadableTrustManager) {
             this.trustManagers = trustManagers;
-            this.trustManager = trustManager;
             this.reloadableTrustManager = reloadableTrustManager;
         }
     }

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -77,7 +77,14 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
 
         if (config.enabled()) {
             if (config.sslContext().isEmpty()) {
-                this.tlsManager = config.manager();
+                TlsManager configuredManager = config.manager();
+                if (configuredManager.getClass() == ConfiguredTlsManager.class) {
+                    configuredManager = new ConfiguredTlsManager();
+                    configuredTls = TlsConfig.builder(config)
+                            .manager(configuredManager)
+                            .buildPrototype();
+                }
+                this.tlsManager = configuredManager;
             } else {
                 this.tlsManager = new ExplicitContextTlsManager(config.sslContext().get());
                 configuredTls = TlsConfig.builder(config)
@@ -255,7 +262,7 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
     }
 
     /**
-     * Provides the SSL context.
+     * Provides the SSL context captured when this TLS instance was created.
      *
      * @return SSL context
      */
@@ -298,6 +305,22 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
         if (enabled) {
             tlsManager.reload(material);
         }
+    }
+
+    /**
+     * Generation of TLS material changes reported by the configured
+     * {@link io.helidon.common.tls.TlsManager#generation()}.
+     * <p>
+     * For enabled TLS, this method returns the configured manager's generation. The generation after the manager's
+     * first successful initialization is zero. A custom manager that inherits the compatibility default continues to
+     * report zero after material changes and may therefore lag behind its current material. When TLS is disabled, this
+     * method also returns zero.
+     *
+     * @return current TLS material generation
+     */
+    @Api.Internal
+    public long generation() {
+        return enabled ? tlsManager.generation() : 0L;
     }
 
     /**

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -80,9 +80,6 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
                 TlsManager configuredManager = config.manager();
                 if (configuredManager.getClass() == ConfiguredTlsManager.class) {
                     configuredManager = new ConfiguredTlsManager();
-                    configuredTls = TlsConfig.builder(config)
-                            .manager(configuredManager)
-                            .buildPrototype();
                 }
                 this.tlsManager = configuredManager;
             } else {

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
@@ -46,10 +46,13 @@ interface TlsConfigBlueprint extends TlsMaterialBlueprint, Prototype.Factory<Tls
     Optional<SSLContext> sslContext();
 
     /**
-     * The Tls manager. If one is not explicitly defined in the config then a default manager will be created.
+     * The configured TLS manager. If one is not explicitly defined in the config then a default manager will be created.
      * Default is either a configuration based TLS manager, or an explicit manager when {@link #sslContext()} is provided.
+     * A {@link Tls} instance backed by the default {@link ConfiguredTlsManager} uses an isolated runtime manager, so this
+     * method returns its configured prototype rather than its runtime manager. Use {@link Tls#generation()} to obtain the
+     * runtime manager's material generation.
      *
-     * @return the tls manager of the tls instance
+     * @return the configured TLS manager
      * @see ConfiguredTlsManager
      */
     @Option.Configured

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsManager.java
@@ -22,24 +22,28 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
+import io.helidon.common.Api;
 import io.helidon.common.DeprecationSupport;
 import io.helidon.config.NamedService;
 import io.helidon.service.registry.Service;
 
 /**
- * Implementors of this contract are responsible for managing the {@link javax.net.ssl.SSLContext} instance lifecycle, as well
- * as the {@link TlsReloadableComponent} instances. When the context changes, it then has the responsible to notify all
- * registered {@link TlsReloadableComponent}s to accept the new {@link Tls} having the reloaded context.
- * <p>
- * How context changes are observed is based upon the implementation of the manager.
+ * Implementors of this contract are responsible for initializing a single {@link javax.net.ssl.SSLContext} identity and
+ * managing the {@link io.helidon.common.tls.TlsReloadableComponent} instances that provide its key and trust material.
+ * Once the context is exposed through an {@link io.helidon.common.tls.Tls} instance, its identity must not change.
+ * Post-initialization material changes are published through the reload methods.
  */
 @Service.Contract
 public interface TlsManager extends NamedService {
 
     /**
-     * Always called before any other method on this type. This method is only called when TLS is enabled.
-     * In case the TLS is disabled, none of the methods on this type can be called.
-
+     * Initializes this manager before any other method is called. This method is only called when TLS is enabled.
+     * In case TLS is disabled, none of the methods on this type can be called.
+     * <p>
+     * A manager can be shared, so this method may be called more than once. Later calls must not replace state already
+     * exposed through an {@link io.helidon.common.tls.Tls} instance. Implementations may ignore later calls or reject
+     * incompatible configuration.
+     *
      * @param tls TLS configuration
      */
     void init(TlsConfig tls);
@@ -76,8 +80,34 @@ public interface TlsManager extends NamedService {
     }
 
     /**
+     * Generation of TLS material changes reported by this manager.
+     * <p>
+     * The generation after the manager's first successful initialization is {@code 0}. An implementation that overrides
+     * this method must advance the value whenever key or trust material changes, including when a reload fails after it may
+     * have published a change. A concurrent read must not return while a material change is being published, and every
+     * direct or provider-driven material publication path must participate. All post-initialization publication paths must
+     * be serialized with the mechanism used by this method.
+     * <p>
+     * A caller can obtain a coherent snapshot by reading the generation, obtaining the manager state, and then reading the
+     * generation again, accepting the snapshot only when both values are equal. An overriding implementation must ensure
+     * equal values mean no material publication crossed that interval.
+     * <p>
+     * The compatibility default always returns {@code 0}. A manager that supports reload but does not override this method
+     * does not report those reloads, so its generation may lag behind its current material.
+     *
+     * @return current TLS material generation
+     */
+    @Api.Internal
+    default long generation() {
+        return 0L;
+    }
+
+    /**
      * SSL context created by this manager.
-     * This method is called only after {@link #init(TlsConfig)} and only if {@link TlsConfig#enabled()} is {@code true}.
+     * This method is called only after
+     * {@link io.helidon.common.tls.TlsManager#init(io.helidon.common.tls.TlsConfig)} and only if
+     * {@link io.helidon.common.tls.TlsConfig#enabled()} is {@code true}.
+     * The returned context identity must remain stable after the first successful initialization.
      *
      * @return the SSL context to use
      */

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsReloadableX509KeyManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsReloadableX509KeyManager.java
@@ -101,6 +101,10 @@ class TlsReloadableX509KeyManager extends X509ExtendedKeyManager implements TlsR
         this.state = new KeyManagerState(keyManager);
     }
 
+    final X509KeyManager current() {
+        return state.keyManager;
+    }
+
     private static X509ExtendedKeyManager extended(X509KeyManager keyManager) {
         if (keyManager instanceof X509ExtendedKeyManager ekm) {
             return ekm;

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsReloadableX509TrustManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsReloadableX509TrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,10 @@ class TlsReloadableX509TrustManager implements X509TrustManager, TlsReloadableCo
         assertValid(trustManager);
         LOGGER.log(System.Logger.Level.DEBUG, "Reloading TLS X509TrustManager");
         this.trustManager = trustManager;
+    }
+
+    final X509TrustManager current() {
+        return trustManager;
     }
 
     static TlsReloadableX509TrustManager create(X509TrustManager trustManager) {

--- a/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
@@ -171,7 +171,7 @@ class ConfiguredTlsManagerTest {
     }
 
     @Test
-    void failedReinitializationDoesNotClearReloadableManagers() {
+    void failedInitialAttemptCanBeRetried() {
         ConfiguredTlsManager manager = new ConfiguredTlsManager();
         X509KeyManager keyManager = new TestKeyManager();
         X509TrustManager trustManager = new TestTrustManager();
@@ -179,6 +179,15 @@ class ConfiguredTlsManagerTest {
         TlsConfig failingConfig = Tls.builder()
                 .provider("missing-provider")
                 .buildPrototype();
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> manager.initSslContext(failingConfig,
+                                                  new SecureRandom(),
+                                                  new KeyManager[] {new TestKeyManager()},
+                                                  new TrustManager[] {new TestTrustManager()}));
+        assertThat(manager.generation(), is(0L));
+        assertThat(manager.keyManager().isEmpty(), is(true));
+        assertThat(manager.trustManager().isEmpty(), is(true));
 
         manager.initSslContext(initialConfig,
                                new SecureRandom(),
@@ -189,21 +198,75 @@ class ConfiguredTlsManagerTest {
         assertThat(manager.sslContext(), sameInstance(sslContext));
         assertThat(manager.keyManager().orElseThrow(), sameInstance(keyManager));
         assertThat(manager.trustManager().orElseThrow(), sameInstance(trustManager));
-
-        assertThrows(IllegalArgumentException.class,
-                     () -> manager.initSslContext(failingConfig,
-                                                  new SecureRandom(),
-                                                  new KeyManager[] {new TestKeyManager()},
-                                                  new TrustManager[] {new TestTrustManager()}));
-
-        assertThat(manager.sslContext(), sameInstance(sslContext));
-        assertThat(manager.keyManager().orElseThrow(), sameInstance(keyManager));
-        assertThat(manager.trustManager().orElseThrow(), sameInstance(trustManager));
+        assertThat(manager.generation(), is(0L));
 
         X509KeyManager reloadedKeyManager = new TestKeyManager();
         X509TrustManager reloadedTrustManager = new TestTrustManager();
         manager.reload(Optional.of(reloadedKeyManager), Optional.of(reloadedTrustManager));
 
+        assertThat(manager.keyManager().orElseThrow(), sameInstance(reloadedKeyManager));
+        assertThat(manager.trustManager().orElseThrow(), sameInstance(reloadedTrustManager));
+        assertThat(manager.generation(), is(1L));
+    }
+
+    @Test
+    void repeatedInitializationKeepsInitialState() {
+        ConfiguredTlsManager manager = new ConfiguredTlsManager();
+        X509KeyManager initialKeyManager = new TestKeyManager();
+        X509TrustManager initialTrustManager = new TestTrustManager();
+
+        manager.initSslContext(Tls.builder().buildPrototype(),
+                               new SecureRandom(),
+                               new KeyManager[] {initialKeyManager},
+                               new TrustManager[] {initialTrustManager});
+        SSLContext initialSslContext = manager.sslContext();
+
+        assertThat(manager.generation(), is(0L));
+        assertThat(manager.keyManager().orElseThrow(), sameInstance(initialKeyManager));
+        assertThat(manager.trustManager().orElseThrow(), sameInstance(initialTrustManager));
+
+        X509KeyManager replacementKeyManager = new TestKeyManager();
+        X509TrustManager replacementTrustManager = new TestTrustManager();
+        manager.initSslContext(Tls.builder().buildPrototype(),
+                               new SecureRandom(),
+                               new KeyManager[] {replacementKeyManager},
+                               new TrustManager[] {replacementTrustManager});
+        manager.initSslContext(Tls.builder().provider("missing-provider").buildPrototype(),
+                               new SecureRandom(),
+                               new KeyManager[] {replacementKeyManager},
+                               new TrustManager[] {replacementTrustManager});
+
+        assertThrows(NullPointerException.class, () -> manager.init(null));
+        assertThrows(NullPointerException.class,
+                     () -> manager.initSslContext(null,
+                                                  null,
+                                                  new KeyManager[] {replacementKeyManager},
+                                                  new TrustManager[] {replacementTrustManager}));
+        assertThrows(NullPointerException.class,
+                     () -> manager.initSslContext(Tls.builder().buildPrototype(),
+                                                  null,
+                                                  null,
+                                                  new TrustManager[] {replacementTrustManager}));
+        assertThrows(NullPointerException.class,
+                     () -> manager.initSslContext(Tls.builder().buildPrototype(),
+                                                  null,
+                                                  new KeyManager[] {replacementKeyManager},
+                                                  null));
+        manager.initSslContext(Tls.builder().buildPrototype(),
+                               null,
+                               new KeyManager[] {replacementKeyManager},
+                               new TrustManager[] {replacementTrustManager});
+
+        assertThat(manager.sslContext(), sameInstance(initialSslContext));
+        assertThat(manager.generation(), is(0L));
+        assertThat(manager.keyManager().orElseThrow(), sameInstance(initialKeyManager));
+        assertThat(manager.trustManager().orElseThrow(), sameInstance(initialTrustManager));
+
+        X509KeyManager reloadedKeyManager = new TestKeyManager();
+        X509TrustManager reloadedTrustManager = new TestTrustManager();
+        manager.reload(Optional.of(reloadedKeyManager), Optional.of(reloadedTrustManager));
+
+        assertThat(manager.generation(), is(1L));
         assertThat(manager.keyManager().orElseThrow(), sameInstance(reloadedKeyManager));
         assertThat(manager.trustManager().orElseThrow(), sameInstance(reloadedTrustManager));
     }
@@ -226,6 +289,7 @@ class ConfiguredTlsManagerTest {
 
         assertThat(exception.getMessage(), is("Cannot set trust manager if one was not set during server start"));
         assertThat(manager.reloadableKeyManager().getPrivateKey("test"), sameInstance(initialPrivateKey));
+        assertThat(manager.generation(), is(0L));
     }
 
     @Test
@@ -238,11 +302,47 @@ class ConfiguredTlsManagerTest {
                                new KeyManager[0],
                                new TrustManager[] {initialTrustManager});
 
+        assertThat(manager.generation(), is(0L));
         manager.reload(TlsMaterial.builder()
                                .trustAll(true)
                                .build());
 
         assertNotSame(initialTrustManager, manager.trustManager().orElseThrow());
+        assertThat(manager.generation(), is(1L));
+    }
+
+    @Test
+    void generationAdvancesWhenReloadFailsAfterPublishingMaterial() {
+        ConfiguredTlsManager manager = new FailingAfterReloadTlsManager();
+        manager.initSslContext(Tls.builder().buildPrototype(),
+                               new SecureRandom(),
+                               new KeyManager[0],
+                               new TrustManager[] {new TestTrustManager()});
+
+        assertThrows(IllegalStateException.class,
+                     () -> manager.reload(TlsMaterial.builder()
+                             .trustAll(true)
+                             .build()));
+
+        assertThat(manager.generation(), is(1L));
+    }
+
+    @Test
+    void keyManagerAccessorUsesReloadableState() {
+        ConfiguredTlsManager manager = new ConfiguredTlsManager();
+        X509KeyManager initialKeyManager = new TestKeyManager();
+        X509TrustManager initialTrustManager = new TestTrustManager();
+
+        manager.initSslContext(Tls.builder().buildPrototype(),
+                               new SecureRandom(),
+                               new KeyManager[] {initialKeyManager},
+                               new TrustManager[] {initialTrustManager});
+
+        X509KeyManager reloadedKeyManager = new TestKeyManager();
+        manager.reloadableKeyManager().reload(reloadedKeyManager);
+
+        assertThat(manager.keyManager().orElseThrow(), sameInstance(reloadedKeyManager));
+        assertThat(manager.trustManager().orElseThrow(), sameInstance(initialTrustManager));
     }
 
     private static SSLContext createSslContext() {
@@ -291,6 +391,14 @@ class ConfiguredTlsManagerTest {
         @Override
         public Optional<X509TrustManager> trustManager() {
             return Optional.empty();
+        }
+    }
+
+    private static final class FailingAfterReloadTlsManager extends ConfiguredTlsManager {
+        @Override
+        protected void reload(Optional<X509KeyManager> keyManager, Optional<X509TrustManager> trustManager) {
+            super.reload(keyManager, trustManager);
+            throw new IllegalStateException("reload failed after publication");
         }
     }
 

--- a/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
@@ -345,6 +345,32 @@ class ConfiguredTlsManagerTest {
         assertThat(manager.trustManager().orElseThrow(), sameInstance(initialTrustManager));
     }
 
+    @Test
+    @SuppressWarnings("removal")
+    void reloadTlsRetriesUntilSourceGenerationIsStable() {
+        X509KeyManager reloadedKeyManager = new TestKeyManager();
+        X509TrustManager initialTrustManager = new TestTrustManager();
+        X509TrustManager reloadedTrustManager = new TestTrustManager();
+        ChangingGenerationTlsManager sourceManager = new ChangingGenerationTlsManager(reloadedKeyManager,
+                                                                                       initialTrustManager,
+                                                                                       reloadedTrustManager);
+        Tls source = Tls.create(it -> it.manager(sourceManager));
+
+        ConfiguredTlsManager targetManager = new ConfiguredTlsManager();
+        targetManager.initSslContext(Tls.builder().buildPrototype(),
+                                     new SecureRandom(),
+                                     new KeyManager[] {new TestKeyManager()},
+                                     new TrustManager[] {new TestTrustManager()});
+
+        targetManager.reload(source);
+
+        assertThat(targetManager.keyManager().orElseThrow(), sameInstance(reloadedKeyManager));
+        assertThat(targetManager.trustManager().orElseThrow(), sameInstance(reloadedTrustManager));
+        assertThat(sourceManager.keyManagerReads, is(2));
+        assertThat(sourceManager.trustManagerReads, is(2));
+        assertThat(sourceManager.generationReads, is(4));
+    }
+
     private static SSLContext createSslContext() {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -399,6 +425,59 @@ class ConfiguredTlsManagerTest {
         protected void reload(Optional<X509KeyManager> keyManager, Optional<X509TrustManager> trustManager) {
             super.reload(keyManager, trustManager);
             throw new IllegalStateException("reload failed after publication");
+        }
+    }
+
+    private static final class ChangingGenerationTlsManager implements TlsManager {
+        private final SSLContext sslContext = createSslContext();
+        private final X509KeyManager keyManager;
+        private final X509TrustManager initialTrustManager;
+        private final X509TrustManager reloadedTrustManager;
+        private int generationReads;
+        private int keyManagerReads;
+        private int trustManagerReads;
+
+        private ChangingGenerationTlsManager(X509KeyManager keyManager,
+                                             X509TrustManager initialTrustManager,
+                                             X509TrustManager reloadedTrustManager) {
+            this.keyManager = keyManager;
+            this.initialTrustManager = initialTrustManager;
+            this.reloadedTrustManager = reloadedTrustManager;
+        }
+
+        @Override
+        public void init(TlsConfig tls) {
+        }
+
+        @Override
+        public long generation() {
+            return generationReads++ == 0 ? 0L : 1L;
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            return sslContext;
+        }
+
+        @Override
+        public Optional<X509KeyManager> keyManager() {
+            keyManagerReads++;
+            return Optional.of(keyManager);
+        }
+
+        @Override
+        public Optional<X509TrustManager> trustManager() {
+            return Optional.of(trustManagerReads++ == 0 ? initialTrustManager : reloadedTrustManager);
+        }
+
+        @Override
+        public String name() {
+            return "changing-generation";
+        }
+
+        @Override
+        public String type() {
+            return "changing-generation";
         }
     }
 

--- a/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/ConfiguredTlsManagerTest.java
@@ -328,24 +328,6 @@ class ConfiguredTlsManagerTest {
     }
 
     @Test
-    void keyManagerAccessorUsesReloadableState() {
-        ConfiguredTlsManager manager = new ConfiguredTlsManager();
-        X509KeyManager initialKeyManager = new TestKeyManager();
-        X509TrustManager initialTrustManager = new TestTrustManager();
-
-        manager.initSslContext(Tls.builder().buildPrototype(),
-                               new SecureRandom(),
-                               new KeyManager[] {initialKeyManager},
-                               new TrustManager[] {initialTrustManager});
-
-        X509KeyManager reloadedKeyManager = new TestKeyManager();
-        manager.reloadableKeyManager().reload(reloadedKeyManager);
-
-        assertThat(manager.keyManager().orElseThrow(), sameInstance(reloadedKeyManager));
-        assertThat(manager.trustManager().orElseThrow(), sameInstance(initialTrustManager));
-    }
-
-    @Test
     @SuppressWarnings("removal")
     void reloadTlsRetriesUntilSourceGenerationIsStable() {
         X509KeyManager reloadedKeyManager = new TestKeyManager();

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsConfiguredProviderReloadTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsConfiguredProviderReloadTest.java
@@ -54,11 +54,36 @@ class TlsConfiguredProviderReloadTest {
         Tls tls = Tls.create(config("configured"));
         SSLContext sslContext = tls.sslContext();
 
+        assertThat(tls.generation(), is(0L));
         StaticReloadTlsManagerProvider.reload(MANAGER_NAME, "reloaded");
 
         assertThat(tls.sslContext(), sameInstance(sslContext));
         assertThat(issuer(tls), is("reloaded"));
         assertThat(tls.newEngine(), notNullValue());
+        assertThat(tls.generation(), is(1L));
+    }
+
+    @Test
+    void repeatedInitializationKeepsReloadedState() {
+        Tls first = Tls.create(config("configured"));
+        SSLContext sslContext = first.sslContext();
+
+        StaticReloadTlsManagerProvider.reload(MANAGER_NAME, "reloaded");
+        Tls second = Tls.create(config("configured"));
+
+        assertThat(first.sslContext(), sameInstance(sslContext));
+        assertThat(second.sslContext(), sameInstance(sslContext));
+        assertThat(issuer(first), is("reloaded"));
+        assertThat(issuer(second), is("reloaded"));
+        assertThat(first.generation(), is(1L));
+        assertThat(second.generation(), is(1L));
+
+        StaticReloadTlsManagerProvider.reload(MANAGER_NAME, "again");
+
+        assertThat(issuer(first), is("again"));
+        assertThat(issuer(second), is("again"));
+        assertThat(first.generation(), is(2L));
+        assertThat(second.generation(), is(2L));
     }
 
     private static Config config(String initialIssuer) {

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsManagerCompatibilityTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsManagerCompatibilityTest.java
@@ -53,20 +53,37 @@ class TlsManagerCompatibilityTest {
         assertThat(manager.reloadedTls.prototype().trustAll(), is(true));
     }
 
+    @Test
+    void defaultGenerationDoesNotReportReloads() {
+        MaterialReloadManager manager = new MaterialReloadManager();
+        TlsMaterial material = TlsMaterial.builder()
+                .trustAll(true)
+                .build();
+
+        assertThat(manager.generation(), is(0L));
+        manager.reload(material);
+        assertThat(manager.generation(), is(0L));
+    }
+
     private abstract static class TestTlsManager implements TlsManager {
+        private final SSLContext sslContext;
+
+        private TestTlsManager() {
+            try {
+                sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(null, null, null);
+            } catch (GeneralSecurityException e) {
+                throw new AssertionError(e);
+            }
+        }
+
         @Override
         public void init(TlsConfig tls) {
         }
 
         @Override
         public SSLContext sslContext() {
-            try {
-                SSLContext sslContext = SSLContext.getInstance("TLS");
-                sslContext.init(null, null, null);
-                return sslContext;
-            } catch (GeneralSecurityException e) {
-                throw new AssertionError(e);
-            }
+            return sslContext;
         }
 
         @Override

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
@@ -192,14 +192,15 @@ public class TlsTest {
         Tls first = builder.build();
         Tls second = builder.trustAll(false).build();
 
-        assertThat(second.prototype().manager(), not(sameInstance(first.prototype().manager())));
+        assertThat(second.prototype().manager(), sameInstance(first.prototype().manager()));
         assertThat(second.sslContext(), not(sameInstance(first.sslContext())));
 
         TlsConfig prototype = Tls.builder().buildPrototype();
         Tls fromPrototype = prototype.build();
         Tls repeatedFromPrototype = prototype.build();
 
-        assertThat(repeatedFromPrototype.prototype().manager(), not(sameInstance(fromPrototype.prototype().manager())));
+        assertThat(fromPrototype.prototype(), sameInstance(prototype));
+        assertThat(repeatedFromPrototype.prototype(), sameInstance(prototype));
         assertThat(repeatedFromPrototype.sslContext(), not(sameInstance(fromPrototype.sslContext())));
     }
 

--- a/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/TlsTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -185,6 +186,24 @@ public class TlsTest {
     }
 
     @Test
+    public void defaultManagerIsOwnedByTlsInstance() {
+        TlsConfig.Builder builder = Tls.builder().trustAll(true);
+
+        Tls first = builder.build();
+        Tls second = builder.trustAll(false).build();
+
+        assertThat(second.prototype().manager(), not(sameInstance(first.prototype().manager())));
+        assertThat(second.sslContext(), not(sameInstance(first.sslContext())));
+
+        TlsConfig prototype = Tls.builder().buildPrototype();
+        Tls fromPrototype = prototype.build();
+        Tls repeatedFromPrototype = prototype.build();
+
+        assertThat(repeatedFromPrototype.prototype().manager(), not(sameInstance(fromPrototype.prototype().manager())));
+        assertThat(repeatedFromPrototype.sslContext(), not(sameInstance(fromPrototype.sslContext())));
+    }
+
+    @Test
     public void explicitSslContextRejectsMaterialReload() {
         SSLContext sslContext = createSslContext();
         Tls tls = Tls.create(it -> it.sslContext(sslContext));
@@ -197,6 +216,39 @@ public class TlsTest {
 
         assertThat(exception.getMessage(),
                    is("TLS cannot be reloaded when an explicit instance of SSL context was used to create it"));
+    }
+
+    @Test
+    public void successfulEnabledReloadsAdvanceGeneration() {
+        Tls tls = Tls.create(it -> it.trustAll(true));
+
+        assertThat(tls.generation(), is(0L));
+        tls.reload(TlsMaterial.builder().trustAll(true).build());
+        assertThat(tls.generation(), is(1L));
+
+        tls.reload(Tls.create(it -> it.trustAll(true)));
+        assertThat(tls.generation(), is(2L));
+    }
+
+    @Test
+    public void failedReloadDoesNotAdvanceGeneration() {
+        Tls tls = Tls.create(it -> it.sslContext(createSslContext()));
+
+        assertThrows(UnsupportedOperationException.class,
+                     () -> tls.reload(TlsMaterial.builder().trustAll(true).build()));
+        assertThat(tls.generation(), is(0L));
+    }
+
+    @Test
+    public void disabledTlsReloadDoesNotAdvanceGeneration() {
+        Tls tls = Tls.builder()
+                .enabled(false)
+                .build();
+
+        tls.reload(TlsMaterial.builder().trustAll(true).build());
+        tls.reload(Tls.create(it -> it.trustAll(true)));
+
+        assertThat(tls.generation(), is(0L));
     }
 
     private static SSLContext createSslContext() {
@@ -240,4 +292,5 @@ public class TlsTest {
             return "failing";
         }
     }
+
 }


### PR DESCRIPTION
Pre-requisite for #3686

Adds a TLS manager generation contract so protocol runtimes can detect changes to key and trust material while retaining a stable `SSLContext`. Existing `TlsManager` implementations remain compatible through a default generation of zero; generation-aware managers can override it.

`ConfiguredTlsManager` serializes reload publication, provides stable generation reads, and derives exposed key and trust managers from the same reloadable delegates used by the `SSLContext`. Automatically configured managers remain owned by each `Tls` instance, while explicitly supplied managers can be shared.
