### PR TITLE
Preserve virtual thread metrics cleanup interrupt

### DIFF
--- a/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/VThreadSystemMetersProvider.java
+++ b/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/VThreadSystemMetersProvider.java
@@ -308,25 +308,35 @@ public class VThreadSystemMetersProvider implements MetersProvider, HelidonShutd
         RecordingStream streamToStop = recordingStream;
         recordingStream = null;
         Throwable stopFailure = null;
+        // RecordingStream cleanup can clear the caller's interrupt status.
+        boolean restoreInterrupt = Thread.currentThread().isInterrupted();
         try {
             LOGGER.log(System.Logger.Level.INFO, "Stopping recording stream");
         } catch (Throwable e) {
             stopFailure = recordCloseFailure(stopFailure, e);
         }
+        restoreInterrupt |= Thread.currentThread().isInterrupted();
         try {
             streamToStop.close();
         } catch (Throwable e) {
             stopFailure = recordCloseFailure(stopFailure, e);
         }
+        restoreInterrupt |= Thread.currentThread().isInterrupted();
+        if (restoreInterrupt) {
+            Thread.currentThread().interrupt();
+        }
         try {
             streamToStop.awaitTermination(Duration.ofSeconds(10));
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            restoreInterrupt = true;
             stopFailure = recordCloseFailure(
                     stopFailure,
                     new IllegalStateException("Interrupted while stopping virtual thread metrics recording", e));
         } catch (Throwable e) {
             stopFailure = recordCloseFailure(stopFailure, e);
+        }
+        if (restoreInterrupt) {
+            Thread.currentThread().interrupt();
         }
         if (stopFailure != null) {
             VThreadSystemMetersProvider.<RuntimeException>rethrow(stopFailure);


### PR DESCRIPTION
Fixes a Windows-only intermittent failure in
`TestVirtualThreadsMetersConfigs.interruptedCloseStillClearsProviderState`
observed in #12275 and #12277.

JFR `RecordingStream.close()` can clear an interrupt raised earlier in stream
cleanup. Track any observed interrupt, reassert it before the termination wait,
and restore it before returning or rethrowing the original cleanup failure.
