### PR TITLE
Avoid CDI tracing lookup during OIDC metadata load

### DIFF
--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
@@ -45,6 +45,7 @@ import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SubjectMappingProvider;
 import io.helidon.security.util.TokenHandler;
 import io.helidon.webclient.api.HttpClientRequest;
+import io.helidon.webclient.api.WebClient;
 
 /**
  * {@link io.helidon.security.spi.SubjectMappingProvider} to obtain roles from IDCS server for a user.
@@ -71,7 +72,8 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
     private final TokenHandler idcsAppNameTokenHandler;
     private final EvictableCache<MtCacheKey, List<Grant>> cache;
     private final MultitenancyEndpoints multitenantEndpoints;
-    private final ConcurrentHashMap<String, AppToken> tokenCache = new ConcurrentHashMap<>();
+    private final RetryableLazyValue<WebClient> appWebClient;
+    private final ConcurrentHashMap<String, RetryableLazyValue<AppToken>> tokenCache = new ConcurrentHashMap<>();
 
     /**
      * Configure instance from any descendant of
@@ -85,6 +87,7 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
         this.idcsTenantTokenHandler = builder.idcsTenantTokenHandler;
         this.idcsAppNameTokenHandler = builder.idcsAppNameTokenHandler;
         this.cache = builder.cache;
+        this.appWebClient = new RetryableLazyValue<>(builder.oidcConfig()::appWebClient);
         if (null == builder.multitentantEndpoints) {
             this.multitenantEndpoints = new DefaultMultitenancyEndpoints(builder.oidcConfig());
         } else {
@@ -288,22 +291,26 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
      */
     protected Optional<String> getAppToken(String idcsTenantId, RoleMapTracing tracing) {
         // if cached and valid, use the cached token
-        return tokenCache.computeIfAbsent(idcsTenantId, key -> {
-            URI tokenEndpoint = multitenantEndpoints.tokenEndpoint(key);
-            OidcConfig oidcConfig = oidcConfig();
+        RetryableLazyValue<AppToken> appToken = tokenCache.computeIfAbsent(
+                idcsTenantId,
+                key -> new RetryableLazyValue<>(() -> createAppToken(key)));
+        return appToken.get().getToken(tracing);
+    }
 
-            if (oidcConfig.tokenEndpointAuthentication() == OidcConfig.ClientAuthentication.CLIENT_SECRET_BASIC
-                    && multitenantEndpoints.useClientCredentials(key, tokenEndpoint)) {
-                return new AppToken(oidcConfig.appWebClient(),
-                                    tokenEndpoint,
-                                    oidcConfig.tokenRefreshSkew(),
-                                    oidcConfig.clientId(),
-                                    oidcConfig.clientSecret());
-            }
+    private AppToken createAppToken(String idcsTenantId) {
+        URI tokenEndpoint = multitenantEndpoints.tokenEndpoint(idcsTenantId);
+        OidcConfig oidcConfig = oidcConfig();
 
-            return new AppToken(oidcConfig.generalWebClient(), tokenEndpoint, oidcConfig.tokenRefreshSkew());
-        })
-                .getToken(tracing);
+        if (oidcConfig.tokenEndpointAuthentication() == OidcConfig.ClientAuthentication.CLIENT_SECRET_BASIC
+                && multitenantEndpoints.useClientCredentials(idcsTenantId, tokenEndpoint)) {
+            return new AppToken(appWebClient.get(),
+                                tokenEndpoint,
+                                oidcConfig.tokenRefreshSkew(),
+                                oidcConfig.clientId(),
+                                oidcConfig.clientSecret());
+        }
+
+        return new AppToken(oidcConfig.generalWebClient(), tokenEndpoint, oidcConfig.tokenRefreshSkew());
     }
 
     /**

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
@@ -45,7 +45,6 @@ import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SubjectMappingProvider;
 import io.helidon.security.util.TokenHandler;
 import io.helidon.webclient.api.HttpClientRequest;
-import io.helidon.webclient.api.WebClient;
 
 /**
  * {@link io.helidon.security.spi.SubjectMappingProvider} to obtain roles from IDCS server for a user.
@@ -472,8 +471,6 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
         private final String urlPrefix;
         private final String assertUrlSuffix;
         private final String tokenUrlSuffix;
-        private final WebClient appClient;
-        private final WebClient generalClient;
 
         // we want to cache endpoints for each tenant
         private final ConcurrentHashMap<String, URI> assertEndpointCache = new ConcurrentHashMap<>();
@@ -503,8 +500,6 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
             urlPrefix = config.identityUri().getScheme() + "://";
             this.assertUrlSuffix = "/admin/v1/Asserter";
             this.tokenUrlSuffix = "/oauth2/v1/token?IDCS_CLIENT_TENANT=";
-            this.generalClient = config.generalWebClient();
-            this.appClient = config.appWebClient();
         }
 
         @Override

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.LazyValue;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
@@ -48,10 +49,9 @@ import io.helidon.webclient.api.HttpClientRequest;
 public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implements SubjectMappingProvider {
     private final EvictableCache<String, List<Grant>> roleCache;
     private final String asserterUri;
-    private final URI tokenEndpointUri;
 
     // caching application token (as that can be re-used for group requests)
-    private final AppToken appToken;
+    private final LazyValue<AppToken> appToken;
 
     /**
      * Constructor that accepts any {@link IdcsRoleMapperProvider.Builder} descendant.
@@ -65,17 +65,7 @@ public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implement
         OidcConfig oidcConfig = builder.oidcConfig();
 
         this.asserterUri = oidcConfig.identityUri() + "/admin/v1/Asserter";
-        this.tokenEndpointUri = oidcConfig.tokenEndpointUri();
-
-        if (oidcConfig.tokenEndpointAuthentication() == OidcConfig.ClientAuthentication.CLIENT_SECRET_BASIC) {
-            this.appToken = new AppToken(oidcConfig.appWebClient(),
-                                         tokenEndpointUri,
-                                         oidcConfig.tokenRefreshSkew(),
-                                         oidcConfig.clientId(),
-                                         oidcConfig.clientSecret());
-        } else {
-            this.appToken = new AppToken(oidcConfig.appWebClient(), tokenEndpointUri, oidcConfig.tokenRefreshSkew());
-        }
+        this.appToken = LazyValue.create(() -> createAppToken(oidcConfig));
     }
 
     /**
@@ -189,7 +179,19 @@ public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implement
 
     // Added for testing purposes
     Optional<String> getAppToken(RoleMapTracing tracing) {
-        return appToken.getToken(tracing);
+        return appToken.get().getToken(tracing);
+    }
+
+    private static AppToken createAppToken(OidcConfig oidcConfig) {
+        URI tokenEndpointUri = oidcConfig.tokenEndpointUri();
+        if (oidcConfig.tokenEndpointAuthentication() == OidcConfig.ClientAuthentication.CLIENT_SECRET_BASIC) {
+            return new AppToken(oidcConfig.appWebClient(),
+                                tokenEndpointUri,
+                                oidcConfig.tokenRefreshSkew(),
+                                oidcConfig.clientId(),
+                                oidcConfig.clientSecret());
+        }
+        return new AppToken(oidcConfig.appWebClient(), tokenEndpointUri, oidcConfig.tokenRefreshSkew());
     }
 
     private List<? extends Grant> obtainGrantsFromServer(String subjectName,

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import io.helidon.common.LazyValue;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
@@ -51,7 +50,7 @@ public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implement
     private final String asserterUri;
 
     // caching application token (as that can be re-used for group requests)
-    private final LazyValue<AppToken> appToken;
+    private final RetryableLazyValue<AppToken> appToken;
 
     /**
      * Constructor that accepts any {@link IdcsRoleMapperProvider.Builder} descendant.
@@ -65,7 +64,7 @@ public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implement
         OidcConfig oidcConfig = builder.oidcConfig();
 
         this.asserterUri = oidcConfig.identityUri() + "/admin/v1/Asserter";
-        this.appToken = LazyValue.create(() -> createAppToken(oidcConfig));
+        this.appToken = new RetryableLazyValue<>(() -> createAppToken(oidcConfig));
     }
 
     /**

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
@@ -23,9 +23,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.context.Context;
@@ -527,6 +529,47 @@ public abstract class IdcsRoleMapperProviderBase implements SubjectMappingProvid
                            e);
             }
             return new AppTokenData();
+        }
+    }
+
+    /**
+     * Shares each initialization attempt with concurrent callers. A successful value remains cached, while a failed
+     * attempt is shared by its callers and replaced so a later call can retry.
+     *
+     * @param <T> type of the initialized value
+     */
+    static final class RetryableLazyValue<T> {
+        private final Supplier<T> supplier;
+        private final AtomicReference<LazyValue<Outcome<T>>> attempt;
+
+        RetryableLazyValue(Supplier<T> supplier) {
+            this.supplier = Objects.requireNonNull(supplier);
+            this.attempt = new AtomicReference<>(newAttempt());
+        }
+
+        T get() {
+            LazyValue<Outcome<T>> currentAttempt = attempt.get();
+            Outcome<T> outcome = currentAttempt.get();
+            RuntimeException failure = outcome.failure();
+            if (failure == null) {
+                return outcome.value();
+            }
+
+            attempt.compareAndSet(currentAttempt, newAttempt());
+            throw failure;
+        }
+
+        private LazyValue<Outcome<T>> newAttempt() {
+            return LazyValue.create(() -> {
+                try {
+                    return new Outcome<>(supplier.get(), null);
+                } catch (RuntimeException e) {
+                    return new Outcome<>(null, e);
+                }
+            });
+        }
+
+        private record Outcome<T>(T value, RuntimeException failure) {
         }
     }
 

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
@@ -101,7 +101,6 @@ public abstract class IdcsRoleMapperProviderBase implements SubjectMappingProvid
      */
     protected IdcsRoleMapperProviderBase(Builder<?> builder) {
         this.oidcConfig = builder.oidcConfig;
-        this.oidcConfig.tokenEndpointUri(); //Remove once IDCS is rewritten to be lazily loaded
         this.defaultIdcsSubjectType = builder.defaultIdcsSubjectType;
         if (builder.supportedTypes.isEmpty()) {
             this.supportedTypes.add(SubjectType.USER);

--- a/security/providers/idcs-mapper/src/test/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderTest.java
+++ b/security/providers/idcs-mapper/src/test/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderTest.java
@@ -341,6 +341,75 @@ class IdcsRoleMapperProviderTest {
         }
     }
 
+    @Test
+    void testMultitenantMetadataLoadsOnFirstTokenRequest() {
+        AtomicInteger metadataRequests = new AtomicInteger();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        JsonObject[] metadata = new JsonObject[1];
+        String accessToken = signedToken();
+
+        WebServer server = WebServer.builder()
+                .host(InetAddress.getLoopbackAddress().getHostAddress())
+                .routing(routing -> routing
+                        .get("/.well-known/openid-configuration", (req, res) -> {
+                            metadataRequests.incrementAndGet();
+                            res.send(metadata[0]);
+                        })
+                        .post("/oauth2/v1/token", (req, res) -> {
+                            authorization.set(req.headers()
+                                                      .first(HeaderNames.AUTHORIZATION)
+                                                      .orElse(null));
+                            res.header(HeaderValues.CONTENT_TYPE_JSON)
+                                    .send("{\"access_token\":\"" + accessToken + "\"}");
+                        }))
+                .build()
+                .start();
+
+        try {
+            String infraHost = "infra.example.test";
+            String tenantId = "tenant1";
+            String tenantHost = tenantId + ".example.test";
+            String baseUri = "http://" + infraHost + ":" + server.port();
+            metadata[0] = JsonObject.builder()
+                    .set("token_endpoint", baseUri + "/oauth2/v1/token")
+                    .set("authorization_endpoint", baseUri + "/oauth2/v1/authorize")
+                    .set("end_session_endpoint", baseUri + "/oauth2/v1/userlogout")
+                    .set("introspection_endpoint", baseUri + "/oauth2/v1/introspect")
+                    .set("issuer", baseUri)
+                    .build();
+
+            OidcConfig oidcConfig = OidcConfig.builder()
+                    .clientId("client-id")
+                    .clientSecret("client-secret")
+                    .identityUri(URI.create(baseUri))
+                    .serverType("idcs")
+                    .validateJwtWithJwk(false)
+                    .webclient(webClient -> webClient.dnsResolver((hostname, dnsAddressLookup) ->
+                                                                           InetAddress.getLoopbackAddress()))
+                    .build();
+            IdcsMtRoleMapperProvider.Builder<?> builder = IdcsMtRoleMapperProvider.builder();
+            builder.oidcConfig(oidcConfig)
+                    .multitenantEndpoints(new TestMultitenancyEndpoints(
+                            oidcConfig,
+                            URI.create("http://" + tenantHost + ":" + server.port()
+                                               + "/oauth2/v1/token?IDCS_CLIENT_TENANT=infra")));
+
+            IdcsMtRoleMapperProvider provider = builder.build();
+
+            assertThat(metadataRequests.get(), is(0));
+
+            Optional<String> token = provider.getAppToken(tenantId, SecurityTracing.get().roleMapTracing("idcs"));
+            String expectedAuthorization = "Basic " + Base64.getEncoder()
+                    .encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
+
+            assertThat(token.orElseThrow(), is(accessToken));
+            assertThat(metadataRequests.get(), is(1));
+            assertThat(authorization.get(), is(expectedAuthorization));
+        } finally {
+            server.stop();
+        }
+    }
+
     private static IdcsRoleMapperProvider.Builder<?> roleMapperBuilder() {
         IdcsRoleMapperProvider.Builder<?> builder = IdcsRoleMapperProvider.builder();
         builder.oidcConfig(OidcConfig.builder()
@@ -408,6 +477,21 @@ class IdcsRoleMapperProviderTest {
         protected List<? extends Grant> addAdditionalGrants(Subject subject, List<Grant> idcsGrants) {
             return List.of(Role.create("additional_" + COUNTER.incrementAndGet()),
                            Role.create("additional-fixed"));
+        }
+    }
+
+    private static final class TestMultitenancyEndpoints
+            extends IdcsMtRoleMapperProvider.DefaultMultitenancyEndpoints {
+        private final URI tokenEndpoint;
+
+        private TestMultitenancyEndpoints(OidcConfig config, URI tokenEndpoint) {
+            super(config);
+            this.tokenEndpoint = tokenEndpoint;
+        }
+
+        @Override
+        public URI tokenEndpoint(String tenantId) {
+            return tokenEndpoint;
         }
     }
 

--- a/security/providers/idcs-mapper/src/test/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderTest.java
+++ b/security/providers/idcs-mapper/src/test/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderTest.java
@@ -279,6 +279,68 @@ class IdcsRoleMapperProviderTest {
         }
     }
 
+    @Test
+    void testSingleTenantMetadataLoadsOnFirstTokenRequest() {
+        AtomicInteger metadataRequests = new AtomicInteger();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        JsonObject[] metadata = new JsonObject[1];
+        String accessToken = signedToken();
+
+        WebServer server = WebServer.builder()
+                .host(InetAddress.getLoopbackAddress().getHostAddress())
+                .routing(routing -> routing
+                        .get("/.well-known/openid-configuration", (req, res) -> {
+                            metadataRequests.incrementAndGet();
+                            res.send(metadata[0]);
+                        })
+                        .post("/oauth2/v1/token", (req, res) -> {
+                            authorization.set(req.headers()
+                                                      .first(HeaderNames.AUTHORIZATION)
+                                                      .orElse(null));
+                            res.header(HeaderValues.CONTENT_TYPE_JSON)
+                                    .send("{\"access_token\":\"" + accessToken + "\"}");
+                        }))
+                .build()
+                .start();
+
+        try {
+            String tokenHost = "idcs-lazy.example.test";
+            String baseUri = "http://" + tokenHost + ":" + server.port();
+            metadata[0] = JsonObject.builder()
+                    .set("token_endpoint", baseUri + "/oauth2/v1/token")
+                    .set("authorization_endpoint", baseUri + "/oauth2/v1/authorize")
+                    .set("end_session_endpoint", baseUri + "/oauth2/v1/userlogout")
+                    .set("introspection_endpoint", baseUri + "/oauth2/v1/introspect")
+                    .set("issuer", baseUri)
+                    .build();
+
+            IdcsRoleMapperProvider.Builder<?> builder = IdcsRoleMapperProvider.builder();
+            builder.oidcConfig(OidcConfig.builder()
+                                       .clientId("client-id")
+                                       .clientSecret("client-secret")
+                                       .identityUri(URI.create(baseUri))
+                                       .serverType("idcs")
+                                       .validateJwtWithJwk(false)
+                                       .webclient(webClient -> webClient.dnsResolver((hostname, dnsAddressLookup) ->
+                                                                                              InetAddress.getLoopbackAddress()))
+                                       .build());
+
+            IdcsRoleMapperProvider provider = builder.build();
+
+            assertThat(metadataRequests.get(), is(0));
+
+            Optional<String> token = provider.getAppToken(SecurityTracing.get().roleMapTracing("idcs"));
+            String expectedAuthorization = "Basic " + Base64.getEncoder()
+                    .encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
+
+            assertThat(token.orElseThrow(), is(accessToken));
+            assertThat(metadataRequests.get(), is(1));
+            assertThat(authorization.get(), is(expectedAuthorization));
+        } finally {
+            server.stop();
+        }
+    }
+
     private static IdcsRoleMapperProvider.Builder<?> roleMapperBuilder() {
         IdcsRoleMapperProvider.Builder<?> builder = IdcsRoleMapperProvider.builder();
         builder.oidcConfig(OidcConfig.builder()

--- a/security/providers/idcs-mapper/src/test/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderTest.java
+++ b/security/providers/idcs-mapper/src/test/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderTest.java
@@ -22,12 +22,21 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntFunction;
 
+import io.helidon.common.Errors;
 import io.helidon.common.parameters.Parameters;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -62,8 +71,10 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableWithSize.iterableWithSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class IdcsRoleMapperProviderTest {
@@ -410,6 +421,164 @@ class IdcsRoleMapperProviderTest {
         }
     }
 
+    @Test
+    void testSingleTenantMetadataFailureIsSharedByConcurrentRequests() throws Exception {
+        assertMetadataFailureSharedByConcurrentRequests(false);
+    }
+
+    @Test
+    void testMultitenantMetadataFailureIsSharedByConcurrentRequests() throws Exception {
+        assertMetadataFailureSharedByConcurrentRequests(true);
+    }
+
+    private void assertMetadataFailureSharedByConcurrentRequests(boolean multitenant) throws Exception {
+        int followerCount = 3;
+        AtomicInteger metadataRequests = new AtomicInteger();
+        AtomicInteger tokenRequests = new AtomicInteger();
+        CountDownLatch firstMetadataRequest = new CountDownLatch(1);
+        CountDownLatch releaseMetadataFailure = new CountDownLatch(1);
+        JsonObject[] metadata = new JsonObject[1];
+        String accessToken = signedToken();
+
+        WebServer server = WebServer.builder()
+                .host(InetAddress.getLoopbackAddress().getHostAddress())
+                .routing(routing -> routing
+                        .get("/.well-known/openid-configuration", (req, res) -> {
+                            if (metadataRequests.incrementAndGet() == 1) {
+                                firstMetadataRequest.countDown();
+                                try {
+                                    releaseMetadataFailure.await();
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                                res.status(Status.INTERNAL_SERVER_ERROR_500)
+                                        .send("metadata unavailable");
+                            } else {
+                                res.send(metadata[0]);
+                            }
+                        })
+                        .post("/oauth2/v1/token", (req, res) -> {
+                            tokenRequests.incrementAndGet();
+                            res.header(HeaderValues.CONTENT_TYPE_JSON)
+                                    .send("{\"access_token\":\"" + accessToken + "\"}");
+                        }))
+                .build()
+                .start();
+        ExecutorService executor = Executors.newFixedThreadPool(followerCount + 1);
+
+        try {
+            String infraHost = "infra.example.test";
+            String tenantHost = "tenant1.example.test";
+            String baseUri = "http://" + infraHost + ":" + server.port();
+            metadata[0] = JsonObject.builder()
+                    .set("token_endpoint", baseUri + "/oauth2/v1/token")
+                    .set("authorization_endpoint", baseUri + "/oauth2/v1/authorize")
+                    .set("end_session_endpoint", baseUri + "/oauth2/v1/userlogout")
+                    .set("introspection_endpoint", baseUri + "/oauth2/v1/introspect")
+                    .set("issuer", baseUri)
+                    .build();
+
+            OidcConfig oidcConfig = OidcConfig.builder()
+                    .clientId("client-id")
+                    .clientSecret("client-secret")
+                    .identityUri(URI.create(baseUri))
+                    .serverType("idcs")
+                    .validateJwtWithJwk(false)
+                    .webclient(webClient -> webClient.dnsResolver((hostname, dnsAddressLookup) ->
+                                                                           InetAddress.getLoopbackAddress()))
+                    .build();
+
+            IntFunction<Optional<String>> tokenRequest;
+            if (multitenant) {
+                IdcsMtRoleMapperProvider.Builder<?> builder = IdcsMtRoleMapperProvider.builder();
+                builder.oidcConfig(oidcConfig)
+                        .multitenantEndpoints(new TestMultitenancyEndpoints(
+                                oidcConfig,
+                                URI.create("http://" + tenantHost + ":" + server.port()
+                                                   + "/oauth2/v1/token?IDCS_CLIENT_TENANT=infra")));
+                IdcsMtRoleMapperProvider provider = builder.build();
+                tokenRequest = requestIndex -> provider.getAppToken(requestIndex % 2 == 0 ? "tenant1" : "tenant2",
+                                                                    SecurityTracing.get().roleMapTracing("idcs"));
+            } else {
+                IdcsRoleMapperProvider.Builder<?> builder = IdcsRoleMapperProvider.builder();
+                builder.oidcConfig(oidcConfig);
+                IdcsRoleMapperProvider provider = builder.build();
+                tokenRequest = requestIndex -> provider.getAppToken(SecurityTracing.get().roleMapTracing("idcs"));
+            }
+
+            List<Future<Optional<String>>> requests = new ArrayList<>();
+            requests.add(executor.submit(() -> tokenRequest.apply(0)));
+            assertThat(firstMetadataRequest.await(10, TimeUnit.SECONDS), is(true));
+
+            CountDownLatch followersAtCallSite = new CountDownLatch(followerCount);
+            Thread[] followerThreads = new Thread[followerCount];
+            for (int i = 1; i <= followerCount; i++) {
+                int requestIndex = i;
+                requests.add(executor.submit(() -> {
+                    followerThreads[requestIndex - 1] = Thread.currentThread();
+                    followersAtCallSite.countDown();
+                    return tokenRequest.apply(requestIndex);
+                }));
+            }
+            assertThat(followersAtCallSite.await(10, TimeUnit.SECONDS), is(true));
+            // A started task can still be descheduled before it reads the current attempt. Wait until every follower
+            // is parked inside the retryable lazy value before allowing that attempt to fail.
+            for (Thread followerThread : followerThreads) {
+                awaitWaitingInRetryableLazyValue(followerThread);
+            }
+            releaseMetadataFailure.countDown();
+
+            RuntimeException firstFailure = null;
+            for (Future<Optional<String>> request : requests) {
+                ExecutionException failure = assertThrows(ExecutionException.class,
+                                                          () -> request.get(10, TimeUnit.SECONDS));
+                assertThat(failure.getCause(), instanceOf(Errors.ErrorMessagesException.class));
+                if (firstFailure == null) {
+                    firstFailure = (RuntimeException) failure.getCause();
+                } else {
+                    assertThat(failure.getCause(), sameInstance(firstFailure));
+                }
+            }
+            assertThat(metadataRequests.get(), is(1));
+            assertThat(tokenRequests.get(), is(0));
+
+            Optional<String> token = tokenRequest.apply(0);
+            assertThat(token.orElseThrow(), is(accessToken));
+            assertThat(metadataRequests.get(), is(2));
+            assertThat(tokenRequests.get(), is(1));
+        } finally {
+            releaseMetadataFailure.countDown();
+            executor.shutdownNow();
+            server.stop();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS), is(true));
+        }
+    }
+
+    private static void awaitWaitingInRetryableLazyValue(Thread thread) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        do {
+            if (waitingInRetryableLazyValue(thread)) {
+                return;
+            }
+            Thread.onSpinWait();
+        } while (deadline - System.nanoTime() > 0);
+        fail("Follower did not join the current initialization attempt: " + thread.getName());
+    }
+
+    private static boolean waitingInRetryableLazyValue(Thread thread) {
+        if (thread.getState() != Thread.State.WAITING) {
+            return false;
+        }
+        String retryableLazyValueClass = IdcsRoleMapperProviderBase.class.getName() + "$RetryableLazyValue";
+        for (StackTraceElement element : thread.getStackTrace()) {
+            if (element.getClassName().equals(retryableLazyValueClass)
+                    && element.getMethodName().equals("get")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static IdcsRoleMapperProvider.Builder<?> roleMapperBuilder() {
         IdcsRoleMapperProvider.Builder<?> builder = IdcsRoleMapperProvider.builder();
         builder.oidcConfig(OidcConfig.builder()
@@ -492,6 +661,11 @@ class IdcsRoleMapperProviderTest {
         @Override
         public URI tokenEndpoint(String tenantId) {
             return tokenEndpoint;
+        }
+
+        @Override
+        public boolean useClientCredentials(String tenantId, URI tokenEndpoint) {
+            return true;
         }
     }
 

--- a/tests/integration/mp-idcs-tracing-startup/pom.xml
+++ b/tests/integration/mp-idcs-tracing-startup/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration-project</artifactId>
+        <version>4.5.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-mp-idcs-tracing-startup</artifactId>
+    <name>Helidon Tests Integration MP IDCS Tracing Startup</name>
+    <description>Verifies IDCS metadata is not loaded during MP telemetry startup.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.telemetry</groupId>
+            <artifactId>helidon-microprofile-telemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.security.providers</groupId>
+            <artifactId>helidon-security-providers-idcs-mapper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-idcs-tracing-startup/src/test/java/io/helidon/tests/integration/idcstracing/IdcsRoleMapperStartupTest.java
+++ b/tests/integration/mp-idcs-tracing-startup/src/test/java/io/helidon/tests/integration/idcstracing/IdcsRoleMapperStartupTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.idcstracing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.net.httpserver.HttpServer;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.microprofile.server.Server;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+class IdcsRoleMapperStartupTest {
+
+    @Test
+    void shouldNotLoadIdcsMetadataDuringMpStartup() throws IOException {
+        AtomicInteger metadataRequests = new AtomicInteger();
+        HttpServer metadataServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        String baseUri = "http://localhost:" + metadataServer.getAddress().getPort();
+        byte[] metadata = ("""
+                {
+                    "token_endpoint": "%1$s/token",
+                    "authorization_endpoint": "%1$s/authorize",
+                    "end_session_endpoint": "%1$s/logout",
+                    "issuer": "%1$s",
+                    "introspection_endpoint": "%1$s/introspect"
+                }
+                """).formatted(baseUri).getBytes(StandardCharsets.UTF_8);
+        metadataServer.createContext("/.well-known/openid-configuration", exchange -> {
+            metadataRequests.incrementAndGet();
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, metadata.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(metadata);
+            }
+        });
+        metadataServer.start();
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("server.port", "0");
+        properties.put("otel.sdk.disabled", "true");
+        properties.put("security.providers.0.idcs-role-mapper.multitenant", "false");
+        properties.put("security.providers.0.idcs-role-mapper.oidc-config.client-id", "test-client");
+        properties.put("security.providers.0.idcs-role-mapper.oidc-config.client-secret", "test-secret");
+        properties.put("security.providers.0.idcs-role-mapper.oidc-config.identity-uri", baseUri);
+
+        Server server = null;
+        try {
+            Config config = Config.create(ConfigSources.create(properties));
+            server = Server.builder()
+                    .config(config)
+                    .host(InetAddress.getLoopbackAddress().getHostAddress())
+                    .port(0)
+                    .build();
+            server.start();
+
+            assertThat(server.port(), greaterThan(0));
+            assertThat(metadataRequests.get(), is(0));
+        } finally {
+            if (server != null && server.port() > 0) {
+                server.stop();
+            }
+            metadataServer.stop(0);
+        }
+    }
+}

--- a/tests/integration/mp-idcs-tracing-startup/src/test/java/io/helidon/tests/integration/idcstracing/IdcsRoleMapperStartupTest.java
+++ b/tests/integration/mp-idcs-tracing-startup/src/test/java/io/helidon/tests/integration/idcstracing/IdcsRoleMapperStartupTest.java
@@ -16,16 +16,21 @@
 
 package io.helidon.tests.integration.idcstracing;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.sun.net.httpserver.HttpServer;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.microprofile.server.Server;
@@ -39,54 +44,138 @@ import static org.hamcrest.Matchers.is;
 class IdcsRoleMapperStartupTest {
 
     @Test
-    void shouldNotLoadIdcsMetadataDuringMpStartup() throws IOException {
-        AtomicInteger metadataRequests = new AtomicInteger();
-        HttpServer metadataServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
-        String baseUri = "http://localhost:" + metadataServer.getAddress().getPort();
-        byte[] metadata = ("""
-                {
-                    "token_endpoint": "%1$s/token",
-                    "authorization_endpoint": "%1$s/authorize",
-                    "end_session_endpoint": "%1$s/logout",
-                    "issuer": "%1$s",
-                    "introspection_endpoint": "%1$s/introspect"
+    void shouldNotLoadSingleTenantIdcsMetadataDuringMpStartup() throws IOException {
+        shouldNotLoadIdcsMetadataDuringMpStartup(false, "localhost");
+    }
+
+    @Test
+    void shouldNotLoadMultitenantIdcsMetadataDuringMpStartup() throws IOException {
+        shouldNotLoadIdcsMetadataDuringMpStartup(true, "127.0.0.1");
+    }
+
+    private void shouldNotLoadIdcsMetadataDuringMpStartup(boolean multitenant, String metadataHost) throws IOException {
+        try (MetadataServer metadataServer = new MetadataServer(metadataHost)) {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("server.port", "0");
+            properties.put("otel.sdk.disabled", "true");
+            properties.put("security.providers.0.idcs-role-mapper.multitenant", Boolean.toString(multitenant));
+            properties.put("security.providers.0.idcs-role-mapper.oidc-config.client-id", "test-client");
+            properties.put("security.providers.0.idcs-role-mapper.oidc-config.client-secret", "test-secret");
+            properties.put("security.providers.0.idcs-role-mapper.oidc-config.identity-uri", metadataServer.baseUri());
+
+            Server server = null;
+            try {
+                Config config = Config.create(ConfigSources.create(properties));
+                server = Server.builder()
+                        .config(config)
+                        .host(InetAddress.getLoopbackAddress().getHostAddress())
+                        .port(0)
+                        .build();
+                server.start();
+
+                assertThat(server.port(), greaterThan(0));
+                assertThat(metadataServer.metadataRequests(), is(0));
+            } finally {
+                if (server != null && server.port() > 0) {
+                    server.stop();
                 }
-                """).formatted(baseUri).getBytes(StandardCharsets.UTF_8);
-        metadataServer.createContext("/.well-known/openid-configuration", exchange -> {
-            metadataRequests.incrementAndGet();
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, metadata.length);
-            try (OutputStream output = exchange.getResponseBody()) {
-                output.write(metadata);
             }
-        });
-        metadataServer.start();
+        }
+    }
 
-        Map<String, String> properties = new HashMap<>();
-        properties.put("server.port", "0");
-        properties.put("otel.sdk.disabled", "true");
-        properties.put("security.providers.0.idcs-role-mapper.multitenant", "false");
-        properties.put("security.providers.0.idcs-role-mapper.oidc-config.client-id", "test-client");
-        properties.put("security.providers.0.idcs-role-mapper.oidc-config.client-secret", "test-secret");
-        properties.put("security.providers.0.idcs-role-mapper.oidc-config.identity-uri", baseUri);
+    private static final class MetadataServer implements AutoCloseable {
+        private final AtomicInteger metadataRequests = new AtomicInteger();
+        private final ServerSocket serverSocket;
+        private final ExecutorService executor;
+        private final String baseUri;
+        private final byte[] metadata;
 
-        Server server = null;
-        try {
-            Config config = Config.create(ConfigSources.create(properties));
-            server = Server.builder()
-                    .config(config)
-                    .host(InetAddress.getLoopbackAddress().getHostAddress())
-                    .port(0)
-                    .build();
-            server.start();
+        private MetadataServer(String host) throws IOException {
+            serverSocket = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+            executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "idcs-metadata-startup-test");
+                thread.setDaemon(true);
+                return thread;
+            });
+            baseUri = "http://" + host + ":" + serverSocket.getLocalPort();
+            metadata = ("""
+                    {
+                        "token_endpoint": "%1$s/token",
+                        "authorization_endpoint": "%1$s/authorize",
+                        "end_session_endpoint": "%1$s/logout",
+                        "issuer": "%1$s",
+                        "introspection_endpoint": "%1$s/introspect"
+                    }
+                    """).formatted(baseUri).getBytes(StandardCharsets.UTF_8);
+            executor.execute(this::serve);
+        }
 
-            assertThat(server.port(), greaterThan(0));
-            assertThat(metadataRequests.get(), is(0));
-        } finally {
-            if (server != null && server.port() > 0) {
-                server.stop();
+        private String baseUri() {
+            return baseUri;
+        }
+
+        private int metadataRequests() {
+            return metadataRequests.get();
+        }
+
+        private void serve() {
+            while (!serverSocket.isClosed()) {
+                try (Socket socket = serverSocket.accept()) {
+                    handle(socket);
+                } catch (IOException e) {
+                    if (!serverSocket.isClosed()) {
+                        throw new IllegalStateException("Metadata test server failed", e);
+                    }
+                }
             }
-            metadataServer.stop(0);
+        }
+
+        private void handle(Socket socket) throws IOException {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                                                                            StandardCharsets.US_ASCII));
+            String requestLine = reader.readLine();
+            String headerLine = reader.readLine();
+            while (headerLine != null && !headerLine.isEmpty()) {
+                headerLine = reader.readLine();
+            }
+
+            boolean metadataRequest = requestLine != null
+                    && requestLine.startsWith("GET /.well-known/openid-configuration ");
+            if (metadataRequest) {
+                metadataRequests.incrementAndGet();
+            }
+
+            byte[] body = metadataRequest ? metadata : new byte[0];
+            String status = metadataRequest ? "200 OK" : "404 Not Found";
+            byte[] headers = ("""
+                    HTTP/1.1 %s\r
+                    Content-Type: application/json\r
+                    Content-Length: %d\r
+                    Connection: close\r
+                    \r
+                    """).formatted(status, body.length).getBytes(StandardCharsets.US_ASCII);
+
+            OutputStream output = socket.getOutputStream();
+            output.write(headers);
+            output.write(body);
+            output.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                serverSocket.close();
+            } finally {
+                executor.shutdown();
+                try {
+                    if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                        executor.shutdownNow();
+                    }
+                } catch (InterruptedException e) {
+                    executor.shutdownNow();
+                    Thread.currentThread().interrupt();
+                }
+            }
         }
     }
 }

--- a/tests/integration/mp-idcs-tracing-startup/src/test/resources/META-INF/beans.xml
+++ b/tests/integration/mp-idcs-tracing-startup/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="annotated"
+       version="4.0">
+</beans>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -56,6 +56,7 @@
         <module>mp-gh-8478</module>
         <module>mp-gh-8495</module>
         <module>mp-gh-8493</module>
+        <module>mp-idcs-tracing-startup</module>
         <module>mp-graphql</module>
         <module>mp-security-client</module>
         <module>mp-ws-services</module>


### PR DESCRIPTION
Fixes #12285

Run well-known metadata discovery with a request-local no-op tracer when no tracer is already available in the Helidon context. This prevents MP startup-time metadata loading from resolving CDI-backed tracing producers before the CDI container is ready.

Add an MP telemetry and IDCS role mapper startup regression test.
