### PR TITLE
27.x pom cleanup

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -70,7 +70,6 @@
         <version.lib.jakarta.transaction-api>2.0.1</version.lib.jakarta.transaction-api>
         <!-- Check Hibernate when upgrading to ensure its supplied jaxb-runtime is compatible. -->
         <version.lib.jakarta.xml.bind-api>4.0.2</version.lib.jakarta.xml.bind-api>
-        <version.lib.jandex>3.3.0</version.lib.jandex>
         <version.lib.jaxb-core>4.0.5</version.lib.jaxb-core>
         <version.lib.jaxb-impl>4.0.5</version.lib.jaxb-impl>
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>

--- a/pom.xml
+++ b/pom.xml
@@ -86,33 +86,31 @@
         -->
 
         <!-- maven plugin versions -->
-        <version.plugin.build-helper>3.4.0</version.plugin.build-helper>
+        <version.plugin.build-helper>3.6.1</version.plugin.build-helper>
         <version.plugin.checkstyle>3.6.0</version.plugin.checkstyle>
-        <version.plugin.compiler>3.11.0</version.plugin.compiler>
-        <version.plugin.dependency>3.10.0</version.plugin.dependency>
+        <version.plugin.compiler>3.15.0</version.plugin.compiler>
+        <version.plugin.dependency>3.11.0</version.plugin.dependency>
         <version.plugin.directory>1.0</version.plugin.directory>
-        <version.plugin.enforcer>3.3.0</version.plugin.enforcer>
-        <version.plugin.exec>3.1.0</version.plugin.exec>
-        <version.plugin.failsafe>3.1.2</version.plugin.failsafe>
-        <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
-        <version.plugin.helidon-build-tools>4.0.26</version.plugin.helidon-build-tools>
-        <version.plugin.install>3.1.2</version.plugin.install>
-        <version.plugin.invoker>3.2.2</version.plugin.invoker>
-        <version.plugin.jar>3.3.0</version.plugin.jar>
-        <version.plugin.javadoc>3.6.2</version.plugin.javadoc>
-        <version.plugin.license>1.16</version.plugin.license>
-        <version.plugin.os>1.5.0.Final</version.plugin.os>
-        <version.plugin.plugin>3.15.1</version.plugin.plugin>
+        <version.plugin.enforcer>3.6.3</version.plugin.enforcer>
+        <version.plugin.exec>3.6.3</version.plugin.exec>
+        <version.plugin.failsafe>3.5.6</version.plugin.failsafe>
+        <version.plugin.helidon-build-tools>4.0.29</version.plugin.helidon-build-tools>
+        <version.plugin.install>3.1.4</version.plugin.install>
+        <version.plugin.invoker>3.10.1</version.plugin.invoker>
+        <version.plugin.jar>3.5.1</version.plugin.jar>
+        <version.plugin.javadoc>3.12.0</version.plugin.javadoc>
+        <version.plugin.license>2.7.1</version.plugin.license>
+        <version.plugin.os>1.7.1</version.plugin.os>
+        <version.plugin.plugin>3.15.2</version.plugin.plugin>
         <version.plugin.protobuf>0.6.1</version.plugin.protobuf>
-        <version.plugin.resources>3.3.1</version.plugin.resources>
-        <version.plugin.shade>3.5.0</version.plugin.shade>
-        <version.plugin.source>3.0.1</version.plugin.source>
-        <version.plugin.spotbugs>4.9.8.2</version.plugin.spotbugs>
-        <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.2.2</version.plugin.dependency-check>
-        <version.plugin.surefire>3.1.0</version.plugin.surefire>
-        <version.plugin.toolchains>1.1</version.plugin.toolchains>
-        <version.plugin.buildnumber>3.1.0</version.plugin.buildnumber>
+        <version.plugin.resources>3.5.0</version.plugin.resources>
+        <version.plugin.source>3.4.0</version.plugin.source>
+        <version.plugin.spotbugs>4.10.4.0</version.plugin.spotbugs>
+        <version.plugin.findsecbugs>1.14.0</version.plugin.findsecbugs>
+        <version.plugin.dependency-check>13.0.0</version.plugin.dependency-check>
+        <version.plugin.surefire>3.5.6</version.plugin.surefire>
+        <version.plugin.toolchains>3.3.0</version.plugin.toolchains>
+        <version.plugin.buildnumber>3.3.0</version.plugin.buildnumber>
         <version.plugin.replacer>1.4.1</version.plugin.replacer>
 
 
@@ -432,23 +430,6 @@
                     <version>${version.plugin.install}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.glassfish.copyright</groupId>
-                    <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>${version.plugin.glassfish-copyright}</version>
-                    <configuration>
-                        <!--suppress UnresolvedMavenProperty -->
-                        <templateFile>${copyright.template}</templateFile>
-                        <!--suppress UnresolvedMavenProperty -->
-                        <excludeFile>${copyright.exclude}</excludeFile>
-                        <scm>git</scm>
-                        <debug>false</debug>
-                        <scmOnly>true</scmOnly>
-                        <warn>true</warn>
-                        <ignoreYear>false</ignoreYear>
-                        <useDash>false</useDash>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${version.plugin.checkstyle}</version>
@@ -564,23 +545,6 @@
                     <configuration>
                         <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-shade-plugin</artifactId>
