### PR TITLE
Share HPACK and QPACK Huffman codec

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/HuffmanCodec.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/HuffmanCodec.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This class is mostly copied from Netty.
+ * Original Copyright:
+ *
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.buffers;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+import io.helidon.common.Api;
+
+/**
+ * HPACK and QPACK Huffman codec defined by RFC 7541, Appendix B.
+ */
+@Api.Internal
+public final class HuffmanCodec {
+    private HuffmanCodec() {
+    }
+
+    /**
+     * Calculate the encoded length of a value.
+     *
+     * @param value octet-valued characters to encode
+     * @return encoded byte count
+     * @throws java.lang.IllegalArgumentException if a character is outside the octet range or the encoded length
+     *                                            exceeds the supported array range
+     */
+    public static int encodedLength(CharSequence value) {
+        Objects.requireNonNull(value, "value");
+        long bitLength = 0;
+        for (int i = 0; i < value.length(); i++) {
+            bitLength += HuffmanTables.HUFFMAN_CODE_LENGTHS[octet(value.charAt(i))];
+        }
+        long byteLength = (bitLength + 7) >>> 3;
+        if (byteLength > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Encoded Huffman value is too long: " + byteLength);
+        }
+        return (int) byteLength;
+    }
+
+    /**
+     * Encode a value into a destination byte array.
+     * <p>
+     * If the destination is too small, its contents are undefined and must be discarded.
+     *
+     * @param value octet-valued characters to encode
+     * @param destination destination byte array
+     * @return encoded byte count, or {@code -1} if the destination is too small
+     * @throws java.lang.IllegalArgumentException if a character is outside the octet range
+     */
+    public static int encode(CharSequence value, byte[] destination) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(destination, "destination");
+
+        int index = 0;
+        long current = 0;
+        int bitCount = 0;
+
+        for (int i = 0; i < value.length(); i++) {
+            int octet = octet(value.charAt(i));
+            int code = HuffmanTables.HUFFMAN_CODES[octet];
+            int codeLength = HuffmanTables.HUFFMAN_CODE_LENGTHS[octet];
+
+            current <<= codeLength;
+            current |= code;
+            bitCount += codeLength;
+
+            while (bitCount >= 8) {
+                if (index == destination.length) {
+                    return -1;
+                }
+                bitCount -= 8;
+                destination[index++] = (byte) (current >> bitCount);
+            }
+        }
+
+        if (bitCount > 0) {
+            if (index == destination.length) {
+                return -1;
+            }
+            current <<= 8 - bitCount;
+            current |= 0xFF >>> bitCount;
+            destination[index++] = (byte) current;
+        }
+
+        return index;
+    }
+
+    /**
+     * Decode bytes into a destination byte array.
+     * <p>
+     * Invalid input may partially advance the source and modify the destination. Range and capacity failures are
+     * detected before either is modified.
+     *
+     * @param source encoded bytes
+     * @param encodedLength encoded byte count
+     * @param destination decoded byte destination
+     * @return decoded byte count
+     * @throws java.lang.IndexOutOfBoundsException if the encoded range exceeds the source or the destination cannot
+     *                                             hold the maximum possible decoded value
+     * @throws java.lang.IllegalArgumentException if the input is malformed
+     */
+    public static int decode(BufferData source, int encodedLength, byte[] destination) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(destination, "destination");
+        Objects.checkFromIndexSize(0, encodedLength, source.available());
+        long maximumDecodedLength = (long) encodedLength * 8 / 5;
+        if (maximumDecodedLength > destination.length) {
+            throw new IndexOutOfBoundsException("Decoded Huffman value may require " + maximumDecodedLength
+                                                       + " bytes, destination has " + destination.length);
+        }
+
+        int destinationIndex = 0;
+        int state = 0;
+
+        for (int i = 0; i < encodedLength; i++) {
+            int input = source.read();
+
+            state = transition(state, input >> 4);
+            if ((state & HuffmanTables.HUFFMAN_EMIT_SYMBOL_SHIFT) != 0) {
+                destination[destinationIndex++] = (byte) state;
+            }
+
+            state = transition(state, input);
+            if ((state & HuffmanTables.HUFFMAN_EMIT_SYMBOL_SHIFT) != 0) {
+                destination[destinationIndex++] = (byte) state;
+            }
+        }
+
+        validateCompletion(state, encodedLength);
+        return destinationIndex;
+    }
+
+    /**
+     * Decode bytes into an appendable.
+     * <p>
+     * Invalid input or an append failure may partially advance the source and modify the destination. Range failures
+     * are detected before either is modified.
+     *
+     * @param source encoded bytes
+     * @param encodedLength encoded byte count
+     * @param destination decoded character destination
+     * @throws java.lang.IndexOutOfBoundsException if the encoded range exceeds the source
+     * @throws java.lang.IllegalArgumentException if the input is malformed
+     * @throws java.io.UncheckedIOException if appending fails
+     */
+    public static void decode(BufferData source, int encodedLength, Appendable destination) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(destination, "destination");
+        Objects.checkFromIndexSize(0, encodedLength, source.available());
+
+        int state = 0;
+
+        for (int i = 0; i < encodedLength; i++) {
+            int input = source.read();
+
+            state = transition(state, input >> 4);
+            if ((state & HuffmanTables.HUFFMAN_EMIT_SYMBOL_SHIFT) != 0) {
+                append(destination, (char) (state & 0xFF));
+            }
+
+            state = transition(state, input);
+            if ((state & HuffmanTables.HUFFMAN_EMIT_SYMBOL_SHIFT) != 0) {
+                append(destination, (char) (state & 0xFF));
+            }
+        }
+
+        validateCompletion(state, encodedLength);
+    }
+
+    private static int octet(char value) {
+        if (value > 0xFF) {
+            throw new IllegalArgumentException("Character is outside the octet range: " + (int) value);
+        }
+        return value;
+    }
+
+    private static int transition(int state, int input) {
+        int next = HuffmanTables.HUFFS[state >> 12 | (input & 0x0F)];
+        if ((next & HuffmanTables.HUFFMAN_FAIL_SHIFT) != 0) {
+            throw new IllegalArgumentException("Cannot decode Huffman encoded value");
+        }
+        return next;
+    }
+
+    private static void append(Appendable destination, char value) {
+        try {
+            destination.append(value);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to append decoded Huffman data", e);
+        }
+    }
+
+    private static void validateCompletion(int state, int encodedLength) {
+        if (encodedLength != 0
+                && (state & HuffmanTables.HUFFMAN_COMPLETE_SHIFT) != HuffmanTables.HUFFMAN_COMPLETE_SHIFT) {
+            throw new IllegalArgumentException("Huffman encoding has invalid padding or is truncated");
+        }
+    }
+}

