### PR TITLE
Wait for all GraphQL tracing spans

### DIFF
--- a/declarative/tests/graphql/src/test/java/io/helidon/declarative/tests/graphql/DeclarativeGraphQlTest.java
+++ b/declarative/tests/graphql/src/test/java/io/helidon/declarative/tests/graphql/DeclarativeGraphQlTest.java
@@ -185,7 +185,7 @@ class DeclarativeGraphQlTest {
 
         assertThat(data.stringValue("tracedHello").orElseThrow(), is("Traced Trace"));
 
-        var spans = spanExporter.spanData("graphql-traced-hello");
+        var spans = spanExporter.spanDataForTrace("graphql-traced-hello", "HTTP Request", "content-write");
         spanExporter.clear();
         SpanData httpRequest = null;
         SpanData contentWrite = null;

--- a/declarative/tests/graphql/src/test/java/io/helidon/declarative/tests/graphql/TestSpanExporter.java
+++ b/declarative/tests/graphql/src/test/java/io/helidon/declarative/tests/graphql/TestSpanExporter.java
@@ -16,7 +16,6 @@
 
 package io.helidon.declarative.tests.graphql;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -27,7 +26,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 
 public class TestSpanExporter implements SpanExporter {
     private final List<SpanData> spanData = new CopyOnWriteArrayList<>();
@@ -57,18 +56,29 @@ public class TestSpanExporter implements SpanExporter {
         return CompletableResultCode.ofSuccess();
     }
 
-    List<SpanData> spanData(String expectedName) {
-        MatcherWithRetry.assertThatWithRetry("Expected span named " + expectedName,
-                                             () -> spanData.stream()
+    List<SpanData> spanDataForTrace(String traceSpanName, String... expectedNames) {
+        MatcherWithRetry.assertThatWithRetry("Expected spans named " + String.join(", ", expectedNames)
+                                                     + " in the same trace as " + traceSpanName,
+                                             () -> spansInTrace(traceSpanName).stream()
                                                      .map(SpanData::getName)
                                                      .toList(),
-                                             hasItem(expectedName),
+                                             hasItems(expectedNames),
                                              120,
                                              500);
-        return new ArrayList<>(spanData);
+        return spansInTrace(traceSpanName);
     }
 
     void clear() {
         spanData.clear();
+    }
+
+    private List<SpanData> spansInTrace(String spanName) {
+        return spanData.stream()
+                .filter(it -> it.getName().equals(spanName))
+                .findFirst()
+                .map(it -> spanData.stream()
+                        .filter(candidate -> candidate.getTraceId().equals(it.getTraceId()))
+                        .toList())
+                .orElseGet(List::of);
     }
 }


### PR DESCRIPTION
The declarative GraphQL tracing test can observe the resolver span before the enclosing request and content-write spans are exported.

Wait for the expected spans from the resolver's trace before asserting their relationships. This prevents unrelated or delayed spans from satisfying the wait and avoids the timing failure observed in #12273.