-                    <version>${version.plugin.shade}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>${version.lib.asm}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm-commons</artifactId>
-                            <version>${version.lib.asm}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>io.helidon.build-tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <version.plugin.enforcer>3.6.3</version.plugin.enforcer>
         <version.plugin.exec>3.6.3</version.plugin.exec>
         <version.plugin.failsafe>3.5.6</version.plugin.failsafe>
-        <version.plugin.helidon-build-tools>4.0.29</version.plugin.helidon-build-tools>
+        <version.plugin.helidon-build-tools>4.0.26</version.plugin.helidon-build-tools>
         <version.plugin.install>3.1.4</version.plugin.install>
         <version.plugin.invoker>3.10.1</version.plugin.invoker>
         <version.plugin.jar>3.5.1</version.plugin.jar>
@@ -105,7 +105,7 @@
         <version.plugin.protobuf>0.6.1</version.plugin.protobuf>
         <version.plugin.resources>3.5.0</version.plugin.resources>
         <version.plugin.source>3.4.0</version.plugin.source>
-        <version.plugin.spotbugs>4.10.4.0</version.plugin.spotbugs>
+        <version.plugin.spotbugs>4.9.8.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.14.0</version.plugin.findsecbugs>
         <version.plugin.dependency-check>13.0.0</version.plugin.dependency-check>
         <version.plugin.surefire>3.5.6</version.plugin.surefire>

--- a/pom.xml
+++ b/pom.xml
@@ -80,15 +80,12 @@
         <version.lib.maven.plugin.api>3.9.15</version.lib.maven.plugin.api>
         <version.lib.maven.plugin.project>2.2.1</version.lib.maven.plugin.project>
         <version.lib.groovy>2.5.23</version.lib.groovy>
-        <version.lib.groovy-all>${version.lib.groovy}</version.lib.groovy-all>
         <version.lib.nimbus.jose.jwt>10.4</version.lib.nimbus.jose.jwt>
         <!--
         !Version statement! - end
         -->
 
         <!-- maven plugin versions -->
-        <version.plugin.archetype>3.1.2</version.plugin.archetype>
-        <version.plugin.ant>3.1.0</version.plugin.ant>
         <version.plugin.build-helper>3.4.0</version.plugin.build-helper>
         <version.plugin.checkstyle>3.6.0</version.plugin.checkstyle>
         <version.plugin.compiler>3.11.0</version.plugin.compiler>
@@ -99,20 +96,15 @@
         <version.plugin.failsafe>3.1.2</version.plugin.failsafe>
         <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
         <version.plugin.helidon-build-tools>4.0.26</version.plugin.helidon-build-tools>
-        <version.plugin.hibernate-enhance>${version.lib.hibernate}</version.plugin.hibernate-enhance>
         <version.plugin.install>3.1.2</version.plugin.install>
         <version.plugin.invoker>3.2.2</version.plugin.invoker>
-        <version.plugin.jandex>${version.lib.jandex}</version.plugin.jandex>
         <version.plugin.jar>3.3.0</version.plugin.jar>
         <version.plugin.javadoc>3.6.2</version.plugin.javadoc>
-        <version.plugin.jaxb>2.5.0</version.plugin.jaxb>
         <version.plugin.license>1.16</version.plugin.license>
         <version.plugin.os>1.5.0.Final</version.plugin.os>
         <version.plugin.plugin>3.15.1</version.plugin.plugin>
-        <version.plugin.project-info-reports>3.0.0</version.plugin.project-info-reports>
         <version.plugin.protobuf>0.6.1</version.plugin.protobuf>
         <version.plugin.resources>3.3.1</version.plugin.resources>
-        <version.plugin.scm-publish-plugin>3.0.0</version.plugin.scm-publish-plugin>
         <version.plugin.shade>3.5.0</version.plugin.shade>
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.9.8.2</version.plugin.spotbugs>
@@ -121,7 +113,6 @@
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.buildnumber>3.1.0</version.plugin.buildnumber>
-        <version.plugin.wiremock>2.14.0</version.plugin.wiremock>
         <version.plugin.replacer>1.4.1</version.plugin.replacer>
 
 
@@ -335,11 +326,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>${version.plugin.project-info-reports}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>${version.plugin.source}</version>
                 </plugin>
@@ -394,11 +380,6 @@
                     <version>${version.plugin.exec}</version>
                 </plugin>
                 <plugin>
