### PR TITLE
Preserve direct handler response metadata

### DIFF
--- a/http/http/src/main/java/io/helidon/http/DirectHandler.java
+++ b/http/http/src/main/java/io/helidon/http/DirectHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -253,6 +253,8 @@ public interface DirectHandler {
 
         /**
          * Configured headers.
+         * The transport may replace or remove {@code Content-Length} to match the final response representation
+         * and status.
          *
          * @return headers
          */
@@ -308,6 +310,8 @@ public interface DirectHandler {
 
             /**
              * Set headers.
+             * The transport may replace or remove {@code Content-Length} to match the final response representation
+             * and status.
              *
              * @param headers headers to use
              * @return updated builder
@@ -320,6 +324,8 @@ public interface DirectHandler {
             /**
              * Set a header (if exists, it would be replaced).
              * Keep alive header is ignored, please use {@link #keepAlive(boolean)}.
+             * The transport may replace or remove {@code Content-Length} to match the final response representation
+             * and status.
              *
              * @param name name of the header
              * @param values value of the header
@@ -333,6 +339,8 @@ public interface DirectHandler {
             /**
              * Set a header (if exists, it would be replaced).
              * Keep alive header is ignored, please use {@link #keepAlive(boolean)}.
+             * The transport may replace or remove {@code Content-Length} to match the final response representation
+             * and status.
              *
              * @param header header value
              * @return updated builder
@@ -355,7 +363,9 @@ public interface DirectHandler {
 
             /**
              * Custom entity. Uses the content, reads it as {@code UTF-8}, configures
-             * {@code Content-Length} header, configures {@code Content-Type} header to {@code text/plain}.
+             * an initial {@code Content-Length} header for a non-empty entity, and configures
+             * {@code Content-Type} header to {@code text/plain}.
+             * The transport determines the final content length.
              * <p>
              * Use {@link #entity(byte[])} for custom encoding.
              * <p>
@@ -370,8 +380,8 @@ public interface DirectHandler {
             }
 
             /**
-             * Custom entity. Uses the content, configures
-             * {@code Content-Length} header.
+             * Custom entity. Uses the content and configures an initial {@code Content-Length} header
+             * for a non-empty entity. The transport determines the final content length.
              * <p>
              * Use {@link #entity(String)} for simple text messages.
              *

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/PostTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/PostTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,8 +159,7 @@ class PostTest {
                 .submit("Hello");
 
         assertThat(response.status(), is(Status.NO_CONTENT_204));
-        String entity = response.entity().as(String.class);
-        assertThat(entity, is(""));
+        assertThat(response.entity().hasEntity(), is(false));
     }
 
     private static class Routes {

--- a/webserver/http2/pom.xml
+++ b/webserver/http2/pom.xml
@@ -72,6 +72,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.http.encoding</groupId>
+            <artifactId>helidon-http-encoding-gzip</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -105,7 +105,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             if (hasStreamFilter()) {
                 // in this case we must honor user's request to filter the stream
                 try (OutputStream os = outputStream()) {
-                    if (!isNoEntityStatus(status())) {
+                    if (!outputStream.noEntityResponse) {
                         os.write(entityBytes, position, length);
                     }
                 } catch (IOException e) {
@@ -126,26 +126,14 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                                                     false,
                                                     DateTime.rfc1123String()));
 
-            int initialStatusCode = status().code();
-            prepareResponse();
+            boolean noEntityResponse = prepareResponse();
 
             int actualLength = length;
             int actualPosition = position;
             byte[] actualBytes = entityBytes;
 
             Status responseStatus = status();
-            int statusCode = responseStatus.code();
-            boolean statusChanged = statusCode != initialStatusCode;
-            boolean noEntityResponse = isNoEntityStatus(responseStatus);
-            if (statusChanged && responseStatus.family() == Status.Family.INFORMATIONAL) {
-                LOGGER.log(System.Logger.Level.ERROR,
-                           "Attempt to send a final informational response. "
-                                   + "Server responded with Internal Server Error.");
-                status(Status.INTERNAL_SERVER_ERROR_500);
-                headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
-                headers.remove(HeaderNames.TRAILER);
-                noEntityResponse = true;
-            } else if (noEntityResponse) {
+            if (noEntityResponse) {
                 normalizeNoEntityHeaders(headers, responseStatus);
             } else {
                 // handle content encoding
@@ -228,27 +216,38 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             headers.add(STREAM_TRAILERS);
         }
 
-        prepareResponse();
+        boolean noEntityResponse = prepareResponse();
         streamingEntity = true;
 
         outputStream = new BlockingOutputStream(request, this, () -> this.isSent = true, () -> {
             this.isSent = true;
             afterSend();
-        }, beforeTrailers());
-        if (isNoEntityStatus(status())) {
+        }, beforeTrailers(), noEntityResponse);
+        if (noEntityResponse) {
             return new ApplicationOutputStream(outputStream, outputStream);
         }
         OutputStream encodedOutputStream = contentEncode(outputStream);
         return new ApplicationOutputStream(applyStreamFilters(encodedOutputStream), outputStream);
     }
 
-    private void prepareResponse() {
+    private boolean prepareResponse() {
         preparingResponse = true;
         try {
             beforeSend();
         } finally {
             preparingResponse = false;
         }
+        if (status().family() == Status.Family.INFORMATIONAL) {
+            LOGGER.log(System.Logger.Level.ERROR,
+                       "Attempt to send a final informational response. "
+                               + "Server responded with Internal Server Error.");
+            status(Status.INTERNAL_SERVER_ERROR_500);
+            headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
+            headers.remove(HeaderNames.TRANSFER_ENCODING);
+            headers.remove(HeaderNames.TRAILER);
+            return true;
+        }
+        return isNoEntityStatus(status());
     }
 
     @Override
@@ -364,6 +363,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         private final Http2ServerResponse response;
         private final Http2ServerStream stream;
         private final boolean headRequest;
+        private final boolean noEntityResponse;
 
         private BufferData firstBuffer;
         private boolean closed;
@@ -377,7 +377,8 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                                      Http2ServerResponse response,
                                      Runnable responseSentRunnable,
                                      Runnable responseCloseRunnable,
-                                     Consumer<ServerResponseTrailers> beforeTrailers) {
+                                     Consumer<ServerResponseTrailers> beforeTrailers,
+                                     boolean noEntityResponse) {
             this.request = request;
             this.response = response;
             this.headers = response.headers;
@@ -388,6 +389,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             this.responseCloseRunnable = responseCloseRunnable;
             this.beforeTrailers = beforeTrailers;
             this.headRequest = request.prologue().method() == Method.HEAD;
+            this.noEntityResponse = noEntityResponse;
         }
 
         @Override
@@ -409,7 +411,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         public void flush() throws IOException {
             if (headRequest) {
                 if (!headResponseSent) {
-                    if (isNoEntityStatus(status)) {
+                    if (noEntityResponse) {
                         normalizeNoEntityHeaders(headers, status);
                     }
                     headers.remove(HeaderNames.TRAILER);
@@ -433,7 +435,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 return;
             }
             this.closed = true;
-            boolean noEntityResponse = isNoEntityStatus(status);
             if (noEntityResponse) {
                 normalizeNoEntityHeaders(headers, status);
             }
@@ -489,7 +490,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 // Encoder and filter finalization after an early HEAD flush must not produce content.
                 return;
             }
-            if (isNoEntityStatus(status)) {
+            if (noEntityResponse) {
                 if (buffer.available() > 0) {
                     throw new IllegalStateException("Attempting to write data on a response with status " + status);
                 }
@@ -580,7 +581,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
 
         private void checkWriteAllowed(int length) throws IOException {
-            if (length > 0 && isNoEntityStatus(status)) {
+            if (length > 0 && noEntityResponse) {
                 throw new IllegalStateException("Attempting to write data on a response with status " + status);
             }
             if (length > 0 && headResponseSent) {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -560,7 +560,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             bytesWritten += stream.writeHeaders(http2Headers, false);
         }
 
-        private void sendTrailers(){
+        private void sendTrailers() {
             if (headers.contains(HeaderNames.TRAILER)
                     && headers.get(HeaderNames.TRAILER).allValues().contains("stream-result")) {
                 // only send if configured

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -100,8 +100,11 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         if (preparingResponse) {
             throw new IllegalStateException("Response preparation already in progress");
         }
+        boolean headRequest = request.prologue().method() == Method.HEAD;
+        if (headRequest && length > 0) {
+            throw new IllegalStateException("Cannot send response entity for a HEAD request");
+        }
         try {
-            boolean headRequest = request.prologue().method() == Method.HEAD;
             if (hasStreamFilter()) {
                 // in this case we must honor user's request to filter the stream
                 try (OutputStream os = outputStream()) {
@@ -222,7 +225,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         outputStream = new BlockingOutputStream(request, this, () -> this.isSent = true, () -> {
             this.isSent = true;
             afterSend();
-        }, beforeTrailers(), noEntityResponse, ctx.listenerContext().config().writeBufferSize());
+        }, beforeTrailers(), noEntityResponse);
         if (noEntityResponse) {
             return new ApplicationOutputStream(outputStream, outputStream);
         }
@@ -364,13 +367,11 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         private final Http2ServerStream stream;
         private final boolean headRequest;
         private final boolean noEntityResponse;
-        private final int headWriteLimit;
 
         private BufferData firstBuffer;
         private boolean closed;
         private boolean firstByte = true;
         private boolean headResponseSent;
-        private long headApplicationBytes;
         private long bytesWritten;
         private long headRepresentationLength;
         private final Consumer<ServerResponseTrailers> beforeTrailers;
@@ -380,8 +381,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                                      Runnable responseSentRunnable,
                                      Runnable responseCloseRunnable,
                                      Consumer<ServerResponseTrailers> beforeTrailers,
-                                     boolean noEntityResponse,
-                                     int headWriteLimit) {
+                                     boolean noEntityResponse) {
             this.request = request;
             this.response = response;
             this.headers = response.headers;
@@ -393,7 +393,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             this.beforeTrailers = beforeTrailers;
             this.headRequest = request.prologue().method() == Method.HEAD;
             this.noEntityResponse = noEntityResponse;
-            this.headWriteLimit = headWriteLimit;
         }
 
         @Override
@@ -414,7 +413,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         @Override
         public void flush() throws IOException {
             if (headRequest) {
-                sendIncompleteHeadResponse();
                 return;
             }
             if (firstByte && firstBuffer != null) {
@@ -522,18 +520,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             headResponseSent = true;
         }
 
-        private void sendIncompleteHeadResponse() {
-            if (headResponseSent) {
-                return;
-            }
-            if (noEntityResponse) {
-                normalizeNoEntityHeaders(headers, status);
-            }
-            headers.remove(HeaderNames.TRAILER);
-            sendHeadHeaders(true);
-            responseSentRunnable.run();
-        }
-
         private void sendFirstChunkOnly(boolean sendTrailers) {
             int contentLength;
             if (firstBuffer == null) {
@@ -590,19 +576,11 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
 
         private void checkWriteAllowed(int length) throws IOException {
+            if (length > 0 && headRequest) {
+                throw new IllegalStateException("Cannot write response entity for a HEAD request");
+            }
             if (length > 0 && noEntityResponse) {
                 throw new IllegalStateException("Attempting to write data on a response with status " + status);
-            }
-            if (length > 0 && headResponseSent) {
-                throw new IOException("HEAD response already sent");
-            }
-            if (length > 0 && headRequest) {
-                if (headApplicationBytes + length > headWriteLimit) {
-                    sendIncompleteHeadResponse();
-                    throw new IOException("HEAD response representation exceeded streaming limit of "
-                                                  + headWriteLimit + " bytes");
-                }
-                headApplicationBytes += length;
             }
         }
     }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -222,7 +222,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         outputStream = new BlockingOutputStream(request, this, () -> this.isSent = true, () -> {
             this.isSent = true;
             afterSend();
-        }, beforeTrailers(), noEntityResponse);
+        }, beforeTrailers(), noEntityResponse, ctx.listenerContext().config().writeBufferSize());
         if (noEntityResponse) {
             return new ApplicationOutputStream(outputStream, outputStream);
         }
@@ -364,11 +364,13 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         private final Http2ServerStream stream;
         private final boolean headRequest;
         private final boolean noEntityResponse;
+        private final int headWriteLimit;
 
         private BufferData firstBuffer;
         private boolean closed;
         private boolean firstByte = true;
         private boolean headResponseSent;
+        private long headApplicationBytes;
         private long bytesWritten;
         private long headRepresentationLength;
         private final Consumer<ServerResponseTrailers> beforeTrailers;
@@ -378,7 +380,8 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                                      Runnable responseSentRunnable,
                                      Runnable responseCloseRunnable,
                                      Consumer<ServerResponseTrailers> beforeTrailers,
-                                     boolean noEntityResponse) {
+                                     boolean noEntityResponse,
+                                     int headWriteLimit) {
             this.request = request;
             this.response = response;
             this.headers = response.headers;
@@ -390,6 +393,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             this.beforeTrailers = beforeTrailers;
             this.headRequest = request.prologue().method() == Method.HEAD;
             this.noEntityResponse = noEntityResponse;
+            this.headWriteLimit = headWriteLimit;
         }
 
         @Override
@@ -410,14 +414,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         @Override
         public void flush() throws IOException {
             if (headRequest) {
-                if (!headResponseSent) {
-                    if (noEntityResponse) {
-                        normalizeNoEntityHeaders(headers, status);
-                    }
-                    headers.remove(HeaderNames.TRAILER);
-                    sendHeadHeaders(true);
-                    responseSentRunnable.run();
-                }
+                sendIncompleteHeadResponse();
                 return;
             }
             if (firstByte && firstBuffer != null) {
@@ -525,6 +522,18 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             headResponseSent = true;
         }
 
+        private void sendIncompleteHeadResponse() {
+            if (headResponseSent) {
+                return;
+            }
+            if (noEntityResponse) {
+                normalizeNoEntityHeaders(headers, status);
+            }
+            headers.remove(HeaderNames.TRAILER);
+            sendHeadHeaders(true);
+            responseSentRunnable.run();
+        }
+
         private void sendFirstChunkOnly(boolean sendTrailers) {
             int contentLength;
             if (firstBuffer == null) {
@@ -586,6 +595,14 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             }
             if (length > 0 && headResponseSent) {
                 throw new IOException("HEAD response already sent");
+            }
+            if (length > 0 && headRequest) {
+                if (headApplicationBytes + length > headWriteLimit) {
+                    sendIncompleteHeadResponse();
+                    throw new IOException("HEAD response representation exceeded streaming limit of "
+                                                  + headWriteLimit + " bytes");
+                }
+                headApplicationBytes += length;
             }
         }
     }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -26,6 +26,7 @@ import io.helidon.http.DateTime;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.ServerResponseTrailers;
 import io.helidon.http.Status;
@@ -100,10 +101,13 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             throw new IllegalStateException("Response preparation already in progress");
         }
         try {
+            boolean headRequest = request.prologue().method() == Method.HEAD;
             if (hasStreamFilter()) {
                 // in this case we must honor user's request to filter the stream
                 try (OutputStream os = outputStream()) {
-                    os.write(entityBytes, position, length);
+                    if (!isNoEntityStatus(status())) {
+                        os.write(entityBytes, position, length);
+                    }
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
@@ -118,37 +122,21 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                                                         + ", do not call send().");
             }
 
-            // handle content encoding
-            int actualLength = length;
-            int actualPosition = position;
-            byte[] actualBytes = entityBytes(entityBytes, position, length);
-            boolean automaticContentEncoding = entityBytes != actualBytes;
-            if (automaticContentEncoding) {       // encoding happened, new byte array
-                actualPosition = 0;
-                actualLength = actualBytes.length;
-            }
-
-            headers.setIfAbsent(HeaderValues.create(HeaderNames.CONTENT_LENGTH,
-                                                    true,
-                                                    false,
-                                                    String.valueOf(actualLength)));
             headers.setIfAbsent(HeaderValues.create(HeaderNames.DATE, true,
                                                     false,
                                                     DateTime.rfc1123String()));
 
             int initialStatusCode = status().code();
             prepareResponse();
-            if (automaticContentEncoding && !headers.containsToken(VARY_ACCEPT_ENCODING)) {
-                headers.add(VARY_ACCEPT_ENCODING);
-            }
+
+            int actualLength = length;
+            int actualPosition = position;
+            byte[] actualBytes = entityBytes;
 
             Status responseStatus = status();
             int statusCode = responseStatus.code();
             boolean statusChanged = statusCode != initialStatusCode;
-            boolean noEntityResponse = statusChanged
-                    && (statusCode == Status.NO_CONTENT_204.code()
-                    || statusCode == Status.RESET_CONTENT_205.code()
-                    || statusCode == Status.NOT_MODIFIED_304.code());
+            boolean noEntityResponse = isNoEntityStatus(responseStatus);
             if (statusChanged && responseStatus.family() == Status.Family.INFORMATIONAL) {
                 LOGGER.log(System.Logger.Level.ERROR,
                            "Attempt to send a final informational response. "
@@ -158,12 +146,22 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 headers.remove(HeaderNames.TRAILER);
                 noEntityResponse = true;
             } else if (noEntityResponse) {
-                if (statusCode == Status.NO_CONTENT_204.code()) {
-                    headers.remove(HeaderNames.CONTENT_LENGTH);
-                } else if (statusCode == Status.RESET_CONTENT_205.code()) {
-                    headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
+                normalizeNoEntityHeaders(headers, responseStatus);
+            } else {
+                // handle content encoding
+                actualBytes = entityBytes(entityBytes, position, length);
+                boolean automaticContentEncoding = entityBytes != actualBytes;
+                if (automaticContentEncoding) {       // encoding happened, new byte array
+                    actualPosition = 0;
+                    actualLength = actualBytes.length;
+                    if (!headers.containsToken(VARY_ACCEPT_ENCODING)) {
+                        headers.add(VARY_ACCEPT_ENCODING);
+                    }
                 }
-                headers.remove(HeaderNames.TRAILER);
+                headers.setIfAbsent(HeaderValues.create(HeaderNames.CONTENT_LENGTH,
+                                                        true,
+                                                        false,
+                                                        String.valueOf(actualLength)));
             }
             isSent = true;
 
@@ -185,9 +183,13 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 afterSend();
                 return;
             }
-            bytesWritten += stream.writeHeadersWithData(http2Headers, actualLength,
-                                                        BufferData.create(actualBytes, actualPosition, actualLength),
-                                                        !sendTrailers);
+            if (headRequest) {
+                bytesWritten += stream.writeHeaders(http2Headers, !sendTrailers);
+            } else {
+                bytesWritten += stream.writeHeadersWithData(http2Headers, actualLength,
+                                                            BufferData.create(actualBytes, actualPosition, actualLength),
+                                                            !sendTrailers);
+            }
 
             if (sendTrailers) {
                 Consumer<ServerResponseTrailers> beforeTrailers = beforeTrailers();
@@ -229,11 +231,15 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         prepareResponse();
         streamingEntity = true;
 
-        outputStream = new BlockingOutputStream(request, this, () -> {
+        outputStream = new BlockingOutputStream(request, this, () -> this.isSent = true, () -> {
             this.isSent = true;
             afterSend();
         }, beforeTrailers());
-        return applyStreamFilters(contentEncode(outputStream));
+        if (isNoEntityStatus(status())) {
+            return new ApplicationOutputStream(outputStream, outputStream);
+        }
+        OutputStream encodedOutputStream = contentEncode(outputStream);
+        return new ApplicationOutputStream(applyStreamFilters(encodedOutputStream), outputStream);
     }
 
     private void prepareResponse() {
@@ -329,24 +335,47 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
     }
 
+    private static boolean isNoEntityStatus(Status status) {
+        int statusCode = status.code();
+        return statusCode == Status.NO_CONTENT_204.code()
+                || statusCode == Status.RESET_CONTENT_205.code()
+                || statusCode == Status.NOT_MODIFIED_304.code();
+    }
+
+    private static void normalizeNoEntityHeaders(ServerResponseHeaders headers, Status status) {
+        int statusCode = status.code();
+        if (statusCode == Status.NO_CONTENT_204.code()) {
+            headers.remove(HeaderNames.CONTENT_LENGTH);
+        } else if (statusCode == Status.RESET_CONTENT_205.code()) {
+            headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
+        }
+        headers.remove(HeaderNames.TRANSFER_ENCODING);
+        headers.remove(HeaderNames.TRAILER);
+    }
+
     private static class BlockingOutputStream extends OutputStream {
 
         private final Http2ServerRequest request;
         private final ServerResponseHeaders headers;
         private final ServerResponseTrailers trailers;
         private final Status status;
+        private final Runnable responseSentRunnable;
         private final Runnable responseCloseRunnable;
         private final Http2ServerResponse response;
         private final Http2ServerStream stream;
+        private final boolean headRequest;
 
         private BufferData firstBuffer;
         private boolean closed;
         private boolean firstByte = true;
+        private boolean headResponseSent;
         private long bytesWritten;
+        private long headRepresentationLength;
         private final Consumer<ServerResponseTrailers> beforeTrailers;
 
         private BlockingOutputStream(Http2ServerRequest request,
                                      Http2ServerResponse response,
+                                     Runnable responseSentRunnable,
                                      Runnable responseCloseRunnable,
                                      Consumer<ServerResponseTrailers> beforeTrailers) {
             this.request = request;
@@ -355,8 +384,10 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             this.trailers = response.trailers;
             this.stream = response.stream;
             this.status = response.status();
+            this.responseSentRunnable = responseSentRunnable;
             this.responseCloseRunnable = responseCloseRunnable;
             this.beforeTrailers = beforeTrailers;
+            this.headRequest = request.prologue().method() == Method.HEAD;
         }
 
         @Override
@@ -376,6 +407,17 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
 
         @Override
         public void flush() throws IOException {
+            if (headRequest) {
+                if (!headResponseSent) {
+                    if (isNoEntityStatus(status)) {
+                        normalizeNoEntityHeaders(headers, status);
+                    }
+                    headers.remove(HeaderNames.TRAILER);
+                    sendHeadHeaders(true);
+                    responseSentRunnable.run();
+                }
+                return;
+            }
             if (firstByte && firstBuffer != null) {
                 write(BufferData.empty());
             }
@@ -391,9 +433,33 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 return;
             }
             this.closed = true;
+            boolean noEntityResponse = isNoEntityStatus(status);
+            if (noEntityResponse) {
+                normalizeNoEntityHeaders(headers, status);
+            }
             boolean sendTrailers = Http2ServerResponse.sendTrailers(headers);
 
-            if (firstByte) {
+            if (noEntityResponse) {
+                headers.setIfAbsent(HeaderValues.create(HeaderNames.DATE, true, false, DateTime.rfc1123String()));
+
+                Http2Headers http2Headers = Http2Headers.create(headers);
+                http2Headers.status(status);
+                response.validateResponse(http2Headers);
+                if (!headResponseSent) {
+                    bytesWritten += stream.writeHeaders(http2Headers, true);
+                }
+            } else if (headRequest) {
+                if (!headResponseSent) {
+                    headers.setIfAbsent(HeaderValues.create(HeaderNames.CONTENT_LENGTH,
+                                                            true,
+                                                            false,
+                                                            String.valueOf(headRepresentationLength)));
+                    sendHeadHeaders(!sendTrailers);
+                    if (sendTrailers) {
+                        sendTrailers();
+                    }
+                }
+            } else if (firstByte) {
                 // if sendTrailers, will not send end-of-stream
                 sendFirstChunkOnly(sendTrailers);
                 if (sendTrailers) {
@@ -419,6 +485,20 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             if (closed) {
                 throw new IOException("Stream already closed");
             }
+            if (headResponseSent) {
+                // Encoder and filter finalization after an early HEAD flush must not produce content.
+                return;
+            }
+            if (isNoEntityStatus(status)) {
+                if (buffer.available() > 0) {
+                    throw new IllegalStateException("Attempting to write data on a response with status " + status);
+                }
+                return;
+            }
+            if (headRequest) {
+                headRepresentationLength += buffer.available();
+                return;
+            }
             if (firstByte && firstBuffer == null) {
                 // if somebody re-uses the byte buffer sent to us, we must copy it
                 firstBuffer = buffer.copy();
@@ -432,6 +512,16 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             } else {
                 bytesWritten += stream.writeData(buffer, false);
             }
+        }
+
+        private void sendHeadHeaders(boolean endStream) {
+            headers.setIfAbsent(HeaderValues.create(HeaderNames.DATE, true, false, DateTime.rfc1123String()));
+
+            Http2Headers http2Headers = Http2Headers.create(headers);
+            http2Headers.status(status);
+            response.validateResponse(http2Headers);
+            bytesWritten += stream.writeHeaders(http2Headers, endStream);
+            headResponseSent = true;
         }
 
         private void sendFirstChunkOnly(boolean sendTrailers) {
@@ -488,5 +578,53 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             Http2Headers http2Headers = Http2Headers.create(trailers);
             bytesWritten += stream.writeTrailers(http2Headers);
         }
+
+        private void checkWriteAllowed(int length) throws IOException {
+            if (length > 0 && isNoEntityStatus(status)) {
+                throw new IllegalStateException("Attempting to write data on a response with status " + status);
+            }
+            if (length > 0 && headResponseSent) {
+                throw new IOException("HEAD response already sent");
+            }
+        }
     }
+
+    private static class ApplicationOutputStream extends OutputStream {
+        private final OutputStream delegate;
+        private final BlockingOutputStream blockingOutputStream;
+
+        private ApplicationOutputStream(OutputStream delegate, BlockingOutputStream blockingOutputStream) {
+            this.delegate = delegate;
+            this.blockingOutputStream = blockingOutputStream;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            blockingOutputStream.checkWriteAllowed(1);
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            blockingOutputStream.checkWriteAllowed(b.length);
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            blockingOutputStream.checkWriteAllowed(len);
+            delegate.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            delegate.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+
 }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -149,10 +149,12 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                         headers.add(VARY_ACCEPT_ENCODING);
                     }
                 }
-                headers.setIfAbsent(HeaderValues.create(HeaderNames.CONTENT_LENGTH,
-                                                        true,
-                                                        false,
-                                                        String.valueOf(actualLength)));
+                if (!headRequest || !suppressImplicitContentLength()) {
+                    headers.setIfAbsent(HeaderValues.create(HeaderNames.CONTENT_LENGTH,
+                                                            true,
+                                                            false,
+                                                            String.valueOf(actualLength)));
+                }
             }
             isSent = true;
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -230,7 +230,10 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             return new ApplicationOutputStream(outputStream, outputStream);
         }
         OutputStream encodedOutputStream = contentEncode(outputStream);
-        return new ApplicationOutputStream(applyStreamFilters(encodedOutputStream), outputStream);
+        OutputStream applicationOutputStream = applyStreamFilters(encodedOutputStream);
+        return outputStream.headRequest
+                ? new ApplicationOutputStream(applicationOutputStream, outputStream)
+                : applicationOutputStream;
     }
 
     private boolean prepareResponse() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -78,6 +78,7 @@ import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 import io.helidon.webserver.http2.spi.SubProtocolResult;
 
 import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.TRACE;
 
 /**
@@ -699,10 +700,18 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                                   message);
 
         Status responseStatus = response.status();
+        boolean finalInformationalResponse = responseStatus.family() == Status.Family.INFORMATIONAL;
+        if (finalInformationalResponse) {
+            LOGGER.log(ERROR,
+                       "Attempt to send a final informational response. "
+                               + "Server responded with Internal Server Error.");
+            responseStatus = Status.INTERNAL_SERVER_ERROR_500;
+        }
         ServerResponseHeaders headers = response.headers();
         int responseStatusCode = responseStatus.code();
         boolean noContentResponse = responseStatusCode == Status.NO_CONTENT_204.code();
-        boolean noEntityResponse = noContentResponse
+        boolean noEntityResponse = finalInformationalResponse
+                || noContentResponse
                 || responseStatusCode == Status.RESET_CONTENT_205.code()
                 || responseStatusCode == Status.NOT_MODIFIED_304.code();
         byte[] entity;
@@ -710,7 +719,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
             entity = BufferData.EMPTY_BYTES;
             if (noContentResponse) {
                 headers.remove(HeaderNames.CONTENT_LENGTH);
-            } else if (responseStatusCode == Status.RESET_CONTENT_205.code()) {
+            } else if (finalInformationalResponse || responseStatusCode == Status.RESET_CONTENT_205.code()) {
                 headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
             }
             headers.remove(HeaderNames.TRANSFER_ENCODING);

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -698,13 +698,29 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                                   exception.responseHeaders(),
                                                                   message);
 
+        Status responseStatus = response.status();
         ServerResponseHeaders headers = response.headers();
-        byte[] entity = response.entity().orElse(BufferData.EMPTY_BYTES);
-        if (entity.length != 0) {
+        int responseStatusCode = responseStatus.code();
+        boolean noContentResponse = responseStatusCode == Status.NO_CONTENT_204.code();
+        boolean noEntityResponse = noContentResponse
+                || responseStatusCode == Status.RESET_CONTENT_205.code()
+                || responseStatusCode == Status.NOT_MODIFIED_304.code();
+        byte[] entity;
+        if (noEntityResponse) {
+            entity = BufferData.EMPTY_BYTES;
+            if (noContentResponse) {
+                headers.remove(HeaderNames.CONTENT_LENGTH);
+            } else if (responseStatusCode == Status.RESET_CONTENT_205.code()) {
+                headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
+            }
+            headers.remove(HeaderNames.TRANSFER_ENCODING);
+            headers.remove(HeaderNames.TRAILER);
+        } else {
+            entity = response.entity().orElse(BufferData.EMPTY_BYTES);
             headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
         }
         Http2Headers http2Headers = Http2Headers.create(headers)
-                .status(exception.status());
+                .status(responseStatus);
         boolean resetRequestBody = prepareRejectedStream(false);
         AtomicBoolean rejectedStreamCompleted = new AtomicBoolean();
         Runnable completeRejectedStream = () -> {
@@ -735,14 +751,14 @@ class Http2ServerStream implements Runnable, Http2Stream {
                     writer.writeHeaders(http2Headers,
                                         streamId,
                                         Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
-                                        new Http2FrameData(dataHeader, BufferData.create(message)),
+                                        new Http2FrameData(dataHeader, BufferData.create(entity)),
                                         flowControl.outbound());
                     completeRejectedStream.run();
                 } else {
                     connectionWriter.writeHeaders(http2Headers,
                                                   streamId,
                                                   Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
-                                                  new Http2FrameData(dataHeader, BufferData.create(message)),
+                                                  new Http2FrameData(dataHeader, BufferData.create(entity)),
                                                   flowControl.outbound(),
                                                   completeRejectedStream);
                 }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -701,8 +701,8 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                                   message);
 
         var responseEntity = response.entity();
-        boolean preserveHeadContentLength = responseEntity.isEmpty()
-                && Method.HEAD_NAME.equals(exception.request().method());
+        boolean headRequest = Method.HEAD_NAME.equals(exception.request().method());
+        boolean preserveHeadContentLength = responseEntity.isEmpty() && headRequest;
         Status responseStatus = response.status();
         boolean finalInformationalResponse = responseStatus.family() == Status.Family.INFORMATIONAL;
         if (finalInformationalResponse) {
@@ -729,9 +729,10 @@ class Http2ServerStream implements Runnable, Http2Stream {
             headers.remove(HeaderNames.TRANSFER_ENCODING);
             headers.remove(HeaderNames.TRAILER);
         } else {
-            entity = responseEntity.orElse(BufferData.EMPTY_BYTES);
+            byte[] responseEntityBytes = responseEntity.orElse(BufferData.EMPTY_BYTES);
+            entity = headRequest ? BufferData.EMPTY_BYTES : responseEntityBytes;
             if (!preserveHeadContentLength) {
-                headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
+                headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(responseEntityBytes.length)));
             }
         }
         Http2Headers http2Headers = Http2Headers.create(headers)

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -701,7 +701,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                                   message);
 
         var responseEntity = response.entity();
-        boolean headRequest = Method.HEAD_NAME.equals(exception.request().method());
+        boolean headRequest = prologue.method() == Method.HEAD;
         boolean preserveHeadContentLength = responseEntity.isEmpty() && headRequest;
         Status responseStatus = response.status();
         boolean finalInformationalResponse = responseStatus.family() == Status.Family.INFORMATIONAL;

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -42,6 +42,7 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
 import io.helidon.http.RequestException;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.Status;
@@ -699,6 +700,9 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                                   exception.responseHeaders(),
                                                                   message);
 
+        var responseEntity = response.entity();
+        boolean preserveHeadContentLength = responseEntity.isEmpty()
+                && Method.HEAD_NAME.equals(exception.request().method());
         Status responseStatus = response.status();
         boolean finalInformationalResponse = responseStatus.family() == Status.Family.INFORMATIONAL;
         if (finalInformationalResponse) {
@@ -725,8 +729,10 @@ class Http2ServerStream implements Runnable, Http2Stream {
             headers.remove(HeaderNames.TRANSFER_ENCODING);
             headers.remove(HeaderNames.TRAILER);
         } else {
-            entity = response.entity().orElse(BufferData.EMPTY_BYTES);
-            headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
+            entity = responseEntity.orElse(BufferData.EMPTY_BYTES);
+            if (!preserveHeadContentLength) {
+                headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
+            }
         }
         Http2Headers http2Headers = Http2Headers.create(headers)
                 .status(responseStatus);

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -150,6 +150,83 @@ class Http2ServerResponseTest {
     }
 
     @Test
+    void directHandlerHeadUsesEncodedRepresentationMetadata() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+        when(request.method()).thenReturn(Method.HEAD_NAME);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.BAD_REQUEST_400)
+                                    .entity("error")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .request(request)
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        Headers sentHeaders = responseHeaders.getValue().httpHeaders();
+        assertAll(
+                () -> assertThat(responseHeaders.getValue().status(), is(Status.BAD_REQUEST_400)),
+                () -> assertThat(sentHeaders.contentLength().orElseThrow(), is(6L)),
+                () -> assertThat(sentHeaders.get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
+                () -> assertThat(sentHeaders.containsToken(HeaderValues.create(HeaderNames.VARY,
+                                                                               HeaderNames.ACCEPT_ENCODING_NAME)),
+                                 is(true))
+        );
+    }
+
+    @Test
+    void directHandlerHeadSkipsRepresentationMetadataForLateInformationalStatus() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        response.beforeSend(() -> response.status(Status.CONTINUE_100));
+        DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+        when(request.method()).thenReturn(Method.HEAD_NAME);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.BAD_REQUEST_400)
+                                    .entity("error")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .request(request)
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        Headers sentHeaders = responseHeaders.getValue().httpHeaders();
+        assertAll(
+                () -> assertThat(responseHeaders.getValue().status(), is(Status.INTERNAL_SERVER_ERROR_500)),
+                () -> assertThat(sentHeaders.contentLength().orElseThrow(), is(0L)),
+                () -> assertThat(sentHeaders.contains(HeaderNames.CONTENT_ENCODING), is(false)),
+                () -> assertThat(sentHeaders.contains(HeaderNames.VARY), is(false))
+        );
+    }
+
+    @Test
     void directHandlerNoContentRemovesContentLength() {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http2;
 
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -538,6 +539,61 @@ class Http2ServerResponseTest {
     }
 
     @Test
+    void streamingHeadRejectsEntityBeforeWritingToFilter() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        AtomicBoolean filterWritten = new AtomicBoolean();
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        response.streamFilter(network -> new FilterOutputStream(network) {
+            @Override
+            public void write(int value) throws IOException {
+                filterWritten.set(true);
+                super.write(value);
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) throws IOException {
+                filterWritten.set(true);
+                super.write(bytes, offset, length);
+            }
+        });
+
+        OutputStream output = response.outputStream();
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                        () -> output.write("entity".getBytes(StandardCharsets.UTF_8)));
+
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(filterWritten.get(), is(false)),
+                () -> assertThat(response.isSent(), is(false))
+        );
+        verifyNoWrites(stream);
+    }
+
+    @Test
+    void streamingHeadRejectsEntityBeforeWritingToEncoder() throws IOException {
+        AtomicBoolean encoderWritten = new AtomicBoolean();
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class)))
+                .thenReturn(testEncoder(() -> encoderWritten.set(true)));
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+
+        OutputStream output = response.outputStream();
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                        () -> output.write("entity".getBytes(StandardCharsets.UTF_8)));
+
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(encoderWritten.get(), is(false)),
+                () -> assertThat(response.isSent(), is(false))
+        );
+        verifyNoWrites(stream);
+    }
+
+    @Test
     void streamingHeadRejectsEntityBeforeSendingResponse() throws IOException {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
@@ -632,18 +688,24 @@ class Http2ServerResponseTest {
     }
 
     private static ContentEncoder testEncoder() {
+        return testEncoder(() -> { });
+    }
+
+    private static ContentEncoder testEncoder(Runnable onWrite) {
         return new ContentEncoder() {
             @Override
             public OutputStream apply(OutputStream network) {
                 return new OutputStream() {
                     @Override
                     public void write(int value) throws IOException {
+                        onWrite.run();
                         network.write('x');
                         network.write(value);
                     }
 
                     @Override
                     public void write(byte[] bytes, int offset, int length) throws IOException {
+                        onWrite.run();
                         network.write('x');
                         network.write(bytes, offset, length);
                     }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -1,0 +1,692 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http2;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.UnaryOperator;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.http.DirectHandler;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Headers;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.http.RequestException;
+import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.encoding.ContentEncoder;
+import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.http.encoding.gzip.GzipEncoding;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.media.MediaContext;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.DirectHandlers;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class Http2ServerResponseTest {
+    private static final List<Status> NO_ENTITY_STATUSES = List.of(Status.NO_CONTENT_204,
+                                                                  Status.RESET_CONTENT_205,
+                                                                  Status.NOT_MODIFIED_304);
+
+    @Test
+    void headUsesEncodedMetadataWithoutSendingEntity() {
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+
+        Http2ServerStream getStream = mock(Http2ServerStream.class);
+        createResponse(getStream, Method.GET, contentEncodingContext).send(entity);
+        var getHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        var getEntity = ArgumentCaptor.forClass(BufferData.class);
+        verify(getStream).writeHeadersWithData(getHeaders.capture(), anyInt(), getEntity.capture(), anyBoolean());
+
+        Http2ServerStream headStream = mock(Http2ServerStream.class);
+        createResponse(headStream, Method.HEAD, contentEncodingContext).send(entity);
+        var headHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(headStream).writeHeaders(headHeaders.capture(), anyBoolean());
+        verify(headStream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+
+        assertAll(
+                () -> assertThat(getHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
+                () -> assertThat(getHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(7L)),
+                () -> assertThat(new String(getEntity.getValue().readBytes(), StandardCharsets.UTF_8), is("xentity")),
+                () -> assertThat(headHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
+                () -> assertThat(headHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(7L))
+        );
+    }
+
+    @Test
+    void directHandlerReplacesContentLengthWithEncodedLength() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        response.contentLength(17);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .entity("error")
+                                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        var responseEntity = ArgumentCaptor.forClass(BufferData.class);
+        verify(stream).writeHeadersWithData(responseHeaders.capture(), eq(6), responseEntity.capture(), eq(true));
+        assertAll(
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(6L)),
+                () -> assertThat(new String(responseEntity.getValue().readBytes(), StandardCharsets.UTF_8), is("xerror"))
+        );
+    }
+
+    @Test
+    void directHandlerHeadPreservesContentLengthWithoutEntity() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+        when(request.method()).thenReturn(Method.HEAD_NAME);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.BAD_REQUEST_400)
+                                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .request(request)
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        assertAll(
+                () -> assertThat(responseHeaders.getValue().status(), is(Status.BAD_REQUEST_400)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(23L))
+        );
+    }
+
+    @Test
+    void directHandlerNoContentRemovesContentLength() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        response.contentLength(17);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.NO_CONTENT_204)
+                                    .entity("ignored")
+                                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                                    .header(HeaderValues.TRANSFER_ENCODING_CHUNKED)
+                                    .header(HeaderNames.TRAILER, "test-trailer")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        assertAll(
+                () -> assertThat(responseHeaders.getValue().status(), is(Status.NO_CONTENT_204)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.TRAILER), is(false))
+        );
+    }
+
+    @Test
+    void presetNoEntityStatusesBypassNegotiatedGzip() {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()
+                    .addContentEncoding(GzipEncoding.create())
+                    .build();
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.set(HeaderNames.ACCEPT_ENCODING, "gzip");
+            Http2ServerStream stream = mock(Http2ServerStream.class);
+            Http2ServerResponse response = createResponse(stream,
+                                                          Method.GET,
+                                                          contentEncodingContext,
+                                                          ServerRequestHeaders.create(requestHeaders));
+            response.status(status);
+            response.contentLength(23);
+            response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+
+            response.send("entity".getBytes(StandardCharsets.UTF_8));
+
+            var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+            verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+            verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+            verify(stream, never()).writeData(any(), anyBoolean());
+            verify(stream, never()).writeTrailers(any());
+            Http2Headers sentHeaders = responseHeaders.getValue();
+            Headers sentHttpHeaders = sentHeaders.httpHeaders();
+            assertAll(
+                    () -> assertThat(sentHeaders.status(), is(status)),
+                    () -> assertNoEntityContentLength(status, sentHttpHeaders),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.CONTENT_ENCODING), is(false)),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.VARY),
+                                     is(status.code() == Status.NOT_MODIFIED_304.code())),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRAILER), is(false))
+            );
+        }
+    }
+
+    @Test
+    void beforeSendNoEntityStatusesBypassNegotiatedGzip() {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()
+                    .addContentEncoding(GzipEncoding.create())
+                    .build();
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.set(HeaderNames.ACCEPT_ENCODING, "gzip");
+            Http2ServerStream stream = mock(Http2ServerStream.class);
+            Http2ServerResponse response = createResponse(stream,
+                                                          Method.GET,
+                                                          contentEncodingContext,
+                                                          ServerRequestHeaders.create(requestHeaders));
+            response.contentLength(23);
+            response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+            response.beforeSend(() -> response.status(status));
+
+            response.send("entity".getBytes(StandardCharsets.UTF_8));
+
+            var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+            verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+            verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+            verify(stream, never()).writeData(any(), anyBoolean());
+            verify(stream, never()).writeTrailers(any());
+            Http2Headers sentHeaders = responseHeaders.getValue();
+            Headers sentHttpHeaders = sentHeaders.httpHeaders();
+            assertAll(
+                    () -> assertThat(sentHeaders.status(), is(status)),
+                    () -> assertNoEntityContentLength(status, sentHttpHeaders),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.CONTENT_ENCODING), is(false)),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.VARY),
+                                     is(status.code() == Status.NOT_MODIFIED_304.code())),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRAILER), is(false))
+            );
+        }
+    }
+
+    @Test
+    void filteredNoEntityStatusesBypassNegotiatedGzip() {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()
+                    .addContentEncoding(GzipEncoding.create())
+                    .build();
+            WritableHeaders<?> requestHeaders = WritableHeaders.create();
+            requestHeaders.set(HeaderNames.ACCEPT_ENCODING, "gzip");
+            Http2ServerStream stream = mock(Http2ServerStream.class);
+            Http2ServerResponse response = createResponse(stream,
+                                                          Method.GET,
+                                                          contentEncodingContext,
+                                                          ServerRequestHeaders.create(requestHeaders));
+            AtomicBoolean filterCalled = new AtomicBoolean();
+            response.status(status);
+            response.contentLength(23);
+            response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+            response.streamFilter(output -> {
+                filterCalled.set(true);
+                return output;
+            });
+
+            response.send("entity".getBytes(StandardCharsets.UTF_8));
+            response.commit();
+
+            var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+            verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+            verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+            verify(stream, never()).writeData(any(), anyBoolean());
+            verify(stream, never()).writeTrailers(any());
+            Http2Headers sentHeaders = responseHeaders.getValue();
+            Headers sentHttpHeaders = sentHeaders.httpHeaders();
+            assertAll(
+                    () -> assertThat(filterCalled.get(), is(false)),
+                    () -> assertThat(sentHeaders.status(), is(status)),
+                    () -> assertNoEntityContentLength(status, sentHttpHeaders),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.CONTENT_ENCODING), is(false)),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRAILER), is(false))
+            );
+        }
+    }
+
+    @Test
+    void filteredSendHonorsBeforeSendNoContent() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        AtomicBoolean filterCalled = new AtomicBoolean();
+        AtomicInteger whenSentCalls = new AtomicInteger();
+        response.streamFilter(output -> {
+            filterCalled.set(true);
+            return output;
+        });
+        response.beforeSend(() -> response.status(Status.NO_CONTENT_204));
+        response.whenSent(whenSentCalls::incrementAndGet);
+
+        response.send("entity".getBytes(StandardCharsets.UTF_8));
+        response.commit();
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        verify(stream, never()).writeTrailers(any());
+        Http2Headers sentHeaders = responseHeaders.getValue();
+        assertAll(
+                () -> assertThat(filterCalled.get(), is(false)),
+                () -> assertThat(response.isSent(), is(true)),
+                () -> assertThat(whenSentCalls.get(), is(1)),
+                () -> assertThat(sentHeaders.status(), is(Status.NO_CONTENT_204)),
+                () -> assertThat(sentHeaders.httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false))
+        );
+    }
+
+    @Test
+    void noEntityApplicationWritesRemainRejected() throws IOException {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            Http2ServerStream stream = mock(Http2ServerStream.class);
+            Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+            AtomicInteger whenSentCalls = new AtomicInteger();
+            response.status(status);
+            response.contentLength(23);
+            response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+            response.whenSent(whenSentCalls::incrementAndGet);
+
+            OutputStream output = response.outputStream();
+            IllegalStateException exception = assertThrows(IllegalStateException.class, () -> output.write('x'));
+            output.write(new byte[0]);
+            output.flush();
+            response.commit();
+
+            var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+            verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+            verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+            verify(stream, never()).writeData(any(), anyBoolean());
+            verify(stream, never()).writeTrailers(any());
+            Headers sentHttpHeaders = responseHeaders.getValue().httpHeaders();
+            assertAll(
+                    () -> assertThat(exception.getMessage(), containsString(status.toString())),
+                    () -> assertThat(responseHeaders.getValue().status(), is(status)),
+                    () -> assertNoEntityContentLength(status, sentHttpHeaders),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                    () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRAILER), is(false)),
+                    () -> assertThat(whenSentCalls.get(), is(1))
+            );
+        }
+    }
+
+    @Test
+    void filteredHeadUsesFilteredMetadataWithoutSendingEntity() {
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+        UnaryOperator<OutputStream> filter = network -> new OutputStream() {
+            @Override
+            public void write(int value) throws IOException {
+                network.write(new byte[] {'y', (byte) value});
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) throws IOException {
+                byte[] filtered = new byte[length + 1];
+                filtered[0] = 'y';
+                System.arraycopy(bytes, offset, filtered, 1, length);
+                network.write(filtered);
+            }
+
+            @Override
+            public void close() throws IOException {
+                network.close();
+            }
+        };
+
+        Http2ServerStream getStream = mock(Http2ServerStream.class);
+        Http2ServerResponse getResponse = createResponse(getStream, Method.GET, contentEncodingContext);
+        getResponse.streamFilter(filter);
+        getResponse.send(entity);
+        getResponse.commit();
+        var getHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        var getEntity = ArgumentCaptor.forClass(BufferData.class);
+        verify(getStream).writeHeaders(getHeaders.capture(), eq(false));
+        verify(getStream).writeData(getEntity.capture(), eq(false));
+
+        Http2ServerStream headStream = mock(Http2ServerStream.class);
+        Http2ServerResponse headResponse = createResponse(headStream, Method.HEAD, contentEncodingContext);
+        headResponse.streamFilter(filter);
+        headResponse.send(entity);
+        headResponse.commit();
+        var headHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(headStream).writeHeaders(headHeaders.capture(), eq(true));
+        verify(headStream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(headStream, never()).writeData(any(), anyBoolean());
+
+        assertAll(
+                () -> assertThat(getHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
+                () -> assertThat(new String(getEntity.getValue().readBytes(), StandardCharsets.UTF_8), is("xyentity")),
+                () -> assertThat(headHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
+                () -> assertThat(headHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(8L))
+        );
+    }
+
+    @Test
+    void streamingHeadUsesEntityMetadataWithoutSendingEntity() throws IOException {
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+
+        Http2ServerStream getStream = mock(Http2ServerStream.class);
+        Http2ServerResponse getResponse = createResponse(getStream, Method.GET, contentEncodingContext);
+        try (OutputStream output = getResponse.outputStream()) {
+            output.write(entity);
+        }
+        getResponse.commit();
+        var getHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        var getEntity = ArgumentCaptor.forClass(BufferData.class);
+        verify(getStream).writeHeadersWithData(getHeaders.capture(), anyInt(), getEntity.capture(), anyBoolean());
+
+        Http2ServerStream headStream = mock(Http2ServerStream.class);
+        Http2ServerResponse headResponse = createResponse(headStream, Method.HEAD, contentEncodingContext);
+        try (OutputStream output = headResponse.outputStream()) {
+            output.write(entity);
+        }
+        headResponse.commit();
+        var headHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(headStream).writeHeaders(headHeaders.capture(), eq(true));
+        verify(headStream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(headStream, never()).writeData(any(), anyBoolean());
+
+        assertAll(
+                () -> assertThat(getHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(6L)),
+                () -> assertThat(new String(getEntity.getValue().readBytes(), StandardCharsets.UTF_8), is("entity")),
+                () -> assertThat(headHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(6L))
+        );
+    }
+
+    @Test
+    void flushedStreamingHeadSendsImmediatelyAndStopsWrites() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        AtomicInteger whenSentCalls = new AtomicInteger();
+        response.whenSent(whenSentCalls::incrementAndGet);
+
+        OutputStream output = response.outputStream();
+        output.write("first".getBytes(StandardCharsets.UTF_8));
+        output.flush();
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        assertAll(
+                () -> assertThat(response.isSent(), is(true)),
+                () -> assertThat(whenSentCalls.get(), is(0)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false))
+        );
+
+        IOException exception = assertThrows(IOException.class,
+                                             () -> output.write("second".getBytes(StandardCharsets.UTF_8)));
+        assertThat(exception.getMessage(), containsString("HEAD response already sent"));
+        response.commit();
+
+        verify(stream).writeHeaders(any(Http2Headers.class), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        assertThat(whenSentCalls.get(), is(1));
+    }
+
+    @Test
+    void flushedStreamingHeadAllowsNegotiatedGzipToFinish() throws IOException {
+        ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()
+                .addContentEncoding(GzipEncoding.create())
+                .build();
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        requestHeaders.set(HeaderNames.ACCEPT_ENCODING, "gzip");
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream,
+                                                      Method.HEAD,
+                                                      contentEncodingContext,
+                                                      ServerRequestHeaders.create(requestHeaders));
+        AtomicInteger whenSentCalls = new AtomicInteger();
+        response.whenSent(whenSentCalls::incrementAndGet);
+
+        OutputStream output = response.outputStream();
+        output.write("first".getBytes(StandardCharsets.UTF_8));
+        output.flush();
+
+        IOException exception = assertThrows(IOException.class, () -> output.write('x'));
+        output.close();
+        response.commit();
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("HEAD response already sent")),
+                () -> assertThat(response.isSent(), is(true)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("gzip")),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false)),
+                () -> assertThat(whenSentCalls.get(), is(1))
+        );
+    }
+
+    @Test
+    void flushedStreamingHeadPreservesExplicitContentLength() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        response.contentLength(42);
+
+        OutputStream output = response.outputStream();
+        output.write("partial".getBytes(StandardCharsets.UTF_8));
+        output.flush();
+        response.commit();
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        assertThat(responseHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(42L));
+    }
+
+    @Test
+    void flushedStreamingHeadOmitsTrailers() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        AtomicBoolean beforeTrailersCalled = new AtomicBoolean();
+        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+        response.beforeTrailers(_ -> beforeTrailersCalled.set(true));
+
+        OutputStream output = response.outputStream();
+        output.write("partial".getBytes(StandardCharsets.UTF_8));
+        output.flush();
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        verify(stream, never()).writeTrailers(any());
+        assertAll(
+                () -> assertThat(beforeTrailersCalled.get(), is(false)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.TRAILER), is(false))
+        );
+
+        response.commit();
+        verify(stream).writeHeaders(any(Http2Headers.class), eq(true));
+        verify(stream, never()).writeTrailers(any());
+        assertThat(beforeTrailersCalled.get(), is(false));
+    }
+
+    @Test
+    void headSendsTrailersWithoutData() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        AtomicBoolean beforeTrailersCalled = new AtomicBoolean();
+        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+        response.beforeTrailers(_ -> beforeTrailersCalled.set(true));
+
+        try (OutputStream output = response.outputStream()) {
+            output.write("entity".getBytes(StandardCharsets.UTF_8));
+        }
+        response.commit();
+
+        verify(stream).writeHeaders(any(Http2Headers.class), eq(false));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        verify(stream).writeTrailers(any());
+        assertThat(beforeTrailersCalled.get(), is(true));
+    }
+
+    private static void assertNoEntityContentLength(Status status, Headers headers) {
+        if (status.code() == Status.NO_CONTENT_204.code()) {
+            assertThat(headers.contains(HeaderNames.CONTENT_LENGTH), is(false));
+        } else {
+            assertThat(headers.contentLength().orElseThrow(),
+                       is(status.code() == Status.RESET_CONTENT_205.code() ? 0L : 23L));
+        }
+    }
+
+    private static ContentEncoder testEncoder() {
+        return new ContentEncoder() {
+            @Override
+            public OutputStream apply(OutputStream network) {
+                return new OutputStream() {
+                    @Override
+                    public void write(int value) throws IOException {
+                        network.write('x');
+                        network.write(value);
+                    }
+
+                    @Override
+                    public void write(byte[] bytes, int offset, int length) throws IOException {
+                        network.write('x');
+                        network.write(bytes, offset, length);
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        network.close();
+                    }
+                };
+            }
+
+            @Override
+            public void headers(WritableHeaders<?> headers) {
+                headers.set(HeaderNames.CONTENT_ENCODING, "test");
+                headers.remove(HeaderNames.CONTENT_LENGTH);
+            }
+        };
+    }
+
+    private static Http2ServerResponse createResponse(Http2ServerStream stream,
+                                                      Method method,
+                                                      ContentEncodingContext contentEncodingContext) {
+        return createResponse(stream,
+                              method,
+                              contentEncodingContext,
+                              ServerRequestHeaders.create(WritableHeaders.create()));
+    }
+
+    private static Http2ServerResponse createResponse(Http2ServerStream stream,
+                                                      Method method,
+                                                      ContentEncodingContext contentEncodingContext,
+                                                      ServerRequestHeaders requestHeaders) {
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
+        when(listenerContext.mediaContext()).thenReturn(MediaContext.create());
+        when(listenerContext.config()).thenReturn(WebServer.builder().buildPrototype());
+
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        when(stream.connectionContext()).thenReturn(connectionContext);
+
+        Http2ServerRequest request = mock(Http2ServerRequest.class);
+        HttpPrologue prologue = mock(HttpPrologue.class);
+        when(prologue.method()).thenReturn(method);
+        when(request.prologue()).thenReturn(prologue);
+        when(request.headers()).thenReturn(requestHeaders);
+
+        return new Http2ServerResponse(stream, request, true);
+    }
+}

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -274,6 +274,66 @@ class Http2ServerResponseTest {
     }
 
     @Test
+    void presetInformationalStatusIsNotSentAsFinalResponse() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        response.status(Status.CONTINUE_100);
+        response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+
+        response.send("entity".getBytes(StandardCharsets.UTF_8));
+
+        assertRejectedInformationalResponse(stream);
+    }
+
+    @Test
+    void filteredInformationalStatusIsNotSentAsFinalResponse() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        AtomicBoolean filterCalled = new AtomicBoolean();
+        response.status(Status.CONTINUE_100);
+        response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+        response.streamFilter(output -> {
+            filterCalled.set(true);
+            return output;
+        });
+
+        response.send("entity".getBytes(StandardCharsets.UTF_8));
+        response.commit();
+
+        assertAll(
+                () -> assertThat(filterCalled.get(), is(false)),
+                () -> assertRejectedInformationalResponse(stream)
+        );
+    }
+
+    @Test
+    void streamingInformationalStatusIsNotSentAsFinalResponse() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        response.status(Status.CONTINUE_100);
+        response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+
+        OutputStream output = response.outputStream();
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> output.write('x'));
+        output.write(new byte[0]);
+        response.commit();
+
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString(Status.INTERNAL_SERVER_ERROR_500.toString())),
+                () -> assertRejectedInformationalResponse(stream)
+        );
+    }
+
+    @Test
     void filteredNoEntityStatusesBypassNegotiatedGzip() {
         for (Status status : NO_ENTITY_STATUSES) {
             ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()
@@ -657,6 +717,22 @@ class Http2ServerResponseTest {
                 headers.remove(HeaderNames.CONTENT_LENGTH);
             }
         };
+    }
+
+    private static void assertRejectedInformationalResponse(Http2ServerStream stream) {
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        verify(stream, never()).writeTrailers(any());
+        Http2Headers sentHeaders = responseHeaders.getValue();
+        Headers sentHttpHeaders = sentHeaders.httpHeaders();
+        assertAll(
+                () -> assertThat(sentHeaders.status(), is(Status.INTERNAL_SERVER_ERROR_500)),
+                () -> assertThat(sentHttpHeaders.contentLength().orElseThrow(), is(0L)),
+                () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                () -> assertThat(sentHttpHeaders.contains(HeaderNames.TRAILER), is(false))
+        );
     }
 
     private static Http2ServerResponse createResponse(Http2ServerStream stream,

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -190,6 +190,53 @@ class Http2ServerResponseTest {
     }
 
     @Test
+    void directHandlerFilteredHeadUsesOnlyConfiguredRepresentationLength() {
+        for (long configuredLength : List.of(-1L, 10L)) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            Http2ServerStream stream = mock(Http2ServerStream.class);
+            Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+            response.streamFilter(output -> new FilterOutputStream(output) {
+                @Override
+                public void write(byte[] bytes, int offset, int length) throws IOException {
+                    out.write(bytes, offset, length);
+                    out.write(bytes, offset, length);
+                }
+            });
+            if (configuredLength >= 0) {
+                response.beforeSend(() -> response.contentLength(configuredLength));
+            }
+            DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+            when(request.method()).thenReturn(Method.HEAD_NAME);
+            DirectHandlers directHandlers = DirectHandlers.builder()
+                    .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                                (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                        .status(Status.BAD_REQUEST_400)
+                                        .entity("error")
+                                        .build())
+                    .build();
+            RequestException requestException = RequestException.builder()
+                    .request(request)
+                    .type(DirectHandler.EventType.BAD_REQUEST)
+                    .message("bad request")
+                    .build();
+
+            directHandlers.handle(requestException, response, true);
+
+            var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+            verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+            verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+            verify(stream, never()).writeData(any(), anyBoolean());
+            Headers sentHeaders = responseHeaders.getValue().httpHeaders();
+            if (configuredLength < 0) {
+                assertThat(sentHeaders.contains(HeaderNames.CONTENT_LENGTH), is(false));
+            } else {
+                assertThat(sentHeaders.contentLength().orElseThrow(), is(configuredLength));
+            }
+        }
+    }
+
+    @Test
     void directHandlerHeadSkipsRepresentationMetadataForLateInformationalStatus() {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.UnaryOperator;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.DirectHandler;
@@ -69,31 +68,21 @@ class Http2ServerResponseTest {
                                                                   Status.NOT_MODIFIED_304);
 
     @Test
-    void headUsesEncodedMetadataWithoutSendingEntity() {
+    void headRejectsEntityBeforeSendingResponse() {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
         when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
 
-        Http2ServerStream getStream = mock(Http2ServerStream.class);
-        createResponse(getStream, Method.GET, contentEncodingContext).send(entity);
-        var getHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        var getEntity = ArgumentCaptor.forClass(BufferData.class);
-        verify(getStream).writeHeadersWithData(getHeaders.capture(), anyInt(), getEntity.capture(), anyBoolean());
-
-        Http2ServerStream headStream = mock(Http2ServerStream.class);
-        createResponse(headStream, Method.HEAD, contentEncodingContext).send(entity);
-        var headHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        verify(headStream).writeHeaders(headHeaders.capture(), anyBoolean());
-        verify(headStream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> response.send(entity));
 
         assertAll(
-                () -> assertThat(getHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
-                () -> assertThat(getHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(7L)),
-                () -> assertThat(new String(getEntity.getValue().readBytes(), StandardCharsets.UTF_8), is("xentity")),
-                () -> assertThat(headHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
-                () -> assertThat(headHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(7L))
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(response.isSent(), is(false))
         );
+        verifyNoWrites(stream);
     }
 
     @Test
@@ -449,186 +438,64 @@ class Http2ServerResponseTest {
     }
 
     @Test
-    void filteredHeadUsesFilteredMetadataWithoutSendingEntity() {
+    void filteredHeadRejectsEntityBeforeApplyingFilter() {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
         when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
-        UnaryOperator<OutputStream> filter = network -> new OutputStream() {
-            @Override
-            public void write(int value) throws IOException {
-                network.write(new byte[] {'y', (byte) value});
-            }
-
-            @Override
-            public void write(byte[] bytes, int offset, int length) throws IOException {
-                byte[] filtered = new byte[length + 1];
-                filtered[0] = 'y';
-                System.arraycopy(bytes, offset, filtered, 1, length);
-                network.write(filtered);
-            }
-
-            @Override
-            public void close() throws IOException {
-                network.close();
-            }
-        };
-
-        Http2ServerStream getStream = mock(Http2ServerStream.class);
-        Http2ServerResponse getResponse = createResponse(getStream, Method.GET, contentEncodingContext);
-        getResponse.streamFilter(filter);
-        getResponse.send(entity);
-        getResponse.commit();
-        var getHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        var getEntity = ArgumentCaptor.forClass(BufferData.class);
-        verify(getStream).writeHeaders(getHeaders.capture(), eq(false));
-        verify(getStream).writeData(getEntity.capture(), eq(false));
-
-        Http2ServerStream headStream = mock(Http2ServerStream.class);
-        Http2ServerResponse headResponse = createResponse(headStream, Method.HEAD, contentEncodingContext);
-        headResponse.streamFilter(filter);
-        headResponse.send(entity);
-        headResponse.commit();
-        var headHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        verify(headStream).writeHeaders(headHeaders.capture(), eq(true));
-        verify(headStream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
-        verify(headStream, never()).writeData(any(), anyBoolean());
+        AtomicBoolean filterApplied = new AtomicBoolean();
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
+        response.streamFilter(network -> {
+            filterApplied.set(true);
+            return network;
+        });
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> response.send(entity));
 
         assertAll(
-                () -> assertThat(getHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
-                () -> assertThat(new String(getEntity.getValue().readBytes(), StandardCharsets.UTF_8), is("xyentity")),
-                () -> assertThat(headHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("test")),
-                () -> assertThat(headHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(8L))
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(filterApplied.get(), is(false)),
+                () -> assertThat(response.isSent(), is(false))
         );
+        verifyNoWrites(stream);
     }
 
     @Test
-    void streamingHeadUsesEntityMetadataWithoutSendingEntity() throws IOException {
+    void streamingHeadRejectsEntityBeforeSendingResponse() throws IOException {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
 
-        Http2ServerStream getStream = mock(Http2ServerStream.class);
-        Http2ServerResponse getResponse = createResponse(getStream, Method.GET, contentEncodingContext);
-        try (OutputStream output = getResponse.outputStream()) {
-            output.write(entity);
-        }
-        getResponse.commit();
-        var getHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        var getEntity = ArgumentCaptor.forClass(BufferData.class);
-        verify(getStream).writeHeadersWithData(getHeaders.capture(), anyInt(), getEntity.capture(), anyBoolean());
-
-        Http2ServerStream headStream = mock(Http2ServerStream.class);
-        Http2ServerResponse headResponse = createResponse(headStream, Method.HEAD, contentEncodingContext);
-        try (OutputStream output = headResponse.outputStream()) {
-            output.write(entity);
-        }
-        headResponse.commit();
-        var headHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        verify(headStream).writeHeaders(headHeaders.capture(), eq(true));
-        verify(headStream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
-        verify(headStream, never()).writeData(any(), anyBoolean());
-
-        assertAll(
-                () -> assertThat(getHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(6L)),
-                () -> assertThat(new String(getEntity.getValue().readBytes(), StandardCharsets.UTF_8), is("entity")),
-                () -> assertThat(headHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(6L))
-        );
-    }
-
-    @Test
-    void streamingHeadStopsAfterConfiguredDiscardLimit() throws IOException {
-        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
-        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
         Http2ServerStream stream = mock(Http2ServerStream.class);
-        ListenerConfig listenerConfig = WebServer.builder().writeBufferSize(4).buildPrototype();
-        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext, listenerConfig);
-        response.contentLength(100);
-
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
         OutputStream output = response.outputStream();
-        output.write("1234".getBytes(StandardCharsets.UTF_8));
-        IOException exception = assertThrows(IOException.class, () -> output.write('5'));
-        response.commit();
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> output.write(entity));
 
-        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
-        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
-        verify(stream, never()).writeData(any(), anyBoolean());
         assertAll(
-                () -> assertThat(exception.getMessage(), containsString("streaming limit of 4 bytes")),
-                () -> assertThat(response.isSent(), is(true)),
-                () -> assertThat(responseHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(100L))
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(response.isSent(), is(false))
         );
+        verifyNoWrites(stream);
     }
 
     @Test
-    void flushedStreamingHeadSendsImmediatelyAndStopsWrites() throws IOException {
+    void flushedStreamingHeadRejectsEntityBeforeSendingResponse() throws IOException {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
         Http2ServerStream stream = mock(Http2ServerStream.class);
         Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
-        AtomicInteger whenSentCalls = new AtomicInteger();
-        response.whenSent(whenSentCalls::incrementAndGet);
 
         OutputStream output = response.outputStream();
-        output.write("first".getBytes(StandardCharsets.UTF_8));
         output.flush();
+        verifyNoWrites(stream);
 
-        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
-        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
-        verify(stream, never()).writeData(any(), anyBoolean());
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                        () -> output.write("entity".getBytes(StandardCharsets.UTF_8)));
         assertAll(
-                () -> assertThat(response.isSent(), is(true)),
-                () -> assertThat(whenSentCalls.get(), is(0)),
-                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false))
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(response.isSent(), is(false))
         );
-
-        IOException exception = assertThrows(IOException.class,
-                                             () -> output.write("second".getBytes(StandardCharsets.UTF_8)));
-        assertThat(exception.getMessage(), containsString("HEAD response already sent"));
-        response.commit();
-
-        verify(stream).writeHeaders(any(Http2Headers.class), eq(true));
-        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
-        verify(stream, never()).writeData(any(), anyBoolean());
-        assertThat(whenSentCalls.get(), is(1));
-    }
-
-    @Test
-    void flushedStreamingHeadAllowsNegotiatedGzipToFinish() throws IOException {
-        ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()
-                .addContentEncoding(GzipEncoding.create())
-                .build();
-        WritableHeaders<?> requestHeaders = WritableHeaders.create();
-        requestHeaders.set(HeaderNames.ACCEPT_ENCODING, "gzip");
-        Http2ServerStream stream = mock(Http2ServerStream.class);
-        Http2ServerResponse response = createResponse(stream,
-                                                      Method.HEAD,
-                                                      contentEncodingContext,
-                                                      ServerRequestHeaders.create(requestHeaders));
-        AtomicInteger whenSentCalls = new AtomicInteger();
-        response.whenSent(whenSentCalls::incrementAndGet);
-
-        OutputStream output = response.outputStream();
-        output.write("first".getBytes(StandardCharsets.UTF_8));
-        output.flush();
-
-        IOException exception = assertThrows(IOException.class, () -> output.write('x'));
-        output.close();
-        response.commit();
-
-        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
-        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
-        verify(stream, never()).writeData(any(), anyBoolean());
-        assertAll(
-                () -> assertThat(exception.getMessage(), containsString("HEAD response already sent")),
-                () -> assertThat(response.isSent(), is(true)),
-                () -> assertThat(responseHeaders.getValue().httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("gzip")),
-                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false)),
-                () -> assertThat(whenSentCalls.get(), is(1))
-        );
+        verifyNoWrites(stream);
     }
 
     @Test
@@ -640,8 +507,8 @@ class Http2ServerResponseTest {
         response.contentLength(42);
 
         OutputStream output = response.outputStream();
-        output.write("partial".getBytes(StandardCharsets.UTF_8));
         output.flush();
+        verifyNoWrites(stream);
         response.commit();
 
         var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
@@ -652,7 +519,7 @@ class Http2ServerResponseTest {
     }
 
     @Test
-    void flushedStreamingHeadOmitsTrailers() throws IOException {
+    void emptyStreamingHeadSendsTrailersWithoutData() throws IOException {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
         Http2ServerStream stream = mock(Http2ServerStream.class);
@@ -661,40 +528,7 @@ class Http2ServerResponseTest {
         response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
         response.beforeTrailers(_ -> beforeTrailersCalled.set(true));
 
-        OutputStream output = response.outputStream();
-        output.write("partial".getBytes(StandardCharsets.UTF_8));
-        output.flush();
-
-        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
-        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
-        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
-        verify(stream, never()).writeData(any(), anyBoolean());
-        verify(stream, never()).writeTrailers(any());
-        assertAll(
-                () -> assertThat(beforeTrailersCalled.get(), is(false)),
-                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false)),
-                () -> assertThat(responseHeaders.getValue().httpHeaders().contains(HeaderNames.TRAILER), is(false))
-        );
-
-        response.commit();
-        verify(stream).writeHeaders(any(Http2Headers.class), eq(true));
-        verify(stream, never()).writeTrailers(any());
-        assertThat(beforeTrailersCalled.get(), is(false));
-    }
-
-    @Test
-    void headSendsTrailersWithoutData() throws IOException {
-        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
-        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
-        Http2ServerStream stream = mock(Http2ServerStream.class);
-        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext);
-        AtomicBoolean beforeTrailersCalled = new AtomicBoolean();
-        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
-        response.beforeTrailers(_ -> beforeTrailersCalled.set(true));
-
-        try (OutputStream output = response.outputStream()) {
-            output.write("entity".getBytes(StandardCharsets.UTF_8));
-        }
+        response.outputStream().close();
         response.commit();
 
         verify(stream).writeHeaders(any(Http2Headers.class), eq(false));
@@ -711,6 +545,13 @@ class Http2ServerResponseTest {
             assertThat(headers.contentLength().orElseThrow(),
                        is(status.code() == Status.RESET_CONTENT_205.code() ? 0L : 23L));
         }
+    }
+
+    private static void verifyNoWrites(Http2ServerStream stream) {
+        verify(stream, never()).writeHeaders(any(), anyBoolean());
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        verify(stream, never()).writeTrailers(any());
     }
 
     private static ContentEncoder testEncoder() {

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -41,6 +41,7 @@ import io.helidon.http.encoding.gzip.GzipEncoding;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.DirectHandlers;
@@ -536,6 +537,31 @@ class Http2ServerResponseTest {
     }
 
     @Test
+    void streamingHeadStopsAfterConfiguredDiscardLimit() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        ListenerConfig listenerConfig = WebServer.builder().writeBufferSize(4).buildPrototype();
+        Http2ServerResponse response = createResponse(stream, Method.HEAD, contentEncodingContext, listenerConfig);
+        response.contentLength(100);
+
+        OutputStream output = response.outputStream();
+        output.write("1234".getBytes(StandardCharsets.UTF_8));
+        IOException exception = assertThrows(IOException.class, () -> output.write('5'));
+        response.commit();
+
+        var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+        verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+        verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+        verify(stream, never()).writeData(any(), anyBoolean());
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("streaming limit of 4 bytes")),
+                () -> assertThat(response.isSent(), is(true)),
+                () -> assertThat(responseHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(100L))
+        );
+    }
+
+    @Test
     void flushedStreamingHeadSendsImmediatelyAndStopsWrites() throws IOException {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
@@ -748,10 +774,33 @@ class Http2ServerResponseTest {
                                                       Method method,
                                                       ContentEncodingContext contentEncodingContext,
                                                       ServerRequestHeaders requestHeaders) {
+        return createResponse(stream,
+                              method,
+                              contentEncodingContext,
+                              requestHeaders,
+                              WebServer.builder().buildPrototype());
+    }
+
+    private static Http2ServerResponse createResponse(Http2ServerStream stream,
+                                                      Method method,
+                                                      ContentEncodingContext contentEncodingContext,
+                                                      ListenerConfig listenerConfig) {
+        return createResponse(stream,
+                              method,
+                              contentEncodingContext,
+                              ServerRequestHeaders.create(WritableHeaders.create()),
+                              listenerConfig);
+    }
+
+    private static Http2ServerResponse createResponse(Http2ServerStream stream,
+                                                      Method method,
+                                                      ContentEncodingContext contentEncodingContext,
+                                                      ServerRequestHeaders requestHeaders,
+                                                      ListenerConfig listenerConfig) {
         ListenerContext listenerContext = mock(ListenerContext.class);
         when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
         when(listenerContext.mediaContext()).thenReturn(MediaContext.create());
-        when(listenerContext.config()).thenReturn(WebServer.builder().buildPrototype());
+        when(listenerContext.config()).thenReturn(listenerConfig);
 
         ConnectionContext connectionContext = mock(ConnectionContext.class);
         when(connectionContext.listenerContext()).thenReturn(listenerContext);

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.http2;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -31,7 +32,9 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketContext;
 import io.helidon.common.uri.UriAuthority;
+import io.helidon.http.DirectHandler;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.RequestException;
@@ -71,6 +74,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -109,6 +113,88 @@ class Http2ServerStreamSniTest {
         assertThat(stream.streamState(), is(Http2StreamState.CLOSED));
         assertThat(streams.get(STREAM_ID), is(nullValue()));
         assertDoesNotThrow(stream::checkDataReceivable);
+    }
+
+    @Test
+    void rejectedStreamUsesDirectHandlerResponse() {
+        byte[] entity = "custom handler entity".getBytes(StandardCharsets.UTF_8);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.NOT_ACCEPTABLE_406)
+                                    .entity(entity)
+                                    .header(HeaderNames.CONTENT_LENGTH, "99")
+                                    .build())
+                .build();
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        when(stream.connectionContext().listenerContext().directHandlers()).thenReturn(directHandlers);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(), false);
+
+        stream.run();
+
+        assertAll(
+                () -> assertThat(writer.headers.status(), is(Status.NOT_ACCEPTABLE_406)),
+                () -> assertThat(writer.headers.httpHeaders().contentLength().orElseThrow(), is((long) entity.length)),
+                () -> assertThat(writer.dataFrame.header().length(), is(entity.length)),
+                () -> assertThat(new String(writer.dataFrame.data().readBytes(), StandardCharsets.UTF_8),
+                                 is("custom handler entity"))
+        );
+    }
+
+    @Test
+    void rejectedStreamSuppressesNoContentEntityAndFraming() {
+        RecordingStreamWriter writer = rejectedStreamWithNoEntityStatus(Status.NO_CONTENT_204);
+
+        assertThat(writer.headers.httpHeaders().contains(HeaderNames.CONTENT_LENGTH), is(false));
+    }
+
+    @Test
+    void rejectedStreamSuppressesResetContentEntityAndFraming() {
+        RecordingStreamWriter writer = rejectedStreamWithNoEntityStatus(Status.RESET_CONTENT_205);
+
+        assertThat(writer.headers.httpHeaders().contentLength().orElseThrow(), is(0L));
+    }
+
+    @Test
+    void rejectedStreamSuppressesNotModifiedEntityAndFraming() {
+        RecordingStreamWriter writer = rejectedStreamWithNoEntityStatus(Status.NOT_MODIFIED_304);
+
+        assertThat(writer.headers.httpHeaders().contentLength().orElseThrow(), is(7L));
+    }
+
+    private static RecordingStreamWriter rejectedStreamWithNoEntityStatus(Status status) {
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(status)
+                                    .entity("ignored")
+                                    .header(HeaderNames.CONTENT_LENGTH, "7")
+                                    .header(HeaderValues.TRANSFER_ENCODING_CHUNKED)
+                                    .header(HeaderNames.TRAILER, "test-trailer")
+                                    .build())
+                .build();
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        when(stream.connectionContext().listenerContext().directHandlers()).thenReturn(directHandlers);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(), false);
+
+        stream.run();
+
+        assertAll(
+                () -> assertThat(writer.headers.status(), is(status)),
+                () -> assertThat(writer.headers.httpHeaders().contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                () -> assertThat(writer.headers.httpHeaders().contains(HeaderNames.TRAILER), is(false)),
+                () -> assertThat(writer.headerFlags.endOfStream(), is(true)),
+                () -> assertThat(writer.dataFrame, is(nullValue()))
+        );
+        return writer;
     }
 
     @Test
@@ -1454,6 +1540,9 @@ class Http2ServerStreamSniTest {
 
     private static final class RecordingStreamWriter implements Http2StreamWriter {
         private Status status;
+        private Http2Headers headers;
+        private Http2Flag.HeaderFlags headerFlags;
+        private Http2FrameData dataFrame;
         private int rstStreamCount;
         private final List<Http2ErrorCode> rstStreamCodes = new ArrayList<>();
 
@@ -1475,6 +1564,9 @@ class Http2ServerStreamSniTest {
                                 Http2Flag.HeaderFlags flags,
                                 FlowControl.Outbound flowControl) {
             this.status = headers.status();
+            this.headers = headers;
+            this.headerFlags = flags;
+            this.dataFrame = null;
             return 0;
         }
 
@@ -1485,6 +1577,9 @@ class Http2ServerStreamSniTest {
                                 Http2FrameData dataFrame,
                                 FlowControl.Outbound flowControl) {
             this.status = headers.status();
+            this.headers = headers;
+            this.headerFlags = flags;
+            this.dataFrame = dataFrame;
             return 0;
         }
     }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -40,6 +40,7 @@ import io.helidon.http.Method;
 import io.helidon.http.RequestException;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.http2.ConnectionFlowControl;
 import io.helidon.http.http2.FlowControl;
 import io.helidon.http.http2.Http2ConnectionWriter;
@@ -202,6 +203,54 @@ class Http2ServerStreamSniTest {
         assertAll(
                 () -> assertThat(writer.headers.status(), is(Status.BAD_REQUEST_400)),
                 () -> assertThat(writer.headers.httpHeaders().contentLength().orElseThrow(), is((long) entity.length)),
+                () -> assertThat(writer.headerFlags.endOfStream(), is(true)),
+                () -> assertThat(writer.dataFrame, is(nullValue()))
+        );
+    }
+
+    @Test
+    void rejectedHeadStreamWithoutExceptionRequestPreservesContentLength() {
+        assertRejectedUnsupportedEncodingHead(false);
+    }
+
+    @Test
+    void rejectedHeadStreamWithoutExceptionRequestSuppressesEntity() {
+        assertRejectedUnsupportedEncodingHead(true);
+    }
+
+    private static void assertRejectedUnsupportedEncodingHead(boolean withEntity) {
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.OTHER,
+                            (_, _, _, _, _) -> {
+                                var builder = DirectHandler.TransportResponse.builder()
+                                        .status(Status.UNSUPPORTED_MEDIA_TYPE_415)
+                                        .header(HeaderNames.CONTENT_LENGTH, "23");
+                                if (withEntity) {
+                                    builder.entity(entity);
+                                }
+                                return builder.build();
+                            })
+                .build();
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentDecodingEnabled()).thenReturn(true);
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        ListenerContext listenerContext = stream.connectionContext().listenerContext();
+        when(listenerContext.directHandlers()).thenReturn(directHandlers);
+        when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(HEAD_PROLOGUE);
+        stream.headers(unsupportedEncodingHeadHeaders(), true);
+
+        stream.run();
+
+        long expectedContentLength = withEntity ? entity.length : 23L;
+        assertAll(
+                () -> assertThat(writer.headers.status(), is(Status.UNSUPPORTED_MEDIA_TYPE_415)),
+                () -> assertThat(writer.headers.httpHeaders().contentLength().orElseThrow(),
+                                 is(expectedContentLength)),
                 () -> assertThat(writer.headerFlags.endOfStream(), is(true)),
                 () -> assertThat(writer.dataFrame, is(nullValue()))
         );
@@ -1574,6 +1623,16 @@ class Http2ServerStreamSniTest {
         if (contentLength != null) {
             headers.add(HeaderNames.CONTENT_LENGTH, contentLength);
         }
+        return Http2Headers.create(headers);
+    }
+
+    private static Http2Headers unsupportedEncodingHeadHeaders() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(Http2Headers.METHOD_NAME, Method.HEAD.text());
+        headers.add(Http2Headers.PATH_NAME, "/");
+        headers.add(Http2Headers.SCHEME_NAME, "https");
+        headers.add(Http2Headers.AUTHORITY_NAME, "api.example.com");
+        headers.add(HeaderNames.CONTENT_ENCODING, "unsupported");
         return Http2Headers.create(headers);
     }
 

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -146,6 +146,56 @@ class Http2ServerStreamSniTest {
     }
 
     @Test
+    void rejectedStreamRejectsEarlyHintsWithEntity() {
+        assertRejectedStreamRejectsInformationalStatus(Status.create(103), true);
+    }
+
+    @Test
+    void rejectedStreamRejectsEarlyHintsWithoutEntity() {
+        assertRejectedStreamRejectsInformationalStatus(Status.create(103), false);
+    }
+
+    @Test
+    void rejectedStreamRejectsSwitchingProtocols() {
+        assertRejectedStreamRejectsInformationalStatus(Status.SWITCHING_PROTOCOLS_101, true);
+    }
+
+    private static void assertRejectedStreamRejectsInformationalStatus(Status status, boolean withEntity) {
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> {
+                                var builder = DirectHandler.TransportResponse.builder()
+                                        .status(status)
+                                        .header(HeaderNames.CONTENT_LENGTH, "7")
+                                        .header(HeaderValues.TRANSFER_ENCODING_CHUNKED)
+                                        .header(HeaderNames.TRAILER, "test-trailer");
+                                if (withEntity) {
+                                    builder.entity("ignored");
+                                }
+                                return builder.build();
+                            })
+                .build();
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        when(stream.connectionContext().listenerContext().directHandlers()).thenReturn(directHandlers);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithoutAuthority(), false);
+
+        stream.run();
+
+        assertAll(
+                () -> assertThat(writer.headers.status(), is(Status.INTERNAL_SERVER_ERROR_500)),
+                () -> assertThat(writer.headers.httpHeaders().contentLength().orElseThrow(), is(0L)),
+                () -> assertThat(writer.headers.httpHeaders().contains(HeaderNames.TRANSFER_ENCODING), is(false)),
+                () -> assertThat(writer.headers.httpHeaders().contains(HeaderNames.TRAILER), is(false)),
+                () -> assertThat(writer.headerFlags.endOfStream(), is(true)),
+                () -> assertThat(writer.dataFrame, is(nullValue()))
+        );
+    }
+
+    @Test
     void rejectedStreamSuppressesNoContentEntityAndFraming() {
         RecordingStreamWriter writer = rejectedStreamWithNoEntityStatus(Status.NO_CONTENT_204);
 

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -95,6 +95,12 @@ class Http2ServerStreamSniTest {
                                                                      Method.GET,
                                                                      "/",
                                                                      true);
+    private static final HttpPrologue HEAD_PROLOGUE = HttpPrologue.create(Http2Connection.FULL_PROTOCOL,
+                                                                          Http2Connection.PROTOCOL,
+                                                                          Http2Connection.PROTOCOL_VERSION,
+                                                                          Method.HEAD,
+                                                                          "/",
+                                                                          true);
 
     @Test
     void missingAuthorityClosesStream() {
@@ -142,6 +148,33 @@ class Http2ServerStreamSniTest {
                 () -> assertThat(writer.dataFrame.header().length(), is(entity.length)),
                 () -> assertThat(new String(writer.dataFrame.data().readBytes(), StandardCharsets.UTF_8),
                                  is("custom handler entity"))
+        );
+    }
+
+    @Test
+    void rejectedHeadStreamPreservesContentLengthWithoutEntity() {
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.BAD_REQUEST_400)
+                                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                                    .build())
+                .build();
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        when(stream.connectionContext().listenerContext().directHandlers()).thenReturn(directHandlers);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(HEAD_PROLOGUE);
+        stream.headers(headersWithoutAuthority(), false);
+
+        stream.run();
+
+        assertAll(
+                () -> assertThat(writer.headers.status(), is(Status.BAD_REQUEST_400)),
+                () -> assertThat(writer.headers.httpHeaders().contentLength().orElseThrow(), is(23L)),
+                () -> assertThat(writer.headerFlags.endOfStream(), is(true)),
+                () -> assertThat(writer.dataFrame, is(nullValue()))
         );
     }
 

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -179,6 +179,35 @@ class Http2ServerStreamSniTest {
     }
 
     @Test
+    void rejectedHeadStreamSuppressesEntity() {
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.BAD_REQUEST_400)
+                                    .entity(entity)
+                                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                                    .build())
+                .build();
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        Http2ServerStream stream = stream(streams, writer);
+        when(stream.connectionContext().listenerContext().directHandlers()).thenReturn(directHandlers);
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(HEAD_PROLOGUE);
+        stream.headers(headersWithoutAuthority(), false);
+
+        stream.run();
+
+        assertAll(
+                () -> assertThat(writer.headers.status(), is(Status.BAD_REQUEST_400)),
+                () -> assertThat(writer.headers.httpHeaders().contentLength().orElseThrow(), is((long) entity.length)),
+                () -> assertThat(writer.headerFlags.endOfStream(), is(true)),
+                () -> assertThat(writer.dataFrame, is(nullValue()))
+        );
+    }
+
+    @Test
     void rejectedStreamRejectsEarlyHintsWithEntity() {
         assertRejectedStreamRejectsInformationalStatus(Status.create(103), true);
     }

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/CachedHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/CachedHandlerTest.java
@@ -82,7 +82,9 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -385,6 +387,28 @@ class CachedHandlerTest {
                        updatedHeaders.get(HeaderNames.ETAG).get(),
                        not(is(initialEtag)));
         }
+    }
+
+    @Test
+    void testClasspathHeadSendsMetadataWithoutEntity() throws IOException, URISyntaxException {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+
+        ServerRequest req = mock(ServerRequest.class);
+        when(req.headers()).thenReturn(ServerRequestHeaders.create());
+        when(req.prologue()).thenReturn(HttpPrologue.create("http/1.1", "http", "1.1", Method.HEAD,
+                                                            "/resource.txt", false));
+
+        ServerResponse res = mock(ServerResponse.class);
+        when(res.headers()).thenReturn(responseHeaders);
+
+        boolean result = classpathHandler.doHandle(Method.HEAD, "resource.txt", req, res, false);
+
+        assertThat("Handler should have found resource.txt", result, is(true));
+        assertThat(responseHeaders, hasHeader(HeaderValues.CONTENT_TYPE_TEXT_PLAIN));
+        assertThat(responseHeaders, hasHeader(RESOURCE_CONTENT_LENGTH));
+        verify(res).send();
+        verify(res, never()).send(any(byte[].class));
+        verify(res, never()).outputStream();
     }
 
     @Test

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentEncodingVaryTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentEncodingVaryTest.java
@@ -114,7 +114,7 @@ class ContentEncodingVaryTest {
                 .request()) {
             assertThat(response.status(), is(Status.NOT_MODIFIED_304));
             assertThat(response.headers(), noHeader(HeaderNames.CONTENT_ENCODING));
-            assertThat(response.entity().as(byte[].class).length, is(0));
+            assertThat(response.entity().hasEntity(), is(false));
 
             var varyValues = response.headers().values(HeaderNames.VARY);
             assertThat("Vary response header " + varyValues,

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadEntityTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadEntityTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class HeadEntityTest {
+    private final Http2Client client;
+
+    HeadEntityTest(Http2Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder router) {
+        router.head("/send", (_, res) -> res.send("entity".getBytes(StandardCharsets.UTF_8)))
+                .head("/stream", (_, res) -> res.outputStream().write('x'))
+                .head("/empty", (_, res) -> {
+                    res.headers().contentLength(6);
+                    res.send();
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/send", "/stream"})
+    void entityWriteIsInternalServerError(String path) {
+        try (var response = client.method(Method.HEAD).uri(path).request()) {
+            assertThat(response.status(), is(Status.INTERNAL_SERVER_ERROR_500));
+            assertThat(response.headers().contentLength().orElseThrow(), is(21L));
+        }
+    }
+
+    @Test
+    void emptyHeadResponsePreservesMetadata() {
+        try (var response = client.method(Method.HEAD).uri("/empty").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.headers().contentLength().orElseThrow(), is(6L));
+        }
+    }
+}

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2AltSvcTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2AltSvcTest.java
@@ -226,7 +226,7 @@ class Http2AltSvcTest {
     void shouldEndNoContentStatusesSelectedByBeforeSendWithHeaders(Http2TestClient testClient) {
         assertHeaderOnlyResponse(testClient, "/before-send-204", Status.NO_CONTENT_204, null, true);
         assertHeaderOnlyResponse(testClient, "/before-send-205", Status.RESET_CONTENT_205, "0", true);
-        assertHeaderOnlyResponse(testClient, "/before-send-304", Status.NOT_MODIFIED_304, "4", true);
+        assertHeaderOnlyResponse(testClient, "/before-send-304", Status.NOT_MODIFIED_304, null, true);
         assertHeaderOnlyResponse(testClient, "/before-send-100", Status.INTERNAL_SERVER_ERROR_500, "0", false);
     }
 

--- a/webserver/tests/observe/health/src/test/java/io/helidon/webserver/tests/observe/health/ObserveHealthTest.java
+++ b/webserver/tests/observe/health/src/test/java/io/helidon/webserver/tests/observe/health/ObserveHealthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.tests.observe.health;
 
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
 import io.helidon.webclient.http1.Http1Client;
@@ -33,6 +34,7 @@ import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static io.helidon.health.HealthCheckResponse.Status.DOWN;
 import static io.helidon.health.HealthCheckResponse.Status.UP;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ServerTest
@@ -63,7 +65,7 @@ class ObserveHealthTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NO_CONTENT_204));
-            assertThat(response.headers(), hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
+            assertThat(response.headers(), not(hasHeader(HeaderNames.CONTENT_LENGTH)));
         }
 
         healthCheck.status(DOWN);
@@ -80,7 +82,7 @@ class ObserveHealthTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NO_CONTENT_204));
-            assertThat(response.headers(), hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
+            assertThat(response.headers(), not(hasHeader(HeaderNames.CONTENT_LENGTH)));
         }
 
         healthCheck.status(DOWN);
@@ -88,7 +90,7 @@ class ObserveHealthTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NO_CONTENT_204));
-            assertThat(response.headers(), hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
+            assertThat(response.headers(), not(hasHeader(HeaderNames.CONTENT_LENGTH)));
         }
     }
 
@@ -98,7 +100,7 @@ class ObserveHealthTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NO_CONTENT_204));
-            assertThat(response.headers(), hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
+            assertThat(response.headers(), not(hasHeader(HeaderNames.CONTENT_LENGTH)));
         }
 
         healthCheck.status(DOWN);
@@ -106,7 +108,7 @@ class ObserveHealthTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NO_CONTENT_204));
-            assertThat(response.headers(), hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
+            assertThat(response.headers(), not(hasHeader(HeaderNames.CONTENT_LENGTH)));
         }
     }
 
@@ -116,7 +118,7 @@ class ObserveHealthTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NO_CONTENT_204));
-            assertThat(response.headers(), hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
+            assertThat(response.headers(), not(hasHeader(HeaderNames.CONTENT_LENGTH)));
         }
 
         healthCheck.status(DOWN);
@@ -133,7 +135,7 @@ class ObserveHealthTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NO_CONTENT_204));
-            assertThat(response.headers(), hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
+            assertThat(response.headers(), not(hasHeader(HeaderNames.CONTENT_LENGTH)));
         }
 
         healthCheck.status(DOWN);
@@ -150,7 +152,7 @@ class ObserveHealthTest {
                 .request()) {
 
             assertThat(response.status(), is(Status.NO_CONTENT_204));
-            assertThat(response.headers(), hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
+            assertThat(response.headers(), not(hasHeader(HeaderNames.CONTENT_LENGTH)));
         }
 
         healthCheck.status(DOWN);

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadRequestTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadRequestTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.tests;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
@@ -41,6 +43,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.noHeader;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -116,6 +119,33 @@ class BadRequestTest {
 
         ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
         assertThat(headers, hasHeader(LOCATION_ERROR_PAGE));
+    }
+
+    @Test
+    void testNoContentBadRequestDoesNotSendEntity() {
+        String response = socketClient.sendAndReceive(Method.GET,
+                                                      "/no-content",
+                                                      null,
+                                                      List.of("Content-Length: 47a"));
+
+        assertThat(SocketHttpClient.statusFromResponse(response), is(Status.NO_CONTENT_204));
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
+        assertThat(headers, noHeader(HeaderNames.CONTENT_LENGTH));
+        assertThat(headers, noHeader(HeaderNames.TRANSFER_ENCODING));
+        assertThat(headers, noHeader(HeaderNames.TRAILER));
+        assertThat(SocketHttpClient.entityFromResponse(response, true), is(""));
+    }
+
+    @Test
+    void testResetContentBadRequestDoesNotSendEntity() throws IOException {
+        assertNoEntityBadRequest("/reset-content", Status.RESET_CONTENT_205, HeaderValues.CONTENT_LENGTH_ZERO);
+    }
+
+    @Test
+    void testNotModifiedBadRequestDoesNotSendEntity() throws IOException {
+        assertNoEntityBadRequest("/not-modified",
+                                 Status.NOT_MODIFIED_304,
+                                 HeaderValues.create(HeaderNames.CONTENT_LENGTH, "23"));
     }
 
     @Test
@@ -342,6 +372,26 @@ class BadRequestTest {
                     .header(HeaderNames.LOCATION, "/errorPage")
                     .build();
         }
+        if (request.path().equals("/no-content")) {
+            return DirectHandler.TransportResponse.builder()
+                    .status(Status.NO_CONTENT_204)
+                    .entity(CUSTOM_ENTITY)
+                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                    .header(HeaderValues.TRANSFER_ENCODING_CHUNKED)
+                    .header(HeaderNames.TRAILER, "test-trailer")
+                    .build();
+        }
+        if (request.path().equals("/reset-content") || request.path().equals("/not-modified")) {
+            return DirectHandler.TransportResponse.builder()
+                    .status(request.path().equals("/reset-content")
+                                    ? Status.RESET_CONTENT_205
+                                    : Status.NOT_MODIFIED_304)
+                    .entity(CUSTOM_ENTITY)
+                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                    .header(HeaderValues.TRANSFER_ENCODING_CHUNKED)
+                    .header(HeaderNames.TRAILER, "test-trailer")
+                    .build();
+        }
         return DirectHandler.TransportResponse.builder()
                 .status(httpStatus.code() == Status.BAD_REQUEST_400.code()
                                 ? Status.create(Status.BAD_REQUEST_400.code(), CUSTOM_REASON_PHRASE)
@@ -349,6 +399,22 @@ class BadRequestTest {
                 .headers(responseHeaders)
                 .entity(CUSTOM_ENTITY)
                 .build();
+    }
+
+    private void assertNoEntityBadRequest(String path, Status status, Header contentLength) throws IOException {
+        socketClient.request(Method.GET,
+                             path,
+                             null,
+                             List.of("Content-Length: 47a"));
+        String response = new String(socketClient.socketInputStream().readAllBytes(), StandardCharsets.ISO_8859_1)
+                .replace("\r\n", "\n");
+
+        assertThat(SocketHttpClient.statusFromResponse(response), is(status));
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
+        assertThat(headers, hasHeader(contentLength));
+        assertThat(headers, noHeader(HeaderNames.TRANSFER_ENCODING));
+        assertThat(headers, noHeader(HeaderNames.TRAILER));
+        assertThat(SocketHttpClient.entityFromResponse(response, true), is(""));
     }
 
     private void assertRejectedSmugglingAttempt(String transferEncodingHeaders) {

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadRequestTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadRequestTest.java
@@ -108,6 +108,23 @@ class BadRequestTest {
     }
 
     @Test
+    void testHeadBadRequestDoesNotSendEntity() throws IOException {
+        socketClient.request(Method.HEAD,
+                             "/",
+                             null,
+                             List.of("Content-Length: 47a"));
+        String response = new String(socketClient.socketInputStream().readAllBytes(), StandardCharsets.ISO_8859_1)
+                .replace("\r\n", "\n");
+
+        assertThat(SocketHttpClient.statusFromResponse(response),
+                   is(Status.create(Status.BAD_REQUEST_400.code(), CUSTOM_REASON_PHRASE)));
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
+        assertThat(headers.contentLength().orElseThrow(),
+                   is((long) CUSTOM_ENTITY.getBytes(StandardCharsets.UTF_8).length));
+        assertThat(SocketHttpClient.entityFromResponse(response, true), is(""));
+    }
+
+    @Test
     void testInvalidRequestWithRedirect() {
         // wrong content length
         String response = socketClient.sendAndReceive(Method.GET,

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadRequestTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadRequestTest.java
@@ -125,6 +125,22 @@ class BadRequestTest {
     }
 
     @Test
+    void testHeadBadRequestPreservesContentLengthWithoutEntity() throws IOException {
+        socketClient.request(Method.HEAD,
+                             "/head-no-entity",
+                             null,
+                             List.of("Content-Length: 47a"));
+        String response = new String(socketClient.socketInputStream().readAllBytes(), StandardCharsets.ISO_8859_1)
+                .replace("\r\n", "\n");
+
+        assertThat(SocketHttpClient.statusFromResponse(response),
+                   is(Status.create(Status.BAD_REQUEST_400.code(), CUSTOM_REASON_PHRASE)));
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
+        assertThat(headers.contentLength().orElseThrow(), is(23L));
+        assertThat(SocketHttpClient.entityFromResponse(response, true), is(""));
+    }
+
+    @Test
     void testInvalidRequestWithRedirect() {
         // wrong content length
         String response = socketClient.sendAndReceive(Method.GET,
@@ -387,6 +403,12 @@ class BadRequestTest {
             return DirectHandler.TransportResponse.builder()
                     .status(Status.TEMPORARY_REDIRECT_307)
                     .header(HeaderNames.LOCATION, "/errorPage")
+                    .build();
+        }
+        if (request.path().equals("/head-no-entity")) {
+            return DirectHandler.TransportResponse.builder()
+                    .status(Status.create(Status.BAD_REQUEST_400.code(), CUSTOM_REASON_PHRASE))
+                    .header(HeaderNames.CONTENT_LENGTH, "23")
                     .build();
         }
         if (request.path().equals("/no-content")) {

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
@@ -45,6 +45,8 @@ class RoutingTest extends RoutingTestBase {
                 .put("/put", (req, res) -> res.send("put"))
                 .delete("/delete", (req, res) -> res.send("delete"))
                 .head("/head", (req, res) -> sendHead(res, "head"))
+                .head("/head_send_entity", (req, res) -> sendHeadEntity(res))
+                .head("/head_stream_entity", (req, res) -> res.outputStream().write('x'))
                 .options("/options", (req, res) -> res.send("options"))
                 .trace("/trace", (req, res) -> res.send("trace"))
                 .patch("/patch", (req, res) -> res.send("patch"))

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.tests;
 
+import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static org.hamcrest.CoreMatchers.is;
@@ -65,7 +67,12 @@ abstract class RoutingTestBase {
 
     static void sendHead(ServerResponse res, String responseMessage) {
         res.headers().set(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage));
-        res.send(responseMessage);
+        res.headers().contentLength(responseMessage.getBytes(StandardCharsets.UTF_8).length);
+        res.send();
+    }
+
+    static void sendHeadEntity(ServerResponse res) {
+        res.send("entity".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -155,6 +162,16 @@ abstract class RoutingTestBase {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers(), hasHeader(MULTI_HANDLER));
             assertResponseEntity(response, responseMessage, hasResponseEntity);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/head_send_entity", "/head_stream_entity"})
+    void testHeadEntityIsInternalServerError(String path) {
+        try (Http1ClientResponse response = client.head(path).request()) {
+            assertThat(response.status(), is(Status.INTERNAL_SERVER_ERROR_500));
+            assertThat(response.headers().contentLength().orElseThrow(), is(21L));
+            assertThrows(IllegalStateException.class, () -> response.as(String.class));
         }
     }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
@@ -44,6 +44,8 @@ class RulesTest extends RoutingTestBase {
                 .put("/put", (req, res) -> res.send("put"))
                 .delete("/delete", (req, res) -> res.send("delete"))
                 .head("/head", (req, res) -> sendHead(res, "head"))
+                .head("/head_send_entity", (req, res) -> sendHeadEntity(res))
+                .head("/head_stream_entity", (req, res) -> res.outputStream().write('x'))
                 .options("/options", (req, res) -> res.send("options"))
                 .trace("/trace", (req, res) -> res.send("trace"))
                 .patch("/patch", (req, res) -> res.send("patch"))

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
@@ -94,8 +94,8 @@ public class DirectHandlers {
                 httpException);
         var entity = response.entity();
         Status status = response.status();
-        boolean preserveHeadContentLength = entity.isEmpty()
-                && Method.HEAD_NAME.equals(request.method());
+        boolean headRequest = Method.HEAD_NAME.equals(request.method());
+        boolean preserveHeadContentLength = entity.isEmpty() && headRequest;
         boolean copyContentLength = preserveHeadContentLength
                 || status.code() == Status.NOT_MODIFIED_304.code();
 
@@ -133,6 +133,9 @@ public class DirectHandlers {
                         .send();
             } else if (status.code() == Status.NOT_MODIFIED_304.code()) {
                 // 304 does not carry an entity, but may describe the selected representation length
+                res.send();
+            } else if (headRequest) {
+                entity.ifPresent(bytes -> res.headers().contentLength(bytes.length));
                 res.send();
             } else {
                 // otherwise send the entity if present

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
@@ -136,17 +136,25 @@ public class DirectHandlers {
                 res.send();
             } else if (headRequest) {
                 if (res instanceof ServerResponseBase<?> responseBase) {
-                    entity.ifPresent(bytes -> responseBase.entityBeforeSend(() -> {
-                        Status responseStatus = res.status();
-                        int responseCode = responseStatus.code();
-                        if (responseStatus.family() != Status.Family.INFORMATIONAL
-                                && responseCode != Status.NO_CONTENT_204.code()
-                                && responseCode != Status.RESET_CONTENT_205.code()
-                                && responseCode != Status.NOT_MODIFIED_304.code()) {
-                            byte[] representation = responseBase.entityBytes(bytes);
-                            res.headers().contentLength(representation.length);
+                    entity.ifPresent(bytes -> {
+                        boolean hasStreamFilter = responseBase.hasStreamFilter();
+                        responseBase.entityBeforeSend(() -> {
+                            Status responseStatus = res.status();
+                            int responseCode = responseStatus.code();
+                            if (responseStatus.family() != Status.Family.INFORMATIONAL
+                                    && responseCode != Status.NO_CONTENT_204.code()
+                                    && responseCode != Status.RESET_CONTENT_205.code()
+                                    && responseCode != Status.NOT_MODIFIED_304.code()) {
+                                byte[] representation = responseBase.entityBytes(bytes);
+                                if (!hasStreamFilter) {
+                                    res.headers().contentLength(representation.length);
+                                }
+                            }
+                        });
+                        if (hasStreamFilter) {
+                            responseBase.prepareFilteredHeadResponse();
                         }
-                    }));
+                    });
                 }
                 res.send();
             } else {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
@@ -79,8 +79,15 @@ public class DirectHandlers {
      * @param keepAlive     whether to keep the connection alive
      */
     public void handle(RequestException httpException, ServerResponse res, boolean keepAlive) {
+        handle(httpException, httpException.request(), res, keepAlive);
+    }
+
+    void handle(RequestException httpException,
+                DirectHandler.TransportRequest request,
+                ServerResponse res,
+                boolean keepAlive) {
         DirectHandler.TransportResponse response = handler(httpException.eventType()).handle(
-                httpException.request(),
+                request,
                 httpException.eventType(),
                 httpException.status(),
                 httpException.responseHeaders(),
@@ -88,7 +95,7 @@ public class DirectHandlers {
         var entity = response.entity();
         Status status = response.status();
         boolean preserveHeadContentLength = entity.isEmpty()
-                && Method.HEAD_NAME.equals(httpException.request().method());
+                && Method.HEAD_NAME.equals(request.method());
         boolean copyContentLength = preserveHeadContentLength
                 || status.code() == Status.NOT_MODIFIED_304.code();
 
@@ -107,7 +114,7 @@ public class DirectHandlers {
                 res.header(header);
             }
         });
-        if (!keepAlive && httpException.request().protocolVersion().startsWith("HTTP/1.")) {
+        if (!keepAlive && request.protocolVersion().startsWith("HTTP/1.")) {
             res.header(HeaderValues.CONNECTION_CLOSE);
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
@@ -135,7 +135,19 @@ public class DirectHandlers {
                 // 304 does not carry an entity, but may describe the selected representation length
                 res.send();
             } else if (headRequest) {
-                entity.ifPresent(bytes -> res.headers().contentLength(bytes.length));
+                if (res instanceof ServerResponseBase<?> responseBase) {
+                    entity.ifPresent(bytes -> responseBase.entityBeforeSend(() -> {
+                        Status responseStatus = res.status();
+                        int responseCode = responseStatus.code();
+                        if (responseStatus.family() != Status.Family.INFORMATIONAL
+                                && responseCode != Status.NO_CONTENT_204.code()
+                                && responseCode != Status.RESET_CONTENT_205.code()
+                                && responseCode != Status.NOT_MODIFIED_304.code()) {
+                            byte[] representation = responseBase.entityBytes(bytes);
+                            res.headers().contentLength(representation.length);
+                        }
+                    }));
+                }
                 res.send();
             } else {
                 // otherwise send the entity if present

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/DirectHandlers.java
@@ -21,7 +21,9 @@ import java.util.Map;
 
 import io.helidon.http.DirectHandler;
 import io.helidon.http.DirectHandler.EventType;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
 import io.helidon.http.RequestException;
 import io.helidon.http.Status;
 import io.helidon.webserver.CloseConnectionException;
@@ -83,10 +85,28 @@ public class DirectHandlers {
                 httpException.status(),
                 httpException.responseHeaders(),
                 httpException);
-
+        var entity = response.entity();
         Status status = response.status();
+        boolean preserveHeadContentLength = entity.isEmpty()
+                && Method.HEAD_NAME.equals(httpException.request().method());
+        boolean copyContentLength = preserveHeadContentLength
+                || status.code() == Status.NOT_MODIFIED_304.code();
+
+        if (!preserveHeadContentLength) {
+            res.headers().remove(HeaderNames.CONTENT_LENGTH);
+        }
         res.status(status);
-        response.headers().forEach(res::header);
+        response.headers().forEach(header -> {
+            if (HeaderNames.CONTENT_LENGTH.equals(header.headerName()) && !copyContentLength) {
+                // Derive the length from the bytes actually sent, as content encoding may change it.
+                return;
+            }
+            if (HeaderNames.VARY.equals(header.headerName())) {
+                res.headers().add(header);
+            } else {
+                res.header(header);
+            }
+        });
         if (!keepAlive && httpException.request().protocolVersion().startsWith("HTTP/1.")) {
             res.header(HeaderValues.CONNECTION_CLOSE);
         }
@@ -97,17 +117,19 @@ public class DirectHandlers {
         }
 
         try {
-            if (status.code() == Status.NO_CONTENT_204.code()
-                    || status.code() == Status.RESET_CONTENT_205.code()
-                    || status.code() == Status.NOT_MODIFIED_304.code()) {
-                // https://www.rfc-editor.org/rfc/rfc9110#status.204
-                // A 204 response is terminated by the end of the header section; it cannot contain content or trailers
-                // ditto for 205, and 304
+            if (status.code() == Status.NO_CONTENT_204.code()) {
+                res.headers().remove(HeaderNames.CONTENT_LENGTH);
+                res.send();
+            } else if (status.code() == Status.RESET_CONTENT_205.code()) {
+                // 205 does not carry an entity and has a known zero length
                 res.header(HeaderValues.CONTENT_LENGTH_ZERO)
                         .send();
+            } else if (status.code() == Status.NOT_MODIFIED_304.code()) {
+                // 304 does not carry an entity, but may describe the selected representation length
+                res.send();
             } else {
                 // otherwise send the entity if present
-                response.entity().ifPresentOrElse(res::send, res::send);
+                entity.ifPresentOrElse(res::send, res::send);
             }
         } catch (IllegalStateException ex) {
             // failed to send - probably output stream was already obtained and used, so status is written

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
@@ -172,7 +172,10 @@ public final class ErrorHandlers {
         }
         ctx.listenerContext()
                 .directHandlers()
-                .handle(e, response, keepAlive);
+                .handle(e,
+                        DirectTransportRequest.create(request.prologue(), request.headers()),
+                        response,
+                        keepAlive);
 
         response.commit();
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -119,6 +119,8 @@ public interface ServerResponse {
 
     /**
      * Send a response with no entity.
+     * Use this method for a {@link io.helidon.http.Method#HEAD HEAD} response after configuring the representation
+     * metadata in the response headers.
      */
     void send();
 
@@ -126,6 +128,7 @@ public interface ServerResponse {
      * Send a byte array response.
      *
      * @param bytes bytes to send
+     * @throws IllegalStateException if non-empty bytes are sent for a {@link io.helidon.http.Method#HEAD HEAD} request
      */
     void send(byte[] bytes);
 
@@ -135,6 +138,7 @@ public interface ServerResponse {
      * @param bytes bytes to send
      * @param position starting position
      * @param length number of bytes send
+     * @throws IllegalStateException if a positive length is sent for a {@link io.helidon.http.Method#HEAD HEAD} request
      */
     default void send(byte[] bytes, int position, int length) {
         send(Arrays.copyOfRange(bytes, position, length));
@@ -144,6 +148,8 @@ public interface ServerResponse {
      * Send an entity, a {@link io.helidon.http.media.MediaContext} will be used to serialize the entity.
      *
      * @param entity entity object
+     * @throws IllegalStateException if serialization writes a non-empty entity for a
+     *                               {@link io.helidon.http.Method#HEAD HEAD} request
      */
     void send(Object entity);
 
@@ -151,6 +157,8 @@ public interface ServerResponse {
      * Send an entity if present, throw {@link io.helidon.http.NotFoundException} if empty.
      *
      * @param entity entity as an optional
+     * @throws IllegalStateException if serialization writes a non-empty entity for a
+     *                               {@link io.helidon.http.Method#HEAD HEAD} request
      */
     default void send(Optional<?> entity) {
         send(entity.orElseThrow(() -> new NotFoundException("")));
@@ -184,6 +192,8 @@ public interface ServerResponse {
      * <p>
      * Configure response status and headers before requesting the output stream. The returned stream completes the
      * response when it is closed, so it must be closed before the handler method returns.
+     * Writing non-empty data to the stream for a {@link io.helidon.http.Method#HEAD HEAD} request throws an
+     * {@link IllegalStateException}.
      *
      * @return output stream
      */

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -210,6 +210,9 @@ public interface ServerResponse {
      * Executed right before the first byte is written to the socket (including response status and headers).
      * Response can be modified (i.e. headers, status) at this point, though modifying the entity may not be done, as
      * this method is most likely called from within one of the {@link #send()} methods.
+     * Changing the response status is supported only if the new status has the same response entity semantics.
+     * For example, changing between an entity-bearing status and a status without an entity may leave response framing
+     * inconsistent and break the response.
      * The listener remains registered if error handling replaces the unsent response entity.
      * <p>
      * Note: this method is implemented as a default method that does nothing, for backward compatibility.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -92,6 +92,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     private Runnable responseBeforeSend;
     private UnaryOperator<OutputStream> responseStreamFilter;
     private UnaryOperator<OutputStream> streamFilter;
+    private boolean suppressImplicitContentLength;
 
     /**
      * Create server response.
@@ -264,6 +265,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         }
         beforeTrailers = null;
         streamFilter = responseStreamFilter;
+        suppressImplicitContentLength = false;
         return true;
     }
 
@@ -304,6 +306,15 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     @Api.Internal
     protected final boolean hasStreamFilter() {
         return streamFilter != null;
+    }
+
+    final void prepareFilteredHeadResponse() {
+        streamFilter = null;
+        suppressImplicitContentLength = true;
+    }
+
+    protected final boolean suppressImplicitContentLength() {
+        return suppressImplicitContentLength;
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -313,6 +313,11 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         suppressImplicitContentLength = true;
     }
 
+    /**
+     * Whether the protocol implementation should suppress an implicit content length.
+     *
+     * @return whether to suppress the implicit content length
+     */
     protected final boolean suppressImplicitContentLength() {
         return suppressImplicitContentLength;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -318,6 +318,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      *
      * @return whether to suppress the implicit content length
      */
+    @Api.Internal
     protected final boolean suppressImplicitContentLength() {
         return suppressImplicitContentLength;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -849,16 +849,24 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         // we are escaping the connection loop, the connection will be closed
         headers.set(HeaderValues.CONNECTION_CLOSE);
 
-        byte[] entity = response.entity().orElse(BufferData.EMPTY_BYTES);
-        headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
+        Status status = response.status();
+        boolean noEntityResponse = Http1ServerResponse.isNoEntityStatus(status);
+        byte[] entity = noEntityResponse
+                ? BufferData.EMPTY_BYTES
+                : response.entity().orElse(BufferData.EMPTY_BYTES);
+        if (noEntityResponse) {
+            Http1ServerResponse.normalizeNoEntityHeaders(headers, status);
+        } else {
+            headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
+        }
 
-        Http1ServerResponse.nonEntityBytes(headers, response.status(), buffer, response.keepAlive(),
+        Http1ServerResponse.nonEntityBytes(headers, status, buffer, response.keepAlive(),
                                            http1Config.validateResponseHeaders());
         if (entity.length != 0) {
             buffer.write(entity);
         }
 
-        sendListener.status(ctx, response.status());
+        sendListener.status(ctx, status);
         sendListener.headers(ctx, headers);
         sendListener.data(ctx, buffer);
         try {
@@ -867,7 +875,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
             throw new ServerConnectionException("Failed to write request exception", writeException);
         }
 
-        if (response.status() == Status.INTERNAL_SERVER_ERROR_500) {
+        if (status == Status.INTERNAL_SERVER_ERROR_500) {
             LOGGER.log(WARNING, "Internal server error", e);
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -855,12 +855,13 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         Status status = response.status();
         boolean noEntityResponse = Http1ServerResponse.isNoEntityStatus(status);
         boolean headRequest = Method.HEAD_NAME.equals(e.request().method());
+        boolean preserveHeadContentLength = headRequest && responseEntity.isEmpty();
         byte[] entity = noEntityResponse || headRequest
                 ? BufferData.EMPTY_BYTES
                 : responseEntityBytes;
         if (noEntityResponse) {
             Http1ServerResponse.normalizeNoEntityHeaders(headers, status);
-        } else {
+        } else if (!preserveHeadContentLength) {
             headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(responseEntityBytes.length)));
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -49,6 +49,7 @@ import io.helidon.http.HeaderValues;
 import io.helidon.http.HtmlEncoder;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.InternalServerException;
+import io.helidon.http.Method;
 import io.helidon.http.RequestException;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.ServerResponseHeaders;
@@ -849,15 +850,18 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         // we are escaping the connection loop, the connection will be closed
         headers.set(HeaderValues.CONNECTION_CLOSE);
 
+        var responseEntity = response.entity();
+        byte[] responseEntityBytes = responseEntity.orElse(BufferData.EMPTY_BYTES);
         Status status = response.status();
         boolean noEntityResponse = Http1ServerResponse.isNoEntityStatus(status);
-        byte[] entity = noEntityResponse
+        boolean headRequest = Method.HEAD_NAME.equals(e.request().method());
+        byte[] entity = noEntityResponse || headRequest
                 ? BufferData.EMPTY_BYTES
-                : response.entity().orElse(BufferData.EMPTY_BYTES);
+                : responseEntityBytes;
         if (noEntityResponse) {
             Http1ServerResponse.normalizeNoEntityHeaders(headers, status);
         } else {
-            headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
+            headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(responseEntityBytes.length)));
         }
 
         Http1ServerResponse.nonEntityBytes(headers, status, buffer, response.keepAlive(),

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -226,7 +226,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                     }
                                     LimitAlgorithm.Outcome outcome = limit.tryAcquireOutcome(true);
                                     if (outcome.disposition() != LimitAlgorithm.Outcome.Disposition.ACCEPTED) {
-                                        throw tooManyConcurrentRequests();
+                                        throw tooManyConcurrentRequests(prologue, headers);
                                     }
                                     LimitAlgorithm.Outcome.Accepted accepted = (LimitAlgorithm.Outcome.Accepted) outcome;
                                     LimitAlgorithm.Token permit = accepted.token();
@@ -295,7 +295,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                         throw e;
                     }
                 } else {
-                    throw tooManyConcurrentRequests();
+                    throw tooManyConcurrentRequests(prologue, headers);
                 }
             }
         } catch (CloseConnectionException e) {
@@ -371,12 +371,13 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         upgradeConnection.handle(limit);
     }
 
-    private RequestException tooManyConcurrentRequests() {
+    private RequestException tooManyConcurrentRequests(HttpPrologue prologue, WritableHeaders<?> headers) {
         ctx.log(LOGGER, TRACE, "Too many concurrent requests, rejecting request and closing connection.");
         return RequestException.builder()
                 .setKeepAlive(false)
                 .status(Status.SERVICE_UNAVAILABLE_503)
                 .type(EventType.OTHER)
+                .request(DirectTransportRequest.create(prologue, headers))
                 .message("Too Many Concurrent Requests")
                 .build();
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -41,6 +41,7 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpException;
+import io.helidon.http.Method;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.ServerResponseTrailers;
 import io.helidon.http.Status;
@@ -115,15 +116,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         status = status == null ? Status.OK_200 : status;
 
-        if (isNoEntityStatus(status)) {
-            // https://www.rfc-editor.org/rfc/rfc9110#status.204
-            // A 204 response is terminated by the end of the header section; it cannot contain content or trailers
-            // ditto for 205, and 304
-            if ((headers.contains(HeaderNames.CONTENT_LENGTH) && !headers.contains(HeaderValues.CONTENT_LENGTH_ZERO))
-                         || headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
-                status = noEntityInternalError(status);
-            }
-        }
+        normalizeNoEntityHeaders(headers, status);
 
         // first write status
         if (status == Status.OK_200) {
@@ -165,18 +158,16 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
     @Override
     public Http1ServerResponse status(Status status) {
+        if (outputStream != null && outputStream.totalBytesWritten() > 0) {
+            throw new IllegalStateException("Cannot set response status after response was already sent.");
+        }
         // set internal state
         super.status(status);
         isNoEntityStatus = isNoEntityStatus(status);
 
         // check consistency if status code should not include entity
         if (isNoEntityStatus) {
-            if (!headers.contains(HeaderNames.CONTENT_LENGTH)) {
-                headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
-            } else if (headers.contentLength().orElse(0) > 0L) {
-                throw new IllegalStateException("Cannot set status to " + status + " with header "
-                                                        + HeaderNames.CONTENT_LENGTH + " greater than zero");
-            }
+            normalizeNoEntityHeaders(headers, status);
         }
         return this;
     }
@@ -212,10 +203,16 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         // send bytes to writer
         beforeSend();
 
-        if (!hasStreamFilter() && !headers.contains(HeaderNames.TRAILER)) {
-            byte[] entity = entityBytes(bytes, position, length);
-            BufferData bufferData = (bytes != entity) ? responseBuffer(entity)
-                    : responseBuffer(entity, position, length);         // no encoding, same length
+        boolean noEntityResponse = isNoEntityStatus(status());
+        if (noEntityResponse) {
+            normalizeNoEntityHeaders(headers, status());
+        }
+        boolean headRequest = request.prologue().method() == Method.HEAD;
+        if (noEntityResponse || !hasStreamFilter() && !headers.contains(HeaderNames.TRAILER)) {
+            byte[] entity = noEntityResponse ? BufferData.EMPTY_BYTES : entityBytes(bytes, position, length);
+            int entityPosition = bytes == entity ? position : 0;
+            int entityLength = noEntityResponse ? 0 : bytes == entity ? length : entity.length;
+            BufferData bufferData = responseBuffer(entity, entityPosition, entityLength, headRequest);
             bytesWritten = bufferData.available();
             isSent = true;
             request.reset();
@@ -459,11 +456,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         }
     }
 
-    private BufferData responseBuffer(byte[] bytes) {
-        return responseBuffer(bytes, 0, bytes.length);
-    }
-
-    private BufferData responseBuffer(byte[] bytes, int position, int length) {
+    private BufferData responseBuffer(byte[] bytes, int position, int length, boolean headRequest) {
         if (isSent) {
             throw new IllegalStateException("Response already sent");
         }
@@ -473,8 +466,13 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         }
 
         boolean forcedChunkedEncoding = false;
+        Status usedStatus = status();
+        boolean noContentResponse = usedStatus.code() == Status.NO_CONTENT_204.code();
 
-        if (headers.contains(HeaderNames.TRANSFER_ENCODING) && headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+        if (noContentResponse) {
+            normalizeNoEntityHeaders(headers, usedStatus);
+        } else if (headers.contains(HeaderNames.TRANSFER_ENCODING)
+                && headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
             headers.remove(HeaderNames.CONTENT_LENGTH);
             // chunked enforced (and even if empty entity, will be used)
             forcedChunkedEncoding = true;
@@ -482,15 +480,14 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             headers.contentLength(length);
         }
 
-        Status usedStatus = status();
         sendListener.status(ctx, usedStatus);
         sendListener.headers(ctx, headers);
 
         // give some space for code and headers + entity
-        BufferData responseBuffer = BufferData.growing(256 + length);
+        BufferData responseBuffer = BufferData.growing(256 + (headRequest || noContentResponse ? 0 : length));
 
         nonEntityBytes(headers, usedStatus, responseBuffer, keepAlive, validateHeaders);
-        if (forcedChunkedEncoding) {
+        if (!headRequest && !noContentResponse && forcedChunkedEncoding) {
             byte[] hex = Integer.toHexString(length).getBytes(StandardCharsets.US_ASCII);
             responseBuffer.write(hex);
             responseBuffer.write('\r');
@@ -499,7 +496,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             responseBuffer.write('\r');
             responseBuffer.write('\n');
             responseBuffer.write(TERMINATING_CHUNK);
-        } else {
+        } else if (!headRequest && !noContentResponse) {
             responseBuffer.write(bytes, position, length);
         }
 
@@ -523,6 +520,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                                                             this::status,
                                                             () -> streamResult,
                                                             dataWriter,
+                                                            () -> this.isSent = true,
                                                             () -> {
                                                                 this.isSent = true;
                                                                 afterSend();
@@ -532,8 +530,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                                                             sendListener,
                                                             request,
                                                             keepAlive,
-                                                            validateHeaders,
-                                                            isNoEntityStatus);
+                                                            validateHeaders);
 
         int writeBufferSize = ctx.listenerContext().config().writeBufferSize();
         outputStream = new ClosingBufferedOutputStream(bos, writeBufferSize);
@@ -543,7 +540,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             encodedOutputStream = contentEncode(outputStream);
             bos.checkResponseHeaders();     // headers can be augmented by encoders
         }
-        return applyStreamFilters(encodedOutputStream);
+        return new ApplicationOutputStream(applyStreamFilters(encodedOutputStream), bos);
     }
 
     boolean keepConnectionOpen() {
@@ -557,11 +554,24 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         return Status.INTERNAL_SERVER_ERROR_500;
     }
 
-    private static boolean isNoEntityStatus(Status status) {
+    static boolean isNoEntityStatus(Status status) {
         int code = status.code();
         return code == Status.NO_CONTENT_204.code()
                 || code == Status.RESET_CONTENT_205.code()
                 || code == Status.NOT_MODIFIED_304.code();
+    }
+
+    static void normalizeNoEntityHeaders(ServerResponseHeaders headers, Status status) {
+        int statusCode = status.code();
+        if (statusCode == Status.NO_CONTENT_204.code()) {
+            headers.remove(HeaderNames.CONTENT_LENGTH);
+        } else if (statusCode == Status.RESET_CONTENT_205.code()) {
+            headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
+        }
+        if (isNoEntityStatus(status)) {
+            headers.remove(HeaderNames.TRANSFER_ENCODING);
+            headers.remove(HeaderNames.TRAILER);
+        }
     }
 
     static class BlockingOutputStream extends OutputStream {
@@ -569,12 +579,14 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         private final WritableHeaders<?> trailers;
         private final Supplier<Status> status;
         private final DataWriter dataWriter;
+        private final Runnable responseSentRunnable;
         private final Runnable responseCloseRunnable;
         private final ConnectionContext ctx;
         private final Http1ConnectionListener sendListener;
         private final Http1ServerRequest request;
         private final boolean keepAlive;
         private final Supplier<String> streamResult;
+        private final boolean headRequest;
         private boolean forcedChunked;
 
         private BufferData firstBuffer;
@@ -583,10 +595,11 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         private long contentLength;
         private boolean isChunked;
         private boolean firstByte = true;
+        private boolean headResponseSent;
         private long responseBytesTotal;
         private boolean closing = false;
+        private boolean committing;
         private final boolean validateHeaders;
-        private final boolean isNoEntityStatus;
         private final Consumer<ServerResponseTrailers> beforeTrailers;
 
         private BlockingOutputStream(ServerResponseHeaders headers,
@@ -595,19 +608,20 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                                      Supplier<Status> status,
                                      Supplier<String> streamResult,
                                      DataWriter dataWriter,
+                                     Runnable responseSentRunnable,
                                      Runnable responseCloseRunnable,
                                      ConnectionContext ctx,
                                      Http1ConnectionListener sendListener,
                                      Http1ServerRequest request,
                                      boolean keepAlive,
-                                     boolean validateHeaders,
-                                     boolean isNoEntityStatus) {
+                                     boolean validateHeaders) {
             this.headers = headers;
             this.trailers = trailers;
             this.beforeTrailers = beforeTrailers;
             this.status = status;
             this.streamResult = streamResult;
             this.dataWriter = dataWriter;
+            this.responseSentRunnable = responseSentRunnable;
             this.responseCloseRunnable = responseCloseRunnable;
             this.ctx = ctx;
             this.sendListener = sendListener;
@@ -615,7 +629,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             this.request = request;
             this.keepAlive = keepAlive;
             this.validateHeaders = validateHeaders;
-            this.isNoEntityStatus = isNoEntityStatus;
+            this.headRequest = request.prologue().method() == Method.HEAD;
         }
 
         void checkResponseHeaders() {
@@ -627,6 +641,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 isChunked = !headers.contains(HeaderNames.CONTENT_LENGTH);
                 forcedChunked = headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED);
             }
+            contentLength = headers.contentLength().orElse(-1);
         }
 
         @Override
@@ -652,8 +667,12 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
          */
         @Override
         public void flush() throws IOException {
-            if (closing) {
+            if (closing || committing) {
                 return;     // ignore final flush
+            }
+            if (headRequest) {
+                sendHeadResponse(false);
+                return;
             }
             if (firstByte && firstBuffer != null) {
                 write(BufferData.empty());
@@ -677,17 +696,45 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             closing = true;
         }
 
+        void committing() {
+            committing = headRequest;
+        }
+
         void commit() {
             if (closed) {
                 return;
             }
             this.closed = true;
+            Status usedStatus = status.get();
+            boolean noEntityResponse = isNoEntityStatus(usedStatus);
+            if (noEntityResponse) {
+                firstBuffer = null;
+                isChunked = false;
+                forcedChunked = false;
+            }
+            normalizeNoEntityHeaders(headers, usedStatus);
             boolean sendTrailers =
                     (isChunked || forcedChunked)
                     && (request.headers().containsToken(HeaderValues.TE_TRAILERS)
                                 || headers.contains(HeaderNames.TRAILER));
 
-            if (firstByte) {
+            if (noEntityResponse && !headResponseSent) {
+                sendListener.status(ctx, usedStatus);
+                sendListener.headers(ctx, headers);
+                BufferData bufferData = BufferData.growing(256);
+                nonEntityBytes(headers, usedStatus, bufferData, keepAlive, validateHeaders);
+                sendListener.data(ctx, bufferData);
+                responseBytesTotal += bufferData.available();
+                writeResponse(dataWriter, bufferData, "Failed to write response");
+            } else if (headRequest) {
+                if (!headResponseSent) {
+                    if (sendTrailers && beforeTrailers != null) {
+                        trailers.set(STREAM_RESULT_NAME, streamResult.get());
+                        beforeTrailers.accept(ServerResponseTrailers.wrap(trailers));
+                    }
+                    sendHeadResponse(true);
+                }
+            } else if (firstByte) {
                 if (forcedChunked && firstBuffer != null) {
                     // no sense in sending no data, only do this if chunked requested through a header
                     sendHeadersAndPrepare();
@@ -700,7 +747,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 terminatingChunk(sendTrailers);
             }
 
-            if (sendTrailers) {
+            if (sendTrailers && !headRequest) {
                 // not optimized, trailers enabled: we need to write trailers
                 trailers.set(STREAM_RESULT_NAME, streamResult.get());
                 if (beforeTrailers != null) {
@@ -753,8 +800,20 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             if (closed) {
                 throw new IOException("Stream already closed");
             }
-            if (isNoEntityStatus && buffer.available() > 0) {
-                throw new IllegalStateException("Attempting to write data on a response with status " + status);
+            if (headResponseSent) {
+                // Encoder and filter finalization after an early HEAD flush must not produce content.
+                return;
+            }
+            if (isNoEntityStatus(status.get())) {
+                // Discard entity data buffered before the status changed and ignore empty writes.
+                return;
+            }
+            if (headRequest) {
+                bytesWritten += buffer.available();
+                if (!isChunked) {
+                    checkContentLength(buffer);
+                }
+                return;
             }
 
             if (!isChunked) {
@@ -795,7 +854,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 }
                 // this is chunked encoding, if anybody managed to set content length, it would break everything
                 if (headers.contains(HeaderNames.CONTENT_LENGTH)
-                        && (isNoEntityStatus || buffer.available() > 0)) {
+                        && buffer.available() > 0) {
                     LOGGER.log(System.Logger.Level.WARNING, "Content length was set after stream was requested, "
                             + "the response is already chunked, cannot use content-length");
                     headers.remove(HeaderNames.CONTENT_LENGTH);
@@ -824,6 +883,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
             // at this moment, we must send headers
             Status usedStatus = status.get();
+            normalizeNoEntityHeaders(headers, usedStatus);
             sendListener.status(ctx, usedStatus);
             sendListener.headers(ctx, headers);
             BufferData bufferData = BufferData.growing(contentLength + 256);
@@ -864,6 +924,45 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             sendListener.data(ctx, bufferData);
             responseBytesTotal += bufferData.available();
             writeResponse(dataWriter, bufferData, "Failed to write response headers");
+        }
+
+        private void sendHeadResponse(boolean completeRepresentation) {
+            if (headResponseSent) {
+                return;
+            }
+            Status usedStatus = status.get();
+            normalizeNoEntityHeaders(headers, usedStatus);
+            if (!completeRepresentation) {
+                headers.remove(HeaderNames.TRAILER);
+            }
+            if (headers.contains(HeaderNames.TRANSFER_ENCODING) || headers.contains(HeaderNames.TRAILER)) {
+                headers.remove(HeaderNames.CONTENT_LENGTH);
+                if (!headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+                    headers.add(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+                }
+            } else if (completeRepresentation && !headers.contains(HeaderNames.CONTENT_LENGTH)) {
+                headers.contentLength(bytesWritten);
+            }
+
+            sendListener.status(ctx, usedStatus);
+            sendListener.headers(ctx, headers);
+            BufferData bufferData = BufferData.growing(256);
+            nonEntityBytes(headers, usedStatus, bufferData, keepAlive, validateHeaders);
+            sendListener.data(ctx, bufferData);
+            responseBytesTotal += bufferData.available();
+            writeResponse(dataWriter, bufferData, "Failed to write response");
+            headResponseSent = true;
+            responseSentRunnable.run();
+        }
+
+        private void checkWriteAllowed(int length) throws IOException {
+            if (length > 0 && headResponseSent) {
+                throw new IOException("HEAD response already sent");
+            }
+            Status usedStatus = status.get();
+            if (length > 0 && isNoEntityStatus(usedStatus)) {
+                throw new IllegalStateException("Attempting to write data on a response with status " + usedStatus);
+            }
         }
 
         private void writeChunked(BufferData buffer) {
@@ -954,12 +1053,51 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         }
 
         void commit() {
+            closingDelegate.committing();
             try {
                 flush();
                 closingDelegate.commit();
             } catch (IOException | UncheckedIOException | SocketWriterException e) {
                 throw new ServerConnectionException("Failed to flush server output stream", e);
             }
+        }
+    }
+
+    private static class ApplicationOutputStream extends OutputStream {
+        private final OutputStream delegate;
+        private final BlockingOutputStream blockingOutputStream;
+
+        private ApplicationOutputStream(OutputStream delegate, BlockingOutputStream blockingOutputStream) {
+            this.delegate = delegate;
+            this.blockingOutputStream = blockingOutputStream;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            blockingOutputStream.checkWriteAllowed(1);
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            blockingOutputStream.checkWriteAllowed(b.length);
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            blockingOutputStream.checkWriteAllowed(len);
+            delegate.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            delegate.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -194,6 +194,10 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
     @Override
     public void send(byte[] bytes, int position, int length) {
+        boolean headRequest = request.prologue().method() == Method.HEAD;
+        if (headRequest && length > 0) {
+            throw new IllegalStateException("Cannot send response entity for a HEAD request");
+        }
         // if no entity status, we cannot send bytes here
         if (isNoEntityStatus && length > 0) {
             status(noEntityInternalError(status()));
@@ -207,7 +211,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         if (noEntityResponse) {
             normalizeNoEntityHeaders(headers, status());
         }
-        boolean headRequest = request.prologue().method() == Method.HEAD;
         if (noEntityResponse || !hasStreamFilter() && !headers.contains(HeaderNames.TRAILER)) {
             byte[] entity = noEntityResponse ? BufferData.EMPTY_BYTES : entityBytes(bytes, position, length);
             int entityPosition = bytes == entity ? position : 0;
@@ -531,8 +534,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                                                             sendListener,
                                                             request,
                                                             keepAlive,
-                                                            validateHeaders,
-                                                            writeBufferSize);
+                                                            validateHeaders);
 
         outputStream = new ClosingBufferedOutputStream(bos, writeBufferSize);
 
@@ -588,7 +590,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         private final boolean keepAlive;
         private final Supplier<String> streamResult;
         private final boolean headRequest;
-        private final int headWriteLimit;
         private boolean forcedChunked;
 
         private BufferData firstBuffer;
@@ -598,7 +599,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         private boolean isChunked;
         private boolean firstByte = true;
         private boolean headResponseSent;
-        private long headApplicationBytes;
         private long responseBytesTotal;
         private boolean closing = false;
         private boolean committing;
@@ -617,8 +617,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                                      Http1ConnectionListener sendListener,
                                      Http1ServerRequest request,
                                      boolean keepAlive,
-                                     boolean validateHeaders,
-                                     int headWriteLimit) {
+                                     boolean validateHeaders) {
             this.headers = headers;
             this.trailers = trailers;
             this.beforeTrailers = beforeTrailers;
@@ -634,7 +633,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             this.keepAlive = keepAlive;
             this.validateHeaders = validateHeaders;
             this.headRequest = request.prologue().method() == Method.HEAD;
-            this.headWriteLimit = headWriteLimit;
         }
 
         void checkResponseHeaders() {
@@ -676,7 +674,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 return;     // ignore final flush
             }
             if (headRequest) {
-                sendHeadResponse(false);
                 return;
             }
             if (firstByte && firstBuffer != null) {
@@ -961,20 +958,12 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         }
 
         private void checkWriteAllowed(int length) throws IOException {
-            if (length > 0 && headResponseSent) {
-                throw new IOException("HEAD response already sent");
+            if (length > 0 && headRequest) {
+                throw new IllegalStateException("Cannot write response entity for a HEAD request");
             }
             Status usedStatus = status.get();
             if (length > 0 && isNoEntityStatus(usedStatus)) {
                 throw new IllegalStateException("Attempting to write data on a response with status " + usedStatus);
-            }
-            if (length > 0 && headRequest) {
-                if (headApplicationBytes + length > headWriteLimit) {
-                    sendHeadResponse(false);
-                    throw new IOException("HEAD response representation exceeded streaming limit of "
-                                                  + headWriteLimit + " bytes");
-                }
-                headApplicationBytes += length;
             }
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -482,7 +482,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             headers.remove(HeaderNames.CONTENT_LENGTH);
             // chunked enforced (and even if empty entity, will be used)
             forcedChunkedEncoding = true;
-        } else if (!headers.contains(HeaderNames.CONTENT_LENGTH)) {
+        } else if (!headers.contains(HeaderNames.CONTENT_LENGTH)
+                && (!headRequest || !suppressImplicitContentLength())) {
             headers.contentLength(length);
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -164,6 +164,9 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         // set internal state
         super.status(status);
         isNoEntityStatus = isNoEntityStatus(status);
+        if (outputStream != null) {
+            outputStream.status(status);
+        }
 
         // check consistency if status code should not include entity
         if (isNoEntityStatus) {
@@ -539,11 +542,14 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         outputStream = new ClosingBufferedOutputStream(bos, writeBufferSize);
 
         OutputStream encodedOutputStream = outputStream;
-        if (!skipEncoders) {
+        if (!skipEncoders && !isNoEntityStatus(status())) {
             encodedOutputStream = contentEncode(outputStream);
             bos.checkResponseHeaders();     // headers can be augmented by encoders
         }
-        return new ApplicationOutputStream(applyStreamFilters(encodedOutputStream), bos);
+        OutputStream applicationOutputStream = applyStreamFilters(encodedOutputStream);
+        return applicationOutputStream == outputStream
+                ? outputStream
+                : new ApplicationOutputStream(applicationOutputStream, bos);
     }
 
     boolean keepConnectionOpen() {
@@ -590,6 +596,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         private final boolean keepAlive;
         private final Supplier<String> streamResult;
         private final boolean headRequest;
+        private Status writeForbiddenStatus;
         private boolean forcedChunked;
 
         private BufferData firstBuffer;
@@ -633,6 +640,12 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             this.keepAlive = keepAlive;
             this.validateHeaders = validateHeaders;
             this.headRequest = request.prologue().method() == Method.HEAD;
+            Status initialStatus = status.get();
+            this.writeForbiddenStatus = isNoEntityStatus(initialStatus) ? initialStatus : null;
+        }
+
+        void status(Status status) {
+            writeForbiddenStatus = isNoEntityStatus(status) ? status : null;
         }
 
         void checkResponseHeaders() {
@@ -806,7 +819,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 // Encoder and filter finalization after an early HEAD flush must not produce content.
                 return;
             }
-            if (isNoEntityStatus(status.get())) {
+            if (writeForbiddenStatus != null) {
                 // Discard entity data buffered before the status changed and ignore empty writes.
                 return;
             }
@@ -961,8 +974,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             if (length > 0 && headRequest) {
                 throw new IllegalStateException("Cannot write response entity for a HEAD request");
             }
-            Status usedStatus = status.get();
-            if (length > 0 && isNoEntityStatus(usedStatus)) {
+            Status usedStatus = writeForbiddenStatus;
+            if (length > 0 && usedStatus != null) {
                 throw new IllegalStateException("Attempting to write data on a response with status " + usedStatus);
             }
         }
@@ -1022,16 +1035,19 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         @Override
         public void write(int b) throws IOException {
+            closingDelegate.checkWriteAllowed(1);
             delegate.write(b);
         }
 
         @Override
         public void write(byte[] b) throws IOException {
+            closingDelegate.checkWriteAllowed(b.length);
             delegate.write(b);
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
+            closingDelegate.checkWriteAllowed(len);
             delegate.write(b, off, len);
         }
 
@@ -1052,6 +1068,10 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         long totalBytesWritten() {
             return closingDelegate.totalBytesWritten();
+        }
+
+        void status(Status status) {
+            closingDelegate.status(status);
         }
 
         void commit() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -467,9 +467,9 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         boolean forcedChunkedEncoding = false;
         Status usedStatus = status();
-        boolean noContentResponse = usedStatus.code() == Status.NO_CONTENT_204.code();
+        boolean noEntityResponse = isNoEntityStatus(usedStatus);
 
-        if (noContentResponse) {
+        if (noEntityResponse) {
             normalizeNoEntityHeaders(headers, usedStatus);
         } else if (headers.contains(HeaderNames.TRANSFER_ENCODING)
                 && headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
@@ -484,10 +484,10 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         sendListener.headers(ctx, headers);
 
         // give some space for code and headers + entity
-        BufferData responseBuffer = BufferData.growing(256 + (headRequest || noContentResponse ? 0 : length));
+        BufferData responseBuffer = BufferData.growing(256 + (headRequest || noEntityResponse ? 0 : length));
 
         nonEntityBytes(headers, usedStatus, responseBuffer, keepAlive, validateHeaders);
-        if (!headRequest && !noContentResponse && forcedChunkedEncoding) {
+        if (!headRequest && !noEntityResponse && forcedChunkedEncoding) {
             byte[] hex = Integer.toHexString(length).getBytes(StandardCharsets.US_ASCII);
             responseBuffer.write(hex);
             responseBuffer.write('\r');
@@ -496,7 +496,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             responseBuffer.write('\r');
             responseBuffer.write('\n');
             responseBuffer.write(TERMINATING_CHUNK);
-        } else if (!headRequest && !noContentResponse) {
+        } else if (!headRequest && !noEntityResponse) {
             responseBuffer.write(bytes, position, length);
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -547,9 +547,11 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             bos.checkResponseHeaders();     // headers can be augmented by encoders
         }
         OutputStream applicationOutputStream = applyStreamFilters(encodedOutputStream);
-        return applicationOutputStream == outputStream
-                ? outputStream
-                : new ApplicationOutputStream(applicationOutputStream, bos);
+        if (applicationOutputStream == outputStream) {
+            outputStream.applicationFacing();
+            return outputStream;
+        }
+        return new ApplicationOutputStream(applicationOutputStream, bos);
     }
 
     boolean keepConnectionOpen() {
@@ -1027,6 +1029,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         private final BlockingOutputStream closingDelegate;
         private final OutputStream delegate;
+        private boolean applicationFacing;
 
         ClosingBufferedOutputStream(BlockingOutputStream out, int size) {
             this.closingDelegate = out;
@@ -1035,19 +1038,19 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         @Override
         public void write(int b) throws IOException {
-            closingDelegate.checkWriteAllowed(1);
+            checkApplicationWrite(1);
             delegate.write(b);
         }
 
         @Override
         public void write(byte[] b) throws IOException {
-            closingDelegate.checkWriteAllowed(b.length);
+            checkApplicationWrite(b.length);
             delegate.write(b);
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            closingDelegate.checkWriteAllowed(len);
+            checkApplicationWrite(len);
             delegate.write(b, off, len);
         }
 
@@ -1072,6 +1075,16 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         void status(Status status) {
             closingDelegate.status(status);
+        }
+
+        void applicationFacing() {
+            applicationFacing = true;
+        }
+
+        private void checkApplicationWrite(int length) throws IOException {
+            if (applicationFacing) {
+                closingDelegate.checkWriteAllowed(length);
+            }
         }
 
         void commit() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -514,6 +514,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         }
         streamingEntity = true;
 
+        int writeBufferSize = ctx.listenerContext().config().writeBufferSize();
         BlockingOutputStream bos = new BlockingOutputStream(headers,
                                                             trailers,
                                                             beforeTrailers(),
@@ -530,9 +531,9 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                                                             sendListener,
                                                             request,
                                                             keepAlive,
-                                                            validateHeaders);
+                                                            validateHeaders,
+                                                            writeBufferSize);
 
-        int writeBufferSize = ctx.listenerContext().config().writeBufferSize();
         outputStream = new ClosingBufferedOutputStream(bos, writeBufferSize);
 
         OutputStream encodedOutputStream = outputStream;
@@ -587,6 +588,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         private final boolean keepAlive;
         private final Supplier<String> streamResult;
         private final boolean headRequest;
+        private final int headWriteLimit;
         private boolean forcedChunked;
 
         private BufferData firstBuffer;
@@ -596,6 +598,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         private boolean isChunked;
         private boolean firstByte = true;
         private boolean headResponseSent;
+        private long headApplicationBytes;
         private long responseBytesTotal;
         private boolean closing = false;
         private boolean committing;
@@ -614,7 +617,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                                      Http1ConnectionListener sendListener,
                                      Http1ServerRequest request,
                                      boolean keepAlive,
-                                     boolean validateHeaders) {
+                                     boolean validateHeaders,
+                                     int headWriteLimit) {
             this.headers = headers;
             this.trailers = trailers;
             this.beforeTrailers = beforeTrailers;
@@ -630,6 +634,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             this.keepAlive = keepAlive;
             this.validateHeaders = validateHeaders;
             this.headRequest = request.prologue().method() == Method.HEAD;
+            this.headWriteLimit = headWriteLimit;
         }
 
         void checkResponseHeaders() {
@@ -962,6 +967,14 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             Status usedStatus = status.get();
             if (length > 0 && isNoEntityStatus(usedStatus)) {
                 throw new IllegalStateException("Attempting to write data on a response with status " + usedStatus);
+            }
+            if (length > 0 && headRequest) {
+                if (headApplicationBytes + length > headWriteLimit) {
+                    sendHeadResponse(false);
+                    throw new IOException("HEAD response representation exceeded streaming limit of "
+                                                  + headWriteLimit + " bytes");
+                }
+                headApplicationBytes += length;
             }
         }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/DirectHandlersTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/DirectHandlersTest.java
@@ -149,7 +149,7 @@ class DirectHandlersTest {
     }
 
     @Test
-    void headSendsNoEntityAndDerivesContentLength() {
+    void headSendsNoEntityWithoutSpeculativeContentLength() {
         ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
         ServerResponse response = mock(ServerResponse.class);
         when(response.status(any())).thenReturn(response);
@@ -177,7 +177,7 @@ class DirectHandlersTest {
 
         directHandlers.handle(requestException, request, response, true);
 
-        assertThat(responseHeaders.contentLength().orElseThrow(), is(5L));
+        assertThat(responseHeaders.contains(HeaderNames.CONTENT_LENGTH), is(false));
         verify(response).send();
         verify(response, never()).send(any(byte[].class));
     }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/DirectHandlersTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/DirectHandlersTest.java
@@ -22,6 +22,7 @@ import io.helidon.http.DirectHandler;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
 import io.helidon.http.RequestException;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.Status;
@@ -31,9 +32,12 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DirectHandlersTest {
@@ -105,6 +109,43 @@ class DirectHandlersTest {
         handle(directResponse, responseHeaders);
 
         assertThat(responseHeaders.contentLength().orElseThrow(), is(23L));
+    }
+
+    @Test
+    void usesAvailableRequestForRequestlessHeadException() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        ServerResponse response = mock(ServerResponse.class);
+        when(response.status(any())).thenReturn(response);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(response.header(any(Header.class))).thenAnswer(invocation -> {
+            responseHeaders.set(invocation.getArgument(0));
+            return response;
+        });
+
+        AtomicReference<DirectHandler.TransportRequest> handledRequest = new AtomicReference<>();
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST, (request, _, _, _, _) -> {
+                    handledRequest.set(request);
+                    return DirectHandler.TransportResponse.builder()
+                            .status(Status.BAD_REQUEST_400)
+                            .header(HeaderNames.CONTENT_LENGTH, "23")
+                            .build();
+                })
+                .build();
+        RequestException requestException = RequestException.builder()
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+        DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+        when(request.method()).thenReturn(Method.HEAD_NAME);
+        when(request.protocolVersion()).thenReturn("HTTP/1.1");
+
+        directHandlers.handle(requestException, request, response, true);
+
+        assertSame(request, handledRequest.get());
+        assertThat(responseHeaders.contentLength().orElseThrow(), is(23L));
+        verify(response).send();
+        verify(response, never()).send(any(byte[].class));
     }
 
     private static void handle(DirectHandler.TransportResponse directResponse,

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/DirectHandlersTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/DirectHandlersTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.http.DirectHandler;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.RequestException;
+import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.Status;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DirectHandlersTest {
+
+    @Test
+    void mergesVaryHeaders() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        responseHeaders.add(HeaderNames.VARY, HeaderNames.ORIGIN_NAME);
+        DirectHandler.TransportResponse directResponse = DirectHandler.TransportResponse.builder()
+                .header(HeaderValues.create(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME))
+                .build();
+
+        handle(directResponse, responseHeaders);
+
+        assertThat(responseHeaders.get(HeaderNames.VARY).allValues(),
+                   containsInAnyOrder(HeaderNames.ORIGIN_NAME, HeaderNames.ACCEPT_ENCODING_NAME));
+    }
+
+    @Test
+    void replacesContentLengthForEntitySent() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        responseHeaders.contentLength(17);
+        DirectHandler.TransportResponse directResponse = DirectHandler.TransportResponse.builder()
+                .header(HeaderValues.create(HeaderNames.CONTENT_LENGTH, "23"))
+                .entity("error")
+                .build();
+
+        handle(directResponse, responseHeaders);
+
+        assertThat(responseHeaders.contentLength().orElseThrow(), is(5L));
+    }
+
+    @Test
+    void replacesContentLengthForEmptyResponse() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        responseHeaders.contentLength(17);
+        DirectHandler.TransportResponse directResponse = DirectHandler.TransportResponse.builder()
+                .header(HeaderValues.create(HeaderNames.CONTENT_LENGTH, "23"))
+                .build();
+
+        handle(directResponse, responseHeaders);
+
+        assertThat(responseHeaders.contentLength().orElseThrow(), is(0L));
+    }
+
+    @Test
+    void removesContentLengthBeforeNoContentStatus() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        responseHeaders.contentLength(17);
+        DirectHandler.TransportResponse directResponse = DirectHandler.TransportResponse.builder()
+                .status(Status.NO_CONTENT_204)
+                .build();
+
+        handle(directResponse, responseHeaders);
+
+        assertThat(responseHeaders.contains(HeaderNames.CONTENT_LENGTH), is(false));
+    }
+
+    @Test
+    void preservesContentLengthForNotModifiedStatus() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        responseHeaders.contentLength(17);
+        DirectHandler.TransportResponse directResponse = DirectHandler.TransportResponse.builder()
+                .status(Status.NOT_MODIFIED_304)
+                .entity("ignored")
+                .header(HeaderNames.CONTENT_LENGTH, "23")
+                .build();
+
+        handle(directResponse, responseHeaders);
+
+        assertThat(responseHeaders.contentLength().orElseThrow(), is(23L));
+    }
+
+    private static void handle(DirectHandler.TransportResponse directResponse,
+                               ServerResponseHeaders responseHeaders) {
+        ServerResponse response = mock(ServerResponse.class);
+        AtomicReference<Status> status = new AtomicReference<>(Status.OK_200);
+        when(response.status(any())).thenAnswer(invocation -> {
+            assertThat(responseHeaders.contains(HeaderNames.CONTENT_LENGTH), is(false));
+            status.set(invocation.getArgument(0));
+            return response;
+        });
+        when(response.headers()).thenReturn(responseHeaders);
+        when(response.header(any(Header.class))).thenAnswer(invocation -> {
+            responseHeaders.set(invocation.getArgument(0));
+            return response;
+        });
+        doAnswer(invocation -> {
+            assertThat(responseHeaders.contains(HeaderNames.CONTENT_LENGTH), is(false));
+            responseHeaders.contentLength(invocation.<byte[]>getArgument(0).length);
+            return null;
+        }).when(response).send(any(byte[].class));
+        doAnswer(_ -> {
+            if (status.get().code() == Status.NO_CONTENT_204.code()) {
+                assertThat(responseHeaders.contains(HeaderNames.CONTENT_LENGTH), is(false));
+            } else if (status.get().code() != Status.NOT_MODIFIED_304.code()) {
+                responseHeaders.contentLength(0);
+            }
+            return null;
+        }).when(response).send();
+
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> directResponse)
+                .build();
+        RequestException requestException = RequestException.builder()
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/DirectHandlersTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/DirectHandlersTest.java
@@ -148,6 +148,40 @@ class DirectHandlersTest {
         verify(response, never()).send(any(byte[].class));
     }
 
+    @Test
+    void headSendsNoEntityAndDerivesContentLength() {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        ServerResponse response = mock(ServerResponse.class);
+        when(response.status(any())).thenReturn(response);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(response.header(any(Header.class))).thenAnswer(invocation -> {
+            responseHeaders.set(invocation.getArgument(0));
+            return response;
+        });
+
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.INTERNAL_ERROR, (_, _, _, _, _) ->
+                        DirectHandler.TransportResponse.builder()
+                                .status(Status.INTERNAL_SERVER_ERROR_500)
+                                .header(HeaderNames.CONTENT_LENGTH, "23")
+                                .entity("error")
+                                .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .type(DirectHandler.EventType.INTERNAL_ERROR)
+                .message("internal error")
+                .build();
+        DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+        when(request.method()).thenReturn(Method.HEAD_NAME);
+        when(request.protocolVersion()).thenReturn("HTTP/1.1");
+
+        directHandlers.handle(requestException, request, response, true);
+
+        assertThat(responseHeaders.contentLength().orElseThrow(), is(5L));
+        verify(response).send();
+        verify(response, never()).send(any(byte[].class));
+    }
+
     private static void handle(DirectHandler.TransportResponse directResponse,
                                ServerResponseHeaders responseHeaders) {
         ServerResponse response = mock(ServerResponse.class);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/ErrorHandlersTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/ErrorHandlersTest.java
@@ -27,6 +27,7 @@ import io.helidon.common.uri.UriQuery;
 import io.helidon.http.DirectHandler;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
+import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.Status;
 import io.helidon.http.media.ReadableEntityBase;
 import io.helidon.webserver.CloseConnectionException;
@@ -143,6 +144,7 @@ class ErrorHandlersTest {
         ListenerContext listenerContext = mock(ListenerContext.class);
 
         when(res.resetEntity()).thenReturn(true);
+        when(res.headers()).thenReturn(ServerResponseHeaders.create());
         when(req.prologue()).thenReturn(HttpPrologue.create("http/1.0",
                                                             "http",
                                                             "1.0",
@@ -202,6 +204,7 @@ class ErrorHandlersTest {
         RoutingRequest req = mock(RoutingRequest.class);
         RoutingResponse res = mock(RoutingResponse.class);
         when(res.resetEntity()).thenReturn(true);
+        when(res.headers()).thenReturn(ServerResponseHeaders.create());
 
         when(req.prologue()).thenReturn(HttpPrologue.create("http/1.0",
                                                             "http",

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
@@ -37,6 +37,7 @@ import io.helidon.http.Method;
 import io.helidon.http.PathMatchers;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.Status;
 import io.helidon.http.media.ReadableEntityBase;
 import io.helidon.webserver.ConnectionContext;
@@ -907,6 +908,7 @@ class HttpServiceLocatorTest {
             when(response.reset()).thenReturn(true);
             when(response.resetEntity()).thenReturn(true);
             when(response.status()).thenReturn(Status.OK_200);
+            when(response.headers()).thenReturn(ServerResponseHeaders.create());
             doAnswer(inv -> {
                 entity.set("");
                 return null;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -18,25 +18,38 @@ package io.helidon.webserver.http1;
 
 import java.io.UncheckedIOException;
 import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.LimitAlgorithm;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.socket.SocketWriter;
 import io.helidon.common.socket.SocketWriterException;
+import io.helidon.http.DirectHandler;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.DirectHandlers;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -44,9 +57,53 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Http1ConnectionTest {
+
+    @Test
+    void rejectedHeadUsesParsedRequestMethod() throws InterruptedException {
+        String response = rejectedRequest(Method.HEAD_NAME,
+                                          DirectHandler.TransportResponse.builder()
+                                                  .status(Status.SERVICE_UNAVAILABLE_503)
+                                                  .header(HeaderNames.CONTENT_LENGTH, "23")
+                                                  .build());
+
+        assertAll(
+                () -> assertThat(response, containsString("HTTP/1.1 503 Service Unavailable\r\n")),
+                () -> assertThat(response, containsString("Content-Length: 23\r\n")),
+                () -> assertThat(response, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
+    void rejectedHeadDoesNotSendHandlerEntity() throws InterruptedException {
+        String response = rejectedRequest(Method.HEAD_NAME,
+                                          DirectHandler.TransportResponse.builder()
+                                                  .status(Status.SERVICE_UNAVAILABLE_503)
+                                                  .entity("error")
+                                                  .build());
+
+        assertAll(
+                () -> assertThat(response, containsString("Content-Length: 5\r\n")),
+                () -> assertThat(response, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
+    void rejectedGetStillSendsHandlerEntity() throws InterruptedException {
+        String response = rejectedRequest(Method.GET_NAME,
+                                          DirectHandler.TransportResponse.builder()
+                                                  .status(Status.SERVICE_UNAVAILABLE_503)
+                                                  .entity("error")
+                                                  .build());
+
+        assertAll(
+                () -> assertThat(response, containsString("Content-Length: 5\r\n")),
+                () -> assertThat(response, endsWith("\r\n\r\nerror"))
+        );
+    }
 
     @Test
     void continueImmediatelyWrapsSocketWriterExceptionFromSmartWriter() {
@@ -70,21 +127,50 @@ class Http1ConnectionTest {
     }
 
     private static Http1Connection createConnection(DataWriter dataWriter) {
+        return createConnection(mock(DataReader.class), dataWriter, DirectHandlers.create());
+    }
+
+    private static Http1Connection createConnection(DataReader dataReader,
+                                                    DataWriter dataWriter,
+                                                    DirectHandlers directHandlers) {
         ListenerContext listenerContext = mock(ListenerContext.class);
         when(listenerContext.contentEncodingContext()).thenReturn(mock(ContentEncodingContext.class));
         when(listenerContext.config()).thenReturn(WebServer.builder().buildPrototype());
+        when(listenerContext.directHandlers()).thenReturn(directHandlers);
 
         ConnectionContext ctx = mock(ConnectionContext.class);
         when(ctx.listenerContext()).thenReturn(listenerContext);
         when(ctx.dataWriter()).thenReturn(dataWriter);
-        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+        when(ctx.dataReader()).thenReturn(dataReader);
         when(ctx.router()).thenReturn(Router.empty());
+        PeerInfo remotePeer = mock(PeerInfo.class);
+        when(remotePeer.tlsCertificates()).thenReturn(Optional.empty());
+        when(ctx.remotePeer()).thenReturn(remotePeer);
 
         return new Http1Connection(ctx,
                                    Http1Config.builder()
                                            .continueImmediately(true)
                                            .build(),
                                    Map.of());
+    }
+
+    private static String rejectedRequest(String method,
+                                          DirectHandler.TransportResponse directResponse) throws InterruptedException {
+        byte[] requestBytes = (method + " / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                .getBytes(StandardCharsets.US_ASCII);
+        DataReader reader = DataReader.create(() -> requestBytes);
+        DataWriter writer = mock(DataWriter.class);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.OTHER, (_, _, _, _, _) -> directResponse)
+                .build();
+        Limit limit = mock(Limit.class);
+        when(limit.tryAcquireOutcome(true)).thenReturn(LimitAlgorithm.Outcome.immediateRejection("test", "test"));
+
+        createConnection(reader, writer, directHandlers).handle(limit);
+
+        ArgumentCaptor<BufferData> responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        return new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
     }
 
     private static SocketWriter smartFailingWriter(ExecutorService executor) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -24,8 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.UnaryOperator;
 
 import javax.net.ssl.SSLException;
 
@@ -69,6 +67,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 class Http1ServerResponseTest {
@@ -358,32 +357,21 @@ class Http1ServerResponseTest {
     }
 
     @Test
-    void headUsesEncodedMetadataWithoutSendingEntity() {
+    void headRejectsEntityBeforeSendingResponse() {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
         when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
 
-        DataWriter getWriter = mock(DataWriter.class);
-        createResponse(getWriter, Method.GET, contentEncodingContext).send(entity);
-        var getBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(getWriter).write(getBuffer.capture());
-        String getResponse = new String(getBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
-
-        DataWriter headWriter = mock(DataWriter.class);
-        createResponse(headWriter, Method.HEAD, contentEncodingContext).send(entity);
-        var headBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(headWriter).write(headBuffer.capture());
-        String headResponse = new String(headBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> response.send(entity));
 
         assertAll(
-                () -> assertThat(getResponse, containsString("Content-Encoding: test\r\n")),
-                () -> assertThat(getResponse, containsString("Content-Length: 7\r\n")),
-                () -> assertThat(getResponse, endsWith("\r\n\r\nxentity")),
-                () -> assertThat(headResponse, containsString("Content-Encoding: test\r\n")),
-                () -> assertThat(headResponse, containsString("Content-Length: 7\r\n")),
-                () -> assertThat(headResponse, endsWith("\r\n\r\n"))
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(response.isSent(), is(false))
         );
+        verifyZeroInteractions(writer);
     }
 
     @Test
@@ -488,150 +476,65 @@ class Http1ServerResponseTest {
     }
 
     @Test
-    void filteredHeadUsesFilteredMetadataWithoutSendingEntity() {
+    void filteredHeadRejectsEntityBeforeApplyingFilter() {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
         when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
-        UnaryOperator<OutputStream> filter = network -> new OutputStream() {
-            @Override
-            public void write(int value) throws IOException {
-                network.write(new byte[] {'y', (byte) value});
-            }
-
-            @Override
-            public void write(byte[] bytes, int offset, int length) throws IOException {
-                byte[] filtered = new byte[length + 1];
-                filtered[0] = 'y';
-                System.arraycopy(bytes, offset, filtered, 1, length);
-                network.write(filtered);
-            }
-
-            @Override
-            public void close() throws IOException {
-                network.close();
-            }
-        };
-
-        DataWriter getWriter = mock(DataWriter.class);
-        Http1ServerResponse getResponse = createResponse(getWriter, Method.GET, contentEncodingContext);
-        getResponse.streamFilter(filter);
-        getResponse.send(entity);
-        getResponse.commit();
-        var getBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(getWriter).write(getBuffer.capture());
-        String getText = new String(getBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
-
-        DataWriter headWriter = mock(DataWriter.class);
-        Http1ServerResponse headResponse = createResponse(headWriter, Method.HEAD, contentEncodingContext);
-        headResponse.streamFilter(filter);
-        headResponse.send(entity);
-        headResponse.commit();
-        var headBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(headWriter).write(headBuffer.capture());
-        String headText = new String(headBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        AtomicBoolean filterApplied = new AtomicBoolean();
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        response.streamFilter(network -> {
+            filterApplied.set(true);
+            return network;
+        });
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> response.send(entity));
 
         assertAll(
-                () -> assertThat(getText, containsString("Content-Encoding: test\r\n")),
-                () -> assertThat(getText, containsString("Content-Length: 8\r\n")),
-                () -> assertThat(getText, endsWith("\r\n\r\nxyentity")),
-                () -> assertThat(headText, containsString("Content-Encoding: test\r\n")),
-                () -> assertThat(headText, containsString("Content-Length: 8\r\n")),
-                () -> assertThat(headText, endsWith("\r\n\r\n"))
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(filterApplied.get(), is(false)),
+                () -> assertThat(response.isSent(), is(false))
         );
+        verifyZeroInteractions(writer);
     }
 
     @Test
-    void streamingHeadUsesEntityMetadataWithoutSendingEntity() throws IOException {
+    void streamingHeadRejectsEntityBeforeSendingResponse() throws IOException {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
 
-        DataWriter getWriter = mock(DataWriter.class);
-        Http1ServerResponse getResponse = createResponse(getWriter, Method.GET, contentEncodingContext);
-        try (OutputStream output = getResponse.outputStream()) {
-            output.write(entity);
-        }
-        getResponse.commit();
-        var getBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(getWriter).write(getBuffer.capture());
-        String getText = new String(getBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
-
-        DataWriter headWriter = mock(DataWriter.class);
-        Http1ServerResponse headResponse = createResponse(headWriter, Method.HEAD, contentEncodingContext);
-        try (OutputStream output = headResponse.outputStream()) {
-            output.write(entity);
-        }
-        headResponse.commit();
-        var headBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(headWriter).write(headBuffer.capture());
-        String headText = new String(headBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
-
-        assertAll(
-                () -> assertThat(getText, containsString("Content-Length: 6\r\n")),
-                () -> assertThat(getText, endsWith("\r\n\r\nentity")),
-                () -> assertThat(headText, containsString("Content-Length: 6\r\n")),
-                () -> assertThat(headText, endsWith("\r\n\r\n"))
-        );
-    }
-
-    @Test
-    void streamingHeadStopsAfterConfiguredDiscardLimit() throws IOException {
-        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
-        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
         DataWriter writer = mock(DataWriter.class);
-        ListenerConfig listenerConfig = WebServer.builder().writeBufferSize(4).buildPrototype();
-        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext, listenerConfig);
-        response.contentLength(100);
-
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
         OutputStream output = response.outputStream();
-        output.write("1234".getBytes(StandardCharsets.UTF_8));
-        IOException exception = assertThrows(IOException.class, () -> output.write('5'));
-        response.commit();
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> output.write(entity));
 
-        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(writer).write(responseBuffer.capture());
-        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
         assertAll(
-                () -> assertThat(exception.getMessage(), containsString("streaming limit of 4 bytes")),
-                () -> assertThat(response.isSent(), is(true)),
-                () -> assertThat(responseText, containsString("Content-Length: 100\r\n")),
-                () -> assertThat(responseText.contains("1234"), is(false)),
-                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(response.isSent(), is(false))
         );
+        verifyZeroInteractions(writer);
     }
 
     @Test
-    void flushedStreamingHeadSendsHeadersWithoutGeneratedMetadata() throws IOException {
+    void flushedStreamingHeadRejectsEntityBeforeSendingResponse() throws IOException {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
         DataWriter writer = mock(DataWriter.class);
         Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
-        AtomicInteger whenSentCalls = new AtomicInteger();
-        response.whenSent(whenSentCalls::incrementAndGet);
 
         OutputStream output = response.outputStream();
-        output.write("first".getBytes(StandardCharsets.UTF_8));
         output.flush();
+        verifyZeroInteractions(writer);
 
-        IOException exception = assertThrows(IOException.class,
-                                             () -> output.write("second".getBytes(StandardCharsets.UTF_8)));
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                        () -> output.write("entity".getBytes(StandardCharsets.UTF_8)));
 
-        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(writer).write(responseBuffer.capture());
-        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
         assertAll(
-                () -> assertThat(exception.getMessage(), containsString("HEAD response already sent")),
-                () -> assertThat(response.isSent(), is(true)),
-                () -> assertThat(whenSentCalls.get(), is(0)),
-                () -> assertThat(responseText.contains("Content-Length:"), is(false)),
-                () -> assertThat(responseText.contains("first"), is(false)),
-                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(response.isSent(), is(false))
         );
-
-        response.commit();
-        verify(writer).write(any(BufferData.class));
-        assertThat(whenSentCalls.get(), is(1));
+        verifyZeroInteractions(writer);
     }
 
     @Test
@@ -662,35 +565,6 @@ class Http1ServerResponseTest {
     }
 
     @Test
-    void flushedStreamingHeadAllowsEncoderToFinish() throws IOException {
-        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
-        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
-        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(finalizingEncoder());
-        DataWriter writer = mock(DataWriter.class);
-        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
-        AtomicInteger whenSentCalls = new AtomicInteger();
-        response.whenSent(whenSentCalls::incrementAndGet);
-
-        OutputStream output = response.outputStream();
-        output.write("first".getBytes(StandardCharsets.UTF_8));
-        output.flush();
-
-        assertThrows(IOException.class, () -> output.write('x'));
-        output.close();
-        response.commit();
-
-        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(writer).write(responseBuffer.capture());
-        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
-        assertAll(
-                () -> assertThat(responseText, containsString("Content-Encoding: test\r\n")),
-                () -> assertThat(responseText.contains("first"), is(false)),
-                () -> assertThat(responseText, endsWith("\r\n\r\n")),
-                () -> assertThat(whenSentCalls.get(), is(1))
-        );
-    }
-
-    @Test
     void flushedStreamingHeadPreservesExplicitContentLength() throws IOException {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
@@ -699,24 +573,21 @@ class Http1ServerResponseTest {
         response.contentLength(11);
 
         OutputStream output = response.outputStream();
-        output.write("first".getBytes(StandardCharsets.UTF_8));
         output.flush();
+        verifyZeroInteractions(writer);
+        response.commit();
 
         var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
         verify(writer).write(responseBuffer.capture());
         String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
         assertAll(
                 () -> assertThat(responseText, containsString("Content-Length: 11\r\n")),
-                () -> assertThat(responseText.contains("first"), is(false)),
                 () -> assertThat(responseText, endsWith("\r\n\r\n"))
         );
-
-        response.commit();
-        verify(writer).write(any(BufferData.class));
     }
 
     @Test
-    void flushedStreamingHeadOmitsTrailers() throws IOException {
+    void emptyStreamingHeadEvaluatesButDoesNotSendTrailers() throws IOException {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
         DataWriter writer = mock(DataWriter.class);
@@ -725,39 +596,7 @@ class Http1ServerResponseTest {
         response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
         response.beforeTrailers(_ -> beforeTrailersCalled.set(true));
 
-        OutputStream output = response.outputStream();
-        output.write("partial".getBytes(StandardCharsets.UTF_8));
-        output.flush();
-
-        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
-        verify(writer).write(responseBuffer.capture());
-        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
-        assertAll(
-                () -> assertThat(beforeTrailersCalled.get(), is(false)),
-                () -> assertThat(responseText.contains("Content-Length:"), is(false)),
-                () -> assertThat(responseText.contains("Trailer:"), is(false)),
-                () -> assertThat(responseText.contains("partial"), is(false)),
-                () -> assertThat(responseText, endsWith("\r\n\r\n"))
-        );
-
-        response.commit();
-        verify(writer).write(any(BufferData.class));
-        assertThat(beforeTrailersCalled.get(), is(false));
-    }
-
-    @Test
-    void headEvaluatesButDoesNotSendTrailers() throws IOException {
-        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
-        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
-        DataWriter writer = mock(DataWriter.class);
-        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
-        AtomicBoolean beforeTrailersCalled = new AtomicBoolean();
-        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
-        response.beforeTrailers(_ -> beforeTrailersCalled.set(true));
-
-        try (OutputStream output = response.outputStream()) {
-            output.write("entity".getBytes(StandardCharsets.UTF_8));
-        }
+        response.outputStream().close();
         response.commit();
 
         var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
@@ -778,9 +617,7 @@ class Http1ServerResponseTest {
         Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
         response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
 
-        try (OutputStream output = response.outputStream()) {
-            output.write("entity".getBytes(StandardCharsets.UTF_8));
-        }
+        response.outputStream().close();
         response.commit();
 
         var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
@@ -874,43 +711,6 @@ class Http1ServerResponseTest {
 
                     @Override
                     public void close() throws IOException {
-                        network.close();
-                    }
-                };
-            }
-
-            @Override
-            public void headers(WritableHeaders<?> headers) {
-                headers.set(HeaderNames.CONTENT_ENCODING, "test");
-                headers.remove(HeaderNames.CONTENT_LENGTH);
-            }
-        };
-    }
-
-    private static ContentEncoder finalizingEncoder() {
-        return new ContentEncoder() {
-            @Override
-            public OutputStream apply(OutputStream network) {
-                return new OutputStream() {
-                    @Override
-                    public void write(int value) throws IOException {
-                        network.write(value);
-                    }
-
-                    @Override
-                    public void write(byte[] bytes, int offset, int length) throws IOException {
-                        network.write(bytes, offset, length);
-                    }
-
-                    @Override
-                    public void flush() throws IOException {
-                        network.write('f');
-                        network.flush();
-                    }
-
-                    @Override
-                    public void close() throws IOException {
-                        network.write('c');
                         network.close();
                     }
                 };

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -16,43 +16,65 @@
 
 package io.helidon.webserver.http1;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.UnaryOperator;
 
 import javax.net.ssl.SSLException;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketWriterException;
+import io.helidon.http.DirectHandler;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Headers;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.http.RequestException;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.ServerResponseTrailers;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.encoding.ContentEncoder;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.DirectHandlers;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Http1ServerResponseTest {
+    private static final List<Status> NO_ENTITY_STATUSES = List.of(Status.NO_CONTENT_204,
+                                                                  Status.RESET_CONTENT_205,
+                                                                  Status.NOT_MODIFIED_304);
 
     @Test
     void resetEntityPreservesPublicBeforeSendListeners() {
@@ -211,20 +233,664 @@ class Http1ServerResponseTest {
         );
     }
 
+    @Test
+    void lateNoEntityStatusSuppressesBufferedEntity() throws IOException {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            DataWriter writer = mock(DataWriter.class);
+            Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+            response.contentLength(23);
+
+            OutputStream output = response.outputStream();
+            output.write("entity".getBytes(StandardCharsets.UTF_8));
+            response.status(status);
+            IllegalStateException exception = assertThrows(IllegalStateException.class, () -> output.write('x'));
+            response.commit();
+
+            var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+            verify(writer, atLeastOnce()).write(responseBuffer.capture());
+            String responseText = responseText(responseBuffer);
+            assertAll(
+                    () -> assertThat(exception.getMessage(), containsString(status.toString())),
+                    () -> assertThat(responseText, containsString("HTTP/1.1 " + status + "\r\n")),
+                    () -> assertNoEntityHeaders(status, responseText),
+                    () -> assertThat(responseText.contains("entity"), is(false)),
+                    () -> assertThat(responseText, endsWith("\r\n\r\n"))
+            );
+        }
+    }
+
+    @Test
+    void flushedFixedLengthResponseRejectsStatusChange() throws IOException {
+        assertFlushedResponseRejectsStatusChange(true);
+    }
+
+    @Test
+    void flushedChunkedResponseRejectsStatusChange() throws IOException {
+        assertFlushedResponseRejectsStatusChange(false);
+    }
+
+    @Test
+    void beforeSendNoEntityStatusSuppressesEntity() {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            DataWriter writer = mock(DataWriter.class);
+            Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+            AtomicBoolean filterApplied = new AtomicBoolean();
+            response.contentLength(23);
+            response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            response.header(HeaderNames.TRAILER, "test-trailer");
+            response.streamFilter(outputStream -> {
+                filterApplied.set(true);
+                return outputStream;
+            });
+            response.beforeSend(() -> response.status(status));
+
+            response.send("entity".getBytes(StandardCharsets.UTF_8));
+
+            var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+            verify(writer).write(responseBuffer.capture());
+            String responseText = responseText(responseBuffer);
+            assertAll(
+                    () -> assertThat(responseText, containsString("HTTP/1.1 " + status + "\r\n")),
+                    () -> assertNoEntityHeaders(status, responseText),
+                    () -> assertThat(responseText.contains("entity"), is(false)),
+                    () -> assertThat(responseText, endsWith("\r\n\r\n")),
+                    () -> assertThat(filterApplied.get(), is(false))
+            );
+        }
+    }
+
+    @Test
+    void noEntityStatusIgnoresEmptyWritesWithoutBuffering() throws IOException {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            DataWriter writer = mock(DataWriter.class);
+            ListenerConfig config = WebServer.builder().writeBufferSize(0).buildPrototype();
+            Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext, config);
+            response.contentLength(23);
+            response.status(status);
+
+            OutputStream output = response.outputStream();
+            output.write(new byte[0]);
+            output.write(new byte[0]);
+            response.commit();
+
+            var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+            verify(writer, atLeastOnce()).write(responseBuffer.capture());
+            String responseText = responseText(responseBuffer);
+            assertAll(
+                    () -> assertThat(responseText, containsString("HTTP/1.1 " + status + "\r\n")),
+                    () -> assertNoEntityHeaders(status, responseText),
+                    () -> assertThat(responseText.substring(responseText.indexOf("\r\n\r\n") + 4), is(""))
+            );
+        }
+    }
+
+    @Test
+    void headUsesEncodedMetadataWithoutSendingEntity() {
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+
+        DataWriter getWriter = mock(DataWriter.class);
+        createResponse(getWriter, Method.GET, contentEncodingContext).send(entity);
+        var getBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(getWriter).write(getBuffer.capture());
+        String getResponse = new String(getBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+
+        DataWriter headWriter = mock(DataWriter.class);
+        createResponse(headWriter, Method.HEAD, contentEncodingContext).send(entity);
+        var headBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(headWriter).write(headBuffer.capture());
+        String headResponse = new String(headBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+
+        assertAll(
+                () -> assertThat(getResponse, containsString("Content-Encoding: test\r\n")),
+                () -> assertThat(getResponse, containsString("Content-Length: 7\r\n")),
+                () -> assertThat(getResponse, endsWith("\r\n\r\nxentity")),
+                () -> assertThat(headResponse, containsString("Content-Encoding: test\r\n")),
+                () -> assertThat(headResponse, containsString("Content-Length: 7\r\n")),
+                () -> assertThat(headResponse, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
+    void directHandlerReplacesContentLengthWithEncodedLength() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+        response.contentLength(17);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .entity("error")
+                                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(responseText, containsString("Content-Length: 6\r\n")),
+                () -> assertThat(responseText, endsWith("\r\n\r\nxerror"))
+        );
+    }
+
+    @Test
+    void directHandlerHeadPreservesContentLengthWithoutEntity() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+        when(request.method()).thenReturn(Method.HEAD_NAME);
+        when(request.protocolVersion()).thenReturn("HTTP/1.1");
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.BAD_REQUEST_400)
+                                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .request(request)
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(responseText, containsString("HTTP/1.1 400 Bad Request\r\n")),
+                () -> assertThat(responseText, containsString("Content-Length: 23\r\n")),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
+    void directHandlerNoContentRemovesContentLength() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+        response.contentLength(17);
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.NO_CONTENT_204)
+                                    .entity("ignored")
+                                    .header(HeaderNames.CONTENT_LENGTH, "23")
+                                    .header(HeaderValues.TRANSFER_ENCODING_CHUNKED)
+                                    .header(HeaderNames.TRAILER, "test-trailer")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(responseText, containsString("HTTP/1.1 204 No Content\r\n")),
+                () -> assertThat(responseText.contains("Content-Length:"), is(false)),
+                () -> assertThat(responseText.contains("Transfer-Encoding:"), is(false)),
+                () -> assertThat(responseText.contains("Trailer:"), is(false)),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
+    void filteredHeadUsesFilteredMetadataWithoutSendingEntity() {
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+        UnaryOperator<OutputStream> filter = network -> new OutputStream() {
+            @Override
+            public void write(int value) throws IOException {
+                network.write(new byte[] {'y', (byte) value});
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) throws IOException {
+                byte[] filtered = new byte[length + 1];
+                filtered[0] = 'y';
+                System.arraycopy(bytes, offset, filtered, 1, length);
+                network.write(filtered);
+            }
+
+            @Override
+            public void close() throws IOException {
+                network.close();
+            }
+        };
+
+        DataWriter getWriter = mock(DataWriter.class);
+        Http1ServerResponse getResponse = createResponse(getWriter, Method.GET, contentEncodingContext);
+        getResponse.streamFilter(filter);
+        getResponse.send(entity);
+        getResponse.commit();
+        var getBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(getWriter).write(getBuffer.capture());
+        String getText = new String(getBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+
+        DataWriter headWriter = mock(DataWriter.class);
+        Http1ServerResponse headResponse = createResponse(headWriter, Method.HEAD, contentEncodingContext);
+        headResponse.streamFilter(filter);
+        headResponse.send(entity);
+        headResponse.commit();
+        var headBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(headWriter).write(headBuffer.capture());
+        String headText = new String(headBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+
+        assertAll(
+                () -> assertThat(getText, containsString("Content-Encoding: test\r\n")),
+                () -> assertThat(getText, containsString("Content-Length: 8\r\n")),
+                () -> assertThat(getText, endsWith("\r\n\r\nxyentity")),
+                () -> assertThat(headText, containsString("Content-Encoding: test\r\n")),
+                () -> assertThat(headText, containsString("Content-Length: 8\r\n")),
+                () -> assertThat(headText, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
+    void streamingHeadUsesEntityMetadataWithoutSendingEntity() throws IOException {
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+
+        DataWriter getWriter = mock(DataWriter.class);
+        Http1ServerResponse getResponse = createResponse(getWriter, Method.GET, contentEncodingContext);
+        try (OutputStream output = getResponse.outputStream()) {
+            output.write(entity);
+        }
+        getResponse.commit();
+        var getBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(getWriter).write(getBuffer.capture());
+        String getText = new String(getBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+
+        DataWriter headWriter = mock(DataWriter.class);
+        Http1ServerResponse headResponse = createResponse(headWriter, Method.HEAD, contentEncodingContext);
+        try (OutputStream output = headResponse.outputStream()) {
+            output.write(entity);
+        }
+        headResponse.commit();
+        var headBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(headWriter).write(headBuffer.capture());
+        String headText = new String(headBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+
+        assertAll(
+                () -> assertThat(getText, containsString("Content-Length: 6\r\n")),
+                () -> assertThat(getText, endsWith("\r\n\r\nentity")),
+                () -> assertThat(headText, containsString("Content-Length: 6\r\n")),
+                () -> assertThat(headText, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
+    void flushedStreamingHeadSendsHeadersWithoutGeneratedMetadata() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        AtomicInteger whenSentCalls = new AtomicInteger();
+        response.whenSent(whenSentCalls::incrementAndGet);
+
+        OutputStream output = response.outputStream();
+        output.write("first".getBytes(StandardCharsets.UTF_8));
+        output.flush();
+
+        IOException exception = assertThrows(IOException.class,
+                                             () -> output.write("second".getBytes(StandardCharsets.UTF_8)));
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("HEAD response already sent")),
+                () -> assertThat(response.isSent(), is(true)),
+                () -> assertThat(whenSentCalls.get(), is(0)),
+                () -> assertThat(responseText.contains("Content-Length:"), is(false)),
+                () -> assertThat(responseText.contains("first"), is(false)),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+
+        response.commit();
+        verify(writer).write(any(BufferData.class));
+        assertThat(whenSentCalls.get(), is(1));
+    }
+
+    @Test
+    void flushedStreamingHeadNoEntityStatusSendsHeadersOnce() throws IOException {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            DataWriter writer = mock(DataWriter.class);
+            Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+            response.contentLength(23);
+            response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            response.header(HeaderNames.TRAILER, "test-trailer");
+            response.status(status);
+
+            OutputStream output = response.outputStream();
+            output.flush();
+            response.commit();
+
+            var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+            verify(writer).write(responseBuffer.capture());
+            String responseText = responseText(responseBuffer);
+            assertAll(
+                    () -> assertThat(responseText, containsString("HTTP/1.1 " + status + "\r\n")),
+                    () -> assertNoEntityHeaders(status, responseText),
+                    () -> assertThat(responseText, endsWith("\r\n\r\n"))
+            );
+        }
+    }
+
+    @Test
+    void flushedStreamingHeadAllowsEncoderToFinish() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(finalizingEncoder());
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        AtomicInteger whenSentCalls = new AtomicInteger();
+        response.whenSent(whenSentCalls::incrementAndGet);
+
+        OutputStream output = response.outputStream();
+        output.write("first".getBytes(StandardCharsets.UTF_8));
+        output.flush();
+
+        assertThrows(IOException.class, () -> output.write('x'));
+        output.close();
+        response.commit();
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(responseText, containsString("Content-Encoding: test\r\n")),
+                () -> assertThat(responseText.contains("first"), is(false)),
+                () -> assertThat(responseText, endsWith("\r\n\r\n")),
+                () -> assertThat(whenSentCalls.get(), is(1))
+        );
+    }
+
+    @Test
+    void flushedStreamingHeadPreservesExplicitContentLength() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        response.contentLength(11);
+
+        OutputStream output = response.outputStream();
+        output.write("first".getBytes(StandardCharsets.UTF_8));
+        output.flush();
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(responseText, containsString("Content-Length: 11\r\n")),
+                () -> assertThat(responseText.contains("first"), is(false)),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+
+        response.commit();
+        verify(writer).write(any(BufferData.class));
+    }
+
+    @Test
+    void flushedStreamingHeadOmitsTrailers() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        AtomicBoolean beforeTrailersCalled = new AtomicBoolean();
+        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+        response.beforeTrailers(_ -> beforeTrailersCalled.set(true));
+
+        OutputStream output = response.outputStream();
+        output.write("partial".getBytes(StandardCharsets.UTF_8));
+        output.flush();
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(beforeTrailersCalled.get(), is(false)),
+                () -> assertThat(responseText.contains("Content-Length:"), is(false)),
+                () -> assertThat(responseText.contains("Trailer:"), is(false)),
+                () -> assertThat(responseText.contains("partial"), is(false)),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+
+        response.commit();
+        verify(writer).write(any(BufferData.class));
+        assertThat(beforeTrailersCalled.get(), is(false));
+    }
+
+    @Test
+    void headEvaluatesButDoesNotSendTrailers() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        AtomicBoolean beforeTrailersCalled = new AtomicBoolean();
+        response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+        response.beforeTrailers(_ -> beforeTrailersCalled.set(true));
+
+        try (OutputStream output = response.outputStream()) {
+            output.write("entity".getBytes(StandardCharsets.UTF_8));
+        }
+        response.commit();
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(beforeTrailersCalled.get(), is(true)),
+                () -> assertThat(responseText, containsString("Trailer: test-trailer\r\n")),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
+    void forcedChunkedHeadSendsHeadersOnly() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+
+        try (OutputStream output = response.outputStream()) {
+            output.write("entity".getBytes(StandardCharsets.UTF_8));
+        }
+        response.commit();
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(responseText, containsString("Transfer-Encoding: chunked\r\n")),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+    }
+
+    private static String responseText(ArgumentCaptor<BufferData> responseBuffer) {
+        StringBuilder responseText = new StringBuilder();
+        for (BufferData buffer : responseBuffer.getAllValues()) {
+            responseText.append(new String(buffer.readBytes(), StandardCharsets.ISO_8859_1));
+        }
+        return responseText.toString();
+    }
+
+    private static void assertFlushedResponseRejectsStatusChange(boolean fixedLength) throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+        byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
+        if (fixedLength) {
+            response.contentLength(entity.length);
+        }
+
+        OutputStream output = response.outputStream();
+        output.write(entity);
+        output.flush();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                        () -> response.status(Status.NO_CONTENT_204));
+        response.commit();
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer, atLeastOnce()).write(responseBuffer.capture());
+        String responseText = responseText(responseBuffer);
+        int statusStart = responseText.indexOf("HTTP/1.1 ");
+        String expectedEnding = fixedLength ? "\r\n\r\nentity" : "0\r\n\r\n";
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("already sent")),
+                () -> assertThat(responseText, containsString("HTTP/1.1 200 OK\r\n")),
+                () -> assertThat(responseText.indexOf("HTTP/1.1 ", statusStart + 1), is(-1)),
+                () -> assertThat(responseText, containsString("entity")),
+                () -> assertThat(responseText, endsWith(expectedEnding))
+        );
+    }
+
+    private static void assertNoEntityHeaders(Status status, String responseText) {
+        int statusCode = status.code();
+        if (statusCode == Status.NO_CONTENT_204.code()) {
+            assertThat(responseText.contains("Content-Length:"), is(false));
+        } else if (statusCode == Status.RESET_CONTENT_205.code()) {
+            assertThat(responseText, containsString("Content-Length: 0\r\n"));
+        } else {
+            assertThat(responseText, containsString("Content-Length: 23\r\n"));
+        }
+        assertThat(responseText.contains("Transfer-Encoding:"), is(false));
+        assertThat(responseText.contains("Trailer:"), is(false));
+    }
+
     private static Http1ServerResponse createResponse(RuntimeException writerFailure) {
         DataWriter dataWriter = mock(DataWriter.class);
         doThrow(writerFailure).when(dataWriter).write(any(BufferData.class));
 
-        Http1ServerRequest request = mock(Http1ServerRequest.class);
-        when(request.headers()).thenReturn(ServerRequestHeaders.create(WritableHeaders.create()));
-
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+
+        return createResponse(dataWriter, Method.GET, contentEncodingContext);
+    }
+
+    private static ContentEncoder testEncoder() {
+        return new ContentEncoder() {
+            @Override
+            public OutputStream apply(OutputStream network) {
+                return new OutputStream() {
+                    @Override
+                    public void write(int value) throws IOException {
+                        network.write('x');
+                        network.write(value);
+                    }
+
+                    @Override
+                    public void write(byte[] bytes, int offset, int length) throws IOException {
+                        network.write('x');
+                        network.write(bytes, offset, length);
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        network.close();
+                    }
+                };
+            }
+
+            @Override
+            public void headers(WritableHeaders<?> headers) {
+                headers.set(HeaderNames.CONTENT_ENCODING, "test");
+                headers.remove(HeaderNames.CONTENT_LENGTH);
+            }
+        };
+    }
+
+    private static ContentEncoder finalizingEncoder() {
+        return new ContentEncoder() {
+            @Override
+            public OutputStream apply(OutputStream network) {
+                return new OutputStream() {
+                    @Override
+                    public void write(int value) throws IOException {
+                        network.write(value);
+                    }
+
+                    @Override
+                    public void write(byte[] bytes, int offset, int length) throws IOException {
+                        network.write(bytes, offset, length);
+                    }
+
+                    @Override
+                    public void flush() throws IOException {
+                        network.write('f');
+                        network.flush();
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        network.write('c');
+                        network.close();
+                    }
+                };
+            }
+
+            @Override
+            public void headers(WritableHeaders<?> headers) {
+                headers.set(HeaderNames.CONTENT_ENCODING, "test");
+                headers.remove(HeaderNames.CONTENT_LENGTH);
+            }
+        };
+    }
+
+    private static Http1ServerResponse createResponse(DataWriter dataWriter,
+                                                      Method method,
+                                                      ContentEncodingContext contentEncodingContext) {
+        return createResponse(dataWriter, method, contentEncodingContext, WebServer.builder().buildPrototype());
+    }
+
+    private static Http1ServerResponse createResponse(DataWriter dataWriter,
+                                                      Method method,
+                                                      ContentEncodingContext contentEncodingContext,
+                                                      ListenerConfig listenerConfig) {
+        Http1ServerRequest request = mock(Http1ServerRequest.class);
+        HttpPrologue prologue = mock(HttpPrologue.class);
+        when(prologue.method()).thenReturn(method);
+        when(request.headers()).thenReturn(ServerRequestHeaders.create(WritableHeaders.create()));
+        when(request.prologue()).thenReturn(prologue);
 
         ListenerContext listenerContext = mock(ListenerContext.class);
         when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
         when(listenerContext.mediaContext()).thenReturn(MediaContext.create());
-        when(listenerContext.config()).thenReturn(WebServer.builder().buildPrototype());
+        when(listenerContext.config()).thenReturn(listenerConfig);
 
         ConnectionContext ctx = mock(ConnectionContext.class);
         when(ctx.listenerContext()).thenReturn(listenerContext);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http1;
 
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -536,6 +537,61 @@ class Http1ServerResponseTest {
     }
 
     @Test
+    void streamingHeadRejectsEntityBeforeWritingToFilter() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        AtomicBoolean filterWritten = new AtomicBoolean();
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        response.streamFilter(network -> new FilterOutputStream(network) {
+            @Override
+            public void write(int value) throws IOException {
+                filterWritten.set(true);
+                super.write(value);
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) throws IOException {
+                filterWritten.set(true);
+                super.write(bytes, offset, length);
+            }
+        });
+
+        OutputStream output = response.outputStream();
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                        () -> output.write("entity".getBytes(StandardCharsets.UTF_8)));
+
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(filterWritten.get(), is(false)),
+                () -> assertThat(response.isSent(), is(false))
+        );
+        verifyZeroInteractions(writer);
+    }
+
+    @Test
+    void streamingHeadRejectsEntityBeforeWritingToEncoder() throws IOException {
+        AtomicBoolean encoderWritten = new AtomicBoolean();
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class)))
+                .thenReturn(testEncoder(() -> encoderWritten.set(true)));
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+
+        OutputStream output = response.outputStream();
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                        () -> output.write("entity".getBytes(StandardCharsets.UTF_8)));
+
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("HEAD request")),
+                () -> assertThat(encoderWritten.get(), is(false)),
+                () -> assertThat(response.isSent(), is(false))
+        );
+        verifyZeroInteractions(writer);
+    }
+
+    @Test
     void streamingHeadRejectsEntityBeforeSendingResponse() throws IOException {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
@@ -730,18 +786,24 @@ class Http1ServerResponseTest {
     }
 
     private static ContentEncoder testEncoder() {
+        return testEncoder(() -> { });
+    }
+
+    private static ContentEncoder testEncoder(Runnable onWrite) {
         return new ContentEncoder() {
             @Override
             public OutputStream apply(OutputStream network) {
                 return new OutputStream() {
                     @Override
                     public void write(int value) throws IOException {
+                        onWrite.run();
                         network.write('x');
                         network.write(value);
                     }
 
                     @Override
                     public void write(byte[] bytes, int offset, int length) throws IOException {
+                        onWrite.run();
                         network.write('x');
                         network.write(bytes, offset, length);
                     }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -576,6 +576,32 @@ class Http1ServerResponseTest {
     }
 
     @Test
+    void streamingHeadStopsAfterConfiguredDiscardLimit() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        DataWriter writer = mock(DataWriter.class);
+        ListenerConfig listenerConfig = WebServer.builder().writeBufferSize(4).buildPrototype();
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext, listenerConfig);
+        response.contentLength(100);
+
+        OutputStream output = response.outputStream();
+        output.write("1234".getBytes(StandardCharsets.UTF_8));
+        IOException exception = assertThrows(IOException.class, () -> output.write('5'));
+        response.commit();
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(exception.getMessage(), containsString("streaming limit of 4 bytes")),
+                () -> assertThat(response.isSent(), is(true)),
+                () -> assertThat(responseText, containsString("Content-Length: 100\r\n")),
+                () -> assertThat(responseText.contains("1234"), is(false)),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
     void flushedStreamingHeadSendsHeadersWithoutGeneratedMetadata() throws IOException {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -304,6 +304,33 @@ class Http1ServerResponseTest {
     }
 
     @Test
+    void noEntityStatusWithoutContentLengthUsesRequiredFraming() {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            DataWriter writer = mock(DataWriter.class);
+            Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+
+            response.status(status).send();
+
+            var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+            verify(writer).write(responseBuffer.capture());
+            String responseText = responseText(responseBuffer);
+            assertAll(
+                    () -> assertThat(responseText, containsString("HTTP/1.1 " + status + "\r\n")),
+                    () -> {
+                        if (status.code() == Status.RESET_CONTENT_205.code()) {
+                            assertThat(responseText, containsString("Content-Length: 0\r\n"));
+                        } else {
+                            assertThat(responseText.contains("Content-Length:"), is(false));
+                        }
+                    },
+                    () -> assertThat(responseText, endsWith("\r\n\r\n"))
+            );
+        }
+    }
+
+    @Test
     void noEntityStatusIgnoresEmptyWritesWithoutBuffering() throws IOException {
         for (Status status : NO_ENTITY_STATUSES) {
             ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -440,6 +440,43 @@ class Http1ServerResponseTest {
     }
 
     @Test
+    void directHandlerHeadUsesEncodedRepresentationMetadata() {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder());
+        DataWriter writer = mock(DataWriter.class);
+        Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+        DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+        when(request.method()).thenReturn(Method.HEAD_NAME);
+        when(request.protocolVersion()).thenReturn("HTTP/1.1");
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.BAD_REQUEST_400)
+                                    .entity("error")
+                                    .build())
+                .build();
+        RequestException requestException = RequestException.builder()
+                .request(request)
+                .type(DirectHandler.EventType.BAD_REQUEST)
+                .message("bad request")
+                .build();
+
+        directHandlers.handle(requestException, response, true);
+
+        var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+        verify(writer).write(responseBuffer.capture());
+        String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+        assertAll(
+                () -> assertThat(responseText, containsString("HTTP/1.1 400 Bad Request\r\n")),
+                () -> assertThat(responseText, containsString("Content-Encoding: test\r\n")),
+                () -> assertThat(responseText, containsString("Vary: Accept-Encoding\r\n")),
+                () -> assertThat(responseText, containsString("Content-Length: 6\r\n")),
+                () -> assertThat(responseText, endsWith("\r\n\r\n"))
+        );
+    }
+
+    @Test
     void directHandlerNoContentRemovesContentLength() {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -478,6 +478,53 @@ class Http1ServerResponseTest {
     }
 
     @Test
+    void directHandlerFilteredHeadUsesOnlyConfiguredRepresentationLength() {
+        for (long configuredLength : List.of(-1L, 10L)) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            DataWriter writer = mock(DataWriter.class);
+            Http1ServerResponse response = createResponse(writer, Method.HEAD, contentEncodingContext);
+            response.streamFilter(output -> new FilterOutputStream(output) {
+                @Override
+                public void write(byte[] bytes, int offset, int length) throws IOException {
+                    out.write(bytes, offset, length);
+                    out.write(bytes, offset, length);
+                }
+            });
+            if (configuredLength >= 0) {
+                response.beforeSend(() -> response.contentLength(configuredLength));
+            }
+            DirectHandler.TransportRequest request = mock(DirectHandler.TransportRequest.class);
+            when(request.method()).thenReturn(Method.HEAD_NAME);
+            when(request.protocolVersion()).thenReturn("HTTP/1.1");
+            DirectHandlers directHandlers = DirectHandlers.builder()
+                    .addHandler(DirectHandler.EventType.BAD_REQUEST,
+                                (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                        .status(Status.BAD_REQUEST_400)
+                                        .entity("error")
+                                        .build())
+                    .build();
+            RequestException requestException = RequestException.builder()
+                    .request(request)
+                    .type(DirectHandler.EventType.BAD_REQUEST)
+                    .message("bad request")
+                    .build();
+
+            directHandlers.handle(requestException, response, true);
+
+            var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+            verify(writer).write(responseBuffer.capture());
+            String responseText = new String(responseBuffer.getValue().readBytes(), StandardCharsets.ISO_8859_1);
+            assertThat(responseText, endsWith("\r\n\r\n"));
+            if (configuredLength < 0) {
+                assertThat(responseText.contains("Content-Length:"), is(false));
+            } else {
+                assertThat(responseText, containsString("Content-Length: " + configuredLength + "\r\n"));
+            }
+        }
+    }
+
+    @Test
     void directHandlerNoContentRemovesContentLength() {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);


### PR DESCRIPTION
Pre-requisite for #12058

Preserve direct-handler response metadata through HTTP/1.1 and HTTP/2 response processing. Apply normal response transformations to HEAD while suppressing response data, and keep no-content response framing consistent.
