### PR TITLE
Stabilize HTTP/2 close-race tests

### DIFF
--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConcurrentStreamsLimitTest.java
@@ -683,11 +683,16 @@ class ConcurrentStreamsLimitTest {
 
             for (int i = 0; i < 70; i++) {
                 BufferData continuation = BufferData.create(new byte[1024]);
-                h2conn.writer().write(new Http2FrameData(Http2FrameHeader.create(continuation.available(),
-                                                                                 Http2FrameTypes.CONTINUATION,
-                                                                                 Http2Flag.ContinuationFlags.create(0),
-                                                                                 1),
-                                                     continuation));
+                try {
+                    h2conn.writer().write(new Http2FrameData(Http2FrameHeader.create(continuation.available(),
+                                                                                     Http2FrameTypes.CONTINUATION,
+                                                                                     Http2Flag.ContinuationFlags.create(0),
+                                                                                     1),
+                                                         continuation));
+                } catch (UncheckedIOException _) {
+                    // The server may close after sending GOAWAY while this client is still writing the flood.
+                    break;
+                }
             }
 
             assertGoAwayError(h2conn, Http2ErrorCode.ENHANCE_YOUR_CALM);

--- a/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
+++ b/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
@@ -24,6 +24,7 @@ import io.helidon.http.Status;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webclient.http2.Http2ClientProtocolConfig;
+import io.helidon.webclient.http2.Http2ClientResponse;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http2.Http2Route;
@@ -81,7 +82,10 @@ class SharedHttp2CacheTest {
                     .baseUri("http://localhost:" + port + "/versionspecific")
                     .build();
             try {
-                int firstReqClientPort = requestClientPort(webClient, clientPortHeader);
+                int firstReqClientPort;
+                try (var res = webClient.post().submit("WHATEVER")) {
+                    firstReqClientPort = clientPort(res, clientPortHeader);
+                }
 
                 if (param.restart()) {
                     // Test severing cached connections
@@ -94,15 +98,8 @@ class SharedHttp2CacheTest {
                 }
 
                 int secondReqClientPort;
-                try {
-                    secondReqClientPort = requestClientPort(webClient, clientPortHeader);
-                } catch (UncheckedIOException e) {
-                    if (!param.restart()) {
-                        throw e;
-                    }
-                    // The connection can close after cache selection but before request headers are written.
-                    // Once that race is observed, the retry uses a fresh connection.
-                    secondReqClientPort = requestClientPort(webClient, clientPortHeader);
+                try (var res = submitWithRestartRetry(webClient, param.restart())) {
+                    secondReqClientPort = clientPort(res, clientPortHeader);
                 }
 
                 if (!param.restart()) {
@@ -121,14 +118,25 @@ class SharedHttp2CacheTest {
         }
     }
 
-    private static int requestClientPort(Http2Client webClient, HeaderName clientPortHeader) {
-        try (var res = webClient.post().submit("WHATEVER")) {
-            int clientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
-            assertThat(res.status(), is(Status.OK_200));
-            // Wait for the empty DATA frame carrying END_STREAM before closing the response.
-            res.entity().consume();
-            return clientPort;
+    private static Http2ClientResponse submitWithRestartRetry(Http2Client webClient, boolean restart) {
+        try {
+            return webClient.post().submit("WHATEVER");
+        } catch (UncheckedIOException e) {
+            if (!restart) {
+                throw e;
+            }
+            // The connection can close after cache selection but before request headers are written.
+            // Once that race is observed, the retry uses a fresh connection.
+            return webClient.post().submit("WHATEVER");
         }
+    }
+
+    private static int clientPort(Http2ClientResponse response, HeaderName clientPortHeader) {
+        int clientPort = response.headers().get(clientPortHeader).get(Integer.TYPE);
+        assertThat(response.status(), is(Status.OK_200));
+        // Wait for the empty DATA frame carrying END_STREAM before closing the response.
+        response.entity().consume();
+        return clientPort;
     }
 
     record Param(boolean usePing, boolean priorKnowledge, boolean restart) {

--- a/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
+++ b/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.tests.upgrade.test;
 
+import java.io.UncheckedIOException;
+
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
@@ -79,13 +81,7 @@ class SharedHttp2CacheTest {
                     .baseUri("http://localhost:" + port + "/versionspecific")
                     .build();
             try {
-                Integer firstReqClientPort;
-                try (var res = webClient.post().submit("WHATEVER")) {
-                    firstReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
-                    assertThat(res.status(), is(Status.OK_200));
-                    // Wait for the empty DATA frame carrying END_STREAM before closing the response.
-                    res.entity().consume();
-                }
+                int firstReqClientPort = requestClientPort(webClient, clientPortHeader);
 
                 if (param.restart()) {
                     // Test severing cached connections
@@ -97,11 +93,16 @@ class SharedHttp2CacheTest {
                             .start();
                 }
 
-                Integer secondReqClientPort;
-                try (var res = webClient.post().submit("WHATEVER")) {
-                    secondReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
-                    assertThat(res.status(), is(Status.OK_200));
-                    res.entity().consume();
+                int secondReqClientPort;
+                try {
+                    secondReqClientPort = requestClientPort(webClient, clientPortHeader);
+                } catch (UncheckedIOException e) {
+                    if (!param.restart()) {
+                        throw e;
+                    }
+                    // The connection can close after cache selection but before request headers are written.
+                    // Once that race is observed, the retry uses a fresh connection.
+                    secondReqClientPort = requestClientPort(webClient, clientPortHeader);
                 }
 
                 if (!param.restart()) {
@@ -117,6 +118,16 @@ class SharedHttp2CacheTest {
             if (webServer != null) {
                 webServer.stop();
             }
+        }
+    }
+
+    private static int requestClientPort(Http2Client webClient, HeaderName clientPortHeader) {
+        try (var res = webClient.post().submit("WHATEVER")) {
+            int clientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
+            assertThat(res.status(), is(Status.OK_200));
+            // Wait for the empty DATA frame carrying END_STREAM before closing the response.
+            res.entity().consume();
+            return clientPort;
         }
     }
 


### PR DESCRIPTION
Stabilize two HTTP/2 tests against expected connection-close races.

The continuation-flood test tolerates a client write failure when the server closes after sending the expected `ENHANCE_YOUR_CALM` GOAWAY, while retaining the GOAWAY assertion.

The cache-restart test retries once when a selected cached connection closes before request headers are written. No-restart cases still require connection reuse, and restart cases still require the same client to reconnect successfully.