-                    <groupId>io.smallrye</groupId>
-                    <artifactId>jandex-maven-plugin</artifactId>
-                    <version>${version.plugin.jandex}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${version.plugin.jar}</version>
@@ -449,11 +430,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>${version.plugin.install}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>${version.plugin.scm-publish-plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
@@ -574,47 +550,6 @@
                     </dependencies>
                 </plugin>
                 <plugin>
-                    <groupId>org.hibernate.orm.tooling</groupId>
-                    <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                    <version>${version.plugin.hibernate-enhance}</version>
-                    <!-- Force upgrade for latest Java support -->
-                    <dependencies>
-                        <dependency>
-                            <groupId>net.bytebuddy</groupId>
-                            <artifactId>byte-buddy</artifactId>
-                            <version>${version.lib.bytebuddy}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>${version.plugin.jaxb}</version>
-                    <dependencies>
-                        <!-- Force upgrade version to use jakarta packages. -->
-                        <dependency>
-                            <groupId>org.glassfish.jaxb</groupId>
-                            <artifactId>jaxb-xjc</artifactId>
-                            <version>${version.lib.jaxb-runtime}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.sun.xml.bind</groupId>
-                            <artifactId>jaxb-impl</artifactId>
-                            <version>${version.lib.jaxb-runtime}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>jakarta.activation</groupId>
-                            <artifactId>jakarta.activation-api</artifactId>
-                            <version>${version.lib.jakarta.activation-api}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>jakarta.xml.bind</groupId>
-                            <artifactId>jakarta.xml.bind-api</artifactId>
-                            <version>${version.lib.jakarta.xml.bind-api}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
                     <version>${version.plugin.buildnumber}</version>
@@ -648,16 +583,6 @@
                     </dependencies>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-archetype-plugin</artifactId>
-                    <version>${version.plugin.archetype}</version>
-                </plugin>
-                <plugin>
-                    <groupId>uk.co.automatictester</groupId>
-                    <artifactId>wiremock-maven-plugin</artifactId>
-                    <version>${version.plugin.wiremock}</version>
-                </plugin>
-                <plugin>
                     <groupId>io.helidon.build-tools</groupId>
                     <artifactId>sitegen-maven-plugin</artifactId>
                     <version>${version.plugin.helidon-build-tools}</version>
@@ -665,16 +590,6 @@
                 <plugin>
                     <groupId>io.helidon.build-tools</groupId>
                     <artifactId>helidon-javadoc-maven-plugin</artifactId>
-                    <version>${version.plugin.helidon-build-tools}</version>
-                </plugin>
-                <plugin>
-                    <groupId>io.helidon.build-tools</groupId>
-                    <artifactId>snakeyaml-codegen-maven-plugin</artifactId>
-                    <version>${version.plugin.helidon-build-tools}</version>
-                </plugin>
-                <plugin>
-                    <groupId>io.helidon.build-tools</groupId>
-                    <artifactId>helidon-stager-maven-plugin</artifactId>
                     <version>${version.plugin.helidon-build-tools}</version>
                 </plugin>
                 <plugin>
@@ -721,11 +636,6 @@
                     <configuration>
                         <mode>fail</mode>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>${version.plugin.ant}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Description

Remove unused plugins from root pom `pluginManagement`:

  - io.smallrye:jandex-maven-plugin
  - org.apache.maven.plugins:maven-project-info-reports-plugin
  - org.apache.maven.plugins:maven-scm-publish-plugin
  - org.hibernate.orm.tooling:hibernate-enhance-maven-plugin
  - org.codehaus.mojo:jaxb2-maven-plugin
  - org.apache.maven.plugins:maven-archetype-plugin
  - org.wiremock:wiremock-maven-plugin
  - org.apache.maven.plugins:maven-antrun-plugin
  - io.helidon.build-tools:snakeyaml-codegen-maven-plugin
  - io.helidon.build-tools:helidon-stager-maven-plugin
  - org.glassfish.copyright:glassfish-copyright-maven-plugin
  - org.apache.maven.plugins:maven-shade-plugin

Upgrade other plugins

  - build-helper-maven-plugin: 3.4.0 -> 3.6.1
  - maven-compiler-plugin: 3.11.0 -> 3.15.0
  - maven-dependency-plugin: 3.10.0 -> 3.11.0
  - maven-enforcer-plugin: 3.3.0 -> 3.6.3
  - exec-maven-plugin: 3.1.0 -> 3.6.3
  - maven-failsafe-plugin: 3.1.2 -> 3.5.6
  - glassfish-copyright-maven-plugin: 2.3 -> 2.4
  - maven-install-plugin: 3.1.2 -> 3.1.4
  - maven-invoker-plugin: 3.2.2 -> 3.10.1
  - maven-jar-plugin: 3.3.0 -> 3.5.1
  - maven-javadoc-plugin: 3.6.2 -> 3.12.0
  - license-maven-plugin: 1.16 -> 2.7.1
  - os-maven-plugin: 1.5.0.Final -> 1.7.1
  - maven-plugin-plugin: 3.15.1 -> 3.15.2
  - maven-resources-plugin: 3.3.1 -> 3.5.0
  - maven-shade-plugin: 3.5.0 -> 3.6.2
  - maven-source-plugin: 3.0.1 -> 3.4.0
  - findsecbugs-plugin: 1.12.0 -> 1.14.0
  - dependency-check-maven: 12.2.2 -> 13.0.0
  - maven-surefire-plugin: 3.1.0 -> 3.5.6
  - maven-toolchains-plugin: 1.1 -> 3.3.0
  - buildnumber-maven-plugin: 3.1.0 -> 3.3.0
