### PR TITLE
Use TypeName class names for JSON converter field suffixes

### DIFF
--- a/json/codegen/src/main/java/io/helidon/json/codegen/JsonConverterGenerator.java
+++ b/json/codegen/src/main/java/io/helidon/json/codegen/JsonConverterGenerator.java
@@ -1248,13 +1248,45 @@ class JsonConverterGenerator {
         }
     }
 
-    private static String ensureUpperStart(TypeName typeName) {
-        String className = typeName.toString();
-        int index = className.lastIndexOf(".");
-        if (index > -1) {
-            className = className.substring(index + 1);
+    /**
+     * Build a Java identifier suffix for converter fields from a type name.
+     * {@link TypeName#toString()} includes generic syntax ({@code <...>}) and must not be used
+     * for generated field names.
+     *
+     * @param typeName type to convert to an identifier suffix
+     * @return capitalized identifier-safe suffix
+     */
+    static String ensureUpperStart(TypeName typeName) {
+        return capitalize(typeIdentifier(typeName));
+    }
+
+    private static String typeIdentifier(TypeName typeName) {
+        StringBuilder name = new StringBuilder();
+        for (String enclosing : typeName.enclosingNames()) {
+            name.append(identifierFragment(enclosing));
         }
-        return capitalize(className.replaceAll("\\[]", "Array"));
+        name.append(identifierFragment(typeName.className()));
+        if (typeName.array()) {
+            String current = name.toString();
+            if (!current.endsWith("Array")) {
+                name.append("Array");
+            }
+        }
+        for (TypeName arg : typeName.typeArguments()) {
+            name.append(typeIdentifier(arg));
+        }
+        return name.toString();
+    }
+
+    private static String identifierFragment(String fragment) {
+        if (fragment.isEmpty()) {
+            return fragment;
+        }
+        if ("?".equals(fragment)) {
+            return "Wildcard";
+        }
+        return fragment.replace("[]", "Array")
+                .replaceAll("[^A-Za-z0-9]", "");
     }
 
     private static int calculateNameHash(String name) {

--- a/json/tests/codegen/src/test/java/io/helidon/json/codegen/JsonConverterGeneratorTest.java
+++ b/json/tests/codegen/src/test/java/io/helidon/json/codegen/JsonConverterGeneratorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.json.codegen;
+
+import java.util.List;
+
+import io.helidon.common.types.TypeName;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JsonConverterGeneratorTest {
+
+    @Test
+    void genericTypeNameDoesNotUseToStringForFieldSuffix() {
+        TypeName person = TypeName.create("io.example.MyTestPerson");
+        TypeName builderBase = TypeName.builder()
+                .packageName("io.example")
+                .className("BuilderBase")
+                .addTypeArgument(person)
+                .build();
+
+        // toString()/resolvedName() keeps generic syntax, which used to leak into field names
+        assertThat(builderBase.toString(), containsString("MyTestPerson>"));
+
+        String suffix = JsonConverterGenerator.ensureUpperStart(builderBase);
+        assertThat(suffix, is("BuilderBaseMyTestPerson"));
+        assertThat(suffix, not(containsString("<")));
+        assertThat(suffix, not(containsString(">")));
+        assertThat(Character.isJavaIdentifierStart(suffix.charAt(0)), is(true));
+        for (int i = 0; i < suffix.length(); i++) {
+            assertThat(Character.isJavaIdentifierPart(suffix.charAt(i)), is(true));
+        }
+    }
+
+    @Test
+    void arrayAndNestedTypesRemainValidIdentifiers() {
+        TypeName stringArray = TypeName.create(String[].class);
+        assertThat(JsonConverterGenerator.ensureUpperStart(stringArray), is("StringArray"));
+
+        TypeName inner = TypeName.builder()
+                .packageName("io.example")
+                .className("Inner")
+                .enclosingNames(List.of("Outer"))
+                .build();
+        assertThat(JsonConverterGenerator.ensureUpperStart(inner), is("OuterInner"));
+    }
+}


### PR DESCRIPTION
Fixes #11399

`JsonConverterGenerator.ensureUpperStart` built field suffixes from `TypeName.toString()`. That string includes generic syntax, so types such as `BuilderBase<MyTestPerson>` became identifiers like `serializerMyTestPerson>`.

Build the suffix from class name, enclosing names, type arguments, and array flag instead, and drop characters that are not valid in a Java identifier.

Tested with `JsonConverterGeneratorTest` (`mvn -Ptests -pl tests/codegen test -Dtest=JsonConverterGeneratorTest` from `json/`).