### PR TITLE
Revalidate cached WebClient protocols

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
@@ -106,11 +106,7 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
     private ClientRequest<?> discoverHttpImplementation() {
         ClientUri resolvedUri = resolvedUri();
         ClientRequestHeaderSupport.validate(headers());
-
         if (preferredProtocolId != null) {
-            /*
-            Explicit protocol id specified for this very request - we must honor it
-             */
             LoomClient.ProtocolSpi httpClientSpi = clients.get(preferredProtocolId);
             if (httpClientSpi == null) {
                 throw new IllegalArgumentException("Requested protocol with id \"" + preferredProtocolId + "\", which is not "
@@ -118,7 +114,6 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
             }
             return httpClientSpi.spi().clientRequest(this, resolvedUri);
         }
-
         String transportKey = transportKey();
         HttpClientConfig clientConfig = clientConfig();
         Tls effectiveTls = effectiveTls(resolvedUri, tls());
@@ -126,7 +121,6 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
         if (requiresFinalHeaders(resolvedUri, effectiveSni, effectiveTls)) {
             return firstTcpProtocol(resolvedUri);
         }
-
         SniSupport.Selection sni = sniSelection(resolvedUri, effectiveSni, effectiveTls, headers());
         LoomClient.EndpointKey endpointKey = new LoomClient.EndpointKey(resolvedUri.scheme(),
                                                                         resolvedUri.authority(),
@@ -136,18 +130,30 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
                                                                         transportKey == null ? proxy() : Proxy.noProxy());
         Optional<HttpClientSpi> spi = clientSpiCache.get(endpointKey);
         if (spi.isPresent()) {
-            /*
-            We already know this is handled by a specific protocol version, handle it again
-             */
-            return spi.get().clientRequest(this, resolvedUri);
+            HttpClientSpi cached = spi.get();
+            if (cached.isTcp()) {
+                for (LoomClient.ProtocolSpi protocol : protocols) {
+                    HttpClientSpi candidate = protocol.spi();
+                    if (candidate == cached) {
+                        break;
+                    }
+                    if (candidate.supports(this, resolvedUri) == HttpClientSpi.SupportLevel.SUPPORTED) {
+                        clientSpiCache.put(endpointKey, candidate);
+                        return candidate.clientRequest(this, resolvedUri);
+                    }
+                }
+            }
+            HttpClientSpi.SupportLevel support = cached.supports(this, resolvedUri);
+            if (support == HttpClientSpi.SupportLevel.SUPPORTED
+                    || support == HttpClientSpi.SupportLevel.COMPATIBLE) {
+                return cached.clientRequest(this, resolvedUri);
+            }
+            clientSpiCache.remove(endpointKey);
         }
-
         // now use the first protocol that supports the request without condition, store first compatible
         HttpClientSpi compatible = null;
         HttpClientSpi unknown = null;
         for (LoomClient.ProtocolSpi protocol : protocols) {
-            // must iterate through list, to maintain weighted ordering
-
             HttpClientSpi client = protocol.spi();
             HttpClientSpi.SupportLevel supports = client.supports(this, resolvedUri);
             if (supports == HttpClientSpi.SupportLevel.SUPPORTED) {
@@ -163,9 +169,7 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
                 unknown = client;
             }
         }
-
         if ("https".equals(resolvedUri.scheme()) && effectiveTls.enabled() && !tcpProtocols.isEmpty()) {
-            // we may use UNIX domain socket here
             UnixDomainSocketAddress unixSocketAddress = null;
             if (address().isPresent()) {
                 var address = address().get();
@@ -174,16 +178,13 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
                 }
             }
             ClientConnection connection;
-
             if (unixSocketAddress == null) {
-                // use ALPN
                 ConnectionKey connectionKey = connectionKey(resolvedUri,
                                                             effectiveSni,
                                                             effectiveTls,
                                                             clientConfig,
                                                             proxy(),
                                                             headers());
-
                 // this is a temporary connection, used to determine which protocol is supported, next
                 // call to the same remote location will be obtained from cache
                 connection = TcpClientConnection.create(webClient,

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/HttpClientSpi.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/HttpClientSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,15 @@ public interface HttpClientSpi extends ReleasableResource {
      * <p>
      * Examples:
      * <ul>
-     *     <li>HTTP/1.1 always returns true, as it is the fallback protocol of all other protocols</li>
-     *     <li>HTTP/2 returns true when upgrade is enabled, false when prior-knowledge is specified (as we can always
-     *     attempt to upgrade and fallback to 1.1 in the first case, but we would fail with prior-knowledge, unless the endpoint
-     *     is known to be HTTP/2</li>
-     *     <li>HTTP/3 would always return true, as it cannot fallback once a connection is attempted</li>
+     *     <li>HTTP/1.1 always returns
+     *     {@link io.helidon.webclient.spi.HttpClientSpi.SupportLevel#COMPATIBLE}, as it is the fallback protocol of all
+     *     other protocols</li>
+     *     <li>A protocol with a reusable connection returns
+     *     {@link io.helidon.webclient.spi.HttpClientSpi.SupportLevel#SUPPORTED}</li>
+     *     <li>A dynamically discovered protocol can move between
+     *     {@link io.helidon.webclient.spi.HttpClientSpi.SupportLevel#NOT_SUPPORTED} and
+     *     {@link io.helidon.webclient.spi.HttpClientSpi.SupportLevel#SUPPORTED} as endpoint information becomes
+     *     available or expires</li>
      * </ul>
      *
      * So how can we get to HTTP/2 with prior knowledge, or HTTP/3? There are the following options:
@@ -43,16 +47,16 @@ public interface HttpClientSpi extends ReleasableResource {
      *     {@link io.helidon.webclient.api.HttpClientRequest#protocolId(String)}</li>
      *     <li>There is no fallback protocol enabled, in such a case, we use the one with highest priority - see
      *     {@link io.helidon.webclient.api.WebClientConfig.Builder#addProtocolPreference(String)}</li>
-     *     <li>We get an {@code Alt-Svc} header from a response that points us to a protocol version (we only support permanent
-     *     protocol changes, {@code Alt-Svc} with timeout will be ignored</li>
+     *     <li>The client dynamically learns that another protocol is viable for the endpoint</li>
      *     <li>This protocol version already handled a request to such an endpoint and has the connection available</li>
      * </ul>
      *
-     * Note that this response is cached.
+     * Note that this result is cached and revalidated for later requests. Implementations must make this method cheap
+     * and safe to invoke repeatedly, including for concurrent requests.
      *
      * @param clientRequest HTTP request
      * @param clientUri     URI to invoke
-     * @return {@code true} if we are sure we can handle this request with this protocol version
+     * @return support level for this protocol and request
      */
     SupportLevel supports(FullClientRequest<?> clientRequest, ClientUri clientUri);
 
@@ -83,7 +87,7 @@ public interface HttpClientSpi extends ReleasableResource {
      */
     enum SupportLevel {
         /**
-         * This request can never be supported by this client.
+         * This request is not currently supported by this client.
          */
         NOT_SUPPORTED,
         /**

--- a/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientRequestProtocolCacheTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientRequestProtocolCacheTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.LruCache;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.ClientResponseTrailers;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ReadableEntity;
+import io.helidon.http.media.ReadableEntityBase;
+import io.helidon.webclient.spi.HttpClientSpi;
+import io.helidon.webclient.spi.Protocol;
+import io.helidon.webclient.spi.ProtocolConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class HttpClientRequestProtocolCacheTest {
+    @Test
+    void invalidatesCachedProtocolWhenSupportIsLost() {
+        TestContext context = TestContext.create();
+        context.dynamic().support(HttpClientSpi.SupportLevel.SUPPORTED);
+
+        context.request().request();
+        assertThat("initial protocol", context.selected().get(), is("dynamic"));
+
+        context.dynamic().support(HttpClientSpi.SupportLevel.NOT_SUPPORTED);
+        context.request().request();
+
+        assertThat("protocol after cached support was lost", context.selected().get(), is("fallback"));
+        assertThat("dynamic protocol support checks", context.dynamic().supportsInvocations(), is(3));
+        assertThat("fallback protocol support checks", context.fallback().supportsInvocations(), is(1));
+    }
+
+    @Test
+    void promotesHigherPriorityProtocolFromCachedTcpFallback() {
+        TestContext context = TestContext.create();
+        context.dynamic().support(HttpClientSpi.SupportLevel.NOT_SUPPORTED);
+
+        context.request().request();
+        assertThat("initial protocol", context.selected().get(), is("fallback"));
+
+        context.dynamic().support(HttpClientSpi.SupportLevel.SUPPORTED);
+        context.request().request();
+
+        assertThat("protocol after higher-priority support appeared", context.selected().get(), is("dynamic"));
+        assertThat("higher-priority protocol support checks", context.dynamic().supportsInvocations(), is(2));
+        assertThat("fallback protocol support checks", context.fallback().supportsInvocations(), is(1));
+    }
+
+    @Test
+    void reusesRevalidatedCompatibleProtocol() {
+        TestContext context = TestContext.create();
+        context.dynamic().support(HttpClientSpi.SupportLevel.NOT_SUPPORTED);
+
+        context.request().request();
+        context.selected().set(null);
+        context.dynamic().support(HttpClientSpi.SupportLevel.COMPATIBLE);
+        context.request().request();
+
+        assertThat("revalidated cached protocol", context.selected().get(), is("fallback"));
+        assertThat("higher-priority compatible protocol support checks",
+                   context.dynamic().supportsInvocations(),
+                   is(2));
+        assertThat("cached compatible protocol support checks", context.fallback().supportsInvocations(), is(2));
+    }
+
+    @Test
+    void explicitProtocolSelectionBypassesAutomaticRevalidation() {
+        TestContext context = TestContext.create();
+
+        context.request().protocolId("dynamic").request();
+
+        assertThat("explicitly selected protocol", context.selected().get(), is("dynamic"));
+        assertThat("explicit protocol support checks", context.dynamic().supportsInvocations(), is(0));
+        assertThat("fallback protocol support checks", context.fallback().supportsInvocations(), is(0));
+    }
+
+    private record TestContext(WebClient webClient,
+                               WebClientConfig config,
+                               List<LoomClient.ProtocolSpi> protocols,
+                               Map<String, LoomClient.ProtocolSpi> clients,
+                               LruCache<LoomClient.EndpointKey, HttpClientSpi> cache,
+                               TestClientSpi dynamic,
+                               TestClientSpi fallback,
+                               AtomicReference<String> selected) {
+        private static TestContext create() {
+            WebClientConfig config = WebClientConfig.builder()
+                    .baseUri("http://example.test")
+                    .buildPrototype();
+            TestWebClient webClient = new TestWebClient(config);
+            AtomicReference<String> selected = new AtomicReference<>();
+            TestClientSpi dynamic = new TestClientSpi("dynamic", false, selected, config);
+            TestClientSpi fallback = new TestClientSpi("fallback", true, selected, config);
+            fallback.support(HttpClientSpi.SupportLevel.COMPATIBLE);
+            LoomClient.ProtocolSpi dynamicProtocol = new LoomClient.ProtocolSpi("dynamic", dynamic);
+            LoomClient.ProtocolSpi fallbackProtocol = new LoomClient.ProtocolSpi("fallback", fallback);
+            return new TestContext(webClient,
+                                   config,
+                                   List.of(dynamicProtocol, fallbackProtocol),
+                                   Map.of("dynamic", dynamicProtocol, "fallback", fallbackProtocol),
+                                   LruCache.create(),
+                                   dynamic,
+                                   fallback,
+                                   selected);
+        }
+
+        private HttpClientRequest request() {
+            return new HttpClientRequest(webClient,
+                                         config,
+                                         Method.GET,
+                                         ClientUri.create(),
+                                         clients,
+                                         protocols,
+                                         List.of(protocols.get(1)),
+                                         List.of("fallback"),
+                                         cache);
+        }
+    }
+
+    private static final class TestClientSpi implements HttpClientSpi {
+        private final String id;
+        private final boolean tcp;
+        private final AtomicReference<String> selected;
+        private final HttpClientConfig clientConfig;
+        private final AtomicReference<SupportLevel> support = new AtomicReference<>(SupportLevel.NOT_SUPPORTED);
+        private final AtomicInteger supportsInvocations = new AtomicInteger();
+
+        private TestClientSpi(String id,
+                              boolean tcp,
+                              AtomicReference<String> selected,
+                              HttpClientConfig clientConfig) {
+            this.id = id;
+            this.tcp = tcp;
+            this.selected = selected;
+            this.clientConfig = clientConfig;
+        }
+
+        @Override
+        public SupportLevel supports(FullClientRequest<?> clientRequest, ClientUri clientUri) {
+            supportsInvocations.incrementAndGet();
+            return support.get();
+        }
+
+        @Override
+        public ClientRequest<?> clientRequest(FullClientRequest<?> clientRequest, ClientUri clientUri) {
+            selected.set(id);
+            return new TestClientRequest(clientConfig, clientRequest, clientUri);
+        }
+
+        @Override
+        public boolean isTcp() {
+            return tcp;
+        }
+
+        @Override
+        public void closeResource() {
+        }
+
+        private void support(SupportLevel support) {
+            this.support.set(support);
+        }
+
+        private int supportsInvocations() {
+            return supportsInvocations.get();
+        }
+    }
+
+    private static final class TestClientRequest extends ClientRequestBase<TestClientRequest, HttpClientResponse> {
+        private TestClientRequest(HttpClientConfig clientConfig,
+                                  FullClientRequest<?> clientRequest,
+                                  ClientUri clientUri) {
+            super(clientConfig,
+                  WebClientCookieManager.builder().build(),
+                  "test",
+                  clientRequest.method(),
+                  clientUri,
+                  clientRequest.properties());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            return new TestClientResponse(resolvedUri());
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            return new TestClientResponse(resolvedUri());
+        }
+    }
+
+    private static final class TestClientResponse implements HttpClientResponse {
+        private final ClientUri endpointUri;
+
+        private TestClientResponse(ClientUri endpointUri) {
+            this.endpointUri = endpointUri;
+        }
+
+        @Override
+        public Status status() {
+            return Status.OK_200;
+        }
+
+        @Override
+        public ClientResponseHeaders headers() {
+            return ClientResponseHeaders.create(WritableHeaders.create());
+        }
+
+        @Override
+        public ClientResponseTrailers trailers() {
+            return ClientResponseTrailers.create();
+        }
+
+        @Override
+        public ClientUri lastEndpointUri() {
+            return endpointUri;
+        }
+
+        @Override
+        public ReadableEntity entity() {
+            return ReadableEntityBase.empty();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class TestWebClient implements WebClient {
+        private final WebClientConfig config;
+        private final WebClientCookieManager cookieManager = WebClientCookieManager.builder().build();
+
+        private TestWebClient(WebClientConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public HttpClientRequest method(Method method) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T, C extends ProtocolConfig> T client(Protocol<T, C> protocol, C protocolConfig) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T, C extends ProtocolConfig> T client(Protocol<T, C> protocol) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ExecutorService executor() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public WebClientCookieManager cookieManager() {
+            return cookieManager;
+        }
+
+        @Override
+        public WebClientConfig prototype() {
+            return config;
+        }
+
+        @Override
+        public void closeResource() {
+        }
+    }
+}


### PR DESCRIPTION
Pre-requisite for #3686

Revalidates cached WebClient protocol selections so dynamically supported higher-priority protocols can replace a cached TCP fallback, while stale cached selections fall back safely.