### PR TITLE
Optimize header token matching

### DIFF
--- a/http/http/src/main/java/io/helidon/http/Headers.java
+++ b/http/http/src/main/java/io/helidon/http/Headers.java
@@ -76,32 +76,97 @@ public interface Headers extends Iterable<Header> {
      * @return {@code true} if all expected tokens are present, ignoring case and surrounding whitespace
      */
     default boolean containsToken(Header value) {
-        List<String> actualValues = values(value.headerName());
+        List<String> actualValues = all(value.headerName(), List::of);
         if (actualValues.isEmpty()) {
             return false;
         }
 
         for (String expectedValue : value.allValues()) {
-            for (String expectedToken : Utils.tokenize(',', "\"", true, expectedValue)) {
-                String trimmedExpected = expectedToken.trim();
-                if (trimmedExpected.isEmpty()) {
-                    continue;
-                }
-
-                boolean matched = false;
-                for (String actualValue : actualValues) {
-                    if (actualValue.trim().equalsIgnoreCase(trimmedExpected)) {
-                        matched = true;
-                        break;
-                    }
-                }
-                if (!matched) {
-                    return false;
-                }
+            if (!containsTokens(actualValues, expectedValue)) {
+                return false;
             }
         }
 
         return true;
+    }
+
+    private static boolean containsTokens(List<String> actualValues, String expectedValue) {
+        int tokenStart = 0;
+        boolean quoted = false;
+        int length = expectedValue.length();
+        for (int i = 0; i < length; i++) {
+            char ch = expectedValue.charAt(i);
+            if (ch == '"') {
+                quoted = !quoted;
+            } else if (ch == ',' && !quoted) {
+                if (!containsToken(actualValues, expectedValue, tokenStart, i)) {
+                    return false;
+                }
+                tokenStart = i + 1;
+            }
+        }
+        return containsToken(actualValues, expectedValue, tokenStart, length);
+    }
+
+    private static boolean containsToken(List<String> actualValues,
+                                         String expectedValue,
+                                         int expectedStart,
+                                         int expectedEnd) {
+        while (expectedStart < expectedEnd && expectedValue.charAt(expectedStart) <= ' ') {
+            expectedStart++;
+        }
+        while (expectedEnd > expectedStart && expectedValue.charAt(expectedEnd - 1) <= ' ') {
+            expectedEnd--;
+        }
+        if (expectedStart == expectedEnd) {
+            return true;
+        }
+
+        for (String actualValue : actualValues) {
+            if (containsToken(actualValue, expectedValue, expectedStart, expectedEnd)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsToken(String actualValue,
+                                         String expectedValue,
+                                         int expectedStart,
+                                         int expectedEnd) {
+        int tokenStart = 0;
+        boolean quoted = false;
+        int length = actualValue.length();
+        for (int i = 0; i < length; i++) {
+            char ch = actualValue.charAt(i);
+            if (ch == '"') {
+                quoted = !quoted;
+            } else if (ch == ',' && !quoted) {
+                if (tokenEquals(actualValue, tokenStart, i, expectedValue, expectedStart, expectedEnd)) {
+                    return true;
+                }
+                tokenStart = i + 1;
+            }
+        }
+        return tokenEquals(actualValue, tokenStart, length, expectedValue, expectedStart, expectedEnd);
+    }
+
+    private static boolean tokenEquals(String actualValue,
+                                       int actualStart,
+                                       int actualEnd,
+                                       String expectedValue,
+                                       int expectedStart,
+                                       int expectedEnd) {
+        while (actualStart < actualEnd && actualValue.charAt(actualStart) <= ' ') {
+            actualStart++;
+        }
+        while (actualEnd > actualStart && actualValue.charAt(actualEnd - 1) <= ' ') {
+            actualEnd--;
+        }
+
+        int length = actualEnd - actualStart;
+        return length == expectedEnd - expectedStart
+                && actualValue.regionMatches(true, actualStart, expectedValue, expectedStart, length);
     }
 
     /**

--- a/http/http/src/test/java/io/helidon/http/HeadersContainsTokenTest.java
+++ b/http/http/src/test/java/io/helidon/http/HeadersContainsTokenTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class HeadersContainsTokenTest {
+
+    @Test
+    void returnsFalseWhenHeaderIsMissing() {
+        Headers headers = WritableHeaders.create();
+
+        assertThat(headers.containsToken(HeaderValues.CONNECTION_CLOSE), is(false));
+        assertThat(headers.containsToken(HeaderValues.create(HeaderNames.CONNECTION, "")), is(false));
+    }
+
+    @Test
+    void requiresCompleteTokenMatch() {
+        Headers headers = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "disclose, closed");
+
+        assertThat(headers.containsToken(HeaderValues.CONNECTION_CLOSE), is(false));
+    }
+
+    @Test
+    void ignoresCaseAndStringTrimWhitespace() {
+        Headers headers = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "\u001f ClOsE \u0000");
+
+        assertThat(headers.containsToken(HeaderValues.CONNECTION_CLOSE), is(true));
+    }
+
+    @Test
+    void searchesRepeatedAndCommaSeparatedValues() {
+        Headers headers = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "keep-alive, upgrade")
+                .add(HeaderNames.CONNECTION, "close");
+        Header expected = HeaderValues.create(HeaderNames.CONNECTION,
+                                              "upgrade, close",
+                                              "keep-alive");
+
+        assertThat(headers.containsToken(expected), is(true));
+        assertThat(headers.containsToken(HeaderValues.create(HeaderNames.CONNECTION,
+                                                             "upgrade, missing")), is(false));
+    }
+
+    @Test
+    void preservesQuotedCommasInTokens() {
+        Headers headers = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "foo, \"bar,baz\", qux");
+
+        assertThat(headers.containsToken(HeaderValues.create(HeaderNames.CONNECTION, "\"bar,baz\"")), is(true));
+        assertThat(headers.containsToken(HeaderValues.create(HeaderNames.CONNECTION, "bar,baz")), is(false));
+    }
+
+    @Test
+    void preservesUnmatchedQuotedRemainder() {
+        Headers headers = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "foo, \"bar,baz,qux");
+
+        assertThat(headers.containsToken(HeaderValues.create(HeaderNames.CONNECTION, "\"bar,baz,qux")), is(true));
+        assertThat(headers.containsToken(HeaderValues.create(HeaderNames.CONNECTION, "qux")), is(false));
+    }
+
+    @Test
+    void ignoresEmptyExpectedTokensWhenHeaderExists() {
+        Headers headers = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "close");
+
+        assertThat(headers.containsToken(HeaderValues.create(HeaderNames.CONNECTION, ", ,\t")), is(true));
+    }
+
+    @Test
+    void usesUnicodeCaseInsensitiveComparison() {
+        HeaderName name = HeaderNames.create("Custom-Token");
+        Headers headers = WritableHeaders.create()
+                .add(name, "\u212A");
+
+        assertThat(headers.containsToken(HeaderValues.create(name, "k")), is(true));
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/http/benchmark/jmh/HeadersContainsTokenJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/http/benchmark/jmh/HeadersContainsTokenJmhBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.benchmark.jmh;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Headers;
+import io.helidon.http.WritableHeaders;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Thread)
+public class HeadersContainsTokenJmhBenchmark {
+    private Headers commonHeaders;
+    private Headers singleTokenHeaders;
+    private Headers repeatedTokenHeaders;
+    private Headers quotedTokenHeaders;
+    private Header connectionClose;
+    private Header connectionKeepAlive;
+    private Header expectContinue;
+    private Header repeatedTokens;
+    private Header quotedToken;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        commonHeaders = WritableHeaders.create()
+                .add(HeaderNames.HOST, "localhost");
+        singleTokenHeaders = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "keep-alive");
+        repeatedTokenHeaders = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "upgrade, keep-alive")
+                .add(HeaderNames.CONNECTION, "close");
+        quotedTokenHeaders = WritableHeaders.create()
+                .add(HeaderNames.CONNECTION, "\"upgrade, websocket\", keep-alive");
+
+        connectionClose = HeaderValues.CONNECTION_CLOSE;
+        connectionKeepAlive = HeaderValues.CONNECTION_KEEP_ALIVE;
+        expectContinue = HeaderValues.EXPECT_100;
+        repeatedTokens = HeaderValues.create(HeaderNames.CONNECTION, "upgrade", "close");
+        quotedToken = HeaderValues.create(HeaderNames.CONNECTION, "\"upgrade, websocket\"");
+    }
+
+    @Benchmark
+    public void absentConnection(Blackhole blackhole) {
+        blackhole.consume(commonHeaders.containsToken(connectionClose));
+    }
+
+    @Benchmark
+    public void absentExpect(Blackhole blackhole) {
+        blackhole.consume(commonHeaders.containsToken(expectContinue));
+    }
+
+    @Benchmark
+    public void presentMatch(Blackhole blackhole) {
+        blackhole.consume(singleTokenHeaders.containsToken(connectionKeepAlive));
+    }
+
+    @Benchmark
+    public void presentMiss(Blackhole blackhole) {
+        blackhole.consume(singleTokenHeaders.containsToken(connectionClose));
+    }
+
+    @Benchmark
+    public void commaSeparatedAndRepeated(Blackhole blackhole) {
+        blackhole.consume(repeatedTokenHeaders.containsToken(repeatedTokens));
+    }
+
+    @Benchmark
+    public void quotedComma(Blackhole blackhole) {
+        blackhole.consume(quotedTokenHeaders.containsToken(quotedToken));
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/http/benchmark/jmh/HeadersContainsTokenJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/http/benchmark/jmh/HeadersContainsTokenJmhRunnerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.benchmark.jmh;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class HeadersContainsTokenJmhRunnerTest {
+    @Test
+    void run() throws RunnerException {
+        String result = System.getProperty("headers.contains-token.jmh.result",
+                                           "./target/headers-contains-token-jmh-result.json");
+        Options options = new OptionsBuilder()
+                .include(".*HeadersContainsTokenJmhBenchmark.*")
+                .forks(3)
+                .threads(1)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .warmupIterations(5)
+                .warmupTime(TimeValue.milliseconds(500))
+                .measurementIterations(8)
+                .measurementTime(TimeValue.seconds(1))
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .build();
+
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
Optimize `Headers.containsToken` to scan raw header values without allocating token collections or trimmed strings.

Add semantic coverage for repeated values, quoted commas, whitespace, empty tokens, and case-insensitive matching, together with focused JMH coverage for the common HTTP/1 and HTTP/2 paths.
