### PR TITLE
Close HTTP/1.1 connections after Connection: close (4.x)

### DIFF
--- a/http/http/src/main/java/io/helidon/http/Headers.java
+++ b/http/http/src/main/java/io/helidon/http/Headers.java
@@ -73,9 +73,13 @@ public interface Headers extends Iterable<Header> {
      * {@code Connection}, {@code TE}, or {@code Transfer-Encoding}.
      *
      * @param value expected header name and tokenized value(s)
-     * @return {@code true} if all expected tokens are present, ignoring case and surrounding whitespace
+    * @return {@code true} if all expected tokens are present, ignoring case and surrounding whitespace
      */
     default boolean containsToken(Header value) {
+        if (!contains(value.headerName())) {
+            return false;
+        }
+
         List<String> actualValues = values(value.headerName());
         if (actualValues.isEmpty()) {
             return false;

--- a/http/http/src/main/java/io/helidon/http/Headers.java
+++ b/http/http/src/main/java/io/helidon/http/Headers.java
@@ -73,7 +73,7 @@ public interface Headers extends Iterable<Header> {
      * {@code Connection}, {@code TE}, or {@code Transfer-Encoding}.
      *
      * @param value expected header name and tokenized value(s)
-    * @return {@code true} if all expected tokens are present, ignoring case and surrounding whitespace
+     * @return {@code true} if all expected tokens are present, ignoring case and surrounding whitespace
      */
     default boolean containsToken(Header value) {
         if (!contains(value.headerName())) {

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/KeepAliveTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/KeepAliveTest.java
@@ -18,8 +18,14 @@ package io.helidon.webserver.tests;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
 
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
@@ -27,11 +33,15 @@ import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
 import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static io.helidon.http.Status.INTERNAL_SERVER_ERROR_500;
@@ -42,9 +52,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @ServerTest
 class KeepAliveTest {
     private final Http1Client webClient;
+    private final URI uri;
 
-    KeepAliveTest(Http1Client client) {
+    KeepAliveTest(Http1Client client, URI uri) {
         this.webClient = client;
+        this.uri = uri;
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.writeQueueLength(2);
+        server.smartAsyncWrites(true);
     }
 
     @SetUpRoute
@@ -69,7 +87,19 @@ class KeepAliveTest {
                 res.status(INTERNAL_SERVER_ERROR_500)
                         .send(e.getMessage());
             }
-        });
+        }).get("/request-close", (req, res) -> res.send("done"))
+                .get("/response-close", (req, res) -> res.header(HeaderValues.CONNECTION_CLOSE)
+                        .send("done"))
+                .get("/request-close-stream", (req, res) -> sendStreamingResponse(res))
+                .get("/response-close-stream", (req, res) -> {
+                    res.header(HeaderValues.CONNECTION_CLOSE);
+                    sendStreamingResponse(res);
+                })
+                .route(Method.PUT, "/response-close-entity", (req, res) -> {
+                    req.content().as(String.class);
+                    res.header(HeaderValues.CONNECTION_CLOSE)
+                            .send("done");
+                });
     }
 
     @RepeatedTest(100)
@@ -93,6 +123,39 @@ class KeepAliveTest {
         try (HttpClientResponse response = testCall(webClient, true, "/close", INTERNAL_SERVER_ERROR_500)) {
             assertThat(response.headers(), hasHeader(HeaderValues.CONNECTION_KEEP_ALIVE));
         }
+    }
+
+    @Test
+    void requestConnectionCloseClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.GET, "/request-close", null, List.of("Connection: close"));
+    }
+
+    @Test
+    void requestConnectionCloseWithEntityClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.PUT, "/plain", "content", List.of("Connection: close"));
+    }
+
+    @Test
+    void responseConnectionCloseClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.GET, "/response-close", null, List.of());
+    }
+
+    @Test
+    void responseConnectionCloseWithEntityClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.PUT, "/response-close-entity", "content", List.of());
+    }
+
+    @Test
+    void requestConnectionCloseWithStreamingResponseClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.GET,
+                                 "/request-close-stream",
+                                 null,
+                                 List.of("Connection: close"));
+    }
+
+    @Test
+    void responseConnectionCloseWithStreamingResponseClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.GET, "/response-close-stream", null, List.of());
     }
 
     private static HttpClientResponse testCall(Http1Client client,
@@ -119,4 +182,23 @@ class KeepAliveTest {
 
         return response;
     }
+
+    private static void sendStreamingResponse(ServerResponse response) {
+        try (OutputStream outputStream = response.outputStream()) {
+            outputStream.write("first".getBytes(StandardCharsets.UTF_8));
+            outputStream.write("second".getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void assertConnectionIsClosed(Method method, String path, String payload, List<String> headers) throws Exception {
+        try (SocketHttpClient client = SocketHttpClient.create(uri.getHost(), uri.getPort(), Duration.ofSeconds(2))) {
+            String response = client.sendAndReceive(method, path, payload, headers);
+            assertThat(SocketHttpClient.statusFromResponse(response), is(OK_200));
+            assertThat(SocketHttpClient.headersFromResponse(response), hasHeader(HeaderValues.CONNECTION_CLOSE));
+            client.assertConnectionIsClosed();
+        }
+    }
+
 }

--- a/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketTest.java
+++ b/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketTest.java
@@ -28,6 +28,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Status;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
@@ -41,6 +44,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -184,6 +188,27 @@ class WebSocketTest {
         assertThat(listener.results().statusCode, is(1009));
         assertThat(listener.results().reason, is("Payload too large"));
         isNormalClose = false;
+    }
+
+    @Test
+    void rejectedUpgradeWithCloseClosesConnection() throws Exception {
+        isNormalClose = false;
+        try (SocketHttpClient socketClient = SocketHttpClient.create(port)) {
+            socketClient.requestRaw("""
+                                            GET /echo HTTP/1.1\r
+                                            Host: localhost:%d\r
+                                            Upgrade: websocket\r
+                                            Connection: Upgrade, close\r
+                                            Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
+                                            Sec-WebSocket-Version: 13\r
+                                            \r
+                                            """.formatted(port));
+
+            String response = socketClient.receive();
+            assertThat(SocketHttpClient.statusFromResponse(response), is(Status.BAD_REQUEST_400));
+            assertThat(SocketHttpClient.headersFromResponse(response), hasHeader(HeaderValues.CONNECTION_CLOSE));
+            socketClient.assertConnectionIsClosed();
+        }
     }
 
     private static class TestListener implements java.net.http.WebSocket.Listener {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -111,6 +111,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     private volatile Thread myThread;
     private volatile boolean canRun = true;
     private volatile boolean closeInterrupt;
+    private volatile boolean closingConnection;
     private volatile boolean currentlyReadingPrologue;
     private volatile ZonedDateTime lastRequestTimestamp;
     private volatile ServerConnection upgradeConnection;
@@ -145,7 +146,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     @Override
     public boolean canInterrupt() {
         if (upgradeConnection == null) {
-            return currentlyReadingPrologue;
+            return currentlyReadingPrologue || closingConnection;
         }
         return true;
     }
@@ -216,6 +217,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                     LimitAlgorithm.Token permit = accepted.token();
                                     ServerConnection routedUpgradeConnection = null;
                                     boolean routeNormally = false;
+                                    boolean keepConnectionOpen = true;
                                     boolean permitCompleted = false;
                                     try {
                                         this.lastRequestTimestamp = DateTime.timestamp();
@@ -233,14 +235,22 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                         default -> throw new IllegalStateException("Unknown routed upgrade result kind");
                                         };
                                         routeNormally = upgradeKind == Http1UpgradeResult.Kind.NOT_APPLICABLE;
+                                        keepConnectionOpen = upgradeKind != Http1UpgradeResult.Kind.RESPONDED
+                                                || response.keepConnectionOpen();
                                         permit.success();
                                         permitCompleted = true;
                                         this.lastRequestTimestamp = DateTime.timestamp();
+                                        if (!keepConnectionOpen) {
+                                            flushBeforeClose();
+                                        }
                                     } catch (Throwable e) {
                                         if (!permitCompleted) {
                                             permit.dropped();
                                         }
                                         throw e;
+                                    }
+                                    if (!keepConnectionOpen) {
+                                        return;
                                     }
                                     if (routedUpgradeConnection != null) {
                                         handleUpgradeConnection(limit, routedUpgradeConnection);
@@ -265,16 +275,8 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                 LimitAlgorithm.Outcome outcome = limit.tryAcquireOutcome(true);
                 if (outcome.disposition() == LimitAlgorithm.Outcome.Disposition.ACCEPTED) {
                     LimitAlgorithm.Outcome.Accepted accepted = (LimitAlgorithm.Outcome.Accepted) outcome;
-                    LimitAlgorithm.Token permit = accepted.token();
-
-                    try {
-                        this.lastRequestTimestamp = DateTime.timestamp();
-                        route(prologue, headers, accepted);
-                        permit.success();
-                        this.lastRequestTimestamp = DateTime.timestamp();
-                    } catch (Throwable e) {
-                        permit.dropped();
-                        throw e;
+                    if (!routeWithPermit(prologue, headers, accepted)) {
+                        return;
                     }
                 } else {
                     throw tooManyConcurrentRequests();
@@ -538,6 +540,40 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         UriValidator.validateNonIpLiteral(hostString);
     }
 
+    private boolean routeWithPermit(HttpPrologue prologue,
+                                    WritableHeaders<?> headers,
+                                    LimitAlgorithm.Outcome.Accepted accepted) {
+        LimitAlgorithm.Token permit = accepted.token();
+        boolean permitCompleted = false;
+        try {
+            this.lastRequestTimestamp = DateTime.timestamp();
+            boolean keepConnectionOpen = route(prologue, headers, accepted);
+            permit.success();
+            permitCompleted = true;
+            this.lastRequestTimestamp = DateTime.timestamp();
+            if (!keepConnectionOpen) {
+                flushBeforeClose();
+            }
+            return keepConnectionOpen;
+        } catch (Throwable e) {
+            if (!permitCompleted) {
+                permit.dropped();
+            }
+            throw e;
+        }
+    }
+
+    private void flushBeforeClose() {
+        closingConnection = true;
+        try {
+            writer.flush();
+        } catch (RuntimeException e) {
+            throw new CloseConnectionException("Failed to flush closing response", e);
+        } finally {
+            closingConnection = false;
+        }
+    }
+
     private BufferData readEntityFromPipeline(HttpPrologue prologue, WritableHeaders<?> headers) {
         if (currentEntitySize == -1) {
             // chunked
@@ -591,9 +627,9 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         return buffer;
     }
 
-    private void route(HttpPrologue prologue,
-                       WritableHeaders<?> headers,
-                       LimitAlgorithm.Outcome limitOutcome) {
+    private boolean route(HttpPrologue prologue,
+                          WritableHeaders<?> headers,
+                          LimitAlgorithm.Outcome limitOutcome) {
         EntityStyle entity = EntityStyle.NONE;
 
         if (headers.contains(HeaderNames.TRANSFER_ENCODING)) {
@@ -626,7 +662,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
 
             routing.route(ctx, request, response);
             // we have handled a request without request entity
-            return;
+            return response.keepConnectionOpen();
         }
 
         boolean expectContinue = false;
@@ -698,6 +734,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                     .cause(e)
                     .build();
         }
+        return response.keepConnectionOpen();
     }
 
     private Http1ServerRequest createNoEntityRequest(HttpPrologue prologue,
@@ -723,7 +760,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     }
 
     private void consumeEntity(Http1ServerRequest request, Http1ServerResponse response, CountDownLatch entityReadLatch) {
-        if (response.headers().containsToken(HeaderValues.CONNECTION_CLOSE) || request.content().consumed()) {
+        if (!response.keepConnectionOpen() || request.content().consumed()) {
             // we do not care about request entity if connection is getting closed
             entityReadLatch.countDown();
             return;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -111,7 +111,6 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     private volatile Thread myThread;
     private volatile boolean canRun = true;
     private volatile boolean closeInterrupt;
-    private volatile boolean closingConnection;
     private volatile boolean currentlyReadingPrologue;
     private volatile ZonedDateTime lastRequestTimestamp;
     private volatile ServerConnection upgradeConnection;
@@ -146,7 +145,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     @Override
     public boolean canInterrupt() {
         if (upgradeConnection == null) {
-            return currentlyReadingPrologue || closingConnection;
+            return currentlyReadingPrologue;
         }
         return true;
     }
@@ -564,13 +563,10 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     }
 
     private void flushBeforeClose() {
-        closingConnection = true;
         try {
             writer.flush();
         } catch (RuntimeException e) {
             throw new CloseConnectionException("Failed to flush closing response", e);
-        } finally {
-            closingConnection = false;
         }
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -538,8 +538,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     }
 
     private boolean resolveKeepConnectionOpen() {
-        return keepAlive
-                && (!headers.contains(HeaderNames.CONNECTION) || !headers.containsToken(HeaderValues.CONNECTION_CLOSE));
+        return keepAlive && !headers.containsToken(HeaderValues.CONNECTION_CLOSE);
     }
 
     static class BlockingOutputStream extends OutputStream {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -70,6 +70,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     private final ServerResponseTrailers trailers;
     private final boolean keepAlive;
     private final boolean sendKeepAliveHeader;
+    private final boolean validateHeaders;
 
     private boolean keepConnectionOpen;
     private boolean streamingEntity;
@@ -78,7 +79,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     private long bytesWritten;
     private String streamResult = "";
     private boolean isNoEntityStatus;
-    private final boolean validateHeaders;
 
     private UnaryOperator<OutputStream> outputStreamFilter;
 
@@ -523,11 +523,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         return keepConnectionOpen;
     }
 
-    private boolean resolveKeepConnectionOpen() {
-        return keepAlive
-                && (!headers.contains(HeaderNames.CONNECTION) || !headers.containsToken(HeaderValues.CONNECTION_CLOSE));
-    }
-
     private static Status noEntityInternalError(Status status) {
         LOGGER.log(System.Logger.Level.ERROR, "Attempt to send status " + status.text() + " with entity."
                 + " Server responded with Internal Server Error. Please fix your routing, this is not allowed "
@@ -540,6 +535,11 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         return code == Status.NO_CONTENT_204.code()
                 || code == Status.RESET_CONTENT_205.code()
                 || code == Status.NOT_MODIFIED_304.code();
+    }
+
+    private boolean resolveKeepConnectionOpen() {
+        return keepAlive
+                && (!headers.contains(HeaderNames.CONNECTION) || !headers.containsToken(HeaderValues.CONNECTION_CLOSE));
     }
 
     static class BlockingOutputStream extends OutputStream {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -71,6 +71,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     private final boolean keepAlive;
     private final boolean sendKeepAliveHeader;
 
+    private boolean keepConnectionOpen;
     private boolean streamingEntity;
     private boolean isSent;
     private ClosingBufferedOutputStream outputStream;
@@ -97,6 +98,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         this.headers = ServerResponseHeaders.create();
         this.trailers = ServerResponseTrailers.create();
         this.keepAlive = keepAlive;
+        this.keepConnectionOpen = keepAlive;
         this.sendKeepAliveHeader = sendKeepAliveHeader;
         this.validateHeaders = validateHeaders;
     }
@@ -326,6 +328,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             return false;
         }
         headers.clear();
+        keepConnectionOpen = keepAlive;
         streamingEntity = false;
         outputStream = null;
         return true;
@@ -455,6 +458,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         // give some space for code and headers + entity
         BufferData responseBuffer = BufferData.growing(256 + length);
 
+        keepConnectionOpen = resolveKeepConnectionOpen();
         nonEntityBytes(headers, usedStatus, responseBuffer, keepAlive, sendKeepAliveHeader, validateHeaders);
         if (forcedChunkedEncoding) {
             byte[] hex = Integer.toHexString(length).getBytes(StandardCharsets.US_ASCII);
@@ -510,11 +514,18 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             encodedOutputStream = contentEncode(outputStream);
             bos.checkResponseHeaders();     // headers can be augmented by encoders
         }
-        return outputStreamFilter == null ? encodedOutputStream : outputStreamFilter.apply(encodedOutputStream);
+        OutputStream result = outputStreamFilter == null ? encodedOutputStream : outputStreamFilter.apply(encodedOutputStream);
+        keepConnectionOpen = resolveKeepConnectionOpen();
+        return result;
     }
 
     boolean keepConnectionOpen() {
-        return keepAlive && !headers.containsToken(HeaderValues.CONNECTION_CLOSE);
+        return keepConnectionOpen;
+    }
+
+    private boolean resolveKeepConnectionOpen() {
+        return keepAlive
+                && (!headers.contains(HeaderNames.CONNECTION) || !headers.containsToken(HeaderValues.CONNECTION_CLOSE));
     }
 
     private static Status noEntityInternalError(Status status) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -18,14 +18,20 @@ package io.helidon.webserver.http1;
 
 import java.io.UncheckedIOException;
 import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.concurrency.limits.FixedLimit;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.socket.SocketWriter;
 import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.encoding.ContentEncodingContext;
@@ -34,10 +40,13 @@ import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.DirectHandlers;
+import io.helidon.webserver.http.HttpRouting;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,6 +56,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class Http1ConnectionTest {
+    private static final byte[] CONNECTION_CLOSE_REQUEST = ("""
+            GET / HTTP/1.1\r
+            Host: localhost\r
+            Connection: close\r
+            \r
+            """).getBytes(StandardCharsets.UTF_8);
 
     @Test
     void continueImmediatelyWrapsSocketWriterExceptionFromSmartWriter() {
@@ -69,16 +84,55 @@ class Http1ConnectionTest {
         }
     }
 
+    @Test
+    void gracefulCloseDoesNotInterruptClosingResponseFlush() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        BlockingDataWriter writer = new BlockingDataWriter();
+        Http1Connection connection = createConnection(writer,
+                                                      DataReader.create(() -> CONNECTION_CLOSE_REQUEST),
+                                                      Router.builder()
+                                                              .addRouting(HttpRouting.builder()
+                                                                                  .get("/", (req, res) -> res.send("done")))
+                                                              .build());
+        try {
+            Future<?> connectionTask = executor.submit(() -> {
+                connection.handle(FixedLimit.create());
+                return null;
+            });
+
+            assertThat("Closing response did not reach the final flush",
+                       writer.flushStarted.await(10, TimeUnit.SECONDS),
+                       is(true));
+            connection.close(false);
+            writer.releaseFlush.countDown();
+            connectionTask.get(2, TimeUnit.SECONDS);
+
+            assertThat("Graceful close interrupted the final response flush", writer.interrupted, is(false));
+        } finally {
+            writer.releaseFlush.countDown();
+            executor.shutdownNow();
+        }
+    }
+
     private static Http1Connection createConnection(DataWriter dataWriter) {
+        return createConnection(dataWriter, mock(DataReader.class), Router.empty());
+    }
+
+    private static Http1Connection createConnection(DataWriter dataWriter, DataReader dataReader, Router router) {
         ListenerContext listenerContext = mock(ListenerContext.class);
         when(listenerContext.contentEncodingContext()).thenReturn(mock(ContentEncodingContext.class));
         when(listenerContext.config()).thenReturn(WebServer.builder().buildPrototype());
+        when(listenerContext.directHandlers()).thenReturn(DirectHandlers.create());
+
+        PeerInfo peerInfo = mock(PeerInfo.class);
 
         ConnectionContext ctx = mock(ConnectionContext.class);
         when(ctx.listenerContext()).thenReturn(listenerContext);
         when(ctx.dataWriter()).thenReturn(dataWriter);
-        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
-        when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.dataReader()).thenReturn(dataReader);
+        when(ctx.router()).thenReturn(router);
+        when(ctx.remotePeer()).thenReturn(peerInfo);
+        when(ctx.localPeer()).thenReturn(peerInfo);
 
         return new Http1Connection(ctx,
                                    Http1Config.builder()
@@ -95,5 +149,38 @@ class Http1ConnectionTest {
                 .when(socket)
                 .write(any(BufferData.class));
         return SocketWriter.create(executor, socket, 2, true);
+    }
+
+    private static final class BlockingDataWriter implements DataWriter {
+        private final CountDownLatch flushStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseFlush = new CountDownLatch(1);
+        private volatile boolean interrupted;
+
+        @Override
+        public void write(BufferData... buffers) {
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+        }
+
+        @Override
+        public void writeNow(BufferData... buffers) {
+        }
+
+        @Override
+        public void writeNow(BufferData buffer) {
+        }
+
+        @Override
+        public void flush() {
+            flushStarted.countDown();
+            try {
+                releaseFlush.await();
+            } catch (InterruptedException e) {
+                interrupted = true;
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #12324

Ensures HTTP/1.1 responses selecting `Connection: close` are fully flushed before the server closes the socket, without holding the request-limit permit. Adds raw-socket coverage for request- and response-driven closure, entities, streaming responses, and rejected routed upgrades. Also avoids tokenizing absent headers when checking connection options.