### PR TITLE
Deprecate OpenTelemetry Zipkin exporter in Helidon 4.x

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/custom/tracing-outputs.xml
+++ b/archetypes/archetypes/src/main/archetype/mp/custom/tracing-outputs.xml
@@ -33,6 +33,7 @@
                 </model>
             </output>
         </method>
+        <!-- Compatibility-only support. OpenTelemetry stopped publishing this exporter in 1.65.0. -->
         <method name="tracing-zipkin">
             <output if="${tracing.provider} == 'zipkin'">
                 <model>
@@ -43,6 +44,7 @@
                         </map>
                     </list>
                     <value key="tracing.provider.for.otel">zipkin</value>
+                    <value key="tracing.provider.deprecated">true</value>
                 </model>
             </output>
         </method>
@@ -67,6 +69,8 @@
                 <value template="mustache"><![CDATA[
 #OpenTelemetry
 otel.sdk.disabled=false
+{{#tracing.provider.deprecated}}# WARNING: The OpenTelemetry Zipkin exporter is deprecated; migrate to OTLP.
+{{/tracing.provider.deprecated}}
 otel.traces.exporter={{tracing.provider.for.otel}}
 otel.service.name=helidon-tracing-service]]></value>
             </list>

--- a/docs/config/io.helidon.telemetry.otelconfig.SpanExporterType.md
+++ b/docs/config/io.helidon.telemetry.otelconfig.SpanExporterType.md
@@ -20,8 +20,7 @@ This type is an enumeration.
 </tr>
 <tr>
 <td><code>ZIPKIN</code></td>
-<td><strong>Deprecated:</strong> OpenTelemetry stopped publishing the Zipkin exporter in 1.65.0, and Helidon 27
-removes support. Use <code>OTLP</code> instead.</td>
+<td>The OpenTelemetry Zipkin exporter (<code>io.<wbr>opentelemetry.<wbr>exporter.<wbr>zipkin.<wbr>Zipkin<wbr>Span<wbr>Exporter</code>) is deprecated; OpenTelemetry stopped publishing it in 1.65.0, Helidon 27 removes support, and users should use OTLP instead</td>
 </tr>
 <tr>
 <td><code>CONSOLE</code></td>

--- a/docs/config/io.helidon.telemetry.otelconfig.SpanExporterType.md
+++ b/docs/config/io.helidon.telemetry.otelconfig.SpanExporterType.md
@@ -20,7 +20,8 @@ This type is an enumeration.
 </tr>
 <tr>
 <td><code>ZIPKIN</code></td>
-<td>Zipkin <code>io.<wbr>opentelemetry.<wbr>exporter.<wbr>zipkin.<wbr>Zipkin<wbr>Span<wbr>Exporter</code></td>
+<td><strong>Deprecated:</strong> OpenTelemetry stopped publishing the Zipkin exporter in 1.65.0, and Helidon 27
+removes support. Use <code>OTLP</code> instead.</td>
 </tr>
 <tr>
 <td><code>CONSOLE</code></td>

--- a/docs/config/io.helidon.telemetry.otelconfig.ZipkinExporterConfig.md
+++ b/docs/config/io.helidon.telemetry.otelconfig.ZipkinExporterConfig.md
@@ -2,7 +2,9 @@
 
 ## Description
 
-<code>N/<wbr>A</code>
+Configuration for the deprecated OpenTelemetry Zipkin exporter. OpenTelemetry stopped publishing the exporter in
+1.65.0, and Helidon 27 removes this configuration. Use
+<a href="io.helidon.telemetry.otelconfig.OtlpExporterConfig.md"><code>Otlp<wbr>Exporter<wbr>Config</code></a> instead.
 
 ## Configuration options
 

--- a/docs/config/io.helidon.telemetry.otelconfig.ZipkinExporterConfig.md
+++ b/docs/config/io.helidon.telemetry.otelconfig.ZipkinExporterConfig.md
@@ -2,9 +2,7 @@
 
 ## Description
 
-Configuration for the deprecated OpenTelemetry Zipkin exporter. OpenTelemetry stopped publishing the exporter in
-1.65.0, and Helidon 27 removes this configuration. Use
-<a href="io.helidon.telemetry.otelconfig.OtlpExporterConfig.md"><code>Otlp<wbr>Exporter<wbr>Config</code></a> instead.
+Configuration for the deprecated OpenTelemetry Zipkin exporter
 
 ## Configuration options
 

--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -501,12 +501,12 @@ should be added to project’s pom.xml file.
     </dependency>
     <dependency>
         <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-exporter-jaeger</artifactId>  <!-- (2) -->
+        <artifactId>opentelemetry-exporter-otlp</artifactId>  <!-- (2) -->
     </dependency>
 </dependencies>
 ```
 1. Helidon Telemetry dependency.
-2. OpenTelemetry Jaeger exporter.
+2. OpenTelemetry OTLP exporter.
 <!--@mdc :: -->
 
 Add these lines to `META-INF/microprofile-config.properties`:
@@ -516,15 +516,15 @@ MicroProfile Telemetry properties:
 <!--@mdc ::code-callout -->
 ```properties
 otel.sdk.disabled=false     <1>
-otel.traces.exporter=jaeger <2>
+otel.traces.exporter=otlp <2>
 otel.service.name=greeting-service <3>
 ```
 1. Enable MicroProfile Telemetry.
-2. Set exporter to Jaeger.
+2. Set exporter to OTLP.
 3. Name of our service.
 <!--@mdc :: -->
 
-Here we enable MicroProfile Telemetry, set tracer to "jaeger" and give a name,
+Here we enable MicroProfile Telemetry, set tracer to "otlp" and give a name,
 which will be used to identify our service in the tracer.
 
 > [!WARNING]

--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -439,8 +439,9 @@ an OpenTelemetry exporter as [described earlier](#otel-exporter-dependencies)
 and, as needed, configure its use. By default OpenTelemetry attempts to use the
 OTLP exporter so you do not need to add configuration to specify that choice. To
 use a different exporter set `otel.traces.exporter` in your configuration to the
-appropriate value: `zipkin`, `prometheus`, etc. See the [examples](#examples)
-section below.
+appropriate value. The `zipkin` value is deprecated because OpenTelemetry
+stopped publishing its Zipkin exporter in 1.65.0; use `otlp` for traces. See
+the [examples](#examples) section below.
 
 ### OpenTelemetry Java Agent
 
@@ -526,11 +527,12 @@ otel.service.name=greeting-service <3>
 Here we enable MicroProfile Telemetry, set tracer to "jaeger" and give a name,
 which will be used to identify our service in the tracer.
 
-> [!NOTE]
-> For this example, you will use Jaeger to manage data tracing. If you prefer to
-> use Zipkin, please set `otel.traces.exporter` property to "zipkin". For more
-> information using about Zipkin, see <https://zipkin.io/>. Also, a
-> corresponding Maven dependency for the exporter should be added:
+> [!WARNING]
+> The OpenTelemetry Zipkin exporter is deprecated. OpenTelemetry stopped
+> publishing it in 1.65.0, and Helidon 27 removes support for it. Existing
+> Helidon 4 applications can continue using `otel.traces.exporter=zipkin` with
+> the corresponding dependency shown below, but should migrate to the OTLP
+> exporter:
 >
 >     <dependency>
 >         <groupId>io.opentelemetry</groupId>

--- a/docs/se/telemetry/opentelemetry.md
+++ b/docs/se/telemetry/opentelemetry.md
@@ -338,7 +338,11 @@ See [Configuration options][io-helidon-telem-5].
 <!--/include-->
 
 
-OpenTelemetry also supports a Zipkin exporter which it has recently deprecated.
+> [!WARNING]
+> The OpenTelemetry Zipkin exporter is deprecated. OpenTelemetry stopped
+> publishing it in 1.65.0, and Helidon 27 removes support for it. Existing
+> Helidon 4 applications can continue using the exporter with the aligned OTel
+> version, but should migrate to the OTLP exporter.
 
 ### Zipkin Exporter
 
@@ -413,9 +417,9 @@ In the table below, the Maven artifacts are all in the `io.opentelemetry` group.
 <td><code>OtlpHttp{signal}Exporter</code></td>
 </tr>
 <tr>
-<td><a href="../../config/io.helidon.telemetry.otelconfig.ZipkinExporterConfig.md"><code>zipkin</code></a></td>
-<td><code>ZipkinSpanExporter</code></td>
-<td><code>opentelemetry-exporter-zipkin</code></td>
+<td><a href="../../config/io.helidon.telemetry.otelconfig.ZipkinExporterConfig.md"><code>zipkin</code></a> (deprecated)</td>
+<td><code>ZipkinSpanExporter</code> (deprecated)</td>
+<td><code>opentelemetry-exporter-zipkin</code> (last published before OTel 1.65.0)</td>
 </tr>
 <tr>
 <td><code>console</code></td>
@@ -482,7 +486,8 @@ telemetry:
   tracing:
     sampler: "always_off"
     exporters:
-      - type: zipkin
+      - type: otlp
+        protocol: http/proto
         compression: gzip
     processors:
       - type: batch
@@ -505,11 +510,10 @@ telemetry:
   tracing:
     sampler: "always_off"
     exporters:
-      - type: zipkin
-        compression: gzip
-        name: "compressed-zipkin"
+      - type: console
+        name: "console"
       - endpoint: "http://collect.com:4317"
-        name: "alternate-otlp""
+        name: "alternate-otlp"
     processors:
       - type: batch
         max-queue-size: 50

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigSupport.java
@@ -44,6 +44,7 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 class OtlpExporterConfigSupport {
+    private static final System.Logger LOGGER = System.getLogger(OtlpExporterConfigSupport.class.getName());
 
     private OtlpExporterConfigSupport() {
     }
@@ -59,6 +60,7 @@ class OtlpExporterConfigSupport {
         }
 
         @Prototype.ConfigFactoryMethod
+        @SuppressWarnings({"deprecation", "removal"})
         static SpanExporter createSpanExporter(Config config) {
             SpanExporterConfig exporterConfig = SpanExporterConfig.create(config);
 
@@ -114,7 +116,12 @@ class OtlpExporterConfigSupport {
             };
         }
 
+        @Deprecated(since = "4.5.4", forRemoval = true)
+        @SuppressWarnings({"deprecation", "removal"})
         static ZipkinSpanExporter createZipkinSpanExporter(Config config) {
+            LOGGER.log(System.Logger.Level.WARNING,
+                       "The OpenTelemetry Zipkin exporter is deprecated and is removed in Helidon 27 because "
+                               + "OpenTelemetry stopped publishing it in 1.65.0. Migrate to the OTLP exporter.");
             ZipkinSpanExporterBuilder builder = ZipkinSpanExporter.builder();
 
             var zipkinConfig = ZipkinExporterConfig.create(config);

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/SpanExporterType.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/SpanExporterType.java
@@ -36,8 +36,7 @@ public enum SpanExporterType {
 
     /**
      * The OpenTelemetry Zipkin exporter ({@link io.opentelemetry.exporter.zipkin.ZipkinSpanExporter}) is deprecated;
-     * OpenTelemetry stopped publishing it in 1.65.0, Helidon 27 removes support, and users should use {@link #OTLP}
-     * instead.
+     * OpenTelemetry stopped publishing it in 1.65.0, Helidon 27 removes support, and users should use OTLP instead.
      *
      * @deprecated OpenTelemetry stopped publishing the Zipkin exporter in 1.65.0, and Helidon 27 removes support.
      * Use {@link #OTLP} instead.

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/SpanExporterType.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/SpanExporterType.java
@@ -35,8 +35,14 @@ public enum SpanExporterType {
     OTLP, // There are different defaults for the different subtypes of OTLP exporters.
 
     /**
-     * Zipkin {@link io.opentelemetry.exporter.zipkin.ZipkinSpanExporter}.
+     * The OpenTelemetry Zipkin exporter ({@link io.opentelemetry.exporter.zipkin.ZipkinSpanExporter}) is deprecated;
+     * OpenTelemetry stopped publishing it in 1.65.0, Helidon 27 removes support, and users should use {@link #OTLP}
+     * instead.
+     *
+     * @deprecated OpenTelemetry stopped publishing the Zipkin exporter in 1.65.0, and Helidon 27 removes support.
+     * Use {@link #OTLP} instead.
      */
+    @Deprecated(since = "4.5.4", forRemoval = true)
     ZIPKIN,
 
     /**

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ZipkinExporterConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ZipkinExporterConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ZipkinExporterConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ZipkinExporterConfigBlueprint.java
@@ -29,9 +29,17 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.Sender;
 
+/**
+ * Configuration for the deprecated OpenTelemetry Zipkin exporter.
+ *
+ * @deprecated OpenTelemetry stopped publishing the Zipkin exporter in 1.65.0. This configuration is removed in
+ * Helidon 27. Use {@link OtlpExporterConfig} instead.
+ */
+@Deprecated(since = "4.5.4", forRemoval = true)
 @Prototype.Configured
 @Prototype.Blueprint(decorator = ZipkinExporterConfigSupport.BuilderDecorator.class)
-interface  ZipkinExporterConfigBlueprint {
+@Prototype.Annotated("java.lang.Deprecated(since = \"4.5.4\", forRemoval = true)")
+interface ZipkinExporterConfigBlueprint {
 
     /**
      * Collector endpoint to which this exporter should transmit.

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ZipkinExporterConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ZipkinExporterConfigSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ZipkinExporterConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ZipkinExporterConfigSupport.java
@@ -21,6 +21,10 @@ import io.helidon.common.LazyValue;
 
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder;
 
+/**
+ * Compatibility support for the deprecated OpenTelemetry Zipkin exporter.
+ */
+@SuppressWarnings({"deprecation", "removal"})
 class ZipkinExporterConfigSupport {
 
     private ZipkinExporterConfigSupport() {

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
@@ -124,6 +124,17 @@ class TestBasicConfig {
     }
 
     @Test
+    @SuppressWarnings("removal")
+    void testZipkinExporterDeprecationMetadata() throws NoSuchFieldException {
+        assertThat("Zipkin exporter type is deprecated",
+                   SpanExporterType.class.getField("ZIPKIN").isAnnotationPresent(Deprecated.class),
+                   is(true));
+        assertThat("Zipkin exporter configuration is deprecated",
+                   ZipkinExporterConfig.class.isAnnotationPresent(Deprecated.class),
+                   is(true));
+    }
+
+    @Test
     void testDisabled() {
         /*
         The main point of this test is to make sure that we can build the OpenTelemetryConfig object without errors when


### PR DESCRIPTION
### Description

Resolves #12312 

#### Release Note
____
Helidon's OpenTelemetry Zipkin exporter integration is deprecated in Helidon 4.x because OpenTelemetry stopped publishing the exporter in version 1.65.0. Existing applications using OpenTelemetry's Zipkin exporter remain supported in Helidon 4.x but should migrate to use the OTLP exporter; Zipkin exporter support will likely be removed in a near-future major release of Helidon.
____

#### PR Overview

This change retains OpenTelemetry Zipkin exporter support in Helidon 4.x for compatibility while marking it for removal and directing users to OTLP.

- Marks `SpanExporterType.ZIPKIN` as `@Deprecated(since = "4.5.4", forRemoval = true)`.
- Marks the generated `ZipkinExporterConfig` API and its blueprint/support code as deprecated.
- Emits a runtime warning when the OpenTelemetry Zipkin exporter is selected.
- Explains that OpenTelemetry stopped publishing the Zipkin exporter in 1.65.0 and that Helidon 27 removes support.
- Updates the generated configuration reference to identify the `zipkin` value and `ZipkinExporterConfig` as deprecated.
- Updates SE and MP telemetry documentation with deprecation warnings and OTLP migration guidance.
- Replaces general Zipkin examples with supported OTLP or console exporter examples.
- Labels the MP archetype's OpenTelemetry Zipkin option as deprecated and adds a warning to generated MP configuration and documentation.
- Leaves the separate SE native Zipkin tracing provider unchanged.

## Compatibility

Existing Helidon 4.x applications can continue using the OpenTelemetry Zipkin exporter with the aligned OpenTelemetry version. No Zipkin behavior is removed from the 4.x branch, but users receive compile-time, runtime, configuration, and documentation warnings encouraging migration to OTLP.

## Testing

- Retains existing Zipkin exporter construction and configuration coverage.
- Adds assertions confirming that `SpanExporterType.ZIPKIN` and the generated `ZipkinExporterConfig` API carry deprecation metadata.
- Verifies the OpenTelemetry configuration module and generated configuration documentation.
### Documentation

If enhancement: provide description with example code/config snippet or pointer to issue with the description

If feature: summarize feature and provide pointer to doc issue

If no doc impact: None
