### PR TITLE
Share resolved WebClient targets

### DIFF
--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -215,6 +215,24 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
     }
 
     /**
+     * Create a TLS socket using a logical peer identity and the configured server names.
+     *
+     * @param alpnProtocols protocol(s) to use (order is significant)
+     * @param socket existing socket
+     * @param tlsPeerHost TLS peer host for SNI and endpoint identification
+     * @param tlsPeerPort TLS peer port for endpoint identification
+     * @return a new socket ready for TLS communication
+     */
+    @Api.Internal
+    public SSLSocket createSocket(List<String> alpnProtocols,
+                                  Socket socket,
+                                  String tlsPeerHost,
+                                  int tlsPeerPort) {
+        Objects.requireNonNull(tlsPeerHost, "tlsPeerHost");
+        return createSocketInternal(alpnProtocols, socket, tlsPeerHost, tlsPeerPort, null);
+    }
+
+    /**
      * Create a SSLSocket for the chosen protocol and the given socket.
      *
      * @param alpnProtocols       protocol(s) to use (order is significant)

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -74,6 +74,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-http1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-http2</artifactId>
         </dependency>
         <dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -78,6 +78,14 @@ public class WebClientConnectionTargetBenchmark {
         }
     }
 
+    private static String[] targetUris(int targetCount, int serverPort) {
+        String[] result = new String[targetCount];
+        for (int i = 0; i < targetCount; i++) {
+            result[i] = "http://target-" + i + ".example:" + serverPort + PATH;
+        }
+        return result;
+    }
+
     @State(Scope.Benchmark)
     public static class ServerState {
         private WebServer server;
@@ -179,13 +187,5 @@ public class WebClientConnectionTargetBenchmark {
         private String targetUri(int index) {
             return targetUris[index];
         }
-    }
-
-    private static String[] targetUris(int targetCount, int serverPort) {
-        String[] result = new String[targetCount];
-        for (int i = 0; i < targetCount; i++) {
-            result[i] = "http://target-" + i + ".example:" + serverPort + PATH;
-        }
-        return result;
     }
 }

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -40,6 +40,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.infra.ThreadParams;
 
@@ -169,6 +170,10 @@ public class WebClientConnectionTargetBenchmark {
         return result;
     }
 
+    private static int targetCount(int prefilledTargetCount, BenchmarkParams benchmarkParams) {
+        return Math.max(prefilledTargetCount, benchmarkParams.getThreads() * TARGETS_PER_THREAD);
+    }
+
     private static InetAddress resolve(String host, ProxyMode proxyMode) {
         boolean proxyHost = "proxy.invalid".equals(host);
         if (proxyMode == ProxyMode.HTTP_FORWARD && !proxyHost) {
@@ -244,16 +249,16 @@ public class WebClientConnectionTargetBenchmark {
         private String[] targetUris;
 
         @Setup(Level.Trial)
-        public void setup(ServerState serverState) {
+        public void setup(ServerState serverState, BenchmarkParams benchmarkParams) {
             http1Client = Http1Client.builder()
                     .shareConnectionCache(false)
                     .servicesDiscoverServices(false)
                     .proxy(proxyMode.proxy(serverState.server.port()))
                     .dnsResolver((host, _) -> resolve(host, proxyMode))
                     .build();
-            targetUris = targetUris(prefilledTargetCount, serverState.server.port());
-            for (String targetUri : targetUris) {
-                try (var response = http1Client.get(targetUri).request()) {
+            targetUris = targetUris(targetCount(prefilledTargetCount, benchmarkParams), serverState.server.port());
+            for (int i = 0; i < prefilledTargetCount; i++) {
+                try (var response = http1Client.get(targetUris[i]).request()) {
                     response.entity().consume();
                     if (response.status().code() != 200) {
                         throw new IllegalStateException("Unexpected HTTP/1.1 status: " + response.status());
@@ -284,7 +289,7 @@ public class WebClientConnectionTargetBenchmark {
         private String[] targetUris;
 
         @Setup(Level.Trial)
-        public void setup(ServerState serverState) {
+        public void setup(ServerState serverState, BenchmarkParams benchmarkParams) {
             http2Client = Http2Client.builder()
                     .shareConnectionCache(false)
                     .servicesDiscoverServices(false)
@@ -292,8 +297,8 @@ public class WebClientConnectionTargetBenchmark {
                     .dnsResolver((host, _) -> resolve(host, proxyMode))
                     .protocolConfig(builder -> builder.priorKnowledge(proxyMode != ProxyMode.HTTP_FORWARD))
                     .build();
-            targetUris = targetUris(prefilledTargetCount, serverState.server.port());
-            for (int i = 0; i < targetUris.length; i++) {
+            targetUris = targetUris(targetCount(prefilledTargetCount, benchmarkParams), serverState.server.port());
+            for (int i = 0; i < prefilledTargetCount; i++) {
                 try (var response = http2Client.get(targetUris[i]).request()) {
                     response.entity().consume();
                     if (response.status().code() != 200) {

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -65,6 +65,21 @@ public class WebClientConnectionTargetBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1OneOff(Http1State state, Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            try (var response = state.http1Client.get(state.targetUri(0)).keepAlive(false).request()) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != 200) {
+                    throw new IllegalStateException("Unexpected HTTP/1.1 status: " + response.status());
+                }
+                blackhole.consume(status);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http2CacheHit(Http2State state, Blackhole blackhole) {
         for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
             try (var response = state.http2Client.get(state.targetUri(0)).request()) {

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -50,6 +50,27 @@ public class WebClientConnectionTargetBenchmark {
     private static final int TARGETS_PER_THREAD = 4;
     private static final String PATH = "/target";
 
+    public enum ProxyMode {
+        NONE(Proxy.noProxy()),
+        IP_NO_PROXY(Proxy.builder()
+                            .type(Proxy.ProxyType.HTTP)
+                            .host("proxy.invalid")
+                            .port(8080)
+                            .addNoProxy(".example")
+                            .addNoProxy("127.0.0.1")
+                            .build());
+
+        private final Proxy proxy;
+
+        ProxyMode(Proxy proxy) {
+            this.proxy = proxy;
+        }
+
+        Proxy proxy() {
+            return proxy;
+        }
+    }
+
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http1CacheHit(Http1State state, Blackhole blackhole) {
@@ -169,6 +190,13 @@ public class WebClientConnectionTargetBenchmark {
         return result;
     }
 
+    private static InetAddress resolve(String host) {
+        if ("proxy.invalid".equals(host)) {
+            throw new IllegalStateException("Proxy host must not be resolved");
+        }
+        return InetAddress.ofLiteral("127.0.0.1");
+    }
+
     @State(Scope.Benchmark)
     public static class ServerState {
         private WebServer server;
@@ -202,6 +230,9 @@ public class WebClientConnectionTargetBenchmark {
         @Param({"1", "64"})
         public int prefilledTargetCount;
 
+        @Param({"NONE", "IP_NO_PROXY"})
+        public ProxyMode proxyMode;
+
         private Http1Client http1Client;
         private String[] targetUris;
 
@@ -210,8 +241,8 @@ public class WebClientConnectionTargetBenchmark {
             http1Client = Http1Client.builder()
                     .shareConnectionCache(false)
                     .servicesDiscoverServices(false)
-                    .proxy(Proxy.noProxy())
-                    .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                    .proxy(proxyMode.proxy())
+                    .dnsResolver((host, _) -> resolve(host))
                     .build();
             targetUris = targetUris(prefilledTargetCount, serverState.server.port());
             for (String targetUri : targetUris) {
@@ -239,6 +270,9 @@ public class WebClientConnectionTargetBenchmark {
         @Param({"1", "64"})
         public int prefilledTargetCount;
 
+        @Param({"NONE", "IP_NO_PROXY"})
+        public ProxyMode proxyMode;
+
         private Http2Client http2Client;
         private String[] targetUris;
 
@@ -247,8 +281,8 @@ public class WebClientConnectionTargetBenchmark {
             http2Client = Http2Client.builder()
                     .shareConnectionCache(false)
                     .servicesDiscoverServices(false)
-                    .proxy(Proxy.noProxy())
-                    .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                    .proxy(proxyMode.proxy())
+                    .dnsResolver((host, _) -> resolve(host))
                     .protocolConfig(builder -> builder.priorKnowledge(true))
                     .build();
             targetUris = targetUris(prefilledTargetCount, serverState.server.port());

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -41,11 +41,13 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.infra.ThreadParams;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class WebClientConnectionTargetBenchmark {
     private static final int REQUESTS_PER_INVOCATION = 16;
+    private static final int TARGETS_PER_THREAD = 4;
     private static final String PATH = "/target";
 
     @Benchmark
@@ -80,9 +82,75 @@ public class WebClientConnectionTargetBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1DistinctTargetPerThread(Http1State state, ThreadParams threadParams, Blackhole blackhole) {
+        int targetIndex = threadParams.getThreadIndex() * TARGETS_PER_THREAD;
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            try (var response = state.http1Client.get(state.targetUri(targetIndex)).request()) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != 200) {
+                    throw new IllegalStateException("Unexpected HTTP/1.1 status: " + response.status());
+                }
+                blackhole.consume(status);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1RotatingTargetsPerThread(Http1State state, ThreadParams threadParams, Blackhole blackhole) {
+        int firstTargetIndex = threadParams.getThreadIndex() * TARGETS_PER_THREAD;
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            int targetIndex = firstTargetIndex + i % TARGETS_PER_THREAD;
+            try (var response = state.http1Client.get(state.targetUri(targetIndex)).request()) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != 200) {
+                    throw new IllegalStateException("Unexpected HTTP/1.1 status: " + response.status());
+                }
+                blackhole.consume(status);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http2CacheHit(Http2State state, Blackhole blackhole) {
         for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
             try (var response = state.http2Client.get(state.targetUri(0)).request()) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != 200) {
+                    throw new IllegalStateException("Unexpected HTTP/2 status: " + response.status());
+                }
+                blackhole.consume(status);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2DistinctTargetPerThread(Http2State state, ThreadParams threadParams, Blackhole blackhole) {
+        int targetIndex = threadParams.getThreadIndex() * TARGETS_PER_THREAD;
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            try (var response = state.http2Client.get(state.targetUri(targetIndex)).request()) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != 200) {
+                    throw new IllegalStateException("Unexpected HTTP/2 status: " + response.status());
+                }
+                blackhole.consume(status);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2RotatingTargetsPerThread(Http2State state, ThreadParams threadParams, Blackhole blackhole) {
+        int firstTargetIndex = threadParams.getThreadIndex() * TARGETS_PER_THREAD;
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            int targetIndex = firstTargetIndex + i % TARGETS_PER_THREAD;
+            try (var response = state.http2Client.get(state.targetUri(targetIndex)).request()) {
                 response.entity().consume();
                 int status = response.status().code();
                 if (status != 200) {

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.http.Method;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http1.Http1Route;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2ConnectionSelector;
+import io.helidon.webserver.http2.Http2Route;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class WebClientConnectionTargetBenchmark {
+    private static final int REQUESTS_PER_INVOCATION = 16;
+    private static final String PATH = "/target";
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1CacheHit(Http1State state, Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            try (var response = state.http1Client.get(state.targetUri(0)).request()) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != 200) {
+                    throw new IllegalStateException("Unexpected HTTP/1.1 status: " + response.status());
+                }
+                blackhole.consume(status);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2CacheHit(Http2State state, Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            try (var response = state.http2Client.get(state.targetUri(0)).request()) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != 200) {
+                    throw new IllegalStateException("Unexpected HTTP/2 status: " + response.status());
+                }
+                blackhole.consume(status);
+            }
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class ServerState {
+        private WebServer server;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            Http2Config http2Config = Http2Config.create();
+            server = WebServer.builder()
+                    .addProtocol(http2Config)
+                    .addConnectionSelector(Http2ConnectionSelector.builder()
+                                                   .http2Config(http2Config)
+                                                   .build())
+                    .host("127.0.0.1")
+                    .routing(builder -> builder
+                            .route(Http1Route.route(Method.GET, PATH,
+                                                    (_, response) -> response.send("ok")))
+                            .route(Http2Route.route(Method.GET, PATH,
+                                                    (_, response) -> response.send("ok"))))
+                    .build()
+                    .start();
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            server.stop();
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class Http1State {
+        @Param({"1", "64"})
+        public int prefilledTargetCount;
+
+        private Http1Client http1Client;
+        private String[] targetUris;
+
+        @Setup(Level.Trial)
+        public void setup(ServerState serverState) {
+            http1Client = Http1Client.builder()
+                    .shareConnectionCache(false)
+                    .servicesDiscoverServices(false)
+                    .proxy(Proxy.noProxy())
+                    .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                    .build();
+            targetUris = targetUris(prefilledTargetCount, serverState.server.port());
+            for (String targetUri : targetUris) {
+                try (var response = http1Client.get(targetUri).request()) {
+                    response.entity().consume();
+                    if (response.status().code() != 200) {
+                        throw new IllegalStateException("Unexpected HTTP/1.1 status: " + response.status());
+                    }
+                }
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            http1Client.closeResource();
+        }
+
+        private String targetUri(int index) {
+            return targetUris[index];
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class Http2State {
+        @Param({"1", "64"})
+        public int prefilledTargetCount;
+
+        private Http2Client http2Client;
+        private String[] targetUris;
+
+        @Setup(Level.Trial)
+        public void setup(ServerState serverState) {
+            http2Client = Http2Client.builder()
+                    .shareConnectionCache(false)
+                    .servicesDiscoverServices(false)
+                    .proxy(Proxy.noProxy())
+                    .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                    .protocolConfig(builder -> builder.priorKnowledge(true))
+                    .build();
+            targetUris = targetUris(prefilledTargetCount, serverState.server.port());
+            for (String targetUri : targetUris) {
+                try (var response = http2Client.get(targetUri).request()) {
+                    response.entity().consume();
+                    if (response.status().code() != 200) {
+                        throw new IllegalStateException("Unexpected HTTP/2 status: " + response.status());
+                    }
+                }
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            http2Client.closeResource();
+        }
+
+        private String targetUri(int index) {
+            return targetUris[index];
+        }
+    }
+
+    private static String[] targetUris(int targetCount, int serverPort) {
+        String[] result = new String[targetCount];
+        for (int i = 0; i < targetCount; i++) {
+            result[i] = "http://target-" + i + ".example:" + serverPort + PATH;
+        }
+        return result;
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -169,31 +169,38 @@ public class WebClientConnectionTargetBenchmark {
         return result;
     }
 
-    private static InetAddress resolve(String host) {
-        if ("proxy.invalid".equals(host)) {
-            throw new IllegalStateException("Proxy host must not be resolved");
+    private static InetAddress resolve(String host, ProxyMode proxyMode) {
+        boolean proxyHost = "proxy.invalid".equals(host);
+        if (proxyMode == ProxyMode.HTTP_FORWARD && !proxyHost) {
+            throw new IllegalStateException("Origin host must not be resolved through an HTTP forward proxy: " + host);
+        }
+        if (proxyMode != ProxyMode.HTTP_FORWARD && proxyHost) {
+            throw new IllegalStateException("Proxy host must not be resolved: " + host);
         }
         return InetAddress.ofLiteral("127.0.0.1");
     }
 
     public enum ProxyMode {
-        NONE(Proxy.noProxy()),
-        IP_NO_PROXY(Proxy.builder()
-                            .type(Proxy.ProxyType.HTTP)
-                            .host("proxy.invalid")
-                            .port(8080)
-                            .addNoProxy(".example")
-                            .addNoProxy("127.0.0.1")
-                            .build());
+        NONE,
+        IP_NO_PROXY,
+        HTTP_FORWARD;
 
-        private final Proxy proxy;
-
-        ProxyMode(Proxy proxy) {
-            this.proxy = proxy;
-        }
-
-        Proxy proxy() {
-            return proxy;
+        Proxy proxy(int serverPort) {
+            return switch (this) {
+                case NONE -> Proxy.noProxy();
+                case IP_NO_PROXY -> Proxy.builder()
+                        .type(Proxy.ProxyType.HTTP)
+                        .host("proxy.invalid")
+                        .port(8080)
+                        .addNoProxy(".example")
+                        .addNoProxy("127.0.0.1")
+                        .build();
+                case HTTP_FORWARD -> Proxy.builder()
+                        .type(Proxy.ProxyType.HTTP)
+                        .host("proxy.invalid")
+                        .port(serverPort)
+                        .build();
+            };
         }
     }
 
@@ -241,8 +248,8 @@ public class WebClientConnectionTargetBenchmark {
             http1Client = Http1Client.builder()
                     .shareConnectionCache(false)
                     .servicesDiscoverServices(false)
-                    .proxy(proxyMode.proxy())
-                    .dnsResolver((host, _) -> resolve(host))
+                    .proxy(proxyMode.proxy(serverState.server.port()))
+                    .dnsResolver((host, _) -> resolve(host, proxyMode))
                     .build();
             targetUris = targetUris(prefilledTargetCount, serverState.server.port());
             for (String targetUri : targetUris) {
@@ -281,16 +288,21 @@ public class WebClientConnectionTargetBenchmark {
             http2Client = Http2Client.builder()
                     .shareConnectionCache(false)
                     .servicesDiscoverServices(false)
-                    .proxy(proxyMode.proxy())
-                    .dnsResolver((host, _) -> resolve(host))
-                    .protocolConfig(builder -> builder.priorKnowledge(true))
+                    .proxy(proxyMode.proxy(serverState.server.port()))
+                    .dnsResolver((host, _) -> resolve(host, proxyMode))
+                    .protocolConfig(builder -> builder.priorKnowledge(proxyMode != ProxyMode.HTTP_FORWARD))
                     .build();
             targetUris = targetUris(prefilledTargetCount, serverState.server.port());
-            for (String targetUri : targetUris) {
-                try (var response = http2Client.get(targetUri).request()) {
+            for (int i = 0; i < targetUris.length; i++) {
+                try (var response = http2Client.get(targetUris[i]).request()) {
                     response.entity().consume();
                     if (response.status().code() != 200) {
                         throw new IllegalStateException("Unexpected HTTP/2 status: " + response.status());
+                    }
+                    if (i == 0
+                            && proxyMode == ProxyMode.HTTP_FORWARD
+                            && !Http1Client.PROTOCOL_ID.equals(response.protocolId())) {
+                        throw new IllegalStateException("Unexpected HTTP forward proxy protocol: " + response.protocolId());
                     }
                 }
             }

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -50,27 +50,6 @@ public class WebClientConnectionTargetBenchmark {
     private static final int TARGETS_PER_THREAD = 4;
     private static final String PATH = "/target";
 
-    public enum ProxyMode {
-        NONE(Proxy.noProxy()),
-        IP_NO_PROXY(Proxy.builder()
-                            .type(Proxy.ProxyType.HTTP)
-                            .host("proxy.invalid")
-                            .port(8080)
-                            .addNoProxy(".example")
-                            .addNoProxy("127.0.0.1")
-                            .build());
-
-        private final Proxy proxy;
-
-        ProxyMode(Proxy proxy) {
-            this.proxy = proxy;
-        }
-
-        Proxy proxy() {
-            return proxy;
-        }
-    }
-
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http1CacheHit(Http1State state, Blackhole blackhole) {
@@ -195,6 +174,27 @@ public class WebClientConnectionTargetBenchmark {
             throw new IllegalStateException("Proxy host must not be resolved");
         }
         return InetAddress.ofLiteral("127.0.0.1");
+    }
+
+    public enum ProxyMode {
+        NONE(Proxy.noProxy()),
+        IP_NO_PROXY(Proxy.builder()
+                            .type(Proxy.ProxyType.HTTP)
+                            .host("proxy.invalid")
+                            .port(8080)
+                            .addNoProxy(".example")
+                            .addNoProxy("127.0.0.1")
+                            .build());
+
+        private final Proxy proxy;
+
+        ProxyMode(Proxy proxy) {
+            this.proxy = proxy;
+        }
+
+        Proxy proxy() {
+            return proxy;
+        }
     }
 
     @State(Scope.Benchmark)

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
@@ -19,6 +19,7 @@ package io.helidon.webclient.benchmark.jmh;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
@@ -41,6 +42,7 @@ class WebClientConnectionTargetJmhRunnerTest {
         String[] targetCounts = contention
                 ? new String[] {"64"}
                 : System.getProperty("webclient.target.jmh.targetCounts", "1,64").split(",");
+        String[] proxyModes = System.getProperty("webclient.target.jmh.proxyModes", "NONE").split(",");
         int[] threadCounts = contention
                 ? new int[] {1, 2, 4, 8, 16}
                 : new int[] {Integer.getInteger("webclient.target.jmh.threads", 1)};
@@ -55,8 +57,10 @@ class WebClientConnectionTargetJmhRunnerTest {
             var optionsBuilder = new OptionsBuilder()
                     .include(include)
                     .param("prefilledTargetCount", targetCounts)
+                    .param("proxyMode", proxyModes)
                     .threads(threadCount)
                     .forks(forks)
+                    .mode(Mode.valueOf(System.getProperty("webclient.target.jmh.mode", "AverageTime")))
                     .warmupIterations(Integer.getInteger("webclient.target.jmh.warmupIterations", 3))
                     .warmupTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.warmupMillis", 500)))
                     .measurementIterations(Integer.getInteger("webclient.target.jmh.measurementIterations", 5))

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
@@ -31,7 +31,7 @@ class WebClientConnectionTargetJmhRunnerTest {
     @Test
     void runExactBenchmark() throws RunnerException {
         String benchmark = WebClientConnectionTargetBenchmark.class.getName();
-        Options options = new OptionsBuilder()
+        var optionsBuilder = new OptionsBuilder()
                 .include(System.getProperty("webclient.target.jmh.include",
                                             "^" + benchmark + "\\.(http1CacheHit|http2CacheHit)$"))
                 .param("prefilledTargetCount",
@@ -46,8 +46,12 @@ class WebClientConnectionTargetJmhRunnerTest {
                 .addProfiler(GCProfiler.class)
                 .shouldFailOnError(true)
                 .resultFormat(ResultFormatType.JSON)
-                .result(System.getProperty("webclient.target.jmh.result", "target/webclient-target-cache.json"))
-                .build();
+                .result(System.getProperty("webclient.target.jmh.result", "target/webclient-target-cache.json"));
+        String jvmArgument = System.getProperty("webclient.target.jmh.jvmArgument");
+        if (jvmArgument != null) {
+            optionsBuilder.jvmArgsAppend(jvmArgument);
+        }
+        Options options = optionsBuilder.build();
         new Runner(options).run();
     }
 }

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
@@ -33,7 +33,7 @@ class WebClientConnectionTargetJmhRunnerTest {
         String benchmark = WebClientConnectionTargetBenchmark.class.getName();
         var optionsBuilder = new OptionsBuilder()
                 .include(System.getProperty("webclient.target.jmh.include",
-                                            "^" + benchmark + "\\.(http1CacheHit|http2CacheHit)$"))
+                                            "^" + benchmark + "\\.(http1CacheHit|http1OneOff|http2CacheHit)$"))
                 .param("prefilledTargetCount",
                        System.getProperty("webclient.target.jmh.targetCounts", "1,64").split(","))
                 .threads(Integer.getInteger("webclient.target.jmh.threads", 1))

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
@@ -31,27 +31,47 @@ class WebClientConnectionTargetJmhRunnerTest {
     @Test
     void runExactBenchmark() throws RunnerException {
         String benchmark = WebClientConnectionTargetBenchmark.class.getName();
-        var optionsBuilder = new OptionsBuilder()
-                .include(System.getProperty("webclient.target.jmh.include",
-                                            "^" + benchmark + "\\.(http1CacheHit|http1OneOff|http2CacheHit)$"))
-                .param("prefilledTargetCount",
-                       System.getProperty("webclient.target.jmh.targetCounts", "1,64").split(","))
-                .threads(Integer.getInteger("webclient.target.jmh.threads", 1))
-                .forks(Integer.getInteger("webclient.target.jmh.forks", 1))
-                .warmupIterations(Integer.getInteger("webclient.target.jmh.warmupIterations", 3))
-                .warmupTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.warmupMillis", 500)))
-                .measurementIterations(Integer.getInteger("webclient.target.jmh.measurementIterations", 5))
-                .measurementTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.measurementMillis", 1000)))
-                .timeUnit(TimeUnit.MICROSECONDS)
-                .addProfiler(GCProfiler.class)
-                .shouldFailOnError(true)
-                .resultFormat(ResultFormatType.JSON)
-                .result(System.getProperty("webclient.target.jmh.result", "target/webclient-target-cache.json"));
-        String jvmArgument = System.getProperty("webclient.target.jmh.jvmArgument");
-        if (jvmArgument != null) {
-            optionsBuilder.jvmArgsAppend(jvmArgument);
+        boolean contention = Boolean.getBoolean("webclient.target.jmh.contention");
+        String include = contention
+                ? "^" + benchmark
+                        + "\\.(http1DistinctTargetPerThread|http1RotatingTargetsPerThread"
+                        + "|http2DistinctTargetPerThread|http2RotatingTargetsPerThread)$"
+                : System.getProperty("webclient.target.jmh.include",
+                                     "^" + benchmark + "\\.(http1CacheHit|http1OneOff|http2CacheHit)$");
+        String[] targetCounts = contention
+                ? new String[] {"64"}
+                : System.getProperty("webclient.target.jmh.targetCounts", "1,64").split(",");
+        int[] threadCounts = contention
+                ? new int[] {1, 2, 4, 8, 16}
+                : new int[] {Integer.getInteger("webclient.target.jmh.threads", 1)};
+        int forks = contention ? 3 : Integer.getInteger("webclient.target.jmh.forks", 1);
+        String contentionResultPrefix = System.getProperty("webclient.target.jmh.contentionResultPrefix",
+                                                           "target/webclient-target-cache-contention");
+
+        for (int threadCount : threadCounts) {
+            String result = contention
+                    ? contentionResultPrefix + "-" + threadCount + "-threads.json"
+                    : System.getProperty("webclient.target.jmh.result", "target/webclient-target-cache.json");
+            var optionsBuilder = new OptionsBuilder()
+                    .include(include)
+                    .param("prefilledTargetCount", targetCounts)
+                    .threads(threadCount)
+                    .forks(forks)
+                    .warmupIterations(Integer.getInteger("webclient.target.jmh.warmupIterations", 3))
+                    .warmupTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.warmupMillis", 500)))
+                    .measurementIterations(Integer.getInteger("webclient.target.jmh.measurementIterations", 5))
+                    .measurementTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.measurementMillis", 1000)))
+                    .timeUnit(TimeUnit.MICROSECONDS)
+                    .addProfiler(GCProfiler.class)
+                    .shouldFailOnError(true)
+                    .resultFormat(ResultFormatType.JSON)
+                    .result(result);
+            String jvmArgument = System.getProperty("webclient.target.jmh.jvmArgument");
+            if (jvmArgument != null) {
+                optionsBuilder.jvmArgsAppend(jvmArgument);
+            }
+            Options options = optionsBuilder.build();
+            new Runner(options).run();
         }
-        Options options = optionsBuilder.build();
-        new Runner(options).run();
     }
 }

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class WebClientConnectionTargetJmhRunnerTest {
+    @Test
+    void runExactBenchmark() throws RunnerException {
+        String benchmark = WebClientConnectionTargetBenchmark.class.getName();
+        Options options = new OptionsBuilder()
+                .include(System.getProperty("webclient.target.jmh.include",
+                                            "^" + benchmark + "\\.(http1CacheHit|http2CacheHit)$"))
+                .param("prefilledTargetCount",
+                       System.getProperty("webclient.target.jmh.targetCounts", "1,64").split(","))
+                .threads(Integer.getInteger("webclient.target.jmh.threads", 1))
+                .forks(Integer.getInteger("webclient.target.jmh.forks", 1))
+                .warmupIterations(Integer.getInteger("webclient.target.jmh.warmupIterations", 3))
+                .warmupTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.warmupMillis", 500)))
+                .measurementIterations(Integer.getInteger("webclient.target.jmh.measurementIterations", 5))
+                .measurementTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.measurementMillis", 1000)))
+                .timeUnit(TimeUnit.MICROSECONDS)
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .result(System.getProperty("webclient.target.jmh.result", "target/webclient-target-cache.json"))
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/webclient/api/etc/spotbugs/exclude.xml
+++ b/webclient/api/etc/spotbugs/exclude.xml
@@ -38,6 +38,14 @@
     </Match>
     <Match>
         <!--
+        The proxy only opens the selected transport socket. TLS is applied by the client connection implementation.
+        -->
+        <Class name="io.helidon.webclient.api.Proxy"/>
+        <Method name="tcpSocket"/>
+        <Bug pattern="UNENCRYPTED_SOCKET"/>
+    </Match>
+    <Match>
+        <!--
         Performance issue but not a DOS risk. Created issue https://github.com/oracle/helidon/issues/2870
         -->
         <Class name="io.helidon.webclient.api.Proxy"/>

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
@@ -1,0 +1,456 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnixDomainSocketAddress;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.Api;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+
+/**
+ * Logical WebClient connection target selected after request services have finalized the URI and headers.
+ * <p>
+ * This value is safe to use as a cache key. A configured IP-based {@code no-proxy} rule retains the address that
+ * selected the direct route so the physical connection cannot use a different DNS answer. That per-acquisition evidence
+ * does not participate in target equality or hashing.
+ */
+@Api.Internal
+public final class ClientConnectionTarget {
+    private static final HeaderName AUTHORITY = HeaderNames.create(":authority");
+
+    private final ConnectionKey connectionKey;
+    private final String scheme;
+    private final UriAuthority originAuthority;
+    private final ProxyRoute proxyRoute;
+    private final SocketAddress transportAddress;
+    private final InetSocketAddress localAddress;
+    private final long tlsGeneration;
+
+    private ClientConnectionTarget(ConnectionKey connectionKey,
+                                   String scheme,
+                                   UriAuthority originAuthority,
+                                   ProxyRoute proxyRoute,
+                                   SocketAddress transportAddress,
+                                   InetSocketAddress localAddress) {
+        this(connectionKey,
+             scheme,
+             originAuthority,
+             proxyRoute,
+             transportAddress,
+             localAddress,
+             connectionKey.tls().generation());
+    }
+
+    private ClientConnectionTarget(ConnectionKey connectionKey,
+                                   String scheme,
+                                   UriAuthority originAuthority,
+                                   ProxyRoute proxyRoute,
+                                   SocketAddress transportAddress,
+                                   InetSocketAddress localAddress,
+                                   long tlsGeneration) {
+        this.connectionKey = Objects.requireNonNull(connectionKey, "connectionKey");
+        this.scheme = Objects.requireNonNull(scheme, "scheme").toLowerCase(Locale.ROOT);
+        this.originAuthority = Objects.requireNonNull(originAuthority, "originAuthority");
+        this.proxyRoute = Objects.requireNonNull(proxyRoute, "proxyRoute");
+        this.transportAddress = transportAddress;
+        this.localAddress = localAddress;
+        this.tlsGeneration = tlsGeneration;
+    }
+
+    /**
+     * Create a logical IP connection target from a final request URI and headers.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param uri final request URI
+     * @param headers final request headers
+     * @return logical connection target
+     */
+    public static ClientConnectionTarget create(ConnectionKey connectionKey,
+                                                ClientUri uri,
+                                                ClientRequestHeaders headers) {
+        Objects.requireNonNull(uri, "uri");
+        Objects.requireNonNull(headers, "headers");
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        String scheme = uri.scheme().toLowerCase(Locale.ROOT);
+        UriAuthority uriAuthority = normalizedAuthority(uri.authority(), scheme);
+        UriAuthority originAuthority = headers.first(AUTHORITY)
+                .or(() -> headers.first(HeaderNames.HOST))
+                .map(authority -> normalizedAuthority(authority, scheme, uriAuthority))
+                .orElse(uriAuthority);
+        ProxyRoute route = key.proxy().effectiveRoute(scheme,
+                                                      key.host(),
+                                                      key.port(),
+                                                      key.tls().enabled(),
+                                                      key.dnsResolver(),
+                                                      key.dnsAddressLookup());
+        return new ClientConnectionTarget(key, scheme, originAuthority, route, null, null);
+    }
+
+    /**
+     * Create a logical IP connection target using an already-selected proxy route.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param uri final request URI
+     * @param headers final request headers
+     * @param selectedProxyRoute selected proxy route
+     * @return logical connection target
+     */
+    public static ClientConnectionTarget create(ConnectionKey connectionKey,
+                                                ClientUri uri,
+                                                ClientRequestHeaders headers,
+                                                ProxyRoute selectedProxyRoute) {
+        Objects.requireNonNull(uri, "uri");
+        Objects.requireNonNull(headers, "headers");
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        String scheme = uri.scheme().toLowerCase(Locale.ROOT);
+        UriAuthority uriAuthority = normalizedAuthority(uri.authority(), scheme);
+        UriAuthority originAuthority = headers.first(AUTHORITY)
+                .or(() -> headers.first(HeaderNames.HOST))
+                .map(authority -> normalizedAuthority(authority, scheme, uriAuthority))
+                .orElse(uriAuthority);
+        ProxyRoute route = routeFor(key, scheme, selectedProxyRoute);
+        return new ClientConnectionTarget(key, scheme, originAuthority, route, null, null);
+    }
+
+    /**
+     * Create a logical IP connection target from an already-normalized origin.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param scheme origin scheme
+     * @param originAuthority normalized effective origin authority
+     * @return logical connection target
+     */
+    public static ClientConnectionTarget create(ConnectionKey connectionKey,
+                                                String scheme,
+                                                UriAuthority originAuthority) {
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        ProxyRoute route = key.proxy().effectiveRoute(scheme,
+                                                      key.host(),
+                                                      key.port(),
+                                                      key.tls().enabled(),
+                                                      key.dnsResolver(),
+                                                      key.dnsAddressLookup());
+        return new ClientConnectionTarget(key, scheme, originAuthority, route, null, null);
+    }
+
+    /**
+     * Create a logical target from an already-normalized origin and selected route.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param scheme origin scheme
+     * @param originAuthority normalized effective origin authority
+     * @param proxyRoute previously selected proxy route
+     * @param tlsGeneration captured TLS reload generation
+     * @return logical connection target
+     */
+    public static ClientConnectionTarget create(ConnectionKey connectionKey,
+                                                String scheme,
+                                                UriAuthority originAuthority,
+                                                ProxyRoute proxyRoute,
+                                                long tlsGeneration) {
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        return new ClientConnectionTarget(key,
+                                          scheme,
+                                          originAuthority,
+                                          routeFor(key, scheme, proxyRoute),
+                                          null,
+                                          null,
+                                          tlsGeneration);
+    }
+
+    /**
+     * Recreate a logical target from an already-selected route and captured generations.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param scheme origin scheme
+     * @param originAuthority normalized effective origin authority
+     * @param proxyRoute previously selected proxy route
+     * @param localAddress local bind address
+     * @param tlsGeneration captured TLS reload generation
+     * @return logical connection target
+     */
+    public static ClientConnectionTarget create(ConnectionKey connectionKey,
+                                                String scheme,
+                                                UriAuthority originAuthority,
+                                                ProxyRoute proxyRoute,
+                                                InetSocketAddress localAddress,
+                                                long tlsGeneration) {
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        return new ClientConnectionTarget(key,
+                                          scheme,
+                                          originAuthority,
+                                          routeFor(key, scheme, proxyRoute),
+                                          null,
+                                          Objects.requireNonNull(localAddress, "localAddress"),
+                                          tlsGeneration);
+    }
+
+    /**
+     * Create a logical Unix-domain-socket target.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param uri final request URI
+     * @param headers final request headers
+     * @param address Unix-domain-socket address
+     * @return logical connection target
+     */
+    public static ClientConnectionTarget createUnixDomainSocket(ConnectionKey connectionKey,
+                                                                ClientUri uri,
+                                                                ClientRequestHeaders headers,
+                                                                UnixDomainSocketAddress address) {
+        ClientConnectionTarget target = create(connectionKey, uri, headers);
+        return new ClientConnectionTarget(target.connectionKey,
+                                          target.scheme,
+                                          target.originAuthority,
+                                          target.proxyRoute,
+                                          Objects.requireNonNull(address, "address"),
+                                          null);
+    }
+
+    /**
+     * Existing connection policy and TLS identity.
+     *
+     * @return connection key
+     */
+    public ConnectionKey connectionKey() {
+        return connectionKey;
+    }
+
+    /**
+     * Normalized origin scheme.
+     *
+     * @return origin scheme
+     */
+    public String scheme() {
+        return scheme;
+    }
+
+    /**
+     * Normalized effective HTTP origin authority.
+     *
+     * @return origin authority
+     */
+    public UriAuthority originAuthority() {
+        return originAuthority;
+    }
+
+    /**
+     * Effective proxy route selected for this target.
+     *
+     * @return effective proxy route
+     */
+    public ProxyRoute proxyRoute() {
+        return proxyRoute;
+    }
+
+    /**
+     * Physical non-IP transport override.
+     *
+     * @return transport address, empty for an IP target
+     */
+    public Optional<SocketAddress> transportAddress() {
+        return Optional.ofNullable(transportAddress);
+    }
+
+    /**
+     * Requested local bind address.
+     *
+     * @return local bind address, empty for the ordinary wildcard bind
+     */
+    public Optional<InetSocketAddress> localAddress() {
+        return Optional.ofNullable(localAddress);
+    }
+
+    /**
+     * Captured TLS reload generation.
+     *
+     * @return TLS generation
+     */
+    public long tlsGeneration() {
+        return tlsGeneration;
+    }
+
+    /**
+     * Whether this target still represents the current TLS reload generation.
+     *
+     * @return whether the TLS generation is current
+     */
+    public boolean currentTlsGeneration() {
+        return tlsGeneration == connectionKey.tls().generation();
+    }
+
+    /**
+     * Whether a retained route was selected for the supplied logical target and proxy policy.
+     *
+     * @param connectionKey connection policy and target tuple
+     * @param scheme logical target scheme
+     * @param proxyRoute retained route
+     * @return whether the route belongs to and matches the target
+     */
+    public static boolean routeMatches(ConnectionKey connectionKey, String scheme, ProxyRoute proxyRoute) {
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        ProxyRoute route = Objects.requireNonNull(proxyRoute, "proxyRoute");
+        return route.belongsTo(key.proxy())
+                && route.selectedFor(scheme, key.host(), key.port(), key.tls().enabled());
+    }
+
+    /**
+     * Match an explicit TCP connection to a fully finalized logical target.
+     *
+     * @param connection explicit connection
+     * @param connectionKey finalized connection identity
+     * @param uri finalized request URI
+     * @param headers finalized request headers
+     * @return the connection's route when its complete logical target matches
+     */
+    public static Optional<ProxyRoute> matchingRoute(ClientConnection connection,
+                                                     ConnectionKey connectionKey,
+                                                     ClientUri uri,
+                                                     ClientRequestHeaders headers) {
+        Objects.requireNonNull(connection, "connection");
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        Objects.requireNonNull(uri, "uri");
+        Objects.requireNonNull(headers, "headers");
+        if (connection instanceof TcpClientConnection tcpConnection) {
+            return tcpConnection.resolvedTarget()
+                    .filter(resolved -> routeMatches(key, uri.scheme(), resolved.proxyRoute()))
+                    .filter(resolved -> resolved.logicalTarget()
+                            .equals(ClientConnectionTarget.create(key, uri, headers, resolved.proxyRoute())))
+                    .map(ResolvedClientTarget::proxyRoute);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Resolve a direct or proxied physical attempt for the connection-key host and port.
+     *
+     * @return resolved target
+     */
+    public ResolvedClientTarget resolve() {
+        return resolve(connectionKey.host(), connectionKey.port(), 0);
+    }
+
+    /**
+     * Resolve a physical attempt for a selected route authority.
+     *
+     * @param routeHost selected direct or alternative route host
+     * @param routePort selected direct or alternative route port
+     * @param networkGeneration network/discovery generation
+     * @return resolved target
+     */
+    public ResolvedClientTarget resolve(String routeHost, int routePort, long networkGeneration) {
+        if (transportAddress != null) {
+            throw new IllegalStateException("A Unix-domain-socket target does not resolve to an IP peer");
+        }
+        if (tlsGeneration != connectionKey.tls().generation()) {
+            throw new IllegalStateException("TLS configuration was reloaded before target resolution");
+        }
+        return ResolvedClientTarget.resolve(this, routeHost, routePort, networkGeneration);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ClientConnectionTarget other)) {
+            return false;
+        }
+        return connectionKey.tls() == other.connectionKey.tls()
+                && connectionKey.equals(other.connectionKey)
+                && scheme.equals(other.scheme)
+                && originAuthority.equals(other.originAuthority)
+                && proxyRoute.equals(other.proxyRoute)
+                && Objects.equals(transportAddress, other.transportAddress)
+                && Objects.equals(localAddress, other.localAddress)
+                && tlsGeneration == other.tlsGeneration;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = connectionKey.hashCode();
+        result = 31 * result + System.identityHashCode(connectionKey.tls());
+        result = 31 * result + scheme.hashCode();
+        result = 31 * result + originAuthority.hashCode();
+        result = 31 * result + proxyRoute.hashCode();
+        result = 31 * result + Objects.hashCode(transportAddress);
+        result = 31 * result + Objects.hashCode(localAddress);
+        return 31 * result + Long.hashCode(tlsGeneration);
+    }
+
+    @Override
+    public String toString() {
+        return "ClientConnectionTarget[scheme=" + scheme
+                + ", originAuthority=" + originAuthority
+                + ", proxyRoute=" + proxyRoute
+                + (transportAddress == null ? "" : ", transportAddress=" + transportAddress)
+                + (localAddress == null ? "" : ", localAddress=" + localAddress)
+                + ", tlsGeneration=" + tlsGeneration
+                + ']';
+    }
+
+    private static UriAuthority normalizedAuthority(String authority, String scheme) {
+        UriAuthority parsed = UriAuthority.create(authority);
+        int port = parsed.port();
+        if (port == UriAuthority.UNDEFINED_PORT) {
+            port = "https".equals(scheme) ? 443 : 80;
+        }
+        return UriAuthority.create(parsed.host(), port);
+    }
+
+    private static UriAuthority normalizedAuthority(String authority,
+                                                    String scheme,
+                                                    UriAuthority fallback) {
+        try {
+            return normalizedAuthority(authority, scheme);
+        } catch (IllegalArgumentException _) {
+            return fallback;
+        }
+    }
+
+    private static ProxyRoute routeFor(ConnectionKey connectionKey, String scheme, ProxyRoute proxyRoute) {
+        ProxyRoute route = Objects.requireNonNull(proxyRoute, "proxyRoute");
+        if (!route.belongsTo(connectionKey.proxy())) {
+            return connectionKey.proxy().effectiveRoute(scheme,
+                                                        connectionKey.host(),
+                                                        connectionKey.port(),
+                                                        connectionKey.tls().enabled(),
+                                                        connectionKey.dnsResolver(),
+                                                        connectionKey.dnsAddressLookup());
+        }
+        if (!route.selectedFor(scheme,
+                               connectionKey.host(),
+                               connectionKey.port(),
+                               connectionKey.tls().enabled())) {
+            return connectionKey.proxy().effectiveRoute(scheme,
+                                                        connectionKey.host(),
+                                                        connectionKey.port(),
+                                                        connectionKey.tls().enabled(),
+                                                        connectionKey.dnsResolver(),
+                                                        connectionKey.dnsAddressLookup());
+        }
+        return route;
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
@@ -81,6 +81,67 @@ public final class ClientConnectionTarget {
     }
 
     /**
+     * Create a DNS-free cache lookup key from a final request URI and headers.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param uri final request URI
+     * @param headers final request headers
+     * @return target lookup key
+     */
+    @Api.Internal
+    public static LookupKey lookupKey(ConnectionKey connectionKey,
+                                      ClientUri uri,
+                                      ClientRequestHeaders headers) {
+        Objects.requireNonNull(uri, "uri");
+        Objects.requireNonNull(headers, "headers");
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        String scheme = uri.scheme().toLowerCase(Locale.ROOT);
+        UriAuthority originAuthority = originAuthority(key, uri, headers, scheme);
+        return new LookupKey(key, scheme, originAuthority, null, null, key.tls().generation());
+    }
+
+    /**
+     * Create a DNS-free cache lookup key using the connection-key origin.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param scheme origin scheme
+     * @return target lookup key
+     */
+    @Api.Internal
+    public static LookupKey lookupKey(ConnectionKey connectionKey, String scheme) {
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        return new LookupKey(key, scheme, null, null, null, key.tls().generation());
+    }
+
+    /**
+     * Create a logical connection target from a cache lookup key.
+     * <p>
+     * This selects the effective proxy route and may resolve DNS when configured IP-based {@code no-proxy} rules
+     * require it.
+     *
+     * @param lookupKey target lookup key
+     * @return logical connection target
+     */
+    @Api.Internal
+    public static ClientConnectionTarget create(LookupKey lookupKey) {
+        LookupKey key = Objects.requireNonNull(lookupKey, "lookupKey");
+        ConnectionKey connectionKey = key.connectionKey;
+        ProxyRoute route = connectionKey.proxy().effectiveRoute(key.scheme,
+                                                                connectionKey.routingHost(),
+                                                                connectionKey.port(),
+                                                                connectionKey.tls().enabled(),
+                                                                connectionKey.dnsResolver(),
+                                                                connectionKey.dnsAddressLookup());
+        return new ClientConnectionTarget(connectionKey,
+                                          key.scheme,
+                                          key.originAuthorityOverride,
+                                          route,
+                                          key.transportAddress,
+                                          key.localAddress,
+                                          key.tlsGeneration);
+    }
+
+    /**
      * Create a logical IP connection target from a final request URI and headers.
      *
      * @param connectionKey connection policy and TLS identity
@@ -356,6 +417,21 @@ public final class ClientConnectionTarget {
     }
 
     /**
+     * Create a cache lookup key for this target without retaining its selected proxy route.
+     *
+     * @return target lookup key
+     */
+    @Api.Internal
+    public LookupKey lookupKey() {
+        return new LookupKey(connectionKey,
+                             scheme,
+                             originAuthorityOverride,
+                             transportAddress,
+                             localAddress,
+                             tlsGeneration);
+    }
+
+    /**
      * Whether this target still represents the current TLS reload generation.
      *
      * @return whether the TLS generation is current
@@ -472,6 +548,82 @@ public final class ClientConnectionTarget {
                 + (localAddress == null ? "" : ", localAddress=" + localAddress)
                 + ", tlsGeneration=" + tlsGeneration
                 + ']';
+    }
+
+    /**
+     * DNS-free identity used to look up a logical WebClient connection target before selecting its proxy route.
+     */
+    @Api.Internal
+    public static final class LookupKey {
+        private final ConnectionKey connectionKey;
+        private final String scheme;
+        private final UriAuthority originAuthorityOverride;
+        private final SocketAddress transportAddress;
+        private final InetSocketAddress localAddress;
+        private final long tlsGeneration;
+
+        private LookupKey(ConnectionKey connectionKey,
+                          String scheme,
+                          UriAuthority originAuthorityOverride,
+                          SocketAddress transportAddress,
+                          InetSocketAddress localAddress,
+                          long tlsGeneration) {
+            this.connectionKey = Objects.requireNonNull(connectionKey, "connectionKey");
+            this.scheme = Objects.requireNonNull(scheme, "scheme").toLowerCase(Locale.ROOT);
+            this.originAuthorityOverride = originAuthorityOverride;
+            this.transportAddress = transportAddress;
+            this.localAddress = localAddress;
+            this.tlsGeneration = tlsGeneration;
+        }
+
+        /**
+         * Whether this key still represents the current TLS reload generation.
+         *
+         * @return whether the TLS generation is current
+         */
+        public boolean currentTlsGeneration() {
+            return tlsGeneration == connectionKey.tls().generation();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof LookupKey other)) {
+                return false;
+            }
+            return connectionKey.tls() == other.connectionKey.tls()
+                    && connectionKey.equals(other.connectionKey)
+                    && scheme.equals(other.scheme)
+                    && Objects.equals(originAuthorityOverride, other.originAuthorityOverride)
+                    && Objects.equals(transportAddress, other.transportAddress)
+                    && Objects.equals(localAddress, other.localAddress)
+                    && tlsGeneration == other.tlsGeneration;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = connectionKey.hashCode();
+            result = 31 * result + System.identityHashCode(connectionKey.tls());
+            result = 31 * result + scheme.hashCode();
+            result = 31 * result + Objects.hashCode(originAuthorityOverride);
+            result = 31 * result + Objects.hashCode(transportAddress);
+            result = 31 * result + Objects.hashCode(localAddress);
+            return 31 * result + Long.hashCode(tlsGeneration);
+        }
+
+        @Override
+        public String toString() {
+            return "ClientConnectionTarget.LookupKey[scheme=" + scheme
+                    + ", originAuthority=" + (originAuthorityOverride == null
+                            ? normalizedOriginAuthority(connectionKey)
+                            : originAuthorityOverride)
+                    + (transportAddress == null ? "" : ", transportAddress=" + transportAddress)
+                    + (localAddress == null ? "" : ", localAddress=" + localAddress)
+                    + ", tlsGeneration=" + tlsGeneration
+                    + ']';
+        }
     }
 
     private static UriAuthority normalizedAuthority(String authority, String scheme) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
@@ -550,6 +550,68 @@ public final class ClientConnectionTarget {
                 + ']';
     }
 
+    private static UriAuthority normalizedAuthority(String authority, String scheme) {
+        UriAuthority parsed = UriAuthority.create(authority);
+        int port = parsed.port();
+        if (port == UriAuthority.UNDEFINED_PORT) {
+            port = "https".equals(scheme) ? 443 : 80;
+        }
+        return UriAuthority.create(parsed.host(), port);
+    }
+
+    private static UriAuthority originAuthority(ConnectionKey connectionKey,
+                                                ClientUri uri,
+                                                ClientRequestHeaders headers,
+                                                String scheme) {
+        UriAuthority fallback = canonicalOriginAuthority(connectionKey,
+                                                         normalizedAuthority(uri.authority(), scheme));
+        String authority = headers.contains(AUTHORITY)
+                ? headers.get(AUTHORITY).get()
+                : headers.contains(HeaderNames.HOST) ? headers.get(HeaderNames.HOST).get() : null;
+        if (authority == null) {
+            return fallback;
+        }
+        try {
+            return canonicalOriginAuthority(connectionKey, normalizedAuthority(authority, scheme));
+        } catch (IllegalArgumentException _) {
+            return fallback;
+        }
+    }
+
+    private static UriAuthority canonicalOriginAuthority(ConnectionKey connectionKey,
+                                                         UriAuthority originAuthority) {
+        UriAuthority authority = Objects.requireNonNull(originAuthority, "originAuthority");
+        return authority.equals(normalizedOriginAuthority(connectionKey)) ? null : authority;
+    }
+
+    private static UriAuthority normalizedOriginAuthority(ConnectionKey connectionKey) {
+        return UriAuthority.create(UriHost.create(connectionKey.routingHost()), connectionKey.port());
+    }
+
+    private static ProxyRoute routeFor(ConnectionKey connectionKey, String scheme, ProxyRoute proxyRoute) {
+        ProxyRoute route = Objects.requireNonNull(proxyRoute, "proxyRoute");
+        if (!route.belongsTo(connectionKey.proxy())) {
+            return connectionKey.proxy().effectiveRoute(scheme,
+                                                        connectionKey.routingHost(),
+                                                        connectionKey.port(),
+                                                        connectionKey.tls().enabled(),
+                                                        connectionKey.dnsResolver(),
+                                                        connectionKey.dnsAddressLookup());
+        }
+        if (!route.selectedFor(scheme,
+                               connectionKey.routingHost(),
+                               connectionKey.port(),
+                               connectionKey.tls().enabled())) {
+            return connectionKey.proxy().effectiveRoute(scheme,
+                                                        connectionKey.routingHost(),
+                                                        connectionKey.port(),
+                                                        connectionKey.tls().enabled(),
+                                                        connectionKey.dnsResolver(),
+                                                        connectionKey.dnsAddressLookup());
+        }
+        return route;
+    }
+
     /**
      * DNS-free identity used to look up a logical WebClient connection target before selecting its proxy route.
      */
@@ -624,67 +686,5 @@ public final class ClientConnectionTarget {
                     + ", tlsGeneration=" + tlsGeneration
                     + ']';
         }
-    }
-
-    private static UriAuthority normalizedAuthority(String authority, String scheme) {
-        UriAuthority parsed = UriAuthority.create(authority);
-        int port = parsed.port();
-        if (port == UriAuthority.UNDEFINED_PORT) {
-            port = "https".equals(scheme) ? 443 : 80;
-        }
-        return UriAuthority.create(parsed.host(), port);
-    }
-
-    private static UriAuthority originAuthority(ConnectionKey connectionKey,
-                                                ClientUri uri,
-                                                ClientRequestHeaders headers,
-                                                String scheme) {
-        UriAuthority fallback = canonicalOriginAuthority(connectionKey,
-                                                         normalizedAuthority(uri.authority(), scheme));
-        String authority = headers.contains(AUTHORITY)
-                ? headers.get(AUTHORITY).get()
-                : headers.contains(HeaderNames.HOST) ? headers.get(HeaderNames.HOST).get() : null;
-        if (authority == null) {
-            return fallback;
-        }
-        try {
-            return canonicalOriginAuthority(connectionKey, normalizedAuthority(authority, scheme));
-        } catch (IllegalArgumentException _) {
-            return fallback;
-        }
-    }
-
-    private static UriAuthority canonicalOriginAuthority(ConnectionKey connectionKey,
-                                                         UriAuthority originAuthority) {
-        UriAuthority authority = Objects.requireNonNull(originAuthority, "originAuthority");
-        return authority.equals(normalizedOriginAuthority(connectionKey)) ? null : authority;
-    }
-
-    private static UriAuthority normalizedOriginAuthority(ConnectionKey connectionKey) {
-        return UriAuthority.create(UriHost.create(connectionKey.routingHost()), connectionKey.port());
-    }
-
-    private static ProxyRoute routeFor(ConnectionKey connectionKey, String scheme, ProxyRoute proxyRoute) {
-        ProxyRoute route = Objects.requireNonNull(proxyRoute, "proxyRoute");
-        if (!route.belongsTo(connectionKey.proxy())) {
-            return connectionKey.proxy().effectiveRoute(scheme,
-                                                        connectionKey.routingHost(),
-                                                        connectionKey.port(),
-                                                        connectionKey.tls().enabled(),
-                                                        connectionKey.dnsResolver(),
-                                                        connectionKey.dnsAddressLookup());
-        }
-        if (!route.selectedFor(scheme,
-                               connectionKey.routingHost(),
-                               connectionKey.port(),
-                               connectionKey.tls().enabled())) {
-            return connectionKey.proxy().effectiveRoute(scheme,
-                                                        connectionKey.routingHost(),
-                                                        connectionKey.port(),
-                                                        connectionKey.tls().enabled(),
-                                                        connectionKey.dnsResolver(),
-                                                        connectionKey.dnsAddressLookup());
-        }
-        return route;
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import io.helidon.common.Api;
 import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -42,7 +43,7 @@ public final class ClientConnectionTarget {
 
     private final ConnectionKey connectionKey;
     private final String scheme;
-    private final UriAuthority originAuthority;
+    private final UriAuthority originAuthorityOverride;
     private final ProxyRoute proxyRoute;
     private final SocketAddress transportAddress;
     private final InetSocketAddress localAddress;
@@ -72,7 +73,7 @@ public final class ClientConnectionTarget {
                                    long tlsGeneration) {
         this.connectionKey = Objects.requireNonNull(connectionKey, "connectionKey");
         this.scheme = Objects.requireNonNull(scheme, "scheme").toLowerCase(Locale.ROOT);
-        this.originAuthority = Objects.requireNonNull(originAuthority, "originAuthority");
+        this.originAuthorityOverride = originAuthority;
         this.proxyRoute = Objects.requireNonNull(proxyRoute, "proxyRoute");
         this.transportAddress = transportAddress;
         this.localAddress = localAddress;
@@ -94,11 +95,7 @@ public final class ClientConnectionTarget {
         Objects.requireNonNull(headers, "headers");
         ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
         String scheme = uri.scheme().toLowerCase(Locale.ROOT);
-        UriAuthority uriAuthority = normalizedAuthority(uri.authority(), scheme);
-        UriAuthority originAuthority = headers.first(AUTHORITY)
-                .or(() -> headers.first(HeaderNames.HOST))
-                .map(authority -> normalizedAuthority(authority, scheme, uriAuthority))
-                .orElse(uriAuthority);
+        UriAuthority originAuthority = originAuthority(key, uri, headers, scheme);
         ProxyRoute route = key.proxy().effectiveRoute(scheme,
                                                       key.host(),
                                                       key.port(),
@@ -125,11 +122,7 @@ public final class ClientConnectionTarget {
         Objects.requireNonNull(headers, "headers");
         ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
         String scheme = uri.scheme().toLowerCase(Locale.ROOT);
-        UriAuthority uriAuthority = normalizedAuthority(uri.authority(), scheme);
-        UriAuthority originAuthority = headers.first(AUTHORITY)
-                .or(() -> headers.first(HeaderNames.HOST))
-                .map(authority -> normalizedAuthority(authority, scheme, uriAuthority))
-                .orElse(uriAuthority);
+        UriAuthority originAuthority = originAuthority(key, uri, headers, scheme);
         ProxyRoute route = routeFor(key, scheme, selectedProxyRoute);
         return new ClientConnectionTarget(key, scheme, originAuthority, route, null, null);
     }
@@ -152,7 +145,75 @@ public final class ClientConnectionTarget {
                                                       key.tls().enabled(),
                                                       key.dnsResolver(),
                                                       key.dnsAddressLookup());
-        return new ClientConnectionTarget(key, scheme, originAuthority, route, null, null);
+        return new ClientConnectionTarget(key,
+                                          scheme,
+                                          canonicalOriginAuthority(key, originAuthority),
+                                          route,
+                                          null,
+                                          null);
+    }
+
+    /**
+     * Create a logical IP connection target using the connection-key origin.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param scheme origin scheme
+     * @return logical connection target
+     */
+    @Api.Internal
+    public static ClientConnectionTarget create(ConnectionKey connectionKey, String scheme) {
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        ProxyRoute route = key.proxy().effectiveRoute(scheme,
+                                                      key.host(),
+                                                      key.port(),
+                                                      key.tls().enabled(),
+                                                      key.dnsResolver(),
+                                                      key.dnsAddressLookup());
+        return new ClientConnectionTarget(key, scheme, null, route, null, null);
+    }
+
+    /**
+     * Create a logical target from an already-normalized origin and selected route.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param scheme origin scheme
+     * @param originAuthority normalized effective origin authority
+     * @param proxyRoute previously selected proxy route
+     * @return logical connection target
+     */
+    @Api.Internal
+    public static ClientConnectionTarget create(ConnectionKey connectionKey,
+                                                String scheme,
+                                                UriAuthority originAuthority,
+                                                ProxyRoute proxyRoute) {
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        return new ClientConnectionTarget(key,
+                                          scheme,
+                                          canonicalOriginAuthority(key, originAuthority),
+                                          routeFor(key, scheme, proxyRoute),
+                                          null,
+                                          null);
+    }
+
+    /**
+     * Create a logical target using the connection-key origin and a selected route.
+     *
+     * @param connectionKey connection policy and TLS identity
+     * @param scheme origin scheme
+     * @param proxyRoute previously selected proxy route
+     * @return logical connection target
+     */
+    @Api.Internal
+    public static ClientConnectionTarget create(ConnectionKey connectionKey,
+                                                String scheme,
+                                                ProxyRoute proxyRoute) {
+        ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
+        return new ClientConnectionTarget(key,
+                                          scheme,
+                                          null,
+                                          routeFor(key, scheme, proxyRoute),
+                                          null,
+                                          null);
     }
 
     /**
@@ -173,7 +234,7 @@ public final class ClientConnectionTarget {
         ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
         return new ClientConnectionTarget(key,
                                           scheme,
-                                          originAuthority,
+                                          canonicalOriginAuthority(key, originAuthority),
                                           routeFor(key, scheme, proxyRoute),
                                           null,
                                           null,
@@ -200,7 +261,7 @@ public final class ClientConnectionTarget {
         ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
         return new ClientConnectionTarget(key,
                                           scheme,
-                                          originAuthority,
+                                          canonicalOriginAuthority(key, originAuthority),
                                           routeFor(key, scheme, proxyRoute),
                                           null,
                                           Objects.requireNonNull(localAddress, "localAddress"),
@@ -223,7 +284,7 @@ public final class ClientConnectionTarget {
         ClientConnectionTarget target = create(connectionKey, uri, headers);
         return new ClientConnectionTarget(target.connectionKey,
                                           target.scheme,
-                                          target.originAuthority,
+                                          target.originAuthorityOverride,
                                           target.proxyRoute,
                                           Objects.requireNonNull(address, "address"),
                                           null);
@@ -253,7 +314,9 @@ public final class ClientConnectionTarget {
      * @return origin authority
      */
     public UriAuthority originAuthority() {
-        return originAuthority;
+        return originAuthorityOverride == null
+                ? normalizedOriginAuthority(connectionKey)
+                : originAuthorityOverride;
     }
 
     /**
@@ -381,7 +444,7 @@ public final class ClientConnectionTarget {
         return connectionKey.tls() == other.connectionKey.tls()
                 && connectionKey.equals(other.connectionKey)
                 && scheme.equals(other.scheme)
-                && originAuthority.equals(other.originAuthority)
+                && Objects.equals(originAuthorityOverride, other.originAuthorityOverride)
                 && proxyRoute.equals(other.proxyRoute)
                 && Objects.equals(transportAddress, other.transportAddress)
                 && Objects.equals(localAddress, other.localAddress)
@@ -393,7 +456,7 @@ public final class ClientConnectionTarget {
         int result = connectionKey.hashCode();
         result = 31 * result + System.identityHashCode(connectionKey.tls());
         result = 31 * result + scheme.hashCode();
-        result = 31 * result + originAuthority.hashCode();
+        result = 31 * result + Objects.hashCode(originAuthorityOverride);
         result = 31 * result + proxyRoute.hashCode();
         result = 31 * result + Objects.hashCode(transportAddress);
         result = 31 * result + Objects.hashCode(localAddress);
@@ -403,7 +466,7 @@ public final class ClientConnectionTarget {
     @Override
     public String toString() {
         return "ClientConnectionTarget[scheme=" + scheme
-                + ", originAuthority=" + originAuthority
+                + ", originAuthority=" + originAuthority()
                 + ", proxyRoute=" + proxyRoute
                 + (transportAddress == null ? "" : ", transportAddress=" + transportAddress)
                 + (localAddress == null ? "" : ", localAddress=" + localAddress)
@@ -420,14 +483,33 @@ public final class ClientConnectionTarget {
         return UriAuthority.create(parsed.host(), port);
     }
 
-    private static UriAuthority normalizedAuthority(String authority,
-                                                    String scheme,
-                                                    UriAuthority fallback) {
+    private static UriAuthority originAuthority(ConnectionKey connectionKey,
+                                                ClientUri uri,
+                                                ClientRequestHeaders headers,
+                                                String scheme) {
+        UriAuthority fallback = canonicalOriginAuthority(connectionKey,
+                                                         normalizedAuthority(uri.authority(), scheme));
+        String authority = headers.contains(AUTHORITY)
+                ? headers.get(AUTHORITY).get()
+                : headers.contains(HeaderNames.HOST) ? headers.get(HeaderNames.HOST).get() : null;
+        if (authority == null) {
+            return fallback;
+        }
         try {
-            return normalizedAuthority(authority, scheme);
+            return canonicalOriginAuthority(connectionKey, normalizedAuthority(authority, scheme));
         } catch (IllegalArgumentException _) {
             return fallback;
         }
+    }
+
+    private static UriAuthority canonicalOriginAuthority(ConnectionKey connectionKey,
+                                                         UriAuthority originAuthority) {
+        UriAuthority authority = Objects.requireNonNull(originAuthority, "originAuthority");
+        return authority.equals(normalizedOriginAuthority(connectionKey)) ? null : authority;
+    }
+
+    private static UriAuthority normalizedOriginAuthority(ConnectionKey connectionKey) {
+        return UriAuthority.create(UriHost.create(connectionKey.host()), connectionKey.port());
     }
 
     private static ProxyRoute routeFor(ConnectionKey connectionKey, String scheme, ProxyRoute proxyRoute) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
@@ -97,7 +97,7 @@ public final class ClientConnectionTarget {
         String scheme = uri.scheme().toLowerCase(Locale.ROOT);
         UriAuthority originAuthority = originAuthority(key, uri, headers, scheme);
         ProxyRoute route = key.proxy().effectiveRoute(scheme,
-                                                      key.host(),
+                                                      key.routingHost(),
                                                       key.port(),
                                                       key.tls().enabled(),
                                                       key.dnsResolver(),
@@ -140,7 +140,7 @@ public final class ClientConnectionTarget {
                                                 UriAuthority originAuthority) {
         ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
         ProxyRoute route = key.proxy().effectiveRoute(scheme,
-                                                      key.host(),
+                                                      key.routingHost(),
                                                       key.port(),
                                                       key.tls().enabled(),
                                                       key.dnsResolver(),
@@ -164,7 +164,7 @@ public final class ClientConnectionTarget {
     public static ClientConnectionTarget create(ConnectionKey connectionKey, String scheme) {
         ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
         ProxyRoute route = key.proxy().effectiveRoute(scheme,
-                                                      key.host(),
+                                                      key.routingHost(),
                                                       key.port(),
                                                       key.tls().enabled(),
                                                       key.dnsResolver(),
@@ -376,7 +376,7 @@ public final class ClientConnectionTarget {
         ConnectionKey key = Objects.requireNonNull(connectionKey, "connectionKey");
         ProxyRoute route = Objects.requireNonNull(proxyRoute, "proxyRoute");
         return route.belongsTo(key.proxy())
-                && route.selectedFor(scheme, key.host(), key.port(), key.tls().enabled());
+                && route.selectedFor(scheme, key.routingHost(), key.port(), key.tls().enabled());
     }
 
     /**
@@ -412,7 +412,7 @@ public final class ClientConnectionTarget {
      * @return resolved target
      */
     public ResolvedClientTarget resolve() {
-        return resolve(connectionKey.host(), connectionKey.port(), 0);
+        return resolve(connectionKey.routingHost(), connectionKey.port(), 0);
     }
 
     /**
@@ -509,25 +509,25 @@ public final class ClientConnectionTarget {
     }
 
     private static UriAuthority normalizedOriginAuthority(ConnectionKey connectionKey) {
-        return UriAuthority.create(UriHost.create(connectionKey.host()), connectionKey.port());
+        return UriAuthority.create(UriHost.create(connectionKey.routingHost()), connectionKey.port());
     }
 
     private static ProxyRoute routeFor(ConnectionKey connectionKey, String scheme, ProxyRoute proxyRoute) {
         ProxyRoute route = Objects.requireNonNull(proxyRoute, "proxyRoute");
         if (!route.belongsTo(connectionKey.proxy())) {
             return connectionKey.proxy().effectiveRoute(scheme,
-                                                        connectionKey.host(),
+                                                        connectionKey.routingHost(),
                                                         connectionKey.port(),
                                                         connectionKey.tls().enabled(),
                                                         connectionKey.dnsResolver(),
                                                         connectionKey.dnsAddressLookup());
         }
         if (!route.selectedFor(scheme,
-                               connectionKey.host(),
+                               connectionKey.routingHost(),
                                connectionKey.port(),
                                connectionKey.tls().enabled())) {
             return connectionKey.proxy().effectiveRoute(scheme,
-                                                        connectionKey.host(),
+                                                        connectionKey.routingHost(),
                                                         connectionKey.port(),
                                                         connectionKey.tls().enabled(),
                                                         connectionKey.dnsResolver(),

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -99,6 +99,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private Tls tls;
     private SniConfig sni;
     private Proxy proxy;
+    private ProxyRoute selectedProxyRoute;
     private boolean keepAlive;
     private ClientConnection connection;
     private Boolean sendExpectContinue;
@@ -383,6 +384,14 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         return identity();
     }
 
+    /**
+     * Clear an internally supplied connection without changing other request state.
+     */
+    @Api.Internal
+    public final void clearConnection() {
+        this.connection = null;
+    }
+
     @Override
     public T keepAlive(boolean keepAlive) {
         this.keepAlive = keepAlive;
@@ -404,30 +413,53 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public T proxy(Proxy proxy) {
         this.proxy = Objects.requireNonNull(proxy);
+        clearSelectedProxyRoute();
         return identity();
     }
 
     @Override
     public R request() {
+        try {
+            return requestWithoutRouteCleanup();
+        } finally {
+            clearSelectedProxyRoute();
+        }
+    }
+
+    /**
+     * Submit an internal request that participates in the enclosing top-level request's selected route.
+     *
+     * @return response
+     */
+    @Api.Internal
+    protected final R requestWithoutRouteCleanup() {
         additionalHeaders();
         return validateAndSubmit(BufferData.EMPTY_BYTES);
     }
 
     @Override
     public R submit(Object entity) {
-        if (!(entity instanceof byte[] bytes && bytes.length == 0)) {
-            rejectHeadWithEntity();
+        try {
+            if (!(entity instanceof byte[] bytes && bytes.length == 0)) {
+                rejectHeadWithEntity();
+            }
+            additionalHeaders();
+            return validateAndSubmit(entity);
+        } finally {
+            clearSelectedProxyRoute();
         }
-        additionalHeaders();
-        return validateAndSubmit(entity);
     }
 
     @Override
     public R outputStream(OutputStreamHandler outputStreamConsumer) {
-        rejectHeadWithEntity();
-        additionalHeaders();
-        validateRequest();
-        return doOutputStream(outputStreamConsumer);
+        try {
+            rejectHeadWithEntity();
+            additionalHeaders();
+            validateRequest();
+            return doOutputStream(outputStreamConsumer);
+        } finally {
+            clearSelectedProxyRoute();
+        }
     }
 
     @Override
@@ -486,6 +518,24 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Override
     public Proxy proxy() {
         return proxy;
+    }
+
+    @Override
+    @Api.Internal
+    public Optional<ProxyRoute> selectedProxyRoute() {
+        return Optional.ofNullable(selectedProxyRoute);
+    }
+
+    @Override
+    @Api.Internal
+    public void selectedProxyRoute(ProxyRoute proxyRoute) {
+        this.selectedProxyRoute = Objects.requireNonNull(proxyRoute);
+    }
+
+    @Override
+    @Api.Internal
+    public void clearSelectedProxyRoute() {
+        this.selectedProxyRoute = null;
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
@@ -21,9 +21,11 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLParameters;
 
 import io.helidon.common.Api;
 import io.helidon.common.tls.Tls;
+import io.helidon.common.uri.UriAuthority;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.webclient.spi.DnsResolver;
 
@@ -82,7 +84,9 @@ public final class ConnectionKey {
                           Transport transport,
                           SniSupport.Selection sni) {
         this.scheme = scheme;
-        this.host = host;
+        this.host = host.startsWith("[") && host.endsWith("]")
+                ? UriAuthority.create(host).host().value()
+                : host;
         this.port = port;
         this.tls = tls;
         this.dnsResolver = dnsResolver;
@@ -348,7 +352,8 @@ public final class ConnectionKey {
      *
      * @return TLS peer host
      */
-    String tlsPeerHost() {
+    @Api.Internal
+    public String tlsPeerHost() {
         return tlsPeerHost;
     }
 
@@ -357,12 +362,27 @@ public final class ConnectionKey {
      *
      * @return TLS peer port
      */
-    int tlsPeerPort() {
+    @Api.Internal
+    public int tlsPeerPort() {
         return tlsPeerPort;
     }
 
     List<SNIServerName> serverNamesOverride() {
         return SniSupport.serverNamesOverride(sni);
+    }
+
+    /**
+     * Apply effective server names to SSL parameters when first-class SNI configuration overrides the TLS defaults.
+     *
+     * @param sslParameters SSL parameters to update
+     */
+    @Api.Internal
+    public void applyServerNames(SSLParameters sslParameters) {
+        SSLParameters parameters = Objects.requireNonNull(sslParameters, "sslParameters");
+        List<SNIServerName> serverNames = serverNamesOverride();
+        if (serverNames != null) {
+            parameters.setServerNames(serverNames);
+        }
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
@@ -35,6 +35,7 @@ import io.helidon.webclient.spi.DnsResolver;
 public final class ConnectionKey {
     private final String scheme;
     private final String host;
+    private final String routingHost;
     private final int port;
     private final Tls tls;
     private final DnsResolver dnsResolver;
@@ -84,7 +85,8 @@ public final class ConnectionKey {
                           Transport transport,
                           SniSupport.Selection sni) {
         this.scheme = scheme;
-        this.host = host.startsWith("[") && host.endsWith("]")
+        this.host = host;
+        this.routingHost = host.startsWith("[") && host.endsWith("]")
                 ? UriAuthority.create(host).host().value()
                 : host;
         this.port = port;
@@ -367,10 +369,6 @@ public final class ConnectionKey {
         return tlsPeerPort;
     }
 
-    List<SNIServerName> serverNamesOverride() {
-        return SniSupport.serverNamesOverride(sni);
-    }
-
     /**
      * Apply effective server names to SSL parameters when first-class SNI configuration overrides the TLS defaults.
      *
@@ -383,6 +381,14 @@ public final class ConnectionKey {
         if (serverNames != null) {
             parameters.setServerNames(serverNames);
         }
+    }
+
+    String routingHost() {
+        return routingHost;
+    }
+
+    List<SNIServerName> serverNamesOverride() {
+        return SniSupport.serverNamesOverride(sni);
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/FullClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/FullClientRequest.java
@@ -19,8 +19,10 @@ package io.helidon.webclient.api;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.Method;
 
@@ -117,6 +119,38 @@ public interface FullClientRequest<T extends ClientRequest<T>> extends ClientReq
      * @return proxy
      */
     Proxy proxy();
+
+    /**
+     * Effective proxy route already selected during the current top-level request invocation.
+     * The route may be shared with protocol fallbacks and other internal handoffs in that invocation.
+     *
+     * @return selected proxy route, or empty when this request still needs route selection
+     */
+    @Api.Internal
+    default Optional<ProxyRoute> selectedProxyRoute() {
+        return Optional.empty();
+    }
+
+    /**
+     * Retain an effective proxy route while handing a request between protocol implementations in the current
+     * top-level request invocation.
+     * The default implementation validates and otherwise ignores the route.
+     *
+     * @param proxyRoute selected proxy route
+     */
+    @Api.Internal
+    default void selectedProxyRoute(ProxyRoute proxyRoute) {
+        Objects.requireNonNull(proxyRoute, "proxyRoute");
+    }
+
+    /**
+     * Clear retained route state after the current top-level request invocation, or when it no longer matches a
+     * finalized request target.
+     * The default implementation has no effect.
+     */
+    @Api.Internal
+    default void clearSelectedProxyRoute() {
+    }
 
     /**
      * Whether to use keep-alive connection (if relevant for the used HTTP version).

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -278,7 +278,8 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      * Each configured HTTP protocol honors this common option independently; it is not an aggregate cache quota across
      * protocol versions. This is a retention limit, not a limit on concurrent requests or streams and not a hard cap on
      * live sockets. Active or draining connections may temporarily cause the number of live sockets for a target to
-     * exceed this value. Defaults to {@code 256}.
+     * exceed this value. Each protocol retains at most {@code 1,000} connection-target entries; adding another target
+     * retires the oldest cached target entry. The value must be greater than zero. Defaults to {@code 256}.
      *
      * @return maximum number of reusable physical connections retained per target by each HTTP protocol
      */

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -270,10 +270,10 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
     boolean sendExpectContinue();
 
     /**
-     * Maximal size of the connection cache for a single connection key.
-     * A connection key is formed by the scheme, host, port, TLS configuration, DNS resolver, DNS address lookup, and proxy.
-     * For UNIX domain socket transports, the key also includes the socket path and does not include proxy configuration.
-     * For TLS connections, configured SNI can further split the cache by TLS peer host, TLS peer port, and SNI mode.
+     * Maximal size of the connection cache for a single connection target.
+     * A connection target identifies the logical HTTP authority, TLS configuration and generation, configured SNI, DNS
+     * resolver and address lookup, selected proxy route, and physical transport. For UNIX domain socket transports, the
+     * target includes the socket path and does not include proxy configuration.
      * <p>
      * For most HTTP protocols, we may cache connections to various endpoints for keep alive (or stream reuse in case of HTTP/2).
      * This option limits the size. Setting this number lower than the "usual" number of target services will cause connections

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -270,16 +270,17 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
     boolean sendExpectContinue();
 
     /**
-     * Maximal size of the connection cache for a single connection target.
+     * Maximum number of reusable physical connections each HTTP protocol retains for a single connection target.
      * A connection target identifies the logical HTTP authority, TLS configuration and generation, configured SNI, DNS
      * resolver and address lookup, selected proxy route, and physical transport. For UNIX domain socket transports, the
      * target includes the socket path and does not include proxy configuration.
      * <p>
-     * For most HTTP protocols, we may cache connections to various endpoints for keep alive (or stream reuse in case of HTTP/2).
-     * This option limits the size. Setting this number lower than the "usual" number of target services will cause connections
-     * to be closed and reopened frequently.
+     * Each configured HTTP protocol honors this common option independently; it is not an aggregate cache quota across
+     * protocol versions. This is a retention limit, not a limit on concurrent requests or streams and not a hard cap on
+     * live sockets. Active or draining connections may temporarily cause the number of live sockets for a target to
+     * exceed this value. Defaults to {@code 256}.
      *
-     * @return maximal size of the connection cache
+     * @return maximum number of reusable physical connections retained per target by each HTTP protocol
      */
     @Option.Configured
     @Option.DefaultInt(256)
@@ -304,9 +305,14 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
     Duration readContinueTimeout();
 
     /**
-     * Whether to share connection cache between all the WebClient instances in JVM.
+     * Whether to use protocol-specific JVM-wide connection caches shared by compatible WebClient instances.
+     * <p>
+     * When {@code true}, each HTTP protocol uses its own JVM-wide cache. Closing an individual client does not close
+     * that shared cache. For each connection target, the first shared client to create the target entry establishes
+     * its capacity from {@link #connectionCacheSize()} for as long as that entry remains cached. When {@code false},
+     * each client owns its connection caches, which are closed when the client is closed. Defaults to {@code true}.
      *
-     * @return true if connection cache is shared
+     * @return whether to use protocol-specific JVM-wide shared connection caches
      */
     @Option.Configured
     @Option.DefaultBoolean(true)

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -357,6 +357,16 @@ public class Proxy {
     }
 
     /**
+     * Whether this proxy can select routes using a configured IP-based {@code no-proxy} rule.
+     *
+     * @return whether IP-based no-proxy route selection is configured
+     */
+    @Api.Internal
+    public boolean ipNoProxyConfigured() {
+        return type == ProxyType.HTTP && ipNoProxyConfigured;
+    }
+
+    /**
      * Verifies whether the specified Uri is using system proxy.
      *
      * @param uri the uri

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -398,7 +398,7 @@ public class Proxy {
         Objects.requireNonNull(scheme, "scheme");
         Objects.requireNonNull(host, "host");
         if (type == null || type == ProxyType.NONE) {
-            return ProxyRoute.direct(this, scheme, host, port, tls);
+            return ProxyRoute.DIRECT;
         }
         if (type == ProxyType.HTTP) {
             if (isNoHosts(InetSocketAddress.createUnresolved(host, port))) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -983,7 +983,8 @@ public class Proxy {
         }
 
         /**
-         * Configure a host pattern that is not going through a proxy.
+         * Configure a host or IP pattern that is not going through a proxy; IP patterns resolve host-name targets locally
+         * and bind direct routes to the matching address.
          * <p>
          * Options are:
          * <ul>

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -38,10 +38,13 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.helidon.common.Api;
 import io.helidon.common.LruCache;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.tls.Tls;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
 import io.helidon.config.Config;
 import io.helidon.config.metadata.Configured;
 import io.helidon.config.metadata.ConfiguredOption;
@@ -50,6 +53,7 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
+import io.helidon.webclient.spi.DnsResolver;
 
 /**
  * A definition of a proxy server to use for outgoing requests.
@@ -58,10 +62,6 @@ public class Proxy {
     private static final System.Logger LOGGER = System.getLogger(Proxy.class.getName());
     private static final Tls NO_TLS = Tls.builder().enabled(false).build();
 
-    /**
-     * No proxy instance.
-     */
-    private static final Proxy NO_PROXY = new Proxy(builder().type(ProxyType.NONE));
     private static final Pattern PORT_PATTERN = Pattern.compile(".*:(\\d+)");
     private static final Pattern IP_V4 = Pattern.compile("^(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\."
                                                                  + "(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}$");
@@ -74,6 +74,10 @@ public class Proxy {
 
     private static final LruCache<String, Boolean> IVP6_HOST_MATCH_RESULTS = LruCache.create(100);
     private static final LruCache<String, Boolean> IVP6_IDENTIFIER_MATCH_RESULTS = LruCache.create(100);
+    /**
+     * No proxy instance.
+     */
+    private static final Proxy NO_PROXY = new Proxy(builder().type(ProxyType.NONE));
 
     private final ProxyType type;
     private final String host;
@@ -84,6 +88,7 @@ public class Proxy {
     private final ProxySelector systemProxySelector;
     private final Optional<Header> proxyAuthHeader;
     private final boolean forceHttpConnect;
+    private final boolean ipNoProxyConfigured;
 
     private Proxy(Proxy.Builder builder) {
         this.host = builder.host();
@@ -101,9 +106,24 @@ public class Proxy {
         if (type == ProxyType.SYSTEM) {
             this.noProxy = inetSocketAddress -> true;
             this.systemProxySelector = ProxySelector.getDefault();
+            this.ipNoProxyConfigured = false;
         } else {
-            this.noProxy = prepareNoProxy(builder.noProxyHosts());
+            Set<String> noProxyHosts = builder.noProxyHosts();
+            this.noProxy = prepareNoProxy(noProxyHosts);
             this.systemProxySelector = null;
+            boolean ipNoProxyConfigured = false;
+            for (String noProxyHost : noProxyHosts) {
+                String hostPart = noProxyHost;
+                Matcher portMatcher = PORT_PATTERN.matcher(noProxyHost);
+                if (portMatcher.matches()) {
+                    hostPart = noProxyHost.substring(0, noProxyHost.lastIndexOf(':'));
+                }
+                if (isIpV4(hostPart) || isIpV6Identifier(hostPart)) {
+                    ipNoProxyConfigured = true;
+                    break;
+                }
+            }
+            this.ipNoProxyConfigured = ipNoProxyConfigured;
         }
 
         if (username.isPresent()) {
@@ -181,8 +201,19 @@ public class Proxy {
         }
 
         if (simple) {
-            return address -> noProxyHosts.contains(address.getHostName())
-                    || noProxyHosts.contains(address.getHostName() + ":" + address.getPort());
+            return address -> {
+                String host = address.getHostString();
+                if (noProxyHosts.contains(host) || noProxyHosts.contains(host + ":" + address.getPort())) {
+                    return true;
+                }
+                InetAddress inetAddress = address.getAddress();
+                if (inetAddress == null) {
+                    return false;
+                }
+                String ipAddress = resolveHost(inetAddress.getHostAddress());
+                return noProxyHosts.contains(ipAddress)
+                        || noProxyHosts.contains(ipAddress + ":" + address.getPort());
+            };
         }
 
         List<BiFunction<String, Integer, Boolean>> hostMatchers = new LinkedList<>();
@@ -279,6 +310,34 @@ public class Proxy {
     }
 
     /**
+     * Create a TCP socket for one preselected and resolved route.
+     *
+     * @param webClient web client used for an HTTP CONNECT exchange
+     * @param target resolved physical target
+     * @param socketOptions socket options
+     * @return connected socket
+     */
+    @Api.Internal
+    public Socket tcpSocket(WebClient webClient,
+                            ResolvedClientTarget target,
+                            SocketOptions socketOptions) {
+        Objects.requireNonNull(target, "target");
+        Objects.requireNonNull(socketOptions, "socketOptions");
+        ProxyRoute route = target.proxyRoute();
+        if (!route.belongsTo(this)) {
+            throw new IllegalArgumentException("Resolved target belongs to a different proxy policy");
+        }
+        if (route.direct()) {
+            return connect(new Socket(), target.localAddress(), target.peerAddress(), socketOptions);
+        }
+        if (route.systemProxyType() != null) {
+            Socket socket = new Socket(new java.net.Proxy(route.systemProxyType(), target.peerAddress()));
+            return connect(socket, target.localAddress(), target.destinationAddress(), socketOptions);
+        }
+        return connectToProxy(webClient, target, this);
+    }
+
+    /**
      * Get proxy type.
      *
      * @return the proxy type
@@ -310,6 +369,97 @@ public class Proxy {
             return !proxies.isEmpty() && !proxies.get(0).equals(java.net.Proxy.NO_PROXY);
         }
         return false;
+    }
+
+    /**
+     * Resolve configured proxy policy to one effective route for a logical request target.
+     * A system selector is invoked exactly once and its selected route is retained by the returned value.
+     * Configured {@code no-proxy} rules that contain only host names are evaluated without DNS lookup. IP-based rules are
+     * evaluated against the supplied host string by this overload; WebClient's connection-target resolution also evaluates
+     * them against the concrete DNS address used for the connection.
+     *
+     * @param scheme logical request scheme
+     * @param host logical request host
+     * @param port logical request port
+     * @param tls whether the application connection uses TLS
+     * @return effective route
+     */
+    @Api.Internal
+    public ProxyRoute effectiveRoute(String scheme, String host, int port, boolean tls) {
+        return effectiveRoute(scheme, host, port, tls, null, null);
+    }
+
+    ProxyRoute effectiveRoute(String scheme,
+                              String host,
+                              int port,
+                              boolean tls,
+                              DnsResolver dnsResolver,
+                              DnsAddressLookup dnsAddressLookup) {
+        Objects.requireNonNull(scheme, "scheme");
+        Objects.requireNonNull(host, "host");
+        if (type == null || type == ProxyType.NONE) {
+            return ProxyRoute.direct(this, scheme, host, port, tls);
+        }
+        if (type == ProxyType.HTTP) {
+            if (isNoHosts(InetSocketAddress.createUnresolved(host, port))) {
+                if (isIpV4(host) || isIpV6Host(host) || isIpV6Identifier(host)) {
+                    return ProxyRoute.direct(this, scheme, host, port, tls, InetAddress.ofLiteral(resolveHost(host)));
+                }
+                return ProxyRoute.direct(this, scheme, host, port, tls);
+            }
+            if (ipNoProxyConfigured && dnsResolver != null) {
+                InetAddress address = dnsResolver.resolveAddress(host,
+                                                                 Objects.requireNonNull(dnsAddressLookup,
+                                                                                        "dnsAddressLookup"));
+                if (isNoHosts(new InetSocketAddress(address, port))) {
+                    return ProxyRoute.direct(this, scheme, host, port, tls, address);
+                }
+            }
+            ProxyRoute.Kind routeKind = forceHttpConnect || tls || username.isPresent()
+                    ? ProxyRoute.Kind.HTTP_TUNNEL
+                    : ProxyRoute.Kind.HTTP_FORWARD;
+            return ProxyRoute.configuredHttp(this,
+                                             routeKind,
+                                             InetSocketAddress.createUnresolved(this.host, this.port),
+                                             scheme,
+                                             host,
+                                             port,
+                                             tls);
+        }
+        if (systemProxySelector == null) {
+            return ProxyRoute.direct(this, scheme, host, port, tls);
+        }
+        UriAuthority authority = UriAuthority.create(UriHost.create(host), port);
+        List<java.net.Proxy> selected = systemProxySelector.select(URI.create(scheme + "://" + authority));
+        if (selected == null || selected.isEmpty()) {
+            return ProxyRoute.direct(this, scheme, host, port, tls);
+        }
+        java.net.Proxy systemProxy = selected.get(0);
+        if (systemProxy == null
+                || systemProxy == java.net.Proxy.NO_PROXY
+                || systemProxy.type() == java.net.Proxy.Type.DIRECT) {
+            return ProxyRoute.direct(this, scheme, host, port, tls);
+        }
+        if (!(systemProxy.address() instanceof InetSocketAddress)) {
+            throw new IllegalArgumentException("System proxy address must be an InetSocketAddress");
+        }
+        return switch (systemProxy.type()) {
+            case HTTP -> ProxyRoute.system(this,
+                                           ProxyRoute.Kind.HTTP_TUNNEL,
+                                           systemProxy,
+                                           scheme,
+                                           host,
+                                           port,
+                                           tls);
+            case SOCKS -> ProxyRoute.system(this,
+                                            ProxyRoute.Kind.SOCKS,
+                                            systemProxy,
+                                            scheme,
+                                            host,
+                                            port,
+                                            tls);
+            case DIRECT -> ProxyRoute.direct(this, scheme, host, port, tls);
+        };
     }
 
     /**
@@ -376,6 +526,7 @@ public class Proxy {
         Proxy proxy = (Proxy) o;
         return port == proxy.port
                 && type == proxy.type
+                && forceHttpConnect == proxy.forceHttpConnect
                 && Objects.equals(systemProxySelector, proxy.systemProxySelector)
                 && Objects.equals(host, proxy.host)
                 && Objects.equals(noProxy, proxy.noProxy)
@@ -385,7 +536,35 @@ public class Proxy {
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, host, port, noProxy, username, password);
+        return Objects.hash(type, host, port, noProxy, username, password, forceHttpConnect);
+    }
+
+    private static Socket connect(Socket socket,
+                                  Optional<InetSocketAddress> localAddress,
+                                  InetSocketAddress destination,
+                                  SocketOptions socketOptions) {
+        try {
+            socketOptions.configureSocket(socket);
+            if (localAddress.isPresent()) {
+                socket.bind(localAddress.get());
+            }
+            socket.connect(destination, (int) socketOptions.connectTimeout().toMillis());
+            return socket;
+        } catch (IOException e) {
+            try {
+                socket.close();
+            } catch (IOException closeFailure) {
+                e.addSuppressed(closeFailure);
+            }
+            throw new UncheckedIOException(e);
+        } catch (RuntimeException | Error e) {
+            try {
+                socket.close();
+            } catch (IOException closeFailure) {
+                e.addSuppressed(closeFailure);
+            }
+            throw e;
+        }
     }
 
     private static String resolveHost(String host) {
@@ -477,6 +656,67 @@ public class Proxy {
             }
             proxy.proxyAuthHeader.ifPresent(request::header);
             // we cannot close the response, as that would close the connection
+            HttpClientResponse response = request.request();
+            if (response.status().family() != Status.Family.SUCCESSFUL) {
+                response.close();
+                throw new IllegalStateException("Proxy sent wrong HTTP response code: " + response.status());
+            }
+        }
+        return connection.socket();
+    }
+
+    private static Socket connectToProxy(WebClient webClient,
+                                         ResolvedClientTarget target,
+                                         Proxy proxy) {
+        WebClientConfig clientConfig = webClient.prototype();
+        InetSocketAddress configuredProxy = target.proxyRoute().proxyAddress().orElseThrow();
+        ConnectionKey proxyConnectionKey = ConnectionKey.create("http",
+                                                                configuredProxy.getHostString(),
+                                                                configuredProxy.getPort(),
+                                                                NO_TLS,
+                                                                clientConfig.dnsResolver(),
+                                                                clientConfig.dnsAddressLookup(),
+                                                                NO_PROXY);
+        UriAuthority proxyAuthority = UriAuthority.create(UriHost.create(proxyConnectionKey.host()),
+                                                          configuredProxy.getPort());
+        ProxyRoute directRoute = proxyConnectionKey.proxy()
+                .effectiveRoute("http", configuredProxy.getHostString(), configuredProxy.getPort(), false);
+        ClientConnectionTarget proxyTarget = target.localAddress()
+                .map(localAddress -> ClientConnectionTarget.create(proxyConnectionKey,
+                                                                   "http",
+                                                                   proxyAuthority,
+                                                                   directRoute,
+                                                                   localAddress,
+                                                                   proxyConnectionKey.tls().generation()))
+                .orElseGet(() -> ClientConnectionTarget.create(proxyConnectionKey,
+                                                               "http",
+                                                               proxyAuthority,
+                                                               directRoute,
+                                                               proxyConnectionKey.tls().generation()));
+        ResolvedClientTarget resolvedProxy = ResolvedClientTarget.direct(proxyTarget,
+                                                                         proxyAuthority,
+                                                                         target.peerAddress(),
+                                                                         target.networkGeneration());
+        TcpClientConnection connection = TcpClientConnection.create(webClient,
+                                                                    resolvedProxy,
+                                                                    List.of(),
+                                                                    it -> false,
+                                                                    it -> {
+                                                                    })
+                .connect();
+        if (target.proxyRoute().kind() == ProxyRoute.Kind.HTTP_TUNNEL) {
+            HttpClientRequest request = webClient.method(Method.CONNECT)
+                    .followRedirects(false)
+                    .connection(connection)
+                    .uri("http://" + proxyAuthority)
+                    .protocolId("http/1.1")
+                    .header(HeaderNames.HOST, target.routeAuthority().toString())
+                    .accept(MediaTypes.WILDCARD);
+            if (clientConfig.keepAlive()) {
+                request.header(HeaderValues.CONNECTION_KEEP_ALIVE)
+                    .header(ClientRequestBase.PROXY_CONNECTION);
+            }
+            proxy.proxyAuthHeader.ifPresent(request::header);
             HttpClientResponse response = request.request();
             if (response.status().family() != Status.Family.SUCCESSFUL) {
                 response.close();
@@ -635,7 +875,8 @@ public class Proxy {
          * <tr>
          *     <td>no-proxy</td>
          *     <td>{@code no default}</td>
-         *     <td>Contains list of the hosts which should be excluded from using proxy</td>
+         *     <td>Contains host or IP patterns which should be excluded from using proxy. IP patterns require local DNS
+         *     resolution of host names and bind a direct route to the matching address.</td>
          * </tr>
          * </table>
          *
@@ -743,6 +984,8 @@ public class Proxy {
          *     <li>Domain name and all sub-domains, such as {@code .helidon.io} (leading dot)</li>
          *     <li>Combination of all options from above with a port, such as {@code .helidon.io:80}</li>
          * </ul>
+         * An IP address pattern requires local DNS resolution of host-name targets. When the resolved address matches,
+         * WebClient selects a direct route and retains that address for the connection attempt.
          *
          * @param noProxyHost to exclude from proxying
          * @return updated builder instance

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -677,7 +677,7 @@ public class Proxy {
                                                                 clientConfig.dnsResolver(),
                                                                 clientConfig.dnsAddressLookup(),
                                                                 NO_PROXY);
-        UriAuthority proxyAuthority = UriAuthority.create(UriHost.create(proxyConnectionKey.host()),
+        UriAuthority proxyAuthority = UriAuthority.create(UriHost.create(proxyConnectionKey.routingHost()),
                                                           configuredProxy.getPort());
         ProxyRoute directRoute = proxyConnectionKey.proxy()
                 .effectiveRoute("http", configuredProxy.getHostString(), configuredProxy.getPort(), false);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ProxyRoute.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ProxyRoute.java
@@ -34,6 +34,8 @@ import io.helidon.common.Api;
  */
 @Api.Internal
 public final class ProxyRoute {
+    static final ProxyRoute DIRECT = new ProxyRoute();
+
     private final Proxy source;
     private final Kind kind;
     private final InetSocketAddress proxyAddress;
@@ -43,6 +45,18 @@ public final class ProxyRoute {
     private final String host;
     private final int port;
     private final boolean tls;
+
+    private ProxyRoute() {
+        this.source = null;
+        this.kind = Kind.DIRECT;
+        this.proxyAddress = null;
+        this.noProxyAddress = null;
+        this.systemProxyType = null;
+        this.scheme = "";
+        this.host = "";
+        this.port = 0;
+        this.tls = false;
+    }
 
     private ProxyRoute(Proxy source,
                        Kind kind,
@@ -200,10 +214,16 @@ public final class ProxyRoute {
     }
 
     boolean belongsTo(Proxy proxy) {
+        if (this == DIRECT) {
+            return proxy.type() == null || proxy.type() == Proxy.ProxyType.NONE;
+        }
         return source.equals(proxy);
     }
 
     boolean selectedFor(String scheme, String host, int port, boolean tls) {
+        if (this == DIRECT) {
+            return true;
+        }
         return this.scheme.equalsIgnoreCase(scheme)
                 && this.host.equalsIgnoreCase(host)
                 && this.port == port
@@ -218,6 +238,9 @@ public final class ProxyRoute {
         if (!(obj instanceof ProxyRoute other)) {
             return false;
         }
+        if (this == DIRECT || other == DIRECT) {
+            return false;
+        }
         return source.equals(other.source)
                 && kind == other.kind
                 && Objects.equals(proxyAddress, other.proxyAddress)
@@ -230,6 +253,9 @@ public final class ProxyRoute {
 
     @Override
     public int hashCode() {
+        if (this == DIRECT) {
+            return 1;
+        }
         int result = source.hashCode();
         result = 31 * result + kind.hashCode();
         result = 31 * result + Objects.hashCode(proxyAddress);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ProxyRoute.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ProxyRoute.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.Api;
+
+/**
+ * Effective proxy route selected for one logical WebClient target.
+ * <p>
+ * The selected route is distinct from configured proxy policy. For example, a system proxy selector or a configured
+ * {@code no-proxy} rule can select a direct route even though the request carries a non-direct {@link Proxy}
+ * configuration.
+ * Address evidence retained for an IP-based {@code no-proxy} match does not participate in route equality or hashing.
+ */
+@Api.Internal
+public final class ProxyRoute {
+    private final Proxy source;
+    private final Kind kind;
+    private final InetSocketAddress proxyAddress;
+    private final InetSocketAddress noProxyAddress;
+    private final java.net.Proxy.Type systemProxyType;
+    private final String scheme;
+    private final String host;
+    private final int port;
+    private final boolean tls;
+
+    private ProxyRoute(Proxy source,
+                       Kind kind,
+                       InetSocketAddress proxyAddress,
+                       InetSocketAddress noProxyAddress,
+                       java.net.Proxy.Type systemProxyType,
+                       String scheme,
+                       String host,
+                       int port,
+                       boolean tls) {
+        this.source = Objects.requireNonNull(source, "source");
+        this.kind = Objects.requireNonNull(kind, "kind");
+        this.proxyAddress = proxyAddress;
+        this.noProxyAddress = noProxyAddress;
+        this.systemProxyType = systemProxyType;
+        this.scheme = Objects.requireNonNull(scheme, "scheme").toLowerCase(Locale.ROOT);
+        this.host = Objects.requireNonNull(host, "host").toLowerCase(Locale.ROOT);
+        this.port = port;
+        this.tls = tls;
+    }
+
+    static ProxyRoute direct(Proxy source,
+                             String scheme,
+                             String host,
+                             int port,
+                             boolean tls) {
+        return new ProxyRoute(source, Kind.DIRECT, null, null, null, scheme, host, port, tls);
+    }
+
+    static ProxyRoute direct(Proxy source,
+                             String scheme,
+                             String host,
+                             int port,
+                             boolean tls,
+                             InetAddress noProxyAddress) {
+        InetAddress address = Objects.requireNonNull(noProxyAddress, "noProxyAddress");
+        return new ProxyRoute(source,
+                              Kind.DIRECT,
+                              null,
+                              new InetSocketAddress(InetAddress.ofLiteral(address.getHostAddress()), port),
+                              null,
+                              scheme,
+                              host,
+                              port,
+                              tls);
+    }
+
+    static ProxyRoute configuredHttp(Proxy source,
+                                     Kind kind,
+                                     InetSocketAddress proxyAddress,
+                                     String scheme,
+                                     String host,
+                                     int port,
+                                     boolean tls) {
+        if (kind != Kind.HTTP_FORWARD && kind != Kind.HTTP_TUNNEL) {
+            throw new IllegalArgumentException("Configured HTTP proxy route must be HTTP_FORWARD or HTTP_TUNNEL");
+        }
+        return new ProxyRoute(source,
+                              kind,
+                              Objects.requireNonNull(proxyAddress, "proxyAddress"),
+                              null,
+                              null,
+                              scheme,
+                              host,
+                              port,
+                              tls);
+    }
+
+    static ProxyRoute system(Proxy source,
+                             Kind kind,
+                             java.net.Proxy systemProxy,
+                             String scheme,
+                             String host,
+                             int port,
+                             boolean tls) {
+        if (kind != Kind.HTTP_TUNNEL && kind != Kind.SOCKS) {
+            throw new IllegalArgumentException("System proxy route must be HTTP_TUNNEL or SOCKS");
+        }
+        if (!(systemProxy.address() instanceof InetSocketAddress proxyAddress)) {
+            throw new IllegalArgumentException("System proxy address must be an InetSocketAddress");
+        }
+        return new ProxyRoute(source,
+                              kind,
+                              proxyAddress,
+                              null,
+                              systemProxy.type(),
+                              scheme,
+                              host,
+                              port,
+                              tls);
+    }
+
+    /**
+     * Selected route kind.
+     *
+     * @return route kind
+     */
+    public Kind kind() {
+        return kind;
+    }
+
+    /**
+     * Whether this is a direct route.
+     *
+     * @return whether the route is direct
+     */
+    public boolean direct() {
+        return kind == Kind.DIRECT;
+    }
+
+    /**
+     * Whether the route supports UDP datagrams.
+     * <p>
+     * Helidon currently supports datagrams only on a direct route. Ordinary HTTP CONNECT and SOCKS routes do not imply
+     * CONNECT-UDP, MASQUE, or SOCKS UDP-associate support.
+     *
+     * @return whether datagrams are supported
+     */
+    public boolean supportsDatagrams() {
+        return direct();
+    }
+
+    /**
+     * Whether HTTP/1.1 must use absolute-form request targets on this route.
+     *
+     * @return whether this is an HTTP forward-proxy route
+     */
+    public boolean forwardProxy() {
+        return kind == Kind.HTTP_FORWARD;
+    }
+
+    /**
+     * Configured or system-selected proxy address.
+     *
+     * @return proxy address, empty for a direct route
+     */
+    public Optional<InetSocketAddress> proxyAddress() {
+        return Optional.ofNullable(proxyAddress);
+    }
+
+    /**
+     * Address whose configured {@code no-proxy} match selected this direct route.
+     * <p>
+     * When present, the same address must be used for the physical connection so a later DNS answer cannot invalidate
+     * the route decision.
+     *
+     * @return resolved no-proxy address, or empty when route selection did not require DNS
+     */
+    Optional<InetSocketAddress> noProxyAddress() {
+        return Optional.ofNullable(noProxyAddress);
+    }
+
+    java.net.Proxy.Type systemProxyType() {
+        return systemProxyType;
+    }
+
+    boolean belongsTo(Proxy proxy) {
+        return source.equals(proxy);
+    }
+
+    boolean selectedFor(String scheme, String host, int port, boolean tls) {
+        return this.scheme.equalsIgnoreCase(scheme)
+                && this.host.equalsIgnoreCase(host)
+                && this.port == port
+                && this.tls == tls;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ProxyRoute other)) {
+            return false;
+        }
+        return source.equals(other.source)
+                && kind == other.kind
+                && Objects.equals(proxyAddress, other.proxyAddress)
+                && systemProxyType == other.systemProxyType
+                && scheme.equals(other.scheme)
+                && host.equals(other.host)
+                && port == other.port
+                && tls == other.tls;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = source.hashCode();
+        result = 31 * result + kind.hashCode();
+        result = 31 * result + Objects.hashCode(proxyAddress);
+        result = 31 * result + Objects.hashCode(systemProxyType);
+        result = 31 * result + scheme.hashCode();
+        result = 31 * result + host.hashCode();
+        result = 31 * result + Integer.hashCode(port);
+        return 31 * result + Boolean.hashCode(tls);
+    }
+
+    @Override
+    public String toString() {
+        return "ProxyRoute[kind=" + kind
+                + (proxyAddress == null ? "" : ", proxyAddress=" + proxyAddress)
+                + (noProxyAddress == null ? "" : ", noProxyAddress=" + noProxyAddress)
+                + ']';
+    }
+
+    /**
+     * Effective route kind.
+     */
+    public enum Kind {
+        /**
+         * Direct route to the selected target.
+         */
+        DIRECT,
+
+        /**
+         * HTTP forward proxy. HTTP/1.1 uses absolute-form request targets.
+         */
+        HTTP_FORWARD,
+
+        /**
+         * HTTP CONNECT tunnel. Application protocols use ordinary origin semantics inside the tunnel.
+         */
+        HTTP_TUNNEL,
+
+        /**
+         * SOCKS proxy route.
+         */
+        SOCKS
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ResolvedClientTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ResolvedClientTarget.java
@@ -64,7 +64,7 @@ public final class ResolvedClientTarget {
         DnsResolver dnsResolver = connectionKey.dnsResolver();
         InetSocketAddress noProxyAddress = proxyRoute.noProxyAddress().orElse(null);
         if (noProxyAddress != null
-                && (!connectionKey.host().equalsIgnoreCase(routeHost) || connectionKey.port() != routePort)) {
+                && (!connectionKey.routingHost().equalsIgnoreCase(routeHost) || connectionKey.port() != routePort)) {
             throw new IllegalArgumentException("An address-bound no-proxy route cannot use an alternative authority");
         }
         InetAddress peer = noProxyAddress == null ? selectedAddress.getAddress() : noProxyAddress.getAddress();

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ResolvedClientTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ResolvedClientTarget.java
@@ -45,9 +45,9 @@ public final class ResolvedClientTarget {
                                  InetSocketAddress destinationAddress,
                                  long networkGeneration) {
         this.logicalTarget = Objects.requireNonNull(logicalTarget, "logicalTarget");
-        this.routeAuthority = Objects.requireNonNull(routeAuthority, "routeAuthority");
+        this.routeAuthority = routeAuthority;
         this.peerAddress = Objects.requireNonNull(peerAddress, "peerAddress");
-        this.destinationAddress = Objects.requireNonNull(destinationAddress, "destinationAddress");
+        this.destinationAddress = destinationAddress;
         this.networkGeneration = networkGeneration;
     }
 
@@ -56,12 +56,24 @@ public final class ResolvedClientTarget {
                                         int routePort,
                                         long networkGeneration) {
         Objects.requireNonNull(routeHost, "routeHost");
-        UriAuthority routeAuthority = UriAuthority.create(UriHost.create(routeHost), routePort);
         ProxyRoute proxyRoute = logicalTarget.proxyRoute();
-        InetSocketAddress selectedAddress = proxyRoute.proxyAddress()
-                .orElseGet(() -> InetSocketAddress.createUnresolved(routeAuthority.host().value(), routePort));
         ConnectionKey connectionKey = logicalTarget.connectionKey();
         DnsResolver dnsResolver = connectionKey.dnsResolver();
+        if (proxyRoute == ProxyRoute.DIRECT
+                && connectionKey.routingHost().equals(routeHost)
+                && connectionKey.port() == routePort) {
+            InetAddress peer = dnsResolver.resolveAddress(routeHost, connectionKey.dnsAddressLookup());
+            InetAddress numericPeer = InetAddress.ofLiteral(peer.getHostAddress());
+            return new ResolvedClientTarget(logicalTarget,
+                                            null,
+                                            new InetSocketAddress(numericPeer, routePort),
+                                            null,
+                                            networkGeneration);
+        }
+
+        UriAuthority routeAuthority = UriAuthority.create(UriHost.create(routeHost), routePort);
+        InetSocketAddress selectedAddress = proxyRoute.proxyAddress()
+                .orElseGet(() -> InetSocketAddress.createUnresolved(routeAuthority.host().value(), routePort));
         InetSocketAddress noProxyAddress = proxyRoute.noProxyAddress().orElse(null);
         if (noProxyAddress != null
                 && (!connectionKey.routingHost().equalsIgnoreCase(routeHost) || connectionKey.port() != routePort)) {
@@ -123,7 +135,11 @@ public final class ResolvedClientTarget {
      * @return route authority
      */
     public UriAuthority routeAuthority() {
-        return routeAuthority;
+        if (routeAuthority != null) {
+            return routeAuthority;
+        }
+        ConnectionKey connectionKey = logicalTarget.connectionKey();
+        return UriAuthority.create(UriHost.create(connectionKey.routingHost()), connectionKey.port());
     }
 
     /**
@@ -143,7 +159,11 @@ public final class ResolvedClientTarget {
      * @return logical destination address
      */
     public InetSocketAddress destinationAddress() {
-        return destinationAddress;
+        if (destinationAddress != null) {
+            return destinationAddress;
+        }
+        UriAuthority authority = routeAuthority();
+        return InetSocketAddress.createUnresolved(authority.host().value(), authority.port());
     }
 
     /**
@@ -191,23 +211,23 @@ public final class ResolvedClientTarget {
             return false;
         }
         return logicalTarget.equals(other.logicalTarget)
-                && routeAuthority.equals(other.routeAuthority)
+                && routeAuthority().equals(other.routeAuthority())
                 && peerAddress.equals(other.peerAddress)
-                && destinationAddress.equals(other.destinationAddress)
+                && destinationAddress().equals(other.destinationAddress())
                 && networkGeneration == other.networkGeneration;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(logicalTarget, routeAuthority, peerAddress, destinationAddress, networkGeneration);
+        return Objects.hash(logicalTarget, routeAuthority(), peerAddress, destinationAddress(), networkGeneration);
     }
 
     @Override
     public String toString() {
         return "ResolvedClientTarget[origin=" + logicalTarget.originAuthority()
-                + ", route=" + routeAuthority
+                + ", route=" + routeAuthority()
                 + ", peerAddress=" + peerAddress
-                + ", destinationAddress=" + destinationAddress
+                + ", destinationAddress=" + destinationAddress()
                 + ", proxyRoute=" + proxyRoute()
                 + ", tlsGeneration=" + tlsGeneration()
                 + ", networkGeneration=" + networkGeneration

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ResolvedClientTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ResolvedClientTarget.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.Api;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
+import io.helidon.webclient.spi.DnsResolver;
+
+/**
+ * Concrete physical WebClient transport target for one new connection attempt.
+ * <p>
+ * Logical HTTP and TLS identity remains in {@link #logicalTarget()}; the concrete peer is routing data only.
+ */
+@Api.Internal
+public final class ResolvedClientTarget {
+    private final ClientConnectionTarget logicalTarget;
+    private final UriAuthority routeAuthority;
+    private final InetSocketAddress peerAddress;
+    private final InetSocketAddress destinationAddress;
+    private final long networkGeneration;
+
+    private ResolvedClientTarget(ClientConnectionTarget logicalTarget,
+                                 UriAuthority routeAuthority,
+                                 InetSocketAddress peerAddress,
+                                 InetSocketAddress destinationAddress,
+                                 long networkGeneration) {
+        this.logicalTarget = Objects.requireNonNull(logicalTarget, "logicalTarget");
+        this.routeAuthority = Objects.requireNonNull(routeAuthority, "routeAuthority");
+        this.peerAddress = Objects.requireNonNull(peerAddress, "peerAddress");
+        this.destinationAddress = Objects.requireNonNull(destinationAddress, "destinationAddress");
+        this.networkGeneration = networkGeneration;
+    }
+
+    static ResolvedClientTarget resolve(ClientConnectionTarget logicalTarget,
+                                        String routeHost,
+                                        int routePort,
+                                        long networkGeneration) {
+        Objects.requireNonNull(routeHost, "routeHost");
+        UriAuthority routeAuthority = UriAuthority.create(UriHost.create(routeHost), routePort);
+        ProxyRoute proxyRoute = logicalTarget.proxyRoute();
+        InetSocketAddress selectedAddress = proxyRoute.proxyAddress()
+                .orElseGet(() -> InetSocketAddress.createUnresolved(routeAuthority.host().value(), routePort));
+        ConnectionKey connectionKey = logicalTarget.connectionKey();
+        DnsResolver dnsResolver = connectionKey.dnsResolver();
+        InetSocketAddress noProxyAddress = proxyRoute.noProxyAddress().orElse(null);
+        if (noProxyAddress != null
+                && (!connectionKey.host().equalsIgnoreCase(routeHost) || connectionKey.port() != routePort)) {
+            throw new IllegalArgumentException("An address-bound no-proxy route cannot use an alternative authority");
+        }
+        InetAddress peer = noProxyAddress == null ? selectedAddress.getAddress() : noProxyAddress.getAddress();
+        if (peer == null) {
+            peer = dnsResolver.resolveAddress(selectedAddress.getHostString(), connectionKey.dnsAddressLookup());
+        }
+        InetAddress numericPeer = InetAddress.ofLiteral(peer.getHostAddress());
+        InetSocketAddress destinationAddress;
+        if (proxyRoute.kind() == ProxyRoute.Kind.SOCKS) {
+            InetAddress destination = dnsResolver.resolveAddress(routeAuthority.host().value(),
+                                                                 connectionKey.dnsAddressLookup());
+            destinationAddress = new InetSocketAddress(destination, routeAuthority.port());
+        } else {
+            destinationAddress = InetSocketAddress.createUnresolved(routeAuthority.host().value(),
+                                                                    routeAuthority.port());
+        }
+        return new ResolvedClientTarget(logicalTarget,
+                                        routeAuthority,
+                                        new InetSocketAddress(numericPeer, selectedAddress.getPort()),
+                                        destinationAddress,
+                                        networkGeneration);
+    }
+
+    static ResolvedClientTarget direct(ClientConnectionTarget logicalTarget,
+                                       UriAuthority routeAuthority,
+                                       InetSocketAddress peerAddress,
+                                       long networkGeneration) {
+        if (!logicalTarget.proxyRoute().direct()) {
+            throw new IllegalArgumentException("A pre-resolved direct target requires a direct proxy route");
+        }
+        if (peerAddress.isUnresolved()) {
+            throw new IllegalArgumentException("A pre-resolved direct peer must contain an InetAddress");
+        }
+        InetAddress numericPeer = InetAddress.ofLiteral(peerAddress.getAddress().getHostAddress());
+        InetSocketAddress normalizedPeer = new InetSocketAddress(numericPeer, peerAddress.getPort());
+        return new ResolvedClientTarget(logicalTarget,
+                                        routeAuthority,
+                                        normalizedPeer,
+                                        InetSocketAddress.createUnresolved(routeAuthority.host().value(),
+                                                                           routeAuthority.port()),
+                                        networkGeneration);
+    }
+
+    /**
+     * Logical connection target and identity.
+     *
+     * @return logical target
+     */
+    public ClientConnectionTarget logicalTarget() {
+        return logicalTarget;
+    }
+
+    /**
+     * Selected direct or alternative route authority.
+     *
+     * @return route authority
+     */
+    public UriAuthority routeAuthority() {
+        return routeAuthority;
+    }
+
+    /**
+     * Concrete socket peer. This is the route peer for a direct connection and the proxy peer for a proxied connection.
+     *
+     * @return concrete peer
+     */
+    public InetSocketAddress peerAddress() {
+        return peerAddress;
+    }
+
+    /**
+     * Logical destination supplied to a proxy tunnel. The address is resolved locally for a system SOCKS route to
+     * preserve WebClient's existing SOCKS behavior, because the selected SOCKS version is not available through the
+     * standard proxy API.
+     *
+     * @return logical destination address
+     */
+    public InetSocketAddress destinationAddress() {
+        return destinationAddress;
+    }
+
+    /**
+     * Effective proxy route.
+     *
+     * @return proxy route
+     */
+    public ProxyRoute proxyRoute() {
+        return logicalTarget.proxyRoute();
+    }
+
+    /**
+     * Optional requested local bind address.
+     *
+     * @return local bind address
+     */
+    public Optional<InetSocketAddress> localAddress() {
+        return logicalTarget.localAddress();
+    }
+
+    /**
+     * Captured TLS reload generation.
+     *
+     * @return TLS generation
+     */
+    public long tlsGeneration() {
+        return logicalTarget.tlsGeneration();
+    }
+
+    /**
+     * Network or discovery generation for this physical attempt.
+     *
+     * @return network generation
+     */
+    public long networkGeneration() {
+        return networkGeneration;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ResolvedClientTarget other)) {
+            return false;
+        }
+        return logicalTarget.equals(other.logicalTarget)
+                && routeAuthority.equals(other.routeAuthority)
+                && peerAddress.equals(other.peerAddress)
+                && destinationAddress.equals(other.destinationAddress)
+                && networkGeneration == other.networkGeneration;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(logicalTarget, routeAuthority, peerAddress, destinationAddress, networkGeneration);
+    }
+
+    @Override
+    public String toString() {
+        return "ResolvedClientTarget[origin=" + logicalTarget.originAuthority()
+                + ", route=" + routeAuthority
+                + ", peerAddress=" + peerAddress
+                + ", destinationAddress=" + destinationAddress
+                + ", proxyRoute=" + proxyRoute()
+                + ", tlsGeneration=" + tlsGeneration()
+                + ", networkGeneration=" + networkGeneration
+                + ']';
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -44,8 +44,6 @@ import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PlainSocket;
 import io.helidon.common.socket.TlsSocket;
 import io.helidon.common.tls.Tls;
-import io.helidon.common.uri.UriAuthority;
-import io.helidon.common.uri.UriHost;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.TRACE;
@@ -176,10 +174,7 @@ public class TcpClientConnection implements ClientConnection {
         if (target == null) {
             ClientConnectionTarget logicalTarget = connectionTarget;
             if (logicalTarget == null) {
-                logicalTarget = ClientConnectionTarget.create(
-                        connectionKey,
-                        connectionKey.scheme(),
-                        UriAuthority.create(UriHost.create(connectionKey.host()), connectionKey.port()));
+                logicalTarget = ClientConnectionTarget.create(connectionKey, connectionKey.scheme());
             }
             target = logicalTarget.resolve();
             resolvedTarget = target;

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -18,8 +18,6 @@ package io.helidon.webclient.api;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
 import java.security.cert.Certificate;
@@ -27,6 +25,8 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -36,6 +36,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
+import io.helidon.common.Api;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
@@ -43,7 +44,8 @@ import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PlainSocket;
 import io.helidon.common.socket.TlsSocket;
 import io.helidon.common.tls.Tls;
-import io.helidon.webclient.spi.DnsResolver;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.TRACE;
@@ -57,6 +59,7 @@ public class TcpClientConnection implements ClientConnection {
 
     private final WebClient webClient;
     private final ConnectionKey connectionKey;
+    private final ClientConnectionTarget connectionTarget;
     private final List<String> tcpProtocolIds;
     private final Function<TcpClientConnection, Boolean> releaseFunction;
     private final Consumer<TcpClientConnection> closeConsumer;
@@ -68,14 +71,33 @@ public class TcpClientConnection implements ClientConnection {
     private DataWriter writer;
     private boolean closed;
     private boolean allowExpectContinue = true;
+    private ResolvedClientTarget resolvedTarget;
 
     private TcpClientConnection(WebClient webClient,
                                 ConnectionKey connectionKey,
                                 List<String> tcpProtocolIds,
                                 Function<TcpClientConnection, Boolean> releaseFunction,
                                 Consumer<TcpClientConnection> closeConsumer) {
+        this(webClient,
+             connectionKey,
+             null,
+             null,
+             tcpProtocolIds,
+             releaseFunction,
+             closeConsumer);
+    }
+
+    private TcpClientConnection(WebClient webClient,
+                                ConnectionKey connectionKey,
+                                ClientConnectionTarget connectionTarget,
+                                ResolvedClientTarget resolvedTarget,
+                                List<String> tcpProtocolIds,
+                                Function<TcpClientConnection, Boolean> releaseFunction,
+                                Consumer<TcpClientConnection> closeConsumer) {
         this.webClient = webClient;
         this.connectionKey = connectionKey;
+        this.connectionTarget = connectionTarget;
+        this.resolvedTarget = resolvedTarget;
         this.tcpProtocolIds = tcpProtocolIds;
         this.releaseFunction = releaseFunction;
         this.closeConsumer = closeConsumer;
@@ -101,6 +123,47 @@ public class TcpClientConnection implements ClientConnection {
     }
 
     /**
+     * Create a TCP connection from a logical connection target.
+     *
+     * @param webClient webclient, may be used to create proxy connections
+     * @param connectionTarget logical connection target
+     * @param tcpProtocolIds protocol IDs for ALPN
+     * @param releaseFunction release callback
+     * @param closeConsumer close callback
+     * @return a new unconnected TCP connection
+     */
+    @Api.Internal
+    public static TcpClientConnection create(WebClient webClient,
+                                             ClientConnectionTarget connectionTarget,
+                                             List<String> tcpProtocolIds,
+                                             Function<TcpClientConnection, Boolean> releaseFunction,
+                                             Consumer<TcpClientConnection> closeConsumer) {
+        ClientConnectionTarget target = Objects.requireNonNull(connectionTarget, "connectionTarget");
+        return new TcpClientConnection(webClient,
+                                       target.connectionKey(),
+                                       target,
+                                       null,
+                                       tcpProtocolIds,
+                                       releaseFunction,
+                                       closeConsumer);
+    }
+
+    static TcpClientConnection create(WebClient webClient,
+                                      ResolvedClientTarget resolvedTarget,
+                                      List<String> tcpProtocolIds,
+                                      Function<TcpClientConnection, Boolean> releaseFunction,
+                                      Consumer<TcpClientConnection> closeConsumer) {
+        ResolvedClientTarget target = Objects.requireNonNull(resolvedTarget, "resolvedTarget");
+        return new TcpClientConnection(webClient,
+                                       target.logicalTarget().connectionKey(),
+                                       target.logicalTarget(),
+                                       target,
+                                       tcpProtocolIds,
+                                       releaseFunction,
+                                       closeConsumer);
+    }
+
+    /**
      * Connect this connection over the network.
      * This will resolve proxy connection, TLS negotiation (including ALPN) and return a connected connection.
      *
@@ -109,16 +172,26 @@ public class TcpClientConnection implements ClientConnection {
     @Override
     public TcpClientConnection connect() {
         Tls tls = connectionKey.tls();
-        InetSocketAddress targetAddress = inetSocketAddress();
+        ResolvedClientTarget target = resolvedTarget;
+        if (target == null) {
+            ClientConnectionTarget logicalTarget = connectionTarget;
+            if (logicalTarget == null) {
+                logicalTarget = ClientConnectionTarget.create(
+                        connectionKey,
+                        connectionKey.scheme(),
+                        UriAuthority.create(UriHost.create(connectionKey.host()), connectionKey.port()));
+            }
+            target = logicalTarget.resolve();
+            resolvedTarget = target;
+        }
 
         /*
         Obtain target socket through proxy (if enabled), or connect to target socket
          */
         this.socket = connectionKey.proxy()
                 .tcpSocket(webClient,
-                           targetAddress,
-                           webClient.prototype().socketOptions(),
-                           tls.enabled());
+                           target,
+                           webClient.prototype().socketOptions());
 
         this.channelId = createChannelId(socket);
 
@@ -141,7 +214,10 @@ public class TcpClientConnection implements ClientConnection {
         if (tls.enabled()) {
             List<SNIServerName> serverNamesOverride = connectionKey.serverNamesOverride();
             SSLSocket sslSocket = serverNamesOverride == null
-                    ? tls.createSocket(tcpProtocolIds, socket, targetAddress)
+                    ? tls.createSocket(tcpProtocolIds,
+                                       socket,
+                                       connectionKey.tlsPeerHost(),
+                                       connectionKey.tlsPeerPort())
                     : tls.createSocket(tcpProtocolIds,
                                        socket,
                                        connectionKey.tlsPeerHost(),
@@ -163,6 +239,17 @@ public class TcpClientConnection implements ClientConnection {
             this.helidonSocket = TlsSocket.client(sslSocket, channelId);
         } else {
             this.helidonSocket = PlainSocket.client(socket, channelId);
+        }
+
+        if (!target.logicalTarget().currentTlsGeneration()) {
+            IllegalStateException failure =
+                    new IllegalStateException("TLS configuration was reloaded during connection setup");
+            try {
+                closeResource();
+            } catch (RuntimeException | Error closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
+            throw failure;
         }
 
         this.reader = DataReader.create(helidonSocket);
@@ -267,18 +354,22 @@ public class TcpClientConnection implements ClientConnection {
         this.allowExpectContinue = allowExpectContinue;
     }
 
+    /**
+     * Concrete target retained by this connection after physical resolution.
+     *
+     * @return resolved target, empty until a target is supplied or resolved
+     */
+    @Api.Internal
+    public Optional<ResolvedClientTarget> resolvedTarget() {
+        return Optional.ofNullable(resolvedTarget);
+    }
+
     Socket socket() {
         return socket;
     }
 
     private String createChannelId(Socket socket) {
         return "0x" + HexFormat.of().toHexDigits(System.identityHashCode(socket));
-    }
-
-    private InetSocketAddress inetSocketAddress() {
-        DnsResolver dnsResolver = connectionKey.dnsResolver();
-        InetAddress address = dnsResolver.resolveAddress(connectionKey.host(), connectionKey.dnsAddressLookup());
-        return new InetSocketAddress(address, connectionKey.port());
     }
 
     static void debugTls(SSLEngine sslEngine, String channelId) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/UnixDomainSocketClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/UnixDomainSocketClientConnection.java
@@ -53,6 +53,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
     private static final System.Logger LOGGER = System.getLogger(UnixDomainSocketClientConnection.class.getName());
 
     private final WebClient webClient;
+    private final long tlsGeneration;
     private final Tls tls;
     private final UnixDomainSocketAddress address;
     private final List<String> alpnId;
@@ -72,6 +73,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
 
     private UnixDomainSocketClientConnection(WebClient webClient,
                                              Tls tls,
+                                             long tlsGeneration,
                                              UnixDomainSocketAddress address,
                                              List<String> alpnId,
                                              String tlsPeerHost,
@@ -81,6 +83,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
                                              Consumer<UnixDomainSocketClientConnection> closeConsumer) {
         this.webClient = Objects.requireNonNull(webClient, "webClient");
         this.tls = Objects.requireNonNull(tls, "tls");
+        this.tlsGeneration = tlsGeneration;
         this.address = Objects.requireNonNull(address, "address");
         this.alpnId = Objects.requireNonNull(alpnId, "alpnId");
         this.tlsPeerHost = tlsPeerHost;
@@ -114,6 +117,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
                                                           Consumer<UnixDomainSocketClientConnection> closeConsumer) {
         return new UnixDomainSocketClientConnection(webClient,
                                                     tls,
+                                                    tls.generation(),
                                                     address,
                                                     tcpProtocolIds,
                                                     null,
@@ -148,6 +152,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
                                                           Consumer<UnixDomainSocketClientConnection> closeConsumer) {
         return new UnixDomainSocketClientConnection(webClient,
                                                     tls,
+                                                    tls.generation(),
                                                     address,
                                                     tcpProtocolIds,
                                                     Objects.requireNonNull(tlsPeerHost, "tlsPeerHost"),
@@ -176,8 +181,45 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
                                                           UnixDomainSocketAddress address,
                                                           Function<UnixDomainSocketClientConnection, Boolean> releaseFunction,
                                                           Consumer<UnixDomainSocketClientConnection> closeConsumer) {
+        Tls tls = connectionKey.tls();
+        return new UnixDomainSocketClientConnection(webClient,
+                                                    tls,
+                                                    tls.generation(),
+                                                    address,
+                                                    tcpProtocolIds,
+                                                    connectionKey.tlsPeerHost(),
+                                                    connectionKey.tlsPeerPort(),
+                                                    connectionKey.serverNamesOverride(),
+                                                    releaseFunction,
+                                                    closeConsumer);
+    }
+
+    /**
+     * Create a new UNIX domain socket connection from a logical connection target.
+     *
+     * @param webClient webclient, to get configuration
+     * @param connectionTarget logical connection target
+     * @param tcpProtocolIds protocol IDs for ALPN
+     * @param releaseFunction release callback
+     * @param closeConsumer close callback
+     * @return a new unconnected UNIX domain socket connection
+     */
+    @Api.Internal
+    public static UnixDomainSocketClientConnection create(WebClient webClient,
+                                                          ClientConnectionTarget connectionTarget,
+                                                          List<String> tcpProtocolIds,
+                                                          Function<UnixDomainSocketClientConnection, Boolean> releaseFunction,
+                                                          Consumer<UnixDomainSocketClientConnection> closeConsumer) {
+        ClientConnectionTarget target = Objects.requireNonNull(connectionTarget, "connectionTarget");
+        ConnectionKey connectionKey = target.connectionKey();
+        UnixDomainSocketAddress address = target.transportAddress()
+                .filter(UnixDomainSocketAddress.class::isInstance)
+                .map(UnixDomainSocketAddress.class::cast)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Connection target must contain a UNIX domain socket address"));
         return new UnixDomainSocketClientConnection(webClient,
                                                     connectionKey.tls(),
+                                                    target.tlsGeneration(),
                                                     address,
                                                     tcpProtocolIds,
                                                     connectionKey.tlsPeerHost(),
@@ -283,6 +325,7 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
      */
     @Override
     public UnixDomainSocketClientConnection connect() {
+        validateTlsGeneration();
         try {
             this.channel = SocketChannel.open(StandardProtocolFamily.UNIX);
             this.channel.connect(this.address);
@@ -326,11 +369,26 @@ public class UnixDomainSocketClientConnection implements ClientConnection {
             throw e;
         }
 
+        validateTlsGeneration();
         this.reader = DataReader.create(this.socket);
         int writeBufferSize = this.webClient.prototype().writeBufferSize();
         this.writer = new TcpClientConnection.BufferedDataWriter(this.socket, writeBufferSize);
 
         return this;
+    }
+
+    private void validateTlsGeneration() {
+        if (tlsGeneration == tls.generation()) {
+            return;
+        }
+        IllegalStateException failure =
+                new IllegalStateException("TLS configuration was reloaded during connection setup");
+        try {
+            closeResource();
+        } catch (RuntimeException | Error closeFailure) {
+            failure.addSuppressed(closeFailure);
+        }
+        throw failure;
     }
 
     private static SocketTimeoutException timeoutException(Duration readTimeout, Throwable cause, DeadlineGuard guard) {

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Isolated
@@ -45,10 +47,11 @@ class ClientConnectionTargetTest {
     private static final Tls NO_TLS = Tls.builder().enabled(false).build();
 
     @Test
-    void keepsLogicalOriginAndTlsIdentitySeparateFromDnsPeer() {
+    void keepsLogicalOriginAndTlsIdentitySeparateFromAlternativeDnsPeer() {
         AtomicInteger resolutions = new AtomicInteger();
         DnsResolver resolver = (host, lookup) -> {
             resolutions.incrementAndGet();
+            assertThat(host, is("alternative.example"));
             return InetAddress.ofLiteral("127.0.0.7");
         };
         ClientUri uri = ClientUri.create(URI.create("https://route.example:8443/path"));
@@ -61,13 +64,41 @@ class ClientConnectionTargetTest {
                                                            Proxy.noProxy());
 
         ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
-        ResolvedClientTarget resolved = target.resolve();
+        ResolvedClientTarget resolved = target.resolve("alternative.example", 7443, 17);
 
         assertThat(target.originAuthority().toString(), is("origin.example:9443"));
-        assertThat(resolved.routeAuthority().toString(), is("route.example:8443"));
+        assertThat(resolved.logicalTarget(), sameInstance(target));
+        assertThat(resolved.routeAuthority().toString(), is("alternative.example:7443"));
         assertThat(resolved.peerAddress().getAddress().getHostAddress(), is("127.0.0.7"));
+        assertThat(resolved.networkGeneration(), is(17L));
         assertThat(connectionKey.tlsPeerHost(), is("route.example"));
         assertThat(resolutions.get(), is(1));
+    }
+
+    @Test
+    void canonicalizesDefaultOriginAuthority() {
+        ClientUri uri = ClientUri.create(URI.create("https://origin.example/path"));
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientRequestHeaders noHost = ClientRequestHeaders.create(WritableHeaders.create());
+        ClientRequestHeaders defaultHost = ClientRequestHeaders.create(WritableHeaders.create());
+        defaultHost.set(HeaderNames.HOST, uri.authority());
+
+        ClientConnectionTarget noHostTarget = ClientConnectionTarget.create(connectionKey, uri, noHost);
+        ClientConnectionTarget defaultHostTarget = ClientConnectionTarget.create(connectionKey, uri, defaultHost);
+        ClientConnectionTarget reconstructedTarget = ClientConnectionTarget.create(connectionKey,
+                                                                                    uri.scheme(),
+                                                                                    noHostTarget.originAuthority(),
+                                                                                    noHostTarget.proxyRoute(),
+                                                                                    noHostTarget.tlsGeneration());
+
+        assertThat(noHostTarget.originAuthority().toString(), is("origin.example:443"));
+        assertThat(defaultHostTarget, is(noHostTarget));
+        assertThat(reconstructedTarget, is(noHostTarget));
     }
 
     @Test
@@ -90,16 +121,22 @@ class ClientConnectionTargetTest {
     @Test
     void fallsBackToUriOriginForInvalidHost() {
         ClientUri uri = ClientUri.create(URI.create("http://route.example:8080/path"));
+        ClientUri keyUri = ClientUri.create(URI.create("http://connection.example:8181/path"));
         ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
         headers.set(HeaderNames.HOST, "route.example:808a");
-        ConnectionKey connectionKey = ConnectionKey.create(uri,
+        ConnectionKey connectionKey = ConnectionKey.create(keyUri,
                                                            NO_TLS,
                                                            (_, _) -> InetAddress.getLoopbackAddress(),
                                                            DnsAddressLookup.IPV4,
                                                            Proxy.noProxy());
 
         ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
+        ClientConnectionTarget defaultTarget = ClientConnectionTarget.create(connectionKey,
+                                                                              uri,
+                                                                              ClientRequestHeaders.create(
+                                                                                      WritableHeaders.create()));
 
+        assertThat(target, is(defaultTarget));
         assertThat(target.originAuthority().toString(), is("route.example:8080"));
         assertThat(headers.get(HeaderNames.HOST).get(), is("route.example:808a"));
     }
@@ -227,6 +264,116 @@ class ClientConnectionTargetTest {
     }
 
     @Test
+    void sharesUnconditionalDirectRouteAcrossLogicalTargets() {
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        ClientUri firstUri = ClientUri.create(URI.create("https://first.example/path"));
+        ConnectionKey firstKey = ConnectionKey.create(firstUri,
+                                                       TLS,
+                                                       resolver,
+                                                       DnsAddressLookup.IPV4,
+                                                       Proxy.noProxy());
+        ClientUri secondUri = ClientUri.create(URI.create("http://second.example:8080/path"));
+        ConnectionKey secondKey = ConnectionKey.create(secondUri,
+                                                        NO_TLS,
+                                                        resolver,
+                                                        DnsAddressLookup.IPV4,
+                                                        Proxy.builder().type(Proxy.ProxyType.NONE).build());
+
+        ProxyRoute firstRoute = ClientConnectionTarget.create(
+                firstKey,
+                firstUri,
+                ClientRequestHeaders.create(WritableHeaders.create())).proxyRoute();
+        ProxyRoute secondRoute = ClientConnectionTarget.create(
+                secondKey,
+                secondUri,
+                ClientRequestHeaders.create(WritableHeaders.create())).proxyRoute();
+
+        assertThat(firstRoute.kind(), is(ProxyRoute.Kind.DIRECT));
+        assertThat(secondRoute, sameInstance(firstRoute));
+    }
+
+    @Test
+    void keepsConfiguredNoProxyRoutesTargetSpecific() {
+        ProxyRoute unconditionalRoute = Proxy.noProxy().effectiveRoute("https", "unconditional.example", 443, true);
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("first.example")
+                .addNoProxy("second.example")
+                .build();
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        ClientUri firstUri = ClientUri.create(URI.create("https://first.example/path"));
+        ConnectionKey firstKey = ConnectionKey.create(firstUri,
+                                                       TLS,
+                                                       resolver,
+                                                       DnsAddressLookup.IPV4,
+                                                       proxy);
+        ClientUri secondUri = ClientUri.create(URI.create("https://second.example/path"));
+        ConnectionKey secondKey = ConnectionKey.create(secondUri,
+                                                        TLS,
+                                                        resolver,
+                                                        DnsAddressLookup.IPV4,
+                                                        proxy);
+
+        ProxyRoute firstRoute = ClientConnectionTarget.create(
+                firstKey,
+                firstUri,
+                ClientRequestHeaders.create(WritableHeaders.create())).proxyRoute();
+        ProxyRoute secondRoute = ClientConnectionTarget.create(
+                secondKey,
+                secondUri,
+                ClientRequestHeaders.create(WritableHeaders.create())).proxyRoute();
+
+        assertThat(firstRoute.kind(), is(ProxyRoute.Kind.DIRECT));
+        assertThat(firstRoute, not(sameInstance(unconditionalRoute)));
+        assertThat(secondRoute, not(sameInstance(unconditionalRoute)));
+        assertThat(secondRoute, not(sameInstance(firstRoute)));
+        assertThat(ClientConnectionTarget.routeMatches(firstKey, firstUri.scheme(), firstRoute), is(true));
+        assertThat(ClientConnectionTarget.routeMatches(secondKey, secondUri.scheme(), firstRoute), is(false));
+    }
+
+    @Test
+    void keepsSystemDirectRoutesTargetSpecific() {
+        ProxySelector previous = ProxySelector.getDefault();
+        ProxySelector.setDefault(new FixedProxySelector(java.net.Proxy.Type.DIRECT));
+        try {
+            ProxyRoute unconditionalRoute = Proxy.noProxy().effectiveRoute("https", "unconditional.example", 443, true);
+            Proxy proxy = Proxy.create();
+            DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+            ClientUri firstUri = ClientUri.create(URI.create("https://first.example/path"));
+            ConnectionKey firstKey = ConnectionKey.create(firstUri,
+                                                           TLS,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+            ClientUri secondUri = ClientUri.create(URI.create("https://second.example/path"));
+            ConnectionKey secondKey = ConnectionKey.create(secondUri,
+                                                            TLS,
+                                                            resolver,
+                                                            DnsAddressLookup.IPV4,
+                                                            proxy);
+
+            ProxyRoute firstRoute = ClientConnectionTarget.create(
+                    firstKey,
+                    firstUri,
+                    ClientRequestHeaders.create(WritableHeaders.create())).proxyRoute();
+            ProxyRoute secondRoute = ClientConnectionTarget.create(
+                    secondKey,
+                    secondUri,
+                    ClientRequestHeaders.create(WritableHeaders.create())).proxyRoute();
+
+            assertThat(firstRoute.kind(), is(ProxyRoute.Kind.DIRECT));
+            assertThat(firstRoute, not(sameInstance(unconditionalRoute)));
+            assertThat(secondRoute, not(sameInstance(unconditionalRoute)));
+            assertThat(secondRoute, not(sameInstance(firstRoute)));
+            assertThat(ClientConnectionTarget.routeMatches(firstKey, firstUri.scheme(), firstRoute), is(true));
+            assertThat(ClientConnectionTarget.routeMatches(secondKey, secondUri.scheme(), firstRoute), is(false));
+        } finally {
+            ProxySelector.setDefault(previous);
+        }
+    }
+
+    @Test
     void selectsSystemProxyExactlyOnceForTargetSnapshot() {
         ProxySelector previous = ProxySelector.getDefault();
         AtomicInteger selections = new AtomicInteger();
@@ -327,6 +474,7 @@ class ClientConnectionTargetTest {
                                                                                             unixAddress);
 
         assertThat(target.equals(otherAuthority), is(false));
+        assertThat(otherAuthority.originAuthority().toString(), is("other.example:443"));
         assertThat(target.equals(otherGeneration), is(false));
         assertThat(target.equals(localBind), is(false));
         assertThat(target.equals(unixTarget), is(false));
@@ -533,6 +681,9 @@ class ClientConnectionTargetTest {
 
         @Override
         public List<java.net.Proxy> select(URI uri) {
+            if (type == java.net.Proxy.Type.DIRECT) {
+                return List.of(java.net.Proxy.NO_PROXY);
+            }
             return List.of(new java.net.Proxy(type,
                                               InetSocketAddress.createUnresolved("proxy.example", 8181)));
         }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
@@ -1,0 +1,544 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.UnixDomainSocketAddress;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.spi.DnsResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Isolated
+class ClientConnectionTargetTest {
+    private static final Tls TLS = Tls.builder().build();
+    private static final Tls NO_TLS = Tls.builder().enabled(false).build();
+
+    @Test
+    void keepsLogicalOriginAndTlsIdentitySeparateFromDnsPeer() {
+        AtomicInteger resolutions = new AtomicInteger();
+        DnsResolver resolver = (host, lookup) -> {
+            resolutions.incrementAndGet();
+            return InetAddress.ofLiteral("127.0.0.7");
+        };
+        ClientUri uri = ClientUri.create(URI.create("https://route.example:8443/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        headers.set(HeaderNames.HOST, "origin.example:9443");
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+
+        ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
+        ResolvedClientTarget resolved = target.resolve();
+
+        assertThat(target.originAuthority().toString(), is("origin.example:9443"));
+        assertThat(resolved.routeAuthority().toString(), is("route.example:8443"));
+        assertThat(resolved.peerAddress().getAddress().getHostAddress(), is("127.0.0.7"));
+        assertThat(connectionKey.tlsPeerHost(), is("route.example"));
+        assertThat(resolutions.get(), is(1));
+    }
+
+    @Test
+    void usesFinalAuthorityBeforeHost() {
+        ClientUri uri = ClientUri.create(URI.create("https://route.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        headers.set(HeaderNames.HOST, "host.example:8443");
+        headers.set(HeaderNames.create(":authority"), "authority.example:9443");
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           (_, _) -> InetAddress.getLoopbackAddress(),
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+
+        ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
+
+        assertThat(target.originAuthority().toString(), is("authority.example:9443"));
+    }
+
+    @Test
+    void fallsBackToUriOriginForInvalidHost() {
+        ClientUri uri = ClientUri.create(URI.create("http://route.example:8080/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        headers.set(HeaderNames.HOST, "route.example:808a");
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           NO_TLS,
+                                                           (_, _) -> InetAddress.getLoopbackAddress(),
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+
+        ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
+
+        assertThat(target.originAuthority().toString(), is("route.example:8080"));
+        assertThat(headers.get(HeaderNames.HOST).get(), is("route.example:808a"));
+    }
+
+    @Test
+    void normalizesBracketedIpv6ConnectionHost() {
+        ClientUri uri = ClientUri.create(URI.create("http://[::1]:8080/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           NO_TLS,
+                                                           (host, lookup) -> {
+                                                               assertThat(host, is("::1"));
+                                                               return InetAddress.ofLiteral("::1");
+                                                           },
+                                                           DnsAddressLookup.IPV6,
+                                                           Proxy.noProxy());
+
+        ResolvedClientTarget target = ClientConnectionTarget.create(connectionKey, uri, headers).resolve();
+
+        assertThat(connectionKey.host(), is("::1"));
+        assertThat(target.routeAuthority().toString(), is("[::1]:8080"));
+    }
+
+    @Test
+    void resolvesProxyPeerWithoutResolvingLogicalDestination() {
+        AtomicInteger resolutions = new AtomicInteger();
+        DnsResolver resolver = (host, lookup) -> {
+            resolutions.incrementAndGet();
+            assertThat(host, is("proxy.example"));
+            return InetAddress.ofLiteral("127.0.0.9");
+        };
+        Proxy proxy = Proxy.builder().host("proxy.example").port(8181).build();
+        ClientUri uri = ClientUri.create(URI.create("http://proxy-only.internal:8080/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           NO_TLS,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+
+        ResolvedClientTarget resolved = ClientConnectionTarget.create(connectionKey, uri, headers).resolve();
+
+        assertThat(resolved.proxyRoute().kind(), is(ProxyRoute.Kind.HTTP_FORWARD));
+        assertThat(resolved.peerAddress().getAddress().getHostAddress(), is("127.0.0.9"));
+        assertThat(resolved.destinationAddress().isUnresolved(), is(true));
+        assertThat(resolved.destinationAddress().getHostString(), is("proxy-only.internal"));
+        assertThat(resolutions.get(), is(1));
+    }
+
+    @Test
+    void stripsProxyHostnameFromResolvedPeer() throws IOException {
+        ProxySelector previous = ProxySelector.getDefault();
+        ProxySelector.setDefault(new FixedProxySelector(java.net.Proxy.Type.HTTP));
+        try {
+            InetAddress namedProxyAddress = InetAddress.getByAddress("proxy.example",
+                                                                    new byte[] {127, 0, 0, 9});
+            ClientUri uri = ClientUri.create(URI.create("https://origin.example/path"));
+            ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                               TLS,
+                                                               (_, _) -> namedProxyAddress,
+                                                               DnsAddressLookup.IPV4,
+                                                               Proxy.create());
+
+            ResolvedClientTarget resolved = ClientConnectionTarget.create(
+                    connectionKey,
+                    uri,
+                    ClientRequestHeaders.create(WritableHeaders.create())).resolve();
+
+            assertThat(resolved.peerAddress().getHostString(), is("127.0.0.9"));
+            assertThat(resolved.peerAddress().getAddress().getHostAddress(), is("127.0.0.9"));
+            assertThat(resolved.destinationAddress().isUnresolved(), is(true));
+        } finally {
+            ProxySelector.setDefault(previous);
+        }
+    }
+
+    @Test
+    void resolvesSystemSocksDestinationLocally() {
+        ProxySelector previous = ProxySelector.getDefault();
+        ProxySelector.setDefault(new FixedProxySelector(java.net.Proxy.Type.SOCKS));
+        try {
+            AtomicInteger resolutions = new AtomicInteger();
+            ClientUri uri = ClientUri.create(URI.create("http://origin.example/path"));
+            ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                               NO_TLS,
+                                                               (host, _) -> {
+                                                                   resolutions.incrementAndGet();
+                                                                   return "proxy.example".equals(host)
+                                                                           ? InetAddress.ofLiteral("127.0.0.9")
+                                                                           : InetAddress.ofLiteral("127.0.0.7");
+                                                               },
+                                                               DnsAddressLookup.IPV4,
+                                                               Proxy.create());
+
+            ResolvedClientTarget resolved = ClientConnectionTarget.create(
+                    connectionKey,
+                    uri,
+                    ClientRequestHeaders.create(WritableHeaders.create())).resolve();
+
+            assertThat(resolved.proxyRoute().kind(), is(ProxyRoute.Kind.SOCKS));
+            assertThat(resolved.destinationAddress().isUnresolved(), is(false));
+            assertThat(resolved.destinationAddress().getAddress().getHostAddress(), is("127.0.0.7"));
+            assertThat(resolutions.get(), is(2));
+        } finally {
+            ProxySelector.setDefault(previous);
+        }
+    }
+
+    @Test
+    void configuredProxyRouteReflectsActualCapability() {
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("direct.example")
+                .build();
+
+        ProxyRoute direct = proxy.effectiveRoute("https", "direct.example", 443, true);
+        ProxyRoute tunnel = proxy.effectiveRoute("https", "origin.example", 443, true);
+
+        assertThat(direct.kind(), is(ProxyRoute.Kind.DIRECT));
+        assertThat(direct.supportsDatagrams(), is(true));
+        assertThat(tunnel.kind(), is(ProxyRoute.Kind.HTTP_TUNNEL));
+        assertThat(tunnel.forwardProxy(), is(false));
+        assertThat(tunnel.supportsDatagrams(), is(false));
+    }
+
+    @Test
+    void selectsSystemProxyExactlyOnceForTargetSnapshot() {
+        ProxySelector previous = ProxySelector.getDefault();
+        AtomicInteger selections = new AtomicInteger();
+        ProxySelector.setDefault(new ProxySelector() {
+            @Override
+            public List<java.net.Proxy> select(URI uri) {
+                selections.incrementAndGet();
+                return List.of(new java.net.Proxy(java.net.Proxy.Type.HTTP,
+                                                  InetSocketAddress.createUnresolved("proxy.example", 8181)));
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+            }
+        });
+        try {
+            ClientUri uri = ClientUri.create(URI.create("https://origin.example/path"));
+            ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                               TLS,
+                                                               (_, _) -> InetAddress.getLoopbackAddress(),
+                                                               DnsAddressLookup.IPV4,
+                                                               Proxy.create());
+
+            ClientConnectionTarget target = ClientConnectionTarget.create(
+                    connectionKey,
+                    uri,
+                    ClientRequestHeaders.create(WritableHeaders.create()));
+            ResolvedClientTarget resolved = target.resolve();
+
+            assertThat(resolved.proxyRoute().kind(), is(ProxyRoute.Kind.HTTP_TUNNEL));
+            assertThat(selections.get(), is(1));
+        } finally {
+            ProxySelector.setDefault(previous);
+        }
+    }
+
+    @Test
+    void forceConnectParticipatesInProxyPolicyIdentity() {
+        Proxy forwardProxy = Proxy.builder().host("proxy.example").port(8181).build();
+        Proxy tunnelProxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .forceHttpConnect(true)
+                .build();
+
+        assertThat(forwardProxy.equals(tunnelProxy), is(false));
+        assertThat(forwardProxy.effectiveRoute("http", "origin.example", 80, false).kind(),
+                   is(ProxyRoute.Kind.HTTP_FORWARD));
+        assertThat(tunnelProxy.effectiveRoute("http", "origin.example", 80, false).kind(),
+                   is(ProxyRoute.Kind.HTTP_TUNNEL));
+    }
+
+    @Test
+    void partitionsConnectionCacheIdentity() {
+        ClientUri uri = ClientUri.create(URI.create("https://origin.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
+        ClientConnectionTarget sameTarget = ClientConnectionTarget.create(connectionKey, uri, headers);
+
+        assertThat(target.equals(sameTarget), is(true));
+        assertThat(target.hashCode(), is(sameTarget.hashCode()));
+
+        ClientRequestHeaders otherAuthorityHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        otherAuthorityHeaders.set(HeaderNames.HOST, "other.example");
+        ClientConnectionTarget otherAuthority = ClientConnectionTarget.create(connectionKey,
+                                                                               uri,
+                                                                               otherAuthorityHeaders);
+        ClientConnectionTarget otherGeneration = ClientConnectionTarget.create(connectionKey,
+                                                                                 target.scheme(),
+                                                                                 target.originAuthority(),
+                                                                                 target.proxyRoute(),
+                                                                                 target.tlsGeneration() + 1);
+        ClientConnectionTarget localBind = ClientConnectionTarget.create(connectionKey,
+                                                                          target.scheme(),
+                                                                          target.originAuthority(),
+                                                                          target.proxyRoute(),
+                                                                          new InetSocketAddress(InetAddress
+                                                                                                        .getLoopbackAddress(),
+                                                                                                0),
+                                                                          target.tlsGeneration());
+        UnixDomainSocketAddress unixAddress = UnixDomainSocketAddress.of("target.sock");
+        ConnectionKey unixKey = ConnectionKey.createUnixDomainSocket("https",
+                                                                      "origin.example",
+                                                                      443,
+                                                                      TLS,
+                                                                      resolver,
+                                                                      DnsAddressLookup.IPV4,
+                                                                      unixAddress);
+        ClientConnectionTarget unixTarget = ClientConnectionTarget.createUnixDomainSocket(unixKey,
+                                                                                            uri,
+                                                                                            headers,
+                                                                                            unixAddress);
+
+        assertThat(target.equals(otherAuthority), is(false));
+        assertThat(target.equals(otherGeneration), is(false));
+        assertThat(target.equals(localBind), is(false));
+        assertThat(target.equals(unixTarget), is(false));
+        assertThrows(IllegalStateException.class, unixTarget::resolve);
+    }
+
+    @Test
+    void partitionsEquivalentTlsInstancesByIdentity() {
+        ClientUri uri = ClientUri.create(URI.create("http://origin.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        ConnectionKey firstKey = ConnectionKey.create(uri,
+                                                      Tls.builder().enabled(false).build(),
+                                                      resolver,
+                                                      DnsAddressLookup.IPV4,
+                                                      Proxy.noProxy());
+        ConnectionKey secondKey = ConnectionKey.create(uri,
+                                                       Tls.builder().enabled(false).build(),
+                                                       resolver,
+                                                       DnsAddressLookup.IPV4,
+                                                       Proxy.noProxy());
+
+        ClientConnectionTarget first = ClientConnectionTarget.create(firstKey, uri, headers);
+        ClientConnectionTarget second = ClientConnectionTarget.create(secondKey, uri, headers);
+
+        assertThat(firstKey.equals(secondKey), is(true));
+        assertThat(first.equals(second), is(false));
+    }
+
+    @Test
+    void rejectsResolutionAfterTlsReload() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientUri uri = ClientUri.create(URI.create("https://origin.example/path"));
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           tls,
+                                                           (_, _) -> {
+                                                               resolutions.incrementAndGet();
+                                                               return InetAddress.getLoopbackAddress();
+                                                           },
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientConnectionTarget target = ClientConnectionTarget.create(
+                connectionKey,
+                uri,
+                ClientRequestHeaders.create(WritableHeaders.create()));
+
+        tls.reload(TlsMaterial.builder().trustAll(true).build());
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, target::resolve);
+        assertThat(failure.getMessage(), is("TLS configuration was reloaded before target resolution"));
+        assertThat(resolutions.get(), is(0));
+    }
+
+    @Test
+    void reselectsRouteWhenLogicalTargetChanges() {
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("first.example")
+                .build();
+        ClientUri firstUri = ClientUri.create(URI.create("https://first.example/path"));
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        ConnectionKey firstKey = ConnectionKey.create(firstUri,
+                                                       TLS,
+                                                       resolver,
+                                                       DnsAddressLookup.IPV4,
+                                                       proxy);
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        ProxyRoute firstRoute = ClientConnectionTarget.create(firstKey, firstUri, headers).proxyRoute();
+
+        ClientUri secondUri = ClientUri.create(URI.create("https://second.example/path"));
+        ConnectionKey secondKey = ConnectionKey.create(secondUri,
+                                                        TLS,
+                                                        resolver,
+                                                        DnsAddressLookup.IPV4,
+                                                        proxy);
+        ClientConnectionTarget secondTarget = ClientConnectionTarget.create(secondKey,
+                                                                             secondUri,
+                                                                             headers,
+                                                                             firstRoute);
+
+        assertThat(firstRoute.kind(), is(ProxyRoute.Kind.DIRECT));
+        assertThat(secondTarget.proxyRoute().kind(), is(ProxyRoute.Kind.HTTP_TUNNEL));
+    }
+
+    @Test
+    void resolvesHostnameToMatchIpNoProxyRule() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        ClientUri uri = ClientUri.create(URI.create("https://hostname.example/path"));
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           (_, _) -> {
+                                                               return resolutions.getAndIncrement() == 0
+                                                                       ? InetAddress.ofLiteral("127.0.0.1")
+                                                                       : InetAddress.ofLiteral("127.0.0.2");
+                                                           },
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+
+        ClientConnectionTarget target = ClientConnectionTarget.create(
+                connectionKey,
+                uri,
+                ClientRequestHeaders.create(WritableHeaders.create()));
+        ResolvedClientTarget resolved = target.resolve();
+
+        assertThat(target.proxyRoute().kind(), is(ProxyRoute.Kind.DIRECT));
+        assertThat(resolved.peerAddress().getAddress(), is(InetAddress.ofLiteral("127.0.0.1")));
+        assertThat(resolutions.get(), is(1));
+    }
+
+    @Test
+    void noProxyResolutionDoesNotPartitionLogicalTargetIdentity() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .addNoProxy("127.0.0.2")
+                .build();
+        ClientUri uri = ClientUri.create(URI.create("https://hostname.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        DnsResolver resolver = (_, _) -> resolutions.getAndIncrement() == 0
+                ? InetAddress.ofLiteral("127.0.0.1")
+                : InetAddress.ofLiteral("127.0.0.2");
+        ConnectionKey firstKey = ConnectionKey.create(uri,
+                                                      TLS,
+                                                      resolver,
+                                                      DnsAddressLookup.IPV4,
+                                                      proxy);
+        ConnectionKey secondKey = ConnectionKey.create(uri,
+                                                       TLS,
+                                                       resolver,
+                                                       DnsAddressLookup.IPV4,
+                                                       proxy);
+
+        ClientConnectionTarget first = ClientConnectionTarget.create(firstKey, uri, headers);
+        ClientConnectionTarget second = ClientConnectionTarget.create(secondKey, uri, headers);
+
+        assertThat(first, is(second));
+        assertThat(first.hashCode(), is(second.hashCode()));
+        assertThat(first.resolve().peerAddress().getAddress(), is(InetAddress.ofLiteral("127.0.0.1")));
+        assertThat(second.resolve().peerAddress().getAddress(), is(InetAddress.ofLiteral("127.0.0.2")));
+        assertThat(resolutions.get(), is(2));
+    }
+
+    @Test
+    void bindsLiteralIpNoProxyRouteWithoutDns() {
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        ClientUri uri = ClientUri.create(URI.create("http://127.0.0.1/path"));
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           NO_TLS,
+                                                           (_, _) -> {
+                                                               throw new AssertionError("DNS must not resolve an IP literal");
+                                                           },
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+
+        ClientConnectionTarget target = ClientConnectionTarget.create(
+                connectionKey,
+                uri,
+                ClientRequestHeaders.create(WritableHeaders.create()));
+
+        assertThat(target.resolve().peerAddress().getAddress(), is(InetAddress.ofLiteral("127.0.0.1")));
+    }
+
+    @Test
+    void rejectsAlternativeAuthorityForAddressBoundNoProxyRoute() {
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        ClientUri uri = ClientUri.create(URI.create("https://hostname.example/path"));
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           (_, _) -> InetAddress.ofLiteral("127.0.0.1"),
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+        ClientConnectionTarget target = ClientConnectionTarget.create(
+                connectionKey,
+                uri,
+                ClientRequestHeaders.create(WritableHeaders.create()));
+
+        assertThrows(IllegalArgumentException.class, () -> target.resolve("alternative.example", 443, 0));
+        assertThrows(IllegalArgumentException.class, () -> target.resolve("hostname.example", 8443, 0));
+    }
+
+    private static final class FixedProxySelector extends ProxySelector {
+        private final java.net.Proxy.Type type;
+
+        private FixedProxySelector(java.net.Proxy.Type type) {
+            this.type = type;
+        }
+
+        @Override
+        public List<java.net.Proxy> select(URI uri) {
+            return List.of(new java.net.Proxy(type,
+                                              InetSocketAddress.createUnresolved("proxy.example", 8181)));
+        }
+
+        @Override
+        public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+        }
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
@@ -142,22 +143,67 @@ class ClientConnectionTargetTest {
     }
 
     @Test
-    void normalizesBracketedIpv6ConnectionHost() {
+    void preservesBracketedIpv6ConnectionHostWhileRoutingWithNormalizedHost() {
         ClientUri uri = ClientUri.create(URI.create("http://[::1]:8080/path"));
         ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
-        ConnectionKey connectionKey = ConnectionKey.create(uri,
+        DnsResolver resolver = (host, lookup) -> {
+            assertThat(host, is("::1"));
+            return InetAddress.ofLiteral("::1");
+        };
+        ConnectionKey connectionKey = ConnectionKey.create("http",
+                                                           "[0:0:0:0:0:0:0:1]",
+                                                           8080,
                                                            NO_TLS,
-                                                           (host, lookup) -> {
-                                                               assertThat(host, is("::1"));
-                                                               return InetAddress.ofLiteral("::1");
-                                                           },
+                                                           resolver,
                                                            DnsAddressLookup.IPV6,
                                                            Proxy.noProxy());
+        ConnectionKey unbracketed = ConnectionKey.create("http",
+                                                         "0:0:0:0:0:0:0:1",
+                                                         8080,
+                                                         NO_TLS,
+                                                         resolver,
+                                                         DnsAddressLookup.IPV6,
+                                                         Proxy.noProxy());
 
         ResolvedClientTarget target = ClientConnectionTarget.create(connectionKey, uri, headers).resolve();
 
-        assertThat(connectionKey.host(), is("::1"));
+        assertThat(connectionKey.host(), is("[0:0:0:0:0:0:0:1]"));
+        assertThat(connectionKey, not(unbracketed));
+        assertThat(connectionKey.toString(), containsString("host=[0:0:0:0:0:0:0:1]"));
         assertThat(target.routeAuthority().toString(), is("[::1]:8080"));
+    }
+
+    @Test
+    void retainedRouteUsesNormalizedBracketedIpv6Host() {
+        ClientUri uri = ClientUri.create(URI.create("http://[::1]:8080/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        DnsResolver resolver = (host, lookup) -> {
+            assertThat(host, is("::1"));
+            return InetAddress.ofLiteral("::1");
+        };
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("::1")
+                .build();
+        ConnectionKey connectionKey = ConnectionKey.create("http",
+                                                           "[::1]",
+                                                           8080,
+                                                           NO_TLS,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV6,
+                                                           proxy);
+
+        ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
+        ClientConnectionTarget retained = ClientConnectionTarget.create(connectionKey,
+                                                                         uri,
+                                                                         headers,
+                                                                         target.proxyRoute());
+
+        assertThat(target.proxyRoute().kind(), is(ProxyRoute.Kind.DIRECT));
+        assertThat(ClientConnectionTarget.routeMatches(connectionKey, "http", target.proxyRoute()), is(true));
+        assertThat(retained.proxyRoute(), sameInstance(target.proxyRoute()));
+        assertThat(retained.resolve().routeAuthority().toString(), is("[::1]:8080"));
     }
 
     @Test

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
@@ -103,6 +103,34 @@ class ClientConnectionTargetTest {
     }
 
     @Test
+    void defaultDirectResolutionPreservesResolvedTargetValue() {
+        InetAddress peer = InetAddress.ofLiteral("127.0.0.7");
+        ConnectionKey connectionKey = ConnectionKey.create("http",
+                                                           "Origin.Example.",
+                                                           80,
+                                                           NO_TLS,
+                                                           (host, _) -> {
+                                                               assertThat(host, is("Origin.Example."));
+                                                               return peer;
+                                                           },
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, "http");
+
+        ResolvedClientTarget resolved = target.resolve();
+        ResolvedClientTarget explicit = ResolvedClientTarget.direct(target,
+                                                                    target.originAuthority(),
+                                                                    new InetSocketAddress(peer, 80),
+                                                                    0);
+
+        assertThat(resolved, is(explicit));
+        assertThat(resolved.hashCode(), is(explicit.hashCode()));
+        assertThat(resolved.routeAuthority().toString(), is("origin.example:80"));
+        assertThat(resolved.destinationAddress().isUnresolved(), is(true));
+        assertThat(resolved.destinationAddress().getHostString(), is("origin.example"));
+    }
+
+    @Test
     void usesFinalAuthorityBeforeHost() {
         ClientUri uri = ClientUri.create(URI.create("https://route.example/path"));
         ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
@@ -567,11 +567,13 @@ class ClientConnectionTargetTest {
                 connectionKey,
                 uri,
                 ClientRequestHeaders.create(WritableHeaders.create()));
+        ClientConnectionTarget.LookupKey lookupKey = target.lookupKey();
 
         tls.reload(TlsMaterial.builder().trustAll(true).build());
 
         IllegalStateException failure = assertThrows(IllegalStateException.class, target::resolve);
         assertThat(failure.getMessage(), is("TLS configuration was reloaded before target resolution"));
+        assertThat(lookupKey.currentTlsGeneration(), is(false));
         assertThat(resolutions.get(), is(0));
     }
 
@@ -605,6 +607,160 @@ class ClientConnectionTargetTest {
 
         assertThat(firstRoute.kind(), is(ProxyRoute.Kind.DIRECT));
         assertThat(secondTarget.proxyRoute().kind(), is(ProxyRoute.Kind.HTTP_TUNNEL));
+    }
+
+    @Test
+    void createsLookupKeyWithoutDns() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        ClientUri uri = ClientUri.create(URI.create("https://hostname.example/path"));
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           (_, _) -> {
+                                                               resolutions.incrementAndGet();
+                                                               return InetAddress.ofLiteral("127.0.0.1");
+                                                           },
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        headers.set(HeaderNames.HOST, "hostname.example");
+
+        ClientConnectionTarget.LookupKey uriKey = ClientConnectionTarget.lookupKey(connectionKey, uri, headers);
+        ClientConnectionTarget.LookupKey schemeKey = ClientConnectionTarget.lookupKey(connectionKey, "HTTPS");
+
+        assertThat(proxy.ipNoProxyConfigured(), is(true));
+        assertThat(Proxy.builder()
+                           .type(Proxy.ProxyType.NONE)
+                           .addNoProxy("127.0.0.1")
+                           .build()
+                           .ipNoProxyConfigured(), is(false));
+        assertThat(uriKey.currentTlsGeneration(), is(true));
+        assertThat(uriKey, is(schemeKey));
+        assertThat(uriKey.hashCode(), is(schemeKey.hashCode()));
+        assertThat(resolutions.get(), is(0));
+    }
+
+    @Test
+    void lookupKeyIgnoresSelectedProxyRoute() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        ClientUri uri = ClientUri.create(URI.create("https://hostname.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           (_, _) -> resolutions.getAndIncrement() == 0
+                                                                   ? InetAddress.ofLiteral("127.0.0.1")
+                                                                   : InetAddress.ofLiteral("127.0.0.2"),
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+
+        ClientConnectionTarget direct = ClientConnectionTarget.create(connectionKey, uri, headers);
+        ClientConnectionTarget proxied = ClientConnectionTarget.create(connectionKey, uri, headers);
+
+        assertThat(direct.proxyRoute().kind(), is(ProxyRoute.Kind.DIRECT));
+        assertThat(proxied.proxyRoute().kind(), is(ProxyRoute.Kind.HTTP_TUNNEL));
+        assertThat(direct, not(proxied));
+        assertThat(direct.lookupKey(), is(proxied.lookupKey()));
+        assertThat(direct.lookupKey().hashCode(), is(proxied.lookupKey().hashCode()));
+        assertThat(resolutions.get(), is(2));
+    }
+
+    @Test
+    void partitionsLookupKeyIdentity() {
+        ClientUri uri = ClientUri.create(URI.create("http://origin.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        Tls firstTls = Tls.builder().enabled(false).build();
+        Tls secondTls = Tls.builder().enabled(false).build();
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           firstTls,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ConnectionKey equivalentKey = ConnectionKey.create(uri,
+                                                           secondTls,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
+        ClientConnectionTarget.LookupKey lookupKey = target.lookupKey();
+
+        ClientRequestHeaders otherAuthorityHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        otherAuthorityHeaders.set(HeaderNames.HOST, "other.example");
+        ClientConnectionTarget.LookupKey otherAuthority = ClientConnectionTarget.lookupKey(connectionKey,
+                                                                                            uri,
+                                                                                            otherAuthorityHeaders);
+        ClientConnectionTarget.LookupKey otherScheme = ClientConnectionTarget.lookupKey(connectionKey, "https");
+        ClientConnectionTarget.LookupKey otherGeneration = ClientConnectionTarget.create(connectionKey,
+                                                                                           target.scheme(),
+                                                                                           target.originAuthority(),
+                                                                                           target.proxyRoute(),
+                                                                                           target.tlsGeneration() + 1)
+                .lookupKey();
+        ClientConnectionTarget.LookupKey localBind = ClientConnectionTarget.create(
+                connectionKey,
+                target.scheme(),
+                target.originAuthority(),
+                target.proxyRoute(),
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
+                target.tlsGeneration()).lookupKey();
+        UnixDomainSocketAddress unixAddress = UnixDomainSocketAddress.of("target.sock");
+        ClientConnectionTarget.LookupKey transportOverride = ClientConnectionTarget.createUnixDomainSocket(
+                connectionKey,
+                uri,
+                headers,
+                unixAddress)
+                .lookupKey();
+        ClientConnectionTarget.LookupKey otherTlsIdentity = ClientConnectionTarget.lookupKey(equivalentKey,
+                                                                                              uri,
+                                                                                              headers);
+
+        assertThat(connectionKey, is(equivalentKey));
+        assertThat(lookupKey, is(ClientConnectionTarget.lookupKey(connectionKey, "HTTP")));
+        assertThat(lookupKey, not(otherAuthority));
+        assertThat(lookupKey, not(otherScheme));
+        assertThat(lookupKey, not(otherGeneration));
+        assertThat(lookupKey, not(localBind));
+        assertThat(lookupKey, not(transportOverride));
+        assertThat(lookupKey, not(otherTlsIdentity));
+    }
+
+    @Test
+    void createsTargetFromLookupKeyOnCacheMiss() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        ClientUri uri = ClientUri.create(URI.create("https://hostname.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        headers.set(HeaderNames.HOST, "origin.example:9443");
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           TLS,
+                                                           (_, _) -> {
+                                                               resolutions.incrementAndGet();
+                                                               return InetAddress.ofLiteral("127.0.0.1");
+                                                           },
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+        ClientConnectionTarget.LookupKey lookupKey = ClientConnectionTarget.lookupKey(connectionKey, uri, headers);
+
+        ClientConnectionTarget target = ClientConnectionTarget.create(lookupKey);
+
+        assertThat(target.lookupKey(), is(lookupKey));
+        assertThat(target.originAuthority().toString(), is("origin.example:9443"));
+        assertThat(target.proxyRoute().kind(), is(ProxyRoute.Kind.DIRECT));
+        assertThat(target.resolve().peerAddress().getAddress(), is(InetAddress.ofLiteral("127.0.0.1")));
+        assertThat(resolutions.get(), is(1));
     }
 
     @Test

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -19,6 +19,7 @@ package io.helidon.webclient.api;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -487,8 +488,50 @@ class ClientRequestBaseTest {
         assertThat(second.query().all("request"), is(List.of("value")));
     }
 
+    @Test
+    void selectedProxyRouteIsScopedToOneRequestInvocation() {
+        Proxy proxy = Proxy.builder().host("proxy.example").port(8181).build();
+        TestRequest request = new TestRequest(HttpClientConfig.builder().proxy(proxy).build(),
+                                              Method.GET,
+                                              "http://service.example");
+        ProxyRoute route = proxy.effectiveRoute("http", "service.example", 80, false);
+        request.selectedProxyRoute(route);
+
+        request.request();
+
+        assertThat(request.routeSeenByEndpoint, is(route));
+        assertThat(request.selectedProxyRoute(), is(Optional.empty()));
+    }
+
+    @Test
+    void selectedProxyRouteIsClearedWhenInvocationFails() {
+        Proxy proxy = Proxy.builder().host("proxy.example").port(8181).build();
+        TestRequest request = new TestRequest(HttpClientConfig.builder().proxy(proxy).build(),
+                                              Method.HEAD,
+                                              "http://service.example");
+        request.selectedProxyRoute(proxy.effectiveRoute("http", "service.example", 80, false));
+
+        assertThrows(IllegalArgumentException.class, () -> request.submit("entity"));
+
+        assertThat(request.selectedProxyRoute(), is(Optional.empty()));
+    }
+
+    @Test
+    void changingProxyClearsSelectedProxyRoute() {
+        Proxy first = Proxy.builder().host("first.example").port(8181).build();
+        TestRequest request = new TestRequest(HttpClientConfig.builder().proxy(first).build(),
+                                              Method.GET,
+                                              "http://service.example");
+        request.selectedProxyRoute(first.effectiveRoute("http", "service.example", 80, false));
+
+        request.proxy(Proxy.builder().host("second.example").port(8282).build());
+
+        assertThat(request.selectedProxyRoute(), is(Optional.empty()));
+    }
+
     private static final class TestRequest extends ClientRequestBase<TestRequest, HttpClientResponse> {
         private final AtomicInteger endpointCount = new AtomicInteger();
+        private ProxyRoute routeSeenByEndpoint;
 
         private TestRequest(Method method, String uri) {
             this(HttpClientConfig.builder().build(), method, uri);
@@ -516,6 +559,7 @@ class ClientRequestBaseTest {
         }
 
         private void invokeEndpoint() {
+            routeSeenByEndpoint = selectedProxyRoute().orElse(null);
             CompletableFuture<WebClientServiceRequest> whenSent = new CompletableFuture<>();
             CompletableFuture<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
             invokeServices(endpoint(), whenSent, whenComplete, resolvedUri());

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ConnectionKeySniTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ConnectionKeySniTest.java
@@ -241,6 +241,42 @@ class ConnectionKeySniTest {
     }
 
     @Test
+    void rawIpv6HostTextRemainsConnectionIdentity() {
+        SniConfig sni = explicit("service.example");
+        ClientRequestHeaders headers = emptyHeaders();
+        ClientUri compact = ClientUri.create()
+                .scheme("https")
+                .host("[::1]")
+                .port(443);
+        ClientUri expanded = ClientUri.create()
+                .scheme("https")
+                .host("[0:0:0:0:0:0:0:1]")
+                .port(443);
+        ConnectionKey compactKey = ConnectionKey.create(compact,
+                                                         sni,
+                                                         TLS,
+                                                         DNS_RESOLVER,
+                                                         DNS_LOOKUP,
+                                                         NO_PROXY,
+                                                         headers);
+        ConnectionKey expandedKey = ConnectionKey.create(expanded,
+                                                          sni,
+                                                          TLS,
+                                                          DNS_RESOLVER,
+                                                          DNS_LOOKUP,
+                                                          NO_PROXY,
+                                                          headers);
+
+        assertThat(compactKey.host(), is("[::1]"));
+        assertThat(expandedKey.host(), is("[0:0:0:0:0:0:0:1]"));
+        assertThat(compactKey.routingHost(), is("::1"));
+        assertThat(expandedKey.routingHost(), is("::1"));
+        assertThat(compactKey.tlsPeerHost(), is("service.example"));
+        assertThat(expandedKey.tlsPeerHost(), is("service.example"));
+        assertThat(compactKey, not(expandedKey));
+    }
+
+    @Test
     void rawTlsServerNamesRemainConfiguredWhenNoSniConfigIsPresent() {
         SSLParameters parameters = new SSLParameters();
         parameters.setServerNames(List.of(new SNIHostName("configured.example")));

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -240,6 +240,13 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         effectiveConnection = suppliedConnection == null
                 ? obtainConnection(connectionTarget, connectionLookupKey, headers, udsAddress)
                 : suppliedConnection;
+        if (connectionLookupKey != null) {
+            TcpClientConnection tcpConnection = (TcpClientConnection) effectiveConnection;
+            ProxyRoute acquiredRoute = tcpConnection.resolvedTarget()
+                    .orElseThrow()
+                    .proxyRoute();
+            originalRequest.selectedProxyRoute(acquiredRoute);
+        }
         effectiveConnection.readTimeout(this.timeout);
 
         DataWriter writer = effectiveConnection.writer();

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -51,6 +51,7 @@ import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.http1.Http1ConnectionListener;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.ClientConnectionTarget;
+import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.HttpClientConfig;
@@ -79,6 +80,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     private final Http1ConnectionListener recvListener;
 
     private ClientConnection effectiveConnection;
+    private boolean forwardProxy;
 
     Http1CallChainBase(Http1ClientImpl http1Client,
                        Http1ClientRequestImpl clientRequest,
@@ -136,20 +138,32 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     }
 
     static void writeHeaders(ClientConnection connection,
-                             Headers headers,
+                             WritableHeaders<?> headers,
                              BufferData bufferData,
+                             boolean addProxyConnection,
                              boolean validate,
                              Http1ConnectionListener sendListener) {
-        for (Header header : headers) {
-            if (validate) {
-                header.validate();
-            }
-            header.writeHttp1Header(bufferData);
+        boolean addedProxyConnection = addProxyConnection
+                && !headers.contains(ClientRequestBase.PROXY_CONNECTION.headerName());
+        if (addedProxyConnection) {
+            headers.set(ClientRequestBase.PROXY_CONNECTION);
         }
-        bufferData.write(Bytes.CR_BYTE);
-        bufferData.write(Bytes.LF_BYTE);
+        try {
+            for (Header header : headers) {
+                if (validate) {
+                    header.validate();
+                }
+                header.writeHttp1Header(bufferData);
+            }
+            bufferData.write(Bytes.CR_BYTE);
+            bufferData.write(Bytes.LF_BYTE);
 
-        sendListener.headers(connection.helidonSocket(), headers);
+            sendListener.headers(connection.helidonSocket(), headers);
+        } finally {
+            if (addedProxyConnection) {
+                headers.remove(ClientRequestBase.PROXY_CONNECTION.headerName());
+            }
+        }
     }
 
     @Override
@@ -247,6 +261,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                   BufferData nonEntityData,
                   WebClientServiceRequest request,
                   ClientUri uri) {
+        forwardProxy = false;
         if (request.method() == Method.CONNECT) {
             // When CONNECT, the first line contains the remote host:port, in the same way as the HOST header.
             nonEntityData.writeAscii(request.method().text()
@@ -258,7 +273,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html which states: "The absoluteURI form is REQUIRED when the
             // request is being made to a proxy."
             String absoluteUri = uri.scheme() + "://" + uri.host() + ":" + uri.port();
-            boolean forwardProxy = effectiveConnection instanceof TcpClientConnection tcpConnection
+            forwardProxy = effectiveConnection instanceof TcpClientConnection tcpConnection
                     ? tcpConnection.resolvedTarget()
                             .map(target -> target.proxyRoute().forwardProxy())
                             .orElse(false)
@@ -330,6 +345,10 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
 
     Http1ConnectionListener sendListener() {
         return sendListener;
+    }
+
+    boolean forwardProxy() {
+        return forwardProxy;
     }
 
     ResponseHead readResponseHead(ClientConnection connection, DataReader reader) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -49,9 +50,13 @@ import io.helidon.http.encoding.ContentDecoder;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.http1.Http1ConnectionListener;
 import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.HttpClientConfig;
 import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.ProxyRoute;
+import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
@@ -156,8 +161,55 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         originalRequest.sanitizeRedirectHeaders(uri, headers);
         headers.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
 
+        var address = originalRequest.address();
+        UnixDomainSocketAddress udsAddress = address.filter(a -> a instanceof UnixDomainSocketAddress)
+                .map(UnixDomainSocketAddress.class::cast)
+                .orElse(null);
+        ClientConnectionTarget connectionTarget = null;
+        ClientConnection suppliedConnection = connection;
+        if (connection != null) {
+            ConnectionKey connectionKey = Http1ConnectionCache.connectionKey(originalRequest,
+                                                                              uri,
+                                                                              headers,
+                                                                              http1Client.clientConfig());
+            originalRequest.clearSelectedProxyRoute();
+            Optional<ProxyRoute> matchingRoute = ClientConnectionTarget.matchingRoute(connection,
+                                                                                      connectionKey,
+                                                                                      uri,
+                                                                                      headers);
+            matchingRoute.ifPresent(originalRequest::selectedProxyRoute);
+            if (originalRequest.ownsExplicitConnection() && matchingRoute.isEmpty()) {
+                originalRequest.clearConnection();
+                suppliedConnection.closeResource();
+                suppliedConnection = null;
+            }
+        }
+        if (suppliedConnection == null && udsAddress == null) {
+            ConnectionKey connectionKey = Http1ConnectionCache.connectionKey(originalRequest,
+                                                                              uri,
+                                                                              headers,
+                                                                              http1Client.clientConfig());
+            connectionTarget = originalRequest.selectedProxyRoute()
+                    .map(route -> ClientConnectionTarget.create(connectionKey, uri, headers, route))
+                    .orElseGet(() -> ClientConnectionTarget.create(connectionKey, uri, headers));
+            originalRequest.selectedProxyRoute(connectionTarget.proxyRoute());
+        } else if (suppliedConnection == null) {
+            ConnectionKey connectionKey = Http1ConnectionCache.unixConnectionKey(originalRequest,
+                                                                                  uri,
+                                                                                  headers,
+                                                                                  udsAddress,
+                                                                                  http1Client.clientConfig());
+            connectionTarget = ClientConnectionTarget.createUnixDomainSocket(connectionKey,
+                                                                               uri,
+                                                                               headers,
+                                                                               udsAddress);
+            originalRequest.clearSelectedProxyRoute();
+        }
+
         // either use the explicit connection, or obtain one (keep alive or one-off)
-        effectiveConnection = connection == null ? obtainConnection(serviceRequest) : connection;
+        effectiveConnection = suppliedConnection == null
+                ? obtainConnection(connectionTarget, headers, udsAddress)
+                : suppliedConnection;
         effectiveConnection.readTimeout(this.timeout);
 
         DataWriter writer = effectiveConnection.writer();
@@ -190,14 +242,15 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html which states: "The absoluteURI form is REQUIRED when the
             // request is being made to a proxy."
             String absoluteUri = uri.scheme() + "://" + uri.host() + ":" + uri.port();
-            String requestUri = proxy == Proxy.noProxy()
-                    || (
-                    proxy.type() == Proxy.ProxyType.HTTP
-                            && proxy.isNoHosts(new InetSocketAddress(uri.host(), uri.port())))
-                    || (proxy.type() == Proxy.ProxyType.SYSTEM && !proxy.isUsingSystemProxy(absoluteUri))
-                    || clientConfig.relativeUris()
-                    ? "" // don't set host details, so it becomes relative URI
-                    : absoluteUri;
+            boolean forwardProxy = effectiveConnection instanceof TcpClientConnection tcpConnection
+                    ? tcpConnection.resolvedTarget()
+                            .map(target -> target.proxyRoute().forwardProxy())
+                            .orElse(false)
+                    : proxy != Proxy.noProxy()
+                            && !(proxy.type() == Proxy.ProxyType.HTTP
+                                    && proxy.isNoHosts(new InetSocketAddress(uri.host(), uri.port())))
+                            && !(proxy.type() == Proxy.ProxyType.SYSTEM && !proxy.isUsingSystemProxy(absoluteUri));
+            String requestUri = forwardProxy && !clientConfig.relativeUris() ? absoluteUri : "";
             nonEntityData.writeAscii(request.method().text()
                                              + " "
                                              + requestUri
@@ -437,25 +490,20 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         }
     }
 
-    private ClientConnection obtainConnection(WebClientServiceRequest request) {
-        var address = originalRequest.address();
-        UnixDomainSocketAddress udsAddress = address.filter(a -> a instanceof UnixDomainSocketAddress)
-                .map(UnixDomainSocketAddress.class::cast)
-                .orElse(null);
-
+    private ClientConnection obtainConnection(ClientConnectionTarget connectionTarget,
+                                              ClientRequestHeaders headers,
+                                              UnixDomainSocketAddress udsAddress) {
         if (udsAddress == null) {
             return http1Client.connectionCache()
                     .connection(http1Client,
-                                originalRequest,
-                                request.uri(),
-                                request.headers(),
+                                connectionTarget,
+                                headers,
                                 keepAlive);
         } else {
             return http1Client.connectionCache()
                     .connection(http1Client,
-                                originalRequest,
-                                request.uri(),
-                                request.headers(),
+                                connectionTarget,
+                                headers,
                                 keepAlive,
                                 udsAddress);
         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -167,6 +167,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                 .map(UnixDomainSocketAddress.class::cast)
                 .orElse(null);
         ClientConnectionTarget connectionTarget = null;
+        ClientConnectionTarget.LookupKey connectionLookupKey = null;
         ClientConnection suppliedConnection = connection;
         if (connection != null) {
             ConnectionKey connectionKey = Http1ConnectionCache.connectionKey(originalRequest,
@@ -191,16 +192,23 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                                                                               headers,
                                                                               http1Client.clientConfig());
             ProxyRoute selectedProxyRoute = originalRequest.selectedProxyRoute().orElse(null);
-            if (originAuthorityOverride) {
-                connectionTarget = selectedProxyRoute == null
-                        ? ClientConnectionTarget.create(connectionKey, uri, headers)
-                        : ClientConnectionTarget.create(connectionKey, uri, headers, selectedProxyRoute);
+            if (selectedProxyRoute == null && connectionKey.proxy().ipNoProxyConfigured()) {
+                connectionLookupKey = originAuthorityOverride
+                        ? ClientConnectionTarget.lookupKey(connectionKey, uri, headers)
+                        : ClientConnectionTarget.lookupKey(connectionKey, uri.scheme());
+                originalRequest.clearSelectedProxyRoute();
             } else {
-                connectionTarget = selectedProxyRoute == null
-                        ? ClientConnectionTarget.create(connectionKey, uri.scheme())
-                        : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
+                if (originAuthorityOverride) {
+                    connectionTarget = selectedProxyRoute == null
+                            ? ClientConnectionTarget.create(connectionKey, uri, headers)
+                            : ClientConnectionTarget.create(connectionKey, uri, headers, selectedProxyRoute);
+                } else {
+                    connectionTarget = selectedProxyRoute == null
+                            ? ClientConnectionTarget.create(connectionKey, uri.scheme())
+                            : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
+                }
+                originalRequest.selectedProxyRoute(connectionTarget.proxyRoute());
             }
-            originalRequest.selectedProxyRoute(connectionTarget.proxyRoute());
         } else if (suppliedConnection == null) {
             ConnectionKey connectionKey = Http1ConnectionCache.unixConnectionKey(originalRequest,
                                                                                   uri,
@@ -216,7 +224,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
 
         // either use the explicit connection, or obtain one (keep alive or one-off)
         effectiveConnection = suppliedConnection == null
-                ? obtainConnection(connectionTarget, headers, udsAddress)
+                ? obtainConnection(connectionTarget, connectionLookupKey, headers, udsAddress)
                 : suppliedConnection;
         effectiveConnection.readTimeout(this.timeout);
 
@@ -499,9 +507,17 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     }
 
     private ClientConnection obtainConnection(ClientConnectionTarget connectionTarget,
+                                              ClientConnectionTarget.LookupKey connectionLookupKey,
                                               ClientRequestHeaders headers,
                                               UnixDomainSocketAddress udsAddress) {
         if (udsAddress == null) {
+            if (connectionLookupKey != null) {
+                return http1Client.connectionCache()
+                        .connection(http1Client,
+                                    connectionLookupKey,
+                                    headers,
+                                    keepAlive);
+            }
             return http1Client.connectionCache()
                     .connection(http1Client,
                                 connectionTarget,

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -159,6 +159,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
 
         writeBuffer.clear();
         originalRequest.sanitizeRedirectHeaders(uri, headers);
+        boolean originAuthorityOverride = headers.contains(HeaderNames.HOST);
         headers.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
 
         var address = originalRequest.address();
@@ -189,9 +190,16 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                                                                               uri,
                                                                               headers,
                                                                               http1Client.clientConfig());
-            connectionTarget = originalRequest.selectedProxyRoute()
-                    .map(route -> ClientConnectionTarget.create(connectionKey, uri, headers, route))
-                    .orElseGet(() -> ClientConnectionTarget.create(connectionKey, uri, headers));
+            ProxyRoute selectedProxyRoute = originalRequest.selectedProxyRoute().orElse(null);
+            if (originAuthorityOverride) {
+                connectionTarget = selectedProxyRoute == null
+                        ? ClientConnectionTarget.create(connectionKey, uri, headers)
+                        : ClientConnectionTarget.create(connectionKey, uri, headers, selectedProxyRoute);
+            } else {
+                connectionTarget = selectedProxyRoute == null
+                        ? ClientConnectionTarget.create(connectionKey, uri.scheme())
+                        : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
+            }
             originalRequest.selectedProxyRoute(connectionTarget.proxyRoute());
         } else if (suppliedConnection == null) {
             ConnectionKey connectionKey = Http1ConnectionCache.unixConnectionKey(originalRequest,

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallEntityChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallEntityChain.java
@@ -59,6 +59,7 @@ class Http1CallEntityChain extends Http1CallChainBase {
         writeHeaders(connection,
                      headers,
                      writeBuffer,
+                     forwardProxy(),
                      protocolConfig().validateRequestHeaders(),
                      sendListener());
         // we have completed writing the headers

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -541,15 +541,14 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                 clientRequest.followRedirects(false);
                 Http1ClientResponseImpl response;
                 if (sendEntity && !sendEmptyEntity) {
-                    response = (Http1ClientResponseImpl) clientRequest
-                            .outputStreamRedirect(true)
-                            .header(HeaderValues.EXPECT_100)
+                    clientRequest.outputStreamRedirect(true);
+                    clientRequest.header(HeaderValues.EXPECT_100)
                             .header(HeaderValues.TRANSFER_ENCODING_CHUNKED)
-                            .readTimeout(originalRequest.readContinueTimeout())
-                            .request();
+                            .readTimeout(originalRequest.readContinueTimeout());
+                    response = clientRequest.redirectProbe();
                     response.connection().readTimeout(originalRequest.readTimeout());
                 } else {
-                    response = (Http1ClientResponseImpl) clientRequest.request();
+                    response = clientRequest.redirectProbe();
                 }
                 lastRequest = clientRequest;
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -431,6 +431,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             writeHeaders(connection,
                          headers,
                          buffer,
+                         callChain.forwardProxy(),
                          protocolConfig.validateRequestHeaders(),
                          sendListener);
             writer.write(buffer);

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientImpl.java
@@ -96,19 +96,19 @@ class Http1ClientImpl implements Http1Client, HttpClientSpi {
         // this is HTTP/1.1 - it should support any and all HTTP requests
         // this method is called from the "generic" HTTP client, that can support any version (that is on classpath).
         // usually HTTP/1.1 is either the only available, or a fallback if other versions cannot be used
-        Http1ClientRequest request = new Http1ClientRequestImpl(this,
-                                                                clientRequest,
-                                                                clientRequest.method(),
-                                                                clientUri,
-                                                                clientRequest.sendExpectContinue().orElse(null),
-                                                                clientRequest.properties());
+        var selectedProxyRoute = clientRequest.selectedProxyRoute();
+        Http1ClientRequestImpl request = new Http1ClientRequestImpl(this,
+                                                                    clientRequest,
+                                                                    clientRequest.method(),
+                                                                    clientUri,
+                                                                    clientRequest.sendExpectContinue().orElse(null),
+                                                                    clientRequest.properties());
 
         clientRequest.connection().ifPresent(request::connection);
         clientRequest.pathParams().forEach(request::pathParam);
         clientRequest.address().ifPresent(request::address);
         clientRequest.sni().ifPresent(request::sni);
-
-        return request.readTimeout(clientRequest.readTimeout())
+        request.readTimeout(clientRequest.readTimeout())
                 .readContinueTimeout(clientRequest.readContinueTimeout())
                 .followRedirects(clientRequest.followRedirects())
                 .maxRedirects(clientRequest.maxRedirects())
@@ -117,6 +117,8 @@ class Http1ClientImpl implements Http1Client, HttpClientSpi {
                 .tls(clientRequest.tls())
                 .headers(clientRequest.headers())
                 .fragment(clientUri.fragment());
+        selectedProxyRoute.ifPresent(request::selectedProxyRoute);
+        return request;
     }
 
     @Override

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -37,7 +37,6 @@ import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.Proxy;
-import io.helidon.webclient.api.Proxy.ProxyType;
 import io.helidon.webclient.api.ProxyRoute;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
@@ -251,14 +250,6 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
     @Override
     protected MediaContext mediaContext() {
         return super.mediaContext();
-    }
-
-    @Override
-    protected void additionalHeaders() {
-        super.additionalHeaders();
-        if (effectiveProxy().type() != ProxyType.NONE) {
-            header(PROXY_CONNECTION);
-        }
     }
 
     Proxy effectiveProxy() {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -38,6 +38,7 @@ import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.Proxy.ProxyType;
+import io.helidon.webclient.api.ProxyRoute;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 
@@ -105,15 +106,33 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
         tls(request.tls());
+        proxy(request.proxy());
         request.sni().ifPresent(this::sni);
         if (sameOrigin(request.resolvedUri(), clientUri)) {
             request.address().ifPresent(this::address);
+            request.selectedProxyRoute().ifPresent(this::selectedProxyRoute);
         }
         readTimeout(request.readTimeout());
         readContinueTimeout(request.readContinueTimeout());
         request.sendExpectContinue().ifPresent(this::sendExpectContinue);
         outputStreamRedirect(request.outputStreamRedirect());
         outputStreamRedirects(request.outputStreamRedirects());
+    }
+
+    @Override
+    public void selectedProxyRoute(ProxyRoute proxyRoute) {
+        super.selectedProxyRoute(proxyRoute);
+        if (delegate != null) {
+            delegate.selectedProxyRoute(proxyRoute);
+        }
+    }
+
+    @Override
+    public void clearSelectedProxyRoute() {
+        super.clearSelectedProxyRoute();
+        if (delegate != null) {
+            delegate.clearSelectedProxyRoute();
+        }
     }
 
     @Override
@@ -179,50 +198,54 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
 
     @Override
     public UpgradeResponse upgrade(String protocol) {
-        if (!headers().contains(HeaderNames.UPGRADE)) {
-            headers().set(HeaderNames.UPGRADE, protocol);
-        }
-        Header requestedUpgrade = headers().get(HeaderNames.UPGRADE);
-        Http1ClientResponseImpl response;
+        try {
+            if (!headers().contains(HeaderNames.UPGRADE)) {
+                headers().set(HeaderNames.UPGRADE, protocol);
+            }
+            Header requestedUpgrade = headers().get(HeaderNames.UPGRADE);
+            Http1ClientResponseImpl response;
 
-        if (followRedirects()) {
-            response = RedirectionProcessor.invokeWithFollowRedirects(this, BufferData.EMPTY_BYTES);
-        } else {
-            response = invokeRequestWithEntity(BufferData.EMPTY_BYTES);
-        }
+            if (followRedirects()) {
+                response = RedirectionProcessor.invokeWithFollowRedirects(this, BufferData.EMPTY_BYTES);
+            } else {
+                response = invokeRequestWithEntity(BufferData.EMPTY_BYTES);
+            }
 
-        if (response.status() == Status.SWITCHING_PROTOCOLS_101) {
-            // is the upgrade request successful?
-            if (upgradeSuccessful(requestedUpgrade, response.headers().get(HeaderNames.UPGRADE))) {
-                if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
-                    response.connection()
-                            .helidonSocket().log(LOGGER,
-                                                 System.Logger.Level.TRACE,
-                                                 "Upgrading to %s",
-                                                 LogFormatter.escape(requestedUpgrade.get()));
+            if (response.status() == Status.SWITCHING_PROTOCOLS_101) {
+                // is the upgrade request successful?
+                if (upgradeSuccessful(requestedUpgrade, response.headers().get(HeaderNames.UPGRADE))) {
+                    if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+                        response.connection()
+                                .helidonSocket().log(LOGGER,
+                                                     System.Logger.Level.TRACE,
+                                                     "Upgrading to %s",
+                                                     LogFormatter.escape(requestedUpgrade.get()));
+                    }
+                    // upgrade was a success
+                    return UpgradeResponse.success(response, response.connection());
+                } else {
+                    if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+                        response.connection().helidonSocket().log(LOGGER,
+                                                                  System.Logger.Level.TRACE,
+                                                                  "Upgrade failed. Expected upgrade: %s, got headers: %s",
+                                                                  LogFormatter.escape(requestedUpgrade.get()),
+                                                                  http1Client.logFormatter().format(response.headers()));
+                    }
                 }
-                // upgrade was a success
-                return UpgradeResponse.success(response, response.connection());
             } else {
                 if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
                     response.connection().helidonSocket().log(LOGGER,
                                                               System.Logger.Level.TRACE,
-                                                              "Upgrade failed. Expected upgrade: %s, got headers: %s",
+                                                              "Upgrade failed. Tried upgrading to %s, got status: %s",
                                                               LogFormatter.escape(requestedUpgrade.get()),
-                                                              http1Client.logFormatter().format(response.headers()));
+                                                              response.status().codeText());
                 }
             }
-        } else {
-            if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
-                response.connection().helidonSocket().log(LOGGER,
-                                                          System.Logger.Level.TRACE,
-                                                          "Upgrade failed. Tried upgrading to %s, got status: %s",
-                                                          LogFormatter.escape(requestedUpgrade.get()),
-                                                          response.status().codeText());
-            }
-        }
 
-        return UpgradeResponse.failure(response);
+            return UpgradeResponse.failure(response);
+        } finally {
+            clearSelectedProxyRoute();
+        }
     }
 
     @Override
@@ -289,6 +312,10 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         return invokeWithServices(callChain, whenSent, whenComplete);
     }
 
+    Http1ClientResponseImpl redirectProbe() {
+        return (Http1ClientResponseImpl) requestWithoutRouteCleanup();
+    }
+
     private Http1ClientResponseImpl invokeWithServices(Http1CallChainBase callChain,
                                                        CompletableFuture<WebClientServiceRequest> whenSent,
                                                        CompletableFuture<WebClientServiceResponse> whenComplete) {
@@ -339,6 +366,13 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
 
     boolean outputStreamRedirect() {
         return outputStreamRedirect;
+    }
+
+    boolean ownsExplicitConnection() {
+        ClientConnection current = connection().orElse(null);
+        return delegate != null
+                && current != null
+                && delegate.connection().orElse(null) != current;
     }
 
     Http1ClientRequestImpl outputStreamRedirects(int outputStreamRedirects) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -305,28 +305,31 @@ class Http1ConnectionCache extends ClientConnectionCache {
             if (!connectionTarget.currentTlsGeneration()) {
                 throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
             }
-            var iterator = cache.entrySet().iterator();
-            while (iterator.hasNext()) {
-                var entry = iterator.next();
-                ClientConnectionTarget cachedTarget = entry.getKey();
-                if (!cachedTarget.equals(connectionTarget)
-                        && cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
-                        && !cachedTarget.currentTlsGeneration()) {
-                    iterator.remove();
+            connectionPool = cache.get(connectionTarget);
+            if (connectionPool == null) {
+                var iterator = cache.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    var entry = iterator.next();
+                    ClientConnectionTarget cachedTarget = entry.getKey();
+                    if (cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
+                            && !cachedTarget.currentTlsGeneration()) {
+                        iterator.remove();
+                        if (stale == null) {
+                            stale = new ArrayList<>();
+                        }
+                        stale.add(entry.getValue());
+                    }
+                }
+                connectionPool = new ConnectionPool(capacity);
+                cache.put(connectionTarget, connectionPool);
+                if (cache.size() > MAX_TARGETS) {
+                    var evictionIterator = cache.entrySet().iterator();
                     if (stale == null) {
                         stale = new ArrayList<>();
                     }
-                    stale.add(entry.getValue());
+                    stale.add(evictionIterator.next().getValue());
+                    evictionIterator.remove();
                 }
-            }
-            connectionPool = cache.computeIfAbsent(connectionTarget, _ -> new ConnectionPool(capacity));
-            if (cache.size() > MAX_TARGETS) {
-                var evictionIterator = cache.entrySet().iterator();
-                if (stale == null) {
-                    stale = new ArrayList<>();
-                }
-                stale.add(evictionIterator.next().getValue());
-                evictionIterator.remove();
             }
         } finally {
             cacheLock.unlock();

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -84,7 +84,6 @@ class Http1ConnectionCache extends ClientConnectionCache {
         if (keepAlive) {
             return keepAliveUnixDomainConnection(http1Client, connectionTarget);
         } else {
-            observeTls(connectionTarget.connectionKey().tls());
             return UnixDomainSocketClientConnection.create(http1Client.webClient(),
                                                            connectionTarget,
                                                            ALPN_ID,
@@ -103,7 +102,6 @@ class Http1ConnectionCache extends ClientConnectionCache {
         if (keepAlive) {
             return keepAliveConnection(http1Client, connectionTarget);
         } else {
-            observeTls(connectionTarget.connectionKey().tls());
             return oneOffConnection(http1Client, connectionTarget);
         }
     }
@@ -338,26 +336,6 @@ class Http1ConnectionCache extends ClientConnectionCache {
             stale.forEach(ConnectionPool::retire);
         }
         return connectionPool;
-    }
-
-    private void observeTls(Tls tls) {
-        List<ConnectionPool> stale = new ArrayList<>();
-        cacheLock.lock();
-        try {
-            var iterator = cache.entrySet().iterator();
-            while (iterator.hasNext()) {
-                var entry = iterator.next();
-                ClientConnectionTarget target = entry.getKey();
-                if (target.connectionKey().tls() == tls
-                        && target.tlsGeneration() != tls.generation()) {
-                    iterator.remove();
-                    stale.add(entry.getValue());
-                }
-            }
-        } finally {
-            cacheLock.unlock();
-        }
-        stale.forEach(ConnectionPool::retire);
     }
 
     private static final class ConnectionPool {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
@@ -54,7 +56,9 @@ class Http1ConnectionCache extends ClientConnectionCache {
     private static final Http1ConnectionCache SHARED = new Http1ConnectionCache(true);
     private static final List<String> ALPN_ID = List.of(Http1Client.PROTOCOL_ID);
 
-    private final Map<ClientConnectionTarget, ConnectionPool> cache = new LinkedHashMap<>(16, 0.75F, true);
+    private final ConcurrentMap<ClientConnectionTarget, ConnectionPool> cache = new ConcurrentHashMap<>();
+    // Mutated only while holding cacheLock.
+    private final Map<ClientConnectionTarget, ConnectionPool> insertionOrder = new LinkedHashMap<>();
     private final AtomicBoolean closed = new AtomicBoolean();
     private final ReentrantLock cacheLock = new ReentrantLock();
 
@@ -123,8 +127,9 @@ class Http1ConnectionCache extends ClientConnectionCache {
         List<ConnectionPool> pools;
         cacheLock.lock();
         try {
-            pools = List.copyOf(cache.values());
+            pools = List.copyOf(insertionOrder.values());
             cache.clear();
+            insertionOrder.clear();
         } finally {
             cacheLock.unlock();
         }
@@ -293,8 +298,18 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     private ConnectionPool connectionPool(ClientConnectionTarget connectionTarget, int capacity) {
-        List<ConnectionPool> stale = null;
-        ConnectionPool connectionPool;
+        if (closed.get()) {
+            throw new IllegalStateException("Connection cache is closed");
+        }
+        if (!connectionTarget.currentTlsGeneration()) {
+            throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
+        }
+        ConnectionPool connectionPool = cache.get(connectionTarget);
+        if (connectionPool != null) {
+            return connectionPool;
+        }
+
+        List<ConnectionPool> toRetire = null;
         cacheLock.lock();
         try {
             if (closed.get()) {
@@ -305,35 +320,41 @@ class Http1ConnectionCache extends ClientConnectionCache {
             }
             connectionPool = cache.get(connectionTarget);
             if (connectionPool == null) {
-                var iterator = cache.entrySet().iterator();
+                var iterator = insertionOrder.entrySet().iterator();
                 while (iterator.hasNext()) {
                     var entry = iterator.next();
                     ClientConnectionTarget cachedTarget = entry.getKey();
                     if (cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
                             && !cachedTarget.currentTlsGeneration()) {
+                        ConnectionPool cachedPool = entry.getValue();
+                        cache.remove(cachedTarget, cachedPool);
                         iterator.remove();
-                        if (stale == null) {
-                            stale = new ArrayList<>();
+                        if (toRetire == null) {
+                            toRetire = new ArrayList<>();
                         }
-                        stale.add(entry.getValue());
+                        toRetire.add(cachedPool);
                     }
                 }
                 connectionPool = new ConnectionPool(capacity);
-                cache.put(connectionTarget, connectionPool);
-                if (cache.size() > MAX_TARGETS) {
-                    var evictionIterator = cache.entrySet().iterator();
-                    if (stale == null) {
-                        stale = new ArrayList<>();
-                    }
-                    stale.add(evictionIterator.next().getValue());
+                if (insertionOrder.size() == MAX_TARGETS) {
+                    var evictionIterator = insertionOrder.entrySet().iterator();
+                    var evicted = evictionIterator.next();
+                    ConnectionPool evictedPool = evicted.getValue();
+                    cache.remove(evicted.getKey(), evictedPool);
                     evictionIterator.remove();
+                    if (toRetire == null) {
+                        toRetire = new ArrayList<>();
+                    }
+                    toRetire.add(evictedPool);
                 }
+                insertionOrder.put(connectionTarget, connectionPool);
+                cache.put(connectionTarget, connectionPool);
             }
         } finally {
             cacheLock.unlock();
         }
-        if (stale != null) {
-            stale.forEach(ConnectionPool::retire);
+        if (toRetire != null) {
+            toRetire.forEach(ConnectionPool::retire);
         }
         return connectionPool;
     }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -17,19 +17,20 @@
 package io.helidon.webclient.http1;
 
 import java.net.UnixDomainSocketAddress;
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.tls.Tls;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.WritableHeaders;
 import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.FullClientRequest;
@@ -40,19 +41,22 @@ import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.spi.ClientConnectionCache;
 
 import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.TRACE;
 
 /**
  * Cache of HTTP/1.1 connections for keep alive.
  */
 class Http1ConnectionCache extends ClientConnectionCache {
     private static final System.Logger LOGGER = System.getLogger(Http1ConnectionCache.class.getName());
+    private static final int MAX_TARGETS = 1_000;
     private static final Tls NO_TLS = Tls.builder().enabled(false).build();
     private static final String HTTPS = "https";
     private static final Http1ConnectionCache SHARED = new Http1ConnectionCache(true);
     private static final List<String> ALPN_ID = List.of(Http1Client.PROTOCOL_ID);
 
-    private final Map<ConnectionKey, LinkedBlockingDeque<ClientConnection>> cache = new ConcurrentHashMap<>();
+    private final Map<ClientConnectionTarget, ConnectionPool> cache = new LinkedHashMap<>(16, 0.75F, true);
     private final AtomicBoolean closed = new AtomicBoolean();
+    private final ReentrantLock cacheLock = new ReentrantLock();
 
     protected Http1ConnectionCache(boolean shared) {
         super(shared);
@@ -67,27 +71,23 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     ClientConnection connection(Http1ClientImpl http1Client,
-                                FullClientRequest<?> request,
-                                ClientUri uri,
+                                ClientConnectionTarget connectionTarget,
                                 ClientRequestHeaders headers,
                                 boolean defaultKeepAlive,
                                 UnixDomainSocketAddress address) {
 
+        if (!connectionTarget.transportAddress().filter(address::equals).isPresent()) {
+            throw new IllegalArgumentException("UNIX domain socket address does not match the connection target");
+        }
+
         boolean keepAlive = handleKeepAlive(defaultKeepAlive, headers);
-        Tls effectiveTls = HTTPS.equals(uri.scheme()) ? request.tls() : NO_TLS;
         if (keepAlive) {
-            return keepAliveUnixDomainConnection(http1Client, request, effectiveTls, uri, headers, address);
+            return keepAliveUnixDomainConnection(http1Client, connectionTarget);
         } else {
-            ConnectionKey connectionKey = unixConnectionKey(request,
-                                                            effectiveTls,
-                                                            uri,
-                                                            headers,
-                                                            address,
-                                                            http1Client.clientConfig());
+            observeTls(connectionTarget.connectionKey().tls());
             return UnixDomainSocketClientConnection.create(http1Client.webClient(),
-                                                           connectionKey,
+                                                           connectionTarget,
                                                            ALPN_ID,
-                                                           address,
                                                            it -> false,
                                                            it -> {
                                                            })
@@ -96,24 +96,41 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     ClientConnection connection(Http1ClientImpl http1Client,
+                                ClientConnectionTarget connectionTarget,
+                                ClientRequestHeaders headers,
+                                boolean defaultKeepAlive) {
+        boolean keepAlive = handleKeepAlive(defaultKeepAlive, headers);
+        if (keepAlive) {
+            return keepAliveConnection(http1Client, connectionTarget);
+        } else {
+            observeTls(connectionTarget.connectionKey().tls());
+            return oneOffConnection(http1Client, connectionTarget);
+        }
+    }
+
+    ClientConnection connection(Http1ClientImpl http1Client,
                                 FullClientRequest<?> request,
                                 ClientUri uri,
                                 ClientRequestHeaders headers,
                                 boolean defaultKeepAlive) {
-        boolean keepAlive = handleKeepAlive(defaultKeepAlive, headers);
-        Tls effectiveTls = HTTPS.equals(uri.scheme()) ? request.tls() : NO_TLS;
-        if (keepAlive) {
-            return keepAliveConnection(http1Client, request, effectiveTls, uri, headers);
-        } else {
-            return oneOffConnection(http1Client, request, effectiveTls, uri, headers);
-        }
+        ConnectionKey connectionKey = connectionKey(request, uri, headers, http1Client.clientConfig());
+        ClientConnectionTarget connectionTarget = request.selectedProxyRoute()
+                .map(route -> ClientConnectionTarget.create(connectionKey, uri, headers, route))
+                .orElseGet(() -> ClientConnectionTarget.create(connectionKey, uri, headers));
+        return connection(http1Client, connectionTarget, headers, defaultKeepAlive);
     }
 
     @Override
     public void evict() {
-        cache.values().stream()
-                .flatMap(Collection::stream)
-                .forEach(ClientConnection::closeResource);
+        List<ConnectionPool> pools;
+        cacheLock.lock();
+        try {
+            pools = List.copyOf(cache.values());
+            cache.clear();
+        } finally {
+            cacheLock.unlock();
+        }
+        pools.forEach(ConnectionPool::retire);
     }
 
     @Override
@@ -122,6 +139,37 @@ class Http1ConnectionCache extends ClientConnectionCache {
             return;
         }
         evict();
+    }
+
+    static ConnectionKey unixConnectionKey(FullClientRequest<?> request,
+                                           ClientUri uri,
+                                           ClientRequestHeaders headers,
+                                           UnixDomainSocketAddress address,
+                                           Http1ClientConfig clientConfig) {
+        Tls tls = HTTPS.equals(uri.scheme()) ? request.tls() : NO_TLS;
+        SniConfig sni = effectiveSni(request, clientConfig);
+        if (sni == null) {
+            return ConnectionKey.createUnixDomainSocket(uri,
+                                                        tls,
+                                                        clientConfig.dnsResolver(),
+                                                        clientConfig.dnsAddressLookup(),
+                                                        address);
+        }
+        return ConnectionKey.createUnixDomainSocket(uri,
+                                                    sni,
+                                                    tls,
+                                                    clientConfig.dnsResolver(),
+                                                    clientConfig.dnsAddressLookup(),
+                                                    address,
+                                                    headers);
+    }
+
+    static ConnectionKey connectionKey(FullClientRequest<?> request,
+                                       ClientUri uri,
+                                       ClientRequestHeaders headers,
+                                       Http1ClientConfig clientConfig) {
+        Tls tls = HTTPS.equals(uri.scheme()) ? request.tls() : NO_TLS;
+        return connectionKey(request, tls, uri, headers, clientConfig);
     }
 
     private boolean handleKeepAlive(boolean defaultKeepAlive, WritableHeaders<?> headers) {
@@ -140,33 +188,25 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     private ClientConnection keepAliveUnixDomainConnection(Http1ClientImpl http1Client,
-                                                           FullClientRequest<?> request,
-                                                           Tls tls,
-                                                           ClientUri uri,
-                                                           ClientRequestHeaders headers,
-                                                           UnixDomainSocketAddress address) {
+                                                           ClientConnectionTarget connectionTarget) {
         if (closed.get()) {
             throw new IllegalStateException("Connection cache is closed");
         }
 
         Http1ClientConfig clientConfig = http1Client.clientConfig();
 
-        ConnectionKey connectionKey = unixConnectionKey(request, tls, uri, headers, address, clientConfig);
-
-        LinkedBlockingDeque<ClientConnection> connectionQueue =
-                cache.computeIfAbsent(connectionKey,
-                                      it -> new LinkedBlockingDeque<>(clientConfig.connectionCacheSize()));
+        ConnectionPool connectionPool = connectionPool(connectionTarget, clientConfig.connectionCacheSize());
 
         ClientConnection connection;
-        while ((connection = connectionQueue.poll()) != null && !connection.isConnected()) {
+        while ((connection = connectionPool.poll()) != null && !connection.isConnected()) {
+            connection.closeResource();
         }
 
         if (connection == null) {
             connection = UnixDomainSocketClientConnection.create(http1Client.webClient(),
-                                                                 connectionKey,
+                                                                 connectionTarget,
                                                                  ALPN_ID,
-                                                                 address,
-                                                                 conn -> finishRequest(connectionQueue, conn),
+                                                                 connectionPool::release,
                                                                  conn -> {
                                                                  })
                     .connect();
@@ -180,56 +220,26 @@ class Http1ConnectionCache extends ClientConnectionCache {
         return connection;
     }
 
-    private static ConnectionKey unixConnectionKey(FullClientRequest<?> request,
-                                                   Tls tls,
-                                                   ClientUri uri,
-                                                   ClientRequestHeaders headers,
-                                                   UnixDomainSocketAddress address,
-                                                   Http1ClientConfig clientConfig) {
-        SniConfig sni = effectiveSni(request, clientConfig);
-        if (sni == null) {
-            return ConnectionKey.createUnixDomainSocket(uri,
-                                                        tls,
-                                                        clientConfig.dnsResolver(),
-                                                        clientConfig.dnsAddressLookup(),
-                                                        address);
-        }
-        return ConnectionKey.createUnixDomainSocket(uri,
-                                                    sni,
-                                                    tls,
-                                                    clientConfig.dnsResolver(),
-                                                    clientConfig.dnsAddressLookup(),
-                                                    address,
-                                                    headers);
-    }
-
     private ClientConnection keepAliveConnection(Http1ClientImpl http1Client,
-                                                 FullClientRequest<?> request,
-                                                 Tls tls,
-                                                 ClientUri uri,
-                                                 ClientRequestHeaders headers) {
+                                                 ClientConnectionTarget connectionTarget) {
 
         if (closed.get()) {
             throw new IllegalStateException("Connection cache is closed");
         }
 
         Http1ClientConfig clientConfig = http1Client.clientConfig();
-
-        ConnectionKey connectionKey = connectionKey(request, tls, uri, headers, clientConfig);
-
-        Queue<ClientConnection> connectionQueue =
-                cache.computeIfAbsent(connectionKey,
-                                      it -> new LinkedBlockingDeque<>(clientConfig.connectionCacheSize()));
+        ConnectionPool connectionPool = connectionPool(connectionTarget, clientConfig.connectionCacheSize());
 
         ClientConnection connection;
-        while ((connection = connectionQueue.poll()) != null && !connection.isConnected()) {
+        while ((connection = connectionPool.poll()) != null && !connection.isConnected()) {
+            connection.closeResource();
         }
 
         if (connection == null) {
             connection = TcpClientConnection.create(http1Client.webClient(),
-                                                    connectionKey,
+                                                    connectionTarget,
                                                     ALPN_ID,
-                                                    conn -> finishRequest(connectionQueue, conn),
+                                                    connectionPool::release,
                                                     conn -> {
                                                     })
                     .connect();
@@ -244,16 +254,12 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     private ClientConnection oneOffConnection(Http1ClientImpl http1Client,
-                                              FullClientRequest<?> request,
-                                              Tls tls,
-                                              ClientUri uri,
-                                              ClientRequestHeaders headers) {
+                                              ClientConnectionTarget connectionTarget) {
 
         WebClient webClient = http1Client.webClient();
-        Http1ClientConfig clientConfig = http1Client.clientConfig();
 
         return TcpClientConnection.create(webClient,
-                                          connectionKey(request, tls, uri, headers, clientConfig),
+                                          connectionTarget,
                                           ALPN_ID,
                                           conn -> false, // always close connection
                                           conn -> {
@@ -288,29 +294,129 @@ class Http1ConnectionCache extends ClientConnectionCache {
         return request.sni().or(clientConfig::sni).orElse(null);
     }
 
-    private boolean finishRequest(Queue<ClientConnection> connectionQueue, ClientConnection conn) {
-        if (conn.isConnected()) {
-            // this must be done before we return the connection to the queue, to avoid race condition, where another client
-            // may take the connection from the queue, and we would set it as idle after that
-            // mark it as idle to stay blocked at read for closed conn detection
-            conn.helidonSocket().idle();
-
-            if (connectionQueue.offer(conn)) {
-                if (LOGGER.isLoggable(DEBUG)) {
-                    LOGGER.log(DEBUG, String.format("[%s] client connection returned %s",
-                                                    conn.channelId(),
-                                                    Thread.currentThread().getName()));
-                }
-                return true;
+    private ConnectionPool connectionPool(ClientConnectionTarget connectionTarget, int capacity) {
+        List<ConnectionPool> stale = null;
+        ConnectionPool connectionPool;
+        cacheLock.lock();
+        try {
+            if (closed.get()) {
+                throw new IllegalStateException("Connection cache is closed");
             }
-            if (LOGGER.isLoggable(DEBUG)) {
-                LOGGER.log(DEBUG, String.format("[%s] Unable to return client connection because queue is full %s",
-                                                conn.channelId(),
-                                                Thread.currentThread().getName()));
+            if (!connectionTarget.currentTlsGeneration()) {
+                throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
+            }
+            var iterator = cache.entrySet().iterator();
+            while (iterator.hasNext()) {
+                var entry = iterator.next();
+                ClientConnectionTarget cachedTarget = entry.getKey();
+                if (!cachedTarget.equals(connectionTarget)
+                        && cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
+                        && !cachedTarget.currentTlsGeneration()) {
+                    iterator.remove();
+                    if (stale == null) {
+                        stale = new ArrayList<>();
+                    }
+                    stale.add(entry.getValue());
+                }
+            }
+            connectionPool = cache.computeIfAbsent(connectionTarget, _ -> new ConnectionPool(capacity));
+            if (cache.size() > MAX_TARGETS) {
+                var evictionIterator = cache.entrySet().iterator();
+                if (stale == null) {
+                    stale = new ArrayList<>();
+                }
+                stale.add(evictionIterator.next().getValue());
+                evictionIterator.remove();
+            }
+        } finally {
+            cacheLock.unlock();
+        }
+        if (stale != null) {
+            stale.forEach(ConnectionPool::retire);
+        }
+        return connectionPool;
+    }
+
+    private void observeTls(Tls tls) {
+        List<ConnectionPool> stale = new ArrayList<>();
+        cacheLock.lock();
+        try {
+            var iterator = cache.entrySet().iterator();
+            while (iterator.hasNext()) {
+                var entry = iterator.next();
+                ClientConnectionTarget target = entry.getKey();
+                if (target.connectionKey().tls() == tls
+                        && target.tlsGeneration() != tls.generation()) {
+                    iterator.remove();
+                    stale.add(entry.getValue());
+                }
+            }
+        } finally {
+            cacheLock.unlock();
+        }
+        stale.forEach(ConnectionPool::retire);
+    }
+
+    private static final class ConnectionPool {
+        private final LinkedBlockingDeque<ClientConnection> connections;
+        private final ReentrantLock lock = new ReentrantLock();
+        private boolean retired;
+
+        private ConnectionPool(int capacity) {
+            connections = new LinkedBlockingDeque<>(capacity);
+        }
+
+        private ClientConnection poll() {
+            lock.lock();
+            try {
+                return retired ? null : connections.poll();
+            } finally {
+                lock.unlock();
             }
         }
 
-        // connection will be closed by the caller, no need to do anything else here
-        return false;
+        private boolean release(ClientConnection connection) {
+            if (!connection.isConnected()) {
+                return false;
+            }
+            // This must happen before publishing the connection to another borrower.
+            connection.helidonSocket().idle();
+            lock.lock();
+            try {
+                if (retired || !connections.offer(connection)) {
+                    return false;
+                }
+                if (LOGGER.isLoggable(DEBUG)) {
+                    LOGGER.log(DEBUG, String.format("[%s] client connection returned %s",
+                                                    connection.channelId(),
+                                                    Thread.currentThread().getName()));
+                }
+                return true;
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private void retire() {
+            List<ClientConnection> toClose;
+            lock.lock();
+            try {
+                if (retired) {
+                    return;
+                }
+                retired = true;
+                toClose = new ArrayList<>(connections);
+                connections.clear();
+            } finally {
+                lock.unlock();
+            }
+            for (ClientConnection connection : toClose) {
+                try {
+                    connection.closeResource();
+                } catch (Throwable e) {
+                    LOGGER.log(TRACE, "Failed to close a retired HTTP/1.1 connection.", e);
+                }
+            }
+        }
     }
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -57,6 +57,9 @@ class Http1ConnectionCache extends ClientConnectionCache {
     private static final List<String> ALPN_ID = List.of(Http1Client.PROTOCOL_ID);
 
     private final ConcurrentMap<ClientConnectionTarget, ConnectionPool> cache = new ConcurrentHashMap<>();
+    // Non-owning aliases, updated only while holding cacheLock.
+    private final ConcurrentMap<ClientConnectionTarget.LookupKey, List<ConnectionPool>> lookupCache =
+            new ConcurrentHashMap<>();
     // Mutated only while holding cacheLock.
     private final Map<ClientConnectionTarget, ConnectionPool> insertionOrder = new LinkedHashMap<>();
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -111,15 +114,76 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     ClientConnection connection(Http1ClientImpl http1Client,
+                                ClientConnectionTarget.LookupKey lookupKey,
+                                ClientRequestHeaders headers,
+                                boolean defaultKeepAlive) {
+        boolean keepAlive = handleKeepAlive(defaultKeepAlive, headers);
+        if (keepAlive) {
+            if (closed.get()) {
+                throw new IllegalStateException("Connection cache is closed");
+            }
+            if (!lookupKey.currentTlsGeneration()) {
+                throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
+            }
+
+            List<ConnectionPool> connectionPools = lookupCache.get(lookupKey);
+            if (connectionPools != null) {
+                for (ConnectionPool connectionPool : connectionPools) {
+                    ClientConnection connection = connectedConnection(connectionPool);
+                    if (connection != null) {
+                        if (LOGGER.isLoggable(DEBUG)) {
+                            LOGGER.log(DEBUG, String.format("[%s] client connection obtained %s",
+                                                            connection.channelId(),
+                                                            Thread.currentThread().getName()));
+                        }
+                        return connection;
+                    }
+                }
+            }
+
+            ClientConnectionTarget connectionTarget = ClientConnectionTarget.create(lookupKey);
+            ConnectionPool connectionPool = connectionPool(connectionTarget,
+                                                           http1Client.clientConfig().connectionCacheSize());
+            ClientConnection connection = connectedConnection(connectionPool);
+            if (connection == null) {
+                connection = TcpClientConnection.create(http1Client.webClient(),
+                                                        connectionTarget,
+                                                        ALPN_ID,
+                                                        connectionPool::release,
+                                                        conn -> {
+                                                        })
+                        .connect();
+            } else if (LOGGER.isLoggable(DEBUG)) {
+                LOGGER.log(DEBUG, String.format("[%s] client connection obtained %s",
+                                                connection.channelId(),
+                                                Thread.currentThread().getName()));
+            }
+            return connection;
+        } else {
+            return oneOffConnection(http1Client, ClientConnectionTarget.create(lookupKey));
+        }
+    }
+
+    ClientConnection connection(Http1ClientImpl http1Client,
                                 FullClientRequest<?> request,
                                 ClientUri uri,
                                 ClientRequestHeaders headers,
                                 boolean defaultKeepAlive) {
         ConnectionKey connectionKey = connectionKey(request, uri, headers, http1Client.clientConfig());
-        ClientConnectionTarget connectionTarget = request.selectedProxyRoute()
-                .map(route -> ClientConnectionTarget.create(connectionKey, uri, headers, route))
-                .orElseGet(() -> ClientConnectionTarget.create(connectionKey, uri, headers));
-        return connection(http1Client, connectionTarget, headers, defaultKeepAlive);
+        return request.selectedProxyRoute()
+                .map(route -> connection(http1Client,
+                                         ClientConnectionTarget.create(connectionKey, uri, headers, route),
+                                         headers,
+                                         defaultKeepAlive))
+                .orElseGet(() -> connectionKey.proxy().ipNoProxyConfigured()
+                        ? connection(http1Client,
+                                     ClientConnectionTarget.lookupKey(connectionKey, uri, headers),
+                                     headers,
+                                     defaultKeepAlive)
+                        : connection(http1Client,
+                                     ClientConnectionTarget.create(connectionKey, uri, headers),
+                                     headers,
+                                     defaultKeepAlive));
     }
 
     @Override
@@ -129,6 +193,7 @@ class Http1ConnectionCache extends ClientConnectionCache {
         try {
             pools = List.copyOf(insertionOrder.values());
             cache.clear();
+            lookupCache.clear();
             insertionOrder.clear();
         } finally {
             cacheLock.unlock();
@@ -200,10 +265,7 @@ class Http1ConnectionCache extends ClientConnectionCache {
 
         ConnectionPool connectionPool = connectionPool(connectionTarget, clientConfig.connectionCacheSize());
 
-        ClientConnection connection;
-        while ((connection = connectionPool.poll()) != null && !connection.isConnected()) {
-            connection.closeResource();
-        }
+        ClientConnection connection = connectedConnection(connectionPool);
 
         if (connection == null) {
             connection = UnixDomainSocketClientConnection.create(http1Client.webClient(),
@@ -233,10 +295,7 @@ class Http1ConnectionCache extends ClientConnectionCache {
         Http1ClientConfig clientConfig = http1Client.clientConfig();
         ConnectionPool connectionPool = connectionPool(connectionTarget, clientConfig.connectionCacheSize());
 
-        ClientConnection connection;
-        while ((connection = connectionPool.poll()) != null && !connection.isConnected()) {
-            connection.closeResource();
-        }
+        ClientConnection connection = connectedConnection(connectionPool);
 
         if (connection == null) {
             connection = TcpClientConnection.create(http1Client.webClient(),
@@ -328,6 +387,9 @@ class Http1ConnectionCache extends ClientConnectionCache {
                             && !cachedTarget.currentTlsGeneration()) {
                         ConnectionPool cachedPool = entry.getValue();
                         cache.remove(cachedTarget, cachedPool);
+                        if (cachedTarget.connectionKey().proxy().ipNoProxyConfigured()) {
+                            removeLookupPool(cachedTarget.lookupKey(), cachedPool);
+                        }
                         iterator.remove();
                         if (toRetire == null) {
                             toRetire = new ArrayList<>();
@@ -341,6 +403,9 @@ class Http1ConnectionCache extends ClientConnectionCache {
                     var evicted = evictionIterator.next();
                     ConnectionPool evictedPool = evicted.getValue();
                     cache.remove(evicted.getKey(), evictedPool);
+                    if (evicted.getKey().connectionKey().proxy().ipNoProxyConfigured()) {
+                        removeLookupPool(evicted.getKey().lookupKey(), evictedPool);
+                    }
                     evictionIterator.remove();
                     if (toRetire == null) {
                         toRetire = new ArrayList<>();
@@ -349,6 +414,17 @@ class Http1ConnectionCache extends ClientConnectionCache {
                 }
                 insertionOrder.put(connectionTarget, connectionPool);
                 cache.put(connectionTarget, connectionPool);
+                if (connectionTarget.connectionKey().proxy().ipNoProxyConfigured()) {
+                    ClientConnectionTarget.LookupKey lookupKey = connectionTarget.lookupKey();
+                    List<ConnectionPool> connectionPools = lookupCache.get(lookupKey);
+                    if (connectionPools == null) {
+                        lookupCache.put(lookupKey, List.of(connectionPool));
+                    } else {
+                        var updatedPools = new ArrayList<>(connectionPools);
+                        updatedPools.add(connectionPool);
+                        lookupCache.put(lookupKey, List.copyOf(updatedPools));
+                    }
+                }
             }
         } finally {
             cacheLock.unlock();
@@ -357,6 +433,29 @@ class Http1ConnectionCache extends ClientConnectionCache {
             toRetire.forEach(ConnectionPool::retire);
         }
         return connectionPool;
+    }
+
+    private void removeLookupPool(ClientConnectionTarget.LookupKey lookupKey, ConnectionPool expectedPool) {
+        lookupCache.computeIfPresent(lookupKey, (_, connectionPools) -> {
+            var updatedPools = new ArrayList<ConnectionPool>(connectionPools.size());
+            for (ConnectionPool connectionPool : connectionPools) {
+                if (connectionPool != expectedPool) {
+                    updatedPools.add(connectionPool);
+                }
+            }
+            if (updatedPools.size() == connectionPools.size()) {
+                return connectionPools;
+            }
+            return updatedPools.isEmpty() ? null : List.copyOf(updatedPools);
+        });
+    }
+
+    private static ClientConnection connectedConnection(ConnectionPool connectionPool) {
+        ClientConnection connection;
+        while ((connection = connectionPool.poll()) != null && !connection.isConnected()) {
+            connection.closeResource();
+        }
+        return connection;
     }
 
     private static final class ConnectionPool {

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -55,6 +55,7 @@ import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PeerInfo;
+import io.helidon.common.socket.SocketContext;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.Header;
@@ -67,6 +68,7 @@ import io.helidon.http.HttpLogConfig;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.http1.Http1ConnectionListener;
 import io.helidon.http.http1.Http1LoggingConnectionListener;
 import io.helidon.http.media.EntityReader;
 import io.helidon.http.media.EntityWriter;
@@ -74,6 +76,7 @@ import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaContextConfig;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.HttpClientConfig;
 import io.helidon.webclient.api.HttpClientRequest;
@@ -720,7 +723,7 @@ class Http1ClientTest {
         try {
             Http1LoggingConnectionListener listener = Http1LoggingConnectionListener.create(HttpLogConfig.create(),
                                                                                             "cl-send");
-            Headers headers = WritableHeaders.create()
+            WritableHeaders<?> headers = WritableHeaders.create()
                     .add(HeaderNames.AUTHORIZATION, "Bearer secret-token")
                     .add(HeaderNames.COOKIE, "session=secret-cookie")
                     .add(HeaderNames.create("X-Safe"), "first\r\nForged: value")
@@ -729,6 +732,7 @@ class Http1ClientTest {
             Http1CallChainBase.writeHeaders(new FakeHttp1ClientConnection(),
                                             headers,
                                             BufferData.growing(128),
+                                            false,
                                             false,
                                             listener);
 
@@ -780,13 +784,14 @@ class Http1ClientTest {
                                                                                                     .unsafeRawData(true)
                                                                                                     .build(),
                                                                                             "cl-send");
-            Headers headers = WritableHeaders.create()
+            WritableHeaders<?> headers = WritableHeaders.create()
                     .add(HeaderNames.AUTHORIZATION, "Bearer secret-token")
                     .add(HeaderNames.COOKIE, "session=secret-cookie");
 
             Http1CallChainBase.writeHeaders(new FakeHttp1ClientConnection(),
                                             headers,
                                             BufferData.growing(128),
+                                            false,
                                             false,
                                             listener);
 
@@ -800,6 +805,40 @@ class Http1ClientTest {
             logger.setUseParentHandlers(previousUseParentHandlers);
             handler.close();
         }
+    }
+
+    @Test
+    void automaticProxyConnectionHeaderIsScopedToSerialization() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        BufferData buffer = BufferData.growing(128);
+        AtomicBoolean listenerObservedHeader = new AtomicBoolean();
+        Http1ConnectionListener listener = new Http1ConnectionListener() {
+            @Override
+            public void headers(SocketContext ctx, Headers sentHeaders) {
+                listenerObservedHeader.set(sentHeaders.contains(ClientRequestBase.PROXY_CONNECTION.headerName()));
+            }
+        };
+
+        Http1CallChainBase.writeHeaders(new FakeHttp1ClientConnection(),
+                                        headers,
+                                        buffer,
+                                        true,
+                                        false,
+                                        listener);
+
+        assertThat(new String(buffer.readBytes(), StandardCharsets.US_ASCII),
+                   containsString("Proxy-Connection: keep-alive\r\n"));
+        assertThat(listenerObservedHeader.get(), is(true));
+        assertThat(headers.contains(ClientRequestBase.PROXY_CONNECTION.headerName()), is(false));
+
+        headers.set(ClientRequestBase.PROXY_CONNECTION);
+        Http1CallChainBase.writeHeaders(new FakeHttp1ClientConnection(),
+                                        headers,
+                                        BufferData.growing(128),
+                                        true,
+                                        false,
+                                        listener);
+        assertThat(headers.contains(ClientRequestBase.PROXY_CONNECTION.headerName()), is(true));
     }
 
     @Test
@@ -1032,6 +1071,9 @@ class Http1ClientTest {
         st.nextToken();
         // Validate URI part
         assertThat(st.nextToken(), startsWith(expectedUriStart));
+        boolean expectedProxyConnection = proxyConfig == ProxyConfiguration.HTTP
+                || proxyConfig == ProxyConfiguration.SYSTEM_SET_PROXY;
+        assertThat(connection.proxyConnectionHeader, is(expectedProxyConnection));
 
         // Clear proxy system properties that were set
         switch (proxyConfig) {
@@ -1437,6 +1479,7 @@ class Http1ClientTest {
         private Throwable serverException;
         private ExecutorService webServerEmulator;
         private String prologue;
+        private boolean proxyConnectionHeader;
         private int releaseCount;
         private int closeCount;
 
@@ -1673,6 +1716,7 @@ class Http1ClientTest {
             WritableHeaders<?> reqHeaders = null;
             try {
                 reqHeaders = Http1HeadersParser.readHeaders(serverReader, 16384, false);
+                proxyConnectionHeader = reqHeaders.contains(ClientRequestBase.PROXY_CONNECTION.headerName());
                 for (Iterator<Header> it = reqHeaders.iterator(); it.hasNext(); ) {
                     Header header = it.next();
                     header.validate();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -113,33 +113,40 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
         requestHeaders = serviceRequest.headers();
 
         clientRequest.sanitizeRedirectHeaders(uri, requestHeaders);
+        boolean originAuthorityOverride = requestHeaders.contains(Http2Headers.AUTHORITY_NAME)
+                || requestHeaders.contains(HeaderNames.HOST);
         alignHostHeader(uri, requestHeaders);
         requestHeaders.remove(HeaderNames.CONNECTION, LogHeaderConsumer.INSTANCE);
         requestHeaders.setIfAbsent(USER_AGENT_HEADER);
 
         ConnectionKey connectionKey = Http2ConnectionKeys.create(uri, clientRequest, clientConfig, requestHeaders);
         boolean ownsExplicitConnection = Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest);
-        Optional<ClientConnection> explicitConnection = clientRequest.connection();
-        Optional<ClientConnectionTarget> explicitTarget = explicitConnection.flatMap(connection -> {
+        ClientConnection explicitConnection = clientRequest.connection().orElse(null);
+        ClientConnectionTarget explicitTarget = null;
+        if (explicitConnection != null) {
             clientRequest.clearSelectedProxyRoute();
-            if (!(connection instanceof TcpClientConnection tcpConnection)) {
-                return Optional.empty();
+            if (explicitConnection instanceof TcpClientConnection tcpConnection) {
+                ResolvedClientTarget resolvedTarget = tcpConnection.resolvedTarget().orElse(null);
+                Optional<ProxyRoute> matchingRoute = ClientConnectionTarget.matchingRoute(explicitConnection,
+                                                                                           connectionKey,
+                                                                                           uri,
+                                                                                           requestHeaders);
+                if (matchingRoute.isPresent()) {
+                    clientRequest.selectedProxyRoute(matchingRoute.get());
+                    if (resolvedTarget != null) {
+                        explicitTarget = resolvedTarget.logicalTarget();
+                    }
+                }
             }
-            Optional<ResolvedClientTarget> resolvedTarget = tcpConnection.resolvedTarget();
-            Optional<ProxyRoute> matchingRoute = ClientConnectionTarget.matchingRoute(connection,
-                                                                                       connectionKey,
-                                                                                       uri,
-                                                                                       requestHeaders);
-            matchingRoute.ifPresent(clientRequest::selectedProxyRoute);
-            return matchingRoute.flatMap(_ -> resolvedTarget.map(ResolvedClientTarget::logicalTarget));
-        });
-        if (ownsExplicitConnection && explicitConnection.isPresent() && explicitTarget.isEmpty()) {
+        }
+        if (ownsExplicitConnection && explicitConnection != null && explicitTarget == null) {
             clientRequest.clearConnection();
-            explicitConnection.get().closeResource();
+            explicitConnection.closeResource();
+            explicitConnection = null;
         }
         ClientConnectionTarget connectionTarget;
-        if (explicitTarget.isPresent()) {
-            connectionTarget = explicitTarget.get();
+        if (explicitTarget != null) {
+            connectionTarget = explicitTarget;
         } else {
             SocketAddress address = clientRequest.address().orElse(null);
             if (address instanceof UnixDomainSocketAddress udsAddress) {
@@ -149,10 +156,17 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
                                                                                    requestHeaders,
                                                                                    udsAddress);
             } else {
-                connectionTarget = clientRequest.selectedProxyRoute()
-                        .map(route -> ClientConnectionTarget.create(connectionKey, uri, requestHeaders, route))
-                        .orElseGet(() -> ClientConnectionTarget.create(connectionKey, uri, requestHeaders));
-                if (clientRequest.connection().isEmpty() || clientRequest.selectedProxyRoute().isPresent()) {
+                ProxyRoute selectedProxyRoute = clientRequest.selectedProxyRoute().orElse(null);
+                if (originAuthorityOverride) {
+                    connectionTarget = selectedProxyRoute == null
+                            ? ClientConnectionTarget.create(connectionKey, uri, requestHeaders)
+                            : ClientConnectionTarget.create(connectionKey, uri, requestHeaders, selectedProxyRoute);
+                } else {
+                    connectionTarget = selectedProxyRoute == null
+                            ? ClientConnectionTarget.create(connectionKey, uri.scheme())
+                            : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
+                }
+                if (explicitConnection == null || clientRequest.selectedProxyRoute().isPresent()) {
                     clientRequest.selectedProxyRoute(connectionTarget.proxyRoute());
                 }
             }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -145,6 +145,7 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
             explicitConnection = null;
         }
         ClientConnectionTarget connectionTarget;
+        ClientConnectionTarget.LookupKey connectionLookupKey = null;
         if (explicitTarget != null) {
             connectionTarget = explicitTarget;
         } else {
@@ -157,23 +158,46 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
                                                                                    udsAddress);
             } else {
                 ProxyRoute selectedProxyRoute = clientRequest.selectedProxyRoute().orElse(null);
-                if (originAuthorityOverride) {
-                    connectionTarget = selectedProxyRoute == null
-                            ? ClientConnectionTarget.create(connectionKey, uri, requestHeaders)
-                            : ClientConnectionTarget.create(connectionKey, uri, requestHeaders, selectedProxyRoute);
+                if (explicitConnection == null
+                        && selectedProxyRoute == null
+                        && connectionKey.proxy().ipNoProxyConfigured()) {
+                    connectionLookupKey = originAuthorityOverride
+                            ? ClientConnectionTarget.lookupKey(connectionKey, uri, requestHeaders)
+                            : ClientConnectionTarget.lookupKey(connectionKey, uri.scheme());
+                    connectionTarget = null;
+                    clientRequest.clearSelectedProxyRoute();
                 } else {
-                    connectionTarget = selectedProxyRoute == null
-                            ? ClientConnectionTarget.create(connectionKey, uri.scheme())
-                            : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
-                }
-                if (explicitConnection == null || clientRequest.selectedProxyRoute().isPresent()) {
-                    clientRequest.selectedProxyRoute(connectionTarget.proxyRoute());
+                    if (originAuthorityOverride) {
+                        connectionTarget = selectedProxyRoute == null
+                                ? ClientConnectionTarget.create(connectionKey, uri, requestHeaders)
+                                : ClientConnectionTarget.create(connectionKey, uri, requestHeaders, selectedProxyRoute);
+                    } else {
+                        connectionTarget = selectedProxyRoute == null
+                                ? ClientConnectionTarget.create(connectionKey, uri.scheme())
+                                : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
+                    }
+                    if (explicitConnection == null || clientRequest.selectedProxyRoute().isPresent()) {
+                        clientRequest.selectedProxyRoute(connectionTarget.proxyRoute());
+                    }
                 }
             }
         }
 
-        Http2ConnectionAttemptResult result = http2Client.connectionCache()
-                .newStream(http2Client, connectionTarget, clientRequest, uri, serviceRequest, http1FallbackHandler);
+        Http2ConnectionAttemptResult result = connectionLookupKey == null
+                ? http2Client.connectionCache()
+                        .newStream(http2Client,
+                                   connectionTarget,
+                                   clientRequest,
+                                   uri,
+                                   serviceRequest,
+                                   http1FallbackHandler)
+                : http2Client.connectionCache()
+                        .newStream(http2Client,
+                                   connectionLookupKey,
+                                   clientRequest,
+                                   uri,
+                                   serviceRequest,
+                                   http1FallbackHandler);
 
         try {
             if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
@@ -191,7 +215,7 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
             if (!clientRequest().outputStreamRedirect()
                     && (clientRequest.connection().isEmpty()
                             || Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest))) {
-                http2Client.connectionCache().remove(connectionTarget, result.handler());
+                http2Client.connectionCache().remove(result.connectionTarget(), result.handler());
                 closeFailedStream(result);
             }
             throw e;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -200,6 +200,9 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
                                    http1FallbackHandler);
 
         try {
+            if (connectionLookupKey != null) {
+                clientRequest.selectedProxyRoute(result.connectionTarget().proxyRoute());
+            }
             if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
                 // ALPN, prior knowledge, or upgrade success
                 this.stream = result.stream();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -17,7 +17,10 @@
 package io.helidon.webclient.http2;
 
 import java.io.InputStream;
+import java.net.SocketAddress;
+import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -37,11 +40,16 @@ import io.helidon.http.encoding.ContentDecoder;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Headers;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.HttpClientConfig;
 import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.ProxyRoute;
 import io.helidon.webclient.api.ReleasableResource;
+import io.helidon.webclient.api.ResolvedClientTarget;
+import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
@@ -109,10 +117,49 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
         requestHeaders.remove(HeaderNames.CONNECTION, LogHeaderConsumer.INSTANCE);
         requestHeaders.setIfAbsent(USER_AGENT_HEADER);
 
-        ConnectionKey connectionKey = connectionKey(serviceRequest);
+        ConnectionKey connectionKey = Http2ConnectionKeys.create(uri, clientRequest, clientConfig, requestHeaders);
+        boolean ownsExplicitConnection = Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest);
+        Optional<ClientConnection> explicitConnection = clientRequest.connection();
+        Optional<ClientConnectionTarget> explicitTarget = explicitConnection.flatMap(connection -> {
+            clientRequest.clearSelectedProxyRoute();
+            if (!(connection instanceof TcpClientConnection tcpConnection)) {
+                return Optional.empty();
+            }
+            Optional<ResolvedClientTarget> resolvedTarget = tcpConnection.resolvedTarget();
+            Optional<ProxyRoute> matchingRoute = ClientConnectionTarget.matchingRoute(connection,
+                                                                                       connectionKey,
+                                                                                       uri,
+                                                                                       requestHeaders);
+            matchingRoute.ifPresent(clientRequest::selectedProxyRoute);
+            return matchingRoute.flatMap(_ -> resolvedTarget.map(ResolvedClientTarget::logicalTarget));
+        });
+        if (ownsExplicitConnection && explicitConnection.isPresent() && explicitTarget.isEmpty()) {
+            clientRequest.clearConnection();
+            explicitConnection.get().closeResource();
+        }
+        ClientConnectionTarget connectionTarget;
+        if (explicitTarget.isPresent()) {
+            connectionTarget = explicitTarget.get();
+        } else {
+            SocketAddress address = clientRequest.address().orElse(null);
+            if (address instanceof UnixDomainSocketAddress udsAddress) {
+                clientRequest.clearSelectedProxyRoute();
+                connectionTarget = ClientConnectionTarget.createUnixDomainSocket(connectionKey,
+                                                                                   uri,
+                                                                                   requestHeaders,
+                                                                                   udsAddress);
+            } else {
+                connectionTarget = clientRequest.selectedProxyRoute()
+                        .map(route -> ClientConnectionTarget.create(connectionKey, uri, requestHeaders, route))
+                        .orElseGet(() -> ClientConnectionTarget.create(connectionKey, uri, requestHeaders));
+                if (clientRequest.connection().isEmpty() || clientRequest.selectedProxyRoute().isPresent()) {
+                    clientRequest.selectedProxyRoute(connectionTarget.proxyRoute());
+                }
+            }
+        }
 
         Http2ConnectionAttemptResult result = http2Client.connectionCache()
-                .newStream(http2Client, connectionKey, clientRequest, uri, serviceRequest, http1FallbackHandler);
+                .newStream(http2Client, connectionTarget, clientRequest, uri, serviceRequest, http1FallbackHandler);
 
         try {
             if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
@@ -130,7 +177,7 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
             if (!clientRequest().outputStreamRedirect()
                     && (clientRequest.connection().isEmpty()
                             || Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest))) {
-                http2Client.connectionCache().remove(connectionKey);
+                http2Client.connectionCache().remove(connectionTarget);
                 closeFailedStream(result);
             }
             throw e;
@@ -329,10 +376,6 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
                 stream.close();
             }
         }
-    }
-
-    private ConnectionKey connectionKey(WebClientServiceRequest serviceRequest) {
-        return Http2ConnectionKeys.create(serviceRequest.uri(), clientRequest, clientConfig, serviceRequest.headers());
     }
 
     static void alignHostHeader(ClientUri uri, ClientRequestHeaders requestHeaders) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -191,7 +191,7 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
             if (!clientRequest().outputStreamRedirect()
                     && (clientRequest.connection().isEmpty()
                             || Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest))) {
-                http2Client.connectionCache().remove(connectionTarget);
+                http2Client.connectionCache().remove(connectionTarget, result.handler());
                 closeFailedStream(result);
             }
             throw e;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -215,10 +215,12 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
         } catch (StreamTimeoutException e) {
             //This request was waiting for 100 Continue, but it was very likely not supported by the server.
             //Do not remove connection from the cache in that case.
-            if (!clientRequest().outputStreamRedirect()
+            Http2ClientConnectionHandler resultHandler = result.handler();
+            if (resultHandler != null
+                    && !clientRequest().outputStreamRedirect()
                     && (clientRequest.connection().isEmpty()
                             || Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest))) {
-                http2Client.connectionCache().remove(result.connectionTarget(), result.handler());
+                http2Client.connectionCache().remove(result.connectionTarget(), resultHandler);
                 closeFailedStream(result);
             }
             throw e;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -516,13 +516,12 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 try {
                     Http2ClientResponseImpl response;
                     if (sendEntity && !sendEmptyEntity) {
-                        response = (Http2ClientResponseImpl) clientRequest
-                                .outputStreamRedirect(true)
-                                .header(HeaderValues.EXPECT_100)
-                                .request();
+                        clientRequest.outputStreamRedirect(true)
+                                .header(HeaderValues.EXPECT_100);
+                        response = clientRequest.redirectProbe();
                     } else {
-                        response = (Http2ClientResponseImpl) clientRequest.outputStreamRedirect(false)
-                                .request();
+                        clientRequest.outputStreamRedirect(false);
+                        response = clientRequest.redirectProbe();
                     }
                     lastRequest = clientRequest;
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -344,13 +344,18 @@ public class Http2ClientConnection {
      * successful exchanges and after failures during stream startup.
      */
     void releaseReservedStream() {
+        boolean finishRetirement;
         reservedStreamsLock.lock();
         try {
             if (reservedStreams > 0) {
                 reservedStreams--;
             }
+            finishRetirement = reservedStreams == 0 && state.get() == State.RETIRING;
         } finally {
             reservedStreamsLock.unlock();
+        }
+        if (finishRetirement) {
+            finishRetirement();
         }
     }
 
@@ -471,6 +476,27 @@ public class Http2ClientConnection {
         closeConnection();
     }
 
+    void retire() {
+        initialSettingsLatch.countDown();
+        if (!clientPrefaceSent) {
+            closeConnection();
+            return;
+        }
+        boolean finishRetirement;
+        reservedStreamsLock.lock();
+        try {
+            if (!state.compareAndSet(State.OPEN, State.RETIRING)) {
+                return;
+            }
+            finishRetirement = reservedStreams == 0;
+        } finally {
+            reservedStreamsLock.unlock();
+        }
+        if (finishRetirement) {
+            finishRetirement();
+        }
+    }
+
     /**
      * Immediately closes this connection without attempting to send an HTTP/2 GOAWAY frame.
      */
@@ -493,6 +519,23 @@ public class Http2ClientConnection {
             } finally {
                 closeListener.accept(this);
             }
+        }
+    }
+
+    private void finishRetirement() {
+        if (!state.compareAndSet(State.RETIRING, State.GO_AWAY)) {
+            return;
+        }
+        try {
+            Http2Settings http2Settings = Http2Settings.create();
+            Http2GoAway frame = new Http2GoAway(0,
+                                                Http2ErrorCode.NO_ERROR,
+                                                "Connection target retired");
+            writer.write(frame.toFrameData(http2Settings, 0, Http2Flag.NoFlags.create()));
+        } catch (Throwable e) {
+            ctx.log(LOGGER, TRACE, "Failed to send HTTP/2 GOAWAY while retiring connection.", e);
+        } finally {
+            closeConnection();
         }
     }
 
@@ -594,7 +637,7 @@ public class Http2ClientConnection {
     private boolean reserveStream() {
         reservedStreamsLock.lock();
         try {
-            if (reservedStreams >= peerMaxConcurrentStreams) {
+            if (state.get() != State.OPEN || reservedStreams >= peerMaxConcurrentStreams) {
                 return false;
             }
             reservedStreams++;
@@ -1009,6 +1052,7 @@ public class Http2ClientConnection {
     private enum State {
         CLOSED(true),
         GO_AWAY(true),
+        RETIRING(true),
         OPEN(false);
 
         private final boolean closed;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -344,19 +344,15 @@ public class Http2ClientConnection {
      * successful exchanges and after failures during stream startup.
      */
     void releaseReservedStream() {
-        boolean finishRetirement;
         reservedStreamsLock.lock();
         try {
             if (reservedStreams > 0) {
                 reservedStreams--;
             }
-            finishRetirement = reservedStreams == 0 && state.get() == State.RETIRING;
         } finally {
             reservedStreamsLock.unlock();
         }
-        if (finishRetirement) {
-            finishRetirement();
-        }
+        finishRetirementIfDrained();
     }
 
     /**
@@ -388,7 +384,7 @@ public class Http2ClientConnection {
         } finally {
             lock.unlock();
         }
-
+        finishRetirementIfDrained();
     }
 
     Http2ClientStream tryStream(Http2StreamConfig config) {
@@ -482,19 +478,15 @@ public class Http2ClientConnection {
             closeConnection();
             return;
         }
-        boolean finishRetirement;
         reservedStreamsLock.lock();
         try {
             if (!state.compareAndSet(State.OPEN, State.RETIRING)) {
                 return;
             }
-            finishRetirement = reservedStreams == 0;
         } finally {
             reservedStreamsLock.unlock();
         }
-        if (finishRetirement) {
-            finishRetirement();
-        }
+        finishRetirementIfDrained();
     }
 
     /**
@@ -537,6 +529,32 @@ public class Http2ClientConnection {
         } finally {
             closeConnection();
         }
+    }
+
+    private void finishRetirementIfDrained() {
+        if (state.get() != State.RETIRING) {
+            return;
+        }
+
+        reservedStreamsLock.lock();
+        try {
+            if (reservedStreams != 0 || state.get() != State.RETIRING) {
+                return;
+            }
+        } finally {
+            reservedStreamsLock.unlock();
+        }
+
+        Lock lock = streamsLock.readLock();
+        lock.lock();
+        try {
+            if (!streams.isEmpty()) {
+                return;
+            }
+        } finally {
+            lock.unlock();
+        }
+        finishRetirement();
     }
 
     private void sendPreface(Http2ClientProtocolConfig config, boolean sendSettings) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -36,8 +36,9 @@ import io.helidon.http.HeaderValues;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2Settings;
 import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientUri;
-import io.helidon.webclient.api.ConnectionKey;
+import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.UnixDomainSocketClientConnection;
@@ -68,15 +69,66 @@ class Http2ClientConnectionHandler {
     private final Map<Http2ClientConnection, Boolean> allConnections = Collections.synchronizedMap(new IdentityHashMap<>());
     private final Set<Http2ClientConnection> pendingUpgradedConnections =
             Collections.newSetFromMap(new IdentityHashMap<>());
-    private final ConnectionKey connectionKey;
     private final AtomicReference<Http2ClientConnection> activeConnection = new AtomicReference<>();
     private final ReentrantLock lock = new ReentrantLock();
     private final ReentrantLock lifecycleLock = new ReentrantLock();
     private final AtomicReference<Result> result = new AtomicReference<>(Result.UNKNOWN);
     private boolean closed;
+    private boolean retired;
+    private boolean connectionsRetired;
+    private int leases;
 
-    Http2ClientConnectionHandler(ConnectionKey connectionKey) {
-        this.connectionKey = connectionKey;
+    boolean acquire() {
+        lifecycleLock.lock();
+        try {
+            if (closed || retired) {
+                return false;
+            }
+            leases++;
+            return true;
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    void release() {
+        boolean retireConnections;
+        lifecycleLock.lock();
+        try {
+            if (leases == 0) {
+                throw new IllegalStateException("HTTP/2 handler lease underflow");
+            }
+            leases--;
+            retireConnections = retired && leases == 0 && !closed && !connectionsRetired;
+            if (retireConnections) {
+                connectionsRetired = true;
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+        if (retireConnections) {
+            retireConnections();
+        }
+    }
+
+    void retire() {
+        boolean retireConnections;
+        lifecycleLock.lock();
+        try {
+            if (closed || retired) {
+                return;
+            }
+            retired = true;
+            retireConnections = leases == 0 && !connectionsRetired;
+            if (retireConnections) {
+                connectionsRetired = true;
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+        if (retireConnections) {
+            retireConnections();
+        }
     }
 
     void close() {
@@ -104,6 +156,7 @@ class Http2ClientConnectionHandler {
     }
 
     Http2ConnectionAttemptResult newStream(Http2ClientImpl http2Client,
+                                           ClientConnectionTarget requestTarget,
                                            Http2ClientRequestImpl request,
                                            ClientUri initialUri,
                                            WebClientServiceRequest serviceRequest,
@@ -112,11 +165,19 @@ class Http2ClientConnectionHandler {
             Optional<ClientConnection> maybeConnection = request.connection();
             if (maybeConnection.isPresent()) {
                 return explicitConnection(http2Client,
+                                          requestTarget,
                                           request,
                                           initialUri,
                                           serviceRequest,
                                           http1FallbackHandler,
                                           maybeConnection.get());
+            }
+            if (requestTarget.proxyRoute().forwardProxy()) {
+                if (request.priorKnowledge() || !http1FallbackAllowed(request)) {
+                    throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
+                }
+                result.set(Result.HTTP_1);
+                return http1(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
             }
 
             return switch (result.get()) {
@@ -124,10 +185,15 @@ class Http2ClientConnectionHandler {
                     if (!http1FallbackAllowed(request)) {
                         throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
                     }
-                    yield http1(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                    yield http1(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
                 }
-                case HTTP_2 -> http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
-                case UNKNOWN -> httpX(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                case HTTP_2 -> http2(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
+                case UNKNOWN -> httpX(http2Client,
+                                      requestTarget,
+                                      request,
+                                      initialUri,
+                                      serviceRequest,
+                                      http1FallbackHandler);
             };
         } catch (RuntimeException | Error e) {
             http1FallbackHandler.completeSentExceptionally(e);
@@ -136,6 +202,7 @@ class Http2ClientConnectionHandler {
     }
 
     Http2ConnectionAttemptResult http2(Http2ClientImpl http2Client,
+                                       ClientConnectionTarget requestTarget,
                                        Http2ClientRequestImpl request,
                                        ClientUri initialUri,
                                        WebClientServiceRequest serviceRequest,
@@ -153,7 +220,12 @@ class Http2ClientConnectionHandler {
             Http2ClientStream stream;
             if (conn == null) {
                 try {
-                    conn = createConnection(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                    conn = createConnection(http2Client,
+                                            requestTarget,
+                                            request,
+                                            initialUri,
+                                            serviceRequest,
+                                            http1FallbackHandler);
                 } catch (Http1FallbackResponse e) {
                     http1FallbackHandler.completeSent(serviceRequest);
                     return new Http2ConnectionAttemptResult(Result.HTTP_1, null, e.response());
@@ -168,7 +240,12 @@ class Http2ClientConnectionHandler {
                 if (stream == null) {
                     // either the connection is closed, or it ran out of streams
                     try {
-                        conn = createConnection(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                        conn = createConnection(http2Client,
+                                                requestTarget,
+                                                request,
+                                                initialUri,
+                                                serviceRequest,
+                                                http1FallbackHandler);
                     } catch (Http1FallbackResponse e) {
                         http1FallbackHandler.completeSent(serviceRequest);
                         return new Http2ConnectionAttemptResult(Result.HTTP_1, null, e.response());
@@ -184,6 +261,7 @@ class Http2ClientConnectionHandler {
     }
 
     private Http2ConnectionAttemptResult httpX(Http2ClientImpl http2Client,
+                                               ClientConnectionTarget requestTarget,
                                                Http2ClientRequestImpl request,
                                                ClientUri initialUri,
                                                WebClientServiceRequest serviceRequest,
@@ -198,7 +276,7 @@ class Http2ClientConnectionHandler {
             if (request.tls().enabled() && "https".equals(initialUri.scheme())) {
                 // use ALPN, not upgrade
                 List<String> alpn = alpnProtocolIds(request);
-                ClientConnection clientConnection = connectClient(webClient, request, initialUri, alpn);
+                ClientConnection clientConnection = connectClient(webClient, requestTarget, request, initialUri, alpn);
                 if (clientConnection.helidonSocket().protocolNegotiated()) {
                     if (Http2Client.PROTOCOL_ID.equals(clientConnection.helidonSocket().protocol())) {
                         result.set(Result.HTTP_2);
@@ -207,7 +285,12 @@ class Http2ClientConnectionHandler {
                                                                                  clientConnection,
                                                                                  true);
                         activateConnection(clientConnection, connection);
-                        return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                        return http2(http2Client,
+                                     requestTarget,
+                                     request,
+                                     initialUri,
+                                     serviceRequest,
+                                     http1FallbackHandler);
                     } else {
                         if (!http1FallbackAllowed(request)) {
                             closeClientConnection(clientConnection);
@@ -215,6 +298,7 @@ class Http2ClientConnectionHandler {
                         }
                         result.set(Result.HTTP_1);
                         return http1WithProbeConnection(http2Client,
+                                                        requestTarget,
                                                         request,
                                                         initialUri,
                                                         serviceRequest,
@@ -229,6 +313,7 @@ class Http2ClientConnectionHandler {
                         }
                         result.set(Result.HTTP_1);
                         return http1WithProbeConnection(http2Client,
+                                                        requestTarget,
                                                         request,
                                                         initialUri,
                                                         serviceRequest,
@@ -240,20 +325,36 @@ class Http2ClientConnectionHandler {
                                                                              clientConnection,
                                                                              true);
                     activateConnection(clientConnection, connection);
-                    return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                    return http2(http2Client,
+                                 requestTarget,
+                                 request,
+                                 initialUri,
+                                 serviceRequest,
+                                 http1FallbackHandler);
                 }
             }
 
             if (result.get() != Result.UNKNOWN) {
-                return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                return http2(http2Client,
+                             requestTarget,
+                             request,
+                             initialUri,
+                             serviceRequest,
+                             http1FallbackHandler);
             }
             // we need to connect
             if (request.priorKnowledge()) {
                 // there is no fallback to HTTP/1 with prior knowledge - it must work or fail
-                return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                return http2(http2Client,
+                             requestTarget,
+                             request,
+                             initialUri,
+                             serviceRequest,
+                             http1FallbackHandler);
             }
             // attempt an upgrade to HTTP/2
             UpgradeResponse upgradeResponse = upgrade(http2Client,
+                                                      requestTarget,
                                                       request,
                                                       initialUri,
                                                       serviceRequest,
@@ -264,7 +365,12 @@ class Http2ClientConnectionHandler {
                 ClientConnection connection = upgradeResponse.connection();
                 Http2ClientConnection conn = createUpgradedHttp2Connection(http2Client, connection);
                 activateConnection(connection, conn);
-                return http2(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+                return http2(http2Client,
+                             requestTarget,
+                             request,
+                             initialUri,
+                             serviceRequest,
+                             http1FallbackHandler);
             } else {
                 HttpClientResponse response = upgradeResponse.response();
                 if (request.followRedirects() && RedirectionProcessor.redirectionStatusCode(response.status())) {
@@ -289,6 +395,7 @@ class Http2ClientConnectionHandler {
     }
 
     private Http2ConnectionAttemptResult http1WithProbeConnection(Http2ClientImpl http2Client,
+                                                                  ClientConnectionTarget requestTarget,
                                                                   Http2ClientRequestImpl request,
                                                                   ClientUri initialUri,
                                                                   WebClientServiceRequest serviceRequest,
@@ -296,7 +403,7 @@ class Http2ClientConnectionHandler {
                                                                   ClientConnection clientConnection) {
         request.connection(clientConnection);
         try {
-            return http1(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+            return http1(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
         } catch (RuntimeException | Error e) {
             closeClientConnection(clientConnection);
             throw e;
@@ -304,13 +411,17 @@ class Http2ClientConnectionHandler {
     }
 
     private UpgradeResponse upgrade(Http2ClientImpl http2Client,
+                                    ClientConnectionTarget requestTarget,
                                     Http2ClientRequestImpl request,
                                     ClientUri requestUri,
                                     WebClientServiceRequest serviceRequest,
                                     Http1FallbackHandler http1FallbackHandler,
                                     Http2ClientProtocolConfig protocolConfig) {
         try {
-            Http1ClientRequest upgradeRequest = http1Request(http2Client.http1FallbackClient(), request, requestUri);
+            Http1ClientRequest upgradeRequest = http1Request(http2Client.http1FallbackClient(),
+                                                             requestTarget,
+                                                             request,
+                                                             requestUri);
             Http1FallbackHandler.copyFinalHeaders(upgradeRequest, serviceRequest);
             UpgradeResponse upgradeResponse = upgradeRequest.header(UPGRADE_HEADER)
                     .header(CONNECTION_UPGRADE_HEADER)
@@ -325,6 +436,7 @@ class Http2ClientConnectionHandler {
     }
 
     private Http2ConnectionAttemptResult explicitConnection(Http2ClientImpl http2Client,
+                                                            ClientConnectionTarget requestTarget,
                                                             Http2ClientRequestImpl request,
                                                             ClientUri initialUri,
                                                             WebClientServiceRequest serviceRequest,
@@ -335,7 +447,12 @@ class Http2ClientConnectionHandler {
             if (!http1FallbackAllowed(request)) {
                 throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
             }
-            return http1(http2Client, request, initialUri, serviceRequest, http1FallbackHandler);
+            return http1(http2Client,
+                         requestTarget,
+                         request,
+                         initialUri,
+                         serviceRequest,
+                         http1FallbackHandler);
         }
         return http2ExplicitConnection(http2Client, request, clientConnection);
     }
@@ -395,11 +512,16 @@ class Http2ClientConnectionHandler {
     }
 
     private Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
-                                               Http2ClientRequestImpl request, ClientUri initialUri,
+                                               ClientConnectionTarget requestTarget,
+                                               Http2ClientRequestImpl request,
+                                               ClientUri initialUri,
                                                WebClientServiceRequest serviceRequest,
                                                Http1FallbackHandler http1FallbackHandler) {
         try {
-            Http1ClientRequest http1Request = http1Request(http2Client.http1FallbackClient(), request, initialUri);
+            Http1ClientRequest http1Request = http1Request(http2Client.http1FallbackClient(),
+                                                           requestTarget,
+                                                           request,
+                                                           initialUri);
             return new Http2ConnectionAttemptResult(Result.HTTP_1,
                                                     null,
                                                     http1FallbackHandler.apply(http1Request, serviceRequest));
@@ -409,7 +531,10 @@ class Http2ClientConnectionHandler {
         }
     }
 
-    private Http1ClientRequest http1Request(Http1Client http1Client, Http2ClientRequestImpl request, ClientUri initialUri) {
+    private Http1ClientRequest http1Request(Http1Client http1Client,
+                                           ClientConnectionTarget requestTarget,
+                                           Http2ClientRequestImpl request,
+                                           ClientUri initialUri) {
         Http1ClientRequest http1Request = http1Client.method(request.method())
                 .uri(initialUri)
                 .keepAlive(request.keepAlive())
@@ -428,10 +553,15 @@ class Http2ClientConnectionHandler {
         // This is a manual HTTP/2-to-HTTP/1 request copy used for h2c probing/fallback. Properties carry internal
         // redirect state, including whether a previous redirect already crossed an origin boundary.
         request.properties().forEach(http1Request::property);
+        if (requestTarget.transportAddress().isEmpty()
+                && http1Request instanceof FullClientRequest<?> fullClientRequest) {
+            fullClientRequest.selectedProxyRoute(requestTarget.proxyRoute());
+        }
         return http1Request;
     }
 
     private Http2ClientConnection createConnection(Http2ClientImpl http2Client,
+                                                   ClientConnectionTarget requestTarget,
                                                    Http2ClientRequestImpl request,
                                                    ClientUri requestUri,
                                                    WebClientServiceRequest serviceRequest,
@@ -450,15 +580,24 @@ class Http2ClientConnectionHandler {
 
             // we know that this is HTTP/2 capable server - still need to support all three (prior, upgrade, alpn)
             if (request.tls().enabled() && "https".equals(requestUri.scheme())) {
-                connection = connectClient(webClient, request, requestUri, List.of(Http2Client.PROTOCOL_ID));
+                connection = connectClient(webClient,
+                                           requestTarget,
+                                           request,
+                                           requestUri,
+                                           List.of(Http2Client.PROTOCOL_ID));
                 usedConnection = createHttp2Connection(http2Client, connection, true);
             } else {
                 if (request.priorKnowledge()) {
-                    connection = connectClient(webClient, request, requestUri, List.of(Http2Client.PROTOCOL_ID));
+                    connection = connectClient(webClient,
+                                               requestTarget,
+                                               request,
+                                               requestUri,
+                                               List.of(Http2Client.PROTOCOL_ID));
                     usedConnection = createHttp2Connection(http2Client, connection, true);
                 } else {
                     // attempt an upgrade to HTTP/2
                     UpgradeResponse upgradeResponse = upgrade(http2Client,
+                                                              requestTarget,
                                                               request,
                                                               requestUri,
                                                               serviceRequest,
@@ -572,6 +711,22 @@ class Http2ClientConnectionHandler {
         }
     }
 
+    private void retireConnections() {
+        Set<Http2ClientConnection> toRetire = new HashSet<>();
+        lifecycleLock.lock();
+        try {
+            toRetire.addAll(pendingUpgradedConnections);
+            toRetire.addAll(allConnections.keySet());
+            Http2ClientConnection active = activeConnection.get();
+            if (active != null) {
+                toRetire.add(active);
+            }
+        } finally {
+            lifecycleLock.unlock();
+        }
+        toRetire.forEach(Http2ClientConnection::retire);
+    }
+
     private static void closeClientConnection(ClientConnection clientConnection) {
         try {
             clientConnection.closeResource();
@@ -611,21 +766,21 @@ class Http2ClientConnectionHandler {
     }
 
     private ClientConnection connectClient(WebClient webClient,
+                                           ClientConnectionTarget requestTarget,
                                            Http2ClientRequestImpl request,
                                            ClientUri uri,
                                            List<String> alpn) {
         var address = request.address();
-        if (address.isPresent() && address.get() instanceof UnixDomainSocketAddress udsAddress) {
+        if (address.isPresent() && address.get() instanceof UnixDomainSocketAddress) {
             return UnixDomainSocketClientConnection.create(webClient,
-                                                          connectionKey,
+                                                          requestTarget,
                                                           alpn,
-                                                          udsAddress,
                                                           connection -> false,
                                                           this::removeClientConnection)
                     .connect();
         }
         return TcpClientConnection.create(webClient,
-                                          connectionKey,
+                                          requestTarget,
                                           alpn,
                                           connection -> false,
                                           this::removeClientConnection)

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -189,7 +189,13 @@ class Http2ClientConnectionHandler {
                 if (!http1FallbackAllowed(request)) {
                     throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
                 }
-                return http1(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
+                return http1(http2Client,
+                             requestTarget,
+                             request,
+                             initialUri,
+                             serviceRequest,
+                             http1FallbackHandler,
+                             this);
             }
 
             return switch (result.get()) {
@@ -197,7 +203,13 @@ class Http2ClientConnectionHandler {
                     if (!http1FallbackAllowed(request)) {
                         throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
                     }
-                    yield http1(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
+                    yield http1(http2Client,
+                                requestTarget,
+                                request,
+                                initialUri,
+                                serviceRequest,
+                                http1FallbackHandler,
+                                this);
                 }
                 case HTTP_2 -> http2(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
                 case UNKNOWN -> httpX(http2Client,
@@ -501,7 +513,13 @@ class Http2ClientConnectionHandler {
                                                                   ClientConnection clientConnection) {
         request.connection(clientConnection);
         try {
-            return http1(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
+            return http1(http2Client,
+                         requestTarget,
+                         request,
+                         initialUri,
+                         serviceRequest,
+                         http1FallbackHandler,
+                         this);
         } catch (RuntimeException | Error e) {
             closeClientConnection(clientConnection);
             throw e;
@@ -550,7 +568,8 @@ class Http2ClientConnectionHandler {
                          request,
                          initialUri,
                          serviceRequest,
-                         http1FallbackHandler);
+                         http1FallbackHandler,
+                         this);
         }
         return http2ExplicitConnection(http2Client, requestTarget, request, clientConnection);
     }
@@ -612,12 +631,13 @@ class Http2ClientConnectionHandler {
         return Base64.getUrlEncoder().encodeToString(b);
     }
 
-    private Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
-                                               ClientConnectionTarget requestTarget,
-                                               Http2ClientRequestImpl request,
-                                               ClientUri initialUri,
-                                               WebClientServiceRequest serviceRequest,
-                                               Http1FallbackHandler http1FallbackHandler) {
+    static Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
+                                              ClientConnectionTarget requestTarget,
+                                              Http2ClientRequestImpl request,
+                                              ClientUri initialUri,
+                                              WebClientServiceRequest serviceRequest,
+                                              Http1FallbackHandler http1FallbackHandler,
+                                              Http2ClientConnectionHandler resultHandler) {
         try {
             Http1ClientRequest http1Request = http1Request(http2Client.http1FallbackClient(),
                                                            requestTarget,
@@ -626,7 +646,7 @@ class Http2ClientConnectionHandler {
             return new Http2ConnectionAttemptResult(Result.HTTP_1,
                                                     null,
                                                     http1FallbackHandler.apply(http1Request, serviceRequest),
-                                                    this,
+                                                    resultHandler,
                                                     requestTarget);
         } catch (RuntimeException | Error e) {
             http1FallbackHandler.completeSentExceptionally(e);
@@ -634,10 +654,10 @@ class Http2ClientConnectionHandler {
         }
     }
 
-    private Http1ClientRequest http1Request(Http1Client http1Client,
-                                           ClientConnectionTarget requestTarget,
-                                           Http2ClientRequestImpl request,
-                                           ClientUri initialUri) {
+    private static Http1ClientRequest http1Request(Http1Client http1Client,
+                                                  ClientConnectionTarget requestTarget,
+                                                  Http2ClientRequestImpl request,
+                                                  ClientUri initialUri) {
         Http1ClientRequest http1Request = http1Client.method(request.method())
                 .uri(initialUri)
                 .keepAlive(request.keepAlive())
@@ -864,7 +884,7 @@ class Http2ClientConnectionHandler {
         }
     }
 
-    private static boolean http1FallbackAllowed(Http2ClientRequestImpl request) {
+    static boolean http1FallbackAllowed(Http2ClientRequestImpl request) {
         return request.tcpProtocolIds().contains(Http1Client.PROTOCOL_ID);
     }
 
@@ -874,9 +894,9 @@ class Http2ClientConnectionHandler {
                                                    + request.tcpProtocolIds());
     }
 
-    private static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri,
-                                                                     Http2ClientRequestImpl request,
-                                                                     Http1FallbackHandler http1FallbackHandler) {
+    static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri,
+                                                             Http2ClientRequestImpl request,
+                                                             Http1FallbackHandler http1FallbackHandler) {
         IllegalArgumentException failure = unsupportedHttp1Fallback(uri, request);
         http1FallbackHandler.completeSentExceptionally(failure);
         return failure;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -172,8 +172,8 @@ class Http2ClientConnectionHandler {
                                           http1FallbackHandler,
                                           maybeConnection.get());
             }
-            if (requestTarget.proxyRoute().forwardProxy()) {
-                if (request.priorKnowledge() || !http1FallbackAllowed(request)) {
+            if (requestTarget.proxyRoute().forwardProxy() && !request.priorKnowledge()) {
+                if (!http1FallbackAllowed(request)) {
                     throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
                 }
                 result.set(Result.HTTP_1);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -189,7 +189,6 @@ class Http2ClientConnectionHandler {
                 if (!http1FallbackAllowed(request)) {
                     throw unsupportedHttp1Fallback(initialUri, request, http1FallbackHandler);
                 }
-                result.set(Result.HTTP_1);
                 return http1(http2Client, requestTarget, request, initialUri, serviceRequest, http1FallbackHandler);
             }
 
@@ -291,7 +290,8 @@ class Http2ClientConnectionHandler {
         Http2ClientConnection connection = activeConnection.get();
         if (connection != null) {
             ClientConnectionTarget connectionTarget = allConnections.get(connection);
-            if (connectionTarget != null) {
+            if (connectionTarget != null
+                    && (request.priorKnowledge() || !connectionTarget.proxyRoute().forwardProxy())) {
                 if (connection.closed(protocolConfig)) {
                     discardConnection(connection);
                 } else {
@@ -319,6 +319,9 @@ class Http2ClientConnectionHandler {
             }
             ClientConnectionTarget connectionTarget = allConnections.get(candidate);
             if (connectionTarget == null) {
+                continue;
+            }
+            if (!request.priorKnowledge() && connectionTarget.proxyRoute().forwardProxy()) {
                 continue;
             }
             if (candidate.closed(protocolConfig)) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -228,7 +228,7 @@ class Http2ClientConnectionHandler {
                                             http1FallbackHandler);
                 } catch (Http1FallbackResponse e) {
                     http1FallbackHandler.completeSent(serviceRequest);
-                    return new Http2ConnectionAttemptResult(Result.HTTP_1, null, e.response());
+                    return new Http2ConnectionAttemptResult(Result.HTTP_1, null, e.response(), this);
                 }
                 // we must assume that a new connection can handle a new stream
                 stream = createStreamOnNewConnection(http2Client, conn, request);
@@ -248,13 +248,13 @@ class Http2ClientConnectionHandler {
                                                 http1FallbackHandler);
                     } catch (Http1FallbackResponse e) {
                         http1FallbackHandler.completeSent(serviceRequest);
-                        return new Http2ConnectionAttemptResult(Result.HTTP_1, null, e.response());
+                        return new Http2ConnectionAttemptResult(Result.HTTP_1, null, e.response(), this);
                     }
                     stream = createStreamOnNewConnection(http2Client, conn, request);
                 }
             }
 
-            return new Http2ConnectionAttemptResult(Result.HTTP_2, stream, null);
+            return new Http2ConnectionAttemptResult(Result.HTTP_2, stream, null, this);
         } finally {
             lock.unlock();
         }
@@ -376,7 +376,7 @@ class Http2ClientConnectionHandler {
                 if (request.followRedirects() && RedirectionProcessor.redirectionStatusCode(response.status())) {
                     // Surface redirect responses instead of treating them as unexpected upgrade failures.
                     http1FallbackHandler.completeSent(serviceRequest);
-                    return new Http2ConnectionAttemptResult(Result.UNKNOWN, null, response);
+                    return new Http2ConnectionAttemptResult(Result.UNKNOWN, null, response, this);
                 }
                 if (!http1FallbackHandler.upgradeFailureResponseAllowed()) {
                     try (response) {
@@ -387,7 +387,7 @@ class Http2ClientConnectionHandler {
                 }
                 result.set(Result.HTTP_1);
                 http1FallbackHandler.completeSent(serviceRequest);
-                return new Http2ConnectionAttemptResult(Result.HTTP_1, null, response);
+                return new Http2ConnectionAttemptResult(Result.HTTP_1, null, response, this);
             }
         } finally {
             lock.unlock();
@@ -492,7 +492,8 @@ class Http2ClientConnectionHandler {
                                                                             http2Client.clientConfig(),
                                                                             http2Client.sendListener(),
                                                                             http2Client.recvListener()),
-                                                    null);
+                                                    null,
+                                                    this);
         } finally {
             lock.unlock();
         }
@@ -524,7 +525,8 @@ class Http2ClientConnectionHandler {
                                                            initialUri);
             return new Http2ConnectionAttemptResult(Result.HTTP_1,
                                                     null,
-                                                    http1FallbackHandler.apply(http1Request, serviceRequest));
+                                                    http1FallbackHandler.apply(http1Request, serviceRequest),
+                                                    this);
         } catch (RuntimeException | Error e) {
             http1FallbackHandler.completeSentExceptionally(e);
             throw e;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -67,7 +67,8 @@ class Http2ClientConnectionHandler {
     private final Map<ClientConnection, Http2ClientConnection> h2ConnByConn =
             Collections.synchronizedMap(new IdentityHashMap<>());
 
-    private final Map<Http2ClientConnection, Boolean> allConnections = Collections.synchronizedMap(new IdentityHashMap<>());
+    private final Map<Http2ClientConnection, ClientConnectionTarget> allConnections =
+            Collections.synchronizedMap(new IdentityHashMap<>());
     private final Set<Http2ClientConnection> pendingUpgradedConnections =
             Collections.newSetFromMap(new IdentityHashMap<>());
     // Creation ordered and compared by identity. Mutated only while holding lifecycleLock.
@@ -213,6 +214,31 @@ class Http2ClientConnectionHandler {
         }
     }
 
+    Http2ConnectionAttemptResult reuseStream(Http2ClientImpl http2Client,
+                                             Http2ClientRequestImpl request) {
+        if (result.get() != Result.HTTP_2) {
+            return null;
+        }
+        try {
+            lock.lockInterruptibly();
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Interrupted", e);
+        }
+        try {
+            ExistingStream existingStream = existingStream(http2Client, request);
+            if (existingStream == null) {
+                return null;
+            }
+            return new Http2ConnectionAttemptResult(Result.HTTP_2,
+                                                    existingStream.stream(),
+                                                    null,
+                                                    this,
+                                                    existingStream.connectionTarget());
+        } finally {
+            lock.unlock();
+        }
+    }
+
     Http2ConnectionAttemptResult http2(Http2ClientImpl http2Client,
                                        ClientConnectionTarget requestTarget,
                                        Http2ClientRequestImpl request,
@@ -226,76 +252,99 @@ class Http2ClientConnectionHandler {
         }
         try {
             // read/write lock to obtain a stream or create a new connection
-            Http2ClientProtocolConfig protocolConfig = http2Client.protocolConfig();
-            Http2ClientConnection conn = activeConnection.get();
-            Http2ClientStream stream = null;
-            if (conn != null) {
-                if (conn.closed(protocolConfig)) {
-                    discardConnection(conn);
-                } else {
-                    stream = conn.tryStream(request,
-                                            http2Client.clientConfig(),
-                                            http2Client.sendListener(),
-                                            http2Client.recvListener());
-                }
-            }
-            if (stream == null) {
-                List<Http2ClientConnection> connections;
-                lifecycleLock.lock();
+            ExistingStream existingStream = existingStream(http2Client, request);
+            if (existingStream == null) {
+                Http2ClientConnection connection;
                 try {
-                    connections = List.copyOf(selectableConnections);
-                } finally {
-                    lifecycleLock.unlock();
-                }
-                for (Http2ClientConnection candidate : connections) {
-                    if (candidate == conn) {
-                        continue;
-                    }
-                    if (candidate.closed(protocolConfig)) {
-                        discardConnection(candidate);
-                        continue;
-                    }
-                    stream = candidate.tryStream(request,
-                                                 http2Client.clientConfig(),
-                                                 http2Client.sendListener(),
-                                                 http2Client.recvListener());
-                    if (stream != null) {
-                        conn = candidate;
-                        lifecycleLock.lock();
-                        try {
-                            for (Http2ClientConnection selectableConnection : selectableConnections) {
-                                if (selectableConnection == candidate) {
-                                    activeConnection.set(candidate);
-                                    break;
-                                }
-                            }
-                        } finally {
-                            lifecycleLock.unlock();
-                        }
-                        break;
-                    }
-                }
-            }
-            if (stream == null) {
-                try {
-                    conn = createConnection(http2Client,
-                                            requestTarget,
-                                            request,
-                                            initialUri,
-                                            serviceRequest,
-                                            http1FallbackHandler);
+                    connection = createConnection(http2Client,
+                                                  requestTarget,
+                                                  request,
+                                                  initialUri,
+                                                  serviceRequest,
+                                                  http1FallbackHandler);
                 } catch (Http1FallbackResponse e) {
                     http1FallbackHandler.completeSent(serviceRequest);
-                    return new Http2ConnectionAttemptResult(Result.HTTP_1, null, e.response(), this);
+                    return new Http2ConnectionAttemptResult(Result.HTTP_1,
+                                                            null,
+                                                            e.response(),
+                                                            this,
+                                                            requestTarget);
                 }
+                result.set(Result.HTTP_2);
                 // we must assume that a new connection can handle a new stream
-                stream = createStreamOnNewConnection(http2Client, conn, request);
+                Http2ClientStream stream = createStreamOnNewConnection(http2Client, connection, request);
+                return new Http2ConnectionAttemptResult(Result.HTTP_2, stream, null, this, requestTarget);
             }
 
-            return new Http2ConnectionAttemptResult(Result.HTTP_2, stream, null, this);
+            return new Http2ConnectionAttemptResult(Result.HTTP_2,
+                                                    existingStream.stream(),
+                                                    null,
+                                                    this,
+                                                    existingStream.connectionTarget());
         } finally {
             lock.unlock();
         }
+    }
+
+    private ExistingStream existingStream(Http2ClientImpl http2Client, Http2ClientRequestImpl request) {
+        Http2ClientProtocolConfig protocolConfig = http2Client.protocolConfig();
+        Http2ClientConnection connection = activeConnection.get();
+        if (connection != null) {
+            ClientConnectionTarget connectionTarget = allConnections.get(connection);
+            if (connectionTarget != null) {
+                if (connection.closed(protocolConfig)) {
+                    discardConnection(connection);
+                } else {
+                    Http2ClientStream stream = connection.tryStream(request,
+                                                                    http2Client.clientConfig(),
+                                                                    http2Client.sendListener(),
+                                                                    http2Client.recvListener());
+                    if (stream != null) {
+                        return new ExistingStream(stream, connectionTarget);
+                    }
+                }
+            }
+        }
+
+        List<Http2ClientConnection> connections;
+        lifecycleLock.lock();
+        try {
+            connections = List.copyOf(selectableConnections);
+        } finally {
+            lifecycleLock.unlock();
+        }
+        for (Http2ClientConnection candidate : connections) {
+            if (candidate == connection) {
+                continue;
+            }
+            ClientConnectionTarget connectionTarget = allConnections.get(candidate);
+            if (connectionTarget == null) {
+                continue;
+            }
+            if (candidate.closed(protocolConfig)) {
+                discardConnection(candidate);
+                continue;
+            }
+            Http2ClientStream stream = candidate.tryStream(request,
+                                                           http2Client.clientConfig(),
+                                                           http2Client.sendListener(),
+                                                           http2Client.recvListener());
+            if (stream != null) {
+                lifecycleLock.lock();
+                try {
+                    for (Http2ClientConnection selectableConnection : selectableConnections) {
+                        if (selectableConnection == candidate) {
+                            activeConnection.set(candidate);
+                            break;
+                        }
+                    }
+                } finally {
+                    lifecycleLock.unlock();
+                }
+                return new ExistingStream(stream, connectionTarget);
+            }
+        }
+        return null;
     }
 
     private Http2ConnectionAttemptResult httpX(Http2ClientImpl http2Client,
@@ -322,7 +371,7 @@ class Http2ClientConnectionHandler {
                         Http2ClientConnection connection = createHttp2Connection(http2Client,
                                                                                  clientConnection,
                                                                                  true);
-                        activateConnection(clientConnection, connection);
+                        activateConnection(requestTarget, clientConnection, connection);
                         return http2(http2Client,
                                      requestTarget,
                                      request,
@@ -362,7 +411,7 @@ class Http2ClientConnectionHandler {
                     Http2ClientConnection connection = createHttp2Connection(http2Client,
                                                                              clientConnection,
                                                                              true);
-                    activateConnection(clientConnection, connection);
+                    activateConnection(requestTarget, clientConnection, connection);
                     return http2(http2Client,
                                  requestTarget,
                                  request,
@@ -402,7 +451,7 @@ class Http2ClientConnectionHandler {
                 result.set(Result.HTTP_2);
                 ClientConnection connection = upgradeResponse.connection();
                 Http2ClientConnection conn = createUpgradedHttp2Connection(http2Client, connection);
-                activateConnection(connection, conn);
+                activateConnection(requestTarget, connection, conn);
                 return http2(http2Client,
                              requestTarget,
                              request,
@@ -414,7 +463,11 @@ class Http2ClientConnectionHandler {
                 if (request.followRedirects() && RedirectionProcessor.redirectionStatusCode(response.status())) {
                     // Surface redirect responses instead of treating them as unexpected upgrade failures.
                     http1FallbackHandler.completeSent(serviceRequest);
-                    return new Http2ConnectionAttemptResult(Result.UNKNOWN, null, response, this);
+                    return new Http2ConnectionAttemptResult(Result.UNKNOWN,
+                                                            null,
+                                                            response,
+                                                            this,
+                                                            requestTarget);
                 }
                 if (!http1FallbackHandler.upgradeFailureResponseAllowed()) {
                     try (response) {
@@ -425,7 +478,11 @@ class Http2ClientConnectionHandler {
                 }
                 result.set(Result.HTTP_1);
                 http1FallbackHandler.completeSent(serviceRequest);
-                return new Http2ConnectionAttemptResult(Result.HTTP_1, null, response, this);
+                return new Http2ConnectionAttemptResult(Result.HTTP_1,
+                                                        null,
+                                                        response,
+                                                        this,
+                                                        requestTarget);
             }
         } finally {
             lock.unlock();
@@ -492,10 +549,11 @@ class Http2ClientConnectionHandler {
                          serviceRequest,
                          http1FallbackHandler);
         }
-        return http2ExplicitConnection(http2Client, request, clientConnection);
+        return http2ExplicitConnection(http2Client, requestTarget, request, clientConnection);
     }
 
     private Http2ConnectionAttemptResult http2ExplicitConnection(Http2ClientImpl http2Client,
+                                                                 ClientConnectionTarget requestTarget,
                                                                  Http2ClientRequestImpl request,
                                                                  ClientConnection clientConnection) {
         try {
@@ -522,7 +580,7 @@ class Http2ClientConnectionHandler {
             }
             if (ownsExplicitConnection) {
                 result.set(Result.HTTP_2);
-                activateConnection(clientConnection, connection);
+                activateConnection(requestTarget, clientConnection, connection);
             }
 
             return new Http2ConnectionAttemptResult(Result.HTTP_2,
@@ -531,7 +589,8 @@ class Http2ClientConnectionHandler {
                                                                             http2Client.sendListener(),
                                                                             http2Client.recvListener()),
                                                     null,
-                                                    this);
+                                                    this,
+                                                    requestTarget);
         } finally {
             lock.unlock();
         }
@@ -564,7 +623,8 @@ class Http2ClientConnectionHandler {
             return new Http2ConnectionAttemptResult(Result.HTTP_1,
                                                     null,
                                                     http1FallbackHandler.apply(http1Request, serviceRequest),
-                                                    this);
+                                                    this,
+                                                    requestTarget);
         } catch (RuntimeException | Error e) {
             http1FallbackHandler.completeSentExceptionally(e);
             throw e;
@@ -668,7 +728,7 @@ class Http2ClientConnectionHandler {
             }
 
             // only set these for requests that do not have an explicit connection defined
-            activateConnection(connection, usedConnection);
+            activateConnection(requestTarget, connection, usedConnection);
         }
 
         return usedConnection;
@@ -719,7 +779,9 @@ class Http2ClientConnectionHandler {
         }
     }
 
-    private void activateConnection(ClientConnection clientConnection, Http2ClientConnection connection) {
+    private void activateConnection(ClientConnectionTarget connectionTarget,
+                                    ClientConnection clientConnection,
+                                    Http2ClientConnection connection) {
         Http2ClientConnection displacedConnection = null;
         boolean closeConnection;
         lifecycleLock.lock();
@@ -727,7 +789,7 @@ class Http2ClientConnectionHandler {
             pendingUpgradedConnections.remove(connection);
             closeConnection = closed;
             if (!closeConnection) {
-                allConnections.put(connection, true);
+                allConnections.put(connection, connectionTarget);
                 h2ConnByConn.put(clientConnection, connection);
                 boolean alreadySelectable = false;
                 for (Http2ClientConnection selectableConnection : selectableConnections) {
@@ -863,6 +925,9 @@ class Http2ClientConnectionHandler {
         } finally {
             lifecycleLock.unlock();
         }
+    }
+
+    private record ExistingStream(Http2ClientStream stream, ClientConnectionTarget connectionTarget) {
     }
 
     private static class Http1FallbackResponse extends RuntimeException {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.http2;
 
 import java.net.UnixDomainSocketAddress;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
@@ -69,14 +70,24 @@ class Http2ClientConnectionHandler {
     private final Map<Http2ClientConnection, Boolean> allConnections = Collections.synchronizedMap(new IdentityHashMap<>());
     private final Set<Http2ClientConnection> pendingUpgradedConnections =
             Collections.newSetFromMap(new IdentityHashMap<>());
+    // Creation ordered and compared by identity. Mutated only while holding lifecycleLock.
+    private final List<Http2ClientConnection> selectableConnections = new ArrayList<>();
     private final AtomicReference<Http2ClientConnection> activeConnection = new AtomicReference<>();
     private final ReentrantLock lock = new ReentrantLock();
     private final ReentrantLock lifecycleLock = new ReentrantLock();
     private final AtomicReference<Result> result = new AtomicReference<>(Result.UNKNOWN);
+    private final int connectionCacheSize;
     private boolean closed;
     private boolean retired;
     private boolean connectionsRetired;
     private int leases;
+
+    Http2ClientConnectionHandler(int connectionCacheSize) {
+        if (connectionCacheSize < 1) {
+            throw new IllegalArgumentException("Connection cache size must be greater than zero");
+        }
+        this.connectionCacheSize = connectionCacheSize;
+    }
 
     boolean acquire() {
         lifecycleLock.lock();
@@ -145,6 +156,7 @@ class Http2ClientConnectionHandler {
             pendingUpgradedConnections.clear();
             allConnections.clear();
             h2ConnByConn.clear();
+            selectableConnections.clear();
             Http2ClientConnection active = activeConnection.getAndSet(null);
             if (active != null) {
                 toClose.add(active);
@@ -214,11 +226,57 @@ class Http2ClientConnectionHandler {
         }
         try {
             // read/write lock to obtain a stream or create a new connection
-            Http2ClientConnection conn = activeConnection.updateAndGet(c -> c != null && c.closed(http2Client.protocolConfig())
-                    ? null
-                    : c);
-            Http2ClientStream stream;
-            if (conn == null) {
+            Http2ClientProtocolConfig protocolConfig = http2Client.protocolConfig();
+            Http2ClientConnection conn = activeConnection.get();
+            Http2ClientStream stream = null;
+            if (conn != null) {
+                if (conn.closed(protocolConfig)) {
+                    discardConnection(conn);
+                } else {
+                    stream = conn.tryStream(request,
+                                            http2Client.clientConfig(),
+                                            http2Client.sendListener(),
+                                            http2Client.recvListener());
+                }
+            }
+            if (stream == null) {
+                List<Http2ClientConnection> connections;
+                lifecycleLock.lock();
+                try {
+                    connections = List.copyOf(selectableConnections);
+                } finally {
+                    lifecycleLock.unlock();
+                }
+                for (Http2ClientConnection candidate : connections) {
+                    if (candidate == conn) {
+                        continue;
+                    }
+                    if (candidate.closed(protocolConfig)) {
+                        discardConnection(candidate);
+                        continue;
+                    }
+                    stream = candidate.tryStream(request,
+                                                 http2Client.clientConfig(),
+                                                 http2Client.sendListener(),
+                                                 http2Client.recvListener());
+                    if (stream != null) {
+                        conn = candidate;
+                        lifecycleLock.lock();
+                        try {
+                            for (Http2ClientConnection selectableConnection : selectableConnections) {
+                                if (selectableConnection == candidate) {
+                                    activeConnection.set(candidate);
+                                    break;
+                                }
+                            }
+                        } finally {
+                            lifecycleLock.unlock();
+                        }
+                        break;
+                    }
+                }
+            }
+            if (stream == null) {
                 try {
                     conn = createConnection(http2Client,
                                             requestTarget,
@@ -232,26 +290,6 @@ class Http2ClientConnectionHandler {
                 }
                 // we must assume that a new connection can handle a new stream
                 stream = createStreamOnNewConnection(http2Client, conn, request);
-            } else {
-                stream = conn.tryStream(request,
-                                        http2Client.clientConfig(),
-                                        http2Client.sendListener(),
-                                        http2Client.recvListener());
-                if (stream == null) {
-                    // either the connection is closed, or it ran out of streams
-                    try {
-                        conn = createConnection(http2Client,
-                                                requestTarget,
-                                                request,
-                                                initialUri,
-                                                serviceRequest,
-                                                http1FallbackHandler);
-                    } catch (Http1FallbackResponse e) {
-                        http1FallbackHandler.completeSent(serviceRequest);
-                        return new Http2ConnectionAttemptResult(Result.HTTP_1, null, e.response(), this);
-                    }
-                    stream = createStreamOnNewConnection(http2Client, conn, request);
-                }
             }
 
             return new Http2ConnectionAttemptResult(Result.HTTP_2, stream, null, this);
@@ -682,6 +720,7 @@ class Http2ClientConnectionHandler {
     }
 
     private void activateConnection(ClientConnection clientConnection, Http2ClientConnection connection) {
+        Http2ClientConnection displacedConnection = null;
         boolean closeConnection;
         lifecycleLock.lock();
         try {
@@ -690,7 +729,21 @@ class Http2ClientConnectionHandler {
             if (!closeConnection) {
                 allConnections.put(connection, true);
                 h2ConnByConn.put(clientConnection, connection);
+                boolean alreadySelectable = false;
+                for (Http2ClientConnection selectableConnection : selectableConnections) {
+                    if (selectableConnection == connection) {
+                        alreadySelectable = true;
+                        break;
+                    }
+                }
+                if (!alreadySelectable) {
+                    selectableConnections.add(connection);
+                }
                 activeConnection.set(connection);
+                if (selectableConnections.size() > connectionCacheSize) {
+                    displacedConnection = selectableConnections.getFirst();
+                    removeSelectableConnection(displacedConnection);
+                }
             }
         } finally {
             lifecycleLock.unlock();
@@ -699,18 +752,27 @@ class Http2ClientConnectionHandler {
             connection.close();
             throw new IllegalStateException("HTTP/2 connection handler is closed");
         }
+        if (displacedConnection != null) {
+            displacedConnection.retire();
+        }
     }
 
     private void removeConnection(Http2ClientConnection connection) {
         lifecycleLock.lock();
         try {
             pendingUpgradedConnections.remove(connection);
-            h2ConnByConn.values().removeIf(it -> it == connection);
             allConnections.remove(connection);
-            activeConnection.compareAndSet(connection, null);
+            removeSelectableConnection(connection);
         } finally {
             lifecycleLock.unlock();
         }
+    }
+
+    // Caller must hold lifecycleLock.
+    private void removeSelectableConnection(Http2ClientConnection connection) {
+        h2ConnByConn.values().removeIf(it -> it == connection);
+        selectableConnections.removeIf(it -> it == connection);
+        activeConnection.compareAndSet(connection, null);
     }
 
     private void retireConnections() {
@@ -796,7 +858,7 @@ class Http2ClientConnectionHandler {
             if (connection != null) {
                 pendingUpgradedConnections.remove(connection);
                 allConnections.remove(connection);
-                activeConnection.compareAndSet(connection, null);
+                removeSelectableConnection(connection);
             }
         } finally {
             lifecycleLock.unlock();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -102,6 +102,7 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
 
     @Override
     public ClientRequest<?> clientRequest(FullClientRequest<?> clientRequest, ClientUri clientUri) {
+        var selectedProxyRoute = clientRequest.selectedProxyRoute();
         Http2ClientRequestImpl request = new Http2ClientRequestImpl(this,
                                                                     clientRequest,
                                                                     clientRequest.method(),
@@ -113,8 +114,7 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
         clientRequest.pathParams().forEach(request::pathParam);
         clientRequest.address().ifPresent(request::address);
         clientRequest.sni().ifPresent(request::sni);
-
-        return request.readTimeout(clientRequest.readTimeout())
+        request.readTimeout(clientRequest.readTimeout())
                 .readContinueTimeout(clientRequest.readContinueTimeout())
                 .followRedirects(clientRequest.followRedirects())
                 .maxRedirects(clientRequest.maxRedirects())
@@ -122,6 +122,8 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
                 .tls(clientRequest.tls())
                 .headers(clientRequest.headers())
                 .fragment(clientUri.fragment());
+        selectedProxyRoute.ifPresent(request::selectedProxyRoute);
+        return request;
     }
 
     @Override

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -23,9 +23,11 @@ import java.util.concurrent.CompletableFuture;
 
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Method;
+import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.FullClientRequest;
+import io.helidon.webclient.api.ProxyRoute;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.http1.Http1Client;
@@ -100,9 +102,11 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
         tls(request.tls());
+        proxy(request.proxy());
         request.sni().ifPresent(this::sni);
         if (sameOrigin(request.resolvedUri(), clientUri)) {
             request.address().ifPresent(this::address);
+            request.selectedProxyRoute().ifPresent(this::selectedProxyRoute);
         }
 
         this.priority(request.priority);
@@ -113,6 +117,22 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         this.readContinueTimeout(request.readContinueTimeout());
         request.sendExpectContinue().ifPresent(this::sendExpectContinue);
         this.outputStreamRedirect(request.outputStreamRedirect);
+    }
+
+    @Override
+    public void selectedProxyRoute(ProxyRoute proxyRoute) {
+        super.selectedProxyRoute(proxyRoute);
+        if (delegate != null) {
+            delegate.selectedProxyRoute(proxyRoute);
+        }
+    }
+
+    @Override
+    public void clearSelectedProxyRoute() {
+        super.clearSelectedProxyRoute();
+        if (delegate != null) {
+            delegate.clearSelectedProxyRoute();
+        }
     }
 
     @Override
@@ -200,7 +220,10 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
     }
 
     boolean ownsExplicitConnection() {
-        return delegate != null && delegate.connection().isEmpty() && connection().isPresent();
+        ClientConnection current = connection().orElse(null);
+        return delegate != null
+                && current != null
+                && delegate.connection().orElse(null) != current;
     }
 
     List<String> tcpProtocolIds() {
@@ -235,6 +258,10 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
                                                                entity);
 
         return invokeWithServices(httpCall, whenSent, whenComplete);
+    }
+
+    Http2ClientResponseImpl redirectProbe() {
+        return (Http2ClientResponseImpl) requestWithoutRouteCleanup();
     }
 
     private Http2ClientResponseImpl invokeWithServices(Http2CallChainBase callChain,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionAttemptResult.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionAttemptResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@ import io.helidon.webclient.api.HttpClientResponse;
 
 record Http2ConnectionAttemptResult(Result result,
                                     Http2ClientStream stream,
-                                    HttpClientResponse response) {
+                                    HttpClientResponse response,
+                                    Http2ClientConnectionHandler handler) {
     enum Result {
         HTTP_1,
         HTTP_2,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionAttemptResult.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionAttemptResult.java
@@ -16,12 +16,14 @@
 
 package io.helidon.webclient.http2;
 
+import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.HttpClientResponse;
 
 record Http2ConnectionAttemptResult(Result result,
                                     Http2ClientStream stream,
                                     HttpClientResponse response,
-                                    Http2ClientConnectionHandler handler) {
+                                    Http2ClientConnectionHandler handler,
+                                    ClientConnectionTarget connectionTarget) {
     enum Result {
         HTTP_1,
         HTTP_2,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -96,13 +96,17 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         return http2Supported.get(ck).isPresent();
     }
 
+    void markSupported(ConnectionKey connectionKey) {
+        http2Supported.put(connectionKey, true);
+    }
+
     void remove(ClientConnectionTarget connectionTarget, Http2ClientConnectionHandler expectedHandler) {
         cacheLock.lock();
         try {
             if (cache.remove(connectionTarget, expectedHandler)) {
                 insertionOrder.remove(connectionTarget, expectedHandler);
                 removeLookupHandler(connectionTarget, expectedHandler);
-                http2Supported.remove(connectionTarget.connectionKey());
+                removeSupportIfUnused(connectionTarget.connectionKey());
             }
         } finally {
             cacheLock.unlock();
@@ -140,7 +144,7 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                     handler.release();
                 }
                 if (result != null) {
-                    http2Supported.put(result.connectionTarget().connectionKey(), true);
+                    markSupported(result.connectionTarget().connectionKey());
                     return result;
                 }
             }
@@ -293,9 +297,18 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2
                 && (request.connection().isEmpty()
                         || Http2ClientConnectionHandler.ownsExplicitConnection(request))) {
-            http2Supported.put(connectionTarget.connectionKey(), true);
+            markSupported(connectionTarget.connectionKey());
         }
         return result;
+    }
+
+    private void removeSupportIfUnused(ConnectionKey connectionKey) {
+        for (ClientConnectionTarget cachedTarget : cache.keySet()) {
+            if (connectionKey.equals(cachedTarget.connectionKey())) {
+                return;
+            }
+        }
+        http2Supported.remove(connectionKey);
     }
 
     private void removeLookupHandler(ClientConnectionTarget connectionTarget,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -40,6 +40,8 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
     private static final Http2ConnectionCache SHARED = new Http2ConnectionCache(true);
     private final LruCache<ConnectionKey, Boolean> http2Supported = LruCache.create(1000);
     private final ConcurrentMap<ClientConnectionTarget, Http2ClientConnectionHandler> cache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ClientConnectionTarget.LookupKey, List<Http2ClientConnectionHandler>> lookupCache =
+            new ConcurrentHashMap<>();
     // Mutated only while holding cacheLock.
     private final Map<ClientConnectionTarget, Http2ClientConnectionHandler> insertionOrder = new LinkedHashMap<>();
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -74,6 +76,7 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         try {
             handlers = List.copyOf(insertionOrder.values());
             cache.clear();
+            lookupCache.clear();
             insertionOrder.clear();
             http2Supported.clear();
         } finally {
@@ -98,6 +101,7 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         try {
             if (cache.remove(connectionTarget, expectedHandler)) {
                 insertionOrder.remove(connectionTarget, expectedHandler);
+                removeLookupHandler(connectionTarget, expectedHandler);
                 http2Supported.remove(connectionTarget.connectionKey());
             }
         } finally {
@@ -105,6 +109,49 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         }
         // The failed stream still owns this handler even when a successor is now mapped.
         expectedHandler.close();
+    }
+
+    Http2ConnectionAttemptResult newStream(Http2ClientImpl http2Client,
+                                           ClientConnectionTarget.LookupKey lookupKey,
+                                           Http2ClientRequestImpl request,
+                                           ClientUri initialUri,
+                                           WebClientServiceRequest serviceRequest,
+                                           Http1FallbackHandler http1FallbackHandler) {
+        if (closed.get()) {
+            throw new IllegalStateException("Connection cache is closed");
+        }
+        if (!lookupKey.currentTlsGeneration()) {
+            throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
+        }
+
+        List<Http2ClientConnectionHandler> handlers = lookupCache.get(lookupKey);
+        if (handlers != null) {
+            for (Http2ClientConnectionHandler handler : handlers) {
+                if (!handler.acquire()) {
+                    continue;
+                }
+                Http2ConnectionAttemptResult result;
+                try {
+                    result = handler.reuseStream(http2Client, request);
+                } catch (RuntimeException | Error e) {
+                    http1FallbackHandler.completeSentExceptionally(e);
+                    throw e;
+                } finally {
+                    handler.release();
+                }
+                if (result != null) {
+                    http2Supported.put(result.connectionTarget().connectionKey(), true);
+                    return result;
+                }
+            }
+        }
+
+        return newStream(http2Client,
+                         ClientConnectionTarget.create(lookupKey),
+                         request,
+                         initialUri,
+                         serviceRequest,
+                         http1FallbackHandler);
     }
 
     Http2ConnectionAttemptResult newStream(Http2ClientImpl http2Client,
@@ -168,6 +215,7 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                             && !cachedTarget.currentTlsGeneration()) {
                         iterator.remove();
                         if (cache.remove(cachedTarget, entry.getValue())) {
+                            removeLookupHandler(cachedTarget, entry.getValue());
                             if (retiredHandlers == null) {
                                 retiredHandlers = new ArrayList<>();
                             }
@@ -181,6 +229,7 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                     var evicted = evictionIterator.next();
                     evictionIterator.remove();
                     if (cache.remove(evicted.getKey(), evicted.getValue())) {
+                        removeLookupHandler(evicted.getKey(), evicted.getValue());
                         if (retiredHandlers == null) {
                             retiredHandlers = new ArrayList<>();
                         }
@@ -194,6 +243,17 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                 }
                 insertionOrder.put(connectionTarget, handler);
                 cache.put(connectionTarget, handler);
+                if (connectionTarget.connectionKey().proxy().ipNoProxyConfigured()) {
+                    ClientConnectionTarget.LookupKey lookupKey = connectionTarget.lookupKey();
+                    List<Http2ClientConnectionHandler> handlers = lookupCache.get(lookupKey);
+                    if (handlers == null) {
+                        lookupCache.put(lookupKey, List.of(handler));
+                    } else {
+                        var updatedHandlers = new ArrayList<>(handlers);
+                        updatedHandlers.add(handler);
+                        lookupCache.put(lookupKey, List.copyOf(updatedHandlers));
+                    }
+                }
                 break;
             } finally {
                 cacheLock.unlock();
@@ -220,6 +280,25 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
             http2Supported.put(connectionTarget.connectionKey(), true);
         }
         return result;
+    }
+
+    private void removeLookupHandler(ClientConnectionTarget connectionTarget,
+                                     Http2ClientConnectionHandler expectedHandler) {
+        if (!connectionTarget.connectionKey().proxy().ipNoProxyConfigured()) {
+            return;
+        }
+        lookupCache.computeIfPresent(connectionTarget.lookupKey(), (_, handlers) -> {
+            var updatedHandlers = new ArrayList<Http2ClientConnectionHandler>(handlers.size());
+            for (Http2ClientConnectionHandler handler : handlers) {
+                if (handler != expectedHandler) {
+                    updatedHandlers.add(handler);
+                }
+            }
+            if (updatedHandlers.size() == handlers.size()) {
+                return handlers;
+            }
+            return updatedHandlers.isEmpty() ? null : List.copyOf(updatedHandlers);
+        });
     }
 
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -37,8 +39,9 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
     private static final int MAX_TARGETS = 1_000;
     private static final Http2ConnectionCache SHARED = new Http2ConnectionCache(true);
     private final LruCache<ConnectionKey, Boolean> http2Supported = LruCache.create(1000);
-    private final Map<ClientConnectionTarget, Http2ClientConnectionHandler> cache =
-            new LinkedHashMap<>(16, 0.75F, true);
+    private final ConcurrentMap<ClientConnectionTarget, Http2ClientConnectionHandler> cache = new ConcurrentHashMap<>();
+    // Mutated only while holding cacheLock.
+    private final Map<ClientConnectionTarget, Http2ClientConnectionHandler> insertionOrder = new LinkedHashMap<>();
     private final AtomicBoolean closed = new AtomicBoolean();
     private final ReentrantLock cacheLock = new ReentrantLock();
 
@@ -69,8 +72,9 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         List<Http2ClientConnectionHandler> handlers;
         cacheLock.lock();
         try {
-            handlers = List.copyOf(cache.values());
+            handlers = List.copyOf(insertionOrder.values());
             cache.clear();
+            insertionOrder.clear();
             http2Supported.clear();
         } finally {
             cacheLock.unlock();
@@ -93,6 +97,7 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         cacheLock.lock();
         try {
             if (cache.remove(connectionTarget, expectedHandler)) {
+                insertionOrder.remove(connectionTarget, expectedHandler);
                 http2Supported.remove(connectionTarget.connectionKey());
             }
         } finally {
@@ -121,10 +126,9 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                                                                http1FallbackHandler);
         }
 
-        List<Http2ClientConnectionHandler> stale = null;
+        List<Http2ClientConnectionHandler> retiredHandlers = null;
         Http2ClientConnectionHandler handler;
-        cacheLock.lock();
-        try {
+        while (true) {
             if (closed.get()) {
                 throw new IllegalStateException("Connection cache is closed");
             }
@@ -132,40 +136,70 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                 throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
             }
             handler = cache.get(connectionTarget);
-            if (handler == null) {
-                var iterator = cache.entrySet().iterator();
+            if (handler != null) {
+                if (handler.acquire()) {
+                    break;
+                }
+                continue;
+            }
+
+            cacheLock.lock();
+            try {
+                if (closed.get()) {
+                    throw new IllegalStateException("Connection cache is closed");
+                }
+                if (!connectionTarget.currentTlsGeneration()) {
+                    throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
+                }
+                handler = cache.get(connectionTarget);
+                if (handler != null) {
+                    if (handler.acquire()) {
+                        break;
+                    }
+                    continue;
+                }
+
+                var iterator = insertionOrder.entrySet().iterator();
                 while (iterator.hasNext()) {
                     var entry = iterator.next();
                     ClientConnectionTarget cachedTarget = entry.getKey();
                     if (cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
                             && !cachedTarget.currentTlsGeneration()) {
                         iterator.remove();
-                        if (stale == null) {
-                            stale = new ArrayList<>();
+                        if (cache.remove(cachedTarget, entry.getValue())) {
+                            if (retiredHandlers == null) {
+                                retiredHandlers = new ArrayList<>();
+                            }
+                            retiredHandlers.add(entry.getValue());
                         }
-                        stale.add(entry.getValue());
                     }
                 }
-                handler = new Http2ClientConnectionHandler();
-                cache.put(connectionTarget, handler);
-                if (cache.size() > MAX_TARGETS) {
-                    var evictionIterator = cache.entrySet().iterator();
+
+                if (insertionOrder.size() >= MAX_TARGETS) {
+                    var evictionIterator = insertionOrder.entrySet().iterator();
                     var evicted = evictionIterator.next();
                     evictionIterator.remove();
-                    if (stale == null) {
-                        stale = new ArrayList<>();
+                    if (cache.remove(evicted.getKey(), evicted.getValue())) {
+                        if (retiredHandlers == null) {
+                            retiredHandlers = new ArrayList<>();
+                        }
+                        retiredHandlers.add(evicted.getValue());
                     }
-                    stale.add(evicted.getValue());
                 }
+
+                handler = new Http2ClientConnectionHandler();
+                if (!handler.acquire()) {
+                    throw new IllegalStateException("New HTTP/2 connection target could not be acquired");
+                }
+                insertionOrder.put(connectionTarget, handler);
+                cache.put(connectionTarget, handler);
+                break;
+            } finally {
+                cacheLock.unlock();
             }
-            if (!handler.acquire()) {
-                throw new IllegalStateException("HTTP/2 connection target was retired during acquisition");
-            }
-        } finally {
-            cacheLock.unlock();
         }
-        if (stale != null) {
-            stale.forEach(Http2ClientConnectionHandler::retire);
+        if (retiredHandlers != null) {
+            retiredHandlers.forEach(Http2ClientConnectionHandler::retire);
         }
 
         Http2ConnectionAttemptResult result;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -134,29 +134,32 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
             if (!connectionTarget.currentTlsGeneration()) {
                 throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
             }
-            var iterator = cache.entrySet().iterator();
-            while (iterator.hasNext()) {
-                var entry = iterator.next();
-                ClientConnectionTarget cachedTarget = entry.getKey();
-                if (!cachedTarget.equals(connectionTarget)
-                        && cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
-                        && !cachedTarget.currentTlsGeneration()) {
-                    iterator.remove();
+            handler = cache.get(connectionTarget);
+            if (handler == null) {
+                var iterator = cache.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    var entry = iterator.next();
+                    ClientConnectionTarget cachedTarget = entry.getKey();
+                    if (cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
+                            && !cachedTarget.currentTlsGeneration()) {
+                        iterator.remove();
+                        if (stale == null) {
+                            stale = new ArrayList<>();
+                        }
+                        stale.add(entry.getValue());
+                    }
+                }
+                handler = new Http2ClientConnectionHandler();
+                cache.put(connectionTarget, handler);
+                if (cache.size() > MAX_TARGETS) {
+                    var evictionIterator = cache.entrySet().iterator();
+                    var evicted = evictionIterator.next();
+                    evictionIterator.remove();
                     if (stale == null) {
                         stale = new ArrayList<>();
                     }
-                    stale.add(entry.getValue());
+                    stale.add(evicted.getValue());
                 }
-            }
-            handler = cache.computeIfAbsent(connectionTarget, _ -> new Http2ClientConnectionHandler());
-            if (cache.size() > MAX_TARGETS) {
-                var evictionIterator = cache.entrySet().iterator();
-                var evicted = evictionIterator.next();
-                evictionIterator.remove();
-                if (stale == null) {
-                    stale = new ArrayList<>();
-                }
-                stale.add(evicted.getValue());
             }
             if (!handler.acquire()) {
                 throw new IllegalStateException("HTTP/2 connection target was retired during acquisition");

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -164,7 +164,9 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         if (closed.get()) {
             throw new IllegalStateException("Connection cache is closed");
         }
-        if (request.connection().isPresent() && !Http2ClientConnectionHandler.ownsExplicitConnection(request)) {
+        boolean forwardHttp1 = connectionTarget.proxyRoute().forwardProxy() && !request.priorKnowledge();
+        if (request.connection().isPresent()
+                && (!Http2ClientConnectionHandler.ownsExplicitConnection(request) || forwardHttp1)) {
             return new Http2ClientConnectionHandler(http2Client.clientConfig().connectionCacheSize())
                     .newStream(http2Client,
                                connectionTarget,
@@ -173,14 +175,19 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                                serviceRequest,
                                http1FallbackHandler);
         }
-        if (connectionTarget.proxyRoute().forwardProxy() && !request.priorKnowledge()) {
-            return new Http2ClientConnectionHandler(http2Client.clientConfig().connectionCacheSize())
-                    .newStream(http2Client,
-                               connectionTarget,
-                               request,
-                               initialUri,
-                               serviceRequest,
-                               http1FallbackHandler);
+        if (forwardHttp1) {
+            if (!Http2ClientConnectionHandler.http1FallbackAllowed(request)) {
+                throw Http2ClientConnectionHandler.unsupportedHttp1Fallback(initialUri,
+                                                                            request,
+                                                                            http1FallbackHandler);
+            }
+            return Http2ClientConnectionHandler.http1(http2Client,
+                                                       connectionTarget,
+                                                       request,
+                                                       initialUri,
+                                                       serviceRequest,
+                                                       http1FallbackHandler,
+                                                       null);
         }
 
         List<Http2ClientConnectionHandler> retiredHandlers = null;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -173,6 +173,15 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                                serviceRequest,
                                http1FallbackHandler);
         }
+        if (connectionTarget.proxyRoute().forwardProxy() && !request.priorKnowledge()) {
+            return new Http2ClientConnectionHandler(http2Client.clientConfig().connectionCacheSize())
+                    .newStream(http2Client,
+                               connectionTarget,
+                               request,
+                               initialUri,
+                               serviceRequest,
+                               http1FallbackHandler);
+        }
 
         List<Http2ClientConnectionHandler> retiredHandlers = null;
         Http2ClientConnectionHandler handler;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -118,12 +118,13 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
             throw new IllegalStateException("Connection cache is closed");
         }
         if (request.connection().isPresent() && !Http2ClientConnectionHandler.ownsExplicitConnection(request)) {
-            return new Http2ClientConnectionHandler().newStream(http2Client,
-                                                               connectionTarget,
-                                                               request,
-                                                               initialUri,
-                                                               serviceRequest,
-                                                               http1FallbackHandler);
+            return new Http2ClientConnectionHandler(http2Client.clientConfig().connectionCacheSize())
+                    .newStream(http2Client,
+                               connectionTarget,
+                               request,
+                               initialUri,
+                               serviceRequest,
+                               http1FallbackHandler);
         }
 
         List<Http2ClientConnectionHandler> retiredHandlers = null;
@@ -187,7 +188,7 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                     }
                 }
 
-                handler = new Http2ClientConnectionHandler();
+                handler = new Http2ClientConnectionHandler(http2Client.clientConfig().connectionCacheSize());
                 if (!handler.acquire()) {
                     throw new IllegalStateException("New HTTP/2 connection target could not be acquired");
                 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -16,12 +16,15 @@
 
 package io.helidon.webclient.http2;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.LruCache;
+import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.WebClientServiceRequest;
@@ -31,10 +34,13 @@ import io.helidon.webclient.spi.ClientConnectionCache;
  * A cache of HTTP2 connections.
  */
 public final class Http2ConnectionCache extends ClientConnectionCache {
+    private static final int MAX_TARGETS = 1_000;
     private static final Http2ConnectionCache SHARED = new Http2ConnectionCache(true);
     private final LruCache<ConnectionKey, Boolean> http2Supported = LruCache.create(1000);
-    private final Map<ConnectionKey, Http2ClientConnectionHandler> cache = new ConcurrentHashMap<>();
+    private final Map<ClientConnectionTarget, Http2ClientConnectionHandler> cache =
+            new LinkedHashMap<>(16, 0.75F, true);
     private final AtomicBoolean closed = new AtomicBoolean();
+    private final ReentrantLock cacheLock = new ReentrantLock();
 
     private Http2ConnectionCache(boolean shared) {
         super(shared);
@@ -60,8 +66,16 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
 
     @Override
     protected void evict() {
-        List.copyOf(cache.keySet())
-                .forEach(this::closeAndRemove);
+        List<Http2ClientConnectionHandler> handlers;
+        cacheLock.lock();
+        try {
+            handlers = List.copyOf(cache.values());
+            cache.clear();
+            http2Supported.clear();
+        } finally {
+            cacheLock.unlock();
+        }
+        handlers.forEach(Http2ClientConnectionHandler::close);
     }
 
     @Override
@@ -75,14 +89,24 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         return http2Supported.get(ck).isPresent();
     }
 
-    void remove(ConnectionKey connectionKey) {
+    void remove(ClientConnectionTarget connectionTarget) {
         if (!closed.get()) {
-            closeAndRemove(connectionKey);
+            Http2ClientConnectionHandler handler;
+            cacheLock.lock();
+            try {
+                handler = cache.remove(connectionTarget);
+            } finally {
+                cacheLock.unlock();
+            }
+            if (handler != null) {
+                handler.close();
+            }
+            http2Supported.remove(connectionTarget.connectionKey());
         }
     }
 
     Http2ConnectionAttemptResult newStream(Http2ClientImpl http2Client,
-                                           ConnectionKey connectionKey,
+                                           ClientConnectionTarget connectionTarget,
                                            Http2ClientRequestImpl request,
                                            ClientUri initialUri,
                                            WebClientServiceRequest serviceRequest,
@@ -91,29 +115,76 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         if (closed.get()) {
             throw new IllegalStateException("Connection cache is closed");
         }
+        if (request.connection().isPresent() && !Http2ClientConnectionHandler.ownsExplicitConnection(request)) {
+            return new Http2ClientConnectionHandler().newStream(http2Client,
+                                                               connectionTarget,
+                                                               request,
+                                                               initialUri,
+                                                               serviceRequest,
+                                                               http1FallbackHandler);
+        }
 
-        // this statement locks all threads - must not do anything complicated (just create a new instance)
-        Http2ConnectionAttemptResult result =
-                cache.computeIfAbsent(connectionKey, Http2ClientConnectionHandler::new)
-                // this statement may block a single connection key
-                .newStream(http2Client,
-                           request,
-                           initialUri,
-                           serviceRequest,
-                           http1FallbackHandler);
+        List<Http2ClientConnectionHandler> stale = null;
+        Http2ClientConnectionHandler handler;
+        cacheLock.lock();
+        try {
+            if (closed.get()) {
+                throw new IllegalStateException("Connection cache is closed");
+            }
+            if (!connectionTarget.currentTlsGeneration()) {
+                throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
+            }
+            var iterator = cache.entrySet().iterator();
+            while (iterator.hasNext()) {
+                var entry = iterator.next();
+                ClientConnectionTarget cachedTarget = entry.getKey();
+                if (!cachedTarget.equals(connectionTarget)
+                        && cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
+                        && !cachedTarget.currentTlsGeneration()) {
+                    iterator.remove();
+                    if (stale == null) {
+                        stale = new ArrayList<>();
+                    }
+                    stale.add(entry.getValue());
+                }
+            }
+            handler = cache.computeIfAbsent(connectionTarget, _ -> new Http2ClientConnectionHandler());
+            if (cache.size() > MAX_TARGETS) {
+                var evictionIterator = cache.entrySet().iterator();
+                var evicted = evictionIterator.next();
+                evictionIterator.remove();
+                if (stale == null) {
+                    stale = new ArrayList<>();
+                }
+                stale.add(evicted.getValue());
+            }
+            if (!handler.acquire()) {
+                throw new IllegalStateException("HTTP/2 connection target was retired during acquisition");
+            }
+        } finally {
+            cacheLock.unlock();
+        }
+        if (stale != null) {
+            stale.forEach(Http2ClientConnectionHandler::retire);
+        }
+
+        Http2ConnectionAttemptResult result;
+        try {
+            result = handler.newStream(http2Client,
+                                       connectionTarget,
+                                       request,
+                                       initialUri,
+                                       serviceRequest,
+                                       http1FallbackHandler);
+        } finally {
+            handler.release();
+        }
         if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2
                 && (request.connection().isEmpty()
                         || Http2ClientConnectionHandler.ownsExplicitConnection(request))) {
-            http2Supported.put(connectionKey, true);
+            http2Supported.put(connectionTarget.connectionKey(), true);
         }
         return result;
     }
 
-    private void closeAndRemove(ConnectionKey connectionKey){
-        Http2ClientConnectionHandler handler = cache.remove(connectionKey);
-        if (handler != null) {
-            handler.close();
-        }
-        http2Supported.remove(connectionKey);
-    }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -89,20 +89,17 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         return http2Supported.get(ck).isPresent();
     }
 
-    void remove(ClientConnectionTarget connectionTarget) {
-        if (!closed.get()) {
-            Http2ClientConnectionHandler handler;
-            cacheLock.lock();
-            try {
-                handler = cache.remove(connectionTarget);
-            } finally {
-                cacheLock.unlock();
+    void remove(ClientConnectionTarget connectionTarget, Http2ClientConnectionHandler expectedHandler) {
+        cacheLock.lock();
+        try {
+            if (cache.remove(connectionTarget, expectedHandler)) {
+                http2Supported.remove(connectionTarget.connectionKey());
             }
-            if (handler != null) {
-                handler.close();
-            }
-            http2Supported.remove(connectionTarget.connectionKey());
+        } finally {
+            cacheLock.unlock();
         }
+        // The failed stream still owns this handler even when a successor is now mapped.
+        expectedHandler.close();
     }
 
     Http2ConnectionAttemptResult newStream(Http2ClientImpl http2Client,

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -47,6 +47,7 @@ import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameListener;
 import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
+import io.helidon.http.http2.Http2GoAway;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanEncoder;
 import io.helidon.http.http2.Http2RstStream;
@@ -57,6 +58,7 @@ import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.WebClient;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -69,7 +71,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -918,6 +922,7 @@ class Http2ClientConnectionTest {
 
             Http2ClientConnection connection = connectionFuture.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             Http2ClientStream failingStream = connection.createStream(STREAM_CONFIG);
+            assertTrue(test.initialWriteNowCallsCompleted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
 
             test.failWrites();
             assertThrows(UncheckedIOException.class, () -> failingStream.writeHeaders(requestHeaders(), false));
@@ -927,6 +932,58 @@ class Http2ClientConnectionTest {
             assertNotNull(recoveredStream);
             recoveredStream.close();
             connection.close();
+        }
+    }
+
+    @Test
+    void retiredConnectionDrainsExistingStreamBeforeClosing() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream existingStream = connection.createStream(STREAM_CONFIG);
+            existingStream.writeHeaders(requestHeaders(), false);
+            assertThat(existingStream.streamId(), is(1));
+            verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(3)).writeNow(any(BufferData.class));
+            clearInvocations(test.dataWriter);
+
+            connection.retire();
+
+            assertNull(connection.tryStream(STREAM_CONFIG));
+            verify(test.clientConnection, never()).closeResource();
+            verify(test.dataWriter, never()).writeNow(any(BufferData.class));
+
+            existingStream.close();
+
+            test.assertConnectionClosed();
+            ArgumentCaptor<BufferData> goAwayFrame = ArgumentCaptor.forClass(BufferData.class);
+            verify(test.dataWriter, times(1)).writeNow(goAwayFrame.capture());
+
+            BufferData frameData = goAwayFrame.getValue();
+            byte[] headerBytes = new byte[Http2FrameHeader.LENGTH];
+            frameData.read(headerBytes);
+            Http2FrameHeader frameHeader = Http2FrameHeader.create(BufferData.create(headerBytes));
+            assertThat(frameHeader.type(), is(Http2FrameType.GO_AWAY));
+            assertThat(frameHeader.streamId(), is(0));
+
+            byte[] payloadBytes = new byte[frameHeader.length()];
+            frameData.read(payloadBytes);
+            Http2GoAway goAway = Http2GoAway.create(BufferData.create(payloadBytes));
+            assertThat(goAway.lastStreamId(), is(0));
+        }
+    }
+
+    @Test
+    void retiredPreUpgradeConnectionClosesWithoutWritingGoAway() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            Http2ClientConnection connection = new Http2ClientConnection(test.client,
+                                                                          test.clientConnection,
+                                                                          _ -> { });
+            clearInvocations(test.dataWriter);
+
+            connection.retire();
+
+            test.assertConnectionClosed();
+            verify(test.dataWriter, never()).writeNow(any(BufferData.class));
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -973,6 +973,42 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void retiredConnectionWaitsForBufferedResponseEntityConsumption() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream existingStream = connection.createStream(STREAM_CONFIG);
+            existingStream.writeHeaders(requestHeaders(), true);
+            verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(3)).writeNow(any(BufferData.class));
+            clearInvocations(test.dataWriter, test.clientConnection);
+
+            connection.retire();
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            byte[] expectedEntity = "entity".getBytes(StandardCharsets.UTF_8);
+            test.offerInbound(encodedHeaderFrame(existingStream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman),
+                              dataFrame(existingStream.streamId(), expectedEntity, true));
+
+            assertThat(existingStream.readHeaders().status(), is(Status.OK_200));
+            BufferData entity = existingStream.read();
+            byte[] actualEntity = new byte[entity.available()];
+            entity.read(actualEntity);
+            assertThat(actualEntity, is(expectedEntity));
+
+            verify(test.clientConnection, never()).closeResource();
+
+            existingStream.close();
+
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
     void retiredPreUpgradeConnectionClosesWithoutWritingGoAway() {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             Http2ClientConnection connection = new Http2ClientConnection(test.client,

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -28,6 +28,7 @@ import java.util.function.IntFunction;
 import io.helidon.common.context.Context;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
 import io.helidon.http.WritableHeaders;
 import io.helidon.webclient.api.ClientConnectionTarget;
@@ -124,6 +125,103 @@ class Http2ConnectionCacheTest {
     void rejectsNonPositiveConnectionCacheSize() {
         assertThrows(IllegalArgumentException.class, () -> new Http2ClientConnectionHandler(0));
         assertThrows(IllegalArgumentException.class, () -> new Http2ClientConnectionHandler(-1));
+    }
+
+    @Test
+    void removingOneTargetRetainsSharedHttp2Support() {
+        Tls tls = Tls.builder().enabled(false).build();
+        Proxy proxy = Proxy.noProxy();
+        DnsResolver dnsResolver = (_, _) -> InetAddress.getLoopbackAddress();
+        ConnectionKey connectionKey = ConnectionKey.create("http",
+                                                           "target.example",
+                                                           80,
+                                                           tls,
+                                                           dnsResolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+        ClientUri initialUri = ClientUri.create(URI.create("http://target.example"));
+        ClientRequestHeaders firstTargetHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        firstTargetHeaders.set(HeaderNames.HOST, "first.example");
+        ClientRequestHeaders secondTargetHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        secondTargetHeaders.set(HeaderNames.HOST, "second.example");
+        ClientConnectionTarget firstTarget = ClientConnectionTarget.create(connectionKey,
+                                                                            initialUri,
+                                                                            firstTargetHeaders);
+        ClientConnectionTarget secondTarget = ClientConnectionTarget.create(connectionKey,
+                                                                             initialUri,
+                                                                             secondTargetHeaders);
+        ClientRequestHeaders requestHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        ClientRequestHeaders fallbackHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        ClientRequestHeaders serviceHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        Http2ClientImpl http2Client = mock(Http2ClientImpl.class);
+        Http1Client http1Client = mock(Http1Client.class);
+        Http1ClientRequest fallbackRequest = mock(Http1ClientRequest.class, Answers.RETURNS_SELF);
+        Http1ClientResponse fallbackResponse = mock(Http1ClientResponse.class);
+        Http2ClientRequestImpl request = mock(Http2ClientRequestImpl.class);
+        WebClientServiceRequest serviceRequest = mock(WebClientServiceRequest.class);
+
+        when(http2Client.clientConfig()).thenReturn(Http2ClientConfig.create());
+        when(http2Client.protocolConfig()).thenReturn(Http2ClientProtocolConfig.create());
+        when(http2Client.http1FallbackClient()).thenReturn(http1Client);
+        when(http1Client.method(Method.GET)).thenReturn(fallbackRequest);
+        when(fallbackRequest.headers()).thenReturn(fallbackHeaders);
+        when(fallbackRequest.upgrade("h2c")).thenReturn(UpgradeResponse.failure(fallbackResponse));
+        when(request.connection()).thenReturn(Optional.empty());
+        when(request.tcpProtocolIds()).thenReturn(List.of(Http1Client.PROTOCOL_ID));
+        when(request.tls()).thenReturn(tls);
+        when(request.proxy()).thenReturn(proxy);
+        when(request.method()).thenReturn(Method.GET);
+        when(request.headers()).thenReturn(requestHeaders);
+        when(request.properties()).thenReturn(Map.of());
+        when(request.address()).thenReturn(Optional.empty());
+        when(request.sni()).thenReturn(Optional.empty());
+        when(request.sendExpectContinue()).thenReturn(Optional.empty());
+        when(serviceRequest.context()).thenReturn(Context.create());
+        when(serviceRequest.headers()).thenReturn(serviceHeaders);
+
+        Http1FallbackHandler fallbackHandler = new Http1FallbackHandler(new CompletableFuture<>(),
+                                                                        _ -> fallbackResponse,
+                                                                        true);
+        Http2ConnectionCache cache = Http2ConnectionCache.create();
+        try {
+            Http2ClientConnectionHandler firstHandler = cache.newStream(http2Client,
+                                                                         firstTarget,
+                                                                         request,
+                                                                         initialUri,
+                                                                         serviceRequest,
+                                                                         fallbackHandler)
+                    .handler();
+            Http2ClientConnectionHandler secondHandler = cache.newStream(http2Client,
+                                                                          secondTarget,
+                                                                          request,
+                                                                          initialUri,
+                                                                          serviceRequest,
+                                                                          fallbackHandler)
+                    .handler();
+            cache.markSupported(connectionKey);
+
+            assertThat(firstTarget, not(secondTarget));
+            assertThat(firstHandler, not(sameInstance(secondHandler)));
+            assertThat(cache.supports(connectionKey), is(true));
+
+            cache.remove(firstTarget, firstHandler);
+
+            assertThat(cache.supports(connectionKey), is(true));
+            assertThat(cache.newStream(http2Client,
+                                       secondTarget,
+                                       request,
+                                       initialUri,
+                                       serviceRequest,
+                                       fallbackHandler)
+                               .handler(),
+                       sameInstance(secondHandler));
+
+            cache.remove(secondTarget, secondHandler);
+
+            assertThat(cache.supports(connectionKey), is(false));
+        } finally {
+            cache.closeResource();
+        }
     }
 
     @Test

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
 
 class Http2ConnectionCacheTest {
     @Test
-    void retiredHandlerTimeoutDoesNotRemoveSuccessor() {
+    void oldestHandlerEvictionDoesNotAllowRetiredHandlerToRemoveSuccessor() {
         Tls tls = Tls.builder().enabled(false).build();
         Proxy proxy = Proxy.builder().host("proxy.example").port(8080).build();
         DnsResolver dnsResolver = (_, _) -> InetAddress.getLoopbackAddress();
@@ -107,19 +107,54 @@ class Http2ConnectionCacheTest {
         try {
             ClientConnectionTarget firstTarget = target.apply(0);
             Http2ConnectionAttemptResult predecessor = newStream.apply(firstTarget);
-            for (int i = 1; i <= 1_000; i++) {
-                newStream.apply(target.apply(i));
-            }
+            Http2ClientConnectionHandler predecessorHandler = predecessor.handler();
+            boolean predecessorLease = predecessorHandler.acquire();
             ClientConnectionTarget equalTarget = target.apply(0);
+            try {
+                assertThat(predecessorLease, is(true));
+                for (int i = 1; i < 1_000; i++) {
+                    newStream.apply(target.apply(i));
+                }
+                Http2ConnectionAttemptResult cached = newStream.apply(equalTarget);
+
+                assertThat(cached.handler(), sameInstance(predecessorHandler));
+
+                newStream.apply(target.apply(1_000));
+                boolean acquiredAfterRetirement = predecessorHandler.acquire();
+                if (acquiredAfterRetirement) {
+                    predecessorHandler.release();
+                }
+                assertThat(acquiredAfterRetirement, is(false));
+            } finally {
+                if (predecessorLease) {
+                    predecessorHandler.release();
+                }
+            }
             Http2ConnectionAttemptResult successor = newStream.apply(equalTarget);
 
             assertThat(equalTarget, is(firstTarget));
-            assertThat(successor.handler(), not(sameInstance(predecessor.handler())));
+            assertThat(successor.handler(), not(sameInstance(predecessorHandler)));
 
-            cache.remove(firstTarget, predecessor.handler());
+            cache.remove(firstTarget, predecessorHandler);
             Http2ConnectionAttemptResult retained = newStream.apply(equalTarget);
 
             assertThat(retained.handler(), sameInstance(successor.handler()));
+
+            Http2ClientConnectionHandler retainedHandler = retained.handler();
+            boolean retainedLease = retainedHandler.acquire();
+            try {
+                assertThat(retainedLease, is(true));
+                cache.closeResource();
+                boolean acquiredAfterClose = retainedHandler.acquire();
+                if (acquiredAfterClose) {
+                    retainedHandler.release();
+                }
+                assertThat(acquiredAfterClose, is(false));
+            } finally {
+                if (retainedLease) {
+                    retainedHandler.release();
+                }
+            }
         } finally {
             cache.closeResource();
         }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -48,10 +48,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class Http2ConnectionCacheTest {
+    @Test
+    void rejectsNonPositiveConnectionCacheSize() {
+        assertThrows(IllegalArgumentException.class, () -> new Http2ClientConnectionHandler(0));
+        assertThrows(IllegalArgumentException.class, () -> new Http2ClientConnectionHandler(-1));
+    }
+
     @Test
     void oldestHandlerEvictionDoesNotAllowRetiredHandlerToRemoveSuccessor() {
         Tls tls = Tls.builder().enabled(false).build();
@@ -77,6 +84,7 @@ class Http2ConnectionCacheTest {
         Http2ClientRequestImpl request = mock(Http2ClientRequestImpl.class);
         WebClientServiceRequest serviceRequest = mock(WebClientServiceRequest.class);
 
+        when(http2Client.clientConfig()).thenReturn(Http2ClientConfig.create());
         when(http2Client.http1FallbackClient()).thenReturn(http1Client);
         when(http1Client.method(Method.GET)).thenReturn(fallbackRequest);
         when(fallbackRequest.headers()).thenReturn(fallbackHeaders);

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -39,6 +39,7 @@ import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
 import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webclient.http1.UpgradeResponse;
 import io.helidon.webclient.spi.DnsResolver;
 
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,7 @@ class Http2ConnectionCacheTest {
     @Test
     void oldestHandlerEvictionDoesNotAllowRetiredHandlerToRemoveSuccessor() {
         Tls tls = Tls.builder().enabled(false).build();
-        Proxy proxy = Proxy.builder().host("proxy.example").port(8080).build();
+        Proxy proxy = Proxy.noProxy();
         DnsResolver dnsResolver = (_, _) -> InetAddress.getLoopbackAddress();
         IntFunction<ClientConnectionTarget> target = id -> ClientConnectionTarget.create(
                 ConnectionKey.create("http",
@@ -85,11 +86,14 @@ class Http2ConnectionCacheTest {
         WebClientServiceRequest serviceRequest = mock(WebClientServiceRequest.class);
 
         when(http2Client.clientConfig()).thenReturn(Http2ClientConfig.create());
+        when(http2Client.protocolConfig()).thenReturn(Http2ClientProtocolConfig.create());
         when(http2Client.http1FallbackClient()).thenReturn(http1Client);
         when(http1Client.method(Method.GET)).thenReturn(fallbackRequest);
         when(fallbackRequest.headers()).thenReturn(fallbackHeaders);
+        when(fallbackRequest.upgrade("h2c")).thenReturn(UpgradeResponse.failure(fallbackResponse));
         when(request.connection()).thenReturn(Optional.empty());
         when(request.tcpProtocolIds()).thenReturn(List.of(Http1Client.PROTOCOL_ID));
+        when(request.tls()).thenReturn(tls);
         when(request.method()).thenReturn(Method.GET);
         when(request.headers()).thenReturn(requestHeaders);
         when(request.properties()).thenReturn(Map.of());

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.api.ClientConnectionTarget;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.ConnectionKey;
+import io.helidon.webclient.api.DnsAddressLookup;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientRequest;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webclient.spi.DnsResolver;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Http2ConnectionCacheTest {
+    @Test
+    void retiredHandlerTimeoutDoesNotRemoveSuccessor() {
+        Tls tls = Tls.builder().enabled(false).build();
+        Proxy proxy = Proxy.builder().host("proxy.example").port(8080).build();
+        DnsResolver dnsResolver = (_, _) -> InetAddress.getLoopbackAddress();
+        IntFunction<ClientConnectionTarget> target = id -> ClientConnectionTarget.create(
+                ConnectionKey.create("http",
+                                     "target-" + id + ".example",
+                                     80,
+                                     tls,
+                                     dnsResolver,
+                                     DnsAddressLookup.IPV4,
+                                     proxy),
+                "http");
+
+        ClientRequestHeaders requestHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        ClientRequestHeaders fallbackHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        ClientRequestHeaders serviceHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        Http2ClientImpl http2Client = mock(Http2ClientImpl.class);
+        Http1Client http1Client = mock(Http1Client.class);
+        Http1ClientRequest fallbackRequest = mock(Http1ClientRequest.class, Answers.RETURNS_SELF);
+        Http1ClientResponse fallbackResponse = mock(Http1ClientResponse.class);
+        Http2ClientRequestImpl request = mock(Http2ClientRequestImpl.class);
+        WebClientServiceRequest serviceRequest = mock(WebClientServiceRequest.class);
+
+        when(http2Client.http1FallbackClient()).thenReturn(http1Client);
+        when(http1Client.method(Method.GET)).thenReturn(fallbackRequest);
+        when(fallbackRequest.headers()).thenReturn(fallbackHeaders);
+        when(request.connection()).thenReturn(Optional.empty());
+        when(request.tcpProtocolIds()).thenReturn(List.of(Http1Client.PROTOCOL_ID));
+        when(request.method()).thenReturn(Method.GET);
+        when(request.headers()).thenReturn(requestHeaders);
+        when(request.properties()).thenReturn(Map.of());
+        when(request.address()).thenReturn(Optional.empty());
+        when(request.sni()).thenReturn(Optional.empty());
+        when(request.sendExpectContinue()).thenReturn(Optional.empty());
+        when(serviceRequest.context()).thenReturn(Context.create());
+        when(serviceRequest.headers()).thenReturn(serviceHeaders);
+
+        ClientUri initialUri = ClientUri.create(URI.create("http://target.example"));
+        Http1FallbackHandler fallbackHandler = new Http1FallbackHandler(new CompletableFuture<>(),
+                                                                        _ -> fallbackResponse,
+                                                                        true);
+        Http2ConnectionCache cache = Http2ConnectionCache.create();
+        Function<ClientConnectionTarget, Http2ConnectionAttemptResult> newStream = connectionTarget -> cache.newStream(
+                http2Client,
+                connectionTarget,
+                request,
+                initialUri,
+                serviceRequest,
+                fallbackHandler);
+
+        try {
+            ClientConnectionTarget firstTarget = target.apply(0);
+            Http2ConnectionAttemptResult predecessor = newStream.apply(firstTarget);
+            for (int i = 1; i <= 1_000; i++) {
+                newStream.apply(target.apply(i));
+            }
+            ClientConnectionTarget equalTarget = target.apply(0);
+            Http2ConnectionAttemptResult successor = newStream.apply(equalTarget);
+
+            assertThat(equalTarget, is(firstTarget));
+            assertThat(successor.handler(), not(sameInstance(predecessor.handler())));
+
+            cache.remove(firstTarget, predecessor.handler());
+            Http2ConnectionAttemptResult retained = newStream.apply(equalTarget);
+
+            assertThat(retained.handler(), sameInstance(successor.handler()));
+        } finally {
+            cache.closeResource();
+        }
+    }
+}

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -48,12 +48,78 @@ import org.mockito.Answers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class Http2ConnectionCacheTest {
+    @Test
+    void forwardProxyFallbackDoesNotCreateHttp2Handler() {
+        Tls tls = Tls.builder().enabled(false).build();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .build();
+        ClientConnectionTarget connectionTarget = ClientConnectionTarget.create(
+                ConnectionKey.create("http",
+                                     "target.example",
+                                     80,
+                                     tls,
+                                     (_, _) -> InetAddress.getLoopbackAddress(),
+                                     DnsAddressLookup.IPV4,
+                                     proxy),
+                "http");
+        ClientUri initialUri = ClientUri.create(URI.create("http://target.example"));
+        ClientRequestHeaders requestHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        ClientRequestHeaders fallbackHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        ClientRequestHeaders serviceHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        Http2ClientImpl http2Client = mock(Http2ClientImpl.class);
+        Http1Client http1Client = mock(Http1Client.class);
+        Http1ClientRequest fallbackRequest = mock(Http1ClientRequest.class, Answers.RETURNS_SELF);
+        Http1ClientResponse fallbackResponse = mock(Http1ClientResponse.class);
+        Http2ClientRequestImpl request = mock(Http2ClientRequestImpl.class);
+        WebClientServiceRequest serviceRequest = mock(WebClientServiceRequest.class);
+
+        when(http2Client.clientConfig()).thenReturn(Http2ClientConfig.create());
+        when(http2Client.http1FallbackClient()).thenReturn(http1Client);
+        when(http1Client.method(Method.GET)).thenReturn(fallbackRequest);
+        when(fallbackRequest.headers()).thenReturn(fallbackHeaders);
+        when(request.connection()).thenReturn(Optional.empty());
+        when(request.tcpProtocolIds()).thenReturn(List.of(Http1Client.PROTOCOL_ID));
+        when(request.tls()).thenReturn(tls);
+        when(request.proxy()).thenReturn(proxy);
+        when(request.method()).thenReturn(Method.GET);
+        when(request.headers()).thenReturn(requestHeaders);
+        when(request.properties()).thenReturn(Map.of());
+        when(request.address()).thenReturn(Optional.empty());
+        when(request.sni()).thenReturn(Optional.empty());
+        when(request.sendExpectContinue()).thenReturn(Optional.empty());
+        when(serviceRequest.context()).thenReturn(Context.create());
+        when(serviceRequest.headers()).thenReturn(serviceHeaders);
+
+        Http1FallbackHandler fallbackHandler = new Http1FallbackHandler(new CompletableFuture<>(),
+                                                                        _ -> fallbackResponse,
+                                                                        true);
+        Http2ConnectionCache cache = Http2ConnectionCache.create();
+        try {
+            Http2ConnectionAttemptResult result = cache.newStream(http2Client,
+                                                                  connectionTarget,
+                                                                  request,
+                                                                  initialUri,
+                                                                  serviceRequest,
+                                                                  fallbackHandler);
+
+            assertThat(result.result(), is(Http2ConnectionAttemptResult.Result.HTTP_1));
+            assertThat(result.response(), sameInstance(fallbackResponse));
+            assertThat(result.connectionTarget(), sameInstance(connectionTarget));
+            assertThat(result.handler(), is(nullValue()));
+        } finally {
+            cache.closeResource();
+        }
+    }
+
     @Test
     void rejectsNonPositiveConnectionCacheSize() {
         assertThrows(IllegalArgumentException.class, () -> new Http2ClientConnectionHandler(0));

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WebClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WebClientTest.java
@@ -18,6 +18,8 @@ package io.helidon.webclient.http2;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
@@ -28,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Handler;
@@ -41,10 +44,15 @@ import io.helidon.common.LazyValue;
 import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.Keys;
 import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
 import io.helidon.http.http2.Http2LoggingFrameListener;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.ResolvedClientTarget;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
@@ -69,6 +77,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 @ServerTest
 class Http2WebClientTest {
@@ -78,9 +90,11 @@ class Http2WebClientTest {
     private static final HeaderName SERVER_HEADER_FROM_PARAM_NAME = HeaderNames.create("header-from-param");
     private static final HeaderName CLIENT_USER_AGENT_HEADER_NAME = HeaderNames.create("client-user-agent");
     private static final String CLIENT_SEND_LOGGER_NAME = Http2LoggingFrameListener.class.getName() + ".cl-send";
+    private static final String FINAL_TLS_SOCKET = "final-https";
     private static ExecutorService executorService;
     private static int plainPort;
     private static int tlsPort;
+    private static int finalTlsPort;
     private static Supplier<Http2Client> localCacheClient = () -> Http2Client.builder()
             .shareConnectionCache(false)
             .connectTimeout(Duration.ofMinutes(10))
@@ -116,6 +130,7 @@ class Http2WebClientTest {
     Http2WebClientTest(WebServer server) {
         plainPort = server.port();
         tlsPort = server.port("https");
+        finalTlsPort = server.port(FINAL_TLS_SOCKET);
     }
 
     @SetUpServer
@@ -142,6 +157,12 @@ class Http2WebClientTest {
                     res.header(SERVER_HEADER_FROM_PARAM_NAME, req.query().get("custQueryParam"));
                     res.send("HTTP/2 route");
                 }))
+                .route(Http2Route.route(GET,
+                                        "/connection-target",
+                                        (req, res) -> res.send(req.requestedUri().host() + "|" + req.socketId())))
+                .route(Http2Route.route(GET,
+                                        "/generic-retarget",
+                                        (req, res) -> res.send("bootstrap|" + req.socketId())))
                 .route(Http2Route.route(PUT, "/versionspecific", (req, res) -> {
                     res.header(SERVER_CUSTOM_HEADER_NAME, req.headers().get(CLIENT_CUSTOM_HEADER_NAME).get());
                     res.header(CLIENT_USER_AGENT_HEADER_NAME, req.headers().get(USER_AGENT).get());
@@ -186,6 +207,11 @@ class Http2WebClientTest {
                     }
                 }));
 
+        HttpRouting.Builder finalTlsRouter = HttpRouting.builder()
+                .route(Http2Route.route(GET,
+                                        "/generic-retarget",
+                                        (req, res) -> res.send("final|" + req.socketId())));
+
         serverBuilder
                 .port(-1)
                 .host("localhost")
@@ -201,9 +227,13 @@ class Http2WebClientTest {
                                 .socketReceiveBufferSize(4096))
                         .backlog(8192)
                 )
+                .putSocket(FINAL_TLS_SOCKET, builder -> builder.port(-1)
+                        .host("localhost")
+                        .tls(tls))
                 .routing(router)
                 // we want the same routing on the other socket
-                .routing("https", router.copy());
+                .routing("https", router.copy())
+                .routing(FINAL_TLS_SOCKET, finalTlsRouter);
     }
 
     static Stream<Arguments> clientTypes() {
@@ -448,5 +478,149 @@ class Http2WebClientTest {
                         .toList()
                         .toArray(new CompletableFuture[0])
         ).get(5, TimeUnit.MINUTES);
+    }
+
+    @Test
+    void serviceFinalTargetsSeparateAndReuseH2cConnections() {
+        Http2Client client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                .baseUri("http://bootstrap.example:" + plainPort + "/connection-target")
+                .addService((chain, request) -> {
+                    request.uri().host(request.properties().get("target-host"));
+                    return chain.proceed(request);
+                })
+                .build();
+
+        try {
+            String first = responseBody(client.get().property("target-host", "first.example"));
+            String second = responseBody(client.get().property("target-host", "second.example"));
+            String reused = responseBody(client.get().property("target-host", "first.example"));
+
+            assertThat(host(first), is("first.example"));
+            assertThat(host(second), is("second.example"));
+            assertThat(host(reused), is("first.example"));
+            assertThat(connectionId(reused), is(connectionId(first)));
+            assertThat(connectionId(second), not(is(connectionId(first))));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void genericClientRetargetsAfterAlpnProtocolDiscovery() {
+        WebClient client = WebClient.builder()
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                .baseUri("https://localhost:" + tlsPort + "/generic-retarget")
+                .tls(Tls.builder()
+                             .trust(trust -> trust
+                                     .keystore(store -> store
+                                             .passphrase("password")
+                                             .trustStore(true)
+                                             .keystore(Resource.create("client.p12"))))
+                             .build())
+                .addService((chain, request) -> {
+                    request.uri().port(finalTlsPort);
+                    return chain.proceed(request);
+                })
+                .build();
+
+        try {
+            String first = client.get().requestEntity(String.class);
+            String reused = client.get().requestEntity(String.class);
+
+            assertThat(first, startsWith("final|"));
+            assertThat(reused, startsWith("final|"));
+            assertThat(connectionId(reused), is(connectionId(first)));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void reconnectUsesCurrentAddressBoundNoProxyTarget() throws IOException {
+        AtomicInteger resolutions = new AtomicInteger();
+        List<ResolvedClientTarget> targets = new CopyOnWriteArrayList<>();
+        List<Socket> sockets = new CopyOnWriteArrayList<>();
+        Proxy proxy = spy(Proxy.builder()
+                                  .host("proxy.example")
+                                  .port(8181)
+                                  .addNoProxy("192.0.2.1")
+                                  .addNoProxy("192.0.2.2")
+                                  .build());
+        doAnswer(invocation -> {
+            ResolvedClientTarget target = invocation.getArgument(1);
+            Socket socket = new Socket(InetAddress.ofLiteral("127.0.0.1"), plainPort);
+            targets.add(target);
+            sockets.add(socket);
+            return socket;
+        }).when(proxy).tcpSocket(any(), any(), any());
+
+        Http2Client client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .dnsResolver((_, _) -> resolutions.getAndIncrement() == 0
+                        ? InetAddress.ofLiteral("192.0.2.1")
+                        : InetAddress.ofLiteral("192.0.2.2"))
+                .proxy(proxy)
+                .baseUri("http://rotating.example:" + plainPort + "/versionspecific")
+                .protocolConfig(pc -> pc.priorKnowledge(true)
+                        .ping(true)
+                        .pingTimeout(Duration.ofSeconds(1)))
+                .build();
+
+        try {
+            assertThat(responseBody(client.get().queryParam("custQueryParam", "first")), is("HTTP/2 route"));
+            assertThat(sockets.size(), is(1));
+            sockets.get(0).close();
+            assertThat(responseBody(client.get().queryParam("custQueryParam", "second")), is("HTTP/2 route"));
+
+            assertThat(targets.size(), is(2));
+            assertThat(resolutions.get(), is(2));
+            ResolvedClientTarget first = targets.get(0);
+            ResolvedClientTarget second = targets.get(1);
+            assertThat(second.logicalTarget(), is(first.logicalTarget()));
+            assertThat(first.peerAddress().getAddress(), is(InetAddress.ofLiteral("192.0.2.1")));
+            assertThat(second.peerAddress().getAddress(), is(InetAddress.ofLiteral("192.0.2.2")));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void tlsReloadRetiresPreviousTargetConnection() {
+        Tls tls = Tls.builder().trustAll(true).build();
+        Http2Client client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .baseUri("https://localhost:" + tlsPort + "/connection-target")
+                .tls(tls)
+                .build();
+
+        try {
+            String first = responseBody(client.get());
+            tls.reload(TlsMaterial.builder().trustAll(true).build());
+            String reloaded = responseBody(client.get());
+
+            assertThat(connectionId(reloaded), not(is(connectionId(first))));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    private static String responseBody(Http2ClientRequest request) {
+        try (Http2ClientResponse response = request.request()) {
+            return response.as(String.class);
+        }
+    }
+
+    private static String host(String responseBody) {
+        return responseBody.substring(0, responseBody.indexOf('|'));
+    }
+
+    private static String connectionId(String responseBody) {
+        return responseBody.substring(responseBody.indexOf('|') + 1);
     }
 }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WebClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WebClientTest.java
@@ -575,8 +575,14 @@ class Http2WebClientTest {
         try {
             assertThat(responseBody(client.get().queryParam("custQueryParam", "first")), is("HTTP/2 route"));
             assertThat(sockets.size(), is(1));
+            assertThat(resolutions.get(), is(1));
+            assertThat(responseBody(client.get().queryParam("custQueryParam", "reused")), is("HTTP/2 route"));
+            assertThat(sockets.size(), is(1));
+            assertThat(targets.size(), is(1));
+            assertThat(resolutions.get(), is(1));
+
             sockets.get(0).close();
-            assertThat(responseBody(client.get().queryParam("custQueryParam", "second")), is("HTTP/2 route"));
+            assertThat(responseBody(client.get().queryParam("custQueryParam", "reconnected")), is("HTTP/2 route"));
 
             assertThat(targets.size(), is(2));
             assertThat(resolutions.get(), is(2));

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -352,6 +353,54 @@ class Http2WireProtocolTest {
                 assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
             }
             assertThat(selectorInvocations.get(), is(1));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void multiHopExpectContinueRedirectRetainsAddressBoundNoProxyRouteAcrossConnectionReplacement() {
+        AtomicInteger resolutions = new AtomicInteger();
+        AtomicReference<Http2ConnectionCache> connectionCache = new AtomicReference<>();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.invalid")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        Http2ClientImpl client = (Http2ClientImpl) Http2Client.builder()
+                .baseUri("http://target.example:" + http2Port)
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .followRedirects(true)
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .dnsResolver((_, _) -> {
+                    resolutions.incrementAndGet();
+                    return InetAddress.ofLiteral("127.0.0.1");
+                })
+                .proxy(proxy)
+                .addService((chain, request) -> {
+                    if (request.uri().path().path().equals("/proxy-route-second")) {
+                        connectionCache.get().evict();
+                    }
+                    return chain.proceed(request);
+                })
+                .build();
+        connectionCache.set(client.connectionCache());
+        String entity = "address-bound no-proxy route";
+
+        try {
+            try (Http2ClientResponse response = client.post("/proxy-route-first")
+                    .maxRedirects(2)
+                    .sendExpectContinue(true)
+                    .outputStream(outputStream -> {
+                        outputStream.write(entity.getBytes(StandardCharsets.UTF_8));
+                        outputStream.close();
+                    })) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class), is(entity));
+                assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
+            }
+            assertThat(resolutions.get(), is(1));
         } finally {
             client.closeResource();
         }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
@@ -16,6 +16,7 @@
 package io.helidon.webclient.http2;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
@@ -33,6 +34,7 @@ import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.Proxy.ProxyType;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.http1.Http1Client;
@@ -77,6 +79,12 @@ class Http2WireProtocolTest {
         Http2Config http2Config = Http2Config.create();
         HttpRouting.Builder http2Routing = HttpRouting.builder()
                 .route(Http2Route.route(GET, "/h2", (req, res) -> res.send("h2")))
+                .route(Http2Route.route(GET, "/forward-proxy", (req, res) -> {
+                    var requestedUri = req.requestedUri();
+                    res.send(requestedUri.scheme()
+                                     + "|" + requestedUri.authority()
+                                     + "|" + requestedUri.path().path());
+                }))
                 .route(Http2Route.route(POST, "/expect-redirect", (req, res) -> {
                     if (req.headers().containsToken(HeaderValues.EXPECT_100)) {
                         res.status(Status.SEE_OTHER_303)
@@ -159,6 +167,38 @@ class Http2WireProtocolTest {
             assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
             assertThat(observations.protocolsAfterProceed(), contains(Http2Client.PROTOCOL_ID));
             assertThat(observations.protocolsWhenSent(), contains(Http2Client.PROTOCOL_ID));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void priorKnowledgeHttp2UsesForwardProxyPeer() {
+        String proxyHost = "h2-forward-proxy.invalid";
+        Proxy proxy = Proxy.builder()
+                .type(ProxyType.HTTP)
+                .host(proxyHost)
+                .port(http2Port)
+                .build();
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://unresolvable.invalid:8181")
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .dnsResolver((host, _) -> {
+                    if (!proxyHost.equals(host)) {
+                        throw new AssertionError("Logical origin must not be resolved: " + host);
+                    }
+                    return InetAddress.ofLiteral("127.0.0.1");
+                })
+                .proxy(proxy)
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .build();
+
+        try (Http2ClientResponse response = client.get("/forward-proxy").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
+            assertThat(response.as(String.class),
+                       is("http|unresolvable.invalid:8181|/forward-proxy"));
         } finally {
             client.closeResource();
         }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
@@ -86,6 +86,12 @@ class Http2WireProtocolTest {
                                      + "|" + requestedUri.authority()
                                      + "|" + requestedUri.path().path());
                 }))
+                .route(Http1Route.route(GET, "/forward-proxy", (req, res) -> {
+                    var requestedUri = req.requestedUri();
+                    res.send(requestedUri.scheme()
+                                     + "|" + requestedUri.authority()
+                                     + "|" + requestedUri.path().path());
+                }))
                 .route(Http2Route.route(POST, "/expect-redirect", (req, res) -> {
                     if (req.headers().containsToken(HeaderValues.EXPECT_100)) {
                         res.status(Status.SEE_OTHER_303)
@@ -200,6 +206,98 @@ class Http2WireProtocolTest {
             assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
             assertThat(response.as(String.class),
                        is("http|unresolvable.invalid:8181|/forward-proxy"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void nonPriorKnowledgeForwardProxyDoesNotPoisonPriorKnowledgeRequest() {
+        String proxyHost = "h2-forward-proxy.invalid";
+        Proxy proxy = Proxy.builder()
+                .type(ProxyType.HTTP)
+                .host(proxyHost)
+                .port(http2Port)
+                .build();
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://unresolvable.invalid:8181")
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .dnsResolver((host, _) -> {
+                    if (!proxyHost.equals(host)) {
+                        throw new AssertionError("Logical origin must not be resolved: " + host);
+                    }
+                    return InetAddress.ofLiteral("127.0.0.1");
+                })
+                .proxy(proxy)
+                .build();
+
+        try {
+            try (Http2ClientResponse response = client.get("/forward-proxy")
+                    .priorKnowledge(false)
+                    .request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.protocolId(), is(Http1Client.PROTOCOL_ID));
+                assertThat(response.as(String.class),
+                           is("http|unresolvable.invalid:8181|/forward-proxy"));
+            }
+            try (Http2ClientResponse response = client.get("/forward-proxy")
+                    .priorKnowledge(true)
+                    .request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
+                assertThat(response.as(String.class),
+                           is("http|unresolvable.invalid:8181|/forward-proxy"));
+            }
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void nonPriorKnowledgeRequestDoesNotReuseCachedForwardProxyH2Stream() {
+        String proxyHost = "h2-forward-proxy.invalid";
+        String originHost = "unresolvable.invalid";
+        AtomicInteger originResolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .type(ProxyType.HTTP)
+                .host(proxyHost)
+                .port(http2Port)
+                .addNoProxy("127.0.0.2")
+                .build();
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://" + originHost + ":8181")
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .dnsResolver((host, _) -> {
+                    if (originHost.equals(host)) {
+                        originResolutions.incrementAndGet();
+                    } else if (!proxyHost.equals(host)) {
+                        throw new AssertionError("Unexpected DNS lookup: " + host);
+                    }
+                    return InetAddress.ofLiteral("127.0.0.1");
+                })
+                .proxy(proxy)
+                .build();
+
+        try {
+            try (Http2ClientResponse response = client.get("/forward-proxy")
+                    .priorKnowledge(true)
+                    .request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
+                assertThat(response.as(String.class),
+                           is("http|unresolvable.invalid:8181|/forward-proxy"));
+            }
+            try (Http2ClientResponse response = client.get("/forward-proxy")
+                    .priorKnowledge(false)
+                    .request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.protocolId(), is(Http1Client.PROTOCOL_ID));
+                assertThat(response.as(String.class),
+                           is("http|unresolvable.invalid:8181|/forward-proxy"));
+            }
+            assertThat(originResolutions.get(), is(2));
         } finally {
             client.closeResource();
         }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WireProtocolTest.java
@@ -15,6 +15,10 @@
  */
 package io.helidon.webclient.http2;
 
+import java.io.IOException;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,13 +26,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
+import io.helidon.webclient.api.FullClientRequest;
+import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientRequest;
+import io.helidon.webclient.http1.UpgradeResponse;
 import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
@@ -82,6 +91,31 @@ class Http2WireProtocolTest {
                     res.status(Status.SEE_OTHER_303)
                             .header(HeaderNames.LOCATION, "http://localhost:" + http1Port + "/redirected")
                             .send();
+                }))
+                .route(Http2Route.route(POST, "/proxy-route-first", (req, res) -> {
+                    if (req.headers().containsToken(HeaderValues.EXPECT_100)) {
+                        res.status(Status.TEMPORARY_REDIRECT_307)
+                                .header(HeaderNames.LOCATION, "/proxy-route-second")
+                                .send();
+                    } else {
+                        res.status(Status.BAD_REQUEST_400).send();
+                    }
+                }))
+                .route(Http2Route.route(POST, "/proxy-route-second", (req, res) -> {
+                    if (req.headers().containsToken(HeaderValues.EXPECT_100)) {
+                        res.status(Status.PERMANENT_REDIRECT_308)
+                                .header(HeaderNames.LOCATION, "/proxy-route-echo")
+                                .send();
+                    } else {
+                        res.status(Status.BAD_REQUEST_400).send();
+                    }
+                }))
+                .route(Http2Route.route(POST, "/proxy-route-echo", (req, res) -> {
+                    if (req.headers().containsToken(HeaderValues.EXPECT_100)) {
+                        res.send(req.content().as(String.class));
+                    } else {
+                        res.status(Status.BAD_REQUEST_400).send();
+                    }
                 }));
         HttpRouting.Builder http1Routing = HttpRouting.builder()
                 .route(Http1Route.route(GET, "/fallback", (req, res) -> res.send("http1")))
@@ -151,6 +185,29 @@ class Http2WireProtocolTest {
     }
 
     @Test
+    void directHttp1UpgradeClearsSelectedProxyRoute() {
+        Proxy proxy = Proxy.noProxy();
+        Http1Client client = Http1Client.builder()
+                .baseUri("http://localhost:" + http1Port)
+                .shareConnectionCache(false)
+                .proxy(proxy)
+                .build();
+        Http1ClientRequest request = client.get("/fallback");
+        FullClientRequest<?> fullRequest = (FullClientRequest<?>) request;
+        fullRequest.selectedProxyRoute(proxy.effectiveRoute("http", "localhost", http1Port, false));
+
+        UpgradeResponse response = request.upgrade("h2c");
+        try {
+            assertThat(response.isUpgraded(), is(false));
+            assertThat(response.response().status(), is(Status.OK_200));
+            assertThat(fullRequest.selectedProxyRoute().isEmpty(), is(true));
+        } finally {
+            response.response().close();
+            client.closeResource();
+        }
+    }
+
+    @Test
     void outputStreamRedirectReportsFinalProtocol() throws Exception {
         ProtocolObservations observations = new ProtocolObservations();
         byte[] entity = "request entity".getBytes(StandardCharsets.UTF_8);
@@ -203,6 +260,58 @@ class Http2WireProtocolTest {
                        contains(Http1Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID));
             assertThat(observations.protocolsWhenSent(),
                        contains(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void multiHopExpectContinueOutputStreamRedirectRetainsSelectedSystemProxyRoute() {
+        AtomicInteger selectorInvocations = new AtomicInteger();
+        ProxySelector countingSelector = new ProxySelector() {
+            @Override
+            public List<java.net.Proxy> select(URI uri) {
+                selectorInvocations.incrementAndGet();
+                return List.of(java.net.Proxy.NO_PROXY);
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+            }
+        };
+
+        Proxy systemProxy;
+        ProxySelector originalSelector = ProxySelector.getDefault();
+        try {
+            ProxySelector.setDefault(countingSelector);
+            systemProxy = Proxy.create();
+        } finally {
+            ProxySelector.setDefault(originalSelector);
+        }
+
+        Http2Client client = Http2Client.builder()
+                .baseUri("http://localhost:" + http2Port)
+                .servicesDiscoverServices(false)
+                .shareConnectionCache(false)
+                .followRedirects(true)
+                .protocolConfig(it -> it.priorKnowledge(true))
+                .proxy(systemProxy)
+                .build();
+        String entity = "selected proxy route";
+
+        try {
+            try (Http2ClientResponse response = client.post("/proxy-route-first")
+                    .maxRedirects(2)
+                    .sendExpectContinue(true)
+                    .outputStream(outputStream -> {
+                        outputStream.write(entity.getBytes(StandardCharsets.UTF_8));
+                        outputStream.close();
+                    })) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class), is(entity));
+                assertThat(response.protocolId(), is(Http2Client.PROTOCOL_ID));
+            }
+            assertThat(selectorInvocations.get(), is(1));
         } finally {
             client.closeResource();
         }

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
@@ -32,6 +32,7 @@ import io.helidon.common.tls.Tls;
 import io.helidon.common.tls.TlsMaterial;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http2.Http2Client;
@@ -44,6 +45,7 @@ import io.helidon.webserver.testing.junit5.SetUpServer;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
@@ -76,6 +78,11 @@ class ResolvedTargetTest {
                 })
                 .get("/generic-connection-target", (req, res) -> {
                     res.send("bootstrap|" + req.socketId());
+                })
+                .get("/proxy-connection", (req, res) -> {
+                    res.send(req.socketId()
+                                     + "|"
+                                     + req.headers().contains(ClientRequestBase.PROXY_CONNECTION.headerName()));
                 })
                 .post("/proxy-route-first", (req, res) -> {
                     res.status(Status.TEMPORARY_REDIRECT_307)
@@ -176,7 +183,7 @@ class ResolvedTargetTest {
                     resolutions.incrementAndGet();
                     return InetAddress.ofLiteral("127.0.0.1");
                 })
-                .baseUri("http://target.example:" + plainPort + "/connection-target")
+                .baseUri("http://target.example:" + plainPort + "/proxy-connection")
                 .proxy(proxy)
                 .build();
 
@@ -185,6 +192,7 @@ class ResolvedTargetTest {
             String reused = client.get().request().as(String.class);
 
             assertThat(reused, is(first));
+            assertThat(first, endsWith("|false"));
             assertThat(resolutions.get(), is(1));
         } finally {
             client.closeResource();

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
@@ -341,7 +341,7 @@ class ResolvedTargetTest {
                     .outputStream(outputStream -> {
                         outputStream.write(entity.getBytes(StandardCharsets.UTF_8));
                         outputStream.close();
-                })) {
+                    })) {
                 assertThat(response.status(), is(Status.OK_200));
                 assertThat(response.as(String.class), is(entity));
             }

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http1;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.Keys;
+import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+
+@ServerTest
+class ResolvedTargetTest {
+    private final int plainPort;
+    private final int tlsPort;
+    private final int finalTlsPort;
+
+    ResolvedTargetTest(WebServer server) {
+        plainPort = server.port();
+        tlsPort = server.port("https");
+        finalTlsPort = server.port("https-final");
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder serverBuilder) {
+        Keys keys = Keys.builder()
+                .keystore(keystore -> keystore.keystore(Resource.create("server.p12"))
+                        .passphrase("password"))
+                .build();
+        Tls tls = Tls.builder()
+                .privateKey(keys.privateKey().get())
+                .privateKeyCertChain(keys.certChain())
+                .build();
+        HttpRouting.Builder routing = HttpRouting.builder()
+                .get("/connection-target", (req, res) -> {
+                    res.send(req.requestedUri().host() + "|" + req.socketId());
+                })
+                .get("/generic-connection-target", (req, res) -> {
+                    res.send("bootstrap|" + req.socketId());
+                })
+                .post("/proxy-route-first", (req, res) -> {
+                    res.status(Status.TEMPORARY_REDIRECT_307)
+                            .header(HeaderNames.LOCATION, "/proxy-route-second")
+                            .send();
+                })
+                .post("/proxy-route-second", (req, res) -> {
+                    res.status(Status.PERMANENT_REDIRECT_308)
+                            .header(HeaderNames.LOCATION, "/proxy-route-echo")
+                            .send();
+                })
+                .post("/proxy-route-echo", (req, res) -> {
+                    res.send(req.content().as(String.class));
+                });
+
+        serverBuilder.port(-1)
+                .host("localhost")
+                .putSocket("https", socket -> socket.port(-1)
+                        .host("localhost")
+                        .tls(tls))
+                .putSocket("https-final", socket -> socket.port(-1)
+                        .host("localhost")
+                        .tls(tls))
+                .routing(routing)
+                .routing("https", routing.copy())
+                .routing("https-final", HttpRouting.builder()
+                        .get("/generic-connection-target", (req, res) -> {
+                            res.send("final|" + req.socketId());
+                        }));
+    }
+
+    @Test
+    void genericClientRetargetsAfterAlpnHttp1Discovery() {
+        WebClient client = WebClient.builder()
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                .baseUri("https://localhost:" + tlsPort + "/generic-connection-target")
+                .tls(Tls.builder().trustAll(true).build())
+                .addService((chain, request) -> {
+                    request.uri().port(finalTlsPort);
+                    return chain.proceed(request);
+                })
+                .build();
+
+        try {
+            String first = client.get().request().as(String.class);
+            String reused = client.get().request().as(String.class);
+
+            assertThat(first, startsWith("final|"));
+            assertThat(reused, is(first));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void finalServiceAuthoritySeparatesAndReusesConnections() {
+        Http1Client client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                .baseUri("http://bootstrap.example:" + plainPort + "/connection-target")
+                .addService((chain, request) -> {
+                    request.uri().host("transport.example");
+                    request.headers().set(HeaderNames.HOST,
+                                          request.properties().get("logical-host") + ":" + plainPort);
+                    return chain.proceed(request);
+                })
+                .build();
+
+        try {
+            String first = client.get().property("logical-host", "first.example").request().as(String.class);
+            String second = client.get().property("logical-host", "second.example").request().as(String.class);
+            String reused = client.get().property("logical-host", "first.example").request().as(String.class);
+
+            assertThat(first.substring(0, first.indexOf('|')), is("first.example"));
+            assertThat(second.substring(0, second.indexOf('|')), is("second.example"));
+            assertThat(reused.substring(reused.indexOf('|')), is(first.substring(first.indexOf('|'))));
+            assertThat(second.substring(second.indexOf('|')), not(is(first.substring(first.indexOf('|')))));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void tlsReloadRetiresPreviousTargetConnection() {
+        Tls tls = Tls.builder().trustAll(true).build();
+        Http1Client client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .baseUri("https://localhost:" + tlsPort + "/connection-target")
+                .tls(tls)
+                .build();
+
+        try {
+            String first = client.get().request().as(String.class);
+            tls.reload(TlsMaterial.builder().trustAll(true).build());
+            String reloaded = client.get().request().as(String.class);
+
+            assertThat(reloaded.substring(reloaded.indexOf('|')), not(is(first.substring(first.indexOf('|')))));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void sameOriginExpectContinueRedirectProbesRetainSelectedProxyRoute() {
+        AtomicInteger selectorInvocations = new AtomicInteger();
+        ProxySelector countingSelector = new ProxySelector() {
+            @Override
+            public List<java.net.Proxy> select(URI uri) {
+                selectorInvocations.incrementAndGet();
+                return List.of(java.net.Proxy.NO_PROXY);
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+            }
+        };
+
+        Proxy systemProxy;
+        ProxySelector originalSelector = ProxySelector.getDefault();
+        try {
+            ProxySelector.setDefault(countingSelector);
+            systemProxy = Proxy.create();
+        } finally {
+            ProxySelector.setDefault(originalSelector);
+        }
+
+        Http1Client client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                .baseUri("http://localhost:" + plainPort)
+                .proxy(systemProxy)
+                .build();
+        String entity = "selected proxy route";
+
+        try {
+            try (Http1ClientResponse response = client.post("/proxy-route-first")
+                    .maxRedirects(2)
+                    .sendExpectContinue(true)
+                    .outputStream(outputStream -> {
+                        outputStream.write(entity.getBytes(StandardCharsets.UTF_8));
+                        outputStream.close();
+                })) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class), is(entity));
+            }
+            assertThat(selectorInvocations.get(), is(1));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void usesLogicalTlsPeerIdentityAfterDnsResolution() throws UnknownHostException {
+        InetAddress physicalAddress = InetAddress.getByAddress("physical.invalid",
+                                                               new byte[] {127, 0, 0, 1});
+        assertThat(physicalAddress.getHostName(), is("physical.invalid"));
+
+        Tls tls = Tls.builder()
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+        Http1Client client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .dnsResolver((_, _) -> physicalAddress)
+                .baseUri("https://localhost:" + tlsPort + "/connection-target")
+                .tls(tls)
+                .build();
+
+        try {
+            assertThat(client.get().request().as(String.class), startsWith("localhost|"));
+        } finally {
+            client.closeResource();
+        }
+    }
+}

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
@@ -182,6 +182,34 @@ class ResolvedTargetTest {
     }
 
     @Test
+    void oneOffRequestAfterTlsReloadCannotReuseStaleConnection() {
+        Tls tls = Tls.builder().trustAll(true).build();
+        Http1Client client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .baseUri("https://localhost:" + tlsPort + "/connection-target")
+                .tls(tls)
+                .build();
+
+        try {
+            String first = client.get().request().as(String.class);
+            tls.reload(TlsMaterial.builder().trustAll(true).build());
+            String oneOff = client.get().keepAlive(false).request().as(String.class);
+            String cached = client.get().request().as(String.class);
+            String reused = client.get().request().as(String.class);
+
+            String firstConnection = first.substring(first.indexOf('|'));
+            String oneOffConnection = oneOff.substring(oneOff.indexOf('|'));
+            String cachedConnection = cached.substring(cached.indexOf('|'));
+            assertThat(oneOffConnection, not(is(firstConnection)));
+            assertThat(cachedConnection, not(is(firstConnection)));
+            assertThat(cachedConnection, not(is(oneOffConnection)));
+            assertThat(reused.substring(reused.indexOf('|')), is(cachedConnection));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
     void sameOriginExpectContinueRedirectProbesRetainSelectedProxyRoute() {
         AtomicInteger selectorInvocations = new AtomicInteger();
         ProxySelector countingSelector = new ProxySelector() {

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
@@ -352,6 +352,43 @@ class ResolvedTargetTest {
     }
 
     @Test
+    void sameOriginExpectContinueRedirectProbesRetainAddressBoundNoProxyRoute() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.invalid")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        Http1Client client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .dnsResolver((_, _) -> {
+                    resolutions.incrementAndGet();
+                    return InetAddress.ofLiteral("127.0.0.1");
+                })
+                .baseUri("http://target.example:" + plainPort)
+                .proxy(proxy)
+                .build();
+        String entity = "address-bound no-proxy route";
+
+        try {
+            try (Http1ClientResponse response = client.post("/proxy-route-first")
+                    .maxRedirects(2)
+                    .sendExpectContinue(true)
+                    .outputStream(outputStream -> {
+                        outputStream.write(entity.getBytes(StandardCharsets.UTF_8));
+                        outputStream.close();
+                    })) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class), is(entity));
+            }
+            assertThat(resolutions.get(), is(1));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
     void usesLogicalTlsPeerIdentityAfterDnsResolution() throws UnknownHostException {
         InetAddress physicalAddress = InetAddress.getByAddress("physical.invalid",
                                                                new byte[] {127, 0, 0, 1});

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
@@ -162,6 +162,66 @@ class ResolvedTargetTest {
     }
 
     @Test
+    void configuredIpNoProxyReusesIdleConnectionWithoutDns() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.invalid")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        Http1Client client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .dnsResolver((_, _) -> {
+                    resolutions.incrementAndGet();
+                    return InetAddress.ofLiteral("127.0.0.1");
+                })
+                .baseUri("http://target.example:" + plainPort + "/connection-target")
+                .proxy(proxy)
+                .build();
+
+        try {
+            String first = client.get().request().as(String.class);
+            String reused = client.get().request().as(String.class);
+
+            assertThat(reused, is(first));
+            assertThat(resolutions.get(), is(1));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void borrowedIpNoProxyPoolResolvesDnsAndOpensAnotherConnection() {
+        AtomicInteger resolutions = new AtomicInteger();
+        Proxy proxy = Proxy.builder()
+                .host("proxy.invalid")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        Http1Client client = Http1Client.builder()
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .dnsResolver((_, _) -> {
+                    resolutions.incrementAndGet();
+                    return InetAddress.ofLiteral("127.0.0.1");
+                })
+                .baseUri("http://target.example:" + plainPort + "/connection-target")
+                .proxy(proxy)
+                .build();
+
+        try (Http1ClientResponse borrowed = client.get().request()) {
+            String second = client.get().request().as(String.class);
+            String first = borrowed.as(String.class);
+
+            assertThat(second.substring(second.indexOf('|')), not(is(first.substring(first.indexOf('|')))));
+            assertThat(resolutions.get(), is(2));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
     void tlsReloadRetiresPreviousTargetConnection() {
         Tls tls = Tls.builder().trustAll(true).build();
         Http1Client client = Http1Client.builder()

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/ResolvedTargetTest.java
@@ -210,6 +210,31 @@ class ResolvedTargetTest {
     }
 
     @Test
+    void cacheEvictionRetiresBorrowedConnection() {
+        Http1ClientImpl client = (Http1ClientImpl) Http1Client.builder()
+                .shareConnectionCache(false)
+                .baseUri("http://localhost:" + plainPort + "/connection-target")
+                .build();
+
+        try {
+            String retired;
+            try (Http1ClientResponse borrowed = client.get().request()) {
+                client.connectionCache().evict();
+                retired = borrowed.as(String.class);
+            }
+            String replacement = client.get().request().as(String.class);
+            String reused = client.get().request().as(String.class);
+
+            String retiredConnection = retired.substring(retired.indexOf('|'));
+            String replacementConnection = replacement.substring(replacement.indexOf('|'));
+            assertThat(replacementConnection, not(is(retiredConnection)));
+            assertThat(reused.substring(reused.indexOf('|')), is(replacementConnection));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
     void sameOriginExpectContinueRedirectProbesRetainSelectedProxyRoute() {
         AtomicInteger selectorInvocations = new AtomicInteger();
         ProxySelector countingSelector = new ProxySelector() {

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,13 @@
 
 package io.helidon.webclient.tests;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.http.Status;
 import io.helidon.webclient.api.ClientRequest;
@@ -38,9 +43,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.http.Method.GET;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ServerTest
@@ -51,7 +58,7 @@ class HttpProxyTest {
     private HttpProxy httpProxy;
 
     private final HttpClient<?> clientHttp1;
-    private final HttpClient<?> clientHttp2;
+    private final Http2Client clientHttp2;
 
     HttpProxyTest(WebServer server) {
         String uri = "http://localhost:" + server.port();
@@ -184,6 +191,63 @@ class HttpProxyTest {
             ProxySelector.setDefault(ProxySelector.of(new InetSocketAddress(PROXY_HOST, proxyPort)));
             Proxy proxy = Proxy.create();
             successVerify(proxy, clientHttp2);
+        } finally {
+            ProxySelector.setDefault(original);
+        }
+    }
+
+    @Test
+    void priorKnowledgeHttp2RejectsForwardProxy() {
+        Proxy proxy = Proxy.builder()
+                .type(ProxyType.HTTP)
+                .host(PROXY_HOST)
+                .port(proxyPort)
+                .build();
+        var request = clientHttp2.get("/get")
+                .proxy(proxy)
+                .priorKnowledge(true);
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class, request::request);
+
+        assertThat(failure.getMessage(), containsString("negotiated HTTP/1.1 fallback is not enabled"));
+        assertThat(httpProxy.counter(), is(0));
+    }
+
+    @Test
+    void reusedHttp2RequestReselectsSystemProxyPerInvocation() {
+        ProxySelector original = ProxySelector.getDefault();
+        AtomicInteger httpSelections = new AtomicInteger();
+        ProxySelector.setDefault(new ProxySelector() {
+            @Override
+            public List<java.net.Proxy> select(URI uri) {
+                if (!"http".equals(uri.getScheme())) {
+                    return List.of(java.net.Proxy.NO_PROXY);
+                }
+                if (httpSelections.getAndIncrement() == 0) {
+                    return List.of(java.net.Proxy.NO_PROXY);
+                }
+                return List.of(new java.net.Proxy(java.net.Proxy.Type.HTTP,
+                                                  InetSocketAddress.createUnresolved(PROXY_HOST, proxyPort)));
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+            }
+        });
+        try {
+            ClientRequest<?> request = clientHttp2.get("/get").proxy(Proxy.create());
+            try (HttpClientResponse response = request.request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.protocolId(), is(Http1Client.PROTOCOL_ID));
+            }
+            assertThat(httpSelections.get(), is(1));
+            assertThat(httpProxy.counter(), is(0));
+            try (HttpClientResponse response = request.request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.protocolId(), is(Http1Client.PROTOCOL_ID));
+            }
+            assertThat(httpSelections.get(), is(2));
+            assertThat(httpProxy.counter(), is(1));
         } finally {
             ProxySelector.setDefault(original);
         }

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
@@ -43,11 +43,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.http.Method.GET;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ServerTest
@@ -194,23 +192,6 @@ class HttpProxyTest {
         } finally {
             ProxySelector.setDefault(original);
         }
-    }
-
-    @Test
-    void priorKnowledgeHttp2RejectsForwardProxy() {
-        Proxy proxy = Proxy.builder()
-                .type(ProxyType.HTTP)
-                .host(PROXY_HOST)
-                .port(proxyPort)
-                .build();
-        var request = clientHttp2.get("/get")
-                .proxy(proxy)
-                .priorKnowledge(true);
-
-        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class, request::request);
-
-        assertThat(failure.getMessage(), containsString("negotiated HTTP/1.1 fallback is not enabled"));
-        assertThat(httpProxy.counter(), is(0));
     }
 
     @Test

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.http.Method.GET;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ServerTest
 class HttpProxyTest {
@@ -72,7 +70,9 @@ class HttpProxyTest {
 
     @SetUpRoute
     static void routing(HttpRouting.Builder router) {
-        router.route(GET, "/get", Routes::get);
+        router.route(GET, "/get", (request, response) -> {
+            response.send("Hello|" + request.headers().contains(ClientRequestBase.PROXY_CONNECTION.headerName()));
+        });
     }
 
     @BeforeEach
@@ -239,7 +239,7 @@ class HttpProxyTest {
         try (HttpClientResponse response = client.get("/get").proxy(proxy).request()) {
             assertThat(response.status(), is(Status.OK_200));
             String entity = response.entity().as(String.class);
-            assertThat(entity, is("Hello"));
+            assertThat(entity, is("Hello|false"));
         }
         assertThat(httpProxy.counter(), is(0));
     }
@@ -249,13 +249,7 @@ class HttpProxyTest {
         try (HttpClientResponse response = request.request()) {
             assertThat(response.status(), is(Status.OK_200));
             String entity = response.entity().as(String.class);
-            assertThat(entity, is("Hello"));
-        }
-        boolean proxyConnection = request.headers().contains(ClientRequestBase.PROXY_CONNECTION);
-        if (client == clientHttp1) {
-            assertTrue(proxyConnection, "HTTP1 requires Proxy-Connection header");
-        } else {
-            assertFalse(proxyConnection, "HTTP2 does not allow Proxy-Connection header");
+            assertThat(entity, is("Hello|false"));
         }
         assertThat(httpProxy.counter(), is(1));
     }
@@ -264,14 +258,8 @@ class HttpProxyTest {
         try (HttpClientResponse response = client.get("/get").request()) {
             assertThat(response.status(), is(Status.OK_200));
             String entity = response.entity().as(String.class);
-            assertThat(entity, is("Hello"));
+            assertThat(entity, is("Hello|false"));
         }
         assertThat(httpProxy.counter(), is(0));
-    }
-
-    private static class Routes {
-        private static String get() {
-            return "Hello";
-        }
     }
 }

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpsProxyTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpsProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.Keys;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.Status;
-import io.helidon.webclient.api.ClientRequest;
 import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.HttpClient;
 import io.helidon.webclient.api.HttpClientResponse;
@@ -46,8 +45,6 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.http.Method.GET;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ServerTest
 class HttpsProxyTest {
@@ -112,7 +109,9 @@ class HttpsProxyTest {
 
     @SetUpRoute
     static void routing(HttpRouting.Builder router) {
-        router.route(GET, "/get", Routes::get);
+        router.route(GET, "/get", (request, response) -> {
+            response.send("Hello|" + request.headers().contains(ClientRequestBase.PROXY_CONNECTION.headerName()));
+        });
     }
 
     @Test
@@ -186,17 +185,10 @@ class HttpsProxyTest {
     }
 
     private void successVerify(Proxy proxy, HttpClient<?> client) {
-        ClientRequest<?> request = client.get("/get").proxy(proxy);
-        try (HttpClientResponse response = request.request()) {
+        try (HttpClientResponse response = client.get("/get").proxy(proxy).request()) {
             assertThat(response.status(), is(Status.OK_200));
             String entity = response.entity().as(String.class);
-            assertThat(entity, is("Hello"));
-        }
-        boolean proxyConnection = request.headers().contains(ClientRequestBase.PROXY_CONNECTION);
-        if (client == clientHttp1) {
-            assertTrue(proxyConnection, "HTTP1 requires Proxy-Connection header");
-        } else {
-            assertFalse(proxyConnection, "HTTP2 does not allow Proxy-Connection header");
+            assertThat(entity, is("Hello|false"));
         }
     }
 
@@ -204,13 +196,7 @@ class HttpsProxyTest {
         try (HttpClientResponse response = client.get("/get").request()) {
             assertThat(response.status(), is(Status.OK_200));
             String entity = response.entity().as(String.class);
-            assertThat(entity, is("Hello"));
-        }
-    }
-
-    private static class Routes {
-        private static String get() {
-            return "Hello";
+            assertThat(entity, is("Hello|false"));
         }
     }
 }

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/H2cShutdownTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -75,8 +76,10 @@ class H2cShutdownTest {
 
     private static final ConcurrentMap<Integer, CompletableFuture<Void>> connectionClosed = new ConcurrentHashMap<>();
 
-    private static volatile CompletableFuture<Integer> heldRequestReceived = new CompletableFuture<>();
-    private static volatile CompletableFuture<Void> releaseHeldRequest = new CompletableFuture<>();
+    private static volatile CompletableFuture<Integer> heldRequestAReceived = new CompletableFuture<>();
+    private static volatile CompletableFuture<Void> releaseHeldRequestA = new CompletableFuture<>();
+    private static volatile CompletableFuture<Integer> heldRequestBReceived = new CompletableFuture<>();
+    private static volatile CompletableFuture<Void> releaseHeldRequestB = new CompletableFuture<>();
 
     private final int serverPort;
 
@@ -101,16 +104,29 @@ class H2cShutdownTest {
 
     @SetUpRoute
     static void routing(HttpRouting.Builder routing) {
-        routing.route(Http2Route.route(Method.GET, "/held", (req, res) -> {
+        routing.route(Http2Route.route(Method.GET, "/held-a", (req, res) -> {
             int clientPort = req.remotePeer().port();
-            heldRequestReceived.complete(clientPort);
+            heldRequestAReceived.complete(clientPort);
             try {
-                releaseHeldRequest.get(HOLD_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                releaseHeldRequestA.get(HOLD_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new IllegalStateException("Interrupted while holding request A", e);
             } catch (ExecutionException | TimeoutException e) {
                 throw new IllegalStateException("Failed while holding request A", e);
+            }
+            res.send(String.valueOf(clientPort));
+        }));
+        routing.route(Http2Route.route(Method.GET, "/held-b", (req, res) -> {
+            int clientPort = req.remotePeer().port();
+            heldRequestBReceived.complete(clientPort);
+            try {
+                releaseHeldRequestB.get(HOLD_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while holding request B", e);
+            } catch (ExecutionException | TimeoutException e) {
+                throw new IllegalStateException("Failed while holding request B", e);
             }
             res.send(String.valueOf(clientPort));
         }));
@@ -122,28 +138,25 @@ class H2cShutdownTest {
     @BeforeEach
     void resetRequests() {
         connectionClosed.clear();
-        heldRequestReceived = new CompletableFuture<>();
-        releaseHeldRequest = new CompletableFuture<>();
+        heldRequestAReceived = new CompletableFuture<>();
+        releaseHeldRequestA = new CompletableFuture<>();
+        heldRequestBReceived = new CompletableFuture<>();
+        releaseHeldRequestB = new CompletableFuture<>();
     }
 
     @Test
     void closesDisplacedUpgradedConnection() {
         Http2Client http2Client = Http2Client.builder()
                 .shareConnectionCache(false)
+                .connectionCacheSize(1)
                 .protocolConfig(Http2ClientProtocolConfig.builder().priorKnowledge(false))
                 .connectTimeout(TIMEOUT)
                 .baseUri("http://127.0.0.1:" + serverPort)
                 .build();
         var executor = Executors.newVirtualThreadPerTaskExecutor();
-        CompletableFuture<Integer> heldResponse = CompletableFuture.supplyAsync(() -> {
-            try (var response = http2Client.get("/held")
-                    .readTimeout(TIMEOUT)
-                    .request()) {
-                return Integer.parseInt(response.entity().as(String.class));
-            }
-        }, executor);
+        CompletableFuture<Integer> heldResponse = requestAsync(http2Client, "/held-a", executor);
         try {
-            int heldClientPort = await(heldRequestReceived, "request A to reach the server");
+            int heldClientPort = await(heldRequestAReceived, "request A to reach the server");
             int secondClientPort;
             try (var response = http2Client.get("/second")
                     .readTimeout(TIMEOUT)
@@ -154,27 +167,99 @@ class H2cShutdownTest {
                        secondClientPort,
                        not(is(heldClientPort)));
 
-            releaseHeldRequest.complete(null);
-            assertThat(await(heldResponse, "request A to complete"), is(heldClientPort));
-
             CompletableFuture<Void> heldConnectionClosed =
                     connectionClosed.computeIfAbsent(heldClientPort, ignored -> new CompletableFuture<>());
             CompletableFuture<Void> secondConnectionClosed =
                     connectionClosed.computeIfAbsent(secondClientPort, ignored -> new CompletableFuture<>());
-            assertThat("request A connection should remain open before client shutdown",
+            assertThat("request A connection should remain open while its stream is held",
                        heldConnectionClosed.isDone(),
                        is(false));
+
+            releaseHeldRequestA.complete(null);
+            assertThat(await(heldResponse, "request A to complete"), is(heldClientPort));
+            await(heldConnectionClosed, "displaced connection from client port " + heldClientPort + " to close");
+
+            int reusedClientPort;
+            try (var response = http2Client.get("/second")
+                    .readTimeout(TIMEOUT)
+                    .request()) {
+                reusedClientPort = Integer.parseInt(response.entity().as(String.class));
+            }
+            assertThat("request B connection should remain reusable after request A connection is retired",
+                       reusedClientPort,
+                       is(secondClientPort));
             assertThat("request B connection should remain open before client shutdown",
                        secondConnectionClosed.isDone(),
                        is(false));
 
             http2Client.closeResource();
             await(secondConnectionClosed, "connection from client port " + secondClientPort + " to close");
-            await(heldConnectionClosed, "connection from client port " + heldClientPort + " to close");
         } finally {
-            releaseHeldRequest.complete(null);
+            releaseHeldRequestA.complete(null);
             http2Client.closeResource();
             heldResponse.cancel(true);
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void reusesAvailableConnectionWithinConfiguredCacheSize() {
+        Http2Client http2Client = Http2Client.builder()
+                .shareConnectionCache(false)
+                .connectionCacheSize(2)
+                .protocolConfig(Http2ClientProtocolConfig.builder().priorKnowledge(false))
+                .connectTimeout(TIMEOUT)
+                .baseUri("http://127.0.0.1:" + serverPort)
+                .build();
+        var executor = Executors.newVirtualThreadPerTaskExecutor();
+        CompletableFuture<Integer> heldResponseA = requestAsync(http2Client, "/held-a", executor);
+        CompletableFuture<Integer> heldResponseB = null;
+        try {
+            int clientPortA = await(heldRequestAReceived, "request A to reach the server");
+            heldResponseB = requestAsync(http2Client, "/held-b", executor);
+            int clientPortB = await(heldRequestBReceived, "request B to reach the server");
+            assertThat("request B should use a new connection while request A occupies the only stream",
+                       clientPortB,
+                       not(is(clientPortA)));
+
+            releaseHeldRequestA.complete(null);
+            assertThat(await(heldResponseA, "request A to complete"), is(clientPortA));
+
+            int clientPortC;
+            try (var response = http2Client.get("/second")
+                    .readTimeout(TIMEOUT)
+                    .request()) {
+                clientPortC = Integer.parseInt(response.entity().as(String.class));
+            }
+            assertThat("request C should reuse request A connection while request B occupies the other connection",
+                       clientPortC,
+                       is(clientPortA));
+
+            releaseHeldRequestB.complete(null);
+            assertThat(await(heldResponseB, "request B to complete"), is(clientPortB));
+
+            CompletableFuture<Void> connectionAClosed =
+                    connectionClosed.computeIfAbsent(clientPortA, ignored -> new CompletableFuture<>());
+            CompletableFuture<Void> connectionBClosed =
+                    connectionClosed.computeIfAbsent(clientPortB, ignored -> new CompletableFuture<>());
+            assertThat("request A connection should remain open before client shutdown",
+                       connectionAClosed.isDone(),
+                       is(false));
+            assertThat("request B connection should remain open before client shutdown",
+                       connectionBClosed.isDone(),
+                       is(false));
+
+            http2Client.closeResource();
+            await(connectionAClosed, "connection from client port " + clientPortA + " to close");
+            await(connectionBClosed, "connection from client port " + clientPortB + " to close");
+        } finally {
+            releaseHeldRequestA.complete(null);
+            releaseHeldRequestB.complete(null);
+            http2Client.closeResource();
+            heldResponseA.cancel(true);
+            if (heldResponseB != null) {
+                heldResponseB.cancel(true);
+            }
             executor.shutdownNow();
         }
     }
@@ -297,6 +382,16 @@ class H2cShutdownTest {
                 };
             }
         };
+    }
+
+    private static CompletableFuture<Integer> requestAsync(Http2Client client, String path, Executor executor) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (var response = client.get(path)
+                    .readTimeout(TIMEOUT)
+                    .request()) {
+                return Integer.parseInt(response.entity().as(String.class));
+            }
+        }, executor);
     }
 
     private static <T> T await(CompletableFuture<T> future, String description) {

--- a/webserver/tests/unix-domain-socket/src/test/java/io/helidon/webserver/tests/unix/domain/socket/UnixDomainSocketTest.java
+++ b/webserver/tests/unix-domain-socket/src/test/java/io/helidon/webserver/tests/unix/domain/socket/UnixDomainSocketTest.java
@@ -18,8 +18,11 @@ package io.helidon.webserver.tests.unix.domain.socket;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
 import java.net.StandardProtocolFamily;
+import java.net.URI;
 import java.net.UnixDomainSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -30,6 +33,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +52,7 @@ import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.api.ConnectedSocketChannelInfo;
 import io.helidon.webclient.api.ConnectedSocketInfo;
 import io.helidon.webclient.api.ConnectionListener;
+import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.UnixDomainSocketClientConnection;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
@@ -336,6 +341,69 @@ public class UnixDomainSocketTest {
                            "HTTP/2 TCP target");
         } finally {
             http2Client.closeResource();
+            targetServer.stop();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void http2UnixSocketHttp1FallbackRedirectSelectsSystemProxyForTcpTarget() {
+        var address = UnixDomainSocketAddress.of(newSocketPath("helidon-http1-fallback-redirect"));
+        WebServer targetServer = startPlainServer("HTTP/1 TCP target", false);
+        try {
+            URI targetUri = URI.create("http://127.0.0.1:" + targetServer.port());
+            WebServerConfig.Builder sourceBuilder = WebServer.builder();
+            configureUdsBinding(sourceBuilder, address);
+            WebServer sourceServer = sourceBuilder
+                    .protocolsDiscoverServices(false)
+                    .addConnectionSelector(Http1ConnectionSelector.builder()
+                                                   .config(Http1Config.builder().build())
+                                                   .build())
+                    .routing(rules -> rules.get("/redirect", (req, res) -> res.status(Status.FOUND_302)
+                            .header(HeaderNames.LOCATION, targetUri.resolve("/target").toString())
+                            .send()))
+                    .build()
+                    .start();
+            try {
+                ProxySelector previousSelector = ProxySelector.getDefault();
+                List<URI> selectedUris = new CopyOnWriteArrayList<>();
+                ProxySelector.setDefault(new ProxySelector() {
+                    @Override
+                    public List<java.net.Proxy> select(URI uri) {
+                        if ("http".equals(uri.getScheme())) {
+                            selectedUris.add(uri);
+                        }
+                        return List.of(java.net.Proxy.NO_PROXY);
+                    }
+
+                    @Override
+                    public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+                    }
+                });
+                try {
+                    Http2Client http2Client = Http2Client.builder()
+                            .shareConnectionCache(false)
+                            .baseUri(LOGICAL_PLAIN_BASE_URI)
+                            .proxy(Proxy.create())
+                            .protocolConfig(it -> it.priorKnowledge(false))
+                            .build();
+                    try {
+                        assertResponse(http2Client.get()
+                                               .address(address)
+                                               .path("/redirect")
+                                               .request(String.class),
+                                       "HTTP/1 TCP target");
+                        assertThat(selectedUris, is(List.of(targetUri)));
+                    } finally {
+                        http2Client.closeResource();
+                    }
+                } finally {
+                    ProxySelector.setDefault(previousSelector);
+                }
+            } finally {
+                sourceServer.stop();
+            }
+        } finally {
             targetServer.stop();
         }
     }


### PR DESCRIPTION
Pre-requisite for #3686.

## Intent

WebClient currently lets each HTTP implementation derive connection information inside its own request flow. HTTP/3 needs to make transport and cache decisions while preserving the same logical origin, TLS peer identity, SNI configuration, proxy decision, and DNS result already used by HTTP/1.1 and HTTP/2. Those values cannot be represented safely by one host and port: the authority used for HTTP and TLS can differ from the proxy or resolved socket peer, and services can finalize the request URI and `Host` header before a connection is acquired.

This change establishes a protocol-neutral target boundary before HTTP/3 is added. It keeps logical origin and TLS identity separate from route selection and physical resolution, so all protocol implementations can use the same connection identity without coupling HTTP/3 to the HTTP/1.1 or HTTP/2 implementations.

## Target model

The internal model separates three concerns:

- `ClientConnectionTarget` is the immutable logical and cache identity created after WebClient services have finalized the URI and authority. It captures TLS identity and reload generation, SNI, DNS policy, the selected proxy route, transport, and local binding.
- `ProxyRoute` records the effective direct, HTTP forward, HTTP CONNECT tunnel, or SOCKS route and its capabilities.
- `ResolvedClientTarget` describes one physical connection attempt, including the concrete peer and proxy destination, without changing the logical HTTP or TLS identity.

A DNS-free lookup key also lets a configured IP-based `no-proxy` policy reuse a healthy cached connection before performing DNS again. A cache miss still resolves current addresses and binds a direct connection to the address that caused the bypass decision.

## HTTP/1.1 and HTTP/2 adoption

HTTP/1.1 and HTTP/2 now construct their connection targets from the final service-mutated request state and cache connections by the complete target. This preserves several invariants needed by the later HTTP/3 implementation:

- TLS endpoint identification and SNI use the logical origin, never the DNS or proxy peer.
- Selected routes survive protocol probing, HTTP/1 fallback, and same-origin redirects, but a reused request re-evaluates dynamic proxy policy on its next top-level invocation.
- IP-based `no-proxy` matching uses one resolved address for both the bypass decision and the physical connection attempt; healthy cache hits do not require another DNS lookup.
- HTTP/1.1 emits `Proxy-Connection` only for an actual forward-proxy exchange.
- HTTP/2 honors `connection-cache-size` as the number of reusable physical connections retained per target and gracefully drains displaced connections without allowing stale failures to remove a replacement handler.

The corresponding cache and shared-cache Javadocs now describe their per-protocol, per-target retention semantics and distinguish retained connections from concurrent requests, streams, and temporarily draining sockets.

## Scope

The change does not add HTTP/3 or QUIC; it supplies the shared routing and cache foundation used by the follow-on implementation.
It adds no configuration keys and does not enable Alt-Svc discovery or alternative routing by itself.
