### PR TITLE
Reset response entity before error handling

### DIFF
--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -542,8 +542,9 @@ metadata before sending the response.
 
 If a handler throws an exception while its response can still be reset, WebServer discards the unsent entity before
 invoking error handling. It also removes entity-related framing, representation, validator, range, digest, and trailer
-metadata. Status and unrelated metadata, such as CORS, cookies, cache controls, `Vary`, and custom headers, remain
-available to the error handler. Once response metadata or entity bytes have been sent, the response cannot be replaced.
+metadata, together with entity-scoped response preparation callbacks and output stream filters. Status and unrelated
+metadata, such as CORS, cookies, cache controls, `Vary`, and custom headers, remain available to the error handler. Once
+response metadata or entity bytes have been sent, the response cannot be replaced.
 
 [[anchor-filtering]]
 === Filtering

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -544,9 +544,11 @@ If a handler throws an exception while its response can still be reset, WebServe
 invoking error handling. It also removes entity-related framing, representation, validator, range, digest, and trailer
 metadata, together with response preparation callbacks and output stream filters explicitly registered by Helidon
 infrastructure for that entity. Public `beforeSend(...)` listeners and `streamFilter(...)` filters remain registered so
-cross-cutting application policies also apply to a replacement error response. Status and unrelated metadata, such as
-CORS, cookies, cache controls, `Vary`, and custom headers, remain available to the error handler. Once response metadata
-or entity bytes have been sent, the response cannot be replaced.
+cross-cutting application policies also apply to a replacement error response. A response-scoped stream filter that
+changes representation metadata must use a response-scoped `beforeSend(...)` listener to configure the matching headers
+for whichever entity is sent. An inherited `206` status is reset when its `Content-Range` is removed. Other status and
+unrelated metadata, such as CORS, cookies, cache controls, `Vary`, and custom headers, remain available to the error
+handler. Once response metadata or entity bytes have been sent, the response cannot be replaced.
 
 [[anchor-filtering]]
 === Filtering

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -537,8 +537,13 @@ headers and entity.
 Status and headers configured on `ServerResponse` are mutable response metadata.
 Configure them before calling `send()` or `outputStream()` when they should apply to the response emitted by the route.
 Once configured, this metadata remains on the current response until later handling changes it.
-Calling `next()`, calling `reroute(...)`, or throwing an exception does not clear it automatically; downstream routes and
-error handlers can replace or remove response metadata before sending the response.
+Calling `next()` or `reroute(...)` does not clear it automatically; downstream routes can replace or remove response
+metadata before sending the response.
+
+If a handler throws an exception while its response can still be reset, WebServer discards the unsent entity before
+invoking error handling. It also removes entity-related framing, representation, validator, range, digest, and trailer
+metadata. Status and unrelated metadata, such as CORS, cookies, cache controls, `Vary`, and custom headers, remain
+available to the error handler. Once response metadata or entity bytes have been sent, the response cannot be replaced.
 
 [[anchor-filtering]]
 === Filtering

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -542,9 +542,11 @@ metadata before sending the response.
 
 If a handler throws an exception while its response can still be reset, WebServer discards the unsent entity before
 invoking error handling. It also removes entity-related framing, representation, validator, range, digest, and trailer
-metadata, together with entity-scoped response preparation callbacks and output stream filters. Status and unrelated
-metadata, such as CORS, cookies, cache controls, `Vary`, and custom headers, remain available to the error handler. Once
-response metadata or entity bytes have been sent, the response cannot be replaced.
+metadata, together with response preparation callbacks and output stream filters explicitly registered by Helidon
+infrastructure for that entity. Public `beforeSend(...)` listeners and `streamFilter(...)` filters remain registered so
+cross-cutting application policies also apply to a replacement error response. Status and unrelated metadata, such as
+CORS, cookies, cache controls, `Vary`, and custom headers, remain available to the error handler. Once response metadata
+or entity bytes have been sent, the response cannot be replaced.
 
 [[anchor-filtering]]
 === Filtering

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -546,9 +546,10 @@ metadata, together with response preparation callbacks and output stream filters
 infrastructure for that entity. Public `beforeSend(...)` listeners and `streamFilter(...)` filters remain registered so
 cross-cutting application policies also apply to a replacement error response. A response-scoped stream filter that
 changes representation metadata must use a response-scoped `beforeSend(...)` listener to configure the matching headers
-for whichever entity is sent. An inherited `206` status is reset when its `Content-Range` is removed. Other status and
-unrelated metadata, such as CORS, cookies, cache controls, `Vary`, and custom headers, remain available to the error
-handler. Once response metadata or entity bytes have been sent, the response cannot be replaced.
+and register any trailer callback for whichever entity is sent. An inherited `206` status is reset when its
+`Content-Range` is removed. Other status and unrelated metadata, such as CORS, cookies, cache controls, `Vary`, and custom
+headers, remain available to the error handler. Once response metadata or entity bytes have been sent, the response
+cannot be replaced.
 
 [[anchor-filtering]]
 === Filtering

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -546,10 +546,10 @@ metadata, together with response preparation callbacks and output stream filters
 infrastructure for that entity. Public `beforeSend(...)` listeners and `streamFilter(...)` filters remain registered so
 cross-cutting application policies also apply to a replacement error response. A response-scoped stream filter that
 changes representation metadata must use a response-scoped `beforeSend(...)` listener to configure the matching headers
