### PR TITLE
Stabilize HTTP/2 cache reuse test

### DIFF
--- a/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
+++ b/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
@@ -79,11 +79,12 @@ class SharedHttp2CacheTest {
                     .baseUri("http://localhost:" + port + "/versionspecific")
                     .build();
             try {
-
                 Integer firstReqClientPort;
                 try (var res = webClient.post().submit("WHATEVER")) {
                     firstReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
                     assertThat(res.status(), is(Status.OK_200));
+                    // Wait for the empty DATA frame carrying END_STREAM before closing the response.
+                    res.entity().consume();
                 }
 
                 if (param.restart()) {
@@ -100,6 +101,7 @@ class SharedHttp2CacheTest {
                 try (var res = webClient.post().submit("WHATEVER")) {
                     secondReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
                     assertThat(res.status(), is(Status.OK_200));
+                    res.entity().consume();
                 }
 
                 if (!param.restart()) {


### PR DESCRIPTION
The HTTP/2 server sends an empty response as HEADERS followed by an empty DATA frame carrying END_STREAM. SharedHttp2CacheTest could close the response after receiving the headers but before processing that final frame. The resulting stream-cancel race could close an otherwise healthy connection, so the second no-restart request used a new client port on Windows.

Consume both response entities before closing them. This waits for normal stream completion while preserving the existing sequential cached-connection reuse and server-restart coverage.

Observed in CI for #12275.