### PR TITLE
Document service static lookup restriction

### DIFF
--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -36,9 +36,9 @@ import io.helidon.common.types.TypeName;
 /**
  * A set of annotations (and APIs) required to declare a service.
  * <p>
- * A service managed by the service registry must never call methods on
+ * Any service instance created by the service registry must never call methods on
  * {@link io.helidon.service.registry.Services}. Required dependencies must be injected into the service. When
- * programmatic lookup is required, inject
+ * programmatic lookup is required during normal operation, inject
  * {@link io.helidon.service.registry.ServiceRegistry} instead. This restriction applies throughout the service lifecycle,
  * including construction, post-construct, business methods, and pre-destroy.
  */
@@ -164,9 +164,10 @@ public final class Service {
      * This also implies that instances that are NOT created within a scope cannot have their pre-destroy methods
      * invoked, as we do not control their lifecycle.
      * <p>
-     * A pre-destroy method must not call methods on {@link io.helidon.service.registry.Services}. Dependencies used during
-     * shutdown must be injected into the service. When programmatic lookup is required, inject
-     * {@link io.helidon.service.registry.ServiceRegistry} instead.
+     * A pre-destroy method is intended to release resources held by the service instance, not to interact with other services.
+     * It must not invoke methods that may instantiate another service. For example, it must not obtain a value from an
+     * injected {@link java.util.function.Supplier} or call an instance lookup method on an injected
+     * {@link io.helidon.service.registry.ServiceRegistry}.
      * <p>
      * The method must not have any parameters and must be accessible (not {@code private}).
      */

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -36,8 +36,9 @@ import io.helidon.common.types.TypeName;
 /**
  * A set of annotations (and APIs) required to declare a service.
  * <p>
- * A service must never call methods on {@link io.helidon.service.registry.Services}. Required dependencies must be
- * injected into the service. When programmatic lookup is required, inject
+ * A service managed by the service registry must never call methods on
+ * {@link io.helidon.service.registry.Services}. Required dependencies must be injected into the service. When
+ * programmatic lookup is required, inject
  * {@link io.helidon.service.registry.ServiceRegistry} instead. This restriction applies throughout the service lifecycle,
  * including construction, post-construct, business methods, and pre-destroy.
  */

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -35,6 +35,11 @@ import io.helidon.common.types.TypeName;
 
 /**
  * A set of annotations (and APIs) required to declare a service.
+ * <p>
+ * A service must never call methods on {@link io.helidon.service.registry.Services}. Required dependencies must be
+ * injected into the service. When programmatic lookup is required, inject
+ * {@link io.helidon.service.registry.ServiceRegistry} instead. This restriction applies throughout the service lifecycle,
+ * including construction, post-construct, business methods, and pre-destroy.
  */
 public final class Service {
     private Service() {
@@ -157,6 +162,10 @@ public final class Service {
      * is created once, and pre-destroy is called when the registry is shut down.
      * This also implies that instances that are NOT created within a scope cannot have their pre-destroy methods
      * invoked, as we do not control their lifecycle.
+     * <p>
+     * A pre-destroy method must not call methods on {@link io.helidon.service.registry.Services}. Dependencies used during
+     * shutdown must be injected into the service. When programmatic lookup is required, inject
+     * {@link io.helidon.service.registry.ServiceRegistry} instead.
      * <p>
      * The method must not have any parameters and must be accessible (not {@code private}).
      */

--- a/service/registry/src/main/java/io/helidon/service/registry/Services.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Services.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,10 @@ import io.helidon.common.types.TypeName;
 
 /**
  * Static access to the service registry.
+ * <p>
+ * <strong>Service implementation restriction:</strong> A service managed by the service registry must never call methods on
+ * this class. Required dependencies must be injected into the service. When programmatic lookup is required, inject
+ * {@link io.helidon.service.registry.ServiceRegistry} instead. This restriction applies throughout the service lifecycle.
  * <p>
  * <b>Note: </b> Using any methods on this class makes the service registry throw away optimization created via
  * the Helidon Service Registry Maven Plugin (code generated binding) for services that use the contracts configured.

--- a/service/registry/src/main/java/io/helidon/service/registry/Services.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Services.java
@@ -26,9 +26,10 @@ import io.helidon.common.types.TypeName;
 /**
  * Static access to the service registry.
  * <p>
- * <strong>Service implementation restriction:</strong> A service managed by the service registry must never call methods on
- * this class. Required dependencies must be injected into the service. When programmatic lookup is required, inject
- * {@link io.helidon.service.registry.ServiceRegistry} instead. This restriction applies throughout the service lifecycle.
+ * <strong>Service implementation restriction:</strong> Any service instance created by the service registry must never call
+ * methods on this class. Required dependencies must be injected into the service. When programmatic lookup is required during
+ * normal operation, inject {@link io.helidon.service.registry.ServiceRegistry} instead. This restriction applies throughout
+ * the service lifecycle.
  * <p>
  * <b>Note: </b> Using any methods on this class makes the service registry throw away optimization created via
  * the Helidon Service Registry Maven Plugin (code generated binding) for services that use the contracts configured.


### PR DESCRIPTION
Documents that registry-managed service implementations must use injected dependencies, or an injected `ServiceRegistry` for programmatic lookup, rather than the static `Services` facade throughout their lifecycle.

Related to #12321.