-and register any trailer callback for whichever entity is sent. An inherited `206` status is reset when its
-`Content-Range` is removed. Other status and unrelated metadata, such as CORS, cookies, cache controls, `Vary`, and custom
-headers, remain available to the error handler. Once response metadata or entity bytes have been sent, the response
-cannot be replaced.
+and register any trailer callback for whichever entity is sent. The configured status and unrelated metadata, such as
+CORS, cookies, cache controls, `Vary`, and custom headers, remain available to the error handler. The error handler is
+responsible for configuring or deliberately retaining an appropriate status before sending the replacement response.
+Once response metadata or entity bytes have been sent, the response cannot be replaced.
 
 [[anchor-filtering]]
 === Filtering

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
@@ -60,11 +60,11 @@ public class ResponseFilterJmhBenchmark {
     private static final String DIRECT_BEFORE_SEND = "/direct-before-send";
     private static final String DIRECT_ENTITY = "/direct-entity";
     private static final String DIRECT_NONE = "/direct-none";
-    private static final String DIRECT_PERSISTENT_BEFORE_SEND = "/direct-persistent-before-send";
-    private static final String DIRECT_PERSISTENT = "/direct-persistent";
+    private static final String DIRECT_ENTITY_BEFORE_SEND = "/direct-entity-before-send";
+    private static final String DIRECT_PUBLIC = "/direct-public";
     private static final String STREAM_ENTITY = "/stream-entity";
     private static final String STREAM_NONE = "/stream-none";
-    private static final String STREAM_PERSISTENT = "/stream-persistent";
+    private static final String STREAM_PUBLIC = "/stream-public";
     private static final int REQUESTS_PER_INVOCATION = 16;
     private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
     private static final Runnable BEFORE_SEND = () -> { };
@@ -75,12 +75,12 @@ public class ResponseFilterJmhBenchmark {
     private Http2Client http2Client;
     private HttpRequest http1DirectNone;
     private HttpRequest http1DirectEntity;
-    private HttpRequest http1DirectPersistent;
+    private HttpRequest http1DirectPublic;
     private HttpRequest http1DirectBeforeSend;
-    private HttpRequest http1DirectPersistentBeforeSend;
+    private HttpRequest http1DirectEntityBeforeSend;
     private HttpRequest http1StreamNone;
     private HttpRequest http1StreamEntity;
-    private HttpRequest http1StreamPersistent;
+    private HttpRequest http1StreamPublic;
 
     @Setup
     public void setup() {
@@ -96,12 +96,12 @@ public class ResponseFilterJmhBenchmark {
                         .addFilter(ResponseFilterJmhBenchmark::configureFilter)
                         .get(DIRECT_NONE, ResponseFilterJmhBenchmark::sendDirect)
                         .get(DIRECT_ENTITY, ResponseFilterJmhBenchmark::sendDirect)
-                        .get(DIRECT_PERSISTENT, ResponseFilterJmhBenchmark::sendDirect)
+                        .get(DIRECT_PUBLIC, ResponseFilterJmhBenchmark::sendDirect)
                         .get(DIRECT_BEFORE_SEND, ResponseFilterJmhBenchmark::sendDirect)
-                        .get(DIRECT_PERSISTENT_BEFORE_SEND, ResponseFilterJmhBenchmark::sendDirect)
+                        .get(DIRECT_ENTITY_BEFORE_SEND, ResponseFilterJmhBenchmark::sendDirect)
                         .get(STREAM_NONE, ResponseFilterJmhBenchmark::sendStream)
                         .get(STREAM_ENTITY, ResponseFilterJmhBenchmark::sendStream)
-                        .get(STREAM_PERSISTENT, ResponseFilterJmhBenchmark::sendStream))
+                        .get(STREAM_PUBLIC, ResponseFilterJmhBenchmark::sendStream))
                 .build()
                 .start();
 
@@ -117,12 +117,12 @@ public class ResponseFilterJmhBenchmark {
                 .build();
         http1DirectNone = request(baseUri, DIRECT_NONE);
         http1DirectEntity = request(baseUri, DIRECT_ENTITY);
-        http1DirectPersistent = request(baseUri, DIRECT_PERSISTENT);
+        http1DirectPublic = request(baseUri, DIRECT_PUBLIC);
         http1DirectBeforeSend = request(baseUri, DIRECT_BEFORE_SEND);
-        http1DirectPersistentBeforeSend = request(baseUri, DIRECT_PERSISTENT_BEFORE_SEND);
+        http1DirectEntityBeforeSend = request(baseUri, DIRECT_ENTITY_BEFORE_SEND);
         http1StreamNone = request(baseUri, STREAM_NONE);
         http1StreamEntity = request(baseUri, STREAM_ENTITY);
-        http1StreamPersistent = request(baseUri, STREAM_PERSISTENT);
+        http1StreamPublic = request(baseUri, STREAM_PUBLIC);
     }
 
     @TearDown
@@ -145,8 +145,8 @@ public class ResponseFilterJmhBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
-    public void http1DirectPersistentFilter(Blackhole blackhole) throws IOException, InterruptedException {
-        http1(http1DirectPersistent, blackhole);
+    public void http1DirectPublicFilter(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1DirectPublic, blackhole);
     }
 
     @Benchmark
@@ -157,8 +157,8 @@ public class ResponseFilterJmhBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
-    public void http1DirectPersistentBeforeSend(Blackhole blackhole) throws IOException, InterruptedException {
-        http1(http1DirectPersistentBeforeSend, blackhole);
+    public void http1DirectEntityBeforeSend(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1DirectEntityBeforeSend, blackhole);
     }
 
     @Benchmark
@@ -175,8 +175,8 @@ public class ResponseFilterJmhBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
-    public void http1StreamPersistentFilter(Blackhole blackhole) throws IOException, InterruptedException {
-        http1(http1StreamPersistent, blackhole);
+    public void http1StreamPublicFilter(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1StreamPublic, blackhole);
     }
 
     @Benchmark
@@ -193,8 +193,8 @@ public class ResponseFilterJmhBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
-    public void http2DirectPersistentFilter(Blackhole blackhole) {
-        http2(DIRECT_PERSISTENT, blackhole);
+    public void http2DirectPublicFilter(Blackhole blackhole) {
+        http2(DIRECT_PUBLIC, blackhole);
     }
 
     @Benchmark
@@ -205,8 +205,8 @@ public class ResponseFilterJmhBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
-    public void http2DirectPersistentBeforeSend(Blackhole blackhole) {
-        http2(DIRECT_PERSISTENT_BEFORE_SEND, blackhole);
+    public void http2DirectEntityBeforeSend(Blackhole blackhole) {
+        http2(DIRECT_ENTITY_BEFORE_SEND, blackhole);
     }
 
     @Benchmark
@@ -223,8 +223,8 @@ public class ResponseFilterJmhBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
-    public void http2StreamPersistentFilter(Blackhole blackhole) {
-        http2(STREAM_PERSISTENT, blackhole);
+    public void http2StreamPublicFilter(Blackhole blackhole) {
+        http2(STREAM_PUBLIC, blackhole);
     }
 
     private static HttpRequest request(String baseUri, String path) {
@@ -236,10 +236,10 @@ public class ResponseFilterJmhBenchmark {
 
     private static void configureFilter(FilterChain chain, RoutingRequest request, RoutingResponse response) {
         switch (request.path().path()) {
-        case DIRECT_ENTITY, STREAM_ENTITY -> response.streamFilter(OUTPUT_FILTER);
-        case DIRECT_PERSISTENT, STREAM_PERSISTENT -> response.persistentStreamFilter(OUTPUT_FILTER);
+        case DIRECT_ENTITY, STREAM_ENTITY -> response.entityStreamFilter(OUTPUT_FILTER);
+        case DIRECT_PUBLIC, STREAM_PUBLIC -> response.streamFilter(OUTPUT_FILTER);
         case DIRECT_BEFORE_SEND -> response.beforeSend(BEFORE_SEND);
-        case DIRECT_PERSISTENT_BEFORE_SEND -> response.persistentBeforeSend(BEFORE_SEND);
+        case DIRECT_ENTITY_BEFORE_SEND -> response.entityBeforeSend(BEFORE_SEND);
         default -> {
         }
         }

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
@@ -57,14 +57,17 @@ import org.openjdk.jmh.infra.Blackhole;
 @State(Scope.Benchmark)
 public class ResponseFilterJmhBenchmark {
     private static final String HOST = "127.0.0.1";
-    private static final String DIRECT_NONE = "/direct-none";
+    private static final String DIRECT_BEFORE_SEND = "/direct-before-send";
     private static final String DIRECT_ENTITY = "/direct-entity";
+    private static final String DIRECT_NONE = "/direct-none";
+    private static final String DIRECT_PERSISTENT_BEFORE_SEND = "/direct-persistent-before-send";
     private static final String DIRECT_PERSISTENT = "/direct-persistent";
-    private static final String STREAM_NONE = "/stream-none";
     private static final String STREAM_ENTITY = "/stream-entity";
+    private static final String STREAM_NONE = "/stream-none";
     private static final String STREAM_PERSISTENT = "/stream-persistent";
     private static final int REQUESTS_PER_INVOCATION = 16;
     private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    private static final Runnable BEFORE_SEND = () -> { };
     private static final UnaryOperator<OutputStream> OUTPUT_FILTER = PassthroughOutputStream::new;
 
     private WebServer server;
@@ -73,6 +76,8 @@ public class ResponseFilterJmhBenchmark {
     private HttpRequest http1DirectNone;
     private HttpRequest http1DirectEntity;
     private HttpRequest http1DirectPersistent;
+    private HttpRequest http1DirectBeforeSend;
+    private HttpRequest http1DirectPersistentBeforeSend;
     private HttpRequest http1StreamNone;
     private HttpRequest http1StreamEntity;
     private HttpRequest http1StreamPersistent;
@@ -92,6 +97,8 @@ public class ResponseFilterJmhBenchmark {
                         .get(DIRECT_NONE, ResponseFilterJmhBenchmark::sendDirect)
                         .get(DIRECT_ENTITY, ResponseFilterJmhBenchmark::sendDirect)
                         .get(DIRECT_PERSISTENT, ResponseFilterJmhBenchmark::sendDirect)
+                        .get(DIRECT_BEFORE_SEND, ResponseFilterJmhBenchmark::sendDirect)
+                        .get(DIRECT_PERSISTENT_BEFORE_SEND, ResponseFilterJmhBenchmark::sendDirect)
                         .get(STREAM_NONE, ResponseFilterJmhBenchmark::sendStream)
                         .get(STREAM_ENTITY, ResponseFilterJmhBenchmark::sendStream)
                         .get(STREAM_PERSISTENT, ResponseFilterJmhBenchmark::sendStream))
@@ -111,6 +118,8 @@ public class ResponseFilterJmhBenchmark {
         http1DirectNone = request(baseUri, DIRECT_NONE);
         http1DirectEntity = request(baseUri, DIRECT_ENTITY);
         http1DirectPersistent = request(baseUri, DIRECT_PERSISTENT);
+        http1DirectBeforeSend = request(baseUri, DIRECT_BEFORE_SEND);
+        http1DirectPersistentBeforeSend = request(baseUri, DIRECT_PERSISTENT_BEFORE_SEND);
         http1StreamNone = request(baseUri, STREAM_NONE);
         http1StreamEntity = request(baseUri, STREAM_ENTITY);
         http1StreamPersistent = request(baseUri, STREAM_PERSISTENT);
@@ -138,6 +147,18 @@ public class ResponseFilterJmhBenchmark {
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http1DirectPersistentFilter(Blackhole blackhole) throws IOException, InterruptedException {
         http1(http1DirectPersistent, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1DirectBeforeSend(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1DirectBeforeSend, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1DirectPersistentBeforeSend(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1DirectPersistentBeforeSend, blackhole);
     }
 
     @Benchmark
@@ -178,6 +199,18 @@ public class ResponseFilterJmhBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2DirectBeforeSend(Blackhole blackhole) {
+        http2(DIRECT_BEFORE_SEND, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2DirectPersistentBeforeSend(Blackhole blackhole) {
+        http2(DIRECT_PERSISTENT_BEFORE_SEND, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http2StreamNoFilter(Blackhole blackhole) {
         http2(STREAM_NONE, blackhole);
     }
@@ -205,6 +238,8 @@ public class ResponseFilterJmhBenchmark {
         switch (request.path().path()) {
         case DIRECT_ENTITY, STREAM_ENTITY -> response.streamFilter(OUTPUT_FILTER);
         case DIRECT_PERSISTENT, STREAM_PERSISTENT -> response.persistentStreamFilter(OUTPUT_FILTER);
+        case DIRECT_BEFORE_SEND -> response.beforeSend(BEFORE_SEND);
+        case DIRECT_PERSISTENT_BEFORE_SEND -> response.persistentBeforeSend(BEFORE_SEND);
         default -> {
         }
         }

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.UnaryOperator;
+
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webclient.http2.Http2ClientResponse;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.FilterChain;
+import io.helidon.webserver.http.RoutingRequest;
+import io.helidon.webserver.http.RoutingResponse;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2ConnectionSelector;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class ResponseFilterJmhBenchmark {
+    private static final String HOST = "127.0.0.1";
+    private static final String DIRECT_NONE = "/direct-none";
+    private static final String DIRECT_ENTITY = "/direct-entity";
+    private static final String DIRECT_PERSISTENT = "/direct-persistent";
+    private static final String STREAM_NONE = "/stream-none";
+    private static final String STREAM_ENTITY = "/stream-entity";
+    private static final String STREAM_PERSISTENT = "/stream-persistent";
+    private static final int REQUESTS_PER_INVOCATION = 16;
+    private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    private static final UnaryOperator<OutputStream> OUTPUT_FILTER = PassthroughOutputStream::new;
+
+    private WebServer server;
+    private HttpClient http1Client;
+    private Http2Client http2Client;
+    private HttpRequest http1DirectNone;
+    private HttpRequest http1DirectEntity;
+    private HttpRequest http1DirectPersistent;
+    private HttpRequest http1StreamNone;
+    private HttpRequest http1StreamEntity;
+    private HttpRequest http1StreamPersistent;
+
+    @Setup
+    public void setup() {
+        LogConfig.configureRuntime();
+        Http2Config http2Config = Http2Config.builder().build();
+        server = WebServer.builder()
+                .host(HOST)
+                .addProtocol(http2Config)
+                .addConnectionSelector(Http2ConnectionSelector.builder()
+                                               .http2Config(http2Config)
+                                               .build())
+                .routing(routing -> routing
+                        .addFilter(ResponseFilterJmhBenchmark::configureFilter)
+                        .get(DIRECT_NONE, ResponseFilterJmhBenchmark::sendDirect)
+                        .get(DIRECT_ENTITY, ResponseFilterJmhBenchmark::sendDirect)
+                        .get(DIRECT_PERSISTENT, ResponseFilterJmhBenchmark::sendDirect)
+                        .get(STREAM_NONE, ResponseFilterJmhBenchmark::sendStream)
+                        .get(STREAM_ENTITY, ResponseFilterJmhBenchmark::sendStream)
+                        .get(STREAM_PERSISTENT, ResponseFilterJmhBenchmark::sendStream))
+                .build()
+                .start();
+
+        String baseUri = "http://" + HOST + ":" + server.port();
+        http1Client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+        http2Client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .protocolConfig(http2 -> http2.priorKnowledge(true))
+                .baseUri(baseUri)
+                .build();
+        http1DirectNone = request(baseUri, DIRECT_NONE);
+        http1DirectEntity = request(baseUri, DIRECT_ENTITY);
+        http1DirectPersistent = request(baseUri, DIRECT_PERSISTENT);
+        http1StreamNone = request(baseUri, STREAM_NONE);
+        http1StreamEntity = request(baseUri, STREAM_ENTITY);
+        http1StreamPersistent = request(baseUri, STREAM_PERSISTENT);
+    }
+
+    @TearDown
+    public void tearDown() {
+        http2Client.closeResource();
+        server.stop();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1DirectNoFilter(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1DirectNone, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1DirectEntityFilter(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1DirectEntity, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1DirectPersistentFilter(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1DirectPersistent, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1StreamNoFilter(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1StreamNone, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1StreamEntityFilter(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1StreamEntity, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1StreamPersistentFilter(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1StreamPersistent, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2DirectNoFilter(Blackhole blackhole) {
+        http2(DIRECT_NONE, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2DirectEntityFilter(Blackhole blackhole) {
+        http2(DIRECT_ENTITY, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2DirectPersistentFilter(Blackhole blackhole) {
+        http2(DIRECT_PERSISTENT, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2StreamNoFilter(Blackhole blackhole) {
+        http2(STREAM_NONE, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2StreamEntityFilter(Blackhole blackhole) {
+        http2(STREAM_ENTITY, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2StreamPersistentFilter(Blackhole blackhole) {
+        http2(STREAM_PERSISTENT, blackhole);
+    }
+
+    private static HttpRequest request(String baseUri, String path) {
+        return HttpRequest.newBuilder()
+                .GET()
+                .uri(URI.create(baseUri + path))
+                .build();
+    }
+
+    private static void configureFilter(FilterChain chain, RoutingRequest request, RoutingResponse response) {
+        switch (request.path().path()) {
+        case DIRECT_ENTITY, STREAM_ENTITY -> response.streamFilter(OUTPUT_FILTER);
+        case DIRECT_PERSISTENT, STREAM_PERSISTENT -> response.persistentStreamFilter(OUTPUT_FILTER);
+        default -> {
+        }
+        }
+        chain.proceed();
+    }
+
+    private static void sendDirect(ServerRequest request, ServerResponse response) {
+        response.send(RESPONSE_BYTES);
+    }
+
+    private static void sendStream(ServerRequest request, ServerResponse response) {
+        try (OutputStream outputStream = response.outputStream()) {
+            outputStream.write(RESPONSE_BYTES);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void http1(HttpRequest request, Blackhole blackhole) throws IOException, InterruptedException {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            HttpResponse<byte[]> response = http1Client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            blackhole.consume(response.statusCode());
+            blackhole.consume(response.body());
+        }
+    }
+
+    private void http2(String path, Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            try (Http2ClientResponse response = http2Client.get(path).request()) {
+                blackhole.consume(response.status());
+                blackhole.consume(response.entity().as(byte[].class));
+            }
+        }
+    }
+
+    private static final class PassthroughOutputStream extends FilterOutputStream {
+        private PassthroughOutputStream(OutputStream outputStream) {
+            super(outputStream);
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhRunnerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class ResponseFilterJmhRunnerTest {
+    @Test
+    void run() throws RunnerException {
+        String benchmark = Pattern.quote(ResponseFilterJmhBenchmark.class.getName());
+        String include = System.getProperty("response.filter.jmh.include", "^" + benchmark + ".*$");
+        String result = System.getProperty("response.filter.jmh.result", "target/response-filter-jmh.json");
+
+        Options options = new OptionsBuilder()
+                .include(include)
+                .forks(Integer.getInteger("response.filter.jmh.forks", 3))
+                .threads(Integer.getInteger("response.filter.jmh.threads", 1))
+                .warmupIterations(Integer.getInteger("response.filter.jmh.warmupIterations", 3))
+                .warmupTime(TimeValue.milliseconds(Long.getLong("response.filter.jmh.warmupMillis", 1000)))
+                .measurementIterations(Integer.getInteger("response.filter.jmh.measurementIterations", 5))
+                .measurementTime(TimeValue.milliseconds(Long.getLong("response.filter.jmh.measurementMillis", 2000)))
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/webserver/hsts/README.md
+++ b/webserver/hsts/README.md
@@ -41,4 +41,5 @@ server:
 - The header is only added when the resolved request URI scheme is `https`.
 - When TLS is terminated by a trusted proxy, this relies on requested-URI discovery being correctly configured so Helidon resolves the external scheme as `https`.
 - Existing `Strict-Transport-Security` headers set by application code are preserved.
-- The feature applies to normal responses, redirects, and framework-generated error responses because the header is added through `beforeSend(...)`.
+- The feature applies to normal responses, redirects, and framework-generated error responses because the header is
+  added through a persistent response-preparation listener.

--- a/webserver/hsts/README.md
+++ b/webserver/hsts/README.md
@@ -42,4 +42,4 @@ server:
 - When TLS is terminated by a trusted proxy, this relies on requested-URI discovery being correctly configured so Helidon resolves the external scheme as `https`.
 - Existing `Strict-Transport-Security` headers set by application code are preserved.
 - The feature applies to normal responses, redirects, and framework-generated error responses because the header is
-  added through a persistent response-preparation listener.
+  added through `beforeSend(...)`.

--- a/webserver/hsts/src/main/java/io/helidon/webserver/hsts/HstsFilter.java
+++ b/webserver/hsts/src/main/java/io/helidon/webserver/hsts/HstsFilter.java
@@ -33,7 +33,7 @@ class HstsFilter implements Filter {
 
     @Override
     public void filter(FilterChain chain, RoutingRequest req, RoutingResponse res) {
-        res.beforeSend(() -> maybeAddHeader(req, res));
+        res.persistentBeforeSend(() -> maybeAddHeader(req, res));
         chain.proceed();
     }
 

--- a/webserver/hsts/src/main/java/io/helidon/webserver/hsts/HstsFilter.java
+++ b/webserver/hsts/src/main/java/io/helidon/webserver/hsts/HstsFilter.java
@@ -33,7 +33,7 @@ class HstsFilter implements Filter {
 
     @Override
     public void filter(FilterChain chain, RoutingRequest req, RoutingResponse res) {
-        res.persistentBeforeSend(() -> maybeAddHeader(req, res));
+        res.beforeSend(() -> maybeAddHeader(req, res));
         chain.proceed();
     }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -303,6 +303,15 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     }
 
     @Override
+    public boolean resetEntity() {
+        if (!super.resetEntity()) {
+            return false;
+        }
+        trailers.clear();
+        return true;
+    }
+
+    @Override
     public void commit() {
         if (outputStream != null) {
             outputStream.commit();

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -19,9 +19,7 @@ package io.helidon.webserver.http2;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.DateTime;
@@ -56,7 +54,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     private boolean preparingResponse;
     private long bytesWritten;
     private BlockingOutputStream outputStream;
-    private UnaryOperator<OutputStream> outputStreamFilter;
     private String streamResult = null;
 
     Http2ServerResponse(Http2ServerStream stream,
@@ -103,7 +100,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             throw new IllegalStateException("Response preparation already in progress");
         }
         try {
-            if (outputStreamFilter != null) {
+            if (hasStreamFilter()) {
                 // in this case we must honor user's request to filter the stream
                 try (OutputStream os = outputStream()) {
                     os.write(entityBytes, position, length);
@@ -236,11 +233,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             this.isSent = true;
             afterSend();
         }, beforeTrailers());
-        if (outputStreamFilter == null) {
-            return contentEncode(outputStream);
-        } else {
-            return outputStreamFilter.apply(contentEncode(outputStream));
-        }
+        return applyStreamFilters(contentEncode(outputStream));
     }
 
     private void prepareResponse() {
@@ -307,7 +300,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         if (!super.resetEntity()) {
             return false;
         }
-        outputStreamFilter = null;
         streamResult = null;
         trailers.clear();
         return true;
@@ -317,24 +309,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     public void commit() {
         if (outputStream != null) {
             outputStream.commit();
-        }
-    }
-
-    @Override
-    public void streamFilter(UnaryOperator<OutputStream> filterFunction) {
-        if (isSent) {
-            throw new IllegalStateException("Response already sent");
-        }
-        if (streamingEntity) {
-            throw new IllegalStateException("OutputStream already obtained");
-        }
-        Objects.requireNonNull(filterFunction);
-
-        UnaryOperator<OutputStream> current = this.outputStreamFilter;
-        if (current == null) {
-            this.outputStreamFilter = filterFunction;
-        } else {
-            this.outputStreamFilter = it -> filterFunction.apply(current.apply(it));
         }
     }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -308,6 +308,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             return false;
         }
         outputStreamFilter = null;
+        streamResult = null;
         trailers.clear();
         return true;
     }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -307,6 +307,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         if (!super.resetEntity()) {
             return false;
         }
+        outputStreamFilter = null;
         trailers.clear();
         return true;
     }

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,7 +237,7 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
             Register an output stream filter to correctly handle content write span
              */
             if (spanConfig.logEnabled(CONTENT_WRITE_SPAN_NAME, true)) {
-                res.streamFilter(os -> {
+                res.persistentStreamFilter(os -> {
                     // this is invoked when the user requests output stream, we just replace it with our own delegate
                     return new TracingStreamOutputDelegate(tracer, span, os);
                 });

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
@@ -237,7 +237,7 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
             Register an output stream filter to correctly handle content write span
              */
             if (spanConfig.logEnabled(CONTENT_WRITE_SPAN_NAME, true)) {
-                res.persistentStreamFilter(os -> {
+                res.streamFilter(os -> {
                     // this is invoked when the user requests output stream, we just replace it with our own delegate
                     return new TracingStreamOutputDelegate(tracer, span, os);
                 });

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -32,7 +32,11 @@ import io.helidon.common.pki.Keys;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.ErrorHandler;
@@ -61,6 +65,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
 
     private static final HeaderName MAIN_HEADER_NAME = HeaderNames.create("main-handler");
     private static final HeaderName ERROR_HEADER_NAME = HeaderNames.create("error-handler");
+    private static final HeaderName STALE_TRAILER_NAME = HeaderNames.create("stale-trailer");
+    private static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
     private static final HeaderName REENTRY_RESULT_HEADER_NAME = HeaderNames.create("reentry-result");
     private static final HeaderName CALLBACK_COUNT_HEADER_NAME = HeaderNames.create("callback-count");
     private static HttpClient httpClient;
@@ -115,6 +121,12 @@ class Http2ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.CACHE_CONTROL, "no-store");
                     res.header(HeaderNames.VARY, "Origin");
                     res.streamFilter(_ -> OutputStream.nullOutputStream());
+                    res.outputStream();
+                    throw new CustomException();
+                }))
+                .route(Http2Route.route(GET, "get-outputStream-stale-trailers", (req, res) -> {
+                    res.beforeTrailers(trailers -> trailers.set(STALE_TRAILER_NAME, "stale"));
+                    res.streamResult("stale-result");
                     res.outputStream();
                     throw new CustomException();
                 }))
@@ -240,6 +252,19 @@ class Http2ErrorHandlingWithOutputStreamTest {
     }
 
     @Test
+    void testGetOutputStreamThenErrorClearsStaleTrailerState(WebClient webClient) {
+        Http2Client client = webClient.client(Http2Client.PROTOCOL);
+        ClientResponseTyped<String> response = client.get("/get-outputStream-stale-trailers")
+                .header(HeaderValues.TE_TRAILERS)
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.I_AM_A_TEAPOT_418));
+        assertThat(response.entity(), is("TeaPotIAm"));
+        assertThat(response.trailers().contains(STALE_TRAILER_NAME), is(false));
+        assertThat(response.trailers().get(STREAM_RESULT_NAME).get(), is("OK"));
+    }
+
+    @Test
     void testGetOutputStreamWriteOnceThenError_expect_CustomErrorHandlerMessage() {
         var response = request("/get-outputStream-writeOnceThenError");
 
@@ -353,6 +378,10 @@ class Http2ErrorHandlingWithOutputStreamTest {
             res.header(ERROR_HEADER_NAME, "err");
             // this is now the responsibility of an error handler, as otherwise we may remove CORS headers etc.
             res.headers().remove(MAIN_HEADER_NAME);
+            if (req.path().path().equals("/get-outputStream-stale-trailers")) {
+                res.header(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
+                res.streamFilter(outputStream -> outputStream);
+            }
             res.send("TeaPotIAm");
         }
     }

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -70,6 +70,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
     private static final HeaderName STALE_TRAILER_NAME = HeaderNames.create("stale-trailer");
     private static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
     private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
+    private static final HeaderName CONTENT_MD5_NAME = HeaderNames.create("Content-MD5");
+    private static final HeaderName DIGEST_NAME = HeaderNames.create("Digest");
     private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
     private static final HeaderName CSP_HEADER_NAME = HeaderNames.create("Content-Security-Policy");
     private static final HeaderName RESPONSE_SIGNATURE_NAME = HeaderNames.create("Response-Signature");
@@ -140,6 +142,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.CONTENT_LOCATION, "/stale");
                     res.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
                     res.header(CONTENT_DIGEST_NAME, "sha-256=:YWJjZA==:");
+                    res.header(CONTENT_MD5_NAME, "YWJjZA==");
+                    res.header(DIGEST_NAME, "SHA-256=YWJjZA==");
                     res.header(REPR_DIGEST_NAME, "sha-256=:YWJjZA==:");
                     res.header(HeaderNames.ETAG, "\"stale\"");
                     res.header(HeaderNames.LAST_MODIFIED, "stale");
@@ -286,6 +290,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
         assertThat(response.headers().firstValue(HeaderNames.CONTENT_LOCATION.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.CONTENT_DISPOSITION.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(CONTENT_DIGEST_NAME.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(CONTENT_MD5_NAME.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(DIGEST_NAME.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(REPR_DIGEST_NAME.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.ETAG.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.LAST_MODIFIED.lowerCase()), is(emptyOptional()));

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -114,6 +114,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.ACCEPT_RANGES, "bytes");
                     res.header(HeaderNames.CACHE_CONTROL, "no-store");
                     res.header(HeaderNames.VARY, "Origin");
+                    res.streamFilter(_ -> OutputStream.nullOutputStream());
                     res.outputStream();
                     throw new CustomException();
                 }))

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -24,6 +24,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -58,6 +59,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
@@ -69,6 +71,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
     private static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
     private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
     private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
+    private static final HeaderName CSP_HEADER_NAME = HeaderNames.create("Content-Security-Policy");
     private static final HeaderName REENTRY_RESULT_HEADER_NAME = HeaderNames.create("reentry-result");
     private static final HeaderName CALLBACK_COUNT_HEADER_NAME = HeaderNames.create("callback-count");
     private static HttpClient httpClient;
@@ -106,6 +109,19 @@ class Http2ErrorHandlingWithOutputStreamTest {
     static void router(HttpRouting.Builder router) {
         // explicitly on HTTP/2 only, to make sure we do upgrade
         router.error(CustomException.class, new CustomRoutingHandler())
+                .addFilter((chain, req, res) -> {
+                    if (req.path().path().equals("/get-cross-cutting-error")) {
+                        res.beforeSend(() -> res.header(CSP_HEADER_NAME, "default-src 'none'"));
+                        res.streamFilter(Base64.getEncoder()::wrap);
+                    } else if (req.path().path().equals("/get-outputStream")) {
+                        res.entityStreamFilter(_ -> OutputStream.nullOutputStream());
+                        res.entityBeforeSend(() -> res.header(HeaderNames.CONTENT_ENCODING, "stale"));
+                    }
+                    chain.proceed();
+                })
+                .route(Http2Route.route(GET, "get-cross-cutting-error", (_, _) -> {
+                    throw new CustomException();
+                }))
                 .route(Http2Route.route(GET, "get-outputStream", (req, res) -> {
                     res.status(Status.OK_200);
                     res.header(MAIN_HEADER_NAME, "x");
@@ -124,8 +140,6 @@ class Http2ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.ACCEPT_RANGES, "bytes");
                     res.header(HeaderNames.CACHE_CONTROL, "no-store");
                     res.header(HeaderNames.VARY, "Origin");
-                    res.streamFilter(_ -> OutputStream.nullOutputStream());
-                    res.beforeSend(() -> res.header(HeaderNames.CONTENT_ENCODING, "stale"));
                     res.outputStream();
                     throw new CustomException();
                 }))
@@ -232,6 +246,18 @@ class Http2ErrorHandlingWithOutputStreamTest {
     }
 
     @Test
+    void testCrossCuttingResponseHooksSurviveErrorReplacement() {
+        var response = request("/get-cross-cutting-error");
+
+        assertAll(
+                () -> assertThat(response.headers().firstValue(CSP_HEADER_NAME.lowerCase()),
+                                 is(Optional.of("default-src 'none'"))),
+                () -> assertThat(response.body(),
+                                 is(Base64.getEncoder().encodeToString("TeaPotIAm".getBytes(StandardCharsets.UTF_8))))
+        );
+    }
+
+    @Test
     void testGetOutputStreamThenError_expect_CustomErrorHandlerMessage() {
         var response = request("/get-outputStream");
 
@@ -255,7 +281,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
         assertThat(response.headers().firstValue(HeaderNames.LAST_MODIFIED.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.ACCEPT_RANGES.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.CACHE_CONTROL.lowerCase()), is(Optional.of("no-store")));
-        assertThat(response.headers().firstValue(HeaderNames.VARY.lowerCase()), is(Optional.of("Origin")));
+        assertThat(response.headers().firstValue(HeaderNames.VARY.lowerCase()),
+                   is(Optional.of("Origin, Accept-Encoding")));
     }
 
     @Test

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -67,6 +67,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
     private static final HeaderName ERROR_HEADER_NAME = HeaderNames.create("error-handler");
     private static final HeaderName STALE_TRAILER_NAME = HeaderNames.create("stale-trailer");
     private static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
+    private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
+    private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
     private static final HeaderName REENTRY_RESULT_HEADER_NAME = HeaderNames.create("reentry-result");
     private static final HeaderName CALLBACK_COUNT_HEADER_NAME = HeaderNames.create("callback-count");
     private static HttpClient httpClient;
@@ -115,6 +117,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.CONTENT_LANGUAGE, "en");
                     res.header(HeaderNames.CONTENT_LOCATION, "/stale");
                     res.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
+                    res.header(CONTENT_DIGEST_NAME, "sha-256=:YWJjZA==:");
+                    res.header(REPR_DIGEST_NAME, "sha-256=:YWJjZA==:");
                     res.header(HeaderNames.ETAG, "\"stale\"");
                     res.header(HeaderNames.LAST_MODIFIED, "stale");
                     res.header(HeaderNames.ACCEPT_RANGES, "bytes");
@@ -244,6 +248,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
         assertThat(response.headers().firstValue(HeaderNames.CONTENT_LANGUAGE.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.CONTENT_LOCATION.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.CONTENT_DISPOSITION.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(CONTENT_DIGEST_NAME.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(REPR_DIGEST_NAME.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.ETAG.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.LAST_MODIFIED.lowerCase()), is(emptyOptional()));
         assertThat(response.headers().firstValue(HeaderNames.ACCEPT_RANGES.lowerCase()), is(emptyOptional()));

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -125,6 +125,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.CACHE_CONTROL, "no-store");
                     res.header(HeaderNames.VARY, "Origin");
                     res.streamFilter(_ -> OutputStream.nullOutputStream());
+                    res.beforeSend(() -> res.header(HeaderNames.CONTENT_ENCODING, "stale"));
                     res.outputStream();
                     throw new CustomException();
                 }))

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -101,6 +101,19 @@ class Http2ErrorHandlingWithOutputStreamTest {
                 .route(Http2Route.route(GET, "get-outputStream", (req, res) -> {
                     res.status(Status.OK_200);
                     res.header(MAIN_HEADER_NAME, "x");
+                    res.header(HeaderNames.CONTENT_LENGTH, "1");
+                    res.header(HeaderNames.TRAILER, "x-stale-trailer");
+                    res.header(HeaderNames.CONTENT_RANGE, "bytes 0-0/1");
+                    res.header(HeaderNames.CONTENT_TYPE, "application/stale");
+                    res.header(HeaderNames.CONTENT_ENCODING, "stale");
+                    res.header(HeaderNames.CONTENT_LANGUAGE, "en");
+                    res.header(HeaderNames.CONTENT_LOCATION, "/stale");
+                    res.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
+                    res.header(HeaderNames.ETAG, "\"stale\"");
+                    res.header(HeaderNames.LAST_MODIFIED, "stale");
+                    res.header(HeaderNames.ACCEPT_RANGES, "bytes");
+                    res.header(HeaderNames.CACHE_CONTROL, "no-store");
+                    res.header(HeaderNames.VARY, "Origin");
                     res.outputStream();
                     throw new CustomException();
                 }))
@@ -208,6 +221,21 @@ class Http2ErrorHandlingWithOutputStreamTest {
         assertThat(response.body(), is("TeaPotIAm"));
         assertThat(response.headers().firstValue(ERROR_HEADER_NAME.lowerCase()), is(Optional.of("err")));
         assertThat(response.headers().firstValue(MAIN_HEADER_NAME.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValueAsLong(HeaderNames.CONTENT_LENGTH.lowerCase()).orElse(-1),
+                   is((long) "TeaPotIAm".getBytes(StandardCharsets.UTF_8).length));
+        assertThat(response.headers().firstValue(HeaderNames.TRAILER.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.CONTENT_RANGE.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.CONTENT_TYPE.lowerCase()),
+                   is(Optional.of("text/plain; charset=UTF-8")));
+        assertThat(response.headers().firstValue(HeaderNames.CONTENT_ENCODING.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.CONTENT_LANGUAGE.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.CONTENT_LOCATION.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.CONTENT_DISPOSITION.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.ETAG.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.LAST_MODIFIED.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.ACCEPT_RANGES.lowerCase()), is(emptyOptional()));
+        assertThat(response.headers().firstValue(HeaderNames.CACHE_CONTROL.lowerCase()), is(Optional.of("no-store")));
+        assertThat(response.headers().firstValue(HeaderNames.VARY.lowerCase()), is(Optional.of("Origin")));
     }
 
     @Test

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -129,7 +129,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
                     res.outputStream();
                     throw new CustomException();
                 }))
-                .route(Http2Route.route(GET, "get-outputStream-stale-trailers", (req, res) -> {
+                .route(Http2Route.route(GET, "get-outputStream-stale-trailers", (_, res) -> {
                     res.beforeTrailers(trailers -> trailers.set(STALE_TRAILER_NAME, "stale"));
                     res.streamResult("stale-result");
                     res.outputStream();

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -72,6 +72,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
     private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
     private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
     private static final HeaderName CSP_HEADER_NAME = HeaderNames.create("Content-Security-Policy");
+    private static final HeaderName RESPONSE_SIGNATURE_NAME = HeaderNames.create("Response-Signature");
     private static final HeaderName REENTRY_RESULT_HEADER_NAME = HeaderNames.create("reentry-result");
     private static final HeaderName CALLBACK_COUNT_HEADER_NAME = HeaderNames.create("callback-count");
     private static HttpClient httpClient;
@@ -114,6 +115,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
                         res.beforeSend(() -> {
                             res.header(CSP_HEADER_NAME, "default-src 'none'");
                             res.header(HeaderNames.CONTENT_ENCODING, "base64");
+                            res.header(HeaderNames.TRAILER, RESPONSE_SIGNATURE_NAME.defaultCase());
+                            res.beforeTrailers(trailers -> trailers.set(RESPONSE_SIGNATURE_NAME, "signed"));
                         });
                         res.streamFilter(Base64.getEncoder()::wrap);
                     } else if (req.path().path().equals("/get-outputStream")) {
@@ -249,16 +252,18 @@ class Http2ErrorHandlingWithOutputStreamTest {
     }
 
     @Test
-    void testCrossCuttingResponseHooksSurviveErrorReplacement() {
-        var response = request("/get-cross-cutting-error");
+    void testCrossCuttingResponseHooksSurviveErrorReplacement(WebClient webClient) {
+        Http2Client client = webClient.client(Http2Client.PROTOCOL);
+        ClientResponseTyped<String> response = client.get("/get-cross-cutting-error")
+                .header(HeaderValues.TE_TRAILERS)
+                .request(String.class);
 
         assertAll(
-                () -> assertThat(response.headers().firstValue(CSP_HEADER_NAME.lowerCase()),
-                                 is(Optional.of("default-src 'none'"))),
-                () -> assertThat(response.headers().firstValue(HeaderNames.CONTENT_ENCODING.lowerCase()),
-                                 is(Optional.of("base64"))),
-                () -> assertThat(response.body(),
-                                 is(Base64.getEncoder().encodeToString("TeaPotIAm".getBytes(StandardCharsets.UTF_8))))
+                () -> assertThat(response.headers().get(CSP_HEADER_NAME).get(), is("default-src 'none'")),
+                () -> assertThat(response.headers().get(HeaderNames.CONTENT_ENCODING).get(), is("base64")),
+                () -> assertThat(response.entity(),
+                                 is(Base64.getEncoder().encodeToString("TeaPotIAm".getBytes(StandardCharsets.UTF_8)))),
+                () -> assertThat(response.trailers().get(RESPONSE_SIGNATURE_NAME).get(), is("signed"))
         );
     }
 

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -111,7 +111,10 @@ class Http2ErrorHandlingWithOutputStreamTest {
         router.error(CustomException.class, new CustomRoutingHandler())
                 .addFilter((chain, req, res) -> {
                     if (req.path().path().equals("/get-cross-cutting-error")) {
-                        res.beforeSend(() -> res.header(CSP_HEADER_NAME, "default-src 'none'"));
+                        res.beforeSend(() -> {
+                            res.header(CSP_HEADER_NAME, "default-src 'none'");
+                            res.header(HeaderNames.CONTENT_ENCODING, "base64");
+                        });
                         res.streamFilter(Base64.getEncoder()::wrap);
                     } else if (req.path().path().equals("/get-outputStream")) {
                         res.entityStreamFilter(_ -> OutputStream.nullOutputStream());
@@ -252,6 +255,8 @@ class Http2ErrorHandlingWithOutputStreamTest {
         assertAll(
                 () -> assertThat(response.headers().firstValue(CSP_HEADER_NAME.lowerCase()),
                                  is(Optional.of("default-src 'none'"))),
+                () -> assertThat(response.headers().firstValue(HeaderNames.CONTENT_ENCODING.lowerCase()),
+                                 is(Optional.of("base64"))),
                 () -> assertThat(response.body(),
                                  is(Base64.getEncoder().encodeToString("TeaPotIAm".getBytes(StandardCharsets.UTF_8))))
         );

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBeforeSendTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseBeforeSendTest.java
@@ -43,23 +43,12 @@ class SseBeforeSendTest {
 
     @SetUpRoute
     static void routing(HttpRules rules) {
-        rules.get("/sseBeforeSendStatus", (req, res) -> {
-            res.beforeSend(() -> res.status(Status.BAD_REQUEST_400));
-            SseBaseTest.sseString1(req, res);
-        });
         rules.get("/sseBeforeSendHeader", (req, res) -> {
             AtomicInteger beforeSendCalls = new AtomicInteger();
             res.beforeSend(() -> res.header(BEFORE_SEND_CALLS,
                                             Integer.toString(beforeSendCalls.incrementAndGet())));
             SseBaseTest.sseString1(req, res);
         });
-    }
-
-    @Test
-    void testBeforeSendStatusIsAppliedToSseWithoutAltSvc() {
-        try (Http1ClientResponse response = client.get("/sseBeforeSendStatus").request()) {
-            assertThat(response.status(), is(Status.BAD_REQUEST_400));
-        }
     }
 
     @Test

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
@@ -59,10 +59,6 @@ class SseServerTest extends SseBaseTest {
     @SetUpRoute
     static void routing(HttpRules rules) {
         rules.get("/sseString1", SseServerTest::sseString1);
-        rules.get("/sseBeforeSendStatus", (req, res) -> {
-            res.beforeSend(() -> res.status(Status.BAD_REQUEST_400));
-            sseString1(req, res);
-        });
         rules.get("/sseCustomAltSvc", (req, res) -> {
             AtomicInteger beforeSendCalls = new AtomicInteger();
             res.beforeSend(() -> {
@@ -157,19 +153,6 @@ class SseServerTest extends SseBaseTest {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers().first(HeaderNames.ALT_SVC).orElse(null),
                        is("h3=\":" + webServer().port() + "\""));
-        } finally {
-            client.closeResource();
-        }
-    }
-
-    @Test
-    void testBeforeSendStatusIsAppliedToSseWithAltSvcConfigured() {
-        Http1Client client = Http1Client.builder()
-                .baseUri("http://localhost:" + webServer().port())
-                .build();
-        try (Http1ClientResponse response = client.get("/sseBeforeSendStatus").request()) {
-            assertThat(response.status(), is(Status.BAD_REQUEST_400));
-            assertThat(response.headers().contains(HeaderNames.ALT_SVC), is(false));
         } finally {
             client.closeResource();
         }

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -54,6 +54,7 @@ class ErrorHandlingWithOutputStreamTest {
     private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
     private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
     private static final HeaderName CSP_HEADER_NAME = HeaderNames.create("Content-Security-Policy");
+    private static final HeaderName RESPONSE_SIGNATURE_NAME = HeaderNames.create("Response-Signature");
 
     private final Http1Client client;
 
@@ -69,6 +70,8 @@ class ErrorHandlingWithOutputStreamTest {
                         res.beforeSend(() -> {
                             res.header(CSP_HEADER_NAME, "default-src 'none'");
                             res.header(HeaderNames.CONTENT_ENCODING, "base64");
+                            res.header(HeaderNames.TRAILER, RESPONSE_SIGNATURE_NAME.defaultCase());
+                            res.beforeTrailers(trailers -> trailers.set(RESPONSE_SIGNATURE_NAME, "signed"));
                         });
                         res.streamFilter(Base64.getEncoder()::wrap);
                     } else if (req.path().path().equals("/get-outputStream")) {
@@ -147,16 +150,19 @@ class ErrorHandlingWithOutputStreamTest {
     }
 
     @Test
-    void testCrossCuttingResponseHooksSurviveErrorReplacement() {
-        try (var response = client.get("/get-cross-cutting-error").request()) {
-            assertAll(
-                    () -> assertThat(response.headers().get(CSP_HEADER_NAME).get(), is("default-src 'none'")),
-                    () -> assertThat(response.headers().get(HeaderNames.CONTENT_ENCODING).get(), is("base64")),
-                    () -> assertThat(response.entity().as(String.class),
-                                     is(Base64.getEncoder()
-                                                .encodeToString("CustomErrorContent".getBytes(StandardCharsets.UTF_8))))
-            );
-        }
+    void testCrossCuttingResponseHooksSurviveErrorReplacement(WebClient webClient) {
+        ClientResponseTyped<String> response = webClient.get("/get-cross-cutting-error")
+                .header(HeaderValues.TE_TRAILERS)
+                .request(String.class);
+
+        assertAll(
+                () -> assertThat(response.headers().get(CSP_HEADER_NAME).get(), is("default-src 'none'")),
+                () -> assertThat(response.headers().get(HeaderNames.CONTENT_ENCODING).get(), is("base64")),
+                () -> assertThat(response.entity(),
+                                 is(Base64.getEncoder()
+                                            .encodeToString("CustomErrorContent".getBytes(StandardCharsets.UTF_8)))),
+                () -> assertThat(response.trailers().get(RESPONSE_SIGNATURE_NAME).get(), is("signed"))
+        );
     }
 
     @Test

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -80,6 +80,7 @@ class ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.CACHE_CONTROL, "no-store");
                     res.header(HeaderNames.VARY, "Origin");
                     res.streamFilter(_ -> OutputStream.nullOutputStream());
+                    res.beforeSend(() -> res.header(HeaderNames.CONTENT_ENCODING, "stale"));
                     res.outputStream();
                     throw new CustomException();
                 })

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -84,7 +84,7 @@ class ErrorHandlingWithOutputStreamTest {
                     res.outputStream();
                     throw new CustomException();
                 })
-                .get("get-outputStream-stale-trailers", (req, res) -> {
+                .get("get-outputStream-stale-trailers", (_, res) -> {
                     res.beforeTrailers(trailers -> trailers.set(STALE_TRAILER_NAME, "stale"));
                     res.streamResult("stale-result");
                     res.outputStream();

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,20 @@ class ErrorHandlingWithOutputStreamTest {
         router.error(CustomException.class, new CustomRoutingHandler())
                 .get("get-outputStream", (req, res) -> {
                     res.header(MAIN_HEADER_NAME, "x");
+                    res.header(HeaderNames.CONTENT_LENGTH, "1");
+                    res.header(HeaderNames.TRANSFER_ENCODING, "chunked");
+                    res.header(HeaderNames.TRAILER, "x-stale-trailer");
+                    res.header(HeaderNames.CONTENT_RANGE, "bytes 0-0/1");
+                    res.header(HeaderNames.CONTENT_TYPE, "application/stale");
+                    res.header(HeaderNames.CONTENT_ENCODING, "stale");
+                    res.header(HeaderNames.CONTENT_LANGUAGE, "en");
+                    res.header(HeaderNames.CONTENT_LOCATION, "/stale");
+                    res.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
+                    res.header(HeaderNames.ETAG, "\"stale\"");
+                    res.header(HeaderNames.LAST_MODIFIED, "stale");
+                    res.header(HeaderNames.ACCEPT_RANGES, "bytes");
+                    res.header(HeaderNames.CACHE_CONTROL, "no-store");
+                    res.header(HeaderNames.VARY, "Origin");
                     res.outputStream();
                     throw new CustomException();
                 })
@@ -105,6 +119,21 @@ class ErrorHandlingWithOutputStreamTest {
             assertThat(response.entity().as(String.class), is("CustomErrorContent"));
             assertThat(response.headers().contains(ERROR_HEADER_NAME), is(true));
             assertThat(response.headers().contains(MAIN_HEADER_NAME), is(false));
+            assertThat(response.headers().contentLength().orElse(-1),
+                       is((long) "CustomErrorContent".getBytes(StandardCharsets.UTF_8).length));
+            assertThat(response.headers().contains(HeaderNames.TRANSFER_ENCODING), is(false));
+            assertThat(response.headers().contains(HeaderNames.TRAILER), is(false));
+            assertThat(response.headers().contains(HeaderNames.CONTENT_RANGE), is(false));
+            assertThat(response.headers().get(HeaderNames.CONTENT_TYPE).get(), is("text/plain; charset=UTF-8"));
+            assertThat(response.headers().contains(HeaderNames.CONTENT_ENCODING), is(false));
+            assertThat(response.headers().contains(HeaderNames.CONTENT_LANGUAGE), is(false));
+            assertThat(response.headers().contains(HeaderNames.CONTENT_LOCATION), is(false));
+            assertThat(response.headers().contains(HeaderNames.CONTENT_DISPOSITION), is(false));
+            assertThat(response.headers().contains(HeaderNames.ETAG), is(false));
+            assertThat(response.headers().contains(HeaderNames.LAST_MODIFIED), is(false));
+            assertThat(response.headers().contains(HeaderNames.ACCEPT_RANGES), is(false));
+            assertThat(response.headers().get(HeaderNames.CACHE_CONTROL).get(), is("no-store"));
+            assertThat(response.headers().get(HeaderNames.VARY).get(), is("Origin"));
         }
     }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.tests;
 
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import io.helidon.common.buffers.DataReader;
 import io.helidon.http.HeaderName;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
@@ -51,6 +53,7 @@ class ErrorHandlingWithOutputStreamTest {
     private static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
     private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
     private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
+    private static final HeaderName CSP_HEADER_NAME = HeaderNames.create("Content-Security-Policy");
 
     private final Http1Client client;
 
@@ -61,6 +64,19 @@ class ErrorHandlingWithOutputStreamTest {
     @SetUpRoute
     static void router(HttpRouting.Builder router) {
         router.error(CustomException.class, new CustomRoutingHandler())
+                .addFilter((chain, req, res) -> {
+                    if (req.path().path().equals("/get-cross-cutting-error")) {
+                        res.beforeSend(() -> res.header(CSP_HEADER_NAME, "default-src 'none'"));
+                        res.streamFilter(Base64.getEncoder()::wrap);
+                    } else if (req.path().path().equals("/get-outputStream")) {
+                        res.entityStreamFilter(_ -> OutputStream.nullOutputStream());
+                        res.entityBeforeSend(() -> res.header(HeaderNames.CONTENT_ENCODING, "stale"));
+                    }
+                    chain.proceed();
+                })
+                .get("get-cross-cutting-error", (_, _) -> {
+                    throw new CustomException();
+                })
                 .get("get-outputStream", (req, res) -> {
                     res.header(MAIN_HEADER_NAME, "x");
                     res.header(HeaderNames.CONTENT_LENGTH, "1");
@@ -79,8 +95,6 @@ class ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.ACCEPT_RANGES, "bytes");
                     res.header(HeaderNames.CACHE_CONTROL, "no-store");
                     res.header(HeaderNames.VARY, "Origin");
-                    res.streamFilter(_ -> OutputStream.nullOutputStream());
-                    res.beforeSend(() -> res.header(HeaderNames.CONTENT_ENCODING, "stale"));
                     res.outputStream();
                     throw new CustomException();
                 })
@@ -126,6 +140,18 @@ class ErrorHandlingWithOutputStreamTest {
         try (var response = client.get().request()) {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.entity().as(String.class), is("ok"));
+        }
+    }
+
+    @Test
+    void testCrossCuttingResponseHooksSurviveErrorReplacement() {
+        try (var response = client.get("/get-cross-cutting-error").request()) {
+            assertAll(
+                    () -> assertThat(response.headers().get(CSP_HEADER_NAME).get(), is("default-src 'none'")),
+                    () -> assertThat(response.entity().as(String.class),
+                                     is(Base64.getEncoder()
+                                                .encodeToString("CustomErrorContent".getBytes(StandardCharsets.UTF_8))))
+            );
         }
     }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -66,7 +66,10 @@ class ErrorHandlingWithOutputStreamTest {
         router.error(CustomException.class, new CustomRoutingHandler())
                 .addFilter((chain, req, res) -> {
                     if (req.path().path().equals("/get-cross-cutting-error")) {
-                        res.beforeSend(() -> res.header(CSP_HEADER_NAME, "default-src 'none'"));
+                        res.beforeSend(() -> {
+                            res.header(CSP_HEADER_NAME, "default-src 'none'");
+                            res.header(HeaderNames.CONTENT_ENCODING, "base64");
+                        });
                         res.streamFilter(Base64.getEncoder()::wrap);
                     } else if (req.path().path().equals("/get-outputStream")) {
                         res.entityStreamFilter(_ -> OutputStream.nullOutputStream());
@@ -148,6 +151,7 @@ class ErrorHandlingWithOutputStreamTest {
         try (var response = client.get("/get-cross-cutting-error").request()) {
             assertAll(
                     () -> assertThat(response.headers().get(CSP_HEADER_NAME).get(), is("default-src 'none'")),
+                    () -> assertThat(response.headers().get(HeaderNames.CONTENT_ENCODING).get(), is("base64")),
                     () -> assertThat(response.entity().as(String.class),
                                      is(Base64.getEncoder()
                                                 .encodeToString("CustomErrorContent".getBytes(StandardCharsets.UTF_8))))

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -52,6 +52,8 @@ class ErrorHandlingWithOutputStreamTest {
     private static final HeaderName STALE_TRAILER_NAME = HeaderNames.create("stale-trailer");
     private static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
     private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
+    private static final HeaderName CONTENT_MD5_NAME = HeaderNames.create("Content-MD5");
+    private static final HeaderName DIGEST_NAME = HeaderNames.create("Digest");
     private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
     private static final HeaderName CSP_HEADER_NAME = HeaderNames.create("Content-Security-Policy");
     private static final HeaderName RESPONSE_SIGNATURE_NAME = HeaderNames.create("Response-Signature");
@@ -95,6 +97,8 @@ class ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.CONTENT_LOCATION, "/stale");
                     res.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
                     res.header(CONTENT_DIGEST_NAME, "sha-256=:YWJjZA==:");
+                    res.header(CONTENT_MD5_NAME, "YWJjZA==");
+                    res.header(DIGEST_NAME, "SHA-256=YWJjZA==");
                     res.header(REPR_DIGEST_NAME, "sha-256=:YWJjZA==:");
                     res.header(HeaderNames.ETAG, "\"stale\"");
                     res.header(HeaderNames.LAST_MODIFIED, "stale");
@@ -183,6 +187,8 @@ class ErrorHandlingWithOutputStreamTest {
             assertThat(response.headers().contains(HeaderNames.CONTENT_LOCATION), is(false));
             assertThat(response.headers().contains(HeaderNames.CONTENT_DISPOSITION), is(false));
             assertThat(response.headers().contains(CONTENT_DIGEST_NAME), is(false));
+            assertThat(response.headers().contains(CONTENT_MD5_NAME), is(false));
+            assertThat(response.headers().contains(DIGEST_NAME), is(false));
             assertThat(response.headers().contains(REPR_DIGEST_NAME), is(false));
             assertThat(response.headers().contains(HeaderNames.ETAG), is(false));
             assertThat(response.headers().contains(HeaderNames.LAST_MODIFIED), is(false));

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -49,6 +49,8 @@ class ErrorHandlingWithOutputStreamTest {
     private static final HeaderName ERROR_HEADER_NAME = HeaderNames.create("error-handler");
     private static final HeaderName STALE_TRAILER_NAME = HeaderNames.create("stale-trailer");
     private static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
+    private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
+    private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
 
     private final Http1Client client;
 
@@ -70,6 +72,8 @@ class ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.CONTENT_LANGUAGE, "en");
                     res.header(HeaderNames.CONTENT_LOCATION, "/stale");
                     res.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
+                    res.header(CONTENT_DIGEST_NAME, "sha-256=:YWJjZA==:");
+                    res.header(REPR_DIGEST_NAME, "sha-256=:YWJjZA==:");
                     res.header(HeaderNames.ETAG, "\"stale\"");
                     res.header(HeaderNames.LAST_MODIFIED, "stale");
                     res.header(HeaderNames.ACCEPT_RANGES, "bytes");
@@ -141,6 +145,8 @@ class ErrorHandlingWithOutputStreamTest {
             assertThat(response.headers().contains(HeaderNames.CONTENT_LANGUAGE), is(false));
             assertThat(response.headers().contains(HeaderNames.CONTENT_LOCATION), is(false));
             assertThat(response.headers().contains(HeaderNames.CONTENT_DISPOSITION), is(false));
+            assertThat(response.headers().contains(CONTENT_DIGEST_NAME), is(false));
+            assertThat(response.headers().contains(REPR_DIGEST_NAME), is(false));
             assertThat(response.headers().contains(HeaderNames.ETAG), is(false));
             assertThat(response.headers().contains(HeaderNames.LAST_MODIFIED), is(false));
             assertThat(response.headers().contains(HeaderNames.ACCEPT_RANGES), is(false));

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -22,8 +22,11 @@ import java.nio.charset.StandardCharsets;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.http.ErrorHandler;
@@ -44,6 +47,8 @@ class ErrorHandlingWithOutputStreamTest {
 
     private static final HeaderName MAIN_HEADER_NAME = HeaderNames.create("main-handler");
     private static final HeaderName ERROR_HEADER_NAME = HeaderNames.create("error-handler");
+    private static final HeaderName STALE_TRAILER_NAME = HeaderNames.create("stale-trailer");
+    private static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
 
     private final Http1Client client;
 
@@ -71,6 +76,12 @@ class ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.CACHE_CONTROL, "no-store");
                     res.header(HeaderNames.VARY, "Origin");
                     res.streamFilter(_ -> OutputStream.nullOutputStream());
+                    res.outputStream();
+                    throw new CustomException();
+                })
+                .get("get-outputStream-stale-trailers", (req, res) -> {
+                    res.beforeTrailers(trailers -> trailers.set(STALE_TRAILER_NAME, "stale"));
+                    res.streamResult("stale-result");
                     res.outputStream();
                     throw new CustomException();
                 })
@@ -139,6 +150,18 @@ class ErrorHandlingWithOutputStreamTest {
     }
 
     @Test
+    void testGetOutputStreamThenErrorClearsStaleTrailerState(WebClient webClient) {
+        ClientResponseTyped<String> response = webClient.get("/get-outputStream-stale-trailers")
+                .header(HeaderValues.TE_TRAILERS)
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.I_AM_A_TEAPOT_418));
+        assertThat(response.entity(), is("CustomErrorContent"));
+        assertThat(response.trailers().contains(STALE_TRAILER_NAME), is(false));
+        assertThat(response.trailers().get(STREAM_RESULT_NAME).get(), is(""));
+    }
+
+    @Test
     void testGetOutputStreamWriteOnceThenError_expect_CustomErrorHandlerMessage() {
         try (var response = client.get("/get-outputStream-writeOnceThenError").request()) {
             assertThat(response.status(), is(Status.I_AM_A_TEAPOT_418));
@@ -189,6 +212,10 @@ class ErrorHandlingWithOutputStreamTest {
             res.header(ERROR_HEADER_NAME, "z");
             // this is now the responsibility of an error handler, as otherwise we may remove CORS headers etc.
             res.headers().remove(MAIN_HEADER_NAME);
+            if (req.path().path().equals("/get-outputStream-stale-trailers")) {
+                res.header(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
+                res.streamFilter(outputStream -> outputStream);
+            }
             res.send("CustomErrorContent");
         }
     }

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ErrorHandlingWithOutputStreamTest.java
@@ -70,6 +70,7 @@ class ErrorHandlingWithOutputStreamTest {
                     res.header(HeaderNames.ACCEPT_RANGES, "bytes");
                     res.header(HeaderNames.CACHE_CONTROL, "no-store");
                     res.header(HeaderNames.VARY, "Origin");
+                    res.streamFilter(_ -> OutputStream.nullOutputStream());
                     res.outputStream();
                     throw new CustomException();
                 })

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandler.java
@@ -29,6 +29,9 @@ public interface ErrorHandler<T extends Throwable> {
      * Error handling consumer.
      * Do not throw an exception from an error handler, it would make this error handler invalid and the exception would be
      * ignored.
+     * <p>
+     * The response retains the status configured before the failure. The error handler is responsible for configuring or
+     * deliberately retaining an appropriate status before sending a replacement response.
      *
      * @param req the server request
      * @param res the server response

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
@@ -145,8 +145,7 @@ public final class ErrorHandlers {
                                         ServerRequest request,
                                         RoutingResponse response,
                                         RequestException e) {
-        // we are only interested in resetting the streams, headers are at the discretion of the error handler
-        if (!response.resetStream()) {
+        if (!response.resetEntity()) {
             HttpPrologue prologue = request.prologue();
             ctx.log(LOGGER, System.Logger.Level.WARNING,
                     "Request failed: %s, cannot send error response, as response already sent",
@@ -219,8 +218,7 @@ public final class ErrorHandlers {
                              RoutingResponse response,
                              Throwable e,
                              ErrorHandler<Throwable> it) {
-        // we are only interested in resetting the streams, headers are at the discretion of the error handler
-        if (!response.resetStream()) {
+        if (!response.resetEntity()) {
             ctx.log(LOGGER,
                     System.Logger.Level.WARNING,
                     "Unable to reset response for error handler, at least part of entity already written. "

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import io.helidon.common.Api;
-import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpPrologue;
 
 /**
@@ -99,34 +98,11 @@ public interface RoutingResponse extends ServerResponse {
      * <p>
      * This resets entity buffers and removes framing, representation, validator, range, and trailer headers.
      * Implementations with separate trailer state must reset that state as well.
-     * <p>
-     * This method calls {@link #resetStream()} and removes entity headers by default.
-     *
      * @return {@code true} if reset was successful and a new entity can be created instead of the existing one,
      *         {@code false} if reset failed and status and headers (and maybe entity bytes) were already sent
      */
     @Api.Internal
-    default boolean resetEntity() {
-        if (!resetStream()) {
-            return false;
-        }
-        var headers = headers();
-        headers.remove(HeaderNames.CONTENT_LENGTH);
-        headers.remove(HeaderNames.TRANSFER_ENCODING);
-        headers.remove(HeaderNames.TRAILER);
-        headers.remove(HeaderNames.CONTENT_RANGE);
-        headers.remove(HeaderNames.CONTENT_TYPE);
-        headers.remove(HeaderNames.CONTENT_ENCODING);
-        headers.remove(HeaderNames.CONTENT_LANGUAGE);
-        headers.remove(HeaderNames.CONTENT_LOCATION);
-        headers.remove(HeaderNames.CONTENT_DISPOSITION);
-        headers.remove(HeaderNames.create("Content-Digest"));
-        headers.remove(HeaderNames.create("Repr-Digest"));
-        headers.remove(HeaderNames.ETAG);
-        headers.remove(HeaderNames.LAST_MODIFIED);
-        headers.remove(HeaderNames.ACCEPT_RANGES);
-        return true;
-    }
+    boolean resetEntity();
 
     /**
      * Configure an infrastructure output stream filter that remains registered when an unsent response entity is reset.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -99,6 +99,8 @@ public interface RoutingResponse extends ServerResponse {
      * Implementations that track entity metadata must override this method to reset entity buffers and remove framing,
      * representation, validator, range, and trailer headers. Implementations with separate trailer state must reset that
      * state as well.
+     * This method does not change the response status. An error handler that replaces the entity is responsible for
+     * configuring or deliberately retaining an appropriate status before sending the replacement response.
      * <p>
      * For compatibility with existing {@link RoutingResponse} implementations, the default implementation calls
      * {@link #resetStream()}.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -95,6 +95,8 @@ public interface RoutingResponse extends ServerResponse {
      * Reset the response entity so an unsent response can be replaced while preserving response metadata unrelated to
      * the entity, such as CORS, cookies, cache controls, and {@code Vary} headers.
      * <p>
+     * This method is intended for Helidon infrastructure that replaces a failed response entity.
+     * <p>
      * This resets entity buffers and removes framing, representation, validator, range, and trailer headers.
      * Implementations with separate trailer state must reset that state as well.
      * <p>
@@ -103,6 +105,7 @@ public interface RoutingResponse extends ServerResponse {
      * @return {@code true} if reset was successful and a new entity can be created instead of the existing one,
      *         {@code false} if reset failed and status and headers (and maybe entity bytes) were already sent
      */
+    @Api.Internal
     default boolean resetEntity() {
         if (!resetStream()) {
             return false;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -96,13 +96,20 @@ public interface RoutingResponse extends ServerResponse {
      * <p>
      * This method is intended for Helidon infrastructure that replaces a failed response entity.
      * <p>
-     * This resets entity buffers and removes framing, representation, validator, range, and trailer headers.
-     * Implementations with separate trailer state must reset that state as well.
+     * Implementations that track entity metadata must override this method to reset entity buffers and remove framing,
+     * representation, validator, range, and trailer headers. Implementations with separate trailer state must reset that
+     * state as well.
+     * <p>
+     * For compatibility with existing {@link RoutingResponse} implementations, the default implementation calls
+     * {@link #resetStream()}.
+     *
      * @return {@code true} if reset was successful and a new entity can be created instead of the existing one,
      *         {@code false} if reset failed and status and headers (and maybe entity bytes) were already sent
      */
     @Api.Internal
-    boolean resetEntity();
+    default boolean resetEntity() {
+        return resetStream();
+    }
 
     /**
      * Configure an infrastructure output stream filter that remains registered when an unsent response entity is reset.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -112,28 +112,30 @@ public interface RoutingResponse extends ServerResponse {
     }
 
     /**
-     * Configure an infrastructure output stream filter that remains registered when an unsent response entity is reset.
+     * Configure an infrastructure output stream filter associated with the current response entity.
      * <p>
-     * This method is intended for Helidon features that must observe or transform both the original response entity and any
-     * replacement entity produced by error handling. Application filters should use {@link #streamFilter(UnaryOperator)}.
+     * Implementations which distinguish entity-scoped filters remove the filter if error handling replaces the unsent
+     * entity. Application filters should use {@link #streamFilter(UnaryOperator)} so they also apply to a replacement
+     * error response. The default fallback registers the filter through the public method and therefore retains it.
      *
      * @param filterFunction function that wraps the response output stream
      */
     @Api.Internal
-    default void persistentStreamFilter(UnaryOperator<OutputStream> filterFunction) {
+    default void entityStreamFilter(UnaryOperator<OutputStream> filterFunction) {
         streamFilter(Objects.requireNonNull(filterFunction));
     }
 
     /**
-     * Register an infrastructure listener that remains registered when an unsent response entity is reset.
+     * Register an infrastructure listener associated with the current response entity.
      * <p>
-     * This method is intended for Helidon features that must prepare both the original response entity and any replacement
-     * entity produced by error handling. Application listeners should use {@link #beforeSend(Runnable)}.
+     * Implementations which distinguish entity-scoped listeners remove the listener if error handling replaces the
+     * unsent entity. Application listeners should use {@link #beforeSend(Runnable)} so they also apply to a replacement
+     * error response. The default fallback registers the listener through the public method and therefore retains it.
      *
      * @param listener listener invoked before the response is sent
      */
     @Api.Internal
-    default void persistentBeforeSend(Runnable listener) {
+    default void entityBeforeSend(Runnable listener) {
         beforeSend(Objects.requireNonNull(listener));
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -16,6 +16,11 @@
 
 package io.helidon.webserver.http;
 
+import java.io.OutputStream;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+import io.helidon.common.Api;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpPrologue;
 
@@ -118,5 +123,18 @@ public interface RoutingResponse extends ServerResponse {
         headers.remove(HeaderNames.LAST_MODIFIED);
         headers.remove(HeaderNames.ACCEPT_RANGES);
         return true;
+    }
+
+    /**
+     * Configure an infrastructure output stream filter that remains registered when an unsent response entity is reset.
+     * <p>
+     * This method is intended for Helidon features that must observe or transform both the original response entity and any
+     * replacement entity produced by error handling. Application filters should use {@link #streamFilter(UnaryOperator)}.
+     *
+     * @param filterFunction function that wraps the response output stream
+     */
+    @Api.Internal
+    default void persistentStreamFilter(UnaryOperator<OutputStream> filterFunction) {
+        streamFilter(Objects.requireNonNull(filterFunction));
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -137,4 +137,17 @@ public interface RoutingResponse extends ServerResponse {
     default void persistentStreamFilter(UnaryOperator<OutputStream> filterFunction) {
         streamFilter(Objects.requireNonNull(filterFunction));
     }
+
+    /**
+     * Register an infrastructure listener that remains registered when an unsent response entity is reset.
+     * <p>
+     * This method is intended for Helidon features that must prepare both the original response entity and any replacement
+     * entity produced by error handling. Application listeners should use {@link #beforeSend(Runnable)}.
+     *
+     * @param listener listener invoked before the response is sent
+     */
+    @Api.Internal
+    default void persistentBeforeSend(Runnable listener) {
+        beforeSend(Objects.requireNonNull(listener));
+    }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http;
 
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpPrologue;
 
 /**
@@ -83,5 +84,37 @@ public interface RoutingResponse extends ServerResponse {
      */
     default boolean resetStream() {
         return reset();
+    }
+
+    /**
+     * Reset the response entity so an unsent response can be replaced while preserving response metadata unrelated to
+     * the entity, such as CORS, cookies, cache controls, and {@code Vary} headers.
+     * <p>
+     * This resets entity buffers and removes framing, representation, validator, range, and trailer headers.
+     * Implementations with separate trailer state must reset that state as well.
+     * <p>
+     * This method calls {@link #resetStream()} and removes entity headers by default.
+     *
+     * @return {@code true} if reset was successful and a new entity can be created instead of the existing one,
+     *         {@code false} if reset failed and status and headers (and maybe entity bytes) were already sent
+     */
+    default boolean resetEntity() {
+        if (!resetStream()) {
+            return false;
+        }
+        var headers = headers();
+        headers.remove(HeaderNames.CONTENT_LENGTH);
+        headers.remove(HeaderNames.TRANSFER_ENCODING);
+        headers.remove(HeaderNames.TRAILER);
+        headers.remove(HeaderNames.CONTENT_RANGE);
+        headers.remove(HeaderNames.CONTENT_TYPE);
+        headers.remove(HeaderNames.CONTENT_ENCODING);
+        headers.remove(HeaderNames.CONTENT_LANGUAGE);
+        headers.remove(HeaderNames.CONTENT_LOCATION);
+        headers.remove(HeaderNames.CONTENT_DISPOSITION);
+        headers.remove(HeaderNames.ETAG);
+        headers.remove(HeaderNames.LAST_MODIFIED);
+        headers.remove(HeaderNames.ACCEPT_RANGES);
+        return true;
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RoutingResponse.java
@@ -112,6 +112,8 @@ public interface RoutingResponse extends ServerResponse {
         headers.remove(HeaderNames.CONTENT_LANGUAGE);
         headers.remove(HeaderNames.CONTENT_LOCATION);
         headers.remove(HeaderNames.CONTENT_DISPOSITION);
+        headers.remove(HeaderNames.create("Content-Digest"));
+        headers.remove(HeaderNames.create("Repr-Digest"));
         headers.remove(HeaderNames.ETAG);
         headers.remove(HeaderNames.LAST_MODIFIED);
         headers.remove(HeaderNames.ACCEPT_RANGES);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -320,6 +320,8 @@ public interface ServerResponse {
     /**
      * Configure a custom output stream to wrap the output stream of the response.
      * The filter remains registered if error handling replaces the unsent response entity.
+     * A filter that changes representation metadata, such as {@code Content-Encoding}, must use
+     * {@link #beforeSend(Runnable)} to configure the matching headers for each entity that is sent.
      *
      * @param filterFunction the function to replace output stream of this response with a user provided one
      */

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -277,6 +277,7 @@ public interface ServerResponse {
      * output stream.
      * The callback is associated with the current response entity and is cleared if error handling replaces that entity
      * before it is sent.
+     * A response-scoped policy should use {@link #beforeSend(Runnable)} to register a fresh callback for each entity.
      *
      * @param beforeTrailers consumer of mutable trailers
      * @return this instance

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -264,6 +264,9 @@ public interface ServerResponse {
 
     /**
      * Response trailers (mutable).
+     * Trailer state is associated with the current response entity and is cleared if error handling replaces that entity
+     * before it is sent.
+     *
      * @return trailers
      * @throws java.lang.IllegalStateException if client didn't ask for trailers with {@code TE: trailers} header in request
      * or response doesn't contain trailer declaration headers {@code Trailer: <trailer-name>}
@@ -273,6 +276,8 @@ public interface ServerResponse {
     /**
      * Callback to update any last minute trailers before they are written to the
      * output stream.
+     * The callback is associated with the current response entity and is cleared if error handling replaces that entity
+     * before it is sent.
      *
      * @param beforeTrailers consumer of mutable trailers
      * @return this instance
@@ -286,6 +291,8 @@ public interface ServerResponse {
      * In case an output stream was used, calling this method will immediately close the stream and return this
      * message as the reason for closing the response.
      * In HTTP/1 this would be in a trailer header
+     * The result is associated with the current response entity and is cleared if error handling replaces that entity
+     * before it is sent.
      *
      * @param result result description
      */

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -200,6 +200,8 @@ public interface ServerResponse {
      * Executed right before the first byte is written to the socket (including response status and headers).
      * Response can be modified (i.e. headers, status) at this point, though modifying the entity may not be done, as
      * this method is most likely called from within one of the {@link #send()} methods.
+     * The listener is associated with the current response entity and may be removed if error handling replaces that entity
+     * before it is sent.
      * <p>
      * Note: this method is implemented as a default method that does nothing, for backward compatibility.
      *

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -200,8 +200,7 @@ public interface ServerResponse {
      * Executed right before the first byte is written to the socket (including response status and headers).
      * Response can be modified (i.e. headers, status) at this point, though modifying the entity may not be done, as
      * this method is most likely called from within one of the {@link #send()} methods.
-     * The listener is associated with the current response entity and may be removed if error handling replaces that entity
-     * before it is sent.
+     * The listener remains registered if error handling replaces the unsent response entity.
      * <p>
      * Note: this method is implemented as a default method that does nothing, for backward compatibility.
      *
@@ -320,8 +319,7 @@ public interface ServerResponse {
 
     /**
      * Configure a custom output stream to wrap the output stream of the response.
-     * The filter is associated with the current response entity and may be removed if error handling replaces that entity
-     * before it is sent.
+     * The filter remains registered if error handling replaces the unsent response entity.
      *
      * @param filterFunction the function to replace output stream of this response with a user provided one
      */

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -103,8 +103,9 @@ public interface ServerResponse {
      * Set header with a value.
      * <p>
      * Headers are mutable response metadata. Once configured, they remain on this response unless later application
-     * code or error handling changes them. Calling {@link #next()}, calling {@link #reroute(String)}, or throwing an
-     * exception does not clear configured headers automatically.
+     * code or error handling changes them. Calling {@link #next()} or {@link #reroute(String)} does not clear configured
+     * headers automatically. If error handling replaces an unsent response entity, it removes entity-specific headers
+     * while preserving response metadata unrelated to the entity.
      * <p>
      * Headers cannot be set after {@link #outputStream()} method is called, or after the response was sent.
      *
@@ -310,6 +311,8 @@ public interface ServerResponse {
 
     /**
      * Configure a custom output stream to wrap the output stream of the response.
+     * The filter is associated with the current response entity and may be removed if error handling replaces that entity
+     * before it is sent.
      *
      * @param filterFunction the function to replace output stream of this response with a user provided one
      */

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
+import io.helidon.common.Api;
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.uri.UriPath;
@@ -154,6 +155,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         return (T) this;
     }
 
+    @Api.Internal
     @Override
     public void entityBeforeSend(Runnable listener) {
         beforeSend.add(Objects.requireNonNull(listener));
@@ -233,6 +235,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         return hasEntity() || isNexted() || shouldReroute();
     }
 
+    @Api.Internal
     @Override
     public boolean resetEntity() {
         if (!resetStream()) {
@@ -274,6 +277,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         streamFilter = addStreamFilter(streamFilter, filterFunction);
     }
 
+    @Api.Internal
     @Override
     public void entityStreamFilter(UnaryOperator<OutputStream> filterFunction) {
         checkStreamFilter(filterFunction);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -86,8 +86,8 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     private UriQuery rerouteQuery;
     private String reroutePath;
     private Consumer<ServerResponseTrailers> beforeTrailers;
-    private Runnable persistentBeforeSend;
-    private UnaryOperator<OutputStream> persistentStreamFilter;
+    private Runnable responseBeforeSend;
+    private UnaryOperator<OutputStream> responseStreamFilter;
     private UnaryOperator<OutputStream> streamFilter;
 
     /**
@@ -142,19 +142,19 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
 
     @Override
     public ServerResponse beforeSend(Runnable listener) {
-        beforeSend.add(Objects.requireNonNull(listener));
-        return (T) this;
-    }
-
-    @Override
-    public void persistentBeforeSend(Runnable listener) {
         Objects.requireNonNull(listener);
-        Runnable current = persistentBeforeSend;
-        persistentBeforeSend = current == null ? listener : () -> {
+        Runnable current = responseBeforeSend;
+        responseBeforeSend = current == null ? listener : () -> {
             current.run();
             listener.run();
         };
         beforeSend.add(listener);
+        return (T) this;
+    }
+
+    @Override
+    public void entityBeforeSend(Runnable listener) {
+        beforeSend.add(Objects.requireNonNull(listener));
     }
 
     @Override
@@ -252,24 +252,24 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         headers.remove(HeaderNames.LAST_MODIFIED);
         headers.remove(HeaderNames.ACCEPT_RANGES);
         beforeSend.clear();
-        if (persistentBeforeSend != null) {
-            beforeSend.add(persistentBeforeSend);
+        if (responseBeforeSend != null) {
+            beforeSend.add(responseBeforeSend);
         }
         beforeTrailers = null;
-        streamFilter = persistentStreamFilter;
+        streamFilter = responseStreamFilter;
         return true;
     }
 
     @Override
     public void streamFilter(UnaryOperator<OutputStream> filterFunction) {
         checkStreamFilter(filterFunction);
+        responseStreamFilter = addStreamFilter(responseStreamFilter, filterFunction);
         streamFilter = addStreamFilter(streamFilter, filterFunction);
     }
 
     @Override
-    public void persistentStreamFilter(UnaryOperator<OutputStream> filterFunction) {
+    public void entityStreamFilter(UnaryOperator<OutputStream> filterFunction) {
         checkStreamFilter(filterFunction);
-        persistentStreamFilter = addStreamFilter(persistentStreamFilter, filterFunction);
         streamFilter = addStreamFilter(streamFilter, filterFunction);
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -246,9 +246,6 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         headers.remove(HeaderNames.TRANSFER_ENCODING);
         headers.remove(HeaderNames.TRAILER);
         headers.remove(HeaderNames.CONTENT_RANGE);
-        if (status != null && status.code() == Status.PARTIAL_CONTENT_206.code()) {
-            status = null;
-        }
         headers.remove(HeaderNames.CONTENT_TYPE);
         headers.remove(HeaderNames.CONTENT_ENCODING);
         headers.remove(HeaderNames.CONTENT_LANGUAGE);
@@ -304,6 +301,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      *
      * @return whether an output stream filter is configured
      */
+    @Api.Internal
     protected final boolean hasStreamFilter() {
         return streamFilter != null;
     }
@@ -314,6 +312,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      * @param outputStream output stream to wrap
      * @return filtered output stream
      */
+    @Api.Internal
     protected final OutputStream applyStreamFilters(OutputStream outputStream) {
         UnaryOperator<OutputStream> filter = streamFilter;
         return filter == null ? outputStream : filter.apply(outputStream);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
@@ -82,6 +84,8 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     private UriQuery rerouteQuery;
     private String reroutePath;
     private Consumer<ServerResponseTrailers> beforeTrailers;
+    private UnaryOperator<OutputStream> persistentStreamFilter;
+    private UnaryOperator<OutputStream> streamFilter;
 
     /**
      * Create server response.
@@ -219,7 +223,21 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
             return false;
         }
         beforeTrailers = null;
+        streamFilter = persistentStreamFilter;
         return true;
+    }
+
+    @Override
+    public void streamFilter(UnaryOperator<OutputStream> filterFunction) {
+        checkStreamFilter(filterFunction);
+        streamFilter = addStreamFilter(streamFilter, filterFunction);
+    }
+
+    @Override
+    public void persistentStreamFilter(UnaryOperator<OutputStream> filterFunction) {
+        checkStreamFilter(filterFunction);
+        persistentStreamFilter = addStreamFilter(persistentStreamFilter, filterFunction);
+        streamFilter = addStreamFilter(streamFilter, filterFunction);
     }
 
     @Override
@@ -235,6 +253,26 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      */
     protected Consumer<ServerResponseTrailers> beforeTrailers() {
         return beforeTrailers;
+    }
+
+    /**
+     * Whether this response has any output stream filters.
+     *
+     * @return whether an output stream filter is configured
+     */
+    protected final boolean hasStreamFilter() {
+        return streamFilter != null;
+    }
+
+    /**
+     * Apply configured output stream filters.
+     *
+     * @param outputStream output stream to wrap
+     * @return filtered output stream
+     */
+    protected final OutputStream applyStreamFilters(OutputStream outputStream) {
+        UnaryOperator<OutputStream> filter = streamFilter;
+        return filter == null ? outputStream : filter.apply(outputStream);
     }
 
     /**
@@ -325,6 +363,24 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         for (Runnable runnable : whenSent) {
             runnable.run();
         }
+    }
+
+    private void checkStreamFilter(UnaryOperator<OutputStream> filterFunction) {
+        if (isSent()) {
+            throw new IllegalStateException("Response already sent");
+        }
+        if (hasEntity()) {
+            throw new IllegalStateException("OutputStream already obtained");
+        }
+        Objects.requireNonNull(filterFunction);
+    }
+
+    private static UnaryOperator<OutputStream> addStreamFilter(UnaryOperator<OutputStream> current,
+                                                               UnaryOperator<OutputStream> filterFunction) {
+        if (current == null) {
+            return filterFunction;
+        }
+        return it -> filterFunction.apply(current.apply(it));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -70,6 +70,8 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     protected static final Header STREAM_TRAILERS =
             HeaderValues.create(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
     private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
+    private static final HeaderName CONTENT_MD5_NAME = HeaderNames.create("Content-MD5");
+    private static final HeaderName DIGEST_NAME = HeaderNames.create("Digest");
     private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
     private static final Header VARY_ACCEPT_ENCODING =
             HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
@@ -250,6 +252,8 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         headers.remove(HeaderNames.CONTENT_LOCATION);
         headers.remove(HeaderNames.CONTENT_DISPOSITION);
         headers.remove(CONTENT_DIGEST_NAME);
+        headers.remove(CONTENT_MD5_NAME);
+        headers.remove(DIGEST_NAME);
         headers.remove(REPR_DIGEST_NAME);
         headers.remove(HeaderNames.ETAG);
         headers.remove(HeaderNames.LAST_MODIFIED);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -241,6 +241,9 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         headers.remove(HeaderNames.TRANSFER_ENCODING);
         headers.remove(HeaderNames.TRAILER);
         headers.remove(HeaderNames.CONTENT_RANGE);
+        if (status != null && status.code() == Status.PARTIAL_CONTENT_206.code()) {
+            status = null;
+        }
         headers.remove(HeaderNames.CONTENT_TYPE);
         headers.remove(HeaderNames.CONTENT_ENCODING);
         headers.remove(HeaderNames.CONTENT_LANGUAGE);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -214,6 +214,15 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     }
 
     @Override
+    public boolean resetEntity() {
+        if (!RoutingResponse.super.resetEntity()) {
+            return false;
+        }
+        beforeTrailers = null;
+        return true;
+    }
+
+    @Override
     public ServerResponse beforeTrailers(Consumer<ServerResponseTrailers> beforeTrailers) {
         this.beforeTrailers = beforeTrailers;
         return this;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -69,6 +69,8 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      */
     protected static final Header STREAM_TRAILERS =
             HeaderValues.create(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
+    private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
+    private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
     private static final Header VARY_ACCEPT_ENCODING =
             HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
     private final ContentEncodingContext contentEncodingContext;
@@ -231,9 +233,24 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
 
     @Override
     public boolean resetEntity() {
-        if (!RoutingResponse.super.resetEntity()) {
+        if (!resetStream()) {
             return false;
         }
+        var headers = headers();
+        headers.remove(HeaderNames.CONTENT_LENGTH);
+        headers.remove(HeaderNames.TRANSFER_ENCODING);
+        headers.remove(HeaderNames.TRAILER);
+        headers.remove(HeaderNames.CONTENT_RANGE);
+        headers.remove(HeaderNames.CONTENT_TYPE);
+        headers.remove(HeaderNames.CONTENT_ENCODING);
+        headers.remove(HeaderNames.CONTENT_LANGUAGE);
+        headers.remove(HeaderNames.CONTENT_LOCATION);
+        headers.remove(HeaderNames.CONTENT_DISPOSITION);
+        headers.remove(CONTENT_DIGEST_NAME);
+        headers.remove(REPR_DIGEST_NAME);
+        headers.remove(HeaderNames.ETAG);
+        headers.remove(HeaderNames.LAST_MODIFIED);
+        headers.remove(HeaderNames.ACCEPT_RANGES);
         beforeSend.clear();
         if (persistentBeforeSend != null) {
             beforeSend.add(persistentBeforeSend);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -84,6 +84,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     private UriQuery rerouteQuery;
     private String reroutePath;
     private Consumer<ServerResponseTrailers> beforeTrailers;
+    private List<Runnable> persistentBeforeSend;
     private UnaryOperator<OutputStream> persistentStreamFilter;
     private UnaryOperator<OutputStream> streamFilter;
 
@@ -139,8 +140,18 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
 
     @Override
     public ServerResponse beforeSend(Runnable listener) {
-        beforeSend.add(listener);
+        beforeSend.add(Objects.requireNonNull(listener));
         return (T) this;
+    }
+
+    @Override
+    public void persistentBeforeSend(Runnable listener) {
+        Objects.requireNonNull(listener);
+        if (persistentBeforeSend == null) {
+            persistentBeforeSend = new ArrayList<>(1);
+        }
+        persistentBeforeSend.add(listener);
+        beforeSend.add(listener);
     }
 
     @Override
@@ -221,6 +232,10 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     public boolean resetEntity() {
         if (!RoutingResponse.super.resetEntity()) {
             return false;
+        }
+        beforeSend.clear();
+        if (persistentBeforeSend != null) {
+            beforeSend.addAll(persistentBeforeSend);
         }
         beforeTrailers = null;
         streamFilter = persistentStreamFilter;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -84,7 +84,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     private UriQuery rerouteQuery;
     private String reroutePath;
     private Consumer<ServerResponseTrailers> beforeTrailers;
-    private List<Runnable> persistentBeforeSend;
+    private Runnable persistentBeforeSend;
     private UnaryOperator<OutputStream> persistentStreamFilter;
     private UnaryOperator<OutputStream> streamFilter;
 
@@ -147,10 +147,11 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     @Override
     public void persistentBeforeSend(Runnable listener) {
         Objects.requireNonNull(listener);
-        if (persistentBeforeSend == null) {
-            persistentBeforeSend = new ArrayList<>(1);
-        }
-        persistentBeforeSend.add(listener);
+        Runnable current = persistentBeforeSend;
+        persistentBeforeSend = current == null ? listener : () -> {
+            current.run();
+            listener.run();
+        };
         beforeSend.add(listener);
     }
 
@@ -235,7 +236,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         }
         beforeSend.clear();
         if (persistentBeforeSend != null) {
-            beforeSend.addAll(persistentBeforeSend);
+            beforeSend.add(persistentBeforeSend);
         }
         beforeTrailers = null;
         streamFilter = persistentStreamFilter;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.HelidonServiceLoader;
@@ -89,8 +88,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     private String streamResult = "";
     private boolean isNoEntityStatus;
     private final boolean validateHeaders;
-
-    private UnaryOperator<OutputStream> outputStreamFilter;
 
     Http1ServerResponse(ConnectionContext ctx,
                         Http1ConnectionListener sendListener,
@@ -215,7 +212,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         // send bytes to writer
         beforeSend();
 
-        if (outputStreamFilter == null && !headers.contains(HeaderNames.TRAILER)) {
+        if (!hasStreamFilter() && !headers.contains(HeaderNames.TRAILER)) {
             byte[] entity = entityBytes(bytes, position, length);
             BufferData bufferData = (bytes != entity) ? responseBuffer(entity)
                     : responseBuffer(entity, position, length);         // no encoding, same length
@@ -352,7 +349,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         if (!super.resetEntity()) {
             return false;
         }
-        outputStreamFilter = null;
         streamResult = "";
         trailers.clear();
         return true;
@@ -412,23 +408,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 };
             }
         });
-    }
-
-    @Override
-    public void streamFilter(UnaryOperator<OutputStream> filterFunction) {
-        if (isSent) {
-            throw new IllegalStateException("Response already sent");
-        }
-        if (streamingEntity) {
-            throw new IllegalStateException("OutputStream already obtained");
-        }
-        Objects.requireNonNull(filterFunction);
-        UnaryOperator<OutputStream> current = this.outputStreamFilter;
-        if (current == null) {
-            this.outputStreamFilter = filterFunction;
-        } else {
-            this.outputStreamFilter = it -> filterFunction.apply(current.apply(it));
-        }
     }
 
     protected Optional<OutputStream> sinkEntityOutputStream(Runnable responsePreparation) {
@@ -564,7 +543,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             encodedOutputStream = contentEncode(outputStream);
             bos.checkResponseHeaders();     // headers can be augmented by encoders
         }
-        return outputStreamFilter == null ? encodedOutputStream : outputStreamFilter.apply(encodedOutputStream);
+        return applyStreamFilters(encodedOutputStream);
     }
 
     boolean keepConnectionOpen() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -352,6 +352,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         if (!super.resetEntity()) {
             return false;
         }
+        outputStreamFilter = null;
         trailers.clear();
         return true;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -348,6 +348,15 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     }
 
     @Override
+    public boolean resetEntity() {
+        if (!super.resetEntity()) {
+            return false;
+        }
+        trailers.clear();
+        return true;
+    }
+
+    @Override
     public void commit() {
         if (outputStream != null) {
             outputStream.commit();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -353,6 +353,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             return false;
         }
         outputStreamFilter = null;
+        streamResult = "";
         trailers.clear();
         return true;
     }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/ErrorHandlersTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/ErrorHandlersTest.java
@@ -142,7 +142,7 @@ class ErrorHandlersTest {
         RoutingResponse res = mock(RoutingResponse.class);
         ListenerContext listenerContext = mock(ListenerContext.class);
 
-        when(res.resetStream()).thenReturn(true);
+        when(res.resetEntity()).thenReturn(true);
         when(req.prologue()).thenReturn(HttpPrologue.create("http/1.0",
                                                             "http",
                                                             "1.0",
@@ -184,7 +184,7 @@ class ErrorHandlersTest {
         ConnectionContext ctx = mock(ConnectionContext.class);
         RoutingRequest req = mock(RoutingRequest.class);
         RoutingResponse res = mock(RoutingResponse.class);
-        when(res.resetStream()).thenReturn(false);
+        when(res.resetEntity()).thenReturn(false);
         ErrorHandlers handlers = ErrorHandlers.create(Map.of(OtherException.class,
                 (request, response, t) -> res.send(t.getMessage())));
         try {
@@ -201,7 +201,7 @@ class ErrorHandlersTest {
         ConnectionContext ctx = mock(ConnectionContext.class);
         RoutingRequest req = mock(RoutingRequest.class);
         RoutingResponse res = mock(RoutingResponse.class);
-        when(res.resetStream()).thenReturn(true);
+        when(res.resetEntity()).thenReturn(true);
 
         when(req.prologue()).thenReturn(HttpPrologue.create("http/1.0",
                                                             "http",
@@ -238,7 +238,7 @@ class ErrorHandlersTest {
         RoutingRequest req = mock(RoutingRequest.class);
         RoutingResponse res = mock(RoutingResponse.class);
         when(res.isSent()).thenReturn(true);
-        when(res.resetStream()).thenReturn(true);
+        when(res.resetEntity()).thenReturn(true);
 
         handlers.runWithErrorHandling(ctx, req, res, () -> {
             throw e;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
@@ -905,7 +905,7 @@ class HttpServiceLocatorTest {
             when(response.hasEntity()).thenAnswer(inv -> entity.get() != null);
             when(response.isSent()).thenAnswer(inv -> entity.get() != null);
             when(response.reset()).thenReturn(true);
-            when(response.resetStream()).thenReturn(true);
+            when(response.resetEntity()).thenReturn(true);
             when(response.status()).thenReturn(Status.OK_200);
             doAnswer(inv -> {
                 entity.set("");

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -20,6 +20,8 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.net.ssl.SSLException;
 
@@ -51,6 +53,30 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class Http1ServerResponseTest {
+
+    @Test
+    void resetEntityPreservesPersistentStreamFilters() {
+        Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
+        List<String> appliedFilters = new ArrayList<>();
+
+        response.persistentStreamFilter(outputStream -> {
+            appliedFilters.add("persistent");
+            return outputStream;
+        });
+        response.streamFilter(outputStream -> {
+            appliedFilters.add("entity");
+            return outputStream;
+        });
+
+        response.outputStream();
+        assertThat(appliedFilters, is(List.of("persistent", "entity")));
+
+        assertThat(response.resetEntity(), is(true));
+        appliedFilters.clear();
+        response.outputStream();
+
+        assertThat(appliedFilters, is(List.of("persistent")));
+    }
 
     @Test
     void resetEntityClearsEntityMetadata() {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -56,6 +56,8 @@ class Http1ServerResponseTest {
     void resetEntityClearsEntityMetadata() {
         Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
         var staleTrailer = HeaderNames.create("x-stale-trailer");
+        var contentDigest = HeaderNames.create("Content-Digest");
+        var reprDigest = HeaderNames.create("Repr-Digest");
 
         response.status(Status.PARTIAL_CONTENT_206);
         response.header(HeaderNames.CONTENT_LENGTH, "1");
@@ -67,6 +69,8 @@ class Http1ServerResponseTest {
         response.header(HeaderNames.CONTENT_LANGUAGE, "en");
         response.header(HeaderNames.CONTENT_LOCATION, "/stale");
         response.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
+        response.header(contentDigest, "sha-256=:YWJjZA==:");
+        response.header(reprDigest, "sha-256=:YWJjZA==:");
         response.header(HeaderNames.ETAG, "\"stale\"");
         response.header(HeaderNames.LAST_MODIFIED, "stale");
         response.header(HeaderNames.ACCEPT_RANGES, "bytes");
@@ -97,6 +101,8 @@ class Http1ServerResponseTest {
                                  response.headers().contains(HeaderNames.CONTENT_LOCATION), is(false)),
                 () -> assertThat(HeaderNames.CONTENT_DISPOSITION.defaultCase(),
                                  response.headers().contains(HeaderNames.CONTENT_DISPOSITION), is(false)),
+                () -> assertThat(contentDigest.defaultCase(), response.headers().contains(contentDigest), is(false)),
+                () -> assertThat(reprDigest.defaultCase(), response.headers().contains(reprDigest), is(false)),
                 () -> assertThat(HeaderNames.ETAG.defaultCase(),
                                  response.headers().contains(HeaderNames.ETAG), is(false)),
                 () -> assertThat(HeaderNames.LAST_MODIFIED.defaultCase(),

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -55,46 +55,46 @@ import static org.mockito.Mockito.when;
 class Http1ServerResponseTest {
 
     @Test
-    void resetEntityPreservesPersistentBeforeSendListeners() {
+    void resetEntityPreservesPublicBeforeSendListeners() {
         Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
         List<String> invokedListeners = new ArrayList<>();
 
-        response.persistentBeforeSend(() -> invokedListeners.add("persistent-1"));
-        response.persistentBeforeSend(() -> invokedListeners.add("persistent-2"));
-        response.beforeSend(() -> invokedListeners.add("entity"));
+        response.beforeSend(() -> invokedListeners.add("public-1"));
+        response.beforeSend(() -> invokedListeners.add("public-2"));
+        response.entityBeforeSend(() -> invokedListeners.add("entity"));
 
         response.outputStream();
-        assertThat(invokedListeners, is(List.of("persistent-1", "persistent-2", "entity")));
+        assertThat(invokedListeners, is(List.of("public-1", "public-2", "entity")));
 
         assertThat(response.resetEntity(), is(true));
         invokedListeners.clear();
         response.outputStream();
 
-        assertThat(invokedListeners, is(List.of("persistent-1", "persistent-2")));
+        assertThat(invokedListeners, is(List.of("public-1", "public-2")));
     }
 
     @Test
-    void resetEntityPreservesPersistentStreamFilters() {
+    void resetEntityPreservesPublicStreamFilters() {
         Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
         List<String> appliedFilters = new ArrayList<>();
 
-        response.persistentStreamFilter(outputStream -> {
-            appliedFilters.add("persistent");
+        response.streamFilter(outputStream -> {
+            appliedFilters.add("public");
             return outputStream;
         });
-        response.streamFilter(outputStream -> {
+        response.entityStreamFilter(outputStream -> {
             appliedFilters.add("entity");
             return outputStream;
         });
 
         response.outputStream();
-        assertThat(appliedFilters, is(List.of("persistent", "entity")));
+        assertThat(appliedFilters, is(List.of("public", "entity")));
 
         assertThat(response.resetEntity(), is(true));
         appliedFilters.clear();
         response.outputStream();
 
-        assertThat(appliedFilters, is(List.of("persistent")));
+        assertThat(appliedFilters, is(List.of("public")));
     }
 
     @Test

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -59,17 +59,18 @@ class Http1ServerResponseTest {
         Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
         List<String> invokedListeners = new ArrayList<>();
 
-        response.persistentBeforeSend(() -> invokedListeners.add("persistent"));
+        response.persistentBeforeSend(() -> invokedListeners.add("persistent-1"));
+        response.persistentBeforeSend(() -> invokedListeners.add("persistent-2"));
         response.beforeSend(() -> invokedListeners.add("entity"));
 
         response.outputStream();
-        assertThat(invokedListeners, is(List.of("persistent", "entity")));
+        assertThat(invokedListeners, is(List.of("persistent-1", "persistent-2", "entity")));
 
         assertThat(response.resetEntity(), is(true));
         invokedListeners.clear();
         response.outputStream();
 
-        assertThat(invokedListeners, is(List.of("persistent")));
+        assertThat(invokedListeners, is(List.of("persistent-1", "persistent-2")));
     }
 
     @Test

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -26,7 +26,10 @@ import javax.net.ssl.SSLException;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketWriterException;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.ServerResponseTrailers;
+import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
@@ -38,6 +41,7 @@ import io.helidon.webserver.WebServer;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,6 +51,63 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class Http1ServerResponseTest {
+
+    @Test
+    void resetEntityClearsEntityMetadata() {
+        Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
+        var staleTrailer = HeaderNames.create("x-stale-trailer");
+
+        response.status(Status.PARTIAL_CONTENT_206);
+        response.header(HeaderNames.CONTENT_LENGTH, "1");
+        response.header(HeaderNames.TRANSFER_ENCODING, "chunked");
+        response.header(HeaderNames.TRAILER, staleTrailer.defaultCase());
+        response.header(HeaderNames.CONTENT_RANGE, "bytes 0-0/1");
+        response.header(HeaderNames.CONTENT_TYPE, "text/plain");
+        response.header(HeaderNames.CONTENT_ENCODING, "br");
+        response.header(HeaderNames.CONTENT_LANGUAGE, "en");
+        response.header(HeaderNames.CONTENT_LOCATION, "/stale");
+        response.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
+        response.header(HeaderNames.ETAG, "\"stale\"");
+        response.header(HeaderNames.LAST_MODIFIED, "stale");
+        response.header(HeaderNames.ACCEPT_RANGES, "bytes");
+        response.header(HeaderNames.CACHE_CONTROL, "no-store");
+        response.header(HeaderNames.VARY, "Origin");
+        ServerResponseTrailers trailers = response.trailers();
+        trailers.set(staleTrailer, "stale");
+
+        assertThat(response.resetEntity(), is(true));
+
+        assertAll(
+                () -> assertThat(response.status(), is(Status.PARTIAL_CONTENT_206)),
+                () -> assertThat(HeaderNames.CONTENT_LENGTH.defaultCase(),
+                                 response.headers().contains(HeaderNames.CONTENT_LENGTH), is(false)),
+                () -> assertThat(HeaderNames.TRANSFER_ENCODING.defaultCase(),
+                                 response.headers().contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                () -> assertThat(HeaderNames.TRAILER.defaultCase(),
+                                 response.headers().contains(HeaderNames.TRAILER), is(false)),
+                () -> assertThat(HeaderNames.CONTENT_RANGE.defaultCase(),
+                                 response.headers().contains(HeaderNames.CONTENT_RANGE), is(false)),
+                () -> assertThat(HeaderNames.CONTENT_TYPE.defaultCase(),
+                                 response.headers().contains(HeaderNames.CONTENT_TYPE), is(false)),
+                () -> assertThat(HeaderNames.CONTENT_ENCODING.defaultCase(),
+                                 response.headers().contains(HeaderNames.CONTENT_ENCODING), is(false)),
+                () -> assertThat(HeaderNames.CONTENT_LANGUAGE.defaultCase(),
+                                 response.headers().contains(HeaderNames.CONTENT_LANGUAGE), is(false)),
+                () -> assertThat(HeaderNames.CONTENT_LOCATION.defaultCase(),
+                                 response.headers().contains(HeaderNames.CONTENT_LOCATION), is(false)),
+                () -> assertThat(HeaderNames.CONTENT_DISPOSITION.defaultCase(),
+                                 response.headers().contains(HeaderNames.CONTENT_DISPOSITION), is(false)),
+                () -> assertThat(HeaderNames.ETAG.defaultCase(),
+                                 response.headers().contains(HeaderNames.ETAG), is(false)),
+                () -> assertThat(HeaderNames.LAST_MODIFIED.defaultCase(),
+                                 response.headers().contains(HeaderNames.LAST_MODIFIED), is(false)),
+                () -> assertThat(HeaderNames.ACCEPT_RANGES.defaultCase(),
+                                 response.headers().contains(HeaderNames.ACCEPT_RANGES), is(false)),
+                () -> assertThat(response.headers().get(HeaderNames.CACHE_CONTROL).get(), is("no-store")),
+                () -> assertThat(response.headers().get(HeaderNames.VARY).get(), is("Origin")),
+                () -> assertThat(staleTrailer.defaultCase(), trailers.contains(staleTrailer), is(false))
+        );
+    }
 
     @Test
     void directSendWrapsUncheckedIOException() {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -55,6 +55,24 @@ import static org.mockito.Mockito.when;
 class Http1ServerResponseTest {
 
     @Test
+    void resetEntityPreservesPersistentBeforeSendListeners() {
+        Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
+        List<String> invokedListeners = new ArrayList<>();
+
+        response.persistentBeforeSend(() -> invokedListeners.add("persistent"));
+        response.beforeSend(() -> invokedListeners.add("entity"));
+
+        response.outputStream();
+        assertThat(invokedListeners, is(List.of("persistent", "entity")));
+
+        assertThat(response.resetEntity(), is(true));
+        invokedListeners.clear();
+        response.outputStream();
+
+        assertThat(invokedListeners, is(List.of("persistent")));
+    }
+
+    @Test
     void resetEntityPreservesPersistentStreamFilters() {
         Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
         List<String> appliedFilters = new ArrayList<>();

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -127,7 +127,7 @@ class Http1ServerResponseTest {
         assertThat(response.resetEntity(), is(true));
 
         assertAll(
-                () -> assertThat(response.status(), is(Status.PARTIAL_CONTENT_206)),
+                () -> assertThat(response.status(), is(Status.OK_200)),
                 () -> assertThat(HeaderNames.CONTENT_LENGTH.defaultCase(),
                                  response.headers().contains(HeaderNames.CONTENT_LENGTH), is(false)),
                 () -> assertThat(HeaderNames.TRANSFER_ENCODING.defaultCase(),

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -102,6 +102,8 @@ class Http1ServerResponseTest {
         Http1ServerResponse response = createResponse(new IllegalStateException("not used"));
         var staleTrailer = HeaderNames.create("x-stale-trailer");
         var contentDigest = HeaderNames.create("Content-Digest");
+        var contentMd5 = HeaderNames.create("Content-MD5");
+        var digest = HeaderNames.create("Digest");
         var reprDigest = HeaderNames.create("Repr-Digest");
 
         response.status(Status.PARTIAL_CONTENT_206);
@@ -115,6 +117,8 @@ class Http1ServerResponseTest {
         response.header(HeaderNames.CONTENT_LOCATION, "/stale");
         response.header(HeaderNames.CONTENT_DISPOSITION, "attachment");
         response.header(contentDigest, "sha-256=:YWJjZA==:");
+        response.header(contentMd5, "YWJjZA==");
+        response.header(digest, "SHA-256=YWJjZA==");
         response.header(reprDigest, "sha-256=:YWJjZA==:");
         response.header(HeaderNames.ETAG, "\"stale\"");
         response.header(HeaderNames.LAST_MODIFIED, "stale");
@@ -147,6 +151,8 @@ class Http1ServerResponseTest {
                 () -> assertThat(HeaderNames.CONTENT_DISPOSITION.defaultCase(),
                                  response.headers().contains(HeaderNames.CONTENT_DISPOSITION), is(false)),
                 () -> assertThat(contentDigest.defaultCase(), response.headers().contains(contentDigest), is(false)),
+                () -> assertThat(contentMd5.defaultCase(), response.headers().contains(contentMd5), is(false)),
+                () -> assertThat(digest.defaultCase(), response.headers().contains(digest), is(false)),
                 () -> assertThat(reprDigest.defaultCase(), response.headers().contains(reprDigest), is(false)),
                 () -> assertThat(HeaderNames.ETAG.defaultCase(),
                                  response.headers().contains(HeaderNames.ETAG), is(false)),

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -131,7 +131,7 @@ class Http1ServerResponseTest {
         assertThat(response.resetEntity(), is(true));
 
         assertAll(
-                () -> assertThat(response.status(), is(Status.OK_200)),
+                () -> assertThat(response.status(), is(Status.PARTIAL_CONTENT_206)),
                 () -> assertThat(HeaderNames.CONTENT_LENGTH.defaultCase(),
                                  response.headers().contains(HeaderNames.CONTENT_LENGTH), is(false)),
                 () -> assertThat(HeaderNames.TRANSFER_ENCODING.defaultCase(),


### PR DESCRIPTION
Pre-requisite for #12058

Reset unsent response entity state before invoking error handling so replacement error responses do not inherit stale content metadata, trailers, or entity-specific filters and listeners.

Preserve infrastructure response filters and listeners across entity replacement. Keep the new `RoutingResponse` hooks internal, with `resetEntity()` delegating to the existing `resetStream()` by default for implementation compatibility.
