### PR TITLE
Fix IDCS startup test module version (4.x)

### DIFF
--- a/tests/integration/mp-idcs-tracing-startup/pom.xml
+++ b/tests/integration/mp-idcs-tracing-startup/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration-project</artifactId>
-        <version>4.5.2-SNAPSHOT</version>
+        <version>4.5.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-mp-idcs-tracing-startup</artifactId>


### PR DESCRIPTION
Updates the newly added IDCS startup integration-test module to inherit the current 4.5.4 reactor version so it exercises the current branch artifacts.
