### PR TITLE
4.x: Upgrade Jackson to 2.21.6. Remove unused maven properties.

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -54,7 +54,6 @@
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.expressly>5.0.0</version.lib.expressly>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
-        <version.lib.failsafe>2.3.1</version.lib.failsafe>
         <version.lib.google-api-client>2.8.1</version.lib.google-api-client>
         <version.lib.google-error-prone-annotations>2.30.0</version.lib.google-error-prone-annotations>
         <version.lib.google-protobuf>4.31.1</version.lib.google-protobuf>
@@ -72,8 +71,7 @@
         <version.lib.hibernate>${version.lib.hibernate.family}.1.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
-        <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.21.5</version.lib.jackson>
+        <version.lib.jackson>2.21.6</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.1.3</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.1.1</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>4.0.1</version.lib.jakarta.cdi-api>
@@ -147,20 +145,16 @@
         <version.lib.oci>3.86.2</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>
-        <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade of okio for dependency convergence: make the OTel otlp exporter use the release langchain4j uses -->
         <version.lib.okio>3.6.0</version.lib.okio>
         <!-- Force upgrade okhttp3 for dependency convergence -->
         <version.lib.okhttp3>4.12.0</version.lib.okhttp3>
         <version.lib.opentelemetry.semconv>1.37.0</version.lib.opentelemetry.semconv>
-        <version.lib.opentelemetry-sdk-extension-autoconfigure>1.62.0</version.lib.opentelemetry-sdk-extension-autoconfigure>
-        <version.lib.opentelemetry.opentracing.shim>1.62.0</version.lib.opentelemetry.opentracing.shim>
         <version.lib.opentelemetry>1.62.0</version.lib.opentelemetry>
         <version.lib.opentelemetry.instrumentation.annotations>2.27.0</version.lib.opentelemetry.instrumentation.annotations>
         <version.lib.opentracing>0.33.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
-        <version.lib.perfmark-api>0.25.0</version.lib.perfmark-api>
         <version.lib.parsson>1.1.9</version.lib.parsson>
         <version.lib.postgresql>42.7.13</version.lib.postgresql>
         <version.lib.prometheus>0.16.0</version.lib.prometheus>


### PR DESCRIPTION
### Description

Upgrade Jackson to 2.21.6.

Remove unused maven properties 
