### PR TITLE
Report the selected WebClient response protocol

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import io.helidon.common.Version;
 import io.helidon.common.buffers.BufferData;
@@ -566,6 +567,38 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                                                       CompletableFuture<WebClientServiceRequest> whenSent,
                                                       CompletableFuture<WebClientServiceResponse> whenComplete,
                                                       ClientUri usedUri) {
+        return invokeServices(httpCallChain, whenSent, whenComplete, usedUri, protocolId, null);
+    }
+
+    /**
+     * Invoke configured client services.
+     *
+     * @param whenSent      completable future to be completed when the request is sent over the network
+     * @param whenComplete  completable future to be completed when the request/response interaction finishes
+     * @param httpCallChain invocation of the HTTP request (the actual network call)
+     * @param usedUri       URI configured on the request, combined with the base URI of the client
+     * @param protocolId    supplier of the actual wire protocol ID when known
+     * @return web client service response
+     */
+    protected WebClientServiceResponse invokeServices(WebClientService.Chain httpCallChain,
+                                                      CompletableFuture<WebClientServiceRequest> whenSent,
+                                                      CompletableFuture<WebClientServiceResponse> whenComplete,
+                                                      ClientUri usedUri,
+                                                      Supplier<String> protocolId) {
+        return invokeServices(httpCallChain,
+                              whenSent,
+                              whenComplete,
+                              usedUri,
+                              null,
+                              Objects.requireNonNull(protocolId));
+    }
+
+    private WebClientServiceResponse invokeServices(WebClientService.Chain httpCallChain,
+                                                    CompletableFuture<WebClientServiceRequest> whenSent,
+                                                    CompletableFuture<WebClientServiceResponse> whenComplete,
+                                                    ClientUri usedUri,
+                                                    String protocolId,
+                                                    Supplier<String> protocolIdSupplier) {
 
         // include any stored cookies in request
         cookieManager.request(usedUri, headers, !redirectSensitiveHeadersShouldBeStripped(usedUri));
@@ -573,6 +606,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         WebClientServiceRequest serviceRequest = new ServiceRequestImpl(usedUri,
                                                                         method,
                                                                         protocolId,
+                                                                        protocolIdSupplier,
                                                                         headers,
                                                                         Contexts.context().orElseGet(Context::create),
                                                                         requestId,

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -33,8 +33,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
+import io.helidon.common.Api;
 import io.helidon.common.Version;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.context.Context;
@@ -577,20 +577,19 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
      * @param whenComplete  completable future to be completed when the request/response interaction finishes
      * @param httpCallChain invocation of the HTTP request (the actual network call)
      * @param usedUri       URI configured on the request, combined with the base URI of the client
-     * @param protocolId    supplier of the actual wire protocol ID when known
      * @return web client service response
      */
-    protected WebClientServiceResponse invokeServices(WebClientService.Chain httpCallChain,
+    @Api.Internal
+    protected WebClientServiceResponse invokeServices(WebClientService.WireProtocolChain httpCallChain,
                                                       CompletableFuture<WebClientServiceRequest> whenSent,
                                                       CompletableFuture<WebClientServiceResponse> whenComplete,
-                                                      ClientUri usedUri,
-                                                      Supplier<String> protocolId) {
+                                                      ClientUri usedUri) {
         return invokeServices(httpCallChain,
                               whenSent,
                               whenComplete,
                               usedUri,
                               null,
-                              Objects.requireNonNull(protocolId));
+                              Objects.requireNonNull(httpCallChain));
     }
 
     private WebClientServiceResponse invokeServices(WebClientService.Chain httpCallChain,
@@ -598,7 +597,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                                                     CompletableFuture<WebClientServiceResponse> whenComplete,
                                                     ClientUri usedUri,
                                                     String protocolId,
-                                                    Supplier<String> protocolIdSupplier) {
+                                                    WebClientService.WireProtocolChain wireProtocolChain) {
 
         // include any stored cookies in request
         cookieManager.request(usedUri, headers, !redirectSensitiveHeadersShouldBeStripped(usedUri));
@@ -606,7 +605,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         WebClientServiceRequest serviceRequest = new ServiceRequestImpl(usedUri,
                                                                         method,
                                                                         protocolId,
-                                                                        protocolIdSupplier,
+                                                                        wireProtocolChain,
                                                                         headers,
                                                                         Contexts.context().orElseGet(Context::create),
                                                                         requestId,

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseBase.java
@@ -25,7 +25,7 @@ import io.helidon.http.Status;
  */
 interface ClientResponseBase {
     /**
-     * Actual protocol used on the wire for this response.
+     * Protocol selected by WebClient for this response.
      * <p>
      * The default implementation returns {@code http/1.1}.
      *

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseBase.java
@@ -27,8 +27,7 @@ interface ClientResponseBase {
     /**
      * Actual protocol used on the wire for this response.
      * <p>
-     * The default implementation returns {@code http/1.1} as a best-effort value. Non-Helidon implementations that can
-     * use another wire protocol should override this method; otherwise the returned value may be inaccurate.
+     * The default implementation returns {@code http/1.1}.
      *
      * @return protocol identifier, such as {@code http/1.1}, {@code h2}, or {@code h3}
      */

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,18 @@ import io.helidon.http.Status;
  * Http client response base.
  */
 interface ClientResponseBase {
+    /**
+     * Actual protocol used on the wire for this response.
+     * <p>
+     * The default implementation returns {@code http/1.1} as a best-effort value. Non-Helidon implementations that can
+     * use another wire protocol should override this method; otherwise the returned value may be inaccurate.
+     *
+     * @return protocol identifier, such as {@code http/1.1}, {@code h2}, or {@code h3}
+     */
+    default String protocolId() {
+        return "http/1.1";
+    }
+
     /**
      * Response status.
      *

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
@@ -66,6 +66,11 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
     }
 
     @Override
+    public String protocolId() {
+        return response.protocolId();
+    }
+
+    @Override
     public Status status() {
         return response.status();
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ServiceRequestImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ServiceRequestImpl.java
@@ -19,16 +19,16 @@ package io.helidon.webclient.api;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
 
 import io.helidon.common.context.Context;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Method;
+import io.helidon.webclient.spi.WebClientService;
 
 class ServiceRequestImpl implements WebClientServiceRequest {
     private final Map<String, String> properties;
     private final String protocolId;
-    private final Supplier<String> protocolIdSupplier;
+    private final WebClientService.WireProtocolChain wireProtocolChain;
     private final ClientUri uri;
     private final Method method;
     private final ClientRequestHeaders headers;
@@ -41,7 +41,7 @@ class ServiceRequestImpl implements WebClientServiceRequest {
     ServiceRequestImpl(ClientUri uri,
                        Method method,
                        String protocolId,
-                       Supplier<String> protocolIdSupplier,
+                       WebClientService.WireProtocolChain wireProtocolChain,
                        ClientRequestHeaders headers,
                        Context context,
                        String requestId,
@@ -51,7 +51,7 @@ class ServiceRequestImpl implements WebClientServiceRequest {
         this.uri = uri;
         this.method = method;
         this.protocolId = protocolId;
-        this.protocolIdSupplier = protocolIdSupplier;
+        this.wireProtocolChain = wireProtocolChain;
         this.headers = headers;
         this.context = context;
         this.requestId = requestId;
@@ -72,7 +72,7 @@ class ServiceRequestImpl implements WebClientServiceRequest {
 
     @Override
     public String protocolId() {
-        return protocolIdSupplier == null ? protocolId : protocolIdSupplier.get();
+        return wireProtocolChain == null ? protocolId : wireProtocolChain.protocolId();
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ServiceRequestImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ServiceRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.webclient.api;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 
 import io.helidon.common.context.Context;
 import io.helidon.http.ClientRequestHeaders;
@@ -27,6 +28,7 @@ import io.helidon.http.Method;
 class ServiceRequestImpl implements WebClientServiceRequest {
     private final Map<String, String> properties;
     private final String protocolId;
+    private final Supplier<String> protocolIdSupplier;
     private final ClientUri uri;
     private final Method method;
     private final ClientRequestHeaders headers;
@@ -39,6 +41,7 @@ class ServiceRequestImpl implements WebClientServiceRequest {
     ServiceRequestImpl(ClientUri uri,
                        Method method,
                        String protocolId,
+                       Supplier<String> protocolIdSupplier,
                        ClientRequestHeaders headers,
                        Context context,
                        String requestId,
@@ -48,6 +51,7 @@ class ServiceRequestImpl implements WebClientServiceRequest {
         this.uri = uri;
         this.method = method;
         this.protocolId = protocolId;
+        this.protocolIdSupplier = protocolIdSupplier;
         this.headers = headers;
         this.context = context;
         this.requestId = requestId;
@@ -68,7 +72,7 @@ class ServiceRequestImpl implements WebClientServiceRequest {
 
     @Override
     public String protocolId() {
-        return protocolId;
+        return protocolIdSupplier == null ? protocolId : protocolIdSupplier.get();
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/WebClientServiceRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/WebClientServiceRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,10 +46,11 @@ public interface WebClientServiceRequest {
      * Returns an HTTP protocol ID, mapped to a specific version. This is the same ID that is used for ALPN
      * (protocol negotiation) - {@code http/1.1} for HTTP/1.1 and {@code h2} for HTTP/2.
      * <p>
-     * If communication starts as a {@code HTTP/1.1} with {@code h2c} upgrade, then it will be automatically
-     * upgraded and this method returns {@code HTTP/2.0}.
+     * The selected protocol may change while the downstream service chain executes, for example when an HTTP/2 client
+     * falls back to HTTP/1.1. The request exposes the selected wire protocol when the chain returns and through
+     * {@link #whenSent()} and {@link #whenComplete()}.
      *
-     * @return an HTTP version
+     * @return protocol identifier, such as {@code http/1.1}, {@code h2}, or {@code h3}
      */
     String protocolId();
 

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/WebClientService.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/WebClientService.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.spi;
 
+import io.helidon.common.Api;
 import io.helidon.config.NamedService;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
@@ -58,5 +59,18 @@ public interface WebClientService extends NamedService {
          * @return response from the next service or HTTP call
          */
         WebClientServiceResponse proceed(WebClientServiceRequest clientRequest);
+    }
+
+    /**
+     * Terminal service chain that exposes the currently selected wire protocol.
+     */
+    @Api.Internal
+    interface WireProtocolChain extends Chain {
+        /**
+         * Protocol currently selected for the request.
+         *
+         * @return protocol identifier
+         */
+        String protocolId();
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/WebClientService.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/WebClientService.java
@@ -23,7 +23,6 @@ import io.helidon.webclient.api.WebClientServiceResponse;
 
 /**
  * Extension that can modify web client behavior.
- * This is now only designed for HTTP/1
  */
 @FunctionalInterface
 public interface WebClientService extends NamedService {

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientResponseTypedProtocolIdTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientResponseTypedProtocolIdTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.ClientResponseTrailers;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ReadableEntity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ClientResponseTypedProtocolIdTest {
+    @Test
+    void typedResponseDelegatesProtocolId() {
+        var response = new ClientResponseTypedImpl<>(new Http2Response(), String.class);
+
+        assertThat(response.protocolId(), is("h2"));
+    }
+
+    private static final class Http2Response implements HttpClientResponse {
+        private static final ClientResponseHeaders EMPTY_HEADERS =
+                ClientResponseHeaders.create(WritableHeaders.create());
+
+        @Override
+        public String protocolId() {
+            return "h2";
+        }
+
+        @Override
+        public Status status() {
+            return Status.OK_200;
+        }
+
+        @Override
+        public ClientResponseHeaders headers() {
+            return EMPTY_HEADERS;
+        }
+
+        @Override
+        public ClientResponseTrailers trailers() {
+            return ClientResponseTrailers.create();
+        }
+
+        @Override
+        public ClientUri lastEndpointUri() {
+            return ClientUri.create();
+        }
+
+        @Override
+        public ReadableEntity entity() {
+            throw new AssertionError("Entity should not be requested");
+        }
+
+        @Override
+        public <T> T as(Class<T> type) {
+            return type.cast("entity");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/compatibility/ClientResponseProtocolIdCompatibilityTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/compatibility/ClientResponseProtocolIdCompatibilityTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api.compatibility;
+
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.ClientResponseTrailers;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ReadableEntity;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ClientResponseProtocolIdCompatibilityTest {
+    private static final ClientResponseHeaders EMPTY_HEADERS =
+            ClientResponseHeaders.create(WritableHeaders.create());
+
+    @Test
+    void externalHttpClientResponseImplementationInheritsHttp1Default() {
+        HttpClientResponse response = new ExternalHttpClientResponse();
+
+        assertThat(response.protocolId(), is("http/1.1"));
+    }
+
+    @Test
+    void externalTypedResponseImplementationInheritsHttp1Default() {
+        ClientResponseTyped<String> response = new ExternalTypedResponse();
+
+        assertThat(response.protocolId(), is("http/1.1"));
+    }
+
+    private static final class ExternalHttpClientResponse implements HttpClientResponse {
+        @Override
+        public Status status() {
+            return Status.OK_200;
+        }
+
+        @Override
+        public ClientResponseHeaders headers() {
+            return EMPTY_HEADERS;
+        }
+
+        @Override
+        public ClientResponseTrailers trailers() {
+            return ClientResponseTrailers.create();
+        }
+
+        @Override
+        public ClientUri lastEndpointUri() {
+            return ClientUri.create();
+        }
+
+        @Override
+        public ReadableEntity entity() {
+            throw new AssertionError("Entity should not be requested");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class ExternalTypedResponse implements ClientResponseTyped<String> {
+        @Override
+        public Status status() {
+            return Status.OK_200;
+        }
+
+        @Override
+        public ClientResponseHeaders headers() {
+            return EMPTY_HEADERS;
+        }
+
+        @Override
+        public ClientResponseTrailers trailers() {
+            return ClientResponseTrailers.create();
+        }
+
+        @Override
+        public ClientUri lastEndpointUri() {
+            return ClientUri.create();
+        }
+
+        @Override
+        public String entity() {
+            return "entity";
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/UpgradeResponse.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/UpgradeResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,6 +109,11 @@ public final class UpgradeResponse {
         }
 
         @Override
+        public String protocolId() {
+            return delegate.protocolId();
+        }
+
+        @Override
         public Status status() {
             return delegate.status();
         }
@@ -139,4 +144,3 @@ public final class UpgradeResponse {
         }
     }
 }
-

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/UpgradeResponseProtocolIdTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/UpgradeResponseProtocolIdTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http1;
+
+import java.time.Duration;
+
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.ClientResponseTrailers;
+import io.helidon.http.Status;
+import io.helidon.http.media.ReadableEntity;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+
+class UpgradeResponseProtocolIdTest {
+    @Test
+    void successfulUpgradeResponseDelegatesProtocolWithoutClosingDelegate() {
+        var delegate = new Http2Response();
+        var connection = new TestConnection();
+
+        UpgradeResponse upgrade = UpgradeResponse.success(delegate, connection);
+
+        assertThat(upgrade.isUpgraded(), is(true));
+        assertThat(upgrade.connection(), sameInstance(connection));
+        assertThat(upgrade.response().protocolId(), is("h2"));
+
+        upgrade.response().close();
+        assertThat(delegate.closed, is(false));
+    }
+
+    private static final class Http2Response implements HttpClientResponse {
+        private boolean closed;
+
+        @Override
+        public String protocolId() {
+            return "h2";
+        }
+
+        @Override
+        public Status status() {
+            throw new AssertionError("Status should not be requested");
+        }
+
+        @Override
+        public ClientResponseHeaders headers() {
+            throw new AssertionError("Headers should not be requested");
+        }
+
+        @Override
+        public ClientResponseTrailers trailers() {
+            throw new AssertionError("Trailers should not be requested");
+        }
+
+        @Override
+        public ClientUri lastEndpointUri() {
+            throw new AssertionError("Endpoint should not be requested");
+        }
+
+        @Override
+        public ReadableEntity entity() {
+            throw new AssertionError("Entity should not be requested");
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    private static final class TestConnection implements ClientConnection {
+        @Override
+        public DataReader reader() {
+            throw new AssertionError("Reader should not be requested");
+        }
+
+        @Override
+        public DataWriter writer() {
+            throw new AssertionError("Writer should not be requested");
+        }
+
+        @Override
+        public String channelId() {
+            throw new AssertionError("Channel ID should not be requested");
+        }
+
+        @Override
+        public HelidonSocket helidonSocket() {
+            throw new AssertionError("Socket should not be requested");
+        }
+
+        @Override
+        public void readTimeout(Duration readTimeout) {
+            throw new AssertionError("Read timeout should not be changed");
+        }
+
+        @Override
+        public void closeResource() {
+            throw new AssertionError("Connection should not be closed");
+        }
+    }
+}

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
 import io.helidon.webclient.http1.Http1ClientResponse;
 
@@ -30,6 +31,7 @@ final class Http1FallbackHandler {
     private final CompletableFuture<WebClientServiceRequest> whenSent;
     private final Function<Http1ClientRequest, Http1ClientResponse> responseFunction;
     private final boolean upgradeFailureResponseAllowed;
+    private volatile String actualProtocolId = Http2Client.PROTOCOL_ID;
 
     Http1FallbackHandler(CompletableFuture<WebClientServiceRequest> whenSent,
                          Function<Http1ClientRequest, Http1ClientResponse> responseFunction,
@@ -46,7 +48,7 @@ final class Http1FallbackHandler {
     <T> T invoke(Http1ClientRequest request,
                  WebClientServiceRequest serviceRequest,
                  Supplier<T> responseSupplier) {
-        Context context = Http1FallbackService.context(serviceRequest, whenSent);
+        Context context = Http1FallbackService.context(serviceRequest, this);
         copyFinalHeaders(request, serviceRequest);
         try {
             return Contexts.runInContext(context, responseSupplier::get);
@@ -57,6 +59,7 @@ final class Http1FallbackHandler {
     }
 
     void completeSent(WebClientServiceRequest serviceRequest) {
+        actualProtocolId = Http1Client.PROTOCOL_ID;
         whenSent.complete(serviceRequest);
     }
 
@@ -66,6 +69,10 @@ final class Http1FallbackHandler {
 
     boolean upgradeFailureResponseAllowed() {
         return upgradeFailureResponseAllowed;
+    }
+
+    String actualProtocolId() {
+        return actualProtocolId;
     }
 
     static void copyFinalHeaders(Http1ClientRequest request, WebClientServiceRequest serviceRequest) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackService.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackService.java
@@ -16,8 +16,6 @@
 
 package io.helidon.webclient.http2;
 
-import java.util.concurrent.CompletableFuture;
-
 import io.helidon.common.context.Context;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
@@ -33,9 +31,9 @@ final class Http1FallbackService implements WebClientService {
                 .ifPresent(fallback -> clientRequest.whenSent()
                         .whenComplete((ignored, throwable) -> {
                             if (throwable == null) {
-                                fallback.whenSent().complete(fallback.serviceRequest());
+                                fallback.fallbackHandler().completeSent(fallback.serviceRequest());
                             } else {
-                                fallback.whenSent().completeExceptionally(throwable);
+                                fallback.fallbackHandler().completeSentExceptionally(throwable);
                             }
                         }));
 
@@ -43,13 +41,13 @@ final class Http1FallbackService implements WebClientService {
     }
 
     static Context context(WebClientServiceRequest serviceRequest,
-                           CompletableFuture<WebClientServiceRequest> whenSent) {
+                           Http1FallbackHandler fallbackHandler) {
         Context context = Context.create(serviceRequest.context());
-        context.register(CONTEXT_KEY, new FallbackContext(serviceRequest, whenSent));
+        context.register(CONTEXT_KEY, new FallbackContext(serviceRequest, fallbackHandler));
         return context;
     }
 
     private record FallbackContext(WebClientServiceRequest serviceRequest,
-                                   CompletableFuture<WebClientServiceRequest> whenSent) {
+                                   Http1FallbackHandler fallbackHandler) {
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.ClientRequestHeaders;
@@ -49,7 +50,7 @@ import io.helidon.webclient.spi.WebClientService;
 import static io.helidon.http.HeaderNames.CONTENT_ENCODING;
 import static io.helidon.webclient.api.ClientRequestBase.USER_AGENT_HEADER;
 
-abstract class Http2CallChainBase implements WebClientService.Chain {
+abstract class Http2CallChainBase implements WebClientService.Chain, Supplier<String> {
     private final Http2ClientImpl http2Client;
     private final HttpClientConfig clientConfig;
     private final Http2ClientRequestImpl clientRequest;
@@ -170,6 +171,15 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
     }
 
     void releaseRequestEntity() {
+    }
+
+    @Override
+    public String get() {
+        return actualProtocolId();
+    }
+
+    String actualProtocolId() {
+        return response == null ? http1FallbackHandler.actualProtocolId() : response.protocolId();
     }
 
     CompletableFuture<WebClientServiceResponse> whenComplete() {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.ClientRequestHeaders;
@@ -50,7 +49,7 @@ import io.helidon.webclient.spi.WebClientService;
 import static io.helidon.http.HeaderNames.CONTENT_ENCODING;
 import static io.helidon.webclient.api.ClientRequestBase.USER_AGENT_HEADER;
 
-abstract class Http2CallChainBase implements WebClientService.Chain, Supplier<String> {
+abstract class Http2CallChainBase implements WebClientService.WireProtocolChain {
     private final Http2ClientImpl http2Client;
     private final HttpClientConfig clientConfig;
     private final Http2ClientRequestImpl clientRequest;
@@ -174,11 +173,7 @@ abstract class Http2CallChainBase implements WebClientService.Chain, Supplier<St
     }
 
     @Override
-    public String get() {
-        return actualProtocolId();
-    }
-
-    String actualProtocolId() {
+    public String protocolId() {
         return response == null ? http1FallbackHandler.actualProtocolId() : response.protocolId();
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -84,6 +84,11 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
     }
 
     @Override
+    String actualProtocolId() {
+        return redirectedResponse == null ? super.actualProtocolId() : redirectedResponse.protocolId();
+    }
+
+    @Override
     protected WebClientServiceResponse doProceed(WebClientServiceRequest serviceRequest,
                                                  ClientRequestHeaders headers,
                                                  Http2ClientStream stream) {
@@ -108,6 +113,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             //If cos is marked as interrupted, we know that our interrupted exception has been thrown, but
             //it was intercepted by the user OutputStreamHandler and not rethrown.
             //This is a fallback mechanism to correctly handle such a situations.
+            redirectedResponse = outputStream.response;
             stream(outputStream.stream);
             return outputStream.serviceResponse();
         } else if (!outputStream.closed()) {
@@ -392,16 +398,10 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
         }
 
         WebClientServiceResponse serviceResponse() {
-            if (serviceResponse != null) {
-                return serviceResponse;
+            if (response != null) {
+                return response.toServiceResponse(request, whenComplete);
             }
-
-            return createServiceResponse(request,
-                                         clientConfig,
-                                         stream,
-                                         whenComplete,
-                                         response.status(),
-                                         response.headers());
+            return serviceResponse;
         }
 
         boolean closed() {
@@ -526,7 +526,9 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                     }
                     lastRequest = clientRequest;
 
-                    stream = response.stream();
+                    if (Http2Client.PROTOCOL_ID.equals(response.protocolId())) {
+                        stream = response.stream();
+                    }
 
                     if (RedirectionProcessor.redirectionStatusCode(response.status())) {
                         try (response) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -84,8 +84,8 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
     }
 
     @Override
-    String actualProtocolId() {
-        return redirectedResponse == null ? super.actualProtocolId() : redirectedResponse.protocolId();
+    public String protocolId() {
+        return redirectedResponse == null ? super.protocolId() : redirectedResponse.protocolId();
     }
 
     @Override

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -244,7 +244,11 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         // will create a copy, so we could invoke this method multiple times
         ClientUri resolvedUri = resolvedUri();
 
-        WebClientServiceResponse serviceResponse = invokeServices(callChain, whenSent, whenComplete, resolvedUri);
+        WebClientServiceResponse serviceResponse = invokeServices(callChain,
+                                                                  whenSent,
+                                                                  whenComplete,
+                                                                  resolvedUri,
+                                                                  callChain);
 
         CompletableFuture<Void> complete = new CompletableFuture<>();
         complete.thenAccept(ignored -> serviceResponse.whenComplete().complete(serviceResponse))
@@ -263,8 +267,8 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         boolean hasRequestEntity = retainRequestEntity && callChain.hasRequestEntity();
         Object requestEntity = retainRequestEntity ? callChain.requestEntity() : null;
         long maxBufferedEntitySize = http2Client.protocolConfig().maxBufferedEntitySize().toBytes();
-        // if this was an HTTP/1.1 response, do something different (just re-use response)
         Http2ClientResponseImpl response = new Http2ClientResponseImpl(clientConfig(),
+                                                                       callChain.actualProtocolId(),
                                                                        serviceResponse.status(),
                                                                        callChain.requestHeaders(),
                                                                        serviceResponse.headers(),

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -244,11 +244,7 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         // will create a copy, so we could invoke this method multiple times
         ClientUri resolvedUri = resolvedUri();
 
-        WebClientServiceResponse serviceResponse = invokeServices(callChain,
-                                                                  whenSent,
-                                                                  whenComplete,
-                                                                  resolvedUri,
-                                                                  callChain);
+        WebClientServiceResponse serviceResponse = invokeServices(callChain, whenSent, whenComplete, resolvedUri);
 
         CompletableFuture<Void> complete = new CompletableFuture<>();
         complete.thenAccept(ignored -> serviceResponse.whenComplete().complete(serviceResponse))
@@ -268,7 +264,7 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         Object requestEntity = retainRequestEntity ? callChain.requestEntity() : null;
         long maxBufferedEntitySize = http2Client.protocolConfig().maxBufferedEntitySize().toBytes();
         Http2ClientResponseImpl response = new Http2ClientResponseImpl(clientConfig(),
-                                                                       callChain.actualProtocolId(),
+                                                                       callChain.protocolId(),
                                                                        serviceResponse.status(),
                                                                        callChain.requestHeaders(),
                                                                        serviceResponse.headers(),

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientResponseImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientResponseImpl.java
@@ -42,6 +42,7 @@ import io.helidon.webclient.api.WebClientServiceResponse;
 
 class Http2ClientResponseImpl implements Http2ClientResponse {
     private final HttpClientConfig httpClientConfig;
+    private final String protocolId;
     private final Status responseStatus;
     private final ClientRequestHeaders requestHeaders;
     private final ClientResponseHeaders responseHeaders;
@@ -59,6 +60,7 @@ class Http2ClientResponseImpl implements Http2ClientResponse {
     private boolean entityRequested;
 
     Http2ClientResponseImpl(HttpClientConfig httpClientConfig,
+                            String protocolId,
                             Status status,
                             ClientRequestHeaders requestHeaders,
                             ClientResponseHeaders responseHeaders,
@@ -73,6 +75,7 @@ class Http2ClientResponseImpl implements Http2ClientResponse {
                             boolean hasRequestEntity,
                             Object requestEntity) {
         this.httpClientConfig = httpClientConfig;
+        this.protocolId = protocolId;
         this.responseStatus = status;
         this.requestHeaders = requestHeaders;
         this.responseHeaders = responseHeaders;
@@ -86,6 +89,11 @@ class Http2ClientResponseImpl implements Http2ClientResponse {
         this.maxBufferedEntitySize = maxBufferedEntitySize;
         this.hasRequestEntity = hasRequestEntity;
         this.requestEntity = requestEntity;
+    }
+
+    @Override
+    public String protocolId() {
+        return protocolId;
     }
 
     @Override

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.http2;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.spi.WebClientService;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http1.Http1Config;
+import io.helidon.webserver.http1.Http1ConnectionSelector;
+import io.helidon.webserver.http1.Http1Route;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2ConnectionSelector;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.http2.Http2Upgrader;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.http.Method.GET;
+import static io.helidon.http.Method.POST;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class Http2WireProtocolTest {
+    private static final String HTTP1_SOCKET = "http1";
+
+    private static int http2Port;
+    private static int http1Port;
+
+    Http2WireProtocolTest(WebServer server) {
+        http2Port = server.port();
+        http1Port = server.port(HTTP1_SOCKET);
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder serverBuilder) {
+        Http2Config http2Config = Http2Config.create();
+        HttpRouting.Builder http2Routing = HttpRouting.builder()
+                .route(Http2Route.route(GET, "/h2", (req, res) -> res.send("h2")))
+                .route(Http2Route.route(POST, "/expect-redirect", (req, res) -> {
+                    if (req.headers().containsToken(HeaderValues.EXPECT_100)) {
+                        res.status(Status.SEE_OTHER_303)
+                                .header(HeaderNames.LOCATION, "http://localhost:" + http1Port + "/redirected")
+                                .send();
+                    } else {
+                        res.status(Status.BAD_REQUEST_400).send();
+                    }
+                }))
+                .route(Http2Route.route(POST, "/redirect", (req, res) -> {
+                    req.content().as(String.class);
+                    res.status(Status.SEE_OTHER_303)
+                            .header(HeaderNames.LOCATION, "http://localhost:" + http1Port + "/redirected")
+                            .send();
+                }));
+        HttpRouting.Builder http1Routing = HttpRouting.builder()
+                .route(Http1Route.route(GET, "/fallback", (req, res) -> res.send("http1")))
+                .route(Http1Route.route(GET, "/redirected", (req, res) -> res.send("redirected")));
+
+        serverBuilder
+                .host("localhost")
+                .port(-1)
+                .protocolsDiscoverServices(false)
+                .addConnectionSelector(Http2ConnectionSelector.builder()
+                                               .http2Config(http2Config)
+                                               .build())
+                .addConnectionSelector(Http1ConnectionSelector.builder()
+                                               .config(Http1Config.create())
+                                               .addUpgrader(Http2Upgrader.create(http2Config))
+                                               .build())
+                .putSocket(HTTP1_SOCKET, socket -> socket
+                        .host("localhost")
+                        .port(-1)
+                        .protocolsDiscoverServices(false)
+                        .addConnectionSelector(Http1ConnectionSelector.builder()
+                                                       .config(Http1Config.create())
+                                                       .build()))
+                .routing(http2Routing)
+                .routing(HTTP1_SOCKET, http1Routing);
+    }
+
+    @Test
+    void priorKnowledgeResponseAndServiceReportH2() throws Exception {
+        ProtocolObservations observations = new ProtocolObservations();
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://localhost:" + http2Port)
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .addService(observations)
+                .build();
+        try (Http2ClientResponse response = client.get("/h2").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("h2"));
+            assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
+            assertThat(observations.protocolsAfterProceed(), contains(Http2Client.PROTOCOL_ID));
+            assertThat(observations.protocolsWhenSent(), contains(Http2Client.PROTOCOL_ID));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void failedH2cUpgradeResponseAndServiceReportHttp11() throws Exception {
+        ProtocolObservations observations = new ProtocolObservations();
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://localhost:" + http1Port)
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .addService(observations)
+                .build();
+        try (Http2ClientResponse response = client.get("/fallback").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("http1"));
+            assertThat(response.protocolId(), is(Http1Client.PROTOCOL_ID));
+            assertThat(observations.protocolsAfterProceed(), contains(Http1Client.PROTOCOL_ID));
+            assertThat(observations.protocolsWhenSent(), contains(Http1Client.PROTOCOL_ID));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void outputStreamRedirectReportsFinalProtocol() throws Exception {
+        ProtocolObservations observations = new ProtocolObservations();
+        byte[] entity = "request entity".getBytes(StandardCharsets.UTF_8);
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://localhost:" + http2Port)
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .followRedirects(true)
+                .addService(observations)
+                .build();
+        try (Http2ClientResponse response = client.post("/redirect")
+                .header(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length))
+                .outputStream(out -> {
+                    out.write(entity);
+                    out.close();
+                })) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("redirected"));
+            assertThat(response.protocolId(), is(Http1Client.PROTOCOL_ID));
+            assertThat(observations.protocolsAfterProceed(),
+                       contains(Http1Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID));
+            assertThat(observations.protocolsWhenSent(),
+                       contains(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void expectContinueRedirectReportsFinalProtocol() throws Exception {
+        ProtocolObservations observations = new ProtocolObservations();
+        byte[] entity = "request entity".getBytes(StandardCharsets.UTF_8);
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://localhost:" + http2Port)
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .followRedirects(true)
+                .addService(observations)
+                .build();
+        try (Http2ClientResponse response = client.post("/expect-redirect")
+                .sendExpectContinue(true)
+                .outputStream(out -> {
+                    out.write(entity);
+                    out.close();
+                })) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("redirected"));
+            assertThat(response.protocolId(), is(Http1Client.PROTOCOL_ID));
+            assertThat(observations.protocolsAfterProceed(),
+                       contains(Http1Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID));
+            assertThat(observations.protocolsWhenSent(),
+                       contains(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    private static final class ProtocolObservations implements WebClientService {
+        private final List<String> protocolsAfterProceed = new ArrayList<>();
+        private final List<CompletableFuture<String>> protocolsWhenSent = new ArrayList<>();
+
+        @Override
+        public WebClientServiceResponse handle(Chain chain, WebClientServiceRequest request) {
+            protocolsWhenSent.add(request.whenSent()
+                                          .thenApply(WebClientServiceRequest::protocolId)
+                                          .toCompletableFuture());
+            WebClientServiceResponse response = chain.proceed(request);
+            protocolsAfterProceed.add(request.protocolId());
+            return response;
+        }
+
+        List<String> protocolsAfterProceed() {
+            return List.copyOf(protocolsAfterProceed);
+        }
+
+        List<String> protocolsWhenSent() throws InterruptedException, ExecutionException, TimeoutException {
+            List<String> result = new ArrayList<>(protocolsWhenSent.size());
+            for (CompletableFuture<String> protocol : protocolsWhenSent) {
+                result.add(protocol.get(10, TimeUnit.SECONDS));
+            }
+            return result;
+        }
+    }
+}

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchResponseImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientBatchResponseImpl.java
@@ -49,6 +49,11 @@ class JsonRpcClientBatchResponseImpl implements JsonRpcClientBatchResponse {
     }
 
     @Override
+    public String protocolId() {
+        return delegate.protocolId();
+    }
+
+    @Override
     public int size() {
         return asJsonArray().size();
     }

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseImpl.java
@@ -53,6 +53,11 @@ class JsonRpcClientResponseImpl implements JsonRpcClientResponse {
     }
 
     @Override
+    public String protocolId() {
+        return delegate.protocolId();
+    }
+
+    @Override
     public Optional<JsonValue> rpcId() {
         return asJsonObject().value("id");
     }

--- a/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseProtocolIdTest.java
+++ b/webclient/jsonrpc/src/test/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseProtocolIdTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.jsonrpc;
+
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.ClientResponseTrailers;
+import io.helidon.http.Status;
+import io.helidon.http.media.ReadableEntity;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.HttpClientResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JsonRpcClientResponseProtocolIdTest {
+    @Test
+    void singleResponseDelegatesProtocolId() {
+        var response = new JsonRpcClientResponseImpl(new Http2Response());
+
+        assertThat(response.protocolId(), is("h2"));
+    }
+
+    @Test
+    void batchResponseDelegatesProtocolId() {
+        var response = new JsonRpcClientBatchResponseImpl(new Http2Response());
+
+        assertThat(response.protocolId(), is("h2"));
+    }
+
+    private static final class Http2Response implements HttpClientResponse {
+        @Override
+        public String protocolId() {
+            return "h2";
+        }
+
+        @Override
+        public Status status() {
+            throw new AssertionError("Status should not be requested");
+        }
+
+        @Override
+        public ClientResponseHeaders headers() {
+            throw new AssertionError("Headers should not be requested");
+        }
+
+        @Override
+        public ClientResponseTrailers trailers() {
+            throw new AssertionError("Trailers should not be requested");
+        }
+
+        @Override
+        public ClientUri lastEndpointUri() {
+            throw new AssertionError("Endpoint should not be requested");
+        }
+
+        @Override
+        public ReadableEntity entity() {
+            throw new AssertionError("Entity should not be requested");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
Pre-requisite for #3686

Adds a compatible response API for reporting the protocol selected by WebClient. Existing response implementations default to `http/1.1`, while Helidon implementations report the selected protocol and transparent response wrappers preserve it.

HTTP/2 requests track fallback and redirects so services and final responses observe `h2` or `http/1.1` at the appropriate point. A typed internal service-chain contract carries dynamic protocol selection without generic supplier plumbing.
