### PR TITLE
Reset HTTP/2 idle timer on inbound PING frames

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -951,6 +951,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         } else {
             ping = Http2Ping.create(inProgressFrame());
             receiveFrameListener.frame(ctx, 0, ping);
+            // PING is observable connection activity (RFC 9113 §6.7 keep-alive)
+            this.lastRequestTimestamp = DateTime.timestamp();
             state = State.SEND_PING_ACK;
         }
     }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -195,6 +195,29 @@ class Http2ConnectionTest {
     }
 
     @Test
+    void pingFrameRefreshesIdleTime() throws InterruptedException {
+        Queue<byte[]> input = new ConcurrentLinkedQueue<>();
+        input.add(frameBytes(Http2Ping.create().toFrameData()));
+
+        AtomicReference<Http2Connection> connectionRef = new AtomicReference<>();
+        DataReader reader = DataReader.create(() -> {
+            byte[] frame = input.poll();
+            if (frame != null) {
+                connectionRef.get().lastRequestTimestamp(ZonedDateTime.now().minusHours(1));
+            }
+            return frame;
+        });
+        ConnectionContext ctx = http2Context(mock(DataWriter.class), reader);
+        Http2Connection connection = new Http2Connection(ctx, Http2Config.create(), List.of());
+        connectionRef.set(connection);
+
+        assertThrows(CloseConnectionException.class,
+                     () -> connection.handle(mock(io.helidon.common.concurrency.limits.Limit.class)));
+
+        assertThat(connection.idleTime(), lessThan(Duration.ofSeconds(5)));
+    }
+
+    @Test
     void connectionErrorWakesActiveStreamTask() throws InterruptedException {
         Queue<byte[]> input = new ConcurrentLinkedQueue<>();
         Http2Headers h2Headers = Http2Headers.create(WritableHeaders.create());


### PR DESCRIPTION
### Description

Fixes #12283.

`Http2Connection.pingFrame()` correctly replies to inbound PING with PING_ACK (RFC 9113 §6.7) but never updated `lastRequestTimestamp`. The idle-connection reaper (`IdleTimeoutHandler`) then closed connections that were kept alive only by client PINGs — typical for gRPC `keepAliveTime` on long-lived, low-throughput streams after the initial HEADERS frame.

The non-ACK PING path now updates `lastRequestTimestamp` the same way HEADERS and stream-level WINDOW_UPDATE already do (`DateTime.timestamp()`). PING ACK for an unsent ping is still ignored.

This does **not** add server-initiated PING keep-alive (tracked separately in #12284).

**How to validate**

```
mvn -pl webserver/http2 test -Dtest=Http2ConnectionTest
```

`Http2ConnectionTest#pingFrameRefreshesIdleTime` is a neighbor of `windowUpdateForActiveStreamRefreshesIdleTime`: backdate the idle timestamp when the PING is read, then assert `idleTime()` is under 5 seconds. Without the timestamp update the assertion fails (`idleTime` stays ~1 hour).

### Documentation

None

Made with [Cursor](https://cursor.com)