--- a/common/buffers/src/main/java/io/helidon/common/buffers/HuffmanCodec.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/HuffmanCodec.java
@@ -72,7 +72,8 @@ public final class HuffmanCodec {
     /**
      * Encode a value into a destination byte array.
      * <p>
-     * If the destination is too small, its contents are undefined and must be discarded.
+     * If encoding is unsuccessful, the destination contents are undefined and must be discarded. A destination that
+     * is too small can be detected before all characters have been validated.
      *
      * @param value octet-valued characters to encode
      * @param destination destination byte array

--- a/common/buffers/src/main/java/io/helidon/common/buffers/HuffmanTables.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/HuffmanTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,27 @@
  * limitations under the License.
  */
 
-package io.helidon.http.http2;
+/*
+ * This class is mostly copied from Netty.
+ * Original Copyright:
+ *
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.buffers;
 
-final class Http2HuffmanConstants {
+final class HuffmanTables {
     static final byte HUFFMAN_COMPLETE = 1;
     static final int HUFFMAN_COMPLETE_SHIFT = HUFFMAN_COMPLETE << 8;
     static final byte HUFFMAN_EMIT_SYMBOL = 1 << 1;
@@ -4922,6 +4940,6 @@ final class Http2HuffmanConstants {
 
     static final int HUFFMAN_EOS = 256;
 
-    private Http2HuffmanConstants() {
+    private HuffmanTables() {
     }
 }

--- a/common/buffers/src/main/java/io/helidon/common/buffers/HuffmanTables.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/HuffmanTables.java
@@ -14,24 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * This class is mostly copied from Netty.
- * Original Copyright:
- *
- * Copyright 2014 Twitter, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.helidon.common.buffers;
 
 final class HuffmanTables {

--- a/common/buffers/src/test/java/io/helidon/common/buffers/HuffmanCodecTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/HuffmanCodecTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.buffers;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HexFormat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HuffmanCodecTest {
+    private static final HexFormat HEX = HexFormat.of();
+
+    @ParameterizedTest
+    @CsvSource({
+            "www.example.com, f1e3c2e5f23a6ba0ab90f4ff",
+            "no-cache, a8eb10649cbf",
+            "custom-key, 25a849e95ba97d7f",
+            "custom-value, 25a849e95bb8e8b4bf"
+    })
+    void rfc7541Examples(String value, String encodedHex) {
+        byte[] expected = HEX.parseHex(encodedHex);
+
+        assertThat(HuffmanCodec.encodedLength(value), is(expected.length));
+
+        byte[] encoded = new byte[expected.length];
+        assertThat(HuffmanCodec.encode(value, encoded), is(expected.length));
+        assertArrayEquals(expected, encoded);
+
+        byte[] decoded = new byte[expected.length * 8 / 5];
+        int decodedLength = HuffmanCodec.decode(BufferData.create(expected), expected.length, decoded);
+        assertArrayEquals(value.getBytes(StandardCharsets.ISO_8859_1), Arrays.copyOf(decoded, decodedLength));
+
+        StringBuilder decodedText = new StringBuilder();
+        HuffmanCodec.decode(BufferData.create(expected), expected.length, decodedText);
+        assertThat(decodedText.toString(), is(value));
+    }
+
+    @Test
+    void roundTripsEveryOctet() {
+        StringBuilder value = new StringBuilder(256);
+        for (int i = 0; i < 256; i++) {
+            value.append((char) i);
+        }
+
+        byte[] encoded = new byte[HuffmanCodec.encodedLength(value)];
+        int encodedLength = HuffmanCodec.encode(value, encoded);
+        assertThat(encodedLength, is(encoded.length));
+
+        byte[] decoded = new byte[encodedLength * 8 / 5];
+        int decodedLength = HuffmanCodec.decode(BufferData.create(encoded), encodedLength, decoded);
+        assertArrayEquals(value.toString().getBytes(StandardCharsets.ISO_8859_1),
+                          Arrays.copyOf(decoded, decodedLength));
+
+        StringBuilder decodedText = new StringBuilder();
+        HuffmanCodec.decode(BufferData.create(encoded), encodedLength, decodedText);
+        assertThat(decodedText.toString(), is(value.toString()));
+    }
+
+    @Test
+    void acceptsEmptyInput() {
+        assertThat(HuffmanCodec.encodedLength(""), is(0));
+        assertThat(HuffmanCodec.encode("", new byte[0]), is(0));
+
+        BufferData byteSource = BufferData.create(new byte[0]);
+        assertThat(HuffmanCodec.decode(byteSource, 0, new byte[0]), is(0));
+        assertThat(byteSource.available(), is(0));
+
+        BufferData textSource = BufferData.create(new byte[0]);
+        StringBuilder decodedText = new StringBuilder("unchanged");
+        HuffmanCodec.decode(textSource, 0, decodedText);
+        assertThat(decodedText.toString(), is("unchanged"));
+        assertThat(textSource.available(), is(0));
+    }
+
+    @Test
+    void reportsShortEncodeDestination() {
+        String value = "www.example.com";
+        int encodedLength = HuffmanCodec.encodedLength(value);
+
+        byte[] exact = new byte[encodedLength];
+        assertThat(HuffmanCodec.encode(value, exact), is(encodedLength));
+
+        byte[] withSentinel = new byte[encodedLength + 1];
+        withSentinel[encodedLength] = 0x5A;
+        assertThat(HuffmanCodec.encode(value, withSentinel), is(encodedLength));
+        assertThat(withSentinel[encodedLength], is((byte) 0x5A));
+
+        assertThat(HuffmanCodec.encode(value, new byte[encodedLength - 1]), is(-1));
+    }
+
+    @Test
+    void preflightsDecodeDestinationCapacity() {
+        byte[] encoded = HEX.parseHex("f1e3c2e5f23a6ba0ab90f4ff");
+        int maximumDecodedLength = encoded.length * 8 / 5;
+
+        BufferData exactSource = BufferData.create(encoded);
+        byte[] exact = new byte[maximumDecodedLength];
+        int decodedLength = HuffmanCodec.decode(exactSource, encoded.length, exact);
+        assertThat(decodedLength, is("www.example.com".length()));
+        assertThat(exactSource.available(), is(0));
+
+        BufferData shortSource = BufferData.create(encoded);
+        int available = shortSource.available();
+        assertThrows(IndexOutOfBoundsException.class,
+                     () -> HuffmanCodec.decode(shortSource, encoded.length, new byte[maximumDecodedLength - 1]));
+        assertThat(shortSource.available(), is(available));
+    }
+
+    @Test
+    void decodesOnlyDeclaredSourceRange() {
+        byte[] encoded = HEX.parseHex("a8eb10649cbf");
+        byte[] withTrailingByte = Arrays.copyOf(encoded, encoded.length + 1);
+        withTrailingByte[encoded.length] = 0x5A;
+
+        BufferData byteSource = BufferData.create(withTrailingByte);
+        byte[] decoded = new byte[encoded.length * 8 / 5];
+        int decodedLength = HuffmanCodec.decode(byteSource, encoded.length, decoded);
+        assertThat(new String(decoded, 0, decodedLength, StandardCharsets.ISO_8859_1), is("no-cache"));
+        assertThat(byteSource.available(), is(1));
+        assertThat(byteSource.read(), is(0x5A));
+
+        BufferData textSource = BufferData.create(withTrailingByte);
+        StringBuilder decodedText = new StringBuilder();
+        HuffmanCodec.decode(textSource, encoded.length, decodedText);
+        assertThat(decodedText.toString(), is("no-cache"));
+        assertThat(textSource.available(), is(1));
+        assertThat(textSource.read(), is(0x5A));
+    }
+
+    @Test
+    void rejectsInvalidSourceLengthBeforeReading() {
+        BufferData negativeByteSource = BufferData.create(new byte[] {0});
+        assertThrows(IndexOutOfBoundsException.class,
+                     () -> HuffmanCodec.decode(negativeByteSource, -1, new byte[1]));
+        assertThat(negativeByteSource.available(), is(1));
+
+        BufferData longByteSource = BufferData.create(new byte[] {0});
+        assertThrows(IndexOutOfBoundsException.class,
+                     () -> HuffmanCodec.decode(longByteSource, 2, new byte[4]));
+        assertThat(longByteSource.available(), is(1));
+
+        BufferData negativeTextSource = BufferData.create(new byte[] {0});
+        assertThrows(IndexOutOfBoundsException.class,
+                     () -> HuffmanCodec.decode(negativeTextSource, -1, new StringBuilder()));
+        assertThat(negativeTextSource.available(), is(1));
+
+        BufferData longTextSource = BufferData.create(new byte[] {0});
+        assertThrows(IndexOutOfBoundsException.class,
+                     () -> HuffmanCodec.decode(longTextSource, 2, new StringBuilder()));
+        assertThat(longTextSource.available(), is(1));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ff", "1e", "1c", "ffffffff"})
+    void rejectsMalformedInput(String encodedHex) {
+        byte[] encoded = HEX.parseHex(encodedHex);
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> HuffmanCodec.decode(BufferData.create(encoded),
+                                               encoded.length,
+                                               new byte[encoded.length * 8 / 5]));
+        assertThrows(IllegalArgumentException.class,
+                     () -> HuffmanCodec.decode(BufferData.create(encoded), encoded.length, new StringBuilder()));
+    }
+
+    @Test
+    void wrapsAppendFailure() {
+        byte[] encoded = HEX.parseHex("a8eb10649cbf");
+        Appendable failing = new Appendable() {
+            @Override
+            public Appendable append(CharSequence value) throws IOException {
+                throw new IOException("expected");
+            }
+
+            @Override
+            public Appendable append(CharSequence value, int start, int end) throws IOException {
+                throw new IOException("expected");
+            }
+
+            @Override
+            public Appendable append(char value) throws IOException {
+                throw new IOException("expected");
+            }
+        };
+
+        UncheckedIOException failure = assertThrows(UncheckedIOException.class,
+                                                    () -> HuffmanCodec.decode(BufferData.create(encoded),
+                                                                              encoded.length,
+                                                                              failing));
+        assertThat(failure.getCause(), instanceOf(IOException.class));
+    }
+
+    @Test
+    void rejectsNullArguments() {
+        assertThrows(NullPointerException.class, () -> HuffmanCodec.encodedLength(null));
+        assertThrows(NullPointerException.class, () -> HuffmanCodec.encode(null, new byte[0]));
+        assertThrows(NullPointerException.class, () -> HuffmanCodec.encode("", null));
+
+        assertThrows(NullPointerException.class, () -> HuffmanCodec.decode(null, 0, new byte[0]));
+        assertThrows(NullPointerException.class,
+                     () -> HuffmanCodec.decode(BufferData.create(new byte[0]), 0, (byte[]) null));
+        assertThrows(NullPointerException.class,
+                     () -> HuffmanCodec.decode(null, 0, new StringBuilder()));
+        assertThrows(NullPointerException.class,
+                     () -> HuffmanCodec.decode(BufferData.create(new byte[0]), 0, (Appendable) null));
+    }
+
+    @Test
+    void rejectsCharactersOutsideOctetRange() {
+        assertThrows(IllegalArgumentException.class, () -> HuffmanCodec.encodedLength("\u0100"));
+        assertThrows(IllegalArgumentException.class, () -> HuffmanCodec.encode("\u0100", new byte[4]));
+    }
+}

--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -36,8 +36,8 @@ record here.
     - File exclusions (exceptions)
     - FileLength cannot be excluded using a @SuppressWarnings
     -->
-    <!-- the huffman constants are long, but this is not actual code, just a set of constants -->
-    <suppress files="http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanConstants\.java"
+    <!-- the Huffman tables are long, but this is not actual code, just the tables from RFC 7541 -->
+    <suppress files="common/buffers/src/main/java/io/helidon/common/buffers/HuffmanTables\.java"
             checks="FileLength"/>
 
     <!-- Once the proper abstraction structure is found for the parsers, this can be removed-->

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanDecoder.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,42 +14,18 @@
  * limitations under the License.
  */
 
-/*
- * This class is mostly copied from Netty.
- * Original Copyright:
- *
- * Copyright 2014 Twitter, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.helidon.http.http2;
 
 import java.nio.charset.StandardCharsets;
-import java.util.function.BiFunction;
 
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.HuffmanCodec;
 
 /**
- * Implementation of HPack Huffman decoding.
+ * Implementation of HPACK Huffman decoding.
  */
 public class Http2HuffmanDecoder {
     private static final String EMPTY_STRING = "";
-    private static final Http2Exception BAD_ENCODING = new Http2Exception(Http2ErrorCode.COMPRESSION,
-                                                                          "Huffman bad encoding.");
-
-    private byte[] dest;
-    private int k;
-    private int state;
 
     /**
      * Huffman decoder.
@@ -58,7 +34,7 @@ public class Http2HuffmanDecoder {
     }
 
     /**
-     * Creates a new HPack Huffman decoder.
+     * Creates a new HPACK Huffman decoder.
      *
      * @return a new Huffman decoder
      */
@@ -77,47 +53,12 @@ public class Http2HuffmanDecoder {
         if (length == 0) {
             return EMPTY_STRING;
         }
-        return decodeBytes(data, length, (bytes, size) -> new String(bytes, 0, size, StandardCharsets.US_ASCII));
-    }
-
-    private boolean process(byte input) {
-        return processNibble(input >> 4) && processNibble(input);
-    }
-
-    private <T> T decodeBytes(BufferData data, int length, BiFunction<byte[], Integer, T> creator) {
-        dest = new byte[length * 8 / 5];
-
+        byte[] destination = new byte[Math.toIntExact((long) length * 8 / 5)];
         try {
-            data.forEach(length, it -> {
-                if (!process(it)) {
-                    throw new Http2Exception(Http2ErrorCode.COMPRESSION,
-                                             "Cannot decode Huffman encoded string");
-                }
-                return true;
-            });
-            if ((state & Http2HuffmanConstants.HUFFMAN_COMPLETE_SHIFT) != Http2HuffmanConstants.HUFFMAN_COMPLETE_SHIFT) {
-                throw BAD_ENCODING;
-            }
-            return creator.apply(dest, k);
-        } finally {
-            dest = null;
-            k = 0;
-            state = 0;
+            int decodedLength = HuffmanCodec.decode(data, length, destination);
+            return new String(destination, 0, decodedLength, StandardCharsets.US_ASCII);
+        } catch (IllegalArgumentException e) {
+            throw new Http2Exception(Http2ErrorCode.COMPRESSION, "Cannot decode Huffman encoded string", e);
         }
-    }
-
-    private boolean processNibble(int input) {
-        // The high nibble of the flags byte of each row is always zero
-        // (low nibble after shifting row by 12), since there are only 3 flag bits
-        int index = state >> 12 | (input & 0x0F);
-        state = Http2HuffmanConstants.HUFFS[index];
-        if ((state & Http2HuffmanConstants.HUFFMAN_FAIL_SHIFT) != 0) {
-            return false;
-        }
-        if ((state & Http2HuffmanConstants.HUFFMAN_EMIT_SYMBOL_SHIFT) != 0) {
-            // state is always positive so can cast without mask here
-            dest[k++] = (byte) state;
-        }
-        return true;
     }
 }

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanEncoder.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,30 +14,15 @@
  * limitations under the License.
  */
 
-/*
- * This class is mostly copied from Netty.
- * Original Copyright:
- *
- * Copyright 2014 Twitter, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.helidon.http.http2;
 
+import java.util.Objects;
+
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.HuffmanCodec;
 
 /**
- * Implementation of HPack Huffman encoding.
+ * Implementation of HPACK Huffman encoding.
  */
 public class Http2HuffmanEncoder {
     private static final int HUFFMAN_ENCODED = 1 << 7;
@@ -49,7 +34,7 @@ public class Http2HuffmanEncoder {
     }
 
     /**
-     * Creates a new HPack Huffman encoder.
+     * Creates a new HPACK Huffman encoder.
      *
      * @return a new Huffman encoder
      */
@@ -58,37 +43,36 @@ public class Http2HuffmanEncoder {
     }
 
     void encode(BufferData buffer, String string) {
-        int index = 0;
-
-        long current = 0;
-        int n = 0;
+        CharSequence value = new Latin1View(string);
         byte[] bytes = new byte[string.length()];
-
-        for (int i = 0; i < string.length(); i++) {
-            int b = string.charAt(i) & 0xFF;
-            int code = Http2HuffmanConstants.HUFFMAN_CODES[b];
-            int nbits = Http2HuffmanConstants.HUFFMAN_CODE_LENGTHS[b];
-
-            current <<= nbits;
-            current |= code;
-            n += nbits;
-
-            while (n >= 8) {
-                n -= 8;
-                bytes[index] = ((byte) (current >> n));
-                index++;
-            }
+        int encodedLength = HuffmanCodec.encode(value, bytes);
+        if (encodedLength == -1) {
+            bytes = new byte[HuffmanCodec.encodedLength(value)];
+            encodedLength = HuffmanCodec.encode(value, bytes);
         }
 
-        if (n > 0) {
-            current <<= 8 - n;
-            current |= 0xFF >>> n; // this should be EOS symbol
-            bytes[index] = ((byte) current);
-            index++;
+        buffer.writeHpackInt(encodedLength, HUFFMAN_ENCODED, 7);
+        buffer.write(bytes, 0, encodedLength);
+    }
+
+    private record Latin1View(String value) implements CharSequence {
+        private Latin1View {
+            Objects.requireNonNull(value, "value");
         }
 
-        buffer.writeHpackInt(index, HUFFMAN_ENCODED, 7);
-        buffer.write(bytes, 0, index);
+        @Override
+        public int length() {
+            return value.length();
+        }
 
+        @Override
+        public char charAt(int index) {
+            return (char) (value.charAt(index) & 0xFF);
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return new Latin1View(value.substring(start, end));
+        }
     }
 }

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HuffmanProtocolTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HuffmanProtocolTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.http2;
+
+import java.util.HexFormat;
+
+import io.helidon.common.buffers.BufferData;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Http2HuffmanProtocolTest {
+    private static final HexFormat HEX = HexFormat.of();
+
+    @Test
+    void encodesValueWhoseHuffmanRepresentationExpands() {
+        assertArrayEquals(HEX.parseHex("82ffc7"), encode("\0"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ff", "1e", "1c", "ffffffff"})
+    void mapsMalformedInputToCompressionError(String encodedHex) {
+        byte[] encoded = HEX.parseHex(encodedHex);
+
+        Http2Exception failure = assertThrows(Http2Exception.class,
+                                              () -> Http2HuffmanDecoder.create()
+                                                      .decodeString(BufferData.create(encoded), encoded.length));
+        assertThat(failure.code(), is(Http2ErrorCode.COMPRESSION));
+        assertThat(failure.getCause(), instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test
+    void preservesLowByteEncodingCompatibility() {
+        assertArrayEquals(encode("abca"), encode("abc\u0161"));
+    }
+
+    private static byte[] encode(String value) {
+        BufferData encoded = BufferData.growing(value.length() + 1);
+        Http2HuffmanEncoder.create().encode(encoded, value);
+        return encoded.readBytes();
+    }
+}


### PR DESCRIPTION
Pre-requisite for #3686

Adds a shared internal Huffman codec to common buffers and migrates HTTP/2 HPACK encoding and decoding to use it, allowing HTTP/3 QPACK to reuse the same implementation.
