### PR TITLE
Remove static service lookups from registry-managed services

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -472,8 +472,10 @@ public final class Prototype {
      * metadata file will be generated for the service provider interfaces.
      * <p>
      * Simply add this annotation to your {@link io.helidon.builder.api.Prototype.Blueprint} type to enable service registry.
-     * Note that if this annotation is NOT present, service registry would not be used, and {@link java.util.ServiceLoader}
-     * is used instead.
+     * If this annotation is not present, registry support is inherited from the nearest parent blueprint or prototype.
+     * If no parent enables registry support, {@link java.util.ServiceLoader} is used instead. An explicit value of
+     * {@code false} disables registry discovery for provider options declared by the annotated blueprint, without removing
+     * registry support already owned by its parent builder.
      * <p>
      * When using this annotation, you cannot use {@code serviceRegistry} as a custom option in your blueprint, as it will
      * be added by the annotation processor, to allow customization of the registry instance.

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
@@ -721,13 +721,13 @@ class BuilderCodegen implements CodegenExtension {
                 .collect(Collectors.toUnmodifiableList());
 
         // abstract class BuilderBase...
-        new GenerateAbstractBuilder(ctx).generate(extensions,
-                                                  classModel,
-                                                  prototypeInfo,
-                                                  typeArguments,
-                                                  typeGenericArguments,
-                                                  options,
-                                                  newDefaults);
+        GenerateAbstractBuilder.generate(ctx,
+                                         extensions,
+                                         classModel,
+                                         prototypeInfo,
+                                         new GenerateAbstractBuilder.TypeArguments(typeArguments, typeGenericArguments),
+                                         options,
+                                         newDefaults);
 
         // class Builder extends BuilderBase ...
         GenerateBuilder.generate(extensions,

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
@@ -454,6 +454,9 @@ class BuilderCodegen implements CodegenExtension {
         if (!registrySupport) {
             return;
         }
+        if (FactoryPrototypeInfo.inheritedServiceRegistryAccessor(prototypeInfo.blueprint()).isPresent()) {
+            return;
+        }
 
         boolean style = prototypeInfo.recordStyle();
         String getter = style ? "serviceRegistry" : "getServiceRegistry";

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
@@ -387,7 +387,7 @@ class BuilderCodegen implements CodegenExtension {
         existingOptions = new ArrayList<>(existingOptions);
         existingOptions.addAll(existingDiscoverServicesOptions);
         configOption(prototypeInfo, newOptions, existingOptions);
-        serviceRegistryOption(prototypeInfo, newOptions);
+        serviceRegistryOption(roundContext, prototypeInfo, newOptions);
 
         /*
         We may have new options that override existing option's:
@@ -448,13 +448,13 @@ class BuilderCodegen implements CodegenExtension {
         generatePrototype(roundContext, extensions, prototypeInfo, optionHandlers, newDefaults);
     }
 
-    private void serviceRegistryOption(PrototypeInfo prototypeInfo, List<OptionInfo> newOptions) {
+    private void serviceRegistryOption(RoundContext ctx, PrototypeInfo prototypeInfo, List<OptionInfo> newOptions) {
         boolean registrySupport = prototypeInfo.registrySupport() || hasRegistryService(newOptions);
 
         if (!registrySupport) {
             return;
         }
-        if (FactoryPrototypeInfo.inheritedServiceRegistryAccessor(prototypeInfo.blueprint()).isPresent()) {
+        if (FactoryPrototypeInfo.inheritedServiceRegistryAccessor(ctx, prototypeInfo.blueprint()).isPresent()) {
             return;
         }
 
@@ -721,13 +721,13 @@ class BuilderCodegen implements CodegenExtension {
                 .collect(Collectors.toUnmodifiableList());
 
         // abstract class BuilderBase...
-        GenerateAbstractBuilder.generate(extensions,
-                                         classModel,
-                                         prototypeInfo,
-                                         typeArguments,
-                                         typeGenericArguments,
-                                         options,
-                                         newDefaults);
+        new GenerateAbstractBuilder(ctx).generate(extensions,
+                                                  classModel,
+                                                  prototypeInfo,
+                                                  typeArguments,
+                                                  typeGenericArguments,
+                                                  options,
+                                                  newDefaults);
 
         // class Builder extends BuilderBase ...
         GenerateBuilder.generate(extensions,

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryPrototypeInfo.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryPrototypeInfo.java
@@ -578,9 +578,103 @@ final class FactoryPrototypeInfo {
     }
 
     private static boolean registrySupport(TypeInfo blueprint) {
-        return blueprint.findAnnotation(Types.PROTOTYPE_SERVICE_REGISTRY)
+        Optional<Annotation> annotation = blueprint.findAnnotation(Types.PROTOTYPE_SERVICE_REGISTRY);
+        if (annotation.isPresent()) {
+            return annotation.get().booleanValue().orElse(true);
+        }
+        return superBlueprintDefinition(blueprint)
+                .map(FactoryPrototypeInfo::registrySupport)
+                .orElse(false);
+    }
+
+    static Optional<String> inheritedServiceRegistryAccessor(TypeInfo blueprint) {
+        return superBlueprintDefinition(blueprint)
+                .flatMap(FactoryPrototypeInfo::serviceRegistryOwner)
+                .map(FactoryPrototypeInfo::serviceRegistryAccessor);
+    }
+
+    static Optional<String> inheritedConfigAccessor(TypeInfo blueprint) {
+        return superBlueprintDefinition(blueprint)
+                .flatMap(FactoryPrototypeInfo::configOwner)
+                .map(FactoryPrototypeInfo::configAccessor);
+    }
+
+    private static Optional<TypeInfo> serviceRegistryOwner(TypeInfo blueprint) {
+        Optional<TypeInfo> inheritedOwner = superBlueprintDefinition(blueprint)
+                .flatMap(FactoryPrototypeInfo::serviceRegistryOwner);
+        if (inheritedOwner.isPresent()) {
+            return inheritedOwner;
+        }
+        return declaresServiceRegistry(blueprint) ? Optional.of(blueprint) : Optional.empty();
+    }
+
+    private static Optional<TypeInfo> configOwner(TypeInfo blueprint) {
+        Optional<TypeInfo> inheritedOwner = superBlueprintDefinition(blueprint)
+                .flatMap(FactoryPrototypeInfo::configOwner);
+        if (inheritedOwner.isPresent()) {
+            return inheritedOwner;
+        }
+        return blueprint.hasAnnotation(PROTOTYPE_CONFIGURED) ? Optional.of(blueprint) : Optional.empty();
+    }
+
+    private static String serviceRegistryAccessor(TypeInfo owner) {
+        return recordStyleAccessors(blueprintAnnotation(owner)) ? "serviceRegistry" : "getServiceRegistry";
+    }
+
+    private static String configAccessor(TypeInfo owner) {
+        return recordStyleAccessors(blueprintAnnotation(owner)) ? "config" : "getConfig";
+    }
+
+    private static Optional<TypeInfo> superBlueprintDefinition(TypeInfo blueprint) {
+        return superBlueprintDefinition(blueprint, new HashSet<>());
+    }
+
+    private static Optional<TypeInfo> superBlueprintDefinition(TypeInfo inProgress, Set<TypeName> processed) {
+        for (TypeInfo superInterface : inProgress.interfaceTypeInfo()) {
+            if (!processed.add(superInterface.typeName())) {
+                continue;
+            }
+            if (superInterface.hasAnnotation(PROTOTYPE_BLUEPRINT)) {
+                return Optional.of(superInterface);
+            }
+            Optional<TypeInfo> prototypeBlueprint = superInterface.interfaceTypeInfo()
+                    .stream()
+                    .filter(it -> it.hasAnnotation(PROTOTYPE_BLUEPRINT))
+                    .findFirst();
+            if (prototypeBlueprint.isPresent()) {
+                return prototypeBlueprint;
+            }
+            Optional<TypeInfo> inheritedBlueprint = superBlueprintDefinition(superInterface, processed);
+            if (inheritedBlueprint.isPresent()) {
+                return inheritedBlueprint;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean declaresServiceRegistry(TypeInfo blueprint) {
+        boolean registrySupport = blueprint.findAnnotation(Types.PROTOTYPE_SERVICE_REGISTRY)
                 .flatMap(Annotation::booleanValue)
                 .orElse(false);
+        return registrySupport || hasRegistryServiceOption(blueprint, new HashSet<>());
+    }
+
+    private static boolean hasRegistryServiceOption(TypeInfo inProgress, Set<TypeName> processed) {
+        if (!processed.add(inProgress.typeName())) {
+            return false;
+        }
+        if (inProgress.elementInfo()
+                .stream()
+                .anyMatch(it -> it.hasAnnotation(Types.OPTION_REGISTRY_SERVICE))) {
+            return true;
+        }
+        return inProgress.interfaceTypeInfo()
+                .stream()
+                .filter(it -> !it.hasAnnotation(PROTOTYPE_BLUEPRINT))
+                .filter(it -> it.interfaceTypeInfo()
+                        .stream()
+                        .noneMatch(parent -> parent.typeName().equals(PROTOTYPE_API)))
+                .anyMatch(it -> hasRegistryServiceOption(it, processed));
     }
 
     private static boolean createEmptyPublic(Annotation blueprintAnnotation) {

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryPrototypeInfo.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryPrototypeInfo.java
@@ -142,6 +142,50 @@ final class FactoryPrototypeInfo {
         return prototype.build();
     }
 
+    static List<Annotation> annotations(Annotated it) {
+        List<Annotation> annotations = new ArrayList<>();
+
+        // annotations to be added to generated code
+        it.findAnnotation(Types.PROTOTYPE_ANNOTATED)
+                .flatMap(Annotation::stringValues)
+                .orElseGet(List::of)
+                .stream()
+                .map(String::trim) // to remove spaces after commas when used
+                .filter(Predicate.not(String::isBlank)) // we do not care about blank values
+                .map(io.helidon.codegen.classmodel.Annotation::parse)
+                .map(io.helidon.codegen.classmodel.Annotation::toTypesAnnotation)
+                .forEach(annotations::add);
+
+        for (var annotation : it.allAnnotations()) {
+            if (isApiAnnotation(annotation)) {
+                // this is an API annotation, add them all (stability, maybe Since) to the generated prototype
+                annotations.add(annotation);
+            }
+        }
+
+        return annotations;
+    }
+
+    static boolean isApiAnnotation(Annotation annotation) {
+        var annotationType = annotation.typeName();
+        List<String> enclosingNames = annotationType.enclosingNames();
+        return enclosingNames.size() == 1
+                && Api.class.getSimpleName().equals(enclosingNames.getFirst())
+                && Api.class.getPackageName().equals(annotationType.packageName());
+    }
+
+    static Optional<String> inheritedServiceRegistryAccessor(TypeInfo blueprint) {
+        return superBlueprintDefinition(blueprint)
+                .flatMap(FactoryPrototypeInfo::serviceRegistryOwner)
+                .map(FactoryPrototypeInfo::serviceRegistryAccessor);
+    }
+
+    static Optional<String> inheritedConfigAccessor(TypeInfo blueprint) {
+        return superBlueprintDefinition(blueprint)
+                .flatMap(FactoryPrototypeInfo::configOwner)
+                .map(FactoryPrototypeInfo::configAccessor);
+    }
+
     private static List<TypedElementInfo> defaultMethodsNotOptions(TypeInfo blueprint,
                                                                    Predicate<String> defaultMethodsPredicate) {
         return blueprint.elementInfo()
@@ -400,38 +444,6 @@ final class FactoryPrototypeInfo {
                 .toList();
     }
 
-    static List<Annotation> annotations(Annotated it) {
-        List<Annotation> annotations = new ArrayList<>();
-
-        // annotations to be added to generated code
-        it.findAnnotation(Types.PROTOTYPE_ANNOTATED)
-                .flatMap(Annotation::stringValues)
-                .orElseGet(List::of)
-                .stream()
-                .map(String::trim) // to remove spaces after commas when used
-                .filter(Predicate.not(String::isBlank)) // we do not care about blank values
-                .map(io.helidon.codegen.classmodel.Annotation::parse)
-                .map(io.helidon.codegen.classmodel.Annotation::toTypesAnnotation)
-                .forEach(annotations::add);
-
-        for (var annotation : it.allAnnotations()) {
-            if (isApiAnnotation(annotation)) {
-                // this is an API annotation, add them all (stability, maybe Since) to the generated prototype
-                annotations.add(annotation);
-            }
-        }
-
-        return annotations;
-    }
-
-    static boolean isApiAnnotation(Annotation annotation) {
-        var annotationType = annotation.typeName();
-        List<String> enclosingNames = annotationType.enclosingNames();
-        return enclosingNames.size() == 1
-                && Api.class.getSimpleName().equals(enclosingNames.getFirst())
-                && Api.class.getPackageName().equals(annotationType.packageName());
-    }
-
     private static Optional<TypeInfo> customMethodsTypeInfo(RoundContext ctx,
                                                             TypeInfo blueprint) {
         // first check the blueprint
@@ -585,18 +597,6 @@ final class FactoryPrototypeInfo {
         return superBlueprintDefinition(blueprint)
                 .map(FactoryPrototypeInfo::registrySupport)
                 .orElse(false);
-    }
-
-    static Optional<String> inheritedServiceRegistryAccessor(TypeInfo blueprint) {
-        return superBlueprintDefinition(blueprint)
-                .flatMap(FactoryPrototypeInfo::serviceRegistryOwner)
-                .map(FactoryPrototypeInfo::serviceRegistryAccessor);
-    }
-
-    static Optional<String> inheritedConfigAccessor(TypeInfo blueprint) {
-        return superBlueprintDefinition(blueprint)
-                .flatMap(FactoryPrototypeInfo::configOwner)
-                .map(FactoryPrototypeInfo::configAccessor);
     }
 
     private static Optional<TypeInfo> serviceRegistryOwner(TypeInfo blueprint) {

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryPrototypeInfo.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryPrototypeInfo.java
@@ -86,7 +86,7 @@ final class FactoryPrototypeInfo {
                 .builderAccessModifier(builderAccessModifier(blueprintAnnotation))
                 .createEmptyCreate(createEmptyPublic(blueprintAnnotation))
                 .recordStyle(recordStyleAccessors(blueprintAnnotation))
-                .registrySupport(registrySupport(blueprint))
+                .registrySupport(registrySupport(ctx, blueprint))
                 .superPrototype(superPrototype)
                 .providerProvides(providerProvides(blueprint))
                 .javadoc(prototypeJavadoc(blueprint))
@@ -174,15 +174,15 @@ final class FactoryPrototypeInfo {
                 && Api.class.getPackageName().equals(annotationType.packageName());
     }
 
-    static Optional<String> inheritedServiceRegistryAccessor(TypeInfo blueprint) {
-        return superBlueprintDefinition(blueprint)
-                .flatMap(FactoryPrototypeInfo::serviceRegistryOwner)
+    static Optional<String> inheritedServiceRegistryAccessor(RoundContext ctx, TypeInfo blueprint) {
+        return superBlueprintDefinition(ctx, blueprint)
+                .flatMap(it -> serviceRegistryOwner(ctx, it))
                 .map(FactoryPrototypeInfo::serviceRegistryAccessor);
     }
 
-    static Optional<String> inheritedConfigAccessor(TypeInfo blueprint) {
-        return superBlueprintDefinition(blueprint)
-                .flatMap(FactoryPrototypeInfo::configOwner)
+    static Optional<String> inheritedConfigAccessor(RoundContext ctx, TypeInfo blueprint) {
+        return superBlueprintDefinition(ctx, blueprint)
+                .flatMap(it -> configOwner(ctx, it))
                 .map(FactoryPrototypeInfo::configAccessor);
     }
 
@@ -589,28 +589,28 @@ final class FactoryPrototypeInfo {
                 .orElseGet(Set::of);
     }
 
-    private static boolean registrySupport(TypeInfo blueprint) {
+    private static boolean registrySupport(RoundContext ctx, TypeInfo blueprint) {
         Optional<Annotation> annotation = blueprint.findAnnotation(Types.PROTOTYPE_SERVICE_REGISTRY);
         if (annotation.isPresent()) {
             return annotation.get().booleanValue().orElse(true);
         }
-        return superBlueprintDefinition(blueprint)
-                .map(FactoryPrototypeInfo::registrySupport)
+        return superBlueprintDefinition(ctx, blueprint)
+                .map(it -> registrySupport(ctx, it))
                 .orElse(false);
     }
 
-    private static Optional<TypeInfo> serviceRegistryOwner(TypeInfo blueprint) {
-        Optional<TypeInfo> inheritedOwner = superBlueprintDefinition(blueprint)
-                .flatMap(FactoryPrototypeInfo::serviceRegistryOwner);
+    private static Optional<TypeInfo> serviceRegistryOwner(RoundContext ctx, TypeInfo blueprint) {
+        Optional<TypeInfo> inheritedOwner = superBlueprintDefinition(ctx, blueprint)
+                .flatMap(it -> serviceRegistryOwner(ctx, it));
         if (inheritedOwner.isPresent()) {
             return inheritedOwner;
         }
         return declaresServiceRegistry(blueprint) ? Optional.of(blueprint) : Optional.empty();
     }
 
-    private static Optional<TypeInfo> configOwner(TypeInfo blueprint) {
-        Optional<TypeInfo> inheritedOwner = superBlueprintDefinition(blueprint)
-                .flatMap(FactoryPrototypeInfo::configOwner);
+    private static Optional<TypeInfo> configOwner(RoundContext ctx, TypeInfo blueprint) {
+        Optional<TypeInfo> inheritedOwner = superBlueprintDefinition(ctx, blueprint)
+                .flatMap(it -> configOwner(ctx, it));
         if (inheritedOwner.isPresent()) {
             return inheritedOwner;
         }
@@ -625,11 +625,13 @@ final class FactoryPrototypeInfo {
         return recordStyleAccessors(blueprintAnnotation(owner)) ? "config" : "getConfig";
     }
 
-    private static Optional<TypeInfo> superBlueprintDefinition(TypeInfo blueprint) {
-        return superBlueprintDefinition(blueprint, new HashSet<>());
+    private static Optional<TypeInfo> superBlueprintDefinition(RoundContext ctx, TypeInfo blueprint) {
+        return superBlueprintDefinition(ctx, blueprint, new HashSet<>());
     }
 
-    private static Optional<TypeInfo> superBlueprintDefinition(TypeInfo inProgress, Set<TypeName> processed) {
+    private static Optional<TypeInfo> superBlueprintDefinition(RoundContext ctx,
+                                                               TypeInfo inProgress,
+                                                               Set<TypeName> processed) {
         for (TypeInfo superInterface : inProgress.interfaceTypeInfo()) {
             if (!processed.add(superInterface.typeName())) {
                 continue;
@@ -641,15 +643,29 @@ final class FactoryPrototypeInfo {
                     .stream()
                     .filter(it -> it.hasAnnotation(PROTOTYPE_BLUEPRINT))
                     .findFirst();
+            if (prototypeBlueprint.isEmpty()) {
+                prototypeBlueprint = generatedPrototypeBlueprint(ctx, superInterface);
+            }
             if (prototypeBlueprint.isPresent()) {
                 return prototypeBlueprint;
             }
-            Optional<TypeInfo> inheritedBlueprint = superBlueprintDefinition(superInterface, processed);
+            Optional<TypeInfo> inheritedBlueprint = superBlueprintDefinition(ctx, superInterface, processed);
             if (inheritedBlueprint.isPresent()) {
                 return inheritedBlueprint;
             }
         }
         return Optional.empty();
+    }
+
+    private static Optional<TypeInfo> generatedPrototypeBlueprint(RoundContext ctx, TypeInfo prototype) {
+        return prototype.findAnnotation(Types.GENERATED)
+                .filter(it -> it.stringValue()
+                        .filter(BuilderCodegen.class.getName()::equals)
+                        .isPresent())
+                .flatMap(it -> it.stringValue("trigger"))
+                .map(TypeName::create)
+                .flatMap(ctx::typeInfo)
+                .filter(it -> it.hasAnnotation(PROTOTYPE_BLUEPRINT));
     }
 
     private static boolean declaresServiceRegistry(TypeInfo blueprint) {

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -59,22 +59,20 @@ import static io.helidon.common.types.TypeNames.SET;
 final class GenerateAbstractBuilder {
 
     private static final String SERVICE_REGISTRY_CONFIG_KEY = "service-registry";
-
-    private final RoundContext ctx;
-
-    GenerateAbstractBuilder(RoundContext ctx) {
-        this.ctx = ctx;
+    private GenerateAbstractBuilder() {
     }
 
-    void generate(List<BuilderCodegenExtension> extensions,
-                  ClassModel.Builder classModel,
-                  PrototypeInfo prototypeInfo,
-                  List<TypeArgument> typeArguments,
-                  List<TypeName> typeArgumentNames,
-                  List<OptionHandler> options,
-                  List<BuilderCodegen.NewDefault> newDefaults) {
+    static void generate(RoundContext ctx,
+                         List<BuilderCodegenExtension> extensions,
+                         ClassModel.Builder classModel,
+                         PrototypeInfo prototypeInfo,
+                         TypeArguments genericArguments,
+                         List<OptionHandler> options,
+                         List<BuilderCodegen.NewDefault> newDefaults) {
         Optional<TypeName> superType = prototypeInfo.superPrototype();
         TypeName prototype = prototypeInfo.prototypeType();
+        List<TypeArgument> typeArguments = genericArguments.arguments();
+        List<TypeName> typeArgumentNames = genericArguments.names();
 
         classModel.addInnerClass(builder -> {
             typeArguments.forEach(builder::addGenericArgument);
@@ -122,7 +120,7 @@ final class GenerateAbstractBuilder {
             fromBuilderMethod(builder, prototypeInfo, options, typeArgumentNames);
 
             // method preBuildPrototype() - handles providers, decorator
-            preBuildPrototypeMethod(extensions, builder, prototypeInfo, options);
+            preBuildPrototypeMethod(ctx, extensions, builder, prototypeInfo, options);
             validatePrototypeMethod(extensions, builder, prototypeInfo, options);
 
             //custom method adding
@@ -468,10 +466,11 @@ final class GenerateAbstractBuilder {
         return type.equals(CONFIG);
     }
 
-    private void preBuildPrototypeMethod(List<BuilderCodegenExtension> extensions,
-                                         InnerClass.Builder classBuilder,
-                                         PrototypeInfo prototypeInfo,
-                                         List<OptionHandler> options) {
+    private static void preBuildPrototypeMethod(RoundContext ctx,
+                                                List<BuilderCodegenExtension> extensions,
+                                                InnerClass.Builder classBuilder,
+                                                PrototypeInfo prototypeInfo,
+                                                List<OptionHandler> options) {
         Method.Builder preBuildBuilder = Method.builder()
                 .name("preBuildPrototype")
                 .accessModifier(AccessModifier.PROTECTED)
@@ -1597,5 +1596,8 @@ final class GenerateAbstractBuilder {
         }
 
         return result.toString();
+    }
+
+    record TypeArguments(List<TypeArgument> arguments, List<TypeName> names) {
     }
 }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.codegen.spi.BuilderCodegenExtension;
+import io.helidon.codegen.RoundContext;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Constructor;
 import io.helidon.codegen.classmodel.ContentBuilder;
@@ -58,16 +59,20 @@ import static io.helidon.common.types.TypeNames.SET;
 final class GenerateAbstractBuilder {
 
     private static final String SERVICE_REGISTRY_CONFIG_KEY = "service-registry";
-    private GenerateAbstractBuilder() {
+
+    private final RoundContext ctx;
+
+    GenerateAbstractBuilder(RoundContext ctx) {
+        this.ctx = ctx;
     }
 
-    static void generate(List<BuilderCodegenExtension> extensions,
-                         ClassModel.Builder classModel,
-                         PrototypeInfo prototypeInfo,
-                         List<TypeArgument> typeArguments,
-                         List<TypeName> typeArgumentNames,
-                         List<OptionHandler> options,
-                         List<BuilderCodegen.NewDefault> newDefaults) {
+    void generate(List<BuilderCodegenExtension> extensions,
+                  ClassModel.Builder classModel,
+                  PrototypeInfo prototypeInfo,
+                  List<TypeArgument> typeArguments,
+                  List<TypeName> typeArgumentNames,
+                  List<OptionHandler> options,
+                  List<BuilderCodegen.NewDefault> newDefaults) {
         Optional<TypeName> superType = prototypeInfo.superPrototype();
         TypeName prototype = prototypeInfo.prototypeType();
 
@@ -463,10 +468,10 @@ final class GenerateAbstractBuilder {
         return type.equals(CONFIG);
     }
 
-    private static void preBuildPrototypeMethod(List<BuilderCodegenExtension> extensions,
-                                                InnerClass.Builder classBuilder,
-                                                PrototypeInfo prototypeInfo,
-                                                List<OptionHandler> options) {
+    private void preBuildPrototypeMethod(List<BuilderCodegenExtension> extensions,
+                                         InnerClass.Builder classBuilder,
+                                         PrototypeInfo prototypeInfo,
+                                         List<OptionHandler> options) {
         Method.Builder preBuildBuilder = Method.builder()
                 .name("preBuildPrototype")
                 .accessModifier(AccessModifier.PROTECTED)
@@ -487,7 +492,7 @@ final class GenerateAbstractBuilder {
 
             if (configured && hasConfiguredRegistryServiceOrProvider(options)) {
                 // need to have a non-null config instance
-                String configAccessor = FactoryPrototypeInfo.inheritedConfigAccessor(prototypeInfo.blueprint())
+                String configAccessor = FactoryPrototypeInfo.inheritedConfigAccessor(ctx, prototypeInfo.blueprint())
                         .orElseGet(() -> prototypeInfo.recordStyle() ? "config" : "getConfig");
                 preBuildBuilder.addContent("var config = ")
                         .addContent(configAccessor)
@@ -497,7 +502,7 @@ final class GenerateAbstractBuilder {
             }
 
             if (prototypeInfo.registrySupport() || hasRegistryService) {
-                String registryAccessor = FactoryPrototypeInfo.inheritedServiceRegistryAccessor(prototypeInfo.blueprint())
+                String registryAccessor = FactoryPrototypeInfo.inheritedServiceRegistryAccessor(ctx, prototypeInfo.blueprint())
                         .orElseGet(() -> prototypeInfo.recordStyle() ? "serviceRegistry" : "getServiceRegistry");
                 preBuildBuilder.addContent("var registry = ")
                         .addContent(registryAccessor)

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -410,9 +410,6 @@ final class GenerateAbstractBuilder {
                 classBuilder.addField(builder -> builder.type(Types.CONFIG).name("config"));
             }
         }
-        if (isBuilder && prototypeInfo.registrySupport()) {
-            classBuilder.addField(builder -> builder.type(Types.SERVICE_REGISTRY).name("serviceRegistry"));
-        }
         for (OptionHandler optionHandler : options) {
             if (!isBuilder && optionHandler.option().builderOptionOnly()) {
                 continue;
@@ -490,15 +487,21 @@ final class GenerateAbstractBuilder {
 
             if (configured && hasConfiguredRegistryServiceOrProvider(options)) {
                 // need to have a non-null config instance
-                preBuildBuilder.addContent("var config = config().orElseGet(")
+                String configAccessor = FactoryPrototypeInfo.inheritedConfigAccessor(prototypeInfo.blueprint())
+                        .orElseGet(() -> prototypeInfo.recordStyle() ? "config" : "getConfig");
+                preBuildBuilder.addContent("var config = ")
+                        .addContent(configAccessor)
+                        .addContent("().orElseGet(")
                         .addContent(CONFIG)
                         .addContentLine("::empty);");
             }
 
             if (prototypeInfo.registrySupport() || hasRegistryService) {
+                String registryAccessor = FactoryPrototypeInfo.inheritedServiceRegistryAccessor(prototypeInfo.blueprint())
+                        .orElseGet(() -> prototypeInfo.recordStyle() ? "serviceRegistry" : "getServiceRegistry");
                 preBuildBuilder.addContent("var registry = ")
-                        .addContent(Optional.class)
-                        .addContentLine(".ofNullable(this.serviceRegistry);");
+                        .addContent(registryAccessor)
+                        .addContentLine("();");
             }
 
             for (OptionHandler optionHandler : options) {

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/DetachedChildProvider.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/DetachedChildProvider.java
@@ -16,15 +16,8 @@
 
 package io.helidon.builder.test.testsubjects;
 
-import java.util.Optional;
-
-import io.helidon.builder.api.Option;
-import io.helidon.builder.api.Prototype;
-
-@Prototype.Blueprint(beanStyle = true)
-@Prototype.Configured
-interface DetachedRegistrySupportChildBlueprint extends DetachedRegistrySupportParent {
-    @Option.Configured
-    @Option.Provider(DetachedChildProvider.class)
-    Optional<InheritedChildProvider.ChildService> getChildService();
+/**
+ * Provider contract used to verify metadata generated from a detached parent prototype.
+ */
+public interface DetachedChildProvider extends InheritedChildProvider {
 }

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/DetachedRegistrySupportParentBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/DetachedRegistrySupportParentBlueprint.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint(detach = true, beanStyle = true)
+@Prototype.Configured
+@Prototype.RegistrySupport
+interface DetachedRegistrySupportParentBlueprint {
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/InheritedChildProvider.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/InheritedChildProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import io.helidon.config.ConfiguredProvider;
+import io.helidon.config.NamedService;
+
+public interface InheritedChildProvider extends ConfiguredProvider<InheritedChildProvider.ChildService> {
+    interface ChildService extends NamedService {
+        String prop();
+    }
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistryServiceChildBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistryServiceChildBlueprint.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.mapper.Mappers;
+
+@Prototype.Blueprint
+interface RegistryServiceChildBlueprint extends RegistryServiceParentBlueprint {
+    @Option.RegistryService
+    Optional<Mappers> childMappers();
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistryServiceOptions.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistryServiceOptions.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.common.mapper.Mappers;
+
+interface RegistryServiceOptions {
+    @Option.RegistryService
+    Optional<Mappers> mappers();
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistryServiceParentBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistryServiceParentBlueprint.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint(beanStyle = true)
+interface RegistryServiceParentBlueprint extends RegistryServiceOptions {
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistrySupportChildBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistrySupportChildBlueprint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.Configured
+interface RegistrySupportChildBlueprint extends RegistrySupportParentBlueprint {
+    @Option.Configured
+    @Option.Provider(InheritedChildProvider.class)
+    Optional<InheritedChildProvider.ChildService> childService();
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistrySupportDisabledChildBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistrySupportDisabledChildBlueprint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.Configured
+@Prototype.RegistrySupport(false)
+interface RegistrySupportDisabledChildBlueprint extends RegistrySupportParentBlueprint {
+    @Option.Configured
+    @Option.Provider(InheritedChildProvider.class)
+    Optional<InheritedChildProvider.ChildService> childService();
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistrySupportParentBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistrySupportParentBlueprint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint(beanStyle = true)
+@Prototype.Configured
+@Prototype.RegistrySupport
+interface RegistrySupportParentBlueprint {
+    @Option.Configured
+    @Option.Provider(SomeProvider.class)
+    Optional<SomeProvider.SomeService> getParentService();
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistrySupportRepeatedChildBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RegistrySupportRepeatedChildBlueprint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.Configured
+@Prototype.RegistrySupport
+interface RegistrySupportRepeatedChildBlueprint extends RegistrySupportParentBlueprint {
+    @Option.Configured
+    @Option.Provider(InheritedChildProvider.class)
+    Optional<InheritedChildProvider.ChildService> middleService();
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.helidon.builder.test.testsubjects.DetachedRegistrySupportChild;
 import io.helidon.builder.test.testsubjects.InheritedChildProvider;
 import io.helidon.builder.test.testsubjects.RegistryServiceChild;
 import io.helidon.builder.test.testsubjects.RegistrySupportChild;
@@ -77,6 +78,23 @@ class ProviderRegistryTest {
 
             assertThat(value.getParentService().map(SomeProvider.SomeService::prop), optionalValue(is("parent")));
             assertThat(value.childService().map(InheritedChildProvider.ChildService::prop), optionalValue(is("child")));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void testInheritedRegistrySupportFromDetachedPrototype() {
+        Config inheritedConfig = Config.just(ConfigSources.create(Map.of(
+                "child-service.registry-provider.value", "child")));
+        ServiceRegistryManager manager = registryManager();
+        try {
+            DetachedRegistrySupportChild value = DetachedRegistrySupportChild.builder()
+                    .config(inheritedConfig)
+                    .setServiceRegistry(manager.registry())
+                    .build();
+
+            assertThat(value.getChildService().map(InheritedChildProvider.ChildService::prop), optionalValue(is("child")));
         } finally {
             manager.shutdown();
         }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.helidon.builder.test.testsubjects.DetachedChildProvider;
 import io.helidon.builder.test.testsubjects.DetachedRegistrySupportChild;
 import io.helidon.builder.test.testsubjects.InheritedChildProvider;
 import io.helidon.builder.test.testsubjects.RegistryServiceChild;
@@ -97,6 +98,16 @@ class ProviderRegistryTest {
             assertThat(value.getChildService().map(InheritedChildProvider.ChildService::prop), optionalValue(is("child")));
         } finally {
             manager.shutdown();
+        }
+    }
+
+    @Test
+    void testInheritedRegistrySupportFromDetachedPrototypeMetadata() throws IOException {
+        String resource = "/META-INF/helidon/service.loader";
+        try (var input = ProviderRegistryTest.class.getResourceAsStream(resource)) {
+            assertThat(input, notNullValue());
+            assertThat(new String(input.readAllBytes(), StandardCharsets.UTF_8),
+                       containsString(DetachedChildProvider.class.getName()));
         }
     }
 
@@ -573,9 +584,21 @@ class ProviderRegistryTest {
                 return new ChildServiceImpl(config.get("value").asString().orElse(name), name);
             }
         };
+        DetachedChildProvider detachedChildProvider = new DetachedChildProvider() {
+            @Override
+            public String configKey() {
+                return "registry-provider";
+            }
+
+            @Override
+            public InheritedChildProvider.ChildService create(Config config, String name) {
+                return new ChildServiceImpl(config.get("value").asString().orElse(name), name);
+            }
+        };
         return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
                                                      .putContractInstance(SomeProvider.class, parentProvider)
                                                      .putContractInstance(InheritedChildProvider.class, childProvider)
+                                                     .putContractInstance(DetachedChildProvider.class, detachedChildProvider)
                                                      .build());
     }
 

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderRegistryTest.java
@@ -16,12 +16,20 @@
 
 package io.helidon.builder.test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.helidon.builder.test.testsubjects.InheritedChildProvider;
+import io.helidon.builder.test.testsubjects.RegistryServiceChild;
+import io.helidon.builder.test.testsubjects.RegistrySupportChild;
+import io.helidon.builder.test.testsubjects.RegistrySupportDisabledGrandchild;
+import io.helidon.builder.test.testsubjects.RegistrySupportDisabledChild;
+import io.helidon.builder.test.testsubjects.RegistrySupportRepeatedGrandchild;
 import io.helidon.builder.test.testsubjects.SomeProvider;
 import io.helidon.builder.test.testsubjects.WithProviderRegistry;
 import io.helidon.common.Errors;
@@ -30,6 +38,8 @@ import io.helidon.config.Config;
 import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigSources;
 import io.helidon.config.spi.ConfigNode;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -38,6 +48,7 @@ import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
 import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.sameInstance;
@@ -50,6 +61,112 @@ class ProviderRegistryTest {
     @BeforeAll
     static void beforeAll() {
         config = Config.just(ConfigSources.classpath("provider-test.yaml"));
+    }
+
+    @Test
+    void testInheritedRegistrySupport() {
+        Config inheritedConfig = Config.just(ConfigSources.create(Map.of(
+                "parent-service.registry-provider.value", "parent",
+                "child-service.registry-provider.value", "child")));
+        ServiceRegistryManager manager = registryManager();
+        try {
+            RegistrySupportChild value = RegistrySupportChild.builder()
+                    .config(inheritedConfig)
+                    .setServiceRegistry(manager.registry())
+                    .build();
+
+            assertThat(value.getParentService().map(SomeProvider.SomeService::prop), optionalValue(is("parent")));
+            assertThat(value.childService().map(InheritedChildProvider.ChildService::prop), optionalValue(is("child")));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void testInheritedRegistrySupportMetadata() throws IOException {
+        String resource = "/META-INF/helidon/io.helidon.builder.test.builder/service.loader";
+        try (var input = ProviderRegistryTest.class.getResourceAsStream(resource)) {
+            assertThat(input, notNullValue());
+            assertThat(new String(input.readAllBytes(), StandardCharsets.UTF_8),
+                       containsString(InheritedChildProvider.class.getName()));
+        }
+    }
+
+    @Test
+    void testExplicitDisabledRegistrySupport() {
+        Config inheritedConfig = Config.just(ConfigSources.create(Map.of(
+                "parent-service.registry-provider.value", "parent")));
+        ServiceRegistryManager manager = registryManager();
+        try {
+            RegistrySupportDisabledChild value = RegistrySupportDisabledChild.builder()
+                    .config(inheritedConfig)
+                    .setServiceRegistry(manager.registry())
+                    .build();
+
+            assertThat(value.getParentService().map(SomeProvider.SomeService::prop), optionalValue(is("parent")));
+            assertThat(value.childService(), optionalEmpty());
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void testRepeatedRegistrySupportUsesOriginalOwner() {
+        Config inheritedConfig = Config.just(ConfigSources.create(Map.of(
+                "parent-service.registry-provider.value", "parent",
+                "middle-service.registry-provider.value", "middle",
+                "leaf-service.registry-provider.value", "leaf")));
+        ServiceRegistryManager manager = registryManager();
+        try {
+            RegistrySupportRepeatedGrandchild value = RegistrySupportRepeatedGrandchild.builder()
+                    .config(inheritedConfig)
+                    .setServiceRegistry(manager.registry())
+                    .build();
+
+            assertThat(value.getParentService().map(SomeProvider.SomeService::prop), optionalValue(is("parent")));
+            assertThat(value.middleService().map(InheritedChildProvider.ChildService::prop),
+                       optionalValue(is("middle")));
+            assertThat(value.leafService().map(InheritedChildProvider.ChildService::prop), optionalValue(is("leaf")));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void testDisabledRegistrySupportIsInheritedThroughPrototype() {
+        Config inheritedConfig = Config.just(ConfigSources.create(Map.of(
+                "parent-service.registry-provider.value", "parent")));
+        ServiceRegistryManager manager = registryManager();
+        try {
+            RegistrySupportDisabledGrandchild value = RegistrySupportDisabledGrandchild.builder()
+                    .config(inheritedConfig)
+                    .setServiceRegistry(manager.registry())
+                    .build();
+
+            assertThat(value.getParentService().map(SomeProvider.SomeService::prop), optionalValue(is("parent")));
+            assertThat(value.childService(), optionalEmpty());
+            assertThat(value.grandchildService(), optionalEmpty());
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void testRegistryServiceInheritedFromRegularOptionInterface() {
+        Mappers mappers = Mappers.create();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Mappers.class, mappers)
+                                                                                .build());
+        try {
+            RegistryServiceChild value = RegistryServiceChild.builder()
+                    .setServiceRegistry(manager.registry())
+                    .build();
+
+            assertThat(value.mappers(), optionalValue(sameInstance(mappers)));
+            assertThat(value.childMappers(), optionalValue(sameInstance(mappers)));
+        } finally {
+            manager.shutdown();
+        }
     }
 
     @Test
@@ -413,6 +530,49 @@ class ProviderRegistryTest {
                 .build();
         assertThat(copy.optionalListDiscover(), optionalValue(is(List.of(someService))));
         assertThat(copy.optionalSetDiscover(), optionalValue(is(Set.of(someService))));
+    }
+
+    private static ServiceRegistryManager registryManager() {
+        SomeProvider parentProvider = new SomeProvider() {
+            @Override
+            public String configKey() {
+                return "registry-provider";
+            }
+
+            @Override
+            public SomeService create(Config config, String name) {
+                return new ParentService(config.get("value").asString().orElse(name), name);
+            }
+        };
+        InheritedChildProvider childProvider = new InheritedChildProvider() {
+            @Override
+            public String configKey() {
+                return "registry-provider";
+            }
+
+            @Override
+            public InheritedChildProvider.ChildService create(Config config, String name) {
+                return new ChildServiceImpl(config.get("value").asString().orElse(name), name);
+            }
+        };
+        return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                     .putContractInstance(SomeProvider.class, parentProvider)
+                                                     .putContractInstance(InheritedChildProvider.class, childProvider)
+                                                     .build());
+    }
+
+    private record ParentService(String prop, String name) implements SomeProvider.SomeService {
+        @Override
+        public String type() {
+            return "registry-provider";
+        }
+    }
+
+    private record ChildServiceImpl(String prop, String name) implements InheritedChildProvider.ChildService {
+        @Override
+        public String type() {
+            return "registry-provider";
+        }
     }
 
     private static class DummyService implements SomeProvider.SomeService {

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/testsubjects/DetachedRegistrySupportChildBlueprint.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/testsubjects/DetachedRegistrySupportChildBlueprint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint(beanStyle = true)
+@Prototype.Configured
+interface DetachedRegistrySupportChildBlueprint extends DetachedRegistrySupportParent {
+    @Option.Configured
+    @Option.Provider(InheritedChildProvider.class)
+    Optional<InheritedChildProvider.ChildService> getChildService();
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/testsubjects/RegistrySupportDisabledGrandchildBlueprint.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/testsubjects/RegistrySupportDisabledGrandchildBlueprint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.Configured
+interface RegistrySupportDisabledGrandchildBlueprint extends RegistrySupportDisabledChild {
+    @Option.Configured
+    @Option.Provider(InheritedChildProvider.class)
+    Optional<InheritedChildProvider.ChildService> grandchildService();
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/testsubjects/RegistrySupportRepeatedGrandchildBlueprint.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/testsubjects/RegistrySupportRepeatedGrandchildBlueprint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.Configured
+interface RegistrySupportRepeatedGrandchildBlueprint extends RegistrySupportRepeatedChild {
+    @Option.Configured
+    @Option.Provider(InheritedChildProvider.class)
+    Optional<InheritedChildProvider.ChildService> leafService();
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/Limit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/Limit.java
@@ -18,8 +18,11 @@ package io.helidon.common.concurrency.limits;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 import io.helidon.config.NamedService;
+import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Tag;
 import io.helidon.service.registry.Service;
 
@@ -67,7 +70,7 @@ public interface Limit extends LimitAlgorithm, NamedService {
          * @return a new limit context
          */
         static InitializationContext create(String originName) {
-            return createContext(originName, List.of());
+            return createContext(originName, List.of(), Optional.empty());
         }
 
         /**
@@ -78,7 +81,21 @@ public interface Limit extends LimitAlgorithm, NamedService {
          * @return a new limit context
          */
         static InitializationContext create(String originName, List<Tag> metricTags) {
-            return createContext(originName, metricTags);
+            return createContext(originName, metricTags, Optional.empty());
+        }
+
+        /**
+         * Create a limit context with metric tags and a meter registry supplier.
+         *
+         * @param originName origin name of the work protected by the limit
+         * @param metricTags metric tags to use when registering limit metrics
+         * @param meterRegistry meter registry supplier to use when metrics are enabled
+         * @return a new limit context
+         */
+        static InitializationContext create(String originName,
+                                            List<Tag> metricTags,
+                                            Supplier<MeterRegistry> meterRegistry) {
+            return createContext(originName, metricTags, Optional.of(Objects.requireNonNull(meterRegistry)));
         }
 
         /**
@@ -95,7 +112,18 @@ public interface Limit extends LimitAlgorithm, NamedService {
          */
         List<Tag> metricTags();
 
-        private static InitializationContext createContext(String originName, List<Tag> metricTags) {
+        /**
+         * Meter registry to use when registering limit metrics.
+         *
+         * @return meter registry to use, if explicitly supplied
+         */
+        default Optional<MeterRegistry> meterRegistry() {
+            return Optional.empty();
+        }
+
+        private static InitializationContext createContext(String originName,
+                                                           List<Tag> metricTags,
+                                                           Optional<Supplier<MeterRegistry>> meterRegistry) {
             Objects.requireNonNull(originName);
             List<Tag> copiedTags = List.copyOf(metricTags);
 
@@ -108,6 +136,11 @@ public interface Limit extends LimitAlgorithm, NamedService {
                 @Override
                 public List<Tag> metricTags() {
                     return copiedTags;
+                }
+
+                @Override
+                public Optional<MeterRegistry> meterRegistry() {
+                    return meterRegistry.map(Supplier::get);
                 }
             };
         }

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreMetrics.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreMetrics.java
@@ -59,7 +59,8 @@ class SemaphoreMetrics {
             return;
         }
 
-        MeterRegistry registry = Services.get(MeterRegistry.class);
+        MeterRegistry registry = context.meterRegistry()
+                .orElseGet(() -> Services.get(MeterRegistry.class));
         init(registry, context);
     }
 

--- a/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitMetricsTest.java
+++ b/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitMetricsTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.not;
@@ -94,6 +95,22 @@ class LimitMetricsTest {
     }
 
     @Test
+    void suppliedMeterRegistryIsUsedForMetrics() {
+        CapturingSemaphoreMetrics metrics = new CapturingSemaphoreMetrics();
+        AtomicInteger supplierCalls = new AtomicInteger();
+
+        metrics.init(Limit.InitializationContext.create("managed",
+                                                        realMeterTags,
+                                                        () -> {
+                                                            supplierCalls.incrementAndGet();
+                                                            return meterRegistry;
+                                                        }));
+
+        assertThat(metrics.capturedMeterRegistry(), sameInstance(meterRegistry));
+        assertThat(supplierCalls.get(), is(1));
+    }
+
+    @Test
     void legacyInitAddsSocketNameTagForNamedOrigin() {
         CapturingSemaphoreMetrics metrics = new CapturingSemaphoreMetrics();
 
@@ -148,15 +165,22 @@ class LimitMetricsTest {
 
     @Test
     void disabledMetricsDoNotRegisterRealMeters() {
+        AtomicInteger supplierCalls = new AtomicInteger();
         Limit disabled = FixedLimit.builder()
                 .name("test_disabled")
                 .permits(1)
                 .enableMetrics(false)
                 .build();
 
-        disabled.init(Limit.InitializationContext.create("unit-test", realMeterTags));
+        disabled.init(Limit.InitializationContext.create("unit-test",
+                                                         realMeterTags,
+                                                         () -> {
+                                                             supplierCalls.incrementAndGet();
+                                                             return meterRegistry;
+                                                         }));
 
         assertThat(hasMeter(meterRegistry, Meter.Type.GAUGE, "test_disabled_concurrent_requests", realMeterTags), is(false));
+        assertThat(supplierCalls.get(), is(0));
     }
 
     private static boolean hasMeter(MeterRegistry meterRegistry,
@@ -186,6 +210,7 @@ class LimitMetricsTest {
 
     private static class CapturingSemaphoreMetrics extends SemaphoreMetrics {
         private Map<String, String> capturedTags;
+        private MeterRegistry capturedMeterRegistry;
 
         CapturingSemaphoreMetrics() {
             super(true, null, "test", new AtomicInteger(), new AtomicInteger());
@@ -193,12 +218,17 @@ class LimitMetricsTest {
 
         @Override
         void register(MetricsFactory metricsFactory, MeterRegistry meterRegistry, List<Tag> tags) {
+            capturedMeterRegistry = meterRegistry;
             capturedTags = tags.stream()
                     .collect(Collectors.toMap(Tag::key, Tag::value));
         }
 
         Map<String, String> capturedTags() {
             return capturedTags;
+        }
+
+        MeterRegistry capturedMeterRegistry() {
+            return capturedMeterRegistry;
         }
     }
 }

--- a/config/config/src/main/java/io/helidon/config/BuilderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/BuilderImpl.java
@@ -90,6 +90,7 @@ class BuilderImpl implements Config.Builder {
      * Other configuration.
      */
     private OverrideSource overrideSource;
+    private Optional<ServiceRegistry> serviceRegistry;
 
     /*
      * Other switches
@@ -104,6 +105,7 @@ class BuilderImpl implements Config.Builder {
 
     BuilderImpl() {
         overrideSource = OverrideSources.empty();
+        serviceRegistry = Optional.empty();
         mapperProviders = MapperProviders.create();
         mapperServicesEnabled = true;
         parsers = new ArrayList<>();
@@ -363,7 +365,7 @@ class BuilderImpl implements Config.Builder {
 
     @Override
     public Config.Builder serviceRegistry(ServiceRegistry serviceRegistry) {
-        // not yet implemented
+        this.serviceRegistry = Optional.of(serviceRegistry);
         return this;
     }
 
@@ -392,7 +394,7 @@ class BuilderImpl implements Config.Builder {
 
         metaConfig.get("sources")
                 .asNodeList()
-                .ifPresent(list -> list.forEach(it -> sourceList.addAll(MetaConfig.configSource(it))));
+                .ifPresent(list -> list.forEach(it -> sourceList.addAll(configSources(it))));
 
         sourceList.forEach(this::addSource);
         sourceList.clear();
@@ -575,6 +577,13 @@ class BuilderImpl implements Config.Builder {
                 .stream()
                 .map(LoadedFilterProvider::new)
                 .forEach(this::addFilter);
+    }
+
+    private List<ConfigSource> configSources(Config metaConfig) {
+        if (serviceRegistry.isPresent()) {
+            return MetaConfig.configSource(metaConfig, serviceRegistry.get());
+        }
+        return MetaConfig.configSource(metaConfig);
     }
 
     private interface PrioritizedMapperProvider extends Weighted,

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1809,6 +1809,8 @@ public interface Config {
          *        optional: true
          *        resource: "application.yaml"
          * </pre>
+         * To resolve declared sources through an explicit service registry, invoke
+         * {@link #serviceRegistry(ServiceRegistry)} before this method.
          *
          * @param metaConfig meta configuration to set this builder up
          * @return updated builder from meta configuration
@@ -1818,6 +1820,8 @@ public interface Config {
         /**
          * Configure an explicit service registry to use when resolving config sources declared by the
          * {@linkplain #config(Config) meta-configuration}. Other builder service discovery is not affected.
+         * This method must be invoked before {@link #config(Config)}, because that method resolves the declared
+         * config sources when it is invoked.
          *
          * @param serviceRegistry registry to use
          * @return updated builder instance

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1816,7 +1816,8 @@ public interface Config {
         Builder config(Config metaConfig);
 
         /**
-         * Configure an explicit service registry to use to discover services (config sources, parsers etc.).
+         * Configure an explicit service registry to use when resolving config sources declared by the
+         * {@linkplain #config(Config) meta-configuration}. Other builder service discovery is not affected.
          *
          * @param serviceRegistry registry to use
          * @return updated builder instance

--- a/config/config/src/main/java/io/helidon/config/ConfigProvider.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigProvider.java
@@ -30,6 +30,7 @@ import io.helidon.config.spi.ConfigMapperProvider;
 import io.helidon.config.spi.ConfigParser;
 import io.helidon.config.spi.ConfigSource;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 
 @Service.Singleton
 @Weight(Weighted.DEFAULT_WEIGHT - 10) // less than default, so it can be easily overridden
@@ -41,9 +42,11 @@ class ConfigProvider implements Supplier<Config> {
                    Supplier<List<ConfigSource>> configSources,
                    Supplier<List<ConfigParser>> configParsers,
                    Supplier<List<ConfigFilter>> configFilters,
-                   Supplier<List<ConfigMapperProvider>> configMappers) {
+                   Supplier<List<ConfigMapperProvider>> configMappers,
+                   ServiceRegistry serviceRegistry) {
         Optional<MetaConfig> metaConfig = metaConfigSupplier.get();
-        Config.Builder builder = Config.builder();
+        Config.Builder builder = Config.builder()
+                .serviceRegistry(serviceRegistry);
 
         if (metaConfig.isPresent()) {
             builder.config(metaConfig.get().metaConfiguration());

--- a/config/config/src/main/java/io/helidon/config/ConfiguredProvider.java
+++ b/config/config/src/main/java/io/helidon/config/ConfiguredProvider.java
@@ -15,6 +15,10 @@
  */
 package io.helidon.config;
 
+import java.util.Objects;
+
+import io.helidon.service.registry.ServiceRegistry;
+
 /**
  * Providers that can be loaded from configuration should implement this interface.
  *
@@ -38,4 +42,21 @@ public interface ConfiguredProvider<T extends NamedService> {
      * @return a new instance created from this config node
      */
     T create(Config config, String name);
+
+    /**
+     * Create a new instance from configuration using services from the registry which owns the configured instance.
+     * <p>
+     * The default implementation delegates to {@link #create(Config, String)} for backward compatibility.
+     *
+     * @param config located at {@link #configKey()} node
+     * @param name name of the configured implementation
+     * @param serviceRegistry service registry which owns the configured instance
+     * @return a new instance created from this config node
+     */
+    default T create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        return create(config, name);
+    }
 }

--- a/config/config/src/main/java/io/helidon/config/MetaConfig.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import io.helidon.config.spi.ConfigSource;
 import io.helidon.config.spi.OverrideSource;
 import io.helidon.config.spi.PollingStrategy;
 import io.helidon.config.spi.RetryPolicy;
+import io.helidon.service.registry.ServiceRegistry;
 
 /**
  * Meta configuration.
@@ -182,28 +183,11 @@ public final class MetaConfig {
      * @see Config.Builder#config(Config)
      */
     public static List<ConfigSource> configSource(Config sourceMetaConfig) {
-        String type = sourceMetaConfig.get("type").asString().get();
-        boolean multiSource = sourceMetaConfig.get("multi-source").asBoolean().orElse(false);
+        return configSource(sourceMetaConfig, Optional.empty());
+    }
 
-        Config sourceProperties = sourceMetaConfig.get("properties");
-
-        if (multiSource) {
-            List<ConfigSource> sources = MetaProviders.configSources(type, sourceProperties);
-
-            if (LOGGER.isLoggable(Level.TRACE)) {
-                LOGGER.log(Level.TRACE, "Loaded sources of type \"" + type + "\", values: " + sources);
-            }
-
-            return sources;
-        } else {
-            ConfigSource source = MetaProviders.configSource(type, sourceProperties);
-
-            if (LOGGER.isLoggable(Level.TRACE)) {
-                LOGGER.log(Level.TRACE, "Loaded source of type \"" + type + "\", class: " + source.getClass().getName());
-            }
-
-            return List.of(source);
-        }
+    static List<ConfigSource> configSource(Config sourceMetaConfig, ServiceRegistry serviceRegistry) {
+        return configSource(sourceMetaConfig, Optional.of(serviceRegistry));
     }
 
     // override config source
@@ -237,6 +221,36 @@ public final class MetaConfig {
      */
     public Config metaConfiguration() {
         return this.metaConfig;
+    }
+
+    private static List<ConfigSource> configSource(Config sourceMetaConfig,
+                                                   Optional<ServiceRegistry> serviceRegistry) {
+        String type = sourceMetaConfig.get("type").asString().get();
+        boolean multiSource = sourceMetaConfig.get("multi-source").asBoolean().orElse(false);
+
+        Config sourceProperties = sourceMetaConfig.get("properties");
+
+        if (multiSource) {
+            List<ConfigSource> sources = serviceRegistry
+                    .map(it -> MetaProviders.configSources(type, sourceProperties, it))
+                    .orElseGet(() -> MetaProviders.configSources(type, sourceProperties));
+
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE, "Loaded sources of type \"" + type + "\", values: " + sources);
+            }
+
+            return sources;
+        } else {
+            ConfigSource source = serviceRegistry
+                    .map(it -> MetaProviders.configSource(type, sourceProperties, it))
+                    .orElseGet(() -> MetaProviders.configSource(type, sourceProperties));
+
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE, "Loaded source of type \"" + type + "\", class: " + source.getClass().getName());
+            }
+
+            return List.of(source);
+        }
     }
 
     private static Config createDefault() {

--- a/config/config/src/main/java/io/helidon/config/MetaConfig.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfig.java
@@ -127,6 +127,10 @@ public final class MetaConfig {
         return MetaConfigFinder.findMetaConfig(SUPPORTED_MEDIA_TYPES::contains, SUPPORTED_SUFFIXES);
     }
 
+    static Optional<Config> metaConfig(ServiceRegistry serviceRegistry) {
+        return MetaConfigFinder.findMetaConfig(SUPPORTED_MEDIA_TYPES::contains, SUPPORTED_SUFFIXES, serviceRegistry);
+    }
+
     /**
      * Load a polling strategy based on its meta configuration.
      *

--- a/config/config/src/main/java/io/helidon/config/MetaConfigFactory.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfigFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 
 /**
  * A ServiceRegistry factory that creates the meta config only if it is defined.
@@ -31,10 +32,16 @@ import io.helidon.service.registry.Service;
 @Service.Singleton
 class MetaConfigFactory implements Service.ServicesFactory<MetaConfig> {
     private static final System.Logger LOGGER = System.getLogger(MetaConfigFactory.class.getName());
+    private final ServiceRegistry serviceRegistry;
+
+    @Service.Inject
+    MetaConfigFactory(ServiceRegistry serviceRegistry) {
+        this.serviceRegistry = serviceRegistry;
+    }
 
     @Override
     public List<Service.QualifiedInstance<MetaConfig>> services() {
-        var foundMetaConfig = MetaConfig.metaConfig();
+        var foundMetaConfig = MetaConfig.metaConfig(serviceRegistry);
         if (foundMetaConfig.isEmpty()) {
             return List.of();
         }

--- a/config/config/src/main/java/io/helidon/config/MetaConfigFinder.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfigFinder.java
@@ -37,6 +37,7 @@ import io.helidon.config.spi.ConfigSource;
 import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceInfo;
+import io.helidon.service.registry.ServiceRegistry;
 
 /**
  * Utility class that locates the meta configuration source.
@@ -89,7 +90,14 @@ final class MetaConfigFinder {
     }
 
     static Optional<Config> findMetaConfig(Function<MediaType, Boolean> supportedMediaType, List<String> supportedSuffixes) {
-        return findMetaConfigSource(supportedMediaType, supportedSuffixes)
+        return findMetaConfigSource(supportedMediaType, supportedSuffixes, Optional.empty())
+                .map(source -> Config.builder(source).build());
+    }
+
+    static Optional<Config> findMetaConfig(Function<MediaType, Boolean> supportedMediaType,
+                                           List<String> supportedSuffixes,
+                                           ServiceRegistry serviceRegistry) {
+        return findMetaConfigSource(supportedMediaType, supportedSuffixes, Optional.of(serviceRegistry))
                 .map(source -> Config.builder(source).build());
     }
 
@@ -138,7 +146,8 @@ final class MetaConfigFinder {
     }
 
     private static Optional<ConfigSource> findMetaConfigSource(Function<MediaType, Boolean> supportedMediaType,
-                                                               List<String> supportedSuffixes) {
+                                                               List<String> supportedSuffixes,
+                                                               Optional<ServiceRegistry> serviceRegistry) {
         ClassLoader cl = contextClassLoader();
         Optional<ConfigSource> source;
 
@@ -174,7 +183,11 @@ final class MetaConfigFinder {
         }
         if (metaConfigFile == null) {
             if (profileName != null) {
-                return Optional.of(profileSource(supportedMediaType, cl, profileName, supportedSuffixes));
+                return Optional.of(profileSource(supportedMediaType,
+                                                 cl,
+                                                 profileName,
+                                                 supportedSuffixes,
+                                                 serviceRegistry));
             }
         } else {
             // is it a file
@@ -198,7 +211,8 @@ final class MetaConfigFinder {
     private static ConfigSource profileSource(Function<MediaType, Boolean> supportedMediaType,
                                               ClassLoader cl,
                                               String profileName,
-                                              List<String> supportedSuffixes) {
+                                              List<String> supportedSuffixes,
+                                              Optional<ServiceRegistry> serviceRegistry) {
         // first try to find the profile itself
         // default name is `config-profile.xxx`, we start with `config-profile-${profile}.xxx`
         String profileFileName = "config-profile-" + profileName + ".";
@@ -223,7 +237,7 @@ final class MetaConfigFinder {
                 .addObject(ObjectNode.builder().addValue("type", "system-properties").build());
 
         // all types from service registry
-        Set<String> namedSources = GlobalServiceRegistry.registry()
+        Set<String> namedSources = serviceRegistry.orElseGet(GlobalServiceRegistry::registry)
                 .allServices(ConfigSource.class)
                 .stream()
                 .map(ServiceInfo::qualifiers)

--- a/config/config/src/main/java/io/helidon/config/MetaProviders.java
+++ b/config/config/src/main/java/io/helidon/config/MetaProviders.java
@@ -312,8 +312,6 @@ final class MetaProviders {
 
         private static final Map<String, Function<Config, ConfigSource>> BUILT_INS = new HashMap<>();
 
-        private final Optional<ServiceRegistry> serviceRegistry;
-
         static {
             BUILT_INS.put(SYSTEM_PROPERTIES_TYPE, config -> ConfigSources.systemProperties().config(config).build());
             BUILT_INS.put(ENVIRONMENT_VARIABLES_TYPE, config -> ConfigSources.environmentVariables());
@@ -325,6 +323,8 @@ final class MetaProviders {
             BUILT_INS.put(PREFIXED_TYPE, PrefixedConfigSource::create);
             BUILT_INS.put(INLINED_TYPE, InlinedConfigSource::create);
         }
+
+        private final Optional<ServiceRegistry> serviceRegistry;
 
         private BuiltInConfigSourcesProvider(Optional<ServiceRegistry> serviceRegistry) {
             this.serviceRegistry = serviceRegistry;

--- a/config/config/src/main/java/io/helidon/config/MetaProviders.java
+++ b/config/config/src/main/java/io/helidon/config/MetaProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import io.helidon.config.spi.PollingStrategy;
 import io.helidon.config.spi.PollingStrategyProvider;
 import io.helidon.config.spi.RetryPolicy;
 import io.helidon.config.spi.RetryPolicyProvider;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.Services;
 
 /**
@@ -109,33 +110,21 @@ final class MetaProviders {
     }
 
     static ConfigSource configSource(String type, Config config) {
-        var all = allProviders();
-        var supported = all.stream()
-                .map(ConfigSourceProvider::supported)
-                .flatMap(Set::stream)
-                .collect(Collectors.toUnmodifiableSet());
+        return configSource(type, config, Optional.empty());
+    }
 
-        return all.stream()
-                .filter(provider -> provider.supports(type))
-                .findFirst()
-                .map(provider -> provider.create(type, config))
-                .or(() -> findSourceFromRegistry(type))
-                .orElseThrow(() -> new MetaConfigException("Config source of type " + type + " is not supported."
-                                                                   + " Supported types: " + supported));
+    static ConfigSource configSource(String type, Config config, ServiceRegistry serviceRegistry) {
+        return configSource(type, config, Optional.of(serviceRegistry));
     }
 
     static List<ConfigSource> configSources(String type, Config sourceProperties) {
-        var all = allProviders();
-        var supported = all.stream()
-                .map(ConfigSourceProvider::supported)
-                .flatMap(Set::stream)
-                .collect(Collectors.toUnmodifiableSet());
-        return all.stream()
-                .filter(provider -> provider.supports(type))
-                .findFirst()
-                .map(provider -> provider.createMulti(type, sourceProperties))
-                .orElseThrow(() -> new MetaConfigException("Config source of type " + type + " is not supported."
-                                                                   + " Supported types: " + supported));
+        return configSources(type, sourceProperties, Optional.empty());
+    }
+
+    static List<ConfigSource> configSources(String type,
+                                            Config sourceProperties,
+                                            ServiceRegistry serviceRegistry) {
+        return configSources(type, sourceProperties, Optional.of(serviceRegistry));
     }
 
     static OverrideSource overrideSource(String type, Config config) {
@@ -165,13 +154,55 @@ final class MetaProviders {
                                                                    + " Supported types: " + SUPPORTED_RETRY_POLICIES));
     }
 
-    private static Optional<ConfigSource> findSourceFromRegistry(String type) {
+    private static ConfigSource configSource(String type,
+                                             Config config,
+                                             Optional<ServiceRegistry> serviceRegistry) {
+        var all = allProviders(serviceRegistry);
+        var supported = all.stream()
+                .map(ConfigSourceProvider::supported)
+                .flatMap(Set::stream)
+                .collect(Collectors.toUnmodifiableSet());
+
+        return all.stream()
+                .filter(provider -> provider.supports(type))
+                .findFirst()
+                .map(provider -> provider.create(type, config))
+                .or(() -> findSource(type, serviceRegistry))
+                .orElseThrow(() -> new MetaConfigException("Config source of type " + type + " is not supported."
+                                                                   + " Supported types: " + supported));
+    }
+
+    private static List<ConfigSource> configSources(String type,
+                                                    Config sourceProperties,
+                                                    Optional<ServiceRegistry> serviceRegistry) {
+        var all = allProviders(serviceRegistry);
+        var supported = all.stream()
+                .map(ConfigSourceProvider::supported)
+                .flatMap(Set::stream)
+                .collect(Collectors.toUnmodifiableSet());
+        return all.stream()
+                .filter(provider -> provider.supports(type))
+                .findFirst()
+                .map(provider -> provider.createMulti(type, sourceProperties))
+                .orElseThrow(() -> new MetaConfigException("Config source of type " + type + " is not supported."
+                                                                   + " Supported types: " + supported));
+    }
+
+    private static Optional<ConfigSource> findSource(String type, Optional<ServiceRegistry> serviceRegistry) {
+        if (serviceRegistry.isPresent()) {
+            return serviceRegistry.get().firstNamed(ConfigSource.class, type);
+        }
         return Services.firstNamed(ConfigSource.class, type);
     }
 
-    private static List<ConfigSourceProvider> allProviders() {
-        var result = new ArrayList<>(Services.all(ConfigSourceProvider.class));
-        result.add(new BuiltInConfigSourcesProvider());
+    private static List<ConfigSourceProvider> allProviders(Optional<ServiceRegistry> serviceRegistry) {
+        List<ConfigSourceProvider> result;
+        if (serviceRegistry.isPresent()) {
+            result = new ArrayList<>(serviceRegistry.get().all(ConfigSourceProvider.class));
+        } else {
+            result = new ArrayList<>(Services.all(ConfigSourceProvider.class));
+        }
+        result.add(new BuiltInConfigSourcesProvider(serviceRegistry));
         return result;
     }
 
@@ -281,6 +312,8 @@ final class MetaProviders {
 
         private static final Map<String, Function<Config, ConfigSource>> BUILT_INS = new HashMap<>();
 
+        private final Optional<ServiceRegistry> serviceRegistry;
+
         static {
             BUILT_INS.put(SYSTEM_PROPERTIES_TYPE, config -> ConfigSources.systemProperties().config(config).build());
             BUILT_INS.put(ENVIRONMENT_VARIABLES_TYPE, config -> ConfigSources.environmentVariables());
@@ -293,6 +326,10 @@ final class MetaProviders {
             BUILT_INS.put(INLINED_TYPE, InlinedConfigSource::create);
         }
 
+        private BuiltInConfigSourcesProvider(Optional<ServiceRegistry> serviceRegistry) {
+            this.serviceRegistry = serviceRegistry;
+        }
+
         @Override
         public boolean supports(String type) {
             return BUILT_INS.containsKey(type);
@@ -300,6 +337,9 @@ final class MetaProviders {
 
         @Override
         public ConfigSource create(String type, Config metaConfig) {
+            if (PREFIXED_TYPE.equals(type) && serviceRegistry.isPresent()) {
+                return PrefixedConfigSource.create(metaConfig, serviceRegistry.get());
+            }
             return BUILT_INS.get(type).apply(metaConfig);
         }
 

--- a/config/config/src/main/java/io/helidon/config/PrefixedConfigSource.java
+++ b/config/config/src/main/java/io/helidon/config/PrefixedConfigSource.java
@@ -27,6 +27,7 @@ import io.helidon.config.spi.ConfigSource;
 import io.helidon.config.spi.EventConfigSource;
 import io.helidon.config.spi.NodeConfigSource;
 import io.helidon.config.spi.RetryPolicy;
+import io.helidon.service.registry.ServiceRegistry;
 
 /**
  * {@link ConfigSource} implementation wraps another config source and add key prefix to original one.
@@ -64,6 +65,13 @@ public final class PrefixedConfigSource implements ConfigSource,
     public static PrefixedConfigSource create(Config metaConfig) {
         String prefix = metaConfig.get(KEY_KEY).asString().orElse("");
         ConfigSource configSource = MetaConfig.configSource(metaConfig).get(0);
+
+        return create(prefix, configSource);
+    }
+
+    static PrefixedConfigSource create(Config metaConfig, ServiceRegistry serviceRegistry) {
+        String prefix = metaConfig.get(KEY_KEY).asString().orElse("");
+        ConfigSource configSource = MetaConfig.configSource(metaConfig, serviceRegistry).get(0);
 
         return create(prefix, configSource);
     }

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -188,47 +188,13 @@ final class ProvidedUtil {
             ProviderSettings settings,
             List<S> existingInstances) {
 
-        // Do not add a configured or discovered service whose selected identity is already present on the builder.
-        Set<TypeAndName> ignoredServices = existingIdentities(configKey, settings.identity(), existingInstances);
-
-        boolean discoverServices = config.get(configKey + "-discover-services")
-                .asBoolean()
-                .orElse(settings.discoverServices());
-        Config providersConfig = config.get(configKey);
-        if (settings.validateConfig()) {
-            validateProviderConfig(providersConfig, settings.identity(), settings.configForm());
-        }
-
-        List<ConfiguredService> configuredServices = new ArrayList<>();
-
-        // all child nodes of the current node
-        List<Config> serviceConfigList = providersConfig.asNodeList()
-                .orElseGet(List::of);
-        boolean isList = providersConfig.isList();
-
-        for (Config serviceConfig : serviceConfigList) {
-            configuredServices.add(configuredService(serviceConfig, isList, settings.identity()));
-        }
-
-        // now we have all service configurations, we can start building up instances
-        if (providersConfig.isList()) {
-            // driven by order of declaration in config
-            return servicesFromList(serviceLoader,
-                                    providerType,
-                                    configType,
-                                    configuredServices,
-                                    discoverServices,
-                                    ignoredServices);
-        } else {
-            // driven by service loader order
-            return servicesFromObject(providersConfig,
-                                      serviceLoader,
-                                      providerType,
-                                      configType,
-                                      configuredServices,
-                                      discoverServices,
-                                      ignoredServices);
-        }
+        return discoverServices(config,
+                                configKey,
+                                new ServiceLoaderProviderSource<>(serviceLoader),
+                                providerType,
+                                configType,
+                                settings,
+                                existingInstances);
     }
 
     static <S extends NamedService,
@@ -260,50 +226,16 @@ final class ProvidedUtil {
             ProviderSettings settings,
             List<S> existingValues) {
 
-        // Do not add a configured or discovered service whose selected identity is already present on the builder.
-        Set<TypeAndName> ignoredServices = existingIdentities(configKey, settings.identity(), existingValues);
-
-        boolean discoverServices = config.get(configKey + "-discover-services")
-                .asBoolean()
-                .orElse(settings.discoverServices());
-        Config providersConfig = config.get(configKey);
-        if (settings.validateConfig()) {
-            validateProviderConfig(providersConfig, settings.identity(), settings.configForm());
-        }
-
-        List<ConfiguredService> configuredServices = new ArrayList<>();
-
-        // all child nodes of the current node
-        List<Config> serviceConfigList = providersConfig.asNodeList()
-                .orElseGet(List::of);
-        boolean isList = providersConfig.isList();
-
-        for (Config serviceConfig : serviceConfigList) {
-            configuredServices.add(configuredService(serviceConfig, isList, settings.identity()));
-        }
-        RegistryWrap wrap = serviceRegistry.isPresent()
-                ? new RealRegistry(serviceRegistry.get())
-                : StaticAccessRegistry.INSTANCE;
-
-        // now we have all service configurations, we can start building up instances
-        if (providersConfig.isList()) {
-            // driven by order of declaration in config
-            return servicesFromList(wrap,
-                                    providerType,
-                                    configType,
-                                    configuredServices,
-                                    discoverServices,
-                                    ignoredServices);
-        } else {
-            // driven by service loader order
-            return servicesFromObject(providersConfig,
-                                      wrap,
-                                      providerType,
-                                      configType,
-                                      configuredServices,
-                                      discoverServices,
-                                      ignoredServices);
-        }
+        ProviderSource<S, T> providerSource = serviceRegistry
+                .<ProviderSource<S, T>>map(registry -> new RegistryProviderSource<>(registry, providerType))
+                .orElseGet(() -> new StaticProviderSource<>(providerType));
+        return discoverServices(config,
+                                configKey,
+                                providerSource,
+                                providerType,
+                                configType,
+                                settings,
+                                existingValues);
     }
 
     static <S extends NamedService,
@@ -368,123 +300,56 @@ final class ProvidedUtil {
     }
 
     private static <S extends NamedService,
-            T extends ConfiguredProvider<S>> List<S> servicesFromObject(
-            Config providersConfig,
-            HelidonServiceLoader<T> serviceLoader,
+            T extends ConfiguredProvider<S>> List<S> discoverServices(
+            Config config,
+            String configKey,
+            ProviderSource<S, T> providerSource,
             Class<T> providerType,
             Class<S> configType,
-            List<ConfiguredService> configuredServices,
-            boolean allFromServiceLoader,
-            Set<TypeAndName> ignoredServices) {
+            ProviderSettings settings,
+            List<S> existingValues) {
 
-        // Object configuration has no ordering contract; providers determine the result grouping order.
-        Set<String> availableProviders = new HashSet<>();
-        Map<String, List<ConfiguredService>> allConfigs = new HashMap<>();
-        configuredServices.forEach(it -> allConfigs.computeIfAbsent(it.typeAndName().type, _ -> new ArrayList<>())
-                .add(it));
-        Set<String> unusedConfigs = new HashSet<>(allConfigs.keySet());
+        // Do not add a configured or discovered service whose selected identity is already present on the builder.
+        Set<TypeAndName> ignoredServices = existingIdentities(configKey, settings.identity(), existingValues);
 
-        List<S> result = new ArrayList<>();
-
-        serviceLoader.forEach(provider -> {
-            List<ConfiguredService> providerConfigs = allConfigs.get(provider.configKey());
-            availableProviders.add(provider.configKey());
-            unusedConfigs.remove(provider.configKey());
-            if (providerConfigs == null) {
-                if (allFromServiceLoader) {
-                    // even though the specific key does not exist, we want to have the real config tree, so we can get to the
-                    // root of it
-                    // when there is no configuration, the name defaults to the type
-                    String type = provider.configKey();
-                    if (ignoredServices.add(new TypeAndName(type, type))) {
-                        result.add(provider.create(providersConfig.get(type), type));
-                    } else {
-                        if (PROVIDER_LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-                            PROVIDER_LOGGER.log(System.Logger.Level.DEBUG, "Service: " + new TypeAndName(type, type)
-                                    + " is already added in builder, ignoring configured one.");
-                        }
-                    }
-                }
-            } else {
-                for (ConfiguredService configuredService : providerConfigs) {
-                    if (configuredService.enabled()) {
-                        if (ignoredServices.add(configuredService.typeAndName())) {
-                            result.add(provider.create(configuredService.serviceConfig(),
-                                                       configuredService.typeAndName().name()));
-                        } else {
-                            if (PROVIDER_LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-                                PROVIDER_LOGGER.log(System.Logger.Level.DEBUG, "Service: " + configuredService.typeAndName()
-                                        + " is already added in builder, ignoring configured one.");
-                            }
-                        }
-                    }
-                }
-            }
-        });
-        if (!unusedConfigs.isEmpty()) {
-            throw new ConfigException("Unknown provider configured. Expected providers with types: " + unusedConfigs
-                                              + ", but only the following providers are supported: " + availableProviders
-                                              + ", provider interface: " + providerType.getName()
-                                              + ", configured service: " + configType.getName());
-        }
-        return result;
-    }
-
-    private static <S extends NamedService,
-            T extends ConfiguredProvider<S>> List<S> servicesFromList(
-            HelidonServiceLoader<T> serviceLoader,
-            Class<T> providerType,
-            Class<S> configType,
-            List<ConfiguredService> configuredServices,
-            boolean allFromServiceLoader,
-            Set<TypeAndName> ignoredServices) {
-
-        Map<String, T> allProvidersByType = new HashMap<>();
-        Map<String, T> unusedProvidersByType = new LinkedHashMap<>();
-        serviceLoader.forEach(it -> {
-            allProvidersByType.putIfAbsent(it.configKey(), it);
-            unusedProvidersByType.putIfAbsent(it.configKey(), it);
-        });
-
-        List<S> result = new ArrayList<S>();
-
-        // first add all configured
-        for (ConfiguredService service : configuredServices) {
-            TypeAndName typeAndName = service.typeAndName();
-            if (!ignoredServices.add(typeAndName)) {
-                unusedProvidersByType.remove(typeAndName.type());
-
-                if (PROVIDER_LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
-                    PROVIDER_LOGGER.log(System.Logger.Level.DEBUG, "Service: " + typeAndName
-                            + " is already added in builder, ignoring configured one.");
-                }
-
-                continue;
-            }
-            T provider = allProvidersByType.get(typeAndName.type());
-            if (provider == null) {
-                throw new ConfigException("Unknown provider configured. Expecting a provider with type \"" + typeAndName.type()
-                                                  + "\", but only the following providers are supported: "
-                                                  + allProvidersByType.keySet() + ", "
-                                                  + "provider interface: " + providerType.getName()
-                                                  + ", configured service: " + configType.getName());
-            }
-            unusedProvidersByType.remove(typeAndName.type());
-            if (service.enabled()) {
-                result.add(provider.create(service.serviceConfig(), typeAndName.name()));
-            }
+        boolean discoverServices = config.get(configKey + "-discover-services")
+                .asBoolean()
+                .orElse(settings.discoverServices());
+        Config providersConfig = config.get(configKey);
+        if (settings.validateConfig()) {
+            validateProviderConfig(providersConfig, settings.identity(), settings.configForm());
         }
 
-        // then (if desired) add the rest
-        if (allFromServiceLoader) {
-            unusedProvidersByType.forEach((type, provider) -> {
-                if (ignoredServices.add(new TypeAndName(type, type))) {
-                    result.add(provider.create(Config.empty(), type));
-                }
-            });
+        List<ConfiguredService> configuredServices = new ArrayList<>();
+
+        // all child nodes of the current node
+        List<Config> serviceConfigList = providersConfig.asNodeList()
+                .orElseGet(List::of);
+        boolean isList = providersConfig.isList();
+
+        for (Config serviceConfig : serviceConfigList) {
+            configuredServices.add(configuredService(serviceConfig, isList, settings.identity()));
         }
 
-        return result;
+        // now we have all service configurations, we can start building up instances
+        if (providersConfig.isList()) {
+            // driven by order of declaration in config
+            return servicesFromList(providerSource,
+                                    providerType,
+                                    configType,
+                                    configuredServices,
+                                    discoverServices,
+                                    ignoredServices);
+        }
+
+        // driven by provider source order
+        return servicesFromObject(providersConfig,
+                                  providerSource,
+                                  providerType,
+                                  configType,
+                                  configuredServices,
+                                  discoverServices,
+                                  ignoredServices);
     }
 
     private static ConfiguredService configuredService(Config serviceConfig, boolean isList, Identity identity) {
@@ -642,17 +507,17 @@ final class ProvidedUtil {
 
     private static <S extends NamedService,
             T extends ConfiguredProvider<S>> List<S> servicesFromList(
-            RegistryWrap serviceRegistry,
+            ProviderSource<S, T> providerSource,
             Class<T> providerType,
             Class<S> configType,
             List<ConfiguredService> configuredServices,
-            boolean allFromServiceLoader,
+            boolean discoverServices,
             Set<TypeAndName> ignoredServices) {
 
         Map<String, T> allProvidersByType = new HashMap<>();
         Map<String, T> unusedProvidersByType = new LinkedHashMap<>();
 
-        serviceRegistry.all(providerType)
+        providerSource.all()
                 .forEach(provider -> {
                     allProvidersByType.putIfAbsent(provider.configKey(), provider);
                     unusedProvidersByType.putIfAbsent(provider.configKey(), provider);
@@ -683,15 +548,15 @@ final class ProvidedUtil {
             }
             unusedProvidersByType.remove(typeAndName.type());
             if (service.enabled()) {
-                result.add(serviceRegistry.create(provider, service.serviceConfig(), typeAndName.name()));
+                result.add(providerSource.create(provider, service.serviceConfig(), typeAndName.name()));
             }
         }
 
         // then (if desired) add the rest
-        if (allFromServiceLoader) {
+        if (discoverServices) {
             unusedProvidersByType.forEach((type, provider) -> {
                 if (ignoredServices.add(new TypeAndName(type, type))) {
-                    result.add(serviceRegistry.create(provider, Config.empty(), type));
+                    result.add(providerSource.create(provider, Config.empty(), type));
                 }
             });
         }
@@ -702,11 +567,11 @@ final class ProvidedUtil {
     private static <S extends NamedService,
             T extends ConfiguredProvider<S>> List<S> servicesFromObject(
             Config providersConfig,
-            RegistryWrap serviceRegistry,
+            ProviderSource<S, T> providerSource,
             Class<T> providerType,
             Class<S> configType,
             List<ConfiguredService> configuredServices,
-            boolean allFromServiceLoader,
+            boolean discoverServices,
             Set<TypeAndName> ignoredServices) {
 
         // Object configuration has no ordering contract; providers determine the result grouping order.
@@ -718,19 +583,19 @@ final class ProvidedUtil {
 
         List<S> result = new ArrayList<>();
 
-        List<T> all = serviceRegistry.all(providerType);
+        List<T> all = providerSource.all();
         for (T provider : all) {
             List<ConfiguredService> providerConfigs = allConfigs.get(provider.configKey());
             availableProviders.add(provider.configKey());
             unusedConfigs.remove(provider.configKey());
             if (providerConfigs == null) {
-                if (allFromServiceLoader) {
+                if (discoverServices) {
                     // even though the specific key does not exist, we want to have the real config tree, so we can get to the
                     // root of it
                     // when there is no configuration, the name defaults to the type
                     String type = provider.configKey();
                     if (ignoredServices.add(new TypeAndName(type, type))) {
-                        result.add(serviceRegistry.create(provider, providersConfig.get(type), type));
+                        result.add(providerSource.create(provider, providersConfig.get(type), type));
                     } else {
                         if (PROVIDER_LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
                             PROVIDER_LOGGER.log(System.Logger.Level.DEBUG, "Service: " + new TypeAndName(type, type)
@@ -742,9 +607,9 @@ final class ProvidedUtil {
                 for (ConfiguredService configuredService : providerConfigs) {
                     if (configuredService.enabled()) {
                         if (ignoredServices.add(configuredService.typeAndName())) {
-                            result.add(serviceRegistry.create(provider,
-                                                              configuredService.serviceConfig(),
-                                                              configuredService.typeAndName().name()));
+                            result.add(providerSource.create(provider,
+                                                             configuredService.serviceConfig(),
+                                                             configuredService.typeAndName().name()));
                         } else {
                             if (PROVIDER_LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
                                 PROVIDER_LOGGER.log(System.Logger.Level.DEBUG, "Service: " + configuredService.typeAndName()
@@ -765,10 +630,10 @@ final class ProvidedUtil {
         return result;
     }
 
-    private interface RegistryWrap {
-        <T> List<T> all(Class<T> type);
+    private interface ProviderSource<S extends NamedService, T extends ConfiguredProvider<S>> {
+        List<T> all();
 
-        <S extends NamedService, T extends ConfiguredProvider<S>> S create(T provider, Config config, String name);
+        S create(T provider, Config config, String name);
     }
 
     private record TypeAndName(String type, String name) {
@@ -777,34 +642,61 @@ final class ProvidedUtil {
     private record ConfiguredService(TypeAndName typeAndName, Config serviceConfig, boolean enabled) {
     }
 
-    private static final class StaticAccessRegistry implements RegistryWrap {
-        private static final StaticAccessRegistry INSTANCE = new StaticAccessRegistry();
+    private static final class ServiceLoaderProviderSource<S extends NamedService, T extends ConfiguredProvider<S>>
+            implements ProviderSource<S, T> {
+        private final HelidonServiceLoader<T> serviceLoader;
 
-        @Override
-        public <T> List<T> all(Class<T> type) {
-            return Services.all(type);
+        private ServiceLoaderProviderSource(HelidonServiceLoader<T> serviceLoader) {
+            this.serviceLoader = serviceLoader;
         }
 
         @Override
-        public <S extends NamedService, T extends ConfiguredProvider<S>> S create(T provider, Config config, String name) {
+        public List<T> all() {
+            return serviceLoader.asList();
+        }
+
+        @Override
+        public S create(T provider, Config config, String name) {
             return provider.create(config, name);
         }
     }
 
-    private static final class RealRegistry implements RegistryWrap {
+    private static final class StaticProviderSource<S extends NamedService, T extends ConfiguredProvider<S>>
+            implements ProviderSource<S, T> {
+        private final Class<T> providerType;
+
+        private StaticProviderSource(Class<T> providerType) {
+            this.providerType = providerType;
+        }
+
+        @Override
+        public List<T> all() {
+            return Services.all(providerType);
+        }
+
+        @Override
+        public S create(T provider, Config config, String name) {
+            return provider.create(config, name);
+        }
+    }
+
+    private static final class RegistryProviderSource<S extends NamedService, T extends ConfiguredProvider<S>>
+            implements ProviderSource<S, T> {
         private final ServiceRegistry serviceRegistry;
+        private final Class<T> providerType;
 
-        private RealRegistry(ServiceRegistry serviceRegistry) {
+        private RegistryProviderSource(ServiceRegistry serviceRegistry, Class<T> providerType) {
             this.serviceRegistry = serviceRegistry;
+            this.providerType = providerType;
         }
 
         @Override
-        public <T> List<T> all(Class<T> type) {
-            return serviceRegistry.all(type);
+        public List<T> all() {
+            return serviceRegistry.all(providerType);
         }
 
         @Override
-        public <S extends NamedService, T extends ConfiguredProvider<S>> S create(T provider, Config config, String name) {
+        public S create(T provider, Config config, String name) {
             return provider.create(config, name, serviceRegistry);
         }
     }

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -29,9 +29,13 @@ import io.helidon.builder.api.Option.Provider.ConfigForm;
 import io.helidon.builder.api.Option.Provider.Identity;
 import io.helidon.builder.api.Prototype;
 import io.helidon.common.HelidonServiceLoader;
+import io.helidon.common.Weighted;
+import io.helidon.common.Weights;
 import io.helidon.config.ConfigBuilderSupport.ProviderSettings;
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.ServiceInstance;
 import io.helidon.service.registry.ServiceRegistry;
-import io.helidon.service.registry.Services;
 
 @SuppressWarnings("ALL")
 final class ProvidedUtil {
@@ -642,6 +646,9 @@ final class ProvidedUtil {
     private record ConfiguredService(TypeAndName typeAndName, Config serviceConfig, boolean enabled) {
     }
 
+    private record WeightedProvider<T>(T provider, double weight) implements Weighted {
+    }
+
     private static final class ServiceLoaderProviderSource<S extends NamedService, T extends ConfiguredProvider<S>>
             implements ProviderSource<S, T> {
         private final HelidonServiceLoader<T> serviceLoader;
@@ -671,14 +678,24 @@ final class ProvidedUtil {
 
         @Override
         public List<T> all() {
-            Map<String, T> providers = new LinkedHashMap<>();
+            Map<String, WeightedProvider<T>> providers = new LinkedHashMap<>();
             HelidonServiceLoader.create(providerType)
-                    .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
-            Map<String, T> registryProviders = new LinkedHashMap<>();
-            Services.all(providerType)
-                    .forEach(provider -> registryProviders.putIfAbsent(provider.configKey(), provider));
-            providers.putAll(registryProviders);
-            return List.copyOf(providers.values());
+                    .forEach(provider -> {
+                        double weight = Weights.find(provider, Weighted.DEFAULT_WEIGHT);
+                        providers.putIfAbsent(provider.configKey(), new WeightedProvider<>(provider, weight));
+                    });
+            List<ServiceInstance<T>> registryProviders = GlobalServiceRegistry.registry()
+                    .lookupInstances(Lookup.create(providerType));
+            for (ServiceInstance<T> providerInstance : registryProviders) {
+                T provider = providerInstance.get();
+                providers.put(provider.configKey(), new WeightedProvider<>(provider, providerInstance.weight()));
+            }
+
+            List<WeightedProvider<T>> sortedProviders = new ArrayList<>(providers.values());
+            Weights.sort(sortedProviders);
+            return sortedProviders.stream()
+                    .map(WeightedProvider::provider)
+                    .toList();
         }
 
         @Override

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -31,7 +31,6 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.config.ConfigBuilderSupport.ProviderSettings;
 import io.helidon.service.registry.ServiceRegistry;
-import io.helidon.service.registry.Services;
 
 @SuppressWarnings("ALL")
 final class ProvidedUtil {
@@ -228,7 +227,7 @@ final class ProvidedUtil {
 
         ProviderSource<S, T> providerSource = serviceRegistry
                 .<ProviderSource<S, T>>map(registry -> new RegistryProviderSource<>(registry, providerType))
-                .orElseGet(() -> new StaticProviderSource<>(providerType));
+                .orElseGet(() -> new ServiceLoaderProviderSource<>(HelidonServiceLoader.create(providerType)));
         return discoverServices(config,
                                 configKey,
                                 providerSource,
@@ -653,25 +652,6 @@ final class ProvidedUtil {
         @Override
         public List<T> all() {
             return serviceLoader.asList();
-        }
-
-        @Override
-        public S create(T provider, Config config, String name) {
-            return provider.create(config, name);
-        }
-    }
-
-    private static final class StaticProviderSource<S extends NamedService, T extends ConfiguredProvider<S>>
-            implements ProviderSource<S, T> {
-        private final Class<T> providerType;
-
-        private StaticProviderSource(Class<T> providerType) {
-            this.providerType = providerType;
-        }
-
-        @Override
-        public List<T> all() {
-            return Services.all(providerType);
         }
 
         @Override

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -683,7 +683,7 @@ final class ProvidedUtil {
             }
             unusedProvidersByType.remove(typeAndName.type());
             if (service.enabled()) {
-                result.add(provider.create(service.serviceConfig(), typeAndName.name()));
+                result.add(serviceRegistry.create(provider, service.serviceConfig(), typeAndName.name()));
             }
         }
 
@@ -691,7 +691,7 @@ final class ProvidedUtil {
         if (allFromServiceLoader) {
             unusedProvidersByType.forEach((type, provider) -> {
                 if (ignoredServices.add(new TypeAndName(type, type))) {
-                    result.add(provider.create(Config.empty(), type));
+                    result.add(serviceRegistry.create(provider, Config.empty(), type));
                 }
             });
         }
@@ -730,7 +730,7 @@ final class ProvidedUtil {
                     // when there is no configuration, the name defaults to the type
                     String type = provider.configKey();
                     if (ignoredServices.add(new TypeAndName(type, type))) {
-                        result.add(provider.create(providersConfig.get(type), type));
+                        result.add(serviceRegistry.create(provider, providersConfig.get(type), type));
                     } else {
                         if (PROVIDER_LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
                             PROVIDER_LOGGER.log(System.Logger.Level.DEBUG, "Service: " + new TypeAndName(type, type)
@@ -742,8 +742,9 @@ final class ProvidedUtil {
                 for (ConfiguredService configuredService : providerConfigs) {
                     if (configuredService.enabled()) {
                         if (ignoredServices.add(configuredService.typeAndName())) {
-                            result.add(provider.create(configuredService.serviceConfig(),
-                                                       configuredService.typeAndName().name()));
+                            result.add(serviceRegistry.create(provider,
+                                                              configuredService.serviceConfig(),
+                                                              configuredService.typeAndName().name()));
                         } else {
                             if (PROVIDER_LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
                                 PROVIDER_LOGGER.log(System.Logger.Level.DEBUG, "Service: " + configuredService.typeAndName()
@@ -766,6 +767,8 @@ final class ProvidedUtil {
 
     private interface RegistryWrap {
         <T> List<T> all(Class<T> type);
+
+        <S extends NamedService, T extends ConfiguredProvider<S>> S create(T provider, Config config, String name);
     }
 
     private record TypeAndName(String type, String name) {
@@ -781,6 +784,11 @@ final class ProvidedUtil {
         public <T> List<T> all(Class<T> type) {
             return Services.all(type);
         }
+
+        @Override
+        public <S extends NamedService, T extends ConfiguredProvider<S>> S create(T provider, Config config, String name) {
+            return provider.create(config, name);
+        }
     }
 
     private static final class RealRegistry implements RegistryWrap {
@@ -793,6 +801,11 @@ final class ProvidedUtil {
         @Override
         public <T> List<T> all(Class<T> type) {
             return serviceRegistry.all(type);
+        }
+
+        @Override
+        public <S extends NamedService, T extends ConfiguredProvider<S>> S create(T provider, Config config, String name) {
+            return provider.create(config, name, serviceRegistry);
         }
     }
 }

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -672,9 +672,9 @@ final class ProvidedUtil {
         @Override
         public List<T> all() {
             Map<String, T> providers = new LinkedHashMap<>();
-            HelidonServiceLoader.create(providerType)
-                    .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
             Services.all(providerType)
+                    .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
+            HelidonServiceLoader.create(providerType)
                     .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
             return List.copyOf(providers.values());
         }

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -674,8 +674,10 @@ final class ProvidedUtil {
             Map<String, T> providers = new LinkedHashMap<>();
             HelidonServiceLoader.create(providerType)
                     .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
+            Map<String, T> registryProviders = new LinkedHashMap<>();
             Services.all(providerType)
-                    .forEach(provider -> providers.put(provider.configKey(), provider));
+                    .forEach(provider -> registryProviders.putIfAbsent(provider.configKey(), provider));
+            providers.putAll(registryProviders);
             return List.copyOf(providers.values());
         }
 

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -683,13 +683,16 @@ final class ProvidedUtil {
                     .forEach(provider -> {
                         double weight = Weights.find(provider, Weighted.DEFAULT_WEIGHT);
                         providers.putIfAbsent(provider.configKey(), new WeightedProvider<>(provider, weight));
-                    });
-            List<ServiceInstance<T>> registryProviders = GlobalServiceRegistry.registry()
+            });
+            Map<String, WeightedProvider<T>> registryProviders = new LinkedHashMap<>();
+            List<ServiceInstance<T>> registryProviderInstances = GlobalServiceRegistry.registry()
                     .lookupInstances(Lookup.create(providerType));
-            for (ServiceInstance<T> providerInstance : registryProviders) {
+            for (ServiceInstance<T> providerInstance : registryProviderInstances) {
                 T provider = providerInstance.get();
-                providers.put(provider.configKey(), new WeightedProvider<>(provider, providerInstance.weight()));
+                registryProviders.putIfAbsent(provider.configKey(),
+                                              new WeightedProvider<>(provider, providerInstance.weight()));
             }
+            providers.putAll(registryProviders);
 
             List<WeightedProvider<T>> sortedProviders = new ArrayList<>(providers.values());
             Weights.sort(sortedProviders);

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -31,6 +31,7 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.config.ConfigBuilderSupport.ProviderSettings;
 import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.Services;
 
 @SuppressWarnings("ALL")
 final class ProvidedUtil {
@@ -227,7 +228,7 @@ final class ProvidedUtil {
 
         ProviderSource<S, T> providerSource = serviceRegistry
                 .<ProviderSource<S, T>>map(registry -> new RegistryProviderSource<>(registry, providerType))
-                .orElseGet(() -> new ServiceLoaderProviderSource<>(HelidonServiceLoader.create(providerType)));
+                .orElseGet(() -> new StaticProviderSource<>(providerType));
         return discoverServices(config,
                                 configKey,
                                 providerSource,
@@ -652,6 +653,30 @@ final class ProvidedUtil {
         @Override
         public List<T> all() {
             return serviceLoader.asList();
+        }
+
+        @Override
+        public S create(T provider, Config config, String name) {
+            return provider.create(config, name);
+        }
+    }
+
+    private static final class StaticProviderSource<S extends NamedService, T extends ConfiguredProvider<S>>
+            implements ProviderSource<S, T> {
+        private final Class<T> providerType;
+
+        private StaticProviderSource(Class<T> providerType) {
+            this.providerType = providerType;
+        }
+
+        @Override
+        public List<T> all() {
+            Map<String, T> providers = new LinkedHashMap<>();
+            HelidonServiceLoader.create(providerType)
+                    .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
+            Services.all(providerType)
+                    .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
+            return List.copyOf(providers.values());
         }
 
         @Override

--- a/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
+++ b/config/config/src/main/java/io/helidon/config/ProvidedUtil.java
@@ -672,10 +672,10 @@ final class ProvidedUtil {
         @Override
         public List<T> all() {
             Map<String, T> providers = new LinkedHashMap<>();
-            Services.all(providerType)
-                    .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
             HelidonServiceLoader.create(providerType)
                     .forEach(provider -> providers.putIfAbsent(provider.configKey(), provider));
+            Services.all(providerType)
+                    .forEach(provider -> providers.put(provider.configKey(), provider));
             return List.copyOf(providers.values());
         }
 

--- a/config/config/src/test/java/io/helidon/config/ConfigProviderRegistryTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigProviderRegistryTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.config.spi.ConfigNode.ListNode;
+import io.helidon.config.spi.ConfigNode.ObjectNode;
+import io.helidon.config.spi.ConfigSource;
+import io.helidon.config.spi.ConfigSourceProvider;
+import io.helidon.service.registry.ServiceRegistry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ConfigProviderRegistryTest {
+    private static final String PROVIDER_TYPE = "registry-provider";
+    private static final String NAMED_SOURCE_TYPE = "registry-named-source";
+
+    @Test
+    void builderUsesConfiguredRegistryForMetaConfigSources() {
+        ServiceRegistry registry = mock(ServiceRegistry.class);
+        when(registry.all(ConfigSourceProvider.class))
+                .thenReturn(List.of(new RegistryConfigSourceProvider()));
+
+        Config config = Config.builder()
+                .serviceRegistry(registry)
+                .config(metaConfig(ObjectNode.builder()
+                                    .addValue("type", PROVIDER_TYPE)
+                                    .build()))
+                .disableParserServices()
+                .disableFilterServices()
+                .disableMapperServices()
+                .build();
+        try {
+            assertThat(config.get("registry-provider-value").asString().get(), is("from-registry-provider"));
+        } finally {
+            config.context().stopChangeSupport();
+        }
+    }
+
+    @Test
+    void managedProviderUsesRegistryForNestedPrefixedSource() {
+        ServiceRegistry registry = mock(ServiceRegistry.class);
+        when(registry.all(ConfigSourceProvider.class)).thenReturn(List.of());
+        when(registry.firstNamed(ConfigSource.class, NAMED_SOURCE_TYPE))
+                .thenReturn(Optional.of(ConfigSources.create(Map.of("value", "from-named-source")).build()));
+
+        Config metaConfig = metaConfig(ObjectNode.builder()
+                                               .addValue("type", "prefixed")
+                                               .addObject("properties", ObjectNode.builder()
+                                                       .addValue("key", "registry")
+                                                       .addValue("type", NAMED_SOURCE_TYPE)
+                                                       .build())
+                                               .build());
+        ConfigProvider provider = new ConfigProvider(() -> Optional.of(new MetaConfig(metaConfig)),
+                                                     List::of,
+                                                     List::of,
+                                                     List::of,
+                                                     List::of,
+                                                     registry);
+        try {
+            assertThat(provider.get().get("registry.value").asString().get(), is("from-named-source"));
+        } finally {
+            provider.preDestroy();
+        }
+    }
+
+    private static Config metaConfig(ObjectNode source) {
+        return Config.just(ConfigSources.create(ObjectNode.builder()
+                                                        .addList("sources", ListNode.builder()
+                                                                .addObject(source)
+                                                                .build())
+                                                        .build()));
+    }
+
+    private static final class RegistryConfigSourceProvider implements ConfigSourceProvider {
+        @Override
+        public boolean supports(String type) {
+            return PROVIDER_TYPE.equals(type);
+        }
+
+        @Override
+        public ConfigSource create(String type, Config metaConfig) {
+            return ConfigSources.create(Map.of("registry-provider-value", "from-registry-provider")).build();
+        }
+
+        @Override
+        public Set<String> supported() {
+            return Set.of(PROVIDER_TYPE);
+        }
+    }
+}

--- a/config/config/src/test/java/io/helidon/config/MetaConfigFactoryTest.java
+++ b/config/config/src/test/java/io/helidon/config/MetaConfigFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.config.spi.ConfigSource;
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.ServiceInfo;
+import io.helidon.service.registry.ServiceRegistry;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Isolated
+class MetaConfigFactoryTest {
+    @Test
+    void profileSynthesisUsesOwningRegistry() {
+        String profileProperty = MetaConfigFinder.HELIDON_CONFIG_PROFILE_SYSTEM_PROPERTY;
+        String previousProfile = System.getProperty(profileProperty);
+        ServiceRegistry previousRegistry = GlobalServiceRegistry.registry();
+        ServiceRegistry ownerRegistry = registryWithNamedSource("owner");
+        ServiceRegistry globalRegistry = registryWithNamedSource("global");
+
+        try {
+            System.setProperty(profileProperty, "missing-owner-profile");
+            GlobalServiceRegistry.registry(globalRegistry);
+
+            Config metaConfig = new MetaConfigFactory(ownerRegistry)
+                    .services()
+                    .getFirst()
+                    .get()
+                    .metaConfiguration();
+            List<String> sourceTypes = metaConfig.get("sources")
+                    .asNodeList()
+                    .orElseThrow()
+                    .stream()
+                    .map(source -> source.get("type").asString().orElseThrow())
+                    .toList();
+
+            assertThat(sourceTypes, hasItem("owner"));
+            assertThat(sourceTypes, not(hasItem("global")));
+        } finally {
+            if (previousProfile == null) {
+                System.clearProperty(profileProperty);
+            } else {
+                System.setProperty(profileProperty, previousProfile);
+            }
+            GlobalServiceRegistry.registry(previousRegistry);
+        }
+    }
+
+    private static ServiceRegistry registryWithNamedSource(String name) {
+        ServiceInfo serviceInfo = mock(ServiceInfo.class);
+        when(serviceInfo.qualifiers()).thenReturn(Set.of(Qualifier.createNamed(name)));
+        ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+        when(serviceRegistry.allServices(ConfigSource.class)).thenReturn(List.of(serviceInfo));
+        return serviceRegistry;
+    }
+}

--- a/config/config/src/test/java/io/helidon/config/ProvidedUtilStaticProviderSourceTest.java
+++ b/config/config/src/test/java/io/helidon/config/ProvidedUtilStaticProviderSourceTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.common.Weight;
+import io.helidon.service.registry.ExistingInstanceDescriptor;
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.ServiceDescriptor;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.testing.junit5.Testing;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+@Testing.Test
+@Isolated
+public class ProvidedUtilStaticProviderSourceTest {
+    @Test
+    void mergesServiceLoaderAndRegistryProvidersByEffectiveWeight() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .addServiceDescriptor(descriptor(
+                                                                                        new RegistryProvider(
+                                                                                                "registry-high",
+                                                                                                "registry-high"),
+                                                                                        400))
+                                                                                .addServiceDescriptor(descriptor(
+                                                                                        new RegistryProvider(
+                                                                                                "replaceable",
+                                                                                                "registry-replacement"),
+                                                                                        100))
+                                                                                .addServiceDescriptor(descriptor(
+                                                                                        new RegistryProvider(
+                                                                                                "registry-low",
+                                                                                                "registry-low"),
+                                                                                        50))
+                                                                                .build());
+        try {
+            GlobalServiceRegistry.registry(manager.registry());
+
+            List<OrderingService> services = ProvidedUtil.discoverServices(Config.empty(),
+                                                                            "services",
+                                                                            Optional.empty(),
+                                                                            OrderingProvider.class,
+                                                                            OrderingService.class,
+                                                                            true,
+                                                                            List.of());
+
+            assertThat(services.stream().map(OrderingService::source).toList(),
+                       contains("registry-high", "loader-high", "registry-replacement", "registry-low"));
+        } finally {
+            manager.shutdown();
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
+    private static ServiceDescriptor<?> descriptor(OrderingProvider provider, double weight) {
+        return ExistingInstanceDescriptor.create(provider, Set.of(OrderingProvider.class), weight);
+    }
+
+    public interface OrderingProvider extends ConfiguredProvider<OrderingService> {
+    }
+
+    private record OrderingService(String name, String type, String source) implements NamedService {
+    }
+
+    private abstract static class BaseProvider implements OrderingProvider {
+        private final String key;
+        private final String source;
+
+        private BaseProvider(String key, String source) {
+            this.key = key;
+            this.source = source;
+        }
+
+        @Override
+        public String configKey() {
+            return key;
+        }
+
+        @Override
+        public OrderingService create(Config config, String name) {
+            return new OrderingService(name, key, source);
+        }
+    }
+
+    @Weight(300)
+    public static final class LoaderHighProvider extends BaseProvider {
+        public LoaderHighProvider() {
+            super("loader-high", "loader-high");
+        }
+    }
+
+    @Weight(200)
+    public static final class LoaderReplaceableProvider extends BaseProvider {
+        public LoaderReplaceableProvider() {
+            super("replaceable", "loader-replaceable");
+        }
+    }
+
+    private static final class RegistryProvider extends BaseProvider {
+        private RegistryProvider(String key, String source) {
+            super(key, source);
+        }
+    }
+}

--- a/config/config/src/test/java/io/helidon/config/ProvidedUtilStaticProviderSourceTest.java
+++ b/config/config/src/test/java/io/helidon/config/ProvidedUtilStaticProviderSourceTest.java
@@ -54,6 +54,11 @@ public class ProvidedUtilStaticProviderSourceTest {
                                                                                         100))
                                                                                 .addServiceDescriptor(descriptor(
                                                                                         new RegistryProvider(
+                                                                                                "replaceable",
+                                                                                                "registry-lower-priority"),
+                                                                                        25))
+                                                                                .addServiceDescriptor(descriptor(
+                                                                                        new RegistryProvider(
                                                                                                 "registry-low",
                                                                                                 "registry-low"),
                                                                                         50))

--- a/config/config/src/test/java/io/helidon/config/ProvidedUtilTest.java
+++ b/config/config/src/test/java/io/helidon/config/ProvidedUtilTest.java
@@ -41,6 +41,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -122,6 +124,42 @@ public class ProvidedUtilTest {
 
         assertThat("Matched services", matchedServices.getFirst().nickname(), is(equalTo("higher")));
         assertThat(matchedServices, hasSize(1));
+    }
+
+    @Test
+    void testServiceRegistryPassedToProviderCreation() {
+        WeightedServiceProviderImpl provider = new WeightedServiceProviderImpl("registry");
+        ServiceRegistry registry = registry(provider);
+
+        ProvidedUtil.discoverServices(config,
+                                      "services",
+                                      Optional.of(registry),
+                                      WeightedServiceProvider.class,
+                                      WeightedServiceImpl.class,
+                                      false,
+                                      List.of());
+
+        assertThat(provider.serviceRegistry(), sameInstance(registry));
+    }
+
+    @Test
+    void testServiceLoaderUsesLegacyProviderCreation() {
+        WeightedServiceProviderImpl provider = new WeightedServiceProviderImpl("loader");
+        HelidonServiceLoader<WeightedServiceProvider> serviceLoader =
+                HelidonServiceLoader.builder(ServiceLoader.load(WeightedServiceProvider.class))
+                        .useSystemServiceLoader(false)
+                        .addService(provider, 1.0)
+                        .build();
+
+        ProvidedUtil.discoverServices(config,
+                                      "services",
+                                      serviceLoader,
+                                      WeightedServiceProvider.class,
+                                      WeightedServiceImpl.class,
+                                      false,
+                                      List.of());
+
+        assertThat(provider.serviceRegistry(), nullValue());
     }
 
     @Test
@@ -462,6 +500,7 @@ public class ProvidedUtilTest {
 
         private final String nickname;
         private int createCount;
+        private ServiceRegistry serviceRegistry;
 
         WeightedServiceProviderImpl() {
             nickname = "unknown";
@@ -482,8 +521,18 @@ public class ProvidedUtilTest {
             return new WeightedServiceImpl(config, name, nickname);
         }
 
+        @Override
+        public WeightedServiceImpl create(Config config, String name, ServiceRegistry serviceRegistry) {
+            this.serviceRegistry = serviceRegistry;
+            return create(config, name);
+        }
+
         int createCount() {
             return createCount;
+        }
+
+        ServiceRegistry serviceRegistry() {
+            return serviceRegistry;
         }
 
     }

--- a/config/config/src/test/resources/META-INF/services/io.helidon.config.ProvidedUtilStaticProviderSourceTest$OrderingProvider
+++ b/config/config/src/test/resources/META-INF/services/io.helidon.config.ProvidedUtilStaticProviderSourceTest$OrderingProvider
@@ -1,0 +1,2 @@
+io.helidon.config.ProvidedUtilStaticProviderSourceTest$LoaderHighProvider
+io.helidon.config.ProvidedUtilStaticProviderSourceTest$LoaderReplaceableProvider

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaRepositoryExecutorImpl.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaRepositoryExecutorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.data.jakarta.persistence;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.Map;
+import java.util.Optional;
 
 import io.helidon.common.Functions;
 import io.helidon.data.DataException;
@@ -27,7 +28,6 @@ import io.helidon.data.NoResultException;
 import io.helidon.data.NonUniqueResultException;
 import io.helidon.data.OptimisticLockException;
 import io.helidon.service.registry.Service;
-import io.helidon.service.registry.Services;
 import io.helidon.transaction.Tx;
 import io.helidon.transaction.spi.TxSupport;
 
@@ -47,13 +47,6 @@ class JpaRepositoryExecutorImpl implements JpaRepositoryExecutor {
 
     private static final Logger LOGGER = System.getLogger(JpaRepositoryExecutorImpl.class.getName());
 
-    // Execute persistence session task outside active transaction scope
-    // Transaction handling depends on current PersistenceUnitTransactionType
-    private static final Map<PersistenceUnitTransactionType, DataRunner> EXECUTORS = Map.of(
-            PersistenceUnitTransactionType.JTA,
-            new JtaDataRunner(),
-            PersistenceUnitTransactionType.RESOURCE_LOCAL,
-            new ResourceLocalDataRunner());
     // Execute persistence session task in active transaction scope
     private static final Map<PersistenceUnitTransactionType, DataRunner> TRANSACTION = Map.of(
             PersistenceUnitTransactionType.JTA,
@@ -64,10 +57,19 @@ class JpaRepositoryExecutorImpl implements JpaRepositoryExecutor {
     // Instance shared by all repository instances
     private final EntityManagerFactory factory;
     private final PersistenceUnitTransactionType transactionType;
+    // Execute persistence session task outside active transaction scope
+    // Transaction handling depends on current PersistenceUnitTransactionType
+    private final Map<PersistenceUnitTransactionType, DataRunner> executors;
 
     @Service.Inject
-    JpaRepositoryExecutorImpl(EntityManagerFactory factory) {
+    JpaRepositoryExecutorImpl(EntityManagerFactory factory, Optional<TxSupport> txSupport) {
         this.factory = factory;
+        TxSupport selectedTxSupport = txSupport.orElse(null);
+        this.executors = Map.of(
+                PersistenceUnitTransactionType.JTA,
+                new JtaDataRunner(selectedTxSupport),
+                PersistenceUnitTransactionType.RESOURCE_LOCAL,
+                new ResourceLocalDataRunner(selectedTxSupport));
         if (factory.getProperties().containsKey(TRANSACTION_TYPE)) {
             this.transactionType = (PersistenceUnitTransactionType) factory.getProperties().get(TRANSACTION_TYPE);
         } else {
@@ -102,7 +104,7 @@ class JpaRepositoryExecutorImpl implements JpaRepositoryExecutor {
             if (LOGGER.isLoggable(Level.DEBUG)) {
                 LOGGER.log(Level.DEBUG, String.format("Running standalone task [%x]", this.hashCode()));
             }
-            return EXECUTORS.get(transactionType)
+            return executors.get(transactionType)
                     .call(this, task);
         }
     }
@@ -124,7 +126,7 @@ class JpaRepositoryExecutorImpl implements JpaRepositoryExecutor {
             if (LOGGER.isLoggable(Level.DEBUG)) {
                 LOGGER.log(Level.DEBUG, String.format("Running standalone task [%x]", this.hashCode()));
             }
-            EXECUTORS.get(transactionType)
+            executors.get(transactionType)
                     .run(this, task);
         }
     }
@@ -218,9 +220,9 @@ class JpaRepositoryExecutorImpl implements JpaRepositoryExecutor {
 
         private final TxSupport txSupport;
 
-        JtaDataRunner() {
+        JtaDataRunner(TxSupport txSupport) {
             super();
-            txSupport = initJtaTxSupport();
+            this.txSupport = txSupport;
         }
 
         @Override
@@ -246,10 +248,6 @@ class JpaRepositoryExecutorImpl implements JpaRepositoryExecutor {
                 run(executor, em, task);
                 return null;
             });
-        }
-
-        private static TxSupport initJtaTxSupport() {
-            return Services.first(TxSupport.class).orElse(null);
         }
 
         // PERF: This check is being run with every task execution but doing it in constructor will crash
@@ -269,9 +267,9 @@ class JpaRepositoryExecutorImpl implements JpaRepositoryExecutor {
 
         private final TxSupport txSupport;
 
-        ResourceLocalDataRunner() {
+        ResourceLocalDataRunner(TxSupport txSupport) {
             super();
-            txSupport = initJtaTxSupport();
+            this.txSupport = txSupport;
         }
 
         @Override
@@ -295,10 +293,6 @@ class JpaRepositoryExecutorImpl implements JpaRepositoryExecutor {
                 run(executor, em, task);
                 return null;
             });
-        }
-
-        private static TxSupport initJtaTxSupport() {
-            return Services.first(TxSupport.class).orElse(null);
         }
 
         // PERF: This check is being run with every task execution but doing it in constructor will crash

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/grpc/client/GrpcClientExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/grpc/client/GrpcClientExtension.java
@@ -61,6 +61,7 @@ import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.GRPC_PR
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.GRPC_SERVICE;
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.GRPC_SERVICE_CLIENT;
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.GRPC_SERVICE_DESCRIPTOR;
+import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.METER_REGISTRY_SUPPLIER;
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.PROTO_FILE_DESCRIPTOR;
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.PROTO_MESSAGE_DESCRIPTOR;
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.RPC_CLIENT_ENDPOINT;
@@ -167,6 +168,9 @@ class GrpcClientExtension implements RegistryCodegenExtension {
                                               .addParameter(config -> config
                                                       .name("config")
                                                       .type(CONFIG))
+                                              .addParameter(meterRegistry -> meterRegistry
+                                                      .name("meterRegistry")
+                                                      .type(METER_REGISTRY_SUPPLIER))
                                               .addParameter(registryClient -> registryClient
                                                       .name(endpoint.clientName().isPresent()
                                                                     ? "registryClient"
@@ -506,6 +510,11 @@ class GrpcClientExtension implements RegistryCodegenExtension {
                 .addContentLine("if (declarative__clientConfig.exists()) {")
                 .increaseContentPadding()
                 .addContentLine("declarative__clientBuilder.config(declarative__clientConfig);")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .addContentLine("if (declarative__clientBuilder.enableMetrics()) {")
+                .increaseContentPadding()
+                .addContentLine("declarative__clientBuilder.meterRegistry(meterRegistry.get());")
                 .decreaseContentPadding()
                 .addContentLine("}")
                 .addContentLine("declarative__clientBuilder.baseUri(uri);")

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/grpc/client/GrpcClientExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/grpc/client/GrpcClientExtension.java
@@ -67,6 +67,7 @@ import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.PROTO_M
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.RPC_CLIENT_ENDPOINT;
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.RPC_CLIENT_QUALIFIER_INSTANCE;
 import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.SERVICE_INSTANCE;
+import static io.helidon.declarative.codegen.grpc.client.GrpcClientTypes.SERVICE_REGISTRY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_NAMED;
 import static java.util.function.Predicate.not;
 
@@ -168,6 +169,9 @@ class GrpcClientExtension implements RegistryCodegenExtension {
                                               .addParameter(config -> config
                                                       .name("config")
                                                       .type(CONFIG))
+                                              .addParameter(serviceRegistry -> serviceRegistry
+                                                      .name("serviceRegistry")
+                                                      .type(SERVICE_REGISTRY))
                                               .addParameter(meterRegistry -> meterRegistry
                                                       .name("meterRegistry")
                                                       .type(METER_REGISTRY_SUPPLIER))
@@ -506,7 +510,10 @@ class GrpcClientExtension implements RegistryCodegenExtension {
                 .update(it -> DelcarativeConfigSupport.assignResolveExpression(it, "config", "uri", endpoint.uri()))
                 .addContent("var declarative__clientBuilder = ")
                 .addContent(GRPC_CLIENT)
-                .addContentLine(".builder();")
+                .addContentLine(".builder()")
+                .increaseContentPadding()
+                .addContentLine(".serviceRegistry(serviceRegistry);")
+                .decreaseContentPadding()
                 .addContentLine("if (declarative__clientConfig.exists()) {")
                 .increaseContentPadding()
                 .addContentLine("declarative__clientBuilder.config(declarative__clientConfig);")

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/grpc/client/GrpcClientTypes.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/grpc/client/GrpcClientTypes.java
@@ -38,6 +38,7 @@ final class GrpcClientTypes {
     static final TypeName GRPC_PROTO_DESCRIPTOR = TypeName.create("io.helidon.grpc.api.Grpc.ProtoDescriptor");
     static final TypeName GRPC_SERVICE = TypeName.create("io.helidon.grpc.api.Grpc.GrpcService");
     static final TypeName SERVICE_INSTANCE = TypeName.create("io.helidon.service.registry.ServiceInstance");
+    static final TypeName SERVICE_REGISTRY = TypeName.create("io.helidon.service.registry.ServiceRegistry");
     static final TypeName PROTO_FILE_DESCRIPTOR = TypeName.create("com.google.protobuf.Descriptors.FileDescriptor");
     static final TypeName PROTO_MESSAGE_DESCRIPTOR = TypeName.create("com.google.protobuf.Descriptors.Descriptor");
 

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/grpc/client/GrpcClientTypes.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/grpc/client/GrpcClientTypes.java
@@ -18,9 +18,15 @@ package io.helidon.declarative.codegen.grpc.client;
 
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
 
 final class GrpcClientTypes {
     static final TypeName GRPC_CLIENT = TypeName.create("io.helidon.webclient.grpc.GrpcClient");
+    static final TypeName METER_REGISTRY = TypeName.create("io.helidon.metrics.api.MeterRegistry");
+    static final TypeName METER_REGISTRY_SUPPLIER = TypeName.builder()
+            .from(TypeNames.SUPPLIER)
+            .addTypeArgument(METER_REGISTRY)
+            .build();
     static final TypeName RPC_CLIENT_ENDPOINT = TypeName.create("io.helidon.webclient.grpc.RpcClient.Endpoint");
     static final TypeName RPC_CLIENT_QUALIFIER = TypeName.create("io.helidon.webclient.grpc.RpcClient.Client");
     static final TypeName GRPC_CLIENT_METHOD_DESCRIPTOR =

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/grpc/client/GrpcClientCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/grpc/client/GrpcClientCodegenTest.java
@@ -36,6 +36,7 @@ import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.service.registry.Dependency;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceDescriptor;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.webclient.api.HttpClientConfig;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.grpc.GrpcClient;
@@ -88,6 +89,7 @@ class GrpcClientCodegenTest {
             RpcClient.class,
             Service.class,
             ServiceDescriptor.class,
+            ServiceRegistry.class,
             StreamObserver.class,
             Tls.class,
             WebClient.class
@@ -225,6 +227,12 @@ class GrpcClientCodegenTest {
         assertThat(client, containsString(".noneMatch(qualifier -> qualifier.typeName().equals(Service.Named.TYPE))"));
         assertThat(client, containsString(".map(ServiceInstance::get)"));
         assertThat(client, containsString("Supplier<MeterRegistry> meterRegistry"));
+        assertThat(client, containsString("ServiceRegistry serviceRegistry"));
+        assertThat(client, containsString(".serviceRegistry(serviceRegistry);"));
+        assertThat("service registry is assigned only to the fallback client",
+                   client.indexOf(".serviceRegistry(serviceRegistry)")
+                           > client.indexOf("if (declarative__client == null)"),
+                   is(true));
         assertThat(client, containsString("declarative__clientBuilder.config(declarative__clientConfig);"));
         assertThat(client, containsString("if (declarative__clientBuilder.enableMetrics())"));
         assertThat(client, containsString("declarative__clientBuilder.meterRegistry(meterRegistry.get());"));

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/grpc/client/GrpcClientCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/grpc/client/GrpcClientCodegenTest.java
@@ -32,6 +32,7 @@ import io.helidon.common.types.Annotation;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigBuilderSupport;
 import io.helidon.grpc.api.Grpc;
+import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.service.registry.Dependency;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceDescriptor;
@@ -77,6 +78,7 @@ class GrpcClientCodegenTest {
             GrpcServiceClient.class,
             GrpcServiceDescriptor.class,
             HttpClientConfig.class,
+            MeterRegistry.class,
             MethodDescriptor.class,
             Descriptors.Descriptor.class,
             Descriptors.FileDescriptor.class,
@@ -222,7 +224,14 @@ class GrpcClientCodegenTest {
         assertThat(client, containsString("declarative__client = registryClients.get().stream()"));
         assertThat(client, containsString(".noneMatch(qualifier -> qualifier.typeName().equals(Service.Named.TYPE))"));
         assertThat(client, containsString(".map(ServiceInstance::get)"));
+        assertThat(client, containsString("Supplier<MeterRegistry> meterRegistry"));
         assertThat(client, containsString("declarative__clientBuilder.config(declarative__clientConfig);"));
+        assertThat(client, containsString("if (declarative__clientBuilder.enableMetrics())"));
+        assertThat(client, containsString("declarative__clientBuilder.meterRegistry(meterRegistry.get());"));
+        assertThat("meter registry is resolved only for the fallback client",
+                   client.indexOf("declarative__clientBuilder.meterRegistry(meterRegistry.get())")
+                           > client.indexOf("if (declarative__client == null)"),
+                   is(true));
         assertThat(client, containsString("declarative__clientBuilder.baseUri(uri);"));
         assertThat(client, not(containsString("uri.regionMatches(true, 0, \"http://\", 0, \"http://\".length())")));
         assertThat(client, not(containsString("declarative__clientBuilder.tls(it -> it.enabled(false));")));

--- a/declarative/tests/cors/src/main/java/module-info.java
+++ b/declarative/tests/cors/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module io.helidon.declarative.tests.cors {
     // for generated code
     requires io.helidon.config.yaml;
     requires io.helidon.metrics.api;
-    requires io.helidon.webclient.api;
+    requires io.helidon.webclient;
     requires io.helidon.common;
 
     exports io.helidon.declarative.tests.cors;

--- a/declarative/tests/graphql/src/main/java/module-info.java
+++ b/declarative/tests/graphql/src/main/java/module-info.java
@@ -34,7 +34,7 @@ module io.helidon.declarative.tests.graphql {
     requires io.helidon.service.registry;
     requires io.helidon.tracing;
     requires io.helidon.validation;
-    requires io.helidon.webclient.api;
+    requires io.helidon.webclient;
     requires io.helidon.webserver;
     requires io.helidon.webserver.concurrency.limits;
     requires io.helidon.webserver.context;

--- a/declarative/tests/http/src/main/java/module-info.java
+++ b/declarative/tests/http/src/main/java/module-info.java
@@ -24,7 +24,7 @@ module io.helidon.declarative.tests.http {
     requires io.helidon.logging.common;
     requires io.helidon.metrics.systemmeters;
     requires io.helidon.scheduling;
-    requires io.helidon.webclient.api;
+    requires io.helidon.webclient;
     requires io.helidon.faulttolerance;
     requires io.helidon.metrics.api;
     requires io.helidon.json.binding;
@@ -38,10 +38,12 @@ module io.helidon.declarative.tests.http {
     requires io.helidon.security.annotations;
 
     // required for generated binding
+    requires io.helidon.health.checks;
+    requires io.helidon.metrics.providers.micrometer;
     requires io.helidon.webserver.context;
     requires io.helidon.webserver.observe;
+    requires io.helidon.webserver.observe.health;
     requires io.helidon.webserver.observe.metrics;
-    requires io.helidon.metrics.providers.micrometer;
 
     exports io.helidon.declarative.tests.http;
 }

--- a/declarative/tests/openapi/src/main/java/module-info.java
+++ b/declarative/tests/openapi/src/main/java/module-info.java
@@ -27,7 +27,7 @@ module io.helidon.declarative.tests.openapi {
     requires io.helidon.openapi.v32;
     requires io.helidon.service.registry;
     requires io.helidon.webserver;
-    requires io.helidon.webclient.api;
+    requires io.helidon.webclient;
 
     // required for generated binding
     requires io.helidon.webserver.context;

--- a/declarative/tests/websocket/pom.xml
+++ b/declarative/tests/websocket/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>
-            <artifactId>helidon-webclient-http1</artifactId>
+            <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>

--- a/declarative/tests/websocket/pom.xml
+++ b/declarative/tests/websocket/pom.xml
@@ -43,6 +43,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-http1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-websocket</artifactId>
         </dependency>
         <dependency>

--- a/declarative/tests/websocket/src/main/java/module-info.java
+++ b/declarative/tests/websocket/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module io.helidon.declarative.tests.websocket {
     requires io.helidon.http;
 
     requires io.helidon.websocket;
+    requires io.helidon.webclient.http1;
     requires io.helidon.webclient.websocket;
     requires io.helidon.config;
     requires io.helidon.webclient.api;

--- a/declarative/tests/websocket/src/main/java/module-info.java
+++ b/declarative/tests/websocket/src/main/java/module-info.java
@@ -29,10 +29,9 @@ module io.helidon.declarative.tests.websocket {
     requires io.helidon.http;
 
     requires io.helidon.websocket;
-    requires io.helidon.webclient.http1;
+    requires io.helidon.webclient;
     requires io.helidon.webclient.websocket;
     requires io.helidon.config;
-    requires io.helidon.webclient.api;
 
     exports io.helidon.declarative.tests.websocket;
 }

--- a/docs/config/io.helidon.webserver.observe.health.HealthObserver.md
+++ b/docs/config/io.helidon.webserver.observe.health.HealthObserver.md
@@ -62,7 +62,7 @@ Configuration of Health observer
 <td>
 <code>true</code>
 </td>
-<td>Whether to use services discovered by <code>java.<wbr>util.<wbr>Service<wbr>Loader</code></td>
+<td>Whether to use discovered health-check services</td>
 </tr>
 <tr>
 <td>

--- a/docs/modules/config/config-profiles.md
+++ b/docs/modules/config/config-profiles.md
@@ -388,7 +388,9 @@ using the owning service registry. The requested type can be provided by a
 built-in source types remain available. An entry configured with
 `multi-source: true` requires a `ConfigSourceProvider`. The same resolution
 applies when an explicit registry is configured using
-`Config.Builder.serviceRegistry` in the Helidon imperative model.
+`Config.Builder.serviceRegistry` in the Helidon imperative model. Invoke
+`serviceRegistry(registry)` before `config(metaConfig)`, because applying the
+meta-configuration resolves its declared sources.
 
 ### Designing a config source that integrates with profiles and default config
 

--- a/docs/modules/config/config-profiles.md
+++ b/docs/modules/config/config-profiles.md
@@ -382,6 +382,12 @@ The interaction is as follows:
 4.  You can also define a `ConfigSourceProvider` as a registry service (and this
     will work the same as in Helidon imperative code)
 
+For a registry-managed `Config`, each source listed in the profile is resolved
+using the owning service registry. The requested type can be provided by a
+`ConfigSourceProvider` or by a named `ConfigSource`; built-in source types remain
+available. The same resolution applies when an explicit registry is configured
+using `Config.Builder.serviceRegistry` in the Helidon imperative model.
+
 ### Designing a config source that integrates with profiles and default config
 
 Note that this approach will only work if you get a `Config` instance from the

--- a/docs/modules/config/config-profiles.md
+++ b/docs/modules/config/config-profiles.md
@@ -384,9 +384,11 @@ The interaction is as follows:
 
 For a registry-managed `Config`, each source listed in the profile is resolved
 using the owning service registry. The requested type can be provided by a
-`ConfigSourceProvider` or by a named `ConfigSource`; built-in source types remain
-available. The same resolution applies when an explicit registry is configured
-using `Config.Builder.serviceRegistry` in the Helidon imperative model.
+`ConfigSourceProvider` or, for a single-source entry, by a named `ConfigSource`;
+built-in source types remain available. An entry configured with
+`multi-source: true` requires a `ConfigSourceProvider`. The same resolution
+applies when an explicit registry is configured using
+`Config.Builder.serviceRegistry` in the Helidon imperative model.
 
 ### Designing a config source that integrates with profiles and default config
 

--- a/docs/modules/config/extensions.md
+++ b/docs/modules/config/extensions.md
@@ -100,9 +100,10 @@ Config sources listed in meta-configuration or a config profile are resolved
 from the selected service registry. A registry-managed `Config` uses its owning
 registry, and an imperative builder can select a registry using
 `Config.Builder.serviceRegistry`. The registry can provide a
-`ConfigSourceProvider` or a named `ConfigSource`. Existing Java service loader
-providers remain compatible when service loader discovery is enabled for the
-registry.
+`ConfigSourceProvider` or, for a single-source entry, a named `ConfigSource`. An
+entry configured with `multi-source: true` requires a `ConfigSourceProvider`.
+Existing Java service loader providers remain compatible when service loader
+discovery is enabled for the registry.
 
 For example for config sources, the interface defines the following methods
 (only subset shown):

--- a/docs/modules/config/extensions.md
+++ b/docs/modules/config/extensions.md
@@ -63,7 +63,7 @@ sections below.
 You can configure a custom extension in two ways:
 
 1.  Manual configuration with builder
-2.  Automatic configuration using a Java service loader
+2.  Automatic discovery
 
 ### Manual Configuration with Builder
 
@@ -83,20 +83,29 @@ Config config = Config.builder()
         .build();
 ```
 
-### Automatic Configuration Using a Service Loader
+### Automatic Discovery
 
-The following extensions are loaded using a service loader for any configuration
-instance, and do not require an explicit setup:
+For a directly constructed `Config`, the following extensions are loaded using a
+service loader and do not require an explicit setup:
 
 - `ConfigParser` - each config parser on the classpath that implements
   `ConfigParserProvider` as a Java service loader service
 - `ConfigFilter` - each filter on the classpath that implements `ConfigFilter`
   as a Java service loader service
 
-Other extensions are only used from Java service loader when you use config
-profiles. Mapping is done through the type configured in config profile, and the
-type defined by the extension provider interface. For example for config
-sources, the interface defines the following methods (only subset shown):
+Other extensions are selected using the type configured in a config profile and
+the types defined by the extension provider interface.
+
+Config sources listed in meta-configuration or a config profile are resolved
+from the selected service registry. A registry-managed `Config` uses its owning
+registry, and an imperative builder can select a registry using
+`Config.Builder.serviceRegistry`. The registry can provide a
+`ConfigSourceProvider` or a named `ConfigSource`. Existing Java service loader
+providers remain compatible when service loader discovery is enabled for the
+registry.
+
+For example for config sources, the interface defines the following methods
+(only subset shown):
 
 ```java
 boolean supports(String type);
@@ -113,12 +122,11 @@ sources:
       my-config: "configuration"
 ```
 
-The config system would iterate through all `ConfigSourceProvider`
-implementations found through Java `ServiceLoader` based on their
-[weight][weight]. First provider that returns `true` when `supports("my-type")`
-is called would be used, and an instance of a `ConfigSource` created using
-`create("my-type", config)`, where `config` is located on the node of
-`properties` from config profile.
+The config system iterates through all `ConfigSourceProvider` implementations in
+the selected registry based on their [weight][weight]. The first provider that
+returns `true` when `supports("my-type")` is called is used, and an instance of a
+`ConfigSource` is created using `create("my-type", config)`, where `config` is
+located on the node of `properties` from the config profile.
 
 ### About Priority
 

--- a/docs/modules/config/extensions.md
+++ b/docs/modules/config/extensions.md
@@ -99,11 +99,13 @@ the types defined by the extension provider interface.
 Config sources listed in meta-configuration or a config profile are resolved
 from the selected service registry. A registry-managed `Config` uses its owning
 registry, and an imperative builder can select a registry using
-`Config.Builder.serviceRegistry`. The registry can provide a
-`ConfigSourceProvider` or, for a single-source entry, a named `ConfigSource`. An
-entry configured with `multi-source: true` requires a `ConfigSourceProvider`.
-Existing Java service loader providers remain compatible when service loader
-discovery is enabled for the registry.
+`Config.Builder.serviceRegistry`. Invoke `serviceRegistry(registry)` before
+`config(metaConfig)`, because applying the meta-configuration resolves its
+declared sources. The registry can provide a `ConfigSourceProvider` or, for a
+single-source entry, a named `ConfigSource`. An entry configured with
+`multi-source: true` requires a `ConfigSourceProvider`. Existing Java service
+loader providers remain compatible when service loader discovery is enabled for
+the registry.
 
 For example for config sources, the interface defines the following methods
 (only subset shown):

--- a/docs/modules/observability.md
+++ b/docs/modules/observability.md
@@ -77,9 +77,22 @@ code.
 
 ### Discovery
 
-`ObserveProvider` instances are discovered using `ServiceLoader`. In case an
-explicit `Observer` is registered with the same `type` as a provider, the
-provider will not be used (so we do not duplicate services).
+When an application is bootstrapped using `ServiceRegistryManager`, the observe
+feature and `ObserveProvider` instances are discovered from the owning service
+registry. Providers loaded using `ServiceLoader` are bridged into the registry
+when service loader discovery is enabled, which preserves compatibility with
+existing providers.
+
+When an `ObserveFeature` is built directly, `ObserveProvider` instances are
+discovered using `ServiceLoader`. In this case, an explicitly configured
+`Observer` with the same `type` as a provider takes precedence so the observer
+is not duplicated.
+
+For fully manual registry setup, set `server.features-discover-services` to
+`false` to disable automatic server feature discovery, including the observe
+feature. Set `server.features.observe.observers-discover-services` to `false`
+to disable automatic observer discovery. The application can then register the
+`ObserveFeature` and its `Observer` instances explicitly.
 
 ### Feature Weight and Endpoint Conflicts
 

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -312,6 +312,52 @@ WebClient provides three DNS resolver implementations out of the box:
 See [Configuration options][io-helidon-webcl].
 <!--/include-->
 
+### Registry-managed WebClients
+
+The service registry provides a default `WebClient` even when no clients are
+configured. The unqualified `WebClient` service and the client named `@default`
+refer to the same instance.
+
+Configure the default client and additional named clients under the `clients`
+root:
+
+```yaml [application.yaml]
+clients:
+  "@default":
+    base-uri: "https://default.example"
+  inventory:
+    base-uri: "https://inventory.example"
+```
+
+Inject the default client without a qualifier and named clients using
+`@Service.Named`:
+
+```java
+@Service.Singleton
+class ClientConsumer {
+    private final WebClient defaultClient;
+    private final WebClient inventoryClient;
+
+    @Service.Inject
+    ClientConsumer(WebClient defaultClient,
+                   @Service.Named("inventory") WebClient inventoryClient) {
+        this.defaultClient = defaultClient;
+        this.inventoryClient = inventoryClient;
+    }
+}
+```
+
+The same clients can be obtained programmatically:
+
+```java
+WebClient defaultClient = serviceRegistry.get(WebClient.class);
+WebClient inventoryClient = serviceRegistry.getNamed(WebClient.class, "inventory");
+```
+
+The `clients` root defines registry-managed WebClient instances. The singular
+`client` root used in the examples below is passed explicitly to a WebClient
+builder and does not define registry services.
+
 ## Protocol Configuration
 
 Protocol specific configuration can be set using the `protocol-configs`

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -312,7 +312,7 @@ WebClient provides three DNS resolver implementations out of the box:
 See [Configuration options][io-helidon-webcl].
 <!--/include-->
 
-### Registry-managed WebClients
+## Registry-managed WebClients
 
 The service registry provides a default `WebClient` even when no clients are
 configured. The unqualified `WebClient` service and the client named `@default`

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
@@ -36,6 +36,7 @@ import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 
 @Service.PerInstance(BulkheadConfigBlueprint.class)
 class BulkheadImpl implements Bulkhead {
@@ -56,9 +57,21 @@ class BulkheadImpl implements Bulkhead {
     private Counter callsCounterMetric;
     private Timer waitingDurationMetric;
 
-    @Service.Inject
     BulkheadImpl(BulkheadConfig config,
                  Supplier<MeterRegistry> meterRegistry) {
+        this(config, meterRegistry, MetricsUtils.defaultEnabled());
+    }
+
+    @Service.Inject
+    BulkheadImpl(BulkheadConfig config,
+                 Supplier<MeterRegistry> meterRegistry,
+                 ServiceRegistry serviceRegistry) {
+        this(config, meterRegistry, MetricsUtils.defaultEnabled(serviceRegistry));
+    }
+
+    private BulkheadImpl(BulkheadConfig config,
+                         Supplier<MeterRegistry> meterRegistry,
+                         boolean metricsDefaultEnabled) {
         this.inProgress = new Semaphore(config.limit(), true);
         this.name = config.name().orElseGet(() -> "bulkhead-" + System.identityHashCode(config));
         this.listeners = config.queueListeners();
@@ -68,7 +81,7 @@ class BulkheadImpl implements Bulkhead {
         this.inProgressLock = new ReentrantLock(true);
         this.config = config;
 
-        this.metricsEnabled = config.enableMetrics() || MetricsUtils.defaultEnabled();
+        this.metricsEnabled = config.enableMetrics() || metricsDefaultEnabled;
         if (metricsEnabled) {
             var mr = meterRegistry.get();
             var mf = mr.metricsFactory();

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
@@ -27,6 +27,7 @@ import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Tag;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 
 @Service.PerInstance(CircuitBreakerConfigBlueprint.class)
 class CircuitBreakerImpl implements CircuitBreaker {
@@ -57,9 +58,21 @@ class CircuitBreakerImpl implements CircuitBreaker {
     private Counter callsCounterMetric;
     private Counter openedCounterMetric;
 
-    @Service.Inject
     CircuitBreakerImpl(CircuitBreakerConfig config,
                        Supplier<MeterRegistry> meterRegistry) {
+        this(config, meterRegistry, MetricsUtils.defaultEnabled());
+    }
+
+    @Service.Inject
+    CircuitBreakerImpl(CircuitBreakerConfig config,
+                       Supplier<MeterRegistry> meterRegistry,
+                       ServiceRegistry serviceRegistry) {
+        this(config, meterRegistry, MetricsUtils.defaultEnabled(serviceRegistry));
+    }
+
+    private CircuitBreakerImpl(CircuitBreakerConfig config,
+                               Supplier<MeterRegistry> meterRegistry,
+                               boolean metricsDefaultEnabled) {
         this.delayMillis = config.delay().toMillis();
         this.successThreshold = config.successThreshold();
         this.results = new ResultWindow(config.volume(), config.errorRatio());
@@ -68,7 +81,7 @@ class CircuitBreakerImpl implements CircuitBreaker {
         this.name = config.name().orElseGet(() -> "circuit-breaker-" + System.identityHashCode(config));
         this.config = config;
 
-        this.metricsEnabled = config.enableMetrics() || MetricsUtils.defaultEnabled();
+        this.metricsEnabled = config.enableMetrics() || metricsDefaultEnabled;
         if (metricsEnabled) {
             var mr = meterRegistry.get();
             var mf = mr.metricsFactory();

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -26,6 +26,7 @@ import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.ServiceRegistry;
 
 import static io.helidon.faulttolerance.FaultTolerance.FT_METRICS_DEFAULT_ENABLED;
 import static io.helidon.metrics.api.Meter.Scope.VENDOR;
@@ -47,7 +48,11 @@ class MetricsUtils {
             return false;
         }
 
-        return GlobalServiceRegistry.registry()
+        return defaultEnabled(GlobalServiceRegistry.registry());
+    }
+
+    static boolean defaultEnabled(ServiceRegistry serviceRegistry) {
+        return serviceRegistry
                 .firstActive(Config.class)
                 .map(config -> config.get(FT_METRICS_DEFAULT_ENABLED)
                         .asBoolean()

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -30,6 +30,7 @@ import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Tag;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 
 class RetryImpl implements Retry {
     private final ErrorChecker errorChecker;
@@ -43,16 +44,28 @@ class RetryImpl implements Retry {
     private Counter callsCounterMetric;
     private Counter retryCounterMetric;
 
-    @Service.Inject
     RetryImpl(RetryConfig retryConfig,
               Supplier<MeterRegistry> meterRegistry) {
+        this(retryConfig, meterRegistry, MetricsUtils.defaultEnabled());
+    }
+
+    @Service.Inject
+    RetryImpl(RetryConfig retryConfig,
+              Supplier<MeterRegistry> meterRegistry,
+              ServiceRegistry serviceRegistry) {
+        this(retryConfig, meterRegistry, MetricsUtils.defaultEnabled(serviceRegistry));
+    }
+
+    private RetryImpl(RetryConfig retryConfig,
+                      Supplier<MeterRegistry> meterRegistry,
+                      boolean metricsDefaultEnabled) {
         this.name = retryConfig.name().orElseGet(() -> "retry-" + System.identityHashCode(retryConfig));
         this.errorChecker = ErrorChecker.create(retryConfig.skipOn(), retryConfig.applyOn());
         this.maxTimeNanos = retryConfig.overallTimeout().toNanos();
         this.retryPolicy = retryConfig.retryPolicy().orElseThrow();
         this.retryConfig = retryConfig;
 
-        this.metricsEnabled = retryConfig.enableMetrics() || MetricsUtils.defaultEnabled();
+        this.metricsEnabled = retryConfig.enableMetrics() || metricsDefaultEnabled;
         if (metricsEnabled) {
             var mr = meterRegistry.get();
             var mf = mr.metricsFactory();

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutImpl.java
@@ -29,6 +29,7 @@ import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 
 @Service.PerInstance(TimeoutConfigBlueprint.class)
 class TimeoutImpl implements Timeout {
@@ -44,16 +45,28 @@ class TimeoutImpl implements Timeout {
     private Counter callsCounterMetric;
     private Timer executionDurationMetric;
 
-    @Service.Inject
     TimeoutImpl(TimeoutConfig config,
                 Supplier<MeterRegistry> meterRegistry) {
+        this(config, meterRegistry, MetricsUtils.defaultEnabled());
+    }
+
+    @Service.Inject
+    TimeoutImpl(TimeoutConfig config,
+                Supplier<MeterRegistry> meterRegistry,
+                ServiceRegistry serviceRegistry) {
+        this(config, meterRegistry, MetricsUtils.defaultEnabled(serviceRegistry));
+    }
+
+    private TimeoutImpl(TimeoutConfig config,
+                        Supplier<MeterRegistry> meterRegistry,
+                        boolean metricsDefaultEnabled) {
         this.timeoutMillis = config.timeout().toMillis();
         this.executor = config.executor().orElseGet(FaultTolerance.executor());
         this.currentThread = config.currentThread();
         this.name = config.name().orElseGet(() -> "timeout-" + System.identityHashCode(config));
         this.config = config;
 
-        this.metricsEnabled = config.enableMetrics() || MetricsUtils.defaultEnabled();
+        this.metricsEnabled = config.enableMetrics() || metricsDefaultEnabled;
         if (metricsEnabled) {
             var mr = meterRegistry.get();
             var mf = mr.metricsFactory();

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsExplicitConfigTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsExplicitConfigTest.java
@@ -17,12 +17,16 @@
 package io.helidon.faulttolerance;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
 
@@ -61,5 +65,30 @@ class MetricsExplicitConfigTest {
                                                     Retry.FT_RETRY_CALLS_TOTAL,
                                                     MetricsUtils.tag(metricsFactory, "name", retry.name()));
         assertThat(callsCounter.count(), is(1L));
+    }
+
+    @Test
+    void managedImplementationsUseOwningConfig() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .discoverServices(false)
+                                                                                .putContractInstance(Config.class,
+                                                                                                     Config.empty())
+                                                                                .build());
+        try {
+            AtomicBoolean meterRegistryResolved = new AtomicBoolean();
+            Supplier<MeterRegistry> meterRegistrySupplier = () -> {
+                meterRegistryResolved.set(true);
+                return meterRegistry;
+            };
+
+            new BulkheadImpl(BulkheadConfig.builder().buildPrototype(), meterRegistrySupplier, manager.registry());
+            new CircuitBreakerImpl(CircuitBreakerConfig.builder().buildPrototype(), meterRegistrySupplier, manager.registry());
+            new RetryImpl(RetryConfig.builder().buildPrototype(), meterRegistrySupplier, manager.registry());
+            new TimeoutImpl(TimeoutConfig.builder().buildPrototype(), meterRegistrySupplier, manager.registry());
+
+            assertThat(meterRegistryResolved.get(), is(false));
+        } finally {
+            manager.shutdown();
+        }
     }
 }

--- a/health/health/src/main/resources/META-INF/helidon/io.helidon.health/service.loader
+++ b/health/health/src/main/resources/META-INF/helidon/io.helidon.health/service.loader
@@ -1,0 +1,2 @@
+# Java ServiceLoader contracts exposed through the Helidon service registry
+io.helidon.health.spi.HealthCheckProvider

--- a/health/health/src/main/resources/META-INF/helidon/manifest
+++ b/health/health/src/main/resources/META-INF/helidon/manifest
@@ -1,0 +1,2 @@
+#HELIDON MANIFEST#
+META-INF/helidon/io.helidon.health/service.loader

--- a/security/security/src/main/java/io/helidon/security/OutboundSecurityClientBuilder.java
+++ b/security/security/src/main/java/io/helidon/security/OutboundSecurityClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.security;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import io.helidon.common.Builder;
@@ -26,9 +27,9 @@ import io.helidon.common.Builder;
 public class OutboundSecurityClientBuilder extends SecurityRequestBuilder<OutboundSecurityClientBuilder>
         implements Builder<OutboundSecurityClientBuilder, SecurityClient<OutboundSecurityResponse>> {
 
-    private final SecurityContextImpl context;
     private final Security security;
 
+    private SecurityContext context;
     private SecurityEnvironment outboundEnvironment;
     private EndpointConfig outboundEndpointConfig;
 
@@ -94,6 +95,19 @@ public class OutboundSecurityClientBuilder extends SecurityRequestBuilder<Outbou
      */
     public OutboundSecurityClientBuilder outboundEndpointConfig(Supplier<EndpointConfig> outboundEndpointConfig) {
         return outboundEndpointConfig(outboundEndpointConfig.get());
+    }
+
+    /**
+     * Configure the security context representing the request for which outbound security is invoked.
+     * The context provides the current user and service subjects to outbound security providers.
+     * Provider selection is still controlled by the {@link Security} instance that created this builder.
+     *
+     * @param context security context of the current request
+     * @return updated builder instance
+     */
+    public OutboundSecurityClientBuilder securityContext(SecurityContext context) {
+        this.context = Objects.requireNonNull(context);
+        return this;
     }
 
     /**

--- a/security/security/src/main/java/io/helidon/security/OutboundSecurityClientImpl.java
+++ b/security/security/src/main/java/io/helidon/security/OutboundSecurityClientImpl.java
@@ -60,16 +60,18 @@ final class OutboundSecurityClientImpl implements SecurityClient<OutboundSecurit
             OutboundSecurityResponse response = providerInstance.outboundSecurity(providerRequest, outboundEnv, outboundEpConfig);
             if (response.status().isSuccess()) {
                 //Audit success
-                context.audit(SecurityAuditEvent.success(AuditEvent.OUTBOUND_TYPE_PREFIX + ".outbound",
-                                                         "Provider %s. Request %s. Subject %s")
+                security.audit(context.id(),
+                               SecurityAuditEvent.success(AuditEvent.OUTBOUND_TYPE_PREFIX + ".outbound",
+                                                          "Provider %s. Request %s. Subject %s")
                                       .addParam(AuditEvent.AuditParam
                                                         .plain("provider", providerInstance.getClass().getName()))
                                       .addParam(AuditEvent.AuditParam.plain("request", this))
                                       .addParam(AuditEvent.AuditParam
                                                         .plain("subject", context.user().orElse(SecurityContext.ANONYMOUS))));
             } else {
-                context.audit(SecurityAuditEvent.failure(AuditEvent.OUTBOUND_TYPE_PREFIX + ".outbound",
-                                                         "Provider %s, Description %s, Request %s. Subject %s")
+                security.audit(context.id(),
+                               SecurityAuditEvent.failure(AuditEvent.OUTBOUND_TYPE_PREFIX + ".outbound",
+                                                          "Provider %s, Description %s, Request %s. Subject %s")
                                       .addParam(AuditEvent.AuditParam
                                                         .plain("provider", providerInstance.getClass().getName()))
                                       .addParam(AuditEvent.AuditParam.plain("request", this))
@@ -83,8 +85,9 @@ final class OutboundSecurityClientImpl implements SecurityClient<OutboundSecurit
 
             return response;
         } catch (Exception e) {
-            context.audit(SecurityAuditEvent.error(AuditEvent.OUTBOUND_TYPE_PREFIX + ".outbound",
-                                                   "Provider %s, Description %s, Request %s. Subject %s")
+            security.audit(context.id(),
+                           SecurityAuditEvent.error(AuditEvent.OUTBOUND_TYPE_PREFIX + ".outbound",
+                                                    "Provider %s, Description %s, Request %s. Subject %s")
                                   .addParam(AuditEvent.AuditParam.plain("provider", providerInstance.getClass().getName()))
                                   .addParam(AuditEvent.AuditParam.plain("request", this))
                                   .addParam(AuditEvent.AuditParam.plain("message", e.getMessage()))

--- a/security/security/src/main/java/io/helidon/security/OutboundSecurityClientImpl.java
+++ b/security/security/src/main/java/io/helidon/security/OutboundSecurityClientImpl.java
@@ -26,14 +26,14 @@ import io.helidon.security.spi.OutboundSecurityProvider;
  */
 final class OutboundSecurityClientImpl implements SecurityClient<OutboundSecurityResponse> {
     private final Security security;
-    private final SecurityContextImpl context;
+    private final SecurityContext context;
     private final String providerName;
     private final ProviderRequest providerRequest;
     private final SecurityEnvironment outboundEnv;
     private final EndpointConfig outboundEpConfig;
 
     OutboundSecurityClientImpl(Security security,
-                               SecurityContextImpl context,
+                               SecurityContext context,
                                SecurityRequest request,
                                String providerName,
                                SecurityEnvironment outboundEnvironment,

--- a/security/security/src/main/java/io/helidon/security/SecurityFactory.java
+++ b/security/security/src/main/java/io/helidon/security/SecurityFactory.java
@@ -21,13 +21,15 @@ import java.util.function.Supplier;
 import io.helidon.common.LazyValue;
 import io.helidon.config.Config;
 import io.helidon.service.registry.Service;
+import io.helidon.tracing.Tracer;
 
 @Service.Singleton
 class SecurityFactory implements Supplier<Security> {
     private final LazyValue<Security> delegate;
 
-    SecurityFactory(Config config) {
+    SecurityFactory(Config config, Tracer tracer) {
         this.delegate = LazyValue.create(() -> Security.builder()
+                .tracer(tracer)
                 .config(config.get("security"))
                 .build());
     }

--- a/security/security/src/main/java/io/helidon/security/SecurityFactory.java
+++ b/security/security/src/main/java/io/helidon/security/SecurityFactory.java
@@ -27,11 +27,16 @@ import io.helidon.tracing.Tracer;
 class SecurityFactory implements Supplier<Security> {
     private final LazyValue<Security> delegate;
 
-    SecurityFactory(Config config, Tracer tracer) {
-        this.delegate = LazyValue.create(() -> Security.builder()
-                .tracer(tracer)
-                .config(config.get("security"))
-                .build());
+    SecurityFactory(Config config, Supplier<Tracer> tracer) {
+        Config securityConfig = config.get("security");
+        this.delegate = LazyValue.create(() -> {
+            Security.Builder builder = Security.builder()
+                    .config(securityConfig);
+            if (securityConfig.get("tracing.enabled").asBoolean().orElse(true)) {
+                builder.tracer(tracer.get());
+            }
+            return builder.build();
+        });
     }
 
     @Override

--- a/security/security/src/test/java/io/helidon/security/SecurityTracingTest.java
+++ b/security/security/src/test/java/io/helidon/security/SecurityTracingTest.java
@@ -17,10 +17,17 @@
 package io.helidon.security;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.security.providers.ProviderForTesting;
+import io.helidon.service.registry.DependencyContext;
+import io.helidon.service.registry.InterceptionMetadata;
+import io.helidon.service.registry.ServiceDescriptor;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.service.registry.Services;
@@ -29,6 +36,7 @@ import io.helidon.tracing.Tracer;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -64,6 +72,26 @@ class SecurityTracingTest {
     }
 
     @Test
+    void disabledManagedSecurityDoesNotInstantiateTracer() {
+        AtomicBoolean tracerInstantiated = new AtomicBoolean();
+        Tracer tracer = mock(Tracer.class);
+        Config config = Config.just(ConfigSources.create(Map.of("security.tracing.enabled", "false")));
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class, config)
+                                                                                .addServiceDescriptor(new TracerDescriptor(tracer,
+                                                                                                                           tracerInstantiated))
+                                                                                .build());
+        try {
+            Security security = manager.registry().get(Security.class);
+
+            assertThat("Disabled security tracer", security.tracer().enabled(), is(false));
+            assertThat("Tracer instantiated", tracerInstantiated.get(), is(false));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     void defaultTracerComesFromServiceRegistry() {
         Tracer tracer = mock(Tracer.class);
         Services.set(Tracer.class, tracer);
@@ -86,5 +114,44 @@ class SecurityTracingTest {
                                                      .putContractInstance(Config.class, config)
                                                      .putContractInstance(Tracer.class, tracer)
                                                      .build());
+    }
+
+    private static final class TracerDescriptor implements ServiceDescriptor<Tracer> {
+        private static final TypeName SERVICE_TYPE = TypeName.create(Tracer.class);
+        private static final TypeName DESCRIPTOR_TYPE = TypeName.create(TracerDescriptor.class);
+
+        private final Tracer tracer;
+        private final AtomicBoolean instantiated;
+
+        private TracerDescriptor(Tracer tracer, AtomicBoolean instantiated) {
+            this.tracer = tracer;
+            this.instantiated = instantiated;
+        }
+
+        @Override
+        public Object instantiate(DependencyContext ctx, InterceptionMetadata interceptionMetadata) {
+            instantiated.set(true);
+            return tracer;
+        }
+
+        @Override
+        public TypeName serviceType() {
+            return SERVICE_TYPE;
+        }
+
+        @Override
+        public TypeName descriptorType() {
+            return DESCRIPTOR_TYPE;
+        }
+
+        @Override
+        public Set<ResolvedType> contracts() {
+            return Set.of(ResolvedType.create(SERVICE_TYPE));
+        }
+
+        @Override
+        public double weight() {
+            return 1000;
+        }
     }
 }

--- a/security/security/src/test/java/io/helidon/security/SecurityTracingTest.java
+++ b/security/security/src/test/java/io/helidon/security/SecurityTracingTest.java
@@ -16,19 +16,53 @@
 
 package io.helidon.security;
 
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 import io.helidon.security.providers.ProviderForTesting;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
 import io.helidon.tracing.Tracer;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 @Testing.Test(perMethod = true)
 class SecurityTracingTest {
+    @Test
+    void managedSecurityUsesOwningRegistryTracer() {
+        Tracer tracer = mock(Tracer.class);
+        ServiceRegistryManager manager = manager(tracer, true);
+        try {
+            Security security = manager.registry().get(Security.class);
+
+            assertThat("Security tracer", security.tracer(), sameInstance(tracer));
+            assertThat("Security context tracer", security.contextBuilder("unitTest").build().tracer(), sameInstance(tracer));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void managedSecurityHonorsDisabledTracing() {
+        Tracer tracer = mock(Tracer.class);
+        ServiceRegistryManager manager = manager(tracer, false);
+        try {
+            Security security = manager.registry().get(Security.class);
+
+            assertThat("Disabled security tracer", security.tracer(), not(sameInstance(tracer)));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
     @Test
     void defaultTracerComesFromServiceRegistry() {
         Tracer tracer = mock(Tracer.class);
@@ -43,5 +77,14 @@ class SecurityTracingTest {
 
         assertThat("Security tracer", security.tracer(), sameInstance(tracer));
         assertThat("Security context tracer", security.contextBuilder("unitTest").build().tracer(), sameInstance(tracer));
+    }
+
+    private static ServiceRegistryManager manager(Tracer tracer, boolean tracingEnabled) {
+        Config config = Config.just(ConfigSources.create(Map.of("security.tracing.enabled",
+                                                                 Boolean.toString(tracingEnabled))));
+        return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                     .putContractInstance(Config.class, config)
+                                                     .putContractInstance(Tracer.class, tracer)
+                                                     .build());
     }
 }

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -297,6 +297,39 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
     }
 
     @Override
+    public <T> List<T> allActive(TypeName contract) {
+        return allActive(Lookup.create(contract));
+    }
+
+    @Override
+    public <T> List<T> allActive(Lookup lookup) {
+        List<ServiceManager<T>> managers = lookupManagers(lookup, false, false);
+
+        if (managers.isEmpty()) {
+            return List.of();
+        }
+
+        traceLookup(lookup, "all active");
+
+        var result = new ArrayList<T>();
+        for (ServiceManager<T> serviceManager : managers) {
+            List<ServiceInstance<T>> thisManager = serviceManager.activeInstances(lookup)
+                    .orElseGet(List::of);
+
+            traceLookupInstance(lookup, serviceManager, thisManager);
+
+            if (!thisManager.isEmpty()) {
+                accessed(serviceManager.descriptor());
+                for (ServiceInstance<T> serviceInstance : thisManager) {
+                    result.add(serviceInstance.get());
+                }
+            }
+        }
+
+        return List.copyOf(result);
+    }
+
+    @Override
     public <T> Supplier<Optional<T>> supplyFirst(TypeName contract) {
         return supplyFirst(Lookup.create(contract));
     }

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
@@ -262,6 +262,78 @@ public interface ServiceRegistry {
     }
 
     /**
+     * Get all active service instances matching the contract.
+     * <p>
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new products for {@link Service.PerLookup} services. Explicitly registered fixed provider or service
+     * instances may be returned when the lookup requests those provider or service instances. The default implementation
+     * delegates to {@link #allActive(TypeName)}.
+     *
+     * @param contract contract to find
+     * @param <T>      type of the contract
+     * @return active service instances, or an empty list
+     */
+    default <T> List<T> allActive(Class<T> contract) {
+        return allActive(TypeName.create(contract));
+    }
+
+    /**
+     * Get all active service instances matching the contract and qualifiers.
+     * <p>
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new products for {@link Service.PerLookup} services. Explicitly registered fixed provider or service
+     * instances may be returned when the lookup requests those provider or service instances. The default implementation
+     * delegates to {@link #allActive(Lookup)}.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return active service instances, or an empty list
+     */
+    default <T> List<T> allActive(Class<T> contract, Qualifier... qualifiers) {
+        return allActive(Lookup.builder()
+                                 .addContract(contract)
+                                 .qualifiers(Set.of(qualifiers))
+                                 .build());
+    }
+
+    /**
+     * Get all active service instances matching the contract.
+     * <p>
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new products for {@link Service.PerLookup} services. Explicitly registered fixed provider or service
+     * instances may be returned when the lookup requests those provider or service instances. The default implementation
+     * delegates to {@link #allActive(Lookup)}.
+     *
+     * @param contract contract to find
+     * @param <T>      type of the contract
+     * @return active service instances, or an empty list
+     */
+    default <T> List<T> allActive(TypeName contract) {
+        return allActive(Lookup.create(contract));
+    }
+
+    /**
+     * Get all active service instances matching the contract and qualifiers.
+     * <p>
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new products for {@link Service.PerLookup} services. Explicitly registered fixed provider or service
+     * instances may be returned when the lookup requests those provider or service instances. The default implementation
+     * delegates to {@link #allActive(Lookup)}.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return active service instances, or an empty list
+     */
+    default <T> List<T> allActive(TypeName contract, Qualifier... qualifiers) {
+        return allActive(Lookup.builder()
+                                 .addContract(contract)
+                                 .qualifiers(Set.of(qualifiers))
+                                 .build());
+    }
+
+    /**
      * Get the first named service instance matching the contract with the expectation that there may not be a match available.
      *
      * @param contract contract to look-up
@@ -587,6 +659,24 @@ public interface ServiceRegistry {
     default <T> Optional<T> firstActive(Lookup lookup) {
         Objects.requireNonNull(lookup);
         return Optional.empty();
+    }
+
+    /**
+     * Get all active service instances matching the lookup.
+     * <p>
+     * Implementations that support active lookup should return only instances that are already active and should not
+     * create new products for {@link Service.PerLookup} services. Explicitly registered fixed provider or service
+     * instances may be returned when the lookup requests those provider or service instances. The default implementation
+     * returns an empty list.
+     *
+     * @param lookup lookup criteria to find matching services
+     * @param <T>    type of the service, if you use any other than {@link java.lang.Object}, make sure
+     *               you have configured appropriate contracts in the lookup, as we cannot infer this
+     * @return active service instances, or an empty list
+     */
+    default <T> List<T> allActive(Lookup lookup) {
+        Objects.requireNonNull(lookup);
+        return List.of();
     }
 
     /**

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RegistryTest.java
@@ -99,6 +99,33 @@ public class RegistryTest {
     }
 
     @Test
+    public void testRegistryAllActive() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry serviceRegistry = manager.registry();
+        FirstActiveService.instances = 0;
+        FirstActiveContract first = new FirstActiveContract() {
+        };
+        FirstActiveContract second = new FirstActiveContract() {
+        };
+
+        Services.registry(serviceRegistry);
+        try {
+            assertThat(serviceRegistry.allActive(FirstActiveContract.class), hasSize(0));
+            assertThat(FirstActiveService.instances, is(0));
+
+            Services.set(FirstActiveContract.class, first, second);
+
+            List<FirstActiveContract> active = serviceRegistry.allActive(FirstActiveContract.class);
+            assertThat(active, hasSize(2));
+            assertThat(active.get(0), sameInstance(first));
+            assertThat(active.get(1), sameInstance(second));
+            assertThat(FirstActiveService.instances, is(0));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     public void testRegistryFirstActiveDoesNotBlockSet() {
         ServiceRegistryManager manager = ServiceRegistryManager.create();
         ServiceRegistry serviceRegistry = manager.registry();

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -48,6 +48,7 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
 @Prototype.Configured
 @Prototype.Blueprint(decorator = HttpClientConfigSupport.HttpBuilderDecorator.class)
 @Prototype.CustomMethods(HttpClientConfigSupport.HttpCustomMethods.class)
+@Prototype.RegistrySupport
 interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
     /**
      * Base uri used by the client in all requests.

--- a/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
@@ -29,8 +29,11 @@ import java.util.concurrent.Executors;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
 import io.helidon.common.LruCache;
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.Method;
+import io.helidon.service.registry.Service;
 import io.helidon.webclient.spi.ClientProtocolProvider;
 import io.helidon.webclient.spi.HttpClientSpi;
 import io.helidon.webclient.spi.HttpClientSpiProvider;
@@ -41,6 +44,8 @@ import io.helidon.webclient.spi.ProtocolConfig;
  * Base class for HTTP implementations of {@link WebClient}.
  */
 @SuppressWarnings("rawtypes")
+@Service.PerInstance(WebClientConfigBlueprint.class)
+@Weight(Weighted.DEFAULT_WEIGHT - 10)
 class LoomClient implements WebClient {
     static final LazyValue<ExecutorService> EXECUTOR =
             LazyValue.create(() -> Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
@@ -75,6 +80,7 @@ class LoomClient implements WebClient {
      * @param config builder the subclass is built from
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
+    @Service.Inject
     protected LoomClient(WebClientConfig config) {
         this.config = config;
         this.protocolConfigs = ProtocolConfigs.create(config.protocolConfigs());
@@ -152,6 +158,7 @@ class LoomClient implements WebClient {
     }
 
     @Override
+    @Service.PreDestroy
     public void closeResource() {
         for (ProtocolSpi o : List.copyOf(clientSpiByProtocol.values())) {
             o.spi().releaseResource();

--- a/webclient/api/src/main/java/io/helidon/webclient/api/WebClientConfigFactory.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/WebClientConfigFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+import io.helidon.config.Config;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
+
+@Service.Singleton
+class WebClientConfigFactory implements Service.ServicesFactory<WebClientConfig> {
+    private static final String CONFIG_KEY = "clients";
+
+    private final Supplier<Config> config;
+    private final ServiceRegistry serviceRegistry;
+
+    @Service.Inject
+    WebClientConfigFactory(Supplier<Config> config, ServiceRegistry serviceRegistry) {
+        this.config = config;
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    @Override
+    public List<Service.QualifiedInstance<WebClientConfig>> services() {
+        Config clientsConfig = config.get().get(CONFIG_KEY);
+        Map<String, Config> configuredClients = new TreeMap<>();
+        boolean isList = clientsConfig.isList();
+
+        for (Config clientConfig : clientsConfig.asNodeList().orElseGet(List::of)) {
+            String name = isList
+                    ? clientConfig.get("name").asString().orElse(clientConfig.name())
+                    : clientConfig.name();
+            configuredClients.put(name, clientConfig);
+        }
+
+        List<Service.QualifiedInstance<WebClientConfig>> result = new ArrayList<>(configuredClients.size() + 1);
+        Config defaultConfig = configuredClients.remove(Service.Named.DEFAULT_NAME);
+        result.add(configured(Service.Named.DEFAULT_NAME, defaultConfig == null ? Config.empty() : defaultConfig));
+        configuredClients.forEach((name, clientConfig) -> result.add(configured(name, clientConfig)));
+        return List.copyOf(result);
+    }
+
+    private Service.QualifiedInstance<WebClientConfig> configured(String name, Config config) {
+        WebClientConfig webClientConfig = WebClientConfig.builder()
+                .config(config)
+                .serviceRegistry(serviceRegistry)
+                .buildPrototype();
+        return Service.QualifiedInstance.create(webClientConfig, Qualifier.createNamed(name));
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/TestHttpClientSpiProvider.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/TestHttpClientSpiProvider.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.webclient.api;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import io.helidon.webclient.spi.HttpClientSpi;
 import io.helidon.webclient.spi.HttpClientSpiProvider;
 import io.helidon.webclient.spi.ProtocolConfig;
@@ -48,8 +50,10 @@ public class TestHttpClientSpiProvider implements HttpClientSpiProvider<Protocol
 
         @Override
         public void closeResource() {
+            CLOSE_COUNT.incrementAndGet();
         }
     };
+    private static final AtomicInteger CLOSE_COUNT = new AtomicInteger();
 
     private static volatile IllegalStateException constructionFailure;
     private static volatile WebClientProtocolResponse protocolResponse;
@@ -102,9 +106,14 @@ public class TestHttpClientSpiProvider implements HttpClientSpiProvider<Protocol
         constructionFailure = null;
         protocolResponse = null;
         failResponseNotification = false;
+        CLOSE_COUNT.set(0);
     }
 
     static IllegalStateException constructionFailure() {
         return constructionFailure;
+    }
+
+    static int closeCount() {
+        return CLOSE_COUNT.get();
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/WebClientRegistryTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/WebClientRegistryTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+class WebClientRegistryTest {
+    @Test
+    void registryCreatesDefaultClientWhenConfigurationIsMissing() {
+        ServiceRegistryManager manager = manager(Config.empty());
+        try {
+            ServiceRegistry registry = manager.registry();
+            WebClient defaultClient = registry.get(WebClient.class);
+            WebClient namedDefault = registry.getNamed(WebClient.class, Service.Named.DEFAULT_NAME);
+
+            assertThat(namedDefault, sameInstance(defaultClient));
+            assertThat(defaultClient.prototype().baseUri().isEmpty(), is(true));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void registryCreatesConfiguredDefaultAndNamedClients() {
+        Config config = Config.just(ConfigSources.create(Map.of(
+                "clients.@default.base-uri", "http://default.example",
+                "clients.one.base-uri", "http://one.example")));
+        TestHttpClientSpiProvider.reset();
+        ServiceRegistryManager manager = manager(config);
+        try {
+            ServiceRegistry registry = manager.registry();
+            WebClient defaultClient = registry.get(WebClient.class);
+            WebClient namedDefault = registry.getNamed(WebClient.class, Service.Named.DEFAULT_NAME);
+            WebClient namedClient = registry.getNamed(WebClient.class, "one");
+
+            assertThat(namedDefault, sameInstance(defaultClient));
+            assertThat(defaultClient.prototype().baseUri().orElseThrow().toString(), is("http://default.example:80/"));
+            assertThat(namedClient.prototype().baseUri().orElseThrow().toString(), is("http://one.example:80/"));
+        } finally {
+            manager.shutdown();
+        }
+        assertThat(TestHttpClientSpiProvider.closeCount(), is(2));
+    }
+
+    @Test
+    void registryCreatesClientsFromListConfiguration() {
+        ConfigNode.ObjectNode root = ConfigNode.ObjectNode.builder()
+                .addList("clients", ConfigNode.ListNode.builder()
+                        .addObject(ConfigNode.ObjectNode.builder()
+                                           .addValue("name", Service.Named.DEFAULT_NAME)
+                                           .addValue("base-uri", "http://default.example")
+                                           .build())
+                        .addObject(ConfigNode.ObjectNode.builder()
+                                           .addValue("name", "one")
+                                           .addValue("base-uri", "http://one.example")
+                                           .build())
+                        .build())
+                .build();
+        ServiceRegistryManager manager = manager(Config.just(ConfigSources.create(root)));
+        try {
+            ServiceRegistry registry = manager.registry();
+
+            assertThat(registry.get(WebClient.class).prototype().baseUri().orElseThrow().toString(),
+                       is("http://default.example:80/"));
+            assertThat(registry.getNamed(WebClient.class, "one").prototype().baseUri().orElseThrow().toString(),
+                       is("http://one.example:80/"));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void explicitClientReplacesBuiltInDefault() {
+        WebClient explicitClient = WebClient.create();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class,
+                                                                                                     Config.empty())
+                                                                                .putContractInstance(WebClient.class,
+                                                                                                     explicitClient)
+                                                                                .build());
+        try {
+            assertThat(manager.registry().get(WebClient.class), sameInstance(explicitClient));
+        } finally {
+            manager.shutdown();
+            explicitClient.closeResource();
+        }
+    }
+
+    private static ServiceRegistryManager manager(Config config) {
+        return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                     .putContractInstance(Config.class, config)
+                                                     .build());
+    }
+}

--- a/webclient/grpc-tracing/pom.xml
+++ b/webclient/grpc-tracing/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>helidon-grpc-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-grpc</artifactId>
         </dependency>
@@ -56,6 +60,11 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracing.java
+++ b/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracing.java
@@ -15,9 +15,14 @@
  */
 package io.helidon.webclient.grpc.tracing;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
 import io.helidon.grpc.core.WeightedBag;
+import io.helidon.service.registry.Services;
+import io.helidon.tracing.Tracer;
 import io.helidon.webclient.grpc.spi.GrpcClientService;
 
 import io.grpc.ClientInterceptor;
@@ -28,9 +33,15 @@ import io.grpc.ClientInterceptor;
 public class GrpcClientTracing implements GrpcClientService {
 
     private final Config config;
+    private final Supplier<Tracer> tracer;
 
     private GrpcClientTracing(Config config) {
+        this(config, () -> Services.get(Tracer.class));
+    }
+
+    private GrpcClientTracing(Config config, Supplier<Tracer> tracer) {
         this.config = config;
+        this.tracer = Objects.requireNonNull(tracer);
     }
 
     /**
@@ -43,6 +54,10 @@ public class GrpcClientTracing implements GrpcClientService {
         return new GrpcClientTracing(config);
     }
 
+    static GrpcClientTracing create(Config config, Supplier<Tracer> tracer) {
+        return new GrpcClientTracing(config, tracer);
+    }
+
     @Override
     public String type() {
         return "tracing";
@@ -51,7 +66,7 @@ public class GrpcClientTracing implements GrpcClientService {
     @Override
     public WeightedBag<ClientInterceptor> interceptors() {
         WeightedBag<ClientInterceptor> interceptors = WeightedBag.create();
-        interceptors.add(new GrpcClientTracingInterceptor(), Weighted.DEFAULT_WEIGHT + 100);
+        interceptors.add(new GrpcClientTracingInterceptor(tracer), Weighted.DEFAULT_WEIGHT + 100);
         return interceptors;
     }
 }

--- a/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingInterceptor.java
+++ b/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingInterceptor.java
@@ -20,9 +20,9 @@ import java.lang.System.Logger.Level;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import io.helidon.service.registry.Services;
 import io.helidon.tracing.HeaderConsumer;
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
@@ -41,6 +41,11 @@ import io.grpc.MethodDescriptor;
  */
 class GrpcClientTracingInterceptor implements ClientInterceptor {
     private static final Logger LOGGER = System.getLogger(GrpcClientTracingInterceptor.class.getName());
+    private final Supplier<Tracer> tracerSupplier;
+
+    GrpcClientTracingInterceptor(Supplier<Tracer> tracerSupplier) {
+        this.tracerSupplier = tracerSupplier;
+    }
 
     @Override
     public <ReqT, ResT> ClientCall<ReqT, ResT> interceptCall(MethodDescriptor<ReqT, ResT> method,
@@ -57,7 +62,7 @@ class GrpcClientTracingInterceptor implements ClientInterceptor {
                 if (LOGGER.isLoggable(Level.DEBUG)) {
                     LOGGER.log(Level.DEBUG, "Call start; metadata keys: {0}", loggableMetadata(headers));
                 }
-                var tracer = Services.get(Tracer.class);
+                var tracer = tracerSupplier.get();
                 // Start a new span for the outgoing gRPC client call.
                 var outgoingClientSpanBuilder = tracer
                         .spanBuilder(method.getServiceName() + "-" + method.getFullMethodName())

--- a/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingProvider.java
+++ b/webclient/grpc-tracing/src/main/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingProvider.java
@@ -16,8 +16,12 @@
 
 package io.helidon.webclient.grpc.tracing;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.tracing.Tracer;
 import io.helidon.webclient.grpc.spi.GrpcClientService;
 import io.helidon.webclient.grpc.spi.GrpcClientServiceProvider;
 
@@ -41,5 +45,13 @@ public class GrpcClientTracingProvider implements GrpcClientServiceProvider {
     @Override
     public GrpcClientService create(Config config, String name) {
         return GrpcClientTracing.create(config);
+    }
+
+    @Override
+    public GrpcClientService create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        return GrpcClientTracing.create(config, () -> serviceRegistry.get(Tracer.class));
     }
 }

--- a/webclient/grpc-tracing/src/main/java/module-info.java
+++ b/webclient/grpc-tracing/src/main/java/module-info.java
@@ -24,6 +24,7 @@ module io.helidon.webclient.grpc.tracing {
     requires transitive io.helidon.webclient;
 
     requires io.helidon.grpc.core;
+    requires io.helidon.service.registry;
     requires io.helidon.tracing;
     requires io.helidon.webclient.grpc;
 

--- a/webclient/grpc-tracing/src/test/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingInterceptorTest.java
+++ b/webclient/grpc-tracing/src/test/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingInterceptorTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.grpc.tracing;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -135,7 +136,7 @@ class GrpcClientTracingInterceptorTest {
         public String parse(InputStream stream) {
             try {
                 return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
-            } catch (java.io.IOException e) {
+                } catch (IOException e) {
                 throw new IllegalStateException(e);
             }
         }

--- a/webclient/grpc-tracing/src/test/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingInterceptorTest.java
+++ b/webclient/grpc-tracing/src/test/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingInterceptorTest.java
@@ -16,15 +16,86 @@
 
 package io.helidon.webclient.grpc.tracing;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
+import io.helidon.tracing.HeaderConsumer;
+import io.helidon.tracing.HeaderProvider;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.SpanListener;
+import io.helidon.tracing.Tracer;
+import io.helidon.webclient.grpc.GrpcClientConfig;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 
+@Testing.Test(perMethod = true)
 class GrpcClientTracingInterceptorTest {
+    @Test
+    void registryConfiguredTracingUsesOwningTracer() {
+        RecordingTracer tracer = new RecordingTracer();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Tracer.class, tracer)
+                                                                                .build());
+        try {
+            Config config = Config.just(ConfigSources.create(Map.of("grpc-services.tracing.enabled", "true")));
+            GrpcClientConfig clientConfig = GrpcClientConfig.builder()
+                    .config(config)
+                    .serviceRegistry(manager.registry())
+                    .buildPrototype();
+            ClientInterceptor interceptor = clientConfig.grpcServices()
+                    .stream()
+                    .filter(service -> service.type().equals("tracing"))
+                    .findFirst()
+                    .orElseThrow()
+                    .interceptors()
+                    .iterator()
+                    .next();
+            invoke(interceptor);
+
+            assertThat(tracer.spanNames(), contains("test.Service-test.Service/Call"));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void directTracingUsesStaticTracer() {
+        RecordingTracer tracer = new RecordingTracer();
+        ClientInterceptor interceptor = GrpcClientTracing.create(Config.empty())
+                .interceptors()
+                .iterator()
+                .next();
+        Services.set(Tracer.class, tracer);
+
+        invoke(interceptor);
+
+        assertThat(tracer.spanNames(), contains("test.Service-test.Service/Call"));
+    }
+
     @Test
     void testMetadataLoggingDoesNotIncludeValues() {
         Metadata metadata = new Metadata();
@@ -37,5 +108,108 @@ class GrpcClientTracingInterceptorTest {
         assertThat(logged, containsString("x-safe"));
         assertThat(logged, not(containsString("Bearer secret-token")));
         assertThat(logged, not(containsString("visible-value")));
+    }
+
+    private static void invoke(ClientInterceptor interceptor) {
+        MethodDescriptor<String, String> method = MethodDescriptor.<String, String>newBuilder()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName("test.Service/Call")
+                .setRequestMarshaller(StringMarshaller.INSTANCE)
+                .setResponseMarshaller(StringMarshaller.INSTANCE)
+                .build();
+        ClientCall<String, String> call = interceptor.interceptCall(method, CallOptions.DEFAULT, new NoOpChannel());
+        call.start(new ClientCall.Listener<>() {
+        }, new Metadata());
+        call.halfClose();
+    }
+
+    private enum StringMarshaller implements MethodDescriptor.Marshaller<String> {
+        INSTANCE;
+
+        @Override
+        public InputStream stream(String value) {
+            return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public String parse(InputStream stream) {
+            try {
+                return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (java.io.IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    private static final class NoOpChannel extends Channel {
+        @Override
+        public <ReqT, ResT> ClientCall<ReqT, ResT> newCall(MethodDescriptor<ReqT, ResT> methodDescriptor,
+                                                           CallOptions callOptions) {
+            return new NoOpClientCall<>();
+        }
+
+        @Override
+        public String authority() {
+            return "test";
+        }
+    }
+
+    private static final class NoOpClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
+        @Override
+        public void start(Listener<ResT> responseListener, Metadata headers) {
+        }
+
+        @Override
+        public void request(int numMessages) {
+        }
+
+        @Override
+        public void cancel(String message, Throwable cause) {
+        }
+
+        @Override
+        public void halfClose() {
+        }
+
+        @Override
+        public void sendMessage(ReqT message) {
+        }
+    }
+
+    private static final class RecordingTracer implements Tracer {
+        private final Tracer delegate = Tracer.noOp();
+        private final List<String> spanNames = new ArrayList<>();
+
+        @Override
+        public boolean enabled() {
+            return true;
+        }
+
+        @Override
+        public Span.Builder<?> spanBuilder(String name) {
+            spanNames.add(name);
+            return delegate.spanBuilder(name);
+        }
+
+        @Override
+        public Optional<SpanContext> extract(HeaderProvider headersProvider) {
+            return delegate.extract(headersProvider);
+        }
+
+        @Override
+        public void inject(SpanContext spanContext,
+                           HeaderProvider inboundHeadersProvider,
+                           HeaderConsumer outboundHeadersConsumer) {
+            delegate.inject(spanContext, inboundHeadersProvider, outboundHeadersConsumer);
+        }
+
+        @Override
+        public Tracer register(SpanListener listener) {
+            return this;
+        }
+
+        private List<String> spanNames() {
+            return List.copyOf(spanNames);
+        }
     }
 }

--- a/webclient/grpc-tracing/src/test/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingInterceptorTest.java
+++ b/webclient/grpc-tracing/src/test/java/io/helidon/webclient/grpc/tracing/GrpcClientTracingInterceptorTest.java
@@ -136,7 +136,7 @@ class GrpcClientTracingInterceptorTest {
         public String parse(InputStream stream) {
             try {
                 return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
-                } catch (IOException e) {
+            } catch (IOException e) {
                 throw new IllegalStateException(e);
             }
         }

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcChannel.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcChannel.java
@@ -47,7 +47,9 @@ public class GrpcChannel extends Channel {
     GrpcChannel(GrpcClient grpcClient) {
         this.grpcClient = (GrpcClientImpl) grpcClient;
         if (this.grpcClient.clientConfig().enableMetrics()) {
-            this.meterRegistry = Services.get(MeterRegistry.class);
+            this.meterRegistry = this.grpcClient.clientConfig()
+                    .meterRegistry()
+                    .orElseGet(() -> Services.get(MeterRegistry.class));
             this.metricsFactory = meterRegistry.metricsFactory();
         } else {
             this.metricsFactory = null;

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientConfigBlueprint.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientConfigBlueprint.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.webclient.api.HttpClientConfig;
 import io.helidon.webclient.grpc.spi.GrpcClientService;
 import io.helidon.webclient.grpc.spi.GrpcClientServiceProvider;
@@ -30,6 +31,7 @@ import io.helidon.webclient.grpc.spi.GrpcClientServiceProvider;
  */
 @Prototype.Blueprint
 @Prototype.Configured
+@Prototype.IncludeDefaultMethods("meterRegistry")
 interface GrpcClientConfigBlueprint extends HttpClientConfig, Prototype.Factory<GrpcClient> {
 
     /**
@@ -57,6 +59,15 @@ interface GrpcClientConfigBlueprint extends HttpClientConfig, Prototype.Factory<
     @Option.Configured
     @Option.DefaultBoolean(false)
     boolean enableMetrics();
+
+    /**
+     * Meter registry to use for gRPC client metrics.
+     *
+     * @return meter registry to use
+     */
+    default Optional<MeterRegistry> meterRegistry() {
+        return Optional.empty();
+    }
 
     /**
      * gRPC client services. Services are discovered automatically by default.

--- a/webclient/grpc/src/main/java/module-info.java
+++ b/webclient/grpc/src/main/java/module-info.java
@@ -37,7 +37,7 @@ module io.helidon.webclient.grpc {
 
     requires io.helidon.common.context;
     requires io.helidon.grpc.core;
-    requires io.helidon.metrics.api;
+    requires transitive io.helidon.metrics.api;
     requires io.helidon.service.registry;
 
     exports io.helidon.webclient.grpc;

--- a/webclient/grpc/src/test/java/io/helidon/webclient/grpc/GrpcChannelTest.java
+++ b/webclient/grpc/src/test/java/io/helidon/webclient/grpc/GrpcChannelTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.sameInstance;
 class GrpcChannelTest {
 
     @Test
-    void usesMeterRegistryOwningFactory() {
+    void directClientUsesStaticMeterRegistryOwningFactory() {
         ServiceRegistryManager ownerManager = ServiceRegistryManager.create();
         ServiceRegistryManager foreignManager = ServiceRegistryManager.create();
         try {
@@ -56,6 +56,34 @@ class GrpcChannelTest {
         } finally {
             foreignManager.shutdown();
             ownerManager.shutdown();
+        }
+    }
+
+    @Test
+    void managedClientUsesInjectedMeterRegistry() {
+        ServiceRegistryManager injectedManager = ServiceRegistryManager.create();
+        ServiceRegistryManager staticManager = ServiceRegistryManager.create();
+        try {
+            MeterRegistry injectedRegistry = injectedManager.registry().get(MeterRegistry.class);
+            MeterRegistry staticRegistry = staticManager.registry().get(MeterRegistry.class);
+            Services.set(MeterRegistry.class, staticRegistry);
+
+            GrpcChannel channel = (GrpcChannel) GrpcClient.builder()
+                    .baseUri("http://localhost")
+                    .enableMetrics(true)
+                    .meterRegistry(injectedRegistry)
+                    .build()
+                    .channel();
+
+            assertThat("Channel uses the injected meter registry",
+                       channel.meterRegistry(),
+                       sameInstance(injectedRegistry));
+            assertThat("Channel ignores the static meter registry",
+                       channel.meterRegistry(),
+                       not(sameInstance(staticRegistry)));
+        } finally {
+            staticManager.shutdown();
+            injectedManager.shutdown();
         }
     }
 }

--- a/webclient/metrics/pom.xml
+++ b/webclient/metrics/pom.xml
@@ -47,9 +47,28 @@
             <artifactId>helidon-metrics-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetric.java
+++ b/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetric.java
@@ -18,6 +18,7 @@ package io.helidon.webclient.metrics;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,7 +44,9 @@ abstract class WebClientMetric implements WebClientService {
     private final boolean errors;
 
     WebClientMetric(Builder builder) {
-        this.registry = Services.get(MeterRegistry.class);
+        this.registry = builder.meterRegistry == null
+                ? Services.get(MeterRegistry.class)
+                : builder.meterRegistry;
         this.metricsFactory = registry.metricsFactory();
         this.methods = builder.methods;
         this.nameFormat = builder.nameFormat;
@@ -141,6 +144,7 @@ abstract class WebClientMetric implements WebClientService {
         private String description;
         private boolean success = true;
         private boolean errors = true;
+        private MeterRegistry meterRegistry;
 
         private Builder(WebClientMetricType type) {
             this.type = type;
@@ -225,6 +229,11 @@ abstract class WebClientMetric implements WebClientService {
          */
         public Builder errors(boolean errors) {
             this.errors = errors;
+            return this;
+        }
+
+        Builder meterRegistry(MeterRegistry meterRegistry) {
+            this.meterRegistry = Objects.requireNonNull(meterRegistry);
             return this;
         }
 

--- a/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetrics.java
+++ b/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetrics.java
@@ -18,8 +18,11 @@ package io.helidon.webclient.metrics;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
+import java.util.function.Function;
 
 import io.helidon.config.Config;
+import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
@@ -78,20 +81,33 @@ public class WebClientMetrics implements WebClientService {
      * @return client metrics instance
      */
     public static WebClientMetrics create(Config config) {
+        return create(config, WebClientMetric::builder);
+    }
+
+    static WebClientMetrics create(Config config, MeterRegistry meterRegistry) {
+        Objects.requireNonNull(meterRegistry);
+        return create(config, type -> WebClientMetric.builder(type).meterRegistry(meterRegistry));
+    }
+
+    private static WebClientMetrics create(Config config,
+                                           Function<WebClientMetricType, WebClientMetric.Builder> metricBuilder) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(metricBuilder);
         WebClientMetrics.Builder builder = new Builder();
         config.asNodeList().ifPresent(configs ->
                 configs.forEach(metricConfig ->
-                        builder.register(processClientMetric(metricConfig))));
+                        builder.register(processClientMetric(metricConfig, metricBuilder))));
         return builder.build();
     }
 
-    private static WebClientMetric processClientMetric(Config metricConfig) {
+    private static WebClientMetric processClientMetric(Config metricConfig,
+                                                       Function<WebClientMetricType, WebClientMetric.Builder> metricBuilder) {
         String type = metricConfig.get("type").asString().orElse("COUNTER");
         return switch (type) {
-            case "COUNTER" -> counter().config(metricConfig).build();
-            case "METER" -> meter().config(metricConfig).build();
-            case "TIMER" -> timer().config(metricConfig).build();
-            case "GAUGE_IN_PROGRESS" -> gaugeInProgress().config(metricConfig).build();
+            case "COUNTER" -> metricBuilder.apply(WebClientMetricType.COUNTER).config(metricConfig).build();
+            case "METER" -> metricBuilder.apply(WebClientMetricType.METER).config(metricConfig).build();
+            case "TIMER" -> metricBuilder.apply(WebClientMetricType.TIMER).config(metricConfig).build();
+            case "GAUGE_IN_PROGRESS" -> metricBuilder.apply(WebClientMetricType.GAUGE_IN_PROGRESS).config(metricConfig).build();
             default -> throw new IllegalStateException(String.format(
                     "Metrics type %s is not supported through service loader",
                     type));

--- a/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetrics.java
+++ b/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetrics.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.helidon.config.Config;
 import io.helidon.metrics.api.MeterRegistry;
@@ -84,9 +85,9 @@ public class WebClientMetrics implements WebClientService {
         return create(config, WebClientMetric::builder);
     }
 
-    static WebClientMetrics create(Config config, MeterRegistry meterRegistry) {
+    static WebClientMetrics create(Config config, Supplier<MeterRegistry> meterRegistry) {
         Objects.requireNonNull(meterRegistry);
-        return create(config, type -> WebClientMetric.builder(type).meterRegistry(meterRegistry));
+        return create(config, type -> WebClientMetric.builder(type).meterRegistry(meterRegistry.get()));
     }
 
     private static WebClientMetrics create(Config config,

--- a/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
+++ b/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
@@ -50,7 +50,7 @@ public class WebClientMetricsProvider implements WebClientServiceProvider {
         Objects.requireNonNull(config);
         Objects.requireNonNull(name);
         Objects.requireNonNull(serviceRegistry);
-        return WebClientMetrics.create(config, serviceRegistry.get(MeterRegistry.class));
+        return WebClientMetrics.create(config, serviceRegistry.supply(MeterRegistry.class));
     }
 
 }

--- a/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
+++ b/webclient/metrics/src/main/java/io/helidon/webclient/metrics/WebClientMetricsProvider.java
@@ -15,8 +15,12 @@
  */
 package io.helidon.webclient.metrics;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webclient.spi.WebClientServiceProvider;
 
@@ -39,6 +43,14 @@ public class WebClientMetricsProvider implements WebClientServiceProvider {
     @Override
     public WebClientService create(Config config, String name) {
         return WebClientMetrics.create(config);
+    }
+
+    @Override
+    public WebClientService create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        return WebClientMetrics.create(config, serviceRegistry.get(MeterRegistry.class));
     }
 
 }

--- a/webclient/metrics/src/main/java/module-info.java
+++ b/webclient/metrics/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module io.helidon.webclient.metrics {
 
     requires io.helidon.common.features.api;
     requires io.helidon.metrics.api;
+    requires io.helidon.service.registry;
     requires io.helidon.webclient;
 
     requires transitive io.helidon.config;

--- a/webclient/metrics/src/test/java/io/helidon/webclient/metrics/WebClientMetricsProviderTest.java
+++ b/webclient/metrics/src/test/java/io/helidon/webclient/metrics/WebClientMetricsProviderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.metrics;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webclient.spi.WebClientService;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WebClientMetricsProviderTest {
+    private static final Config METRICS_CONFIG = metricsConfig();
+
+    @Test
+    void registryCreationUsesOwningMeterRegistry() {
+        MeterRegistry meterRegistry = mock(MeterRegistry.class);
+        MetricsFactory metricsFactory = mock(MetricsFactory.class);
+        when(meterRegistry.metricsFactory()).thenReturn(metricsFactory);
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(MeterRegistry.class,
+                                                                                                     meterRegistry)
+                                                                                .build());
+        try {
+            WebClientService service = new WebClientMetricsProvider()
+                    .create(METRICS_CONFIG, "metrics", manager.registry());
+
+            assertThat(service, instanceOf(WebClientMetrics.class));
+            verify(meterRegistry, times(WebClientMetricType.values().length)).metricsFactory();
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private static Config metricsConfig() {
+        ConfigNode.ListNode.Builder metrics = ConfigNode.ListNode.builder();
+        for (WebClientMetricType type : WebClientMetricType.values()) {
+            metrics.addObject(ConfigNode.ObjectNode.builder()
+                                      .addValue("type", type.name())
+                                      .build());
+        }
+        ConfigNode.ObjectNode root = ConfigNode.ObjectNode.builder()
+                .addList("metrics", metrics.build())
+                .build();
+        return Config.just(ConfigSources.create(root)).get("metrics");
+    }
+}

--- a/webclient/metrics/src/test/java/io/helidon/webclient/metrics/WebClientMetricsProviderTest.java
+++ b/webclient/metrics/src/test/java/io/helidon/webclient/metrics/WebClientMetricsProviderTest.java
@@ -16,11 +16,14 @@
 
 package io.helidon.webclient.metrics;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.config.spi.ConfigNode;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.webclient.spi.WebClientService;
@@ -29,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,6 +40,22 @@ import static org.mockito.Mockito.when;
 
 class WebClientMetricsProviderTest {
     private static final Config METRICS_CONFIG = metricsConfig();
+
+    @Test
+    void emptyConfigurationDoesNotResolveMeterRegistry() {
+        AtomicBoolean resolved = new AtomicBoolean();
+        ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+        when(serviceRegistry.supply(MeterRegistry.class)).thenReturn(() -> {
+            resolved.set(true);
+            return mock(MeterRegistry.class);
+        });
+
+        WebClientService service = new WebClientMetricsProvider()
+                .create(Config.empty(), "metrics", serviceRegistry);
+
+        assertThat(service, instanceOf(WebClientMetrics.class));
+        assertThat(resolved.get(), is(false));
+    }
 
     @Test
     void registryCreationUsesOwningMeterRegistry() {

--- a/webclient/security/pom.xml
+++ b/webclient/security/pom.xml
@@ -55,6 +55,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/webclient/security/pom.xml
+++ b/webclient/security/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>helidon-security-providers-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
@@ -52,6 +52,7 @@ public class WebClientSecurity implements WebClientService {
     private static final String PROVIDER_NAME = "io.helidon.security.rest.client.security.providerName";
 
     private final Security security;
+    private final boolean defaultOutboundSecurity;
 
     private WebClientSecurity() {
         this(null);
@@ -59,6 +60,7 @@ public class WebClientSecurity implements WebClientService {
 
     private WebClientSecurity(Security security) {
         this.security = security;
+        this.defaultOutboundSecurity = security != null && !security.resolveOutboundProvider(null).isEmpty();
     }
 
     /**
@@ -96,6 +98,14 @@ public class WebClientSecurity implements WebClientService {
             return chain.proceed(request);
         }
 
+        String explicitProvider = request.properties().get(PROVIDER_NAME);
+        if (security != null
+                && (explicitProvider == null
+                        ? !defaultOutboundSecurity
+                        : security.resolveOutboundProvider(explicitProvider).isEmpty())) {
+            return chain.proceed(request);
+        }
+
         Context requestContext = request.context();
         // context either from request or create a new one
         Optional<SecurityContext> maybeContext = requestContext.get(SecurityContext.class);
@@ -130,8 +140,6 @@ public class WebClientSecurity implements WebClientService {
                     .start();
 
         }
-        String explicitProvider = request.properties().get(PROVIDER_NAME);
-
         OutboundSecurityClientBuilder clientBuilder;
 
         try {

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
@@ -166,6 +166,7 @@ public class WebClientSecurity implements WebClientService {
             }
 
             clientBuilder = context.outboundClientBuilder()
+                    .securityContext(maybeContext.orElse(context))
                     .outboundEnvironment(outboundEnv)
                     .outboundEndpointConfig(outboundEp)
                     .explicitProvider(explicitProvider);

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurity.java
@@ -100,9 +100,10 @@ public class WebClientSecurity implements WebClientService {
 
         String explicitProvider = request.properties().get(PROVIDER_NAME);
         if (security != null
-                && (explicitProvider == null
-                        ? !defaultOutboundSecurity
-                        : security.resolveOutboundProvider(explicitProvider).isEmpty())) {
+                && (!security.enabled()
+                        || (explicitProvider == null
+                                ? !defaultOutboundSecurity
+                                : security.resolveOutboundProvider(explicitProvider).isEmpty()))) {
             return chain.proceed(request);
         }
 

--- a/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurityProvider.java
+++ b/webclient/security/src/main/java/io/helidon/webclient/security/WebClientSecurityProvider.java
@@ -15,8 +15,12 @@
  */
 package io.helidon.webclient.security;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.security.Security;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webclient.spi.WebClientServiceProvider;
 
@@ -40,5 +44,13 @@ public class WebClientSecurityProvider implements WebClientServiceProvider {
     @Override
     public WebClientService create(Config config, String name) {
         return WebClientSecurity.create();
+    }
+
+    @Override
+    public WebClientService create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        return WebClientSecurity.create(serviceRegistry.get(Security.class));
     }
 }

--- a/webclient/security/src/main/java/module-info.java
+++ b/webclient/security/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 module io.helidon.webclient.security {
 
     requires io.helidon.security.providers.common;
+    requires io.helidon.service.registry;
     requires io.helidon.webclient;
 
     requires transitive io.helidon.security;

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityProviderTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityProviderTest.java
@@ -61,4 +61,34 @@ class WebClientSecurityProviderTest {
             client.closeResource();
         }
     }
+
+    @Test
+    void firstExplicitProviderWithSameKeyWins() {
+        WebClientService higherPriorityService = (chain, request) -> chain.proceed(request);
+        WebClientService lowerPriorityService = (chain, request) -> chain.proceed(request);
+        Services.set(WebClientServiceProvider.class,
+                     provider(higherPriorityService),
+                     provider(lowerPriorityService));
+
+        Http1Client client = Http1Client.builder().build();
+        try {
+            assertThat(client.prototype().services(), hasItem(sameInstance(higherPriorityService)));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    private static WebClientServiceProvider provider(WebClientService service) {
+        return new WebClientServiceProvider() {
+            @Override
+            public String configKey() {
+                return "security";
+            }
+
+            @Override
+            public WebClientService create(Config config, String name) {
+                return service;
+            }
+        };
+    }
 }

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityProviderTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityProviderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.security;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.config.Config;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.spi.WebClientService;
+import io.helidon.webclient.spi.WebClientServiceProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+@Testing.Test(perMethod = true)
+class WebClientSecurityProviderTest {
+
+    @Test
+    void explicitProviderOverridesServiceLoaderProvider() {
+        AtomicInteger createCount = new AtomicInteger();
+        WebClientService replacementService = (chain, request) -> chain.proceed(request);
+        WebClientServiceProvider replacementProvider = new WebClientServiceProvider() {
+            @Override
+            public String configKey() {
+                return "security";
+            }
+
+            @Override
+            public WebClientService create(Config config, String name) {
+                createCount.incrementAndGet();
+                return replacementService;
+            }
+        };
+        Services.set(WebClientServiceProvider.class, replacementProvider);
+
+        Http1Client client = Http1Client.builder().build();
+        try {
+            assertThat(client.prototype().services(), hasItem(sameInstance(replacementService)));
+            assertThat("Replacement provider create count", createCount.get(), is(1));
+        } finally {
+            client.closeResource();
+        }
+    }
+}

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
@@ -60,6 +60,7 @@ class WebClientSecurityTest {
                                                                       return List.of();
                                                                   }
                                                                   return switch (method.getName()) {
+                                                                      case "enabled" -> true;
                                                                       case "equals" -> proxy == args[0];
                                                                       case "hashCode" -> System.identityHashCode(proxy);
                                                                       case "toString" -> "Security without outbound providers";
@@ -84,6 +85,38 @@ class WebClientSecurityTest {
             assertThrows(TestException.class, () -> client.get().request());
 
             assertThat("Outbound provider lookups", providerLookups.get(), is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void registryWebClientSkipsDisabledSecurityWithOutboundProvider() {
+        AtomicInteger outboundCalls = new AtomicInteger();
+        Security security = Security.builder()
+                .enabled(false)
+                .addOutboundSecurityProvider((request, environment, config) -> {
+                    outboundCalls.incrementAndGet();
+                    return OutboundSecurityResponse.abstain();
+                })
+                .build();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Security.class, security)
+                                                                                .build());
+        try {
+            WebClientService stopBeforeNetwork = (chain, request) -> {
+                throw new TestException();
+            };
+            Http1Client client = Http1Client.builder()
+                    .baseUri("https://example.test")
+                    .servicesDiscoverServices(false)
+                    .addService(managedSecurityService(manager))
+                    .addService(stopBeforeNetwork)
+                    .build();
+
+            assertThrows(TestException.class, () -> client.get().request());
+
+            assertThat("Disabled security outbound provider calls", outboundCalls.get(), is(0));
         } finally {
             manager.shutdown();
         }

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
@@ -17,12 +17,19 @@
 package io.helidon.webclient.security;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.OutboundSecurityResponse;
+import io.helidon.security.Principal;
 import io.helidon.security.Security;
+import io.helidon.security.SecurityContext;
 import io.helidon.security.SecurityEnvironment;
+import io.helidon.security.Subject;
 import io.helidon.security.providers.common.OutboundConfig;
 import io.helidon.security.providers.common.OutboundTarget;
 import io.helidon.service.registry.ServiceRegistryConfig;
@@ -52,26 +59,65 @@ class WebClientSecurityTest {
                                                                                 .putContractInstance(Security.class, security)
                                                                                 .build());
         try {
-            WebClient managedClient = manager.registry().get(WebClient.class);
-            WebClientService securityService = managedClient.prototype()
-                    .services()
-                    .stream()
-                    .filter(service -> service.type().equals("security"))
-                    .findFirst()
-                    .orElseThrow();
             WebClientService stopBeforeNetwork = (chain, request) -> {
                 throw new TestException();
             };
             Http1Client client = Http1Client.builder()
                     .baseUri("https://example.test")
                     .servicesDiscoverServices(false)
-                    .addService(securityService)
+                    .addService(managedSecurityService(manager))
                     .addService(stopBeforeNetwork)
                     .build();
 
             assertThrows(TestException.class, () -> client.get().request());
 
             assertThat("Owning registry outbound provider calls", outboundCalls.get(), is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void registryWebClientPreservesAuthenticatedSubjects() {
+        Subject user = Subject.create(Principal.create("test-user"));
+        Subject service = Subject.create(Principal.create("test-service"));
+        Security requestSecurity = Security.builder()
+                .authenticationProvider(request -> AuthenticationResponse.success(user, service))
+                .build();
+        SecurityContext securityContext = requestSecurity.createContext("test-request");
+        securityContext.authenticate();
+        Context context = Context.create();
+        context.register(securityContext);
+
+        AtomicReference<Optional<Subject>> outboundUser = new AtomicReference<>();
+        AtomicReference<Optional<Subject>> outboundService = new AtomicReference<>();
+        Security clientSecurity = Security.builder()
+                .addOutboundSecurityProvider((request, environment, config) -> {
+                    outboundUser.set(request.subject());
+                    outboundService.set(request.service());
+                    return OutboundSecurityResponse.abstain();
+                })
+                .build();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Security.class,
+                                                                                                     clientSecurity)
+                                                                                .build());
+        try {
+            WebClientService stopBeforeNetwork = (chain, request) -> {
+                throw new TestException();
+            };
+            Http1Client client = Http1Client.builder()
+                    .baseUri("https://example.test")
+                    .servicesDiscoverServices(false)
+                    .addService(managedSecurityService(manager))
+                    .addService(stopBeforeNetwork)
+                    .build();
+
+            Contexts.runInContext(context,
+                                  () -> assertThrows(TestException.class, () -> client.get().request()));
+
+            assertThat("Outbound user subject", outboundUser.get(), is(Optional.of(user)));
+            assertThat("Outbound service subject", outboundService.get(), is(Optional.of(service)));
         } finally {
             manager.shutdown();
         }
@@ -185,6 +231,16 @@ class WebClientSecurityTest {
         assertThat(outboundTarget.get(), is("/p?"));
         assertThat(environment.targetUri().getRawQuery(), is(""));
         assertThat(environment.requestedQuery().orElseThrow().rawValue(), is(""));
+    }
+
+    private static WebClientService managedSecurityService(ServiceRegistryManager manager) {
+        WebClient managedClient = manager.registry().get(WebClient.class);
+        return managedClient.prototype()
+                .services()
+                .stream()
+                .filter(service -> service.type().equals("security"))
+                .findFirst()
+                .orElseThrow();
     }
 
     private static final class TestException extends RuntimeException {

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
@@ -32,6 +32,7 @@ import io.helidon.security.SecurityEnvironment;
 import io.helidon.security.Subject;
 import io.helidon.security.providers.common.OutboundConfig;
 import io.helidon.security.providers.common.OutboundTarget;
+import io.helidon.security.spi.AuditProvider;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.webclient.api.WebClient;
@@ -81,8 +82,13 @@ class WebClientSecurityTest {
     void registryWebClientPreservesAuthenticatedSubjects() {
         Subject user = Subject.create(Principal.create("test-user"));
         Subject service = Subject.create(Principal.create("test-service"));
+        AtomicInteger requestAudits = new AtomicInteger();
+        AtomicInteger clientAudits = new AtomicInteger();
+        AtomicReference<String> clientAuditTracingId = new AtomicReference<>();
         Security requestSecurity = Security.builder()
                 .authenticationProvider(request -> AuthenticationResponse.success(user, service))
+                .addAuditProvider(outboundAuditor(requestAudits, new AtomicReference<>()))
+                .disableTracing()
                 .build();
         SecurityContext securityContext = requestSecurity.createContext("test-request");
         securityContext.authenticate();
@@ -97,6 +103,8 @@ class WebClientSecurityTest {
                     outboundService.set(request.service());
                     return OutboundSecurityResponse.abstain();
                 })
+                .addAuditProvider(outboundAuditor(clientAudits, clientAuditTracingId))
+                .disableTracing()
                 .build();
         ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
                                                                                 .putContractInstance(Security.class,
@@ -118,6 +126,9 @@ class WebClientSecurityTest {
 
             assertThat("Outbound user subject", outboundUser.get(), is(Optional.of(user)));
             assertThat("Outbound service subject", outboundService.get(), is(Optional.of(service)));
+            assertThat("Request security outbound audits", requestAudits.get(), is(0));
+            assertThat("Client security outbound audits", clientAudits.get(), is(1));
+            assertThat("Client audit tracing ID", clientAuditTracingId.get(), is(securityContext.id()));
         } finally {
             manager.shutdown();
         }
@@ -241,6 +252,15 @@ class WebClientSecurityTest {
                 .filter(service -> service.type().equals("security"))
                 .findFirst()
                 .orElseThrow();
+    }
+
+    private static AuditProvider outboundAuditor(AtomicInteger count, AtomicReference<String> tracingId) {
+        return () -> event -> {
+            if ("outbound.outbound".equals(event.eventType())) {
+                count.incrementAndGet();
+                tracingId.set(event.tracingId());
+            }
+        };
     }
 
     private static final class TestException extends RuntimeException {

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
@@ -16,7 +16,9 @@
 
 package io.helidon.webclient.security;
 
+import java.lang.reflect.Proxy;
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -46,6 +48,46 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class WebClientSecurityTest {
+
+    @Test
+    void registryWebClientWithoutOutboundProvidersSkipsSecurityContextCreation() {
+        AtomicInteger providerLookups = new AtomicInteger();
+        Security security = (Security) Proxy.newProxyInstance(Security.class.getClassLoader(),
+                                                              new Class<?>[] {Security.class},
+                                                              (proxy, method, args) -> {
+                                                                  if (method.getName().equals("resolveOutboundProvider")) {
+                                                                      providerLookups.incrementAndGet();
+                                                                      return List.of();
+                                                                  }
+                                                                  return switch (method.getName()) {
+                                                                      case "equals" -> proxy == args[0];
+                                                                      case "hashCode" -> System.identityHashCode(proxy);
+                                                                      case "toString" -> "Security without outbound providers";
+                                                                      default -> throw new AssertionError(
+                                                                              "Unexpected security call: " + method);
+                                                                  };
+                                                              });
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Security.class, security)
+                                                                                .build());
+        try {
+            WebClientService stopBeforeNetwork = (chain, request) -> {
+                throw new TestException();
+            };
+            Http1Client client = Http1Client.builder()
+                    .baseUri("https://example.test")
+                    .servicesDiscoverServices(false)
+                    .addService(managedSecurityService(manager))
+                    .addService(stopBeforeNetwork)
+                    .build();
+
+            assertThrows(TestException.class, () -> client.get().request());
+
+            assertThat("Outbound provider lookups", providerLookups.get(), is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
 
     @Test
     void registryWebClientUsesOwningRegistrySecurity() {

--- a/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/WebClientSecurityTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.security;
 
 import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.security.OutboundSecurityResponse;
@@ -24,6 +25,9 @@ import io.helidon.security.Security;
 import io.helidon.security.SecurityEnvironment;
 import io.helidon.security.providers.common.OutboundConfig;
 import io.helidon.security.providers.common.OutboundTarget;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.spi.WebClientService;
 
@@ -34,6 +38,44 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class WebClientSecurityTest {
+
+    @Test
+    void registryWebClientUsesOwningRegistrySecurity() {
+        AtomicInteger outboundCalls = new AtomicInteger();
+        Security security = Security.builder()
+                .addOutboundSecurityProvider((request, environment, config) -> {
+                    outboundCalls.incrementAndGet();
+                    return OutboundSecurityResponse.abstain();
+                })
+                .build();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Security.class, security)
+                                                                                .build());
+        try {
+            WebClient managedClient = manager.registry().get(WebClient.class);
+            WebClientService securityService = managedClient.prototype()
+                    .services()
+                    .stream()
+                    .filter(service -> service.type().equals("security"))
+                    .findFirst()
+                    .orElseThrow();
+            WebClientService stopBeforeNetwork = (chain, request) -> {
+                throw new TestException();
+            };
+            Http1Client client = Http1Client.builder()
+                    .baseUri("https://example.test")
+                    .servicesDiscoverServices(false)
+                    .addService(securityService)
+                    .addService(stopBeforeNetwork)
+                    .build();
+
+            assertThrows(TestException.class, () -> client.get().request());
+
+            assertThat("Owning registry outbound provider calls", outboundCalls.get(), is(1));
+        } finally {
+            manager.shutdown();
+        }
+    }
 
     @Test
     void matchesHttpsOutboundTargetUsingRequestScheme() {

--- a/webclient/telemetry/metrics/pom.xml
+++ b/webclient/telemetry/metrics/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>helidon-telemetry-opentelemetry-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>

--- a/webclient/telemetry/metrics/src/main/java/io/helidon/webclient/telemetry/metrics/WebClientTelemetryMetrics.java
+++ b/webclient/telemetry/metrics/src/main/java/io/helidon/webclient/telemetry/metrics/WebClientTelemetryMetrics.java
@@ -17,10 +17,13 @@
 package io.helidon.webclient.telemetry.metrics;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.config.Config;
 import io.helidon.http.Status;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.Services;
 import io.helidon.telemetry.otelconfig.HelidonOpenTelemetry;
 import io.helidon.webclient.api.WebClientServiceRequest;
@@ -54,10 +57,14 @@ public class WebClientTelemetryMetrics implements WebClientService {
     static final String URL_SCHEME = "url.scheme";
     static final String URL_TEMPLATE = "url.template";
 
-    private final LazyValue<DoubleHistogram> outboundHttpRequestDuration =
-            LazyValue.create(WebClientTelemetryMetrics::createHistogram);
+    private final LazyValue<DoubleHistogram> outboundHttpRequestDuration;
 
     private WebClientTelemetryMetrics() {
+        this(WebClientTelemetryMetrics::createHistogram);
+    }
+
+    private WebClientTelemetryMetrics(Supplier<DoubleHistogram> histogramSupplier) {
+        outboundHttpRequestDuration = LazyValue.create(histogramSupplier);
     }
 
     /**
@@ -77,6 +84,20 @@ public class WebClientTelemetryMetrics implements WebClientService {
      */
     public static WebClientTelemetryMetrics create(Config config) {
         return create();
+    }
+
+    /**
+     * Creates a new instance of the telemetry metrics service using the provided configuration and service registry.
+     *
+     * @param config telemetry metrics configuration
+     * @param serviceRegistry service registry which owns this service
+     * @return telemetry metrics service initialized using the configuration and service registry
+     */
+    public static WebClientTelemetryMetrics create(Config config, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        ServiceRegistry owningRegistry = Objects.requireNonNull(serviceRegistry);
+        return new WebClientTelemetryMetrics(() -> createHistogram(owningRegistry.get(Config.class),
+                                                                   owningRegistry.get(OpenTelemetry.class)));
     }
 
     @Override
@@ -110,11 +131,14 @@ public class WebClientTelemetryMetrics implements WebClientService {
     }
 
     private static DoubleHistogram createHistogram() {
-        var config = Services.get(Config.class);
+        return createHistogram(Services.get(Config.class), Services.get(OpenTelemetry.class));
+    }
+
+    private static DoubleHistogram createHistogram(Config config, OpenTelemetry openTelemetry) {
         HelidonOpenTelemetry helidonOpenTelemetry = HelidonOpenTelemetry.builder()
                 .config(config.get(HelidonOpenTelemetry.CONFIG_KEY))
                 .build();
-        return Services.get(OpenTelemetry.class)
+        return openTelemetry
                 .getMeterProvider()
                 .get(helidonOpenTelemetry.prototype().service())
                 .histogramBuilder(REQUEST_DURATION)

--- a/webclient/telemetry/metrics/src/main/java/module-info.java
+++ b/webclient/telemetry/metrics/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module io.helidon.webclient.telemetry.metrics {
     requires static io.helidon.common.features.api;
 
     requires io.helidon.config;
+    requires transitive io.helidon.service.registry;
     requires io.helidon.telemetry.otelconfig;
     requires transitive io.helidon.webclient.api;
     requires io.opentelemetry.api;

--- a/webclient/telemetry/telemetry/pom.xml
+++ b/webclient/telemetry/telemetry/pom.xml
@@ -63,6 +63,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.testing</groupId>
             <artifactId>helidon-common-testing-http-junit5</artifactId>
             <scope>test</scope>

--- a/webclient/telemetry/telemetry/pom.xml
+++ b/webclient/telemetry/telemetry/pom.xml
@@ -37,6 +37,14 @@
             <artifactId>helidon-webclient-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing</groupId>
+            <artifactId>helidon-tracing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-telemetry-metrics</artifactId>
         </dependency>

--- a/webclient/telemetry/telemetry/src/main/java/io/helidon/webclient/telemetry/WebClientTelemetryProvider.java
+++ b/webclient/telemetry/telemetry/src/main/java/io/helidon/webclient/telemetry/WebClientTelemetryProvider.java
@@ -18,9 +18,13 @@ package io.helidon.webclient.telemetry;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
 
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.tracing.Tracer;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
@@ -32,9 +36,6 @@ import io.helidon.webclient.telemetry.tracing.WebClientTelemetryTracing;
  * Provider for a grouping service which gathers telemetry-related webclient services.
  */
 public class WebClientTelemetryProvider implements WebClientServiceProvider {
-
-    private final List<WebClientService> subservices = new ArrayList<>();
-
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
@@ -49,11 +50,26 @@ public class WebClientTelemetryProvider implements WebClientServiceProvider {
 
     @Override
     public WebClientService create(Config config, String name) {
+        return create(config, WebClientTelemetryTracing::create);
+    }
+
+    @Override
+    public WebClientService create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        return create(config,
+                      tracingConfig -> WebClientTelemetryTracing.create(tracingConfig,
+                                                                        serviceRegistry.get(Tracer.class)));
+    }
+
+    private WebClientService create(Config config, Function<Config, WebClientService> tracingFactory) {
+        List<WebClientService> subservices = new ArrayList<>();
         if (config.get("metrics").exists()) {
             subservices.add(WebClientTelemetryMetrics.create(config.get("metrics")));
         }
         if (config.get("tracing").exists()) {
-            subservices.add(WebClientTelemetryTracing.create(config.get("tracing")));
+            subservices.add(tracingFactory.apply(config.get("tracing")));
         }
 
         return subservices.isEmpty()

--- a/webclient/telemetry/telemetry/src/main/java/io/helidon/webclient/telemetry/WebClientTelemetryProvider.java
+++ b/webclient/telemetry/telemetry/src/main/java/io/helidon/webclient/telemetry/WebClientTelemetryProvider.java
@@ -61,7 +61,7 @@ public class WebClientTelemetryProvider implements WebClientServiceProvider {
         return create(config,
                       metricsConfig -> WebClientTelemetryMetrics.create(metricsConfig, serviceRegistry),
                       tracingConfig -> WebClientTelemetryTracing.create(tracingConfig,
-                                                                        serviceRegistry.get(Tracer.class)));
+                                                                        serviceRegistry.supply(Tracer.class)));
     }
 
     private WebClientService create(Config config,

--- a/webclient/telemetry/telemetry/src/main/java/io/helidon/webclient/telemetry/WebClientTelemetryProvider.java
+++ b/webclient/telemetry/telemetry/src/main/java/io/helidon/webclient/telemetry/WebClientTelemetryProvider.java
@@ -50,7 +50,7 @@ public class WebClientTelemetryProvider implements WebClientServiceProvider {
 
     @Override
     public WebClientService create(Config config, String name) {
-        return create(config, WebClientTelemetryTracing::create);
+        return create(config, WebClientTelemetryMetrics::create, WebClientTelemetryTracing::create);
     }
 
     @Override
@@ -59,14 +59,17 @@ public class WebClientTelemetryProvider implements WebClientServiceProvider {
         Objects.requireNonNull(name);
         Objects.requireNonNull(serviceRegistry);
         return create(config,
+                      metricsConfig -> WebClientTelemetryMetrics.create(metricsConfig, serviceRegistry),
                       tracingConfig -> WebClientTelemetryTracing.create(tracingConfig,
                                                                         serviceRegistry.get(Tracer.class)));
     }
 
-    private WebClientService create(Config config, Function<Config, WebClientService> tracingFactory) {
+    private WebClientService create(Config config,
+                                    Function<Config, WebClientService> metricsFactory,
+                                    Function<Config, WebClientService> tracingFactory) {
         List<WebClientService> subservices = new ArrayList<>();
         if (config.get("metrics").exists()) {
-            subservices.add(WebClientTelemetryMetrics.create(config.get("metrics")));
+            subservices.add(metricsFactory.apply(config.get("metrics")));
         }
         if (config.get("tracing").exists()) {
             subservices.add(tracingFactory.apply(config.get("tracing")));

--- a/webclient/telemetry/telemetry/src/main/java/module-info.java
+++ b/webclient/telemetry/telemetry/src/main/java/module-info.java
@@ -19,6 +19,8 @@
 module io.helidon.webclient.telemetry {
 
     requires io.helidon.config;
+    requires io.helidon.service.registry;
+    requires io.helidon.tracing;
     requires io.helidon.webclient.telemetry.metrics;
     requires io.helidon.webclient.telemetry.tracing;
 

--- a/webclient/telemetry/telemetry/src/test/java/io/helidon/webclient/telemetry/WebClientTelemetryProviderTest.java
+++ b/webclient/telemetry/telemetry/src/test/java/io/helidon/webclient/telemetry/WebClientTelemetryProviderTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.telemetry;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.helidon.common.context.Context;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.tracing.HeaderConsumer;
+import io.helidon.tracing.HeaderProvider;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.SpanListener;
+import io.helidon.tracing.Tracer;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+import io.helidon.webclient.spi.WebClientService;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.sameInstance;
+
+class WebClientTelemetryProviderTest {
+    private static final Config TRACING_CONFIG = Config.just(ConfigSources.create(Map.of("tracing.enabled", "true")));
+
+    @Test
+    void registryCreationUsesOwningRegistryTracer() {
+        RecordingTracer tracer = new RecordingTracer();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Tracer.class, tracer)
+                                                                                .build());
+        try {
+            WebClientService service = new WebClientTelemetryProvider()
+                    .create(TRACING_CONFIG, "telemetry", manager.registry());
+
+            service.handle(WebClientTelemetryProviderTest::response, request("http://localhost/registry"));
+
+            assertThat(tracer.spanNames(), contains("GET"));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void requestContextTracerTakesPrecedenceOverOwningRegistryTracer() {
+        RecordingTracer registryTracer = new RecordingTracer();
+        RecordingTracer contextTracer = new RecordingTracer();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Tracer.class,
+                                                                                                     registryTracer)
+                                                                                .build());
+        try {
+            WebClientService service = new WebClientTelemetryProvider()
+                    .create(TRACING_CONFIG, "telemetry", manager.registry());
+            WebClientServiceRequest request = request("http://localhost/context");
+            request.context().register(contextTracer);
+
+            service.handle(WebClientTelemetryProviderTest::response, request);
+
+            assertThat(contextTracer.spanNames(), contains("GET"));
+            assertThat(registryTracer.spanNames(), empty());
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void providerDoesNotRetainServicesAcrossClients() {
+        WebClientTelemetryProvider provider = new WebClientTelemetryProvider();
+        RecordingTracer tracer = new RecordingTracer();
+        WebClientServiceRequest request = request("http://localhost/isolated");
+        request.context().register(tracer);
+        provider.create(TRACING_CONFIG, "first");
+        WebClientService second = provider.create(Config.empty(), "second");
+        WebClientServiceResponse response = response(request);
+
+        assertThat(second.handle(_ -> response, request), sameInstance(response));
+        assertThat(tracer.spanNames(), empty());
+    }
+
+    private static WebClientServiceRequest request(String uri) {
+        return new TestRequest(uri);
+    }
+
+    private static WebClientServiceResponse response(WebClientServiceRequest request) {
+        CompletableFuture<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
+        WebClientServiceResponse response = WebClientServiceResponse.builder()
+                .connection(() -> {
+                })
+                .headers(ClientResponseHeaders.create(WritableHeaders.create()))
+                .status(Status.OK_200)
+                .whenComplete(whenComplete)
+                .serviceRequest(request)
+                .build();
+        whenComplete.complete(response);
+        return response;
+    }
+
+    private static final class TestRequest implements WebClientServiceRequest {
+        private final ClientUri uri;
+        private final ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        private final Context context = Context.create();
+        private final CompletableFuture<WebClientServiceRequest> whenSent = CompletableFuture.completedFuture(this);
+        private final CompletableFuture<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
+        private String requestId = "test-request";
+
+        private TestRequest(String uri) {
+            this.uri = ClientUri.create(URI.create(uri));
+        }
+
+        @Override
+        public ClientUri uri() {
+            return uri;
+        }
+
+        @Override
+        public Method method() {
+            return Method.GET;
+        }
+
+        @Override
+        public String protocolId() {
+            return "http/1.1";
+        }
+
+        @Override
+        public ClientRequestHeaders headers() {
+            return headers;
+        }
+
+        @Override
+        public Context context() {
+            return context;
+        }
+
+        @Override
+        public String requestId() {
+            return requestId;
+        }
+
+        @Override
+        public void requestId(String requestId) {
+            this.requestId = requestId;
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceRequest> whenSent() {
+            return whenSent;
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceResponse> whenComplete() {
+            return whenComplete;
+        }
+
+        @Override
+        public Map<String, String> properties() {
+            return Map.of();
+        }
+    }
+
+    private static final class RecordingTracer implements Tracer {
+        private final Tracer delegate = Tracer.noOp();
+        private final List<String> spanNames = new ArrayList<>();
+
+        @Override
+        public boolean enabled() {
+            return true;
+        }
+
+        @Override
+        public Span.Builder<?> spanBuilder(String name) {
+            spanNames.add(name);
+            return delegate.spanBuilder(name);
+        }
+
+        @Override
+        public Optional<SpanContext> extract(HeaderProvider headersProvider) {
+            return delegate.extract(headersProvider);
+        }
+
+        @Override
+        public void inject(SpanContext spanContext,
+                           HeaderProvider inboundHeadersProvider,
+                           HeaderConsumer outboundHeadersConsumer) {
+            delegate.inject(spanContext, inboundHeadersProvider, outboundHeadersConsumer);
+        }
+
+        @Override
+        public Tracer register(SpanListener listener) {
+            return this;
+        }
+
+        private List<String> spanNames() {
+            return List.copyOf(spanNames);
+        }
+    }
+}

--- a/webclient/telemetry/telemetry/src/test/java/io/helidon/webclient/telemetry/WebClientTelemetryProviderTest.java
+++ b/webclient/telemetry/telemetry/src/test/java/io/helidon/webclient/telemetry/WebClientTelemetryProviderTest.java
@@ -45,15 +45,62 @@ import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
 
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 class WebClientTelemetryProviderTest {
+    private static final String OTEL_SERVICE = "owning-registry-service";
+    private static final Config METRICS_CONFIG = Config.just(ConfigSources.create(Map.of("metrics.enabled", "true")));
     private static final Config TRACING_CONFIG = Config.just(ConfigSources.create(Map.of("tracing.enabled", "true")));
+
+    @Test
+    void registryCreationUsesOwningRegistryTelemetry() {
+        OpenTelemetry openTelemetry = mock(OpenTelemetry.class);
+        MeterProvider meterProvider = mock(MeterProvider.class);
+        Meter meter = mock(Meter.class);
+        DoubleHistogramBuilder histogramBuilder = mock(DoubleHistogramBuilder.class);
+        DoubleHistogram histogram = mock(DoubleHistogram.class);
+        when(openTelemetry.getMeterProvider()).thenReturn(meterProvider);
+        when(meterProvider.get(OTEL_SERVICE)).thenReturn(meter);
+        when(meter.histogramBuilder("http.client.request.duration")).thenReturn(histogramBuilder);
+        when(histogramBuilder.setDescription("Outbound HTTP request duration")).thenReturn(histogramBuilder);
+        when(histogramBuilder.setUnit("s")).thenReturn(histogramBuilder);
+        when(histogramBuilder.setExplicitBucketBoundariesAdvice(any())).thenReturn(histogramBuilder);
+        when(histogramBuilder.build()).thenReturn(histogram);
+        Config rootConfig = Config.just(ConfigSources.create(Map.of("telemetry.service", OTEL_SERVICE)));
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class, rootConfig)
+                                                                                .putContractInstance(OpenTelemetry.class,
+                                                                                                     openTelemetry)
+                                                                                .build());
+        try {
+            WebClientService service = new WebClientTelemetryProvider()
+                    .create(METRICS_CONFIG, "telemetry", manager.registry());
+            verifyNoMoreInteractions(openTelemetry);
+
+            service.handle(WebClientTelemetryProviderTest::response, request("http://localhost/metrics"));
+
+            verify(meterProvider).get(OTEL_SERVICE);
+            verify(histogram).record(anyDouble(), any());
+        } finally {
+            manager.shutdown();
+        }
+    }
 
     @Test
     void registryCreationUsesOwningRegistryTracer() {

--- a/webclient/telemetry/telemetry/src/test/java/io/helidon/webclient/telemetry/WebClientTelemetryProviderTest.java
+++ b/webclient/telemetry/telemetry/src/test/java/io/helidon/webclient/telemetry/WebClientTelemetryProviderTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.helidon.common.context.Context;
 import io.helidon.config.Config;
@@ -32,6 +33,7 @@ import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.tracing.HeaderConsumer;
@@ -55,6 +57,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
@@ -105,42 +108,43 @@ class WebClientTelemetryProviderTest {
     @Test
     void registryCreationUsesOwningRegistryTracer() {
         RecordingTracer tracer = new RecordingTracer();
-        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
-                                                                                .putContractInstance(Tracer.class, tracer)
-                                                                                .build());
-        try {
-            WebClientService service = new WebClientTelemetryProvider()
-                    .create(TRACING_CONFIG, "telemetry", manager.registry());
+        AtomicBoolean resolved = new AtomicBoolean();
+        ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+        when(serviceRegistry.supply(Tracer.class)).thenReturn(() -> {
+            resolved.set(true);
+            return tracer;
+        });
+        WebClientService service = new WebClientTelemetryProvider()
+                .create(TRACING_CONFIG, "telemetry", serviceRegistry);
 
-            service.handle(WebClientTelemetryProviderTest::response, request("http://localhost/registry"));
+        assertThat(resolved.get(), is(false));
 
-            assertThat(tracer.spanNames(), contains("GET"));
-        } finally {
-            manager.shutdown();
-        }
+        service.handle(WebClientTelemetryProviderTest::response, request("http://localhost/registry"));
+
+        assertThat(resolved.get(), is(true));
+        assertThat(tracer.spanNames(), contains("GET"));
     }
 
     @Test
     void requestContextTracerTakesPrecedenceOverOwningRegistryTracer() {
         RecordingTracer registryTracer = new RecordingTracer();
         RecordingTracer contextTracer = new RecordingTracer();
-        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
-                                                                                .putContractInstance(Tracer.class,
-                                                                                                     registryTracer)
-                                                                                .build());
-        try {
-            WebClientService service = new WebClientTelemetryProvider()
-                    .create(TRACING_CONFIG, "telemetry", manager.registry());
-            WebClientServiceRequest request = request("http://localhost/context");
-            request.context().register(contextTracer);
+        AtomicBoolean resolved = new AtomicBoolean();
+        ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+        when(serviceRegistry.supply(Tracer.class)).thenReturn(() -> {
+            resolved.set(true);
+            return registryTracer;
+        });
+        WebClientService service = new WebClientTelemetryProvider()
+                .create(TRACING_CONFIG, "telemetry", serviceRegistry);
+        WebClientServiceRequest request = request("http://localhost/context");
+        request.context().register(contextTracer);
 
-            service.handle(WebClientTelemetryProviderTest::response, request);
+        service.handle(WebClientTelemetryProviderTest::response, request);
 
-            assertThat(contextTracer.spanNames(), contains("GET"));
-            assertThat(registryTracer.spanNames(), empty());
-        } finally {
-            manager.shutdown();
-        }
+        assertThat(resolved.get(), is(false));
+        assertThat(contextTracer.spanNames(), contains("GET"));
+        assertThat(registryTracer.spanNames(), empty());
     }
 
     @Test

--- a/webclient/telemetry/tracing/src/main/java/io/helidon/webclient/telemetry/tracing/WebClientTelemetryTracing.java
+++ b/webclient/telemetry/tracing/src/main/java/io/helidon/webclient/telemetry/tracing/WebClientTelemetryTracing.java
@@ -93,9 +93,21 @@ public class WebClientTelemetryTracing implements WebClientService {
      * @return new tracing semantic conventions implementation
      */
     public static WebClientTelemetryTracing create(Config config, Tracer tracer) {
-        Objects.requireNonNull(config);
         Tracer fallbackTracer = Objects.requireNonNull(tracer);
-        return new WebClientTelemetryTracing(() -> fallbackTracer);
+        return create(config, () -> fallbackTracer);
+    }
+
+    /**
+     * Creates a new service instance to emit tracing spans compliant with OpenTelemetry semantic conventions
+     * for clients using the provided configuration and tracer supplier.
+     *
+     * @param config telemetry tracing config
+     * @param tracer supplier of the fallback tracer when the request context does not contain one
+     * @return new tracing semantic conventions implementation
+     */
+    public static WebClientTelemetryTracing create(Config config, Supplier<Tracer> tracer) {
+        Objects.requireNonNull(config);
+        return new WebClientTelemetryTracing(Objects.requireNonNull(tracer));
     }
 
     @Override

--- a/webclient/telemetry/tracing/src/main/java/io/helidon/webclient/telemetry/tracing/WebClientTelemetryTracing.java
+++ b/webclient/telemetry/tracing/src/main/java/io/helidon/webclient/telemetry/tracing/WebClientTelemetryTracing.java
@@ -17,8 +17,10 @@
 package io.helidon.webclient.telemetry.tracing;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.helidon.common.context.Context;
 import io.helidon.config.Config;
@@ -53,8 +55,12 @@ public class WebClientTelemetryTracing implements WebClientService {
     private final Function<Context, Tracer> tracerFunction;
 
     private WebClientTelemetryTracing() {
+        this(() -> Services.get(Tracer.class));
+    }
+
+    private WebClientTelemetryTracing(Supplier<Tracer> tracer) {
         tracerFunction = ctx -> ctx.get(Tracer.class)
-                .orElseGet(() -> Services.get(Tracer.class));
+                .orElseGet(tracer);
     }
 
     /**
@@ -76,6 +82,20 @@ public class WebClientTelemetryTracing implements WebClientService {
      */
     public static WebClientTelemetryTracing create(Config config) {
         return create();
+    }
+
+    /**
+     * Creates a new service instance to emit tracing spans compliant with OpenTelemetry semantic conventions
+     * for clients using the provided configuration and tracer.
+     *
+     * @param config telemetry tracing config
+     * @param tracer fallback tracer when the request context does not contain one
+     * @return new tracing semantic conventions implementation
+     */
+    public static WebClientTelemetryTracing create(Config config, Tracer tracer) {
+        Objects.requireNonNull(config);
+        Tracer fallbackTracer = Objects.requireNonNull(tracer);
+        return new WebClientTelemetryTracing(() -> fallbackTracer);
     }
 
     @Override

--- a/webclient/telemetry/tracing/src/main/java/module-info.java
+++ b/webclient/telemetry/tracing/src/main/java/module-info.java
@@ -27,7 +27,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Preview
 module io.helidon.webclient.telemetry.tracing {
     requires io.helidon.webclient.api;
-    requires io.helidon.tracing;
+    requires transitive io.helidon.tracing;
     requires io.helidon.config;
 
     requires static io.helidon.common.features.api;

--- a/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracing.java
+++ b/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracing.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.context.Context;
@@ -51,7 +52,11 @@ public class WebClientTracing implements WebClientService {
     private final Function<Context, Tracer> tracerFunction;
 
     private WebClientTracing() {
-        this.applicationTracer = LazyValue.create(() -> Services.get(Tracer.class));
+        this(() -> Services.get(Tracer.class));
+    }
+
+    private WebClientTracing(Supplier<Tracer> tracer) {
+        this.applicationTracer = LazyValue.create(tracer);
         tracerFunction = ctx -> ctx.get(Tracer.class)
                 .orElseGet(applicationTracer);
     }
@@ -77,6 +82,10 @@ public class WebClientTracing implements WebClientService {
      * @return client tracing service
      */
     public static WebClientService create(Tracer tracer) {
+        return new WebClientTracing(tracer);
+    }
+
+    static WebClientService create(Supplier<Tracer> tracer) {
         return new WebClientTracing(tracer);
     }
 

--- a/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
+++ b/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
@@ -16,10 +16,14 @@
 
 package io.helidon.webclient.tracing;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.tracing.Tracer;
 import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webclient.spi.WebClientServiceProvider;
 
@@ -46,5 +50,13 @@ public class WebClientTracingProvider implements WebClientServiceProvider {
     @Override
     public WebClientService create(Config config, String name) {
         return WebClientTracing.create();
+    }
+
+    @Override
+    public WebClientService create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        return WebClientTracing.create(() -> serviceRegistry.get(Tracer.class));
     }
 }

--- a/webclient/tracing/src/test/java/io/helidon/webclient/tracing/WebClientTracingTest.java
+++ b/webclient/tracing/src/test/java/io/helidon/webclient/tracing/WebClientTracingTest.java
@@ -41,6 +41,7 @@ import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.SpanListener;
 import io.helidon.tracing.Tracer;
 import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
@@ -76,6 +77,27 @@ class WebClientTracingTest {
         } finally {
             firstManager.shutdown();
             secondManager.shutdown();
+        }
+    }
+
+    @Test
+    void registryWebClientUsesOwningRegistryTracer() {
+        RecordingTracer tracer = new RecordingTracer();
+        ServiceRegistryManager manager = registryManager(tracer);
+        try {
+            WebClient client = manager.registry().get(WebClient.class);
+            WebClientService tracingService = client.prototype()
+                    .services()
+                    .stream()
+                    .filter(service -> service.type().equals("tracing"))
+                    .findFirst()
+                    .orElseThrow();
+
+            tracingService.handle(WebClientTracingTest::response, request("http://localhost/registry"));
+
+            assertThat(tracer.spanNames(), contains("GET-http://localhost:80/registry"));
+        } finally {
+            manager.shutdown();
         }
     }
 

--- a/webserver/grpc-security/pom.xml
+++ b/webserver/grpc-security/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>

--- a/webserver/grpc-security/src/main/java/io/helidon/webserver/grpc/security/GrpcSecurityServiceProvider.java
+++ b/webserver/grpc-security/src/main/java/io/helidon/webserver/grpc/security/GrpcSecurityServiceProvider.java
@@ -16,11 +16,13 @@
 
 package io.helidon.webserver.grpc.security;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.security.Security;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.webserver.grpc.spi.GrpcServerService;
 import io.helidon.webserver.grpc.spi.GrpcServerServiceProvider;
 
@@ -47,5 +49,13 @@ public class GrpcSecurityServiceProvider implements GrpcServerServiceProvider {
         Security securityInstance = security.orElseGet(() -> Security.create(config.root().get("security")));
 
         return GrpcSecurity.create(securityInstance, config);
+    }
+
+    @Override
+    public GrpcServerService create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        return GrpcSecurity.create(serviceRegistry.get(Security.class), config);
     }
 }

--- a/webserver/grpc-security/src/main/java/module-info.java
+++ b/webserver/grpc-security/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module io.helidon.webserver.grpc.security {
     requires transitive io.helidon.builder.api;
     requires transitive io.helidon.config;
     requires transitive io.helidon.security;
+    requires transitive io.helidon.service.registry;
     requires transitive io.helidon.webserver.grpc;
 
     exports io.helidon.webserver.grpc.security;

--- a/webserver/grpc-security/src/test/java/io/helidon/webserver/grpc/security/GrpcSecurityServiceProviderTest.java
+++ b/webserver/grpc-security/src/test/java/io/helidon/webserver/grpc/security/GrpcSecurityServiceProviderTest.java
@@ -17,11 +17,15 @@
 package io.helidon.webserver.grpc.security;
 
 import io.helidon.config.Config;
+import io.helidon.security.Security;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
 class GrpcSecurityServiceProviderTest {
     @Test
@@ -29,5 +33,23 @@ class GrpcSecurityServiceProviderTest {
         GrpcSecurityServiceProvider provider = new GrpcSecurityServiceProvider();
 
         assertThat(provider.create(Config.empty(), GrpcSecurity.TYPE).type(), is(GrpcSecurity.TYPE));
+    }
+
+    @Test
+    void registryCreationUsesOwningSecurity() {
+        Security security = Security.create(Config.empty());
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .discoverServices(false)
+                                                                                .putContractInstance(Security.class,
+                                                                                                     security)
+                                                                                .build());
+        try {
+            GrpcSecurity grpcSecurity = (GrpcSecurity) new GrpcSecurityServiceProvider()
+                    .create(Config.empty(), GrpcSecurity.TYPE, manager.registry());
+
+            assertThat(grpcSecurity.security(), sameInstance(security));
+        } finally {
+            manager.shutdown();
+        }
     }
 }

--- a/webserver/grpc-tracing/src/main/java/io/helidon/webserver/grpc/tracing/GrpcTracingService.java
+++ b/webserver/grpc-tracing/src/main/java/io/helidon/webserver/grpc/tracing/GrpcTracingService.java
@@ -15,8 +15,11 @@
  */
 package io.helidon.webserver.grpc.tracing;
 
+import java.util.Objects;
+
 import io.helidon.common.Weighted;
 import io.helidon.grpc.core.WeightedBag;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.Services;
 import io.helidon.tracing.Tracer;
 import io.helidon.webserver.grpc.spi.GrpcServerService;
@@ -42,8 +45,17 @@ class GrpcTracingService implements GrpcServerService {
 
     @Override
     public WeightedBag<ServerInterceptor> interceptors() {
+        return interceptors(Services.get(Tracer.class));
+    }
+
+    @Override
+    public WeightedBag<ServerInterceptor> interceptors(ServiceRegistry serviceRegistry) {
+        return interceptors(Objects.requireNonNull(serviceRegistry).get(Tracer.class));
+    }
+
+    private WeightedBag<ServerInterceptor> interceptors(Tracer tracer) {
         WeightedBag<ServerInterceptor> interceptors = WeightedBag.create();
-        interceptors.add(GrpcTracingInterceptor.create(Services.get(Tracer.class), config),
+        interceptors.add(GrpcTracingInterceptor.create(tracer, config),
                          Weighted.DEFAULT_WEIGHT + 100);
         return interceptors;
     }

--- a/webserver/grpc-tracing/src/test/java/io/helidon/webserver/grpc/tracing/GrpcTracingServiceTest.java
+++ b/webserver/grpc-tracing/src/test/java/io/helidon/webserver/grpc/tracing/GrpcTracingServiceTest.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
 import io.helidon.tracing.Span;
@@ -43,10 +44,36 @@ import static org.mockito.Mockito.when;
 
 @Testing.Test(perMethod = true)
 class GrpcTracingServiceTest {
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    void defaultTracerComesFromServiceRegistry() {
+    void staticRegistryProvidesTracerForDirectUse() {
         Tracer tracer = mock(Tracer.class);
+        Services.set(Tracer.class, tracer);
+
+        ServerInterceptor interceptor = GrpcTracingService.create(GrpcTracingConfig.create())
+                .interceptors()
+                .iterator()
+                .next();
+
+        verifyTracerUsed(interceptor, tracer);
+    }
+
+    @Test
+    void suppliedServiceRegistryProvidesTracer() {
+        Tracer tracer = mock(Tracer.class);
+        ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+        when(serviceRegistry.get(Tracer.class)).thenReturn(tracer);
+
+        ServerInterceptor interceptor = GrpcTracingService.create(GrpcTracingConfig.create())
+                .interceptors(serviceRegistry)
+                .iterator()
+                .next();
+
+        verifyTracerUsed(interceptor, tracer);
+        verify(serviceRegistry).get(Tracer.class);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void verifyTracerUsed(ServerInterceptor interceptor, Tracer tracer) {
         Span.Builder spanBuilder = mock(Span.Builder.class);
         Span span = mock(Span.class);
         SpanContext spanContext = mock(SpanContext.class);
@@ -68,12 +95,7 @@ class GrpcTracingServiceTest {
         when(call.getMethodDescriptor()).thenReturn(method);
         when(call.getAttributes()).thenReturn(Attributes.EMPTY);
         when(next.startCall(same(call), any(Metadata.class))).thenReturn(listener);
-        Services.set(Tracer.class, tracer);
 
-        ServerInterceptor interceptor = GrpcTracingService.create(GrpcTracingConfig.create())
-                .interceptors()
-                .iterator()
-                .next();
         interceptor.interceptCall(call, new Metadata(), next);
 
         verify(tracer).spanBuilder("test.Service/Call");

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
@@ -32,7 +32,6 @@ import io.helidon.http.http2.Http2StreamWriter;
 import io.helidon.http.http2.StreamFlowControl;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MetricsFactory;
-import io.helidon.service.registry.Services;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
@@ -94,8 +93,7 @@ public class GrpcProtocolSelector implements Http2SubProtocolSelector {
                 if (grpcConfig.enableMetrics() && metrics.owner().get() == null) {
                     MetricsOwner owner = Contexts.runInContext(ctx.listenerContext().context(),
                                                                () -> {
-                                                                   MeterRegistry meterRegistry =
-                                                                           Services.get(MeterRegistry.class);
+                                                                   MeterRegistry meterRegistry = routing.meterRegistry();
                                                                    return new MetricsOwner(meterRegistry.metricsFactory(),
                                                                                            meterRegistry);
                                                                });

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -38,6 +39,7 @@ import io.helidon.grpc.core.WeightedBag;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.PathMatchers;
 import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.grpc.spi.GrpcServerService;
@@ -166,6 +168,7 @@ public class GrpcRouting implements Routing {
         private final Set<String> excludedServiceNames = new LinkedHashSet<>();
 
         private Config config;
+        private Optional<ServiceRegistry> serviceRegistry = Optional.empty();
         private Supplier<MeterRegistry> meterRegistry = DEFAULT_METER_REGISTRY;
 
         private Builder() {
@@ -223,7 +226,10 @@ public class GrpcRouting implements Routing {
                     .forEach(programmaticServerServiceTypes::add);
             for (GrpcServerService serverService : configuredServices.values()) {
                 if (!programmaticServerServiceTypes.contains(serverService.type())) {
-                    configuredInterceptors.merge(serverService.interceptors());
+                    WeightedBag<ServerInterceptor> serviceInterceptors = serviceRegistry
+                            .map(serverService::interceptors)
+                            .orElseGet(serverService::interceptors);
+                    configuredInterceptors.merge(serviceInterceptors);
                 }
             }
             WeightedBag<ServerInterceptor> routingInterceptors = configuredInterceptors.copyMe();
@@ -368,6 +374,11 @@ public class GrpcRouting implements Routing {
 
         Builder meterRegistry(Supplier<MeterRegistry> meterRegistry) {
             this.meterRegistry = Objects.requireNonNull(meterRegistry);
+            return this;
+        }
+
+        Builder serviceRegistry(ServiceRegistry serviceRegistry) {
+            this.serviceRegistry = Optional.of(Objects.requireNonNull(serviceRegistry));
             return this;
         }
 

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
@@ -176,7 +176,12 @@ public class GrpcRouting implements Routing {
 
         @Override
         public GrpcRouting build() {
-            Config routingConfig = config == null ? Services.get(Config.class) : config;
+            Config routingConfig = config;
+            if (routingConfig == null) {
+                routingConfig = serviceRegistry
+                        .map(registry -> registry.get(Config.class))
+                        .orElseGet(() -> Services.get(Config.class));
+            }
             WeightedBag<ServerInterceptor> configuredInterceptors = WeightedBag.create(InterceptorWeights.USER);
             List<GrpcRoute> routes = new LinkedList<>();
 

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
@@ -238,6 +238,16 @@ public class GrpcRouting implements Routing {
             return new GrpcRouting(routes, routingInterceptors, services, meterRegistry);
         }
 
+        Builder meterRegistry(Supplier<MeterRegistry> meterRegistry) {
+            this.meterRegistry = Objects.requireNonNull(meterRegistry);
+            return this;
+        }
+
+        Builder serviceRegistry(ServiceRegistry serviceRegistry) {
+            this.serviceRegistry = Optional.of(Objects.requireNonNull(serviceRegistry));
+            return this;
+        }
+
         private static ConfiguredGrpcServices configuredServices(Config config) {
             Set<String> configuredProviderTypes = new LinkedHashSet<>();
             Set<GrpcServerServiceIdentity> configuredServices = new LinkedHashSet<>();
@@ -388,16 +398,6 @@ public class GrpcRouting implements Routing {
          */
         public Builder config(Config config) {
             this.config = Objects.requireNonNull(config);
-            return this;
-        }
-
-        Builder meterRegistry(Supplier<MeterRegistry> meterRegistry) {
-            this.meterRegistry = Objects.requireNonNull(meterRegistry);
-            return this;
-        }
-
-        Builder serviceRegistry(ServiceRegistry serviceRegistry) {
-            this.serviceRegistry = Optional.of(Objects.requireNonNull(serviceRegistry));
             return this;
         }
 

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import io.helidon.common.Api;
 import io.helidon.common.HelidonServiceLoader;
@@ -36,6 +37,7 @@ import io.helidon.grpc.core.InterceptorWeights;
 import io.helidon.grpc.core.WeightedBag;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.PathMatchers;
+import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.grpc.spi.GrpcServerService;
@@ -55,23 +57,27 @@ public class GrpcRouting implements Routing {
     private static final String SERVER_PROTOCOL_CONFIG_KEY = "server.protocols." + GrpcProtocolProvider.CONFIG_NAME;
     private static final Config DISCOVERY_DISABLED_CONFIG = Config.just(ConfigSources.create(
             Map.of("grpc-services-discover-services", "false")));
+    private static final Supplier<MeterRegistry> DEFAULT_METER_REGISTRY = () -> Services.get(MeterRegistry.class);
 
     static {
         WeightedBag<ServerInterceptor> interceptors = WeightedBag.create(InterceptorWeights.USER);
         interceptors.add(ContextSettingServerInterceptor.instance());
-        EMPTY = new GrpcRouting(List.of(), interceptors, Map.of());
+        EMPTY = new GrpcRouting(List.of(), interceptors, Map.of(), DEFAULT_METER_REGISTRY);
     }
 
     private final ArrayList<GrpcRoute> routes;
     private final WeightedBag<ServerInterceptor> interceptors;
     private final ArrayList<GrpcServiceDescriptor> services;
+    private final Supplier<MeterRegistry> meterRegistry;
 
     private GrpcRouting(List<GrpcRoute> routes,
                         WeightedBag<ServerInterceptor> interceptors,
-                        Map<String, GrpcServiceDescriptor> services) {
+                        Map<String, GrpcServiceDescriptor> services,
+                        Supplier<MeterRegistry> meterRegistry) {
         this.routes = new ArrayList<>(routes);
         this.interceptors = interceptors;
         this.services = new ArrayList<>(services.values());
+        this.meterRegistry = meterRegistry;
     }
 
     @Override
@@ -146,6 +152,10 @@ public class GrpcRouting implements Routing {
         return routes;
     }
 
+    MeterRegistry meterRegistry() {
+        return meterRegistry.get();
+    }
+
     /**
      * Fluent API builder for {@link GrpcRouting}.
      */
@@ -156,6 +166,7 @@ public class GrpcRouting implements Routing {
         private final Set<String> excludedServiceNames = new LinkedHashSet<>();
 
         private Config config;
+        private Supplier<MeterRegistry> meterRegistry = DEFAULT_METER_REGISTRY;
 
         private Builder() {
         }
@@ -218,7 +229,7 @@ public class GrpcRouting implements Routing {
             WeightedBag<ServerInterceptor> routingInterceptors = configuredInterceptors.copyMe();
             routingInterceptors.merge(interceptors);
             routeRegistrations.forEach(registration -> registration.register(routes, routingInterceptors));
-            return new GrpcRouting(routes, routingInterceptors, services);
+            return new GrpcRouting(routes, routingInterceptors, services, meterRegistry);
         }
 
         private static ConfiguredGrpcServices configuredServices(Config config) {
@@ -352,6 +363,11 @@ public class GrpcRouting implements Routing {
          */
         public Builder config(Config config) {
             this.config = Objects.requireNonNull(config);
+            return this;
+        }
+
+        Builder meterRegistry(Supplier<MeterRegistry> meterRegistry) {
+            this.meterRegistry = Objects.requireNonNull(meterRegistry);
             return this;
         }
 

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
@@ -269,25 +269,19 @@ public class GrpcRouting implements Routing {
             return new ConfiguredGrpcServices(configuredProviderTypes, configuredServices);
         }
 
-        private static void addConfiguredGrpcServices(Config config,
-                                                      Set<String> excludedServiceNames,
-                                                      Map<String, GrpcServerService> configuredServices) {
+        private void addConfiguredGrpcServices(Config config,
+                                               Set<String> excludedServiceNames,
+                                               Map<String, GrpcServerService> configuredServices) {
             Config configuredOnly = MergedConfig.create(DISCOVERY_DISABLED_CONFIG, config);
             if (excludedServiceNames.isEmpty()) {
-                for (GrpcServerService serverService : ConfigBuilderSupport.discoverServices(
-                        configuredOnly,
-                        "grpc-services",
-                        GrpcServerServiceProvider.class,
-                        GrpcServerService.class,
-                        false,
-                        List.of())) {
+                for (GrpcServerService serverService : discoverConfiguredGrpcServices(configuredOnly, List.of())) {
                     configuredServices.put(serverService.name(), serverService);
                 }
                 return;
             }
 
             Set<String> providerTypes = new LinkedHashSet<>();
-            HelidonServiceLoader.create(GrpcServerServiceProvider.class)
+            grpcServerServiceProviders()
                     .forEach(provider -> providerTypes.add(provider.configKey()));
             Config grpcServices = config.get("grpc-services");
             List<GrpcServerService> ignoredServices = new ArrayList<>(excludedServiceNames.size() * 2);
@@ -321,31 +315,56 @@ public class GrpcRouting implements Routing {
                 }
             }
 
-            for (GrpcServerService serverService : ConfigBuilderSupport.discoverServices(
-                    configuredOnly,
-                    "grpc-services",
-                    GrpcServerServiceProvider.class,
-                    GrpcServerService.class,
-                    false,
-                    ignoredServices)) {
+            for (GrpcServerService serverService : discoverConfiguredGrpcServices(configuredOnly, ignoredServices)) {
                 configuredServices.put(serverService.name(), serverService);
             }
         }
 
-        private static void addDiscoveredGrpcServices(Config config,
-                                                      Set<String> configuredProviderTypes,
-                                                      Set<String> excludedServiceNames,
-                                                      Map<String, GrpcServerService> configuredServices) {
-            HelidonServiceLoader.create(GrpcServerServiceProvider.class).forEach(provider -> {
+        private void addDiscoveredGrpcServices(Config config,
+                                               Set<String> configuredProviderTypes,
+                                               Set<String> excludedServiceNames,
+                                               Map<String, GrpcServerService> configuredServices) {
+            grpcServerServiceProviders().forEach(provider -> {
                 String type = provider.configKey();
                 if (configuredProviderTypes.contains(type) || excludedServiceNames.contains(type)) {
                     return;
                 }
-                GrpcServerService service = provider.create(config.get("grpc-services").get(type), type);
+                GrpcServerService service = create(provider, config.get("grpc-services").get(type), type);
                 if (!excludedServiceNames.contains(service.name())) {
                     configuredServices.putIfAbsent(service.name(), service);
                 }
             });
+        }
+
+        private List<GrpcServerService> discoverConfiguredGrpcServices(Config config,
+                                                                        List<GrpcServerService> ignoredServices) {
+            if (serviceRegistry.isPresent()) {
+                return ConfigBuilderSupport.discoverServices(config,
+                                                             "grpc-services",
+                                                             serviceRegistry,
+                                                             GrpcServerServiceProvider.class,
+                                                             GrpcServerService.class,
+                                                             false,
+                                                             ignoredServices);
+            }
+            return ConfigBuilderSupport.discoverServices(config,
+                                                         "grpc-services",
+                                                         GrpcServerServiceProvider.class,
+                                                         GrpcServerService.class,
+                                                         false,
+                                                         ignoredServices);
+        }
+
+        private List<GrpcServerServiceProvider> grpcServerServiceProviders() {
+            return serviceRegistry
+                    .map(registry -> registry.all(GrpcServerServiceProvider.class))
+                    .orElseGet(() -> HelidonServiceLoader.create(GrpcServerServiceProvider.class).asList());
+        }
+
+        private GrpcServerService create(GrpcServerServiceProvider provider, Config config, String name) {
+            return serviceRegistry
+                    .map(registry -> provider.create(config, name, registry))
+                    .orElseGet(() -> provider.create(config, name));
         }
 
         private record ExcludedGrpcServerService(String type, String name) implements GrpcServerService {

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServerFeature.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServerFeature.java
@@ -81,10 +81,10 @@ class GrpcServerFeature implements ServerFeature {
             RoutingBuilders routingBuilders = socketBuilders.routingBuilders();
             GrpcRouting.Builder builder = routingBuilders.routingBuilder(GrpcRouting.Builder.class,
                                                                          () -> GrpcRouting.builder()
-                                                                                 .config(config)
-                                                                                 .meterRegistry(meterRegistry)
-                                                                                 .serviceRegistry(serviceRegistry));
-            builder.service(route.descriptor());
+                                                                                 .config(config));
+            builder.meterRegistry(meterRegistry)
+                    .serviceRegistry(serviceRegistry)
+                    .service(route.descriptor());
         }
     }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServerFeature.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServerFeature.java
@@ -21,6 +21,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 
 import io.helidon.config.Config;
+import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.spi.ServerFeature;
@@ -31,12 +32,16 @@ class GrpcServerFeature implements ServerFeature {
     private static final System.Logger LOGGER = System.getLogger(GrpcServerFeature.class.getName());
 
     private final Config config;
+    private final Supplier<MeterRegistry> meterRegistry;
     private final Supplier<List<GrpcRouteRegistration>> routes;
     private final boolean enabled;
 
-    GrpcServerFeature(Config config, Supplier<List<GrpcRouteRegistration>> routes) {
+    GrpcServerFeature(Config config,
+                      Supplier<MeterRegistry> meterRegistry,
+                      Supplier<List<GrpcRouteRegistration>> routes) {
         this.config = config;
         this.enabled = config.get("server.features." + TYPE + ".enabled").asBoolean().orElse(true);
+        this.meterRegistry = meterRegistry;
         this.routes = routes;
     }
 
@@ -71,7 +76,9 @@ class GrpcServerFeature implements ServerFeature {
 
             RoutingBuilders routingBuilders = socketBuilders.routingBuilders();
             GrpcRouting.Builder builder = routingBuilders.routingBuilder(GrpcRouting.Builder.class,
-                                                                         () -> GrpcRouting.builder().config(config));
+                                                                         () -> GrpcRouting.builder()
+                                                                                 .config(config)
+                                                                                 .meterRegistry(meterRegistry));
             builder.service(route.descriptor());
         }
     }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServerFeature.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServerFeature.java
@@ -30,10 +30,12 @@ class GrpcServerFeature implements ServerFeature {
     private static final String TYPE = "grpc-route-registration";
     private static final System.Logger LOGGER = System.getLogger(GrpcServerFeature.class.getName());
 
+    private final Config config;
     private final Supplier<List<GrpcRouteRegistration>> routes;
     private final boolean enabled;
 
     GrpcServerFeature(Config config, Supplier<List<GrpcRouteRegistration>> routes) {
+        this.config = config;
         this.enabled = config.get("server.features." + TYPE + ".enabled").asBoolean().orElse(true);
         this.routes = routes;
     }
@@ -69,7 +71,7 @@ class GrpcServerFeature implements ServerFeature {
 
             RoutingBuilders routingBuilders = socketBuilders.routingBuilders();
             GrpcRouting.Builder builder = routingBuilders.routingBuilder(GrpcRouting.Builder.class,
-                                                                         GrpcRouting::builder);
+                                                                         () -> GrpcRouting.builder().config(config));
             builder.service(route.descriptor());
         }
     }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServerFeature.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServerFeature.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.spi.ServerFeature;
 
@@ -32,15 +33,18 @@ class GrpcServerFeature implements ServerFeature {
     private static final System.Logger LOGGER = System.getLogger(GrpcServerFeature.class.getName());
 
     private final Config config;
+    private final ServiceRegistry serviceRegistry;
     private final Supplier<MeterRegistry> meterRegistry;
     private final Supplier<List<GrpcRouteRegistration>> routes;
     private final boolean enabled;
 
     GrpcServerFeature(Config config,
+                      ServiceRegistry serviceRegistry,
                       Supplier<MeterRegistry> meterRegistry,
                       Supplier<List<GrpcRouteRegistration>> routes) {
         this.config = config;
         this.enabled = config.get("server.features." + TYPE + ".enabled").asBoolean().orElse(true);
+        this.serviceRegistry = serviceRegistry;
         this.meterRegistry = meterRegistry;
         this.routes = routes;
     }
@@ -78,7 +82,8 @@ class GrpcServerFeature implements ServerFeature {
             GrpcRouting.Builder builder = routingBuilders.routingBuilder(GrpcRouting.Builder.class,
                                                                          () -> GrpcRouting.builder()
                                                                                  .config(config)
-                                                                                 .meterRegistry(meterRegistry));
+                                                                                 .meterRegistry(meterRegistry)
+                                                                                 .serviceRegistry(serviceRegistry));
             builder.service(route.descriptor());
         }
     }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/spi/GrpcServerService.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/spi/GrpcServerService.java
@@ -16,8 +16,11 @@
 
 package io.helidon.webserver.grpc.spi;
 
+import java.util.Objects;
+
 import io.helidon.config.NamedService;
 import io.helidon.grpc.core.WeightedBag;
+import io.helidon.service.registry.ServiceRegistry;
 
 import io.grpc.ServerInterceptor;
 
@@ -43,4 +46,15 @@ public interface GrpcServerService extends NamedService {
      * @return weighted bag of interceptors
      */
     WeightedBag<ServerInterceptor> interceptors();
+
+    /**
+     * Insert a list of server interceptors for a gRPC call, using the provided service registry for dependencies.
+     *
+     * @param serviceRegistry service registry to use for interceptor dependencies
+     * @return weighted bag of interceptors
+     */
+    default WeightedBag<ServerInterceptor> interceptors(ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(serviceRegistry);
+        return interceptors();
+    }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/spi/GrpcServerService.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/spi/GrpcServerService.java
@@ -49,6 +49,8 @@ public interface GrpcServerService extends NamedService {
 
     /**
      * Insert a list of server interceptors for a gRPC call, using the provided service registry for dependencies.
+     * The default implementation validates the registry and delegates to {@link #interceptors()}. Implementations that
+     * resolve dependencies from the owning registry must override this method.
      *
      * @param serviceRegistry service registry to use for interceptor dependencies
      * @return weighted bag of interceptors

--- a/webserver/grpc/src/main/resources/META-INF/helidon/io.helidon.webserver.grpc/service.loader
+++ b/webserver/grpc/src/main/resources/META-INF/helidon/io.helidon.webserver.grpc/service.loader
@@ -1,0 +1,2 @@
+# Java ServiceLoader contracts exposed through the Helidon service registry
+io.helidon.webserver.grpc.spi.GrpcServerServiceProvider

--- a/webserver/grpc/src/main/resources/META-INF/helidon/manifest
+++ b/webserver/grpc/src/main/resources/META-INF/helidon/manifest
@@ -1,0 +1,2 @@
+#HELIDON MANIFEST#
+META-INF/helidon/io.helidon.webserver.grpc/service.loader

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcModuleInfoTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcModuleInfoTest.java
@@ -25,6 +25,7 @@ import io.helidon.webserver.grpc.spi.GrpcServerServiceProvider;
 import org.junit.jupiter.api.Test;
 
 import static java.lang.module.ModuleDescriptor.Requires.Modifier.TRANSITIVE;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -52,5 +53,14 @@ class GrpcModuleInfoTest {
                 .findFirst()
                 .orElseThrow();
         assertThat(serviceRegistry.modifiers(), hasItem(TRANSITIVE));
+    }
+
+    @Test
+    void grpcServiceProvidersAreBridgedIntoRegistry() throws IOException {
+        Path serviceLoader = Path.of("target/classes/META-INF/helidon/io.helidon.webserver.grpc/service.loader");
+        Path manifest = Path.of("target/classes/META-INF/helidon/manifest");
+
+        assertThat(Files.readString(serviceLoader), containsString(GrpcServerServiceProvider.class.getName()));
+        assertThat(Files.readString(manifest), containsString("META-INF/helidon/io.helidon.webserver.grpc/service.loader"));
     }
 }

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcRoutingRegistryTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcRoutingRegistryTest.java
@@ -16,17 +16,28 @@
 
 package io.helidon.webserver.grpc;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
+import io.helidon.common.Builder;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.grpc.core.WeightedBag;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.grpc.spi.GrpcServerService;
 import io.helidon.webserver.grpc.spi.GrpcServerServiceProvider;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.spi.ServerFeature;
 
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
 import io.grpc.ServerInterceptor;
 import org.junit.jupiter.api.Test;
 
@@ -78,6 +89,38 @@ class GrpcRoutingRegistryTest {
         }
     }
 
+    @Test
+    void serverFeatureConfiguresExistingRoutingBuilder() throws Descriptors.DescriptorValidationException {
+        TestProvider provider = new TestProvider();
+        ServiceRegistryManager manager = registry(provider);
+        try {
+            ServiceRegistry serviceRegistry = manager.registry();
+            Config rootConfig = Config.just(ConfigSources.create(Map.of("grpc.grpc-services.owner.enabled", "true",
+                                                                        "grpc.grpc-services-discover-services", "false")));
+            GrpcRouting.Builder routingBuilder = GrpcRouting.builder()
+                    .config(rootConfig.get("grpc"));
+            AtomicBoolean meterRegistryRequested = new AtomicBoolean();
+            GrpcServiceDescriptor descriptor = descriptor("feature");
+            GrpcServerFeature feature = new GrpcServerFeature(rootConfig,
+                                                              serviceRegistry,
+                                                              () -> {
+                                                                  meterRegistryRequested.set(true);
+                                                                  return null;
+                                                              },
+                                                              () -> List.of(() -> descriptor));
+
+            feature.setup(new TestFeatureContext(routingBuilder));
+            GrpcRouting routing = routingBuilder.build();
+            routing.meterRegistry();
+
+            assertThat(provider.createCount, is(1));
+            assertThat(provider.serviceRegistry, sameInstance(serviceRegistry));
+            assertThat(meterRegistryRequested.get(), is(true));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
     private static Config routingConfig(Map<String, String> values) {
         return Config.just(ConfigSources.create(values)).get("grpc");
     }
@@ -88,6 +131,104 @@ class GrpcRoutingRegistryTest {
                                                      .discoverServicesFromServiceLoader(false)
                                                      .putContractInstance(GrpcServerServiceProvider.class, provider)
                                                      .build());
+    }
+
+    private static GrpcServiceDescriptor descriptor(String protoPackage)
+            throws Descriptors.DescriptorValidationException {
+        return GrpcServiceDescriptor.builder(GrpcRoutingRegistryTest.class, protoPackage + ".Greeter")
+                .proto(proto(protoPackage))
+                .build();
+    }
+
+    private static Descriptors.FileDescriptor proto(String protoPackage)
+            throws Descriptors.DescriptorValidationException {
+        DescriptorProtos.DescriptorProto request = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("GreetingRequest")
+                .build();
+        DescriptorProtos.DescriptorProto reply = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("GreetingReply")
+                .build();
+        DescriptorProtos.MethodDescriptorProto method = DescriptorProtos.MethodDescriptorProto.newBuilder()
+                .setName("SayHello")
+                .setInputType("." + protoPackage + ".GreetingRequest")
+                .setOutputType("." + protoPackage + ".GreetingReply")
+                .build();
+        DescriptorProtos.ServiceDescriptorProto service = DescriptorProtos.ServiceDescriptorProto.newBuilder()
+                .setName("Greeter")
+                .addMethod(method)
+                .build();
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName(protoPackage + "_greeter.proto")
+                .setPackage(protoPackage)
+                .addMessageType(request)
+                .addMessageType(reply)
+                .addService(service)
+                .build();
+
+        return Descriptors.FileDescriptor.buildFrom(file, new Descriptors.FileDescriptor[0]);
+    }
+
+    private static final class TestFeatureContext implements ServerFeature.ServerFeatureContext {
+        private final ServerFeature.SocketBuilders socketBuilders;
+
+        private TestFeatureContext(GrpcRouting.Builder routingBuilder) {
+            this.socketBuilders = new TestSocketBuilders(routingBuilder);
+        }
+
+        @Override
+        public WebServerConfig serverConfig() {
+            return null;
+        }
+
+        @Override
+        public Set<String> sockets() {
+            return Set.of();
+        }
+
+        @Override
+        public boolean socketExists(String socketName) {
+            return true;
+        }
+
+        @Override
+        public ServerFeature.SocketBuilders socket(String socketName) {
+            return socketBuilders;
+        }
+    }
+
+    private record TestSocketBuilders(ServerFeature.RoutingBuilders routingBuilders)
+            implements ServerFeature.SocketBuilders {
+        private TestSocketBuilders(GrpcRouting.Builder routingBuilder) {
+            this(new TestRoutingBuilders(routingBuilder));
+        }
+
+        @Override
+        public ListenerConfig listener() {
+            return null;
+        }
+
+        @Override
+        public HttpRouting.Builder httpRouting() {
+            return null;
+        }
+    }
+
+    private record TestRoutingBuilders(GrpcRouting.Builder routingBuilder)
+            implements ServerFeature.RoutingBuilders {
+        @Override
+        public boolean hasRouting(Class<?> builderType) {
+            return builderType == GrpcRouting.Builder.class;
+        }
+
+        @Override
+        public <T extends Builder<T, ?>> T routingBuilder(Class<T> builderType) {
+            return builderType.cast(routingBuilder);
+        }
+
+        @Override
+        public <T extends Builder<T, ?>> T routingBuilder(Class<T> builderType, Supplier<T> builderSupplier) {
+            return routingBuilder(builderType);
+        }
     }
 
     private static final class TestProvider implements GrpcServerServiceProvider {

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcRoutingRegistryTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcRoutingRegistryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.grpc;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.grpc.core.WeightedBag;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.grpc.spi.GrpcServerService;
+import io.helidon.webserver.grpc.spi.GrpcServerServiceProvider;
+
+import io.grpc.ServerInterceptor;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class GrpcRoutingRegistryTest {
+    @Test
+    void configuredServiceUsesOwningRegistryProvider() {
+        TestProvider provider = new TestProvider();
+        ServiceRegistryManager manager = registry(provider);
+        try {
+            ServiceRegistry serviceRegistry = manager.registry();
+            Config config = routingConfig(Map.of("grpc.grpc-services.owner.enabled", "true",
+                                                 "grpc.grpc-services-discover-services", "false"));
+
+            GrpcRouting.builder()
+                    .config(config)
+                    .serviceRegistry(serviceRegistry)
+                    .build();
+
+            assertThat(provider.createCount, is(1));
+            assertThat(provider.name, is("owner"));
+            assertThat(provider.serviceRegistry, sameInstance(serviceRegistry));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void discoveredServiceUsesOwningRegistryProvider() {
+        TestProvider provider = new TestProvider();
+        ServiceRegistryManager manager = registry(provider);
+        try {
+            ServiceRegistry serviceRegistry = manager.registry();
+            Config config = routingConfig(Map.of("grpc.marker", "present"));
+
+            GrpcRouting.builder()
+                    .config(config)
+                    .serviceRegistry(serviceRegistry)
+                    .build();
+
+            assertThat(provider.createCount, is(1));
+            assertThat(provider.name, is("owner"));
+            assertThat(provider.serviceRegistry, sameInstance(serviceRegistry));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private static Config routingConfig(Map<String, String> values) {
+        return Config.just(ConfigSources.create(values)).get("grpc");
+    }
+
+    private static ServiceRegistryManager registry(GrpcServerServiceProvider provider) {
+        return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                     .discoverServices(false)
+                                                     .discoverServicesFromServiceLoader(false)
+                                                     .putContractInstance(GrpcServerServiceProvider.class, provider)
+                                                     .build());
+    }
+
+    private static final class TestProvider implements GrpcServerServiceProvider {
+        private ServiceRegistry serviceRegistry;
+        private String name;
+        private int createCount;
+
+        @Override
+        public String configKey() {
+            return "owner";
+        }
+
+        @Override
+        public GrpcServerService create(Config config, String name) {
+            throw new AssertionError("Managed service creation must use the owning registry");
+        }
+
+        @Override
+        public GrpcServerService create(Config config, String name, ServiceRegistry serviceRegistry) {
+            this.serviceRegistry = serviceRegistry;
+            this.name = name;
+            createCount++;
+            return new TestService(name);
+        }
+    }
+
+    private record TestService(String name) implements GrpcServerService {
+        @Override
+        public String type() {
+            return "owner";
+        }
+
+        @Override
+        public WeightedBag<ServerInterceptor> interceptors() {
+            return WeightedBag.create();
+        }
+    }
+}

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcRoutingRegistryTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcRoutingRegistryTest.java
@@ -29,6 +29,8 @@ import io.helidon.grpc.core.WeightedBag;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
 import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.grpc.spi.GrpcServerService;
@@ -45,15 +47,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Testing.Test(perMethod = true)
 class GrpcRoutingRegistryTest {
     @Test
     void configuredServiceUsesOwningRegistryProvider() {
         TestProvider provider = new TestProvider();
-        ServiceRegistryManager manager = registry(provider);
+        Config config = routingConfig(Map.of("grpc.grpc-services.owner.enabled", "true",
+                                             "grpc.grpc-services-discover-services", "false"));
+        ServiceRegistryManager manager = registry(provider, config);
         try {
             ServiceRegistry serviceRegistry = manager.registry();
-            Config config = routingConfig(Map.of("grpc.grpc-services.owner.enabled", "true",
-                                                 "grpc.grpc-services-discover-services", "false"));
 
             GrpcRouting.builder()
                     .config(config)
@@ -71,10 +74,10 @@ class GrpcRoutingRegistryTest {
     @Test
     void discoveredServiceUsesOwningRegistryProvider() {
         TestProvider provider = new TestProvider();
-        ServiceRegistryManager manager = registry(provider);
+        Config config = routingConfig(Map.of("grpc.marker", "present"));
+        ServiceRegistryManager manager = registry(provider, config);
         try {
             ServiceRegistry serviceRegistry = manager.registry();
-            Config config = routingConfig(Map.of("grpc.marker", "present"));
 
             GrpcRouting.builder()
                     .config(config)
@@ -92,16 +95,18 @@ class GrpcRoutingRegistryTest {
     @Test
     void serverFeatureConfiguresExistingRoutingBuilder() throws Descriptors.DescriptorValidationException {
         TestProvider provider = new TestProvider();
-        ServiceRegistryManager manager = registry(provider);
+        Config owningConfig = Config.just(ConfigSources.create(Map.of("grpc.grpc-services.owner.marker", "owning",
+                                                                      "grpc.grpc-services-discover-services", "false")));
+        Config explicitConfig = Config.just(ConfigSources.create(Map.of("grpc.grpc-services.owner.marker", "explicit",
+                                                                        "grpc.grpc-services-discover-services", "false")));
+        ServiceRegistryManager manager = registry(provider, owningConfig);
         try {
             ServiceRegistry serviceRegistry = manager.registry();
-            Config rootConfig = Config.just(ConfigSources.create(Map.of("grpc.grpc-services.owner.enabled", "true",
-                                                                        "grpc.grpc-services-discover-services", "false")));
             GrpcRouting.Builder routingBuilder = GrpcRouting.builder()
-                    .config(rootConfig.get("grpc"));
+                    .config(explicitConfig.get("grpc"));
             AtomicBoolean meterRegistryRequested = new AtomicBoolean();
             GrpcServiceDescriptor descriptor = descriptor("feature");
-            GrpcServerFeature feature = new GrpcServerFeature(rootConfig,
+            GrpcServerFeature feature = new GrpcServerFeature(owningConfig,
                                                               serviceRegistry,
                                                               () -> {
                                                                   meterRegistryRequested.set(true);
@@ -114,8 +119,39 @@ class GrpcRoutingRegistryTest {
             routing.meterRegistry();
 
             assertThat(provider.createCount, is(1));
+            assertThat(provider.config.get("marker").asString().orElseThrow(), is("explicit"));
             assertThat(provider.serviceRegistry, sameInstance(serviceRegistry));
             assertThat(meterRegistryRequested.get(), is(true));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void serverFeatureUsesOwningConfigForExistingUnconfiguredRoutingBuilder()
+            throws Descriptors.DescriptorValidationException {
+        TestProvider provider = new TestProvider();
+        Config owningConfig = Config.just(ConfigSources.create(Map.of("grpc.grpc-services.owner.marker", "owning",
+                                                                      "grpc.grpc-services-discover-services", "false")));
+        Config globalConfig = Config.just(ConfigSources.create(Map.of("grpc.grpc-services.owner.marker", "global",
+                                                                      "grpc.grpc-services-discover-services", "false")));
+        Services.set(Config.class, globalConfig);
+        ServiceRegistryManager manager = registry(provider, owningConfig);
+        try {
+            ServiceRegistry serviceRegistry = manager.registry();
+            GrpcRouting.Builder routingBuilder = GrpcRouting.builder();
+            GrpcServiceDescriptor descriptor = descriptor("feature");
+            GrpcServerFeature feature = new GrpcServerFeature(owningConfig,
+                                                              serviceRegistry,
+                                                              () -> null,
+                                                              () -> List.of(() -> descriptor));
+
+            feature.setup(new TestFeatureContext(routingBuilder));
+            routingBuilder.build();
+
+            assertThat(provider.createCount, is(1));
+            assertThat(provider.config.get("marker").asString().orElseThrow(), is("owning"));
+            assertThat(provider.serviceRegistry, sameInstance(serviceRegistry));
         } finally {
             manager.shutdown();
         }
@@ -125,10 +161,11 @@ class GrpcRoutingRegistryTest {
         return Config.just(ConfigSources.create(values)).get("grpc");
     }
 
-    private static ServiceRegistryManager registry(GrpcServerServiceProvider provider) {
+    private static ServiceRegistryManager registry(GrpcServerServiceProvider provider, Config config) {
         return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
                                                      .discoverServices(false)
                                                      .discoverServicesFromServiceLoader(false)
+                                                     .putContractInstance(Config.class, config)
                                                      .putContractInstance(GrpcServerServiceProvider.class, provider)
                                                      .build());
     }
@@ -232,6 +269,7 @@ class GrpcRoutingRegistryTest {
     }
 
     private static final class TestProvider implements GrpcServerServiceProvider {
+        private Config config;
         private ServiceRegistry serviceRegistry;
         private String name;
         private int createCount;
@@ -248,6 +286,7 @@ class GrpcRoutingRegistryTest {
 
         @Override
         public GrpcServerService create(Config config, String name, ServiceRegistry serviceRegistry) {
+            this.config = config;
             this.serviceRegistry = serviceRegistry;
             this.name = name;
             createCount++;

--- a/webserver/observe/config/pom.xml
+++ b/webserver/observe/config/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media-json</artifactId>
         </dependency>
@@ -112,6 +116,11 @@
                             <version>${helidon.version}</version>
                         </path>
                         <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
                             <groupId>io.helidon.codegen</groupId>
                             <artifactId>helidon-codegen-helidon-copyright</artifactId>
                             <version>${helidon.version}</version>
@@ -137,6 +146,11 @@
                     <dependency>
                         <groupId>io.helidon.builder</groupId>
                         <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                     <dependency>

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
@@ -18,12 +18,15 @@ package io.helidon.webserver.observe.config;
 
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for config observe provider.
  */
+@Service.Singleton
 public class ConfigObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
@@ -43,5 +46,14 @@ public class ConfigObserveProvider implements ObserveProvider {
                 .config(config)
                 .name(name)
                 .build();
+    }
+
+    @Override
+    public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+        var observerConfig = ConfigObserver.builder()
+                .config(config)
+                .name(name)
+                .buildPrototype();
+        return ConfigObserver.create(observerConfig, serviceRegistry.supply(Config.class));
     }
 }

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.observe.config;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.service.registry.Service;
@@ -50,6 +52,9 @@ public class ConfigObserveProvider implements ObserveProvider {
 
     @Override
     public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
         var observerConfig = ConfigObserver.builder()
                 .config(config)
                 .name(name)

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserveProvider.java
@@ -26,7 +26,8 @@ import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
- * {@link java.util.ServiceLoader} provider implementation for config observe provider.
+ * Config observe provider implementation, discoverable through
+ * {@link io.helidon.service.registry.ServiceRegistry} and {@link java.util.ServiceLoader}.
  */
 @Service.Singleton
 public class ConfigObserveProvider implements ObserveProvider {

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserver.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserver.java
@@ -18,11 +18,14 @@ package io.helidon.webserver.observe.config;
 
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.config.Config;
+import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.HttpFeature;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.observe.DisabledObserverFeature;
@@ -36,11 +39,16 @@ public class ConfigObserver implements Observer, RuntimeType.Api<ConfigObserverC
     private final ConfigObserverConfig config;
     private final List<Pattern> secretPatterns;
     private final List<Pattern> safeKeyPatterns;
+    private final Supplier<Config> configSupplier;
 
-    private ConfigObserver(ConfigObserverConfig config, List<Pattern> secretPatterns, List<Pattern> safeKeyPatterns) {
+    private ConfigObserver(ConfigObserverConfig config,
+                           List<Pattern> secretPatterns,
+                           List<Pattern> safeKeyPatterns,
+                           Supplier<Config> configSupplier) {
         this.config = config;
         this.secretPatterns = secretPatterns;
         this.safeKeyPatterns = safeKeyPatterns;
+        this.configSupplier = configSupplier;
     }
 
     /**
@@ -59,6 +67,10 @@ public class ConfigObserver implements Observer, RuntimeType.Api<ConfigObserverC
      * @return a new observer
      */
     public static ConfigObserver create(ConfigObserverConfig config) {
+        return create(config, () -> Services.get(Config.class));
+    }
+
+    static ConfigObserver create(ConfigObserverConfig config, Supplier<Config> configSupplier) {
         List<Pattern> secretPatterns = Stream.concat(ConfigObserverConfigDefaults.SECRETS.stream(),
                                                      config.secrets().stream())
                 .distinct()
@@ -68,7 +80,7 @@ public class ConfigObserver implements Observer, RuntimeType.Api<ConfigObserverC
                 .stream()
                 .map(it -> Pattern.compile(it, Pattern.CASE_INSENSITIVE))
                 .toList();
-        return new ConfigObserver(config, secretPatterns, safeKeyPatterns);
+        return new ConfigObserver(config, secretPatterns, safeKeyPatterns, configSupplier);
     }
 
     /**
@@ -117,7 +129,8 @@ public class ConfigObserver implements Observer, RuntimeType.Api<ConfigObserverC
                                                          safeKeyPatterns,
                                                          findProfile(),
                                                          config.permitAll(),
-                                                         config.unsafeValues()));
+                                                         config.unsafeValues(),
+                                                         configSupplier));
             }
         } else {
             for (HttpRouting.Builder builder : observeEndpointRouting) {
@@ -150,24 +163,33 @@ public class ConfigObserver implements Observer, RuntimeType.Api<ConfigObserverC
         private final String profile;
         private final boolean permitAll;
         private final boolean unsafeValues;
+        private final Supplier<Config> configSupplier;
 
         private ConfigHttpFeature(String endpoint,
                                   List<Pattern> secretPatterns,
                                   List<Pattern> safeKeyPatterns,
                                   String profile,
                                   boolean permitAll,
-                                  boolean unsafeValues) {
+                                  boolean unsafeValues,
+                                  Supplier<Config> configSupplier) {
             this.endpoint = endpoint;
             this.secretPatterns = secretPatterns;
             this.safeKeyPatterns = safeKeyPatterns;
             this.profile = profile;
             this.permitAll = permitAll;
             this.unsafeValues = unsafeValues;
+            this.configSupplier = configSupplier;
         }
 
         @Override
         public void setup(HttpRouting.Builder routing) {
-            routing.register(endpoint, new ConfigService(secretPatterns, safeKeyPatterns, profile, permitAll, unsafeValues));
+            routing.register(endpoint,
+                             new ConfigService(secretPatterns,
+                                               safeKeyPatterns,
+                                               profile,
+                                               permitAll,
+                                               unsafeValues,
+                                               configSupplier));
         }
     }
 }

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigService.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigService.java
@@ -29,7 +29,6 @@ import io.helidon.http.NotFoundException;
 import io.helidon.http.media.EntityWriter;
 import io.helidon.http.media.json.JsonSupport;
 import io.helidon.json.JsonObject;
-import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.SecureHandler;
@@ -46,18 +45,20 @@ class ConfigService implements HttpService {
     private final boolean permitAll;
     private final boolean unsafeValues;
     private final ConcurrentMap<String, Boolean> obfuscatedKeys = new ConcurrentHashMap<>();
-    private final LazyValue<Config> config = LazyValue.create(() -> Services.get(Config.class));
+    private final LazyValue<Config> config;
 
     ConfigService(List<Pattern> secretPatterns,
                   List<Pattern> safeKeyPatterns,
                   String profile,
                   boolean permitAll,
-                  boolean unsafeValues) {
+                  boolean unsafeValues,
+                  Supplier<Config> configSupplier) {
         this.secretPatterns = secretPatterns;
         this.safeKeyPatterns = safeKeyPatterns;
         this.profile = profile;
         this.permitAll = permitAll;
         this.unsafeValues = unsafeValues;
+        this.config = LazyValue.create(configSupplier);
     }
 
     @Override

--- a/webserver/observe/config/src/main/java/module-info.java
+++ b/webserver/observe/config/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module io.helidon.webserver.observe.config {
     requires static io.helidon.config.metadata;
 
     requires io.helidon.json;
+    requires io.helidon.service.registry;
     requires io.helidon.webserver;
 
     requires transitive io.helidon.config;

--- a/webserver/observe/config/src/test/java/io/helidon/webserver/observe/config/ConfigObserveProviderRegistryTest.java
+++ b/webserver/observe/config/src/test/java/io/helidon/webserver/observe/config/ConfigObserveProviderRegistryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe.config;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.observe.ObserveFeature;
+import io.helidon.webserver.observe.spi.Observer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ConfigObserveProviderRegistryTest {
+    private static final AtomicBoolean DISABLED_CONFIG_RESOLVED = new AtomicBoolean();
+
+    @Test
+    void managedObserverUsesOwningRegistryConfig() {
+        Config config = Config.just(ConfigSources.create(Map.of("registry.source", "owning-registry")));
+        ServiceRegistryManager registryManager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                       .discoverServices(false)
+                                                                                       .discoverServicesFromServiceLoader(false)
+                                                                                       .putContractInstance(Config.class, config)
+                                                                                       .build());
+
+        Config observerConfig = Config.just(ConfigSources.create(Map.of("endpoint", "managed-config",
+                                                                         "permit-all", "true",
+                                                                         "unsafe-values", "true")));
+        Observer managedObserver = new ConfigObserveProvider().create(observerConfig,
+                                                                      "managed",
+                                                                      registryManager.registry());
+        WebServer server = WebServer.builder()
+                .port(0)
+                .featuresDiscoverServices(false)
+                .addFeature(ObserveFeature.just(managedObserver))
+                .build();
+        try {
+            server.start();
+            WebClient client = WebClient.builder()
+                    .baseUri(URI.create("http://localhost:" + server.port()))
+                    .build();
+            ClientResponseTyped<JsonObject> response = client.get("/observe/managed-config/values/registry.source")
+                    .request(JsonObject.class);
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().stringValue("value").orElseThrow(), is("owning-registry"));
+        } finally {
+            server.stop();
+            registryManager.shutdown();
+        }
+    }
+
+    @Test
+    void disabledObserverDoesNotResolveConfig() {
+        var disabledConfig = ConfigObserver.builder()
+                .enabled(false)
+                .endpoint("disabled")
+                .name("disabled")
+                .buildPrototype();
+        Observer disabledObserver = ConfigObserver.create(disabledConfig, () -> {
+            DISABLED_CONFIG_RESOLVED.set(true);
+            return Config.empty();
+        });
+
+        disabledObserver.register(null, List.of(), endpoint -> endpoint);
+
+        assertThat(DISABLED_CONFIG_RESOLVED.get(), is(false));
+    }
+}

--- a/webserver/observe/health/pom.xml
+++ b/webserver/observe/health/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
             <artifactId>helidon-webserver-observe</artifactId>
         </dependency>
@@ -116,6 +120,11 @@
                             <version>${helidon.version}</version>
                         </path>
                         <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
                             <groupId>io.helidon.codegen</groupId>
                             <artifactId>helidon-codegen-helidon-copyright</artifactId>
                             <version>${helidon.version}</version>
@@ -141,6 +150,11 @@
                     <dependency>
                         <groupId>io.helidon.builder</groupId>
                         <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                     <dependency>

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.observe.health;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.health.HealthCheck;
@@ -52,6 +54,9 @@ public class HealthObserveProvider implements ObserveProvider {
 
     @Override
     public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
         var observerConfig = HealthObserverConfig.builder()
                 .config(config)
                 .name(name)

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
@@ -28,7 +28,8 @@ import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
- * {@link java.util.ServiceLoader} provider implementation for health observe provider.
+ * Health observe provider implementation, discoverable through
+ * {@link io.helidon.service.registry.ServiceRegistry} and {@link java.util.ServiceLoader}.
  */
 @Service.Singleton
 public class HealthObserveProvider implements ObserveProvider {

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserveProvider.java
@@ -18,12 +18,17 @@ package io.helidon.webserver.observe.health;
 
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.health.HealthCheck;
+import io.helidon.health.spi.HealthCheckProvider;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for health observe provider.
  */
+@Service.Singleton
 public class HealthObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
@@ -43,5 +48,17 @@ public class HealthObserveProvider implements ObserveProvider {
                 .config(config)
                 .name(name)
                 .build();
+    }
+
+    @Override
+    public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+        var observerConfig = HealthObserverConfig.builder()
+                .config(config)
+                .name(name)
+                .buildPrototype();
+        return new HealthObserver(observerConfig,
+                                  serviceRegistry.supply(Config.class),
+                                  serviceRegistry.supplyAll(HealthCheckProvider.class),
+                                  serviceRegistry.supplyAll(HealthCheck.class));
     }
 }

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserver.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -46,21 +47,28 @@ public class HealthObserver implements Observer, RuntimeType.Api<HealthObserverC
     private final List<HealthCheck> all;
 
     private HealthObserver(HealthObserverConfig config) {
+        this(config,
+             () -> config.config().orElseGet(Config::empty),
+             HealthObserver::loadHealthCheckProviders,
+             () -> Services.all(HealthCheck.class));
+    }
+
+    HealthObserver(HealthObserverConfig config,
+                   Supplier<Config> rootConfig,
+                   Supplier<List<HealthCheckProvider>> healthCheckProviders,
+                   Supplier<List<HealthCheck>> healthChecks) {
         this.config = config;
 
         List<HealthCheck> checks = new ArrayList<>(config.healthChecks());
         if (config.useSystemServices()) {
-            Config cfg = config.config().orElseGet(Config::empty);
-            HelidonServiceLoader.create(ServiceLoader.load(HealthCheckProvider.class))
-                    .asList()
+            Config configRoot = rootConfig.get();
+            healthCheckProviders.get()
                     .stream()
-                    .map(provider -> provider.healthChecks(cfg))
+                    .map(provider -> provider.healthChecks(configRoot))
                     .flatMap(Collection::stream)
                     .forEach(checks::add);
 
-            // also lookup all health check from the service registry
-            // our own implementation are currently not services, so this should not duplicate them
-            checks.addAll(Services.all(HealthCheck.class));
+            checks.addAll(healthChecks.get());
         }
         // Omit any checks requested to be excluded by name.
         this.all = checks.stream()
@@ -144,6 +152,10 @@ public class HealthObserver implements Observer, RuntimeType.Api<HealthObserverC
     // primarily for testing
     List<HealthCheck> all() {
         return Collections.unmodifiableList(all);
+    }
+
+    private static List<HealthCheckProvider> loadHealthCheckProviders() {
+        return HelidonServiceLoader.create(ServiceLoader.load(HealthCheckProvider.class)).asList();
     }
 
     private static class HealthHttpFeature implements HttpFeature {

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserverConfigBlueprint.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserverConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,8 +67,10 @@ interface HealthObserverConfigBlueprint extends ObserverConfigBase, Prototype.Fa
     List<HealthCheck> healthChecks();
 
     /**
-     * Whether to use services discovered by {@link java.util.ServiceLoader}.
-     * By default, all {@link io.helidon.health.spi.HealthCheckProvider} based health checks are added.
+     * Whether to use discovered health-check services.
+     * By default, all {@link io.helidon.health.spi.HealthCheckProvider} and
+     * {@link io.helidon.health.HealthCheck} services are added. A directly created observer discovers services using
+     * {@link java.util.ServiceLoader} and the global service registry. A registry-managed observer uses its owning registry.
      *
      * @return set to {@code false} to disable discovery
      */

--- a/webserver/observe/health/src/main/java/module-info.java
+++ b/webserver/observe/health/src/main/java/module-info.java
@@ -26,6 +26,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 module io.helidon.webserver.observe.health {
 
     requires io.helidon.http.media.json;
+    requires io.helidon.service.registry;
     requires io.helidon.webserver;
     requires java.management;
 

--- a/webserver/observe/health/src/test/java/io/helidon/webserver/observe/health/HealthObserveProviderRegistryTest.java
+++ b/webserver/observe/health/src/test/java/io/helidon/webserver/observe/health/HealthObserveProviderRegistryTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe.health;
+
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.health.HealthCheck;
+import io.helidon.health.HealthCheckResponse;
+import io.helidon.health.spi.HealthCheckProvider;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+class HealthObserveProviderRegistryTest {
+    @Test
+    void providerUsesServicesFromOwningRegistryWhenDiscoveryIsDisabled() {
+        Config rootConfig = Config.just(ConfigSources.create(Map.of("health-check-name", "provider-check")));
+        HealthCheckProvider healthCheckProvider = config -> List.of(healthCheck(config.get("health-check-name")
+                                                                                       .asString()
+                                                                                       .orElseThrow()));
+        HealthCheck healthCheck = healthCheck("registry-check");
+        var registryConfig = ServiceRegistryConfig.builder()
+                .discoverServices(false)
+                .discoverServicesFromServiceLoader(false)
+                .putContractInstance(Config.class, rootConfig)
+                .putContractInstance(HealthCheckProvider.class, healthCheckProvider)
+                .putContractInstance(HealthCheck.class, healthCheck)
+                .build();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(registryConfig);
+        try {
+            HealthObserver observer = (HealthObserver) new HealthObserveProvider()
+                    .create(Config.empty(), "test", manager.registry());
+
+            assertThat(observer.all().stream().map(HealthCheck::name).toList(),
+                       contains("provider-check", "registry-check"));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void managedObserverPreservesDiscoveryOrder() {
+        HealthObserverConfig config = HealthObserverConfig.builder()
+                .addCheck(healthCheck("explicit-check"))
+                .buildPrototype();
+        HealthObserver observer = new HealthObserver(config,
+                                                     Config::empty,
+                                                     () -> List.of(_ -> List.of(healthCheck("provider-check"))),
+                                                     () -> List.of(healthCheck("registry-check")));
+
+        assertThat(observer.all().stream().map(HealthCheck::name).toList(),
+                   contains("explicit-check", "provider-check", "registry-check"));
+    }
+
+    @Test
+    void systemServiceDiscoveryCanBeDisabledPerObserver() {
+        HealthObserverConfig config = HealthObserverConfig.builder()
+                .useSystemServices(false)
+                .addCheck(healthCheck("explicit-check"))
+                .buildPrototype();
+        HealthObserver observer = new HealthObserver(config,
+                                                     () -> {
+                                                         throw new AssertionError("Root config must not be resolved");
+                                                     },
+                                                     () -> {
+                                                         throw new AssertionError("Providers must not be resolved");
+                                                     },
+                                                     () -> {
+                                                         throw new AssertionError("Checks must not be resolved");
+                                                     });
+
+        assertThat(observer.all().stream().map(HealthCheck::name).toList(), contains("explicit-check"));
+    }
+
+    @Test
+    void legacyHealthCheckProviderIsBridgedIntoRegistry() {
+        var registryConfig = ServiceRegistryConfig.builder()
+                .discoverServices(false)
+                .build();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(registryConfig);
+        try {
+            assertThat(manager.registry()
+                               .all(HealthCheckProvider.class)
+                               .stream()
+                               .map(provider -> provider.getClass().getName())
+                               .toList(),
+                       hasItem("io.helidon.health.checks.BuiltInHealthCheckProvider"));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void legacyHealthCheckProviderDiscoveryCanBeDisabled() {
+        var registryConfig = ServiceRegistryConfig.builder()
+                .discoverServices(false)
+                .discoverServicesFromServiceLoader(false)
+                .build();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(registryConfig);
+        try {
+            assertThat(manager.registry().all(HealthCheckProvider.class), empty());
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private static HealthCheck healthCheck(String name) {
+        return new HealthCheck() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public HealthCheckResponse call() {
+                return HealthCheckResponse.builder().status(HealthCheckResponse.Status.UP).build();
+            }
+        };
+    }
+}

--- a/webserver/observe/info/pom.xml
+++ b/webserver/observe/info/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
@@ -108,6 +112,11 @@
                             <version>${helidon.version}</version>
                         </path>
                         <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
                             <groupId>io.helidon.codegen</groupId>
                             <artifactId>helidon-codegen-helidon-copyright</artifactId>
                             <version>${helidon.version}</version>
@@ -133,6 +142,11 @@
                     <dependency>
                         <groupId>io.helidon.builder</groupId>
                         <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                     <dependency>

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
@@ -18,12 +18,14 @@ package io.helidon.webserver.observe.info;
 
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.service.registry.Service;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for application information observe provider.
  */
+@Service.Singleton
 public class InfoObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserveProvider.java
@@ -23,7 +23,8 @@ import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
- * {@link java.util.ServiceLoader} provider implementation for application information observe provider.
+ * Application information observe provider implementation, discoverable through
+ * {@link io.helidon.service.registry.ServiceRegistry} and {@link java.util.ServiceLoader}.
  */
 @Service.Singleton
 public class InfoObserveProvider implements ObserveProvider {

--- a/webserver/observe/info/src/main/java/module-info.java
+++ b/webserver/observe/info/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module io.helidon.webserver.observe.info {
 
     requires io.helidon.http.media.json;
     requires io.helidon.json;
+    requires io.helidon.service.registry;
     requires io.helidon.webserver;
 
     requires transitive io.helidon.config;

--- a/webserver/observe/log/pom.xml
+++ b/webserver/observe/log/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
@@ -113,6 +117,11 @@
                             <version>${helidon.version}</version>
                         </path>
                         <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
                             <groupId>io.helidon.codegen</groupId>
                             <artifactId>helidon-codegen-helidon-copyright</artifactId>
                             <version>${helidon.version}</version>
@@ -138,6 +147,11 @@
                     <dependency>
                         <groupId>io.helidon.builder</groupId>
                         <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                     <dependency>

--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
@@ -23,7 +23,8 @@ import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
- * {@link java.util.ServiceLoader} provider implementation for logging observe provider.
+ * Logging observe provider implementation, discoverable through
+ * {@link io.helidon.service.registry.ServiceRegistry} and {@link java.util.ServiceLoader}.
  * <p>
  * Java Util Logging uses weak references to loggers (and does not support adding level configuration to LogManager at runtime),
  *  so changing a log level for a logger may be temporary (in case a garbage collector runs and the reference is not kept

--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserveProvider.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.observe.log;
 
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.service.registry.Service;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
@@ -29,6 +30,7 @@ import io.helidon.webserver.observe.spi.Observer;
  *  anywhere).
  * In Helidon, most loggers are referenced for the duration of the application, so this should not impact Helidon components.
  */
+@Service.Singleton
 public class LogObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/webserver/observe/log/src/main/java/module-info.java
+++ b/webserver/observe/log/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module io.helidon.webserver.observe.log {
     requires static io.helidon.config.metadata;
 
     requires io.helidon.http.media.json;
+    requires io.helidon.service.registry;
     requires io.helidon.webserver;
     requires java.logging;
 

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -66,15 +66,23 @@ class MetricsFeature {
     private KeyPerformanceIndicatorSupport.Metrics kpiMetrics;
 
     MetricsFeature(MetricsObserverConfig config) {
+        this(config,
+             () -> Services.get(MeterRegistry.class),
+             () -> Services.all(MeterRegistryFormatterProvider.class));
+    }
+
+    MetricsFeature(MetricsObserverConfig config,
+                   Supplier<MeterRegistry> meterRegistry,
+                   Supplier<List<MeterRegistryFormatterProvider>> formatterProviders) {
         this.metricsObserverConfig = config;
         Optional<MeterRegistry> configuredMeterRegistry = config.meterRegistry();
-        this.meterRegistry = configuredMeterRegistry.orElseGet(() -> Services.get(MeterRegistry.class));
+        this.meterRegistry = configuredMeterRegistry.orElseGet(meterRegistry);
         if (configuredMeterRegistry.isPresent()) {
             this.metricsConfig = config.metricsConfig();
         } else {
-            this.metricsConfig = meterRegistry.metricsFactory().metricsConfig();
+            this.metricsConfig = this.meterRegistry.metricsFactory().metricsConfig();
         }
-        this.formatterProviders = Services.all(MeterRegistryFormatterProvider.class);
+        this.formatterProviders = formatterProviders.get();
     }
 
     /**

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
@@ -29,7 +29,8 @@ import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
- * {@link java.util.ServiceLoader} provider implementation for metrics observe provider.
+ * Metrics observe provider implementation, discoverable through
+ * {@link io.helidon.service.registry.ServiceRegistry} and {@link java.util.ServiceLoader}.
  */
 @Service.Singleton
 public class MetricsObserveProvider implements ObserveProvider {

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserveProvider.java
@@ -16,14 +16,22 @@
 
 package io.helidon.webserver.observe.metrics;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.config.Config;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.spi.MeterRegistryFormatterProvider;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.webserver.observe.metrics.spi.AutoHttpMetricsProvider;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for metrics observe provider.
  */
+@Service.Singleton
 public class MetricsObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
@@ -43,5 +51,19 @@ public class MetricsObserveProvider implements ObserveProvider {
                 .config(config)
                 .name(name)
                 .build();
+    }
+
+    @Override
+    public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        return new MetricsObserver(MetricsObserverConfig.builder()
+                                           .config(config)
+                                           .name(name)
+                                           .buildPrototype(),
+                                   serviceRegistry.supply(MeterRegistry.class),
+                                   serviceRegistry.supplyAll(MeterRegistryFormatterProvider.class),
+                                   serviceRegistry.supplyAll(AutoHttpMetricsProvider.class));
     }
 }

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserver.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserver.java
@@ -20,10 +20,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.LazyValue;
 import io.helidon.config.Config;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.spi.MeterRegistryFormatterProvider;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpFeature;
@@ -59,11 +63,23 @@ import io.helidon.webserver.spi.ServerFeature;
  */
 public class MetricsObserver implements Observer, RuntimeType.Api<MetricsObserverConfig> {
     private final MetricsObserverConfig config;
-    private MetricsFeature metricsFeature;
+    private final LazyValue<MetricsFeature> metricsFeature;
+    private final Supplier<List<AutoHttpMetricsProvider>> autoHttpMetricsProviders;
 
     private MetricsObserver(MetricsObserverConfig config) {
+        this(config,
+             () -> Services.get(MeterRegistry.class),
+             () -> Services.all(MeterRegistryFormatterProvider.class),
+             () -> Services.all(AutoHttpMetricsProvider.class));
+    }
+
+    MetricsObserver(MetricsObserverConfig config,
+                    Supplier<MeterRegistry> meterRegistry,
+                    Supplier<List<MeterRegistryFormatterProvider>> formatterProviders,
+                    Supplier<List<AutoHttpMetricsProvider>> autoHttpMetricsProviders) {
         this.config = config;
-        this.metricsFeature = new MetricsFeature(config);
+        this.metricsFeature = LazyValue.create(() -> new MetricsFeature(config, meterRegistry, formatterProviders));
+        this.autoHttpMetricsProviders = autoHttpMetricsProviders;
     }
 
     /**
@@ -138,7 +154,7 @@ public class MetricsObserver implements Observer, RuntimeType.Api<MetricsObserve
         if (config.enabled()) {
             for (HttpRouting.Builder routing : observeEndpointRouting) {
                 // register the service itself
-                routing.addFeature(new MetricsHttpFeature(endpoint, metricsFeature));
+                routing.addFeature(new MetricsHttpFeature(endpoint, metricsFeature.get()));
 
                 prepareAutoMetrics(featureContext);
             }
@@ -155,7 +171,7 @@ public class MetricsObserver implements Observer, RuntimeType.Api<MetricsObserve
      * @param rules rules to use
      */
     public void configureVendorMetrics(HttpRouting.Builder rules) {
-        metricsFeature.configureVendorMetrics(rules);
+        metricsFeature.get().configureVendorMetrics(rules);
     }
 
     private void prepareAutoMetrics(ServerFeature.ServerFeatureContext featureContext) {
@@ -172,7 +188,7 @@ public class MetricsObserver implements Observer, RuntimeType.Api<MetricsObserve
         }
 
         for (String socketName : socketNamesForAutoMetrics) {
-            for (AutoHttpMetricsProvider metricsProvider : Services.all(AutoHttpMetricsProvider.class)) {
+            for (AutoHttpMetricsProvider metricsProvider : autoHttpMetricsProviders.get()) {
                 metricsProvider.filter(config)
                         .ifPresent(filter -> featureContext.socket(socketName)
                                 .httpRouting()

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserverConfigBlueprint.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserverConfigBlueprint.java
@@ -85,11 +85,9 @@ interface MetricsObserverConfigBlueprint extends ObserverConfigBase, Prototype.F
      * <p>
      * A custom meter registry passed to an observer remains caller-owned. Close it after all observers using it have stopped.
      * <p>
-     * If this method is not called,
-     * {@link MetricsObserver} uses the shared
-     * instance as provided by
-     * {@link io.helidon.service.registry.Services#get(java.lang.Class)
-     * Services.get(MeterRegistry.class)}.
+     * If this method is not called, a registry-managed {@link MetricsObserver} uses the shared instance from its owning
+     * {@link io.helidon.service.registry.ServiceRegistry}. A directly created observer uses the global shared instance as
+     * provided by {@link io.helidon.service.registry.Services#get(java.lang.Class) Services.get(MeterRegistry.class)}.
      *
      * @return meterRegistry to use in this metric support
      */

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/MetricsObserverRegistryTest.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/MetricsObserverRegistryTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.observe.metrics;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+
+import io.helidon.config.Config;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MeterRegistryFormatter;
+import io.helidon.metrics.api.MetricsConfig;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.spi.MeterRegistryFormatterProvider;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.observe.metrics.spi.AutoHttpMetricsProvider;
+import io.helidon.webserver.observe.spi.Observer;
+import io.helidon.webserver.spi.ServerFeature;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+class MetricsObserverRegistryTest {
+
+    @Test
+    void managedProviderUsesOwningRegistry() {
+        MeterRegistry owningRegistry = Services.get(MetricsFactory.class)
+                .createMeterRegistry(MetricsConfig.builder()
+                                             .warnOnMultipleRegistries(false)
+                                             .build());
+        assertThat("Owning registry is distinct from the global registry",
+                   owningRegistry == Services.get(MeterRegistry.class), is(false));
+        var formatterRegistry = new AtomicReference<MeterRegistry>();
+        var autoProviderInvocations = new AtomicInteger();
+        MeterRegistryFormatterProvider formatterProvider = formatterProvider(formatterRegistry);
+        AutoHttpMetricsProvider autoHttpMetricsProvider = config -> {
+            autoProviderInvocations.incrementAndGet();
+            return Optional.empty();
+        };
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .discoverServices(false)
+                                                                                .discoverServicesFromServiceLoader(false)
+                                                                                .putContractInstance(MeterRegistry.class,
+                                                                                                     owningRegistry)
+                                                                                .putContractInstance(
+                                                                                        MeterRegistryFormatterProvider.class,
+                                                                                        formatterProvider)
+                                                                                .putContractInstance(
+                                                                                        AutoHttpMetricsProvider.class,
+                                                                                        autoHttpMetricsProvider)
+                                                                                .build());
+        HttpRouting routing = null;
+        try {
+            Observer observer = new MetricsObserveProvider().create(Config.empty(), "metrics", manager.registry());
+            routing = registerAndBuild(observer);
+
+            assertThat("Formatter sees the owning meter registry",
+                       formatterRegistry.get(), sameInstance(owningRegistry));
+            assertThat("Owning automatic metrics provider is consulted", autoProviderInvocations.get(), is(1));
+            assertThat("KPI meter is registered with the owning registry",
+                       hasMeter(owningRegistry, "requests.count"), is(true));
+            routing.afterStop();
+            routing = null;
+            assertThat("KPI meter is removed when routing stops",
+                       hasMeter(owningRegistry, "requests.count"), is(false));
+        } finally {
+            if (routing != null) {
+                routing.afterStop();
+            }
+            manager.shutdown();
+            owningRegistry.close();
+        }
+    }
+
+    @Test
+    void explicitMeterRegistryTakesPrecedence() {
+        MeterRegistry explicitRegistry = Services.get(MetricsFactory.class)
+                .createMeterRegistry(MetricsConfig.builder()
+                                             .warnOnMultipleRegistries(false)
+                                             .build());
+        var sharedRegistryLookups = new AtomicInteger();
+        var formatterRegistry = new AtomicReference<MeterRegistry>();
+        try {
+            MetricsFeature metricsFeature = new MetricsFeature(MetricsObserverConfig.builder()
+                                                                       .meterRegistry(explicitRegistry)
+                                                                       .buildPrototype(),
+                                                               () -> {
+                                                                   sharedRegistryLookups.incrementAndGet();
+                                                                   throw new AssertionError("Shared registry must not be resolved");
+                                                               },
+                                                               () -> List.of(formatterProvider(formatterRegistry)));
+
+            assertThat("Explicit registry enables the endpoint", metricsFeature.enabled(), is(true));
+            assertThat("Formatter sees the explicitly configured registry",
+                       formatterRegistry.get(), sameInstance(explicitRegistry));
+            assertThat("Shared registry supplier is not resolved", sharedRegistryLookups.get(), is(0));
+        } finally {
+            explicitRegistry.close();
+        }
+    }
+
+    @Test
+    void disabledManagedObserverDoesNotResolveDependencies() {
+        var dependencyLookups = new AtomicInteger();
+        MetricsObserver observer = new MetricsObserver(MetricsObserverConfig.builder()
+                                                               .enabled(false)
+                                                               .buildPrototype(),
+                                                       () -> {
+                                                           dependencyLookups.incrementAndGet();
+                                                           throw new AssertionError("Meter registry must not be resolved");
+                                                       },
+                                                       () -> {
+                                                           dependencyLookups.incrementAndGet();
+                                                           throw new AssertionError("Formatter providers must not be resolved");
+                                                       },
+                                                       () -> {
+                                                           dependencyLookups.incrementAndGet();
+                                                           throw new AssertionError("Auto-metrics providers must not be resolved");
+                                                       });
+
+        observer.register(featureContext(HttpRouting.builder()),
+                          List.of(HttpRouting.builder()),
+                          UnaryOperator.identity());
+
+        assertThat("Disabled observer leaves registry dependencies unresolved", dependencyLookups.get(), is(0));
+    }
+
+    @Test
+    void directProviderRetainsGlobalFallback() {
+        Observer observer = new MetricsObserveProvider().create(Config.empty(), "metrics");
+        HttpRouting routing = registerAndBuild(observer);
+        try {
+            assertThat(routing, notNullValue());
+        } finally {
+            routing.afterStop();
+        }
+    }
+
+    private static HttpRouting registerAndBuild(Observer observer) {
+        HttpRouting.Builder observeRouting = HttpRouting.builder();
+        observer.register(featureContext(HttpRouting.builder()),
+                          List.of(observeRouting),
+                          UnaryOperator.identity());
+        return observeRouting.build();
+    }
+
+    private static ServerFeature.ServerFeatureContext featureContext(HttpRouting.Builder applicationRouting) {
+        return new ServerFeature.ServerFeatureContext() {
+            @Override
+            public WebServerConfig serverConfig() {
+                throw new AssertionError("Server config is not expected");
+            }
+
+            @Override
+            public Set<String> sockets() {
+                return Set.of();
+            }
+
+            @Override
+            public boolean socketExists(String socketName) {
+                return true;
+            }
+
+            @Override
+            public ServerFeature.SocketBuilders socket(String socketName) {
+                return new ServerFeature.SocketBuilders() {
+                    @Override
+                    public ListenerConfig listener() {
+                        throw new AssertionError("Listener config is not expected");
+                    }
+
+                    @Override
+                    public HttpRouting.Builder httpRouting() {
+                        return applicationRouting;
+                    }
+
+                    @Override
+                    public ServerFeature.RoutingBuilders routingBuilders() {
+                        throw new AssertionError("Other routing builders are not expected");
+                    }
+                };
+            }
+        };
+    }
+
+    private static MeterRegistryFormatterProvider formatterProvider(AtomicReference<MeterRegistry> registrySeen) {
+        return (mediaType, metricsConfig, meterRegistry, scopeTagName, scopeSelection, nameSelection) -> {
+            registrySeen.set(meterRegistry);
+            return Optional.of(new MeterRegistryFormatter() {
+                @Override
+                public Optional<Object> format() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<Object> formatMetadata() {
+                    return Optional.empty();
+                }
+            });
+        };
+    }
+
+    private static boolean hasMeter(MeterRegistry meterRegistry, String name) {
+        return meterRegistry.meters()
+                .stream()
+                .anyMatch(meter -> meter.id().name().equals(name));
+    }
+}

--- a/webserver/observe/observe/README.md
+++ b/webserver/observe/observe/README.md
@@ -9,8 +9,12 @@ that may collide with the business code.
 
 # Discovery
 
-`ObserveProvider` instances are discovered using `ServiceLoader`. In case an explicit `Observer` is registered with the
-same `type` as a provider, the provider will not be used (so we do not duplicate services).
+When an application is bootstrapped using `ServiceRegistryManager`, `ObserveProvider` instances are discovered from the
+owning service registry. Existing providers loaded using `ServiceLoader` are bridged into the registry when service loader
+discovery is enabled.
+
+When an `ObserveFeature` is built directly, providers are discovered using `ServiceLoader`. An explicitly configured
+`Observer` with the same `type` takes precedence so the observer is not duplicated.
 
 # Endpoints
 

--- a/webserver/observe/observe/pom.xml
+++ b/webserver/observe/observe/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
@@ -99,6 +103,11 @@
                             <version>${helidon.version}</version>
                         </path>
                         <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
                             <groupId>io.helidon.codegen</groupId>
                             <artifactId>helidon-codegen-helidon-copyright</artifactId>
                             <version>${helidon.version}</version>
@@ -124,6 +133,11 @@
                     <dependency>
                         <groupId>io.helidon.builder</groupId>
                         <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                     <dependency>

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeature.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeature.java
@@ -201,6 +201,10 @@ public class ObserveFeature implements ServerFeature, Weighted, RuntimeType.Api<
         return weight;
     }
 
+    List<Observer> observers() {
+        return observers;
+    }
+
     private static UnaryOperator<String> endpoint(String observeEndpoint) {
         return observerEndpoint -> {
             if (observerEndpoint.startsWith("/")) {

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureProvider.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureProvider.java
@@ -31,7 +31,8 @@ import io.helidon.webserver.observe.spi.Observer;
 import io.helidon.webserver.spi.ServerFeatureProvider;
 
 /**
- * {@link java.util.ServiceLoader} provider implementation for observe feature for {@link io.helidon.webserver.WebServer}.
+ * Provider implementation for the observe feature for {@link io.helidon.webserver.WebServer}, discoverable through
+ * {@link io.helidon.service.registry.ServiceRegistry} and {@link java.util.ServiceLoader}.
  */
 @Weight(ObserveFeature.WEIGHT)
 @Service.Singleton

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureProvider.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureProvider.java
@@ -16,15 +16,25 @@
 
 package io.helidon.webserver.observe;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigBuilderSupport;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.webserver.observe.spi.ObserveProvider;
+import io.helidon.webserver.observe.spi.Observer;
 import io.helidon.webserver.spi.ServerFeatureProvider;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for observe feature for {@link io.helidon.webserver.WebServer}.
  */
 @Weight(ObserveFeature.WEIGHT)
+@Service.Singleton
 public class ObserveFeatureProvider implements ServerFeatureProvider<ObserveFeature> {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
@@ -44,5 +54,83 @@ public class ObserveFeatureProvider implements ServerFeatureProvider<ObserveFeat
                 .config(config)
                 .name(name)
                 .build();
+    }
+
+    @Override
+    public ObserveFeature create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
+        boolean discoverServices = config.get("observers-discover-services")
+                .asBoolean()
+                .orElse(true);
+        List<Observer> observers = ConfigBuilderSupport.discoverServices(config,
+                                                                         "observers",
+                                                                         Optional.of(serviceRegistry),
+                                                                         ObserveProvider.class,
+                                                                         Observer.class,
+                                                                         discoverServices,
+                                                                         List.of());
+        return ObserveFeature.create(new RegistryObserveFeatureConfig(config, name, observers));
+    }
+
+    private static final class RegistryObserveFeatureConfig implements ObserveFeatureConfig {
+        private final boolean enabled;
+        private final double weight;
+        private final List<Observer> observers;
+        private final List<String> sockets;
+        private final Config config;
+        private final String endpoint;
+        private final String name;
+
+        private RegistryObserveFeatureConfig(Config config, String name, List<Observer> observers) {
+            this.config = config;
+            this.name = name;
+            this.observers = List.copyOf(observers);
+            this.enabled = config.get("enabled").asBoolean().orElse(true);
+            this.endpoint = config.get("endpoint").asString().orElse("/observe");
+            this.weight = config.get("weight").asDouble().orElse(ObserveFeature.WEIGHT);
+            this.sockets = config.get("sockets").asList(String.class).orElseGet(List::of);
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public String endpoint() {
+            return endpoint;
+        }
+
+        @Override
+        public double weight() {
+            return weight;
+        }
+
+        @Override
+        public List<Observer> observers() {
+            return observers;
+        }
+
+        @Override
+        public Optional<Config> config() {
+            return Optional.of(config);
+        }
+
+        @Override
+        public List<String> sockets() {
+            return sockets;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public ObserveFeature build() {
+            return ObserveFeature.create(this);
+        }
     }
 }

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureServicesFactory.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureServicesFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe;
+
+import java.util.List;
+
+import io.helidon.common.Weight;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.RunLevel(Service.RunLevel.SERVER)
+@Weight(ObserveFeature.WEIGHT)
+class ObserveFeatureServicesFactory implements Service.ServicesFactory<ObserveFeature> {
+    private final ObserveServices observeServices;
+
+    @Service.Inject
+    ObserveFeatureServicesFactory(ObserveServices observeServices) {
+        this.observeServices = observeServices;
+    }
+
+    @Override
+    public List<Service.QualifiedInstance<ObserveFeature>> services() {
+        return observeServices.features()
+                .stream()
+                .map(feature -> Service.QualifiedInstance.create(feature, Qualifier.createNamed(feature.name())))
+                .toList();
+    }
+}

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureServicesFactory.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeatureServicesFactory.java
@@ -21,11 +21,12 @@ import java.util.List;
 import io.helidon.common.Weight;
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
+import io.helidon.webserver.spi.ConfiguredServerFeatureFactory;
 
 @Service.Singleton
 @Service.RunLevel(Service.RunLevel.SERVER)
 @Weight(ObserveFeature.WEIGHT)
-class ObserveFeatureServicesFactory implements Service.ServicesFactory<ObserveFeature> {
+class ObserveFeatureServicesFactory implements Service.ServicesFactory<ObserveFeature>, ConfiguredServerFeatureFactory {
     private final ObserveServices observeServices;
 
     @Service.Inject

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveServices.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveServices.java
@@ -19,6 +19,7 @@ package io.helidon.webserver.observe;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -61,6 +62,7 @@ class ObserveServices {
         boolean discoverFeatures = serverConfig.get("features-discover-services")
                 .asBoolean()
                 .orElse(true);
+        Optional<ObserveFeature> activeFeature = serviceRegistry.firstActive(ObserveFeature.class);
 
         LazyValue<ServerFeatureProvider<ObserveFeature>> featureProvider = LazyValue.create(() -> featureProviders.get()
                 .stream()
@@ -82,6 +84,9 @@ class ObserveServices {
                                                   + ": type \"" + OBSERVE
                                                   + "\", name \"" + configuredFeature.name() + "\"");
             }
+            if (activeFeature.filter(feature -> sameIdentity(feature, configuredFeature.name())).isPresent()) {
+                continue;
+            }
             if (configuredFeature.enabled()) {
                 features.add(featureProvider.get().create(configuredFeature.config(),
                                                           configuredFeature.name(),
@@ -89,7 +94,9 @@ class ObserveServices {
             }
         }
 
-        if (discoverFeatures && !observeConfigured) {
+        if (discoverFeatures
+                && !observeConfigured
+                && activeFeature.filter(feature -> sameIdentity(feature, OBSERVE)).isEmpty()) {
             features.add(featureProvider.get().create(featuresConfig.get(OBSERVE), OBSERVE, serviceRegistry));
         }
 
@@ -106,6 +113,10 @@ class ObserveServices {
             }
         }
         return new Graph(List.copyOf(features), List.copyOf(observers));
+    }
+
+    private static boolean sameIdentity(ObserveFeature feature, String name) {
+        return OBSERVE.equals(feature.type()) && name.equals(feature.name());
     }
 
     private static List<ConfiguredFeature> configuredFeatures(Config featuresConfig) {

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveServices.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveServices.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.helidon.common.LazyValue;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigException;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.webserver.observe.spi.Observer;
+
+@Service.Singleton
+class ObserveServices {
+    private static final String OBSERVE = ObserveFeature.OBSERVE_ID;
+
+    private final LazyValue<Graph> graph;
+
+    @Service.Inject
+    ObserveServices(Supplier<Config> config, ServiceRegistry serviceRegistry) {
+        this.graph = LazyValue.create(() -> createGraph(config.get(), serviceRegistry));
+    }
+
+    List<ObserveFeature> features() {
+        return graph.get().features();
+    }
+
+    List<Service.QualifiedInstance<Observer>> observers() {
+        return graph.get().observers();
+    }
+
+    private static Graph createGraph(Config rootConfig, ServiceRegistry serviceRegistry) {
+        Config serverConfig = rootConfig.get("server");
+        Config featuresConfig = serverConfig.get("features");
+        List<ConfiguredFeature> configuredFeatures = configuredFeatures(featuresConfig);
+        boolean discoverFeatures = serverConfig.get("features-discover-services")
+                .asBoolean()
+                .orElse(true);
+
+        var featureProvider = new ObserveFeatureProvider();
+        var features = new ArrayList<ObserveFeature>();
+        boolean observeConfigured = false;
+        Set<String> names = new HashSet<>();
+
+        for (ConfiguredFeature configuredFeature : configuredFeatures) {
+            if (!OBSERVE.equals(configuredFeature.type())) {
+                continue;
+            }
+            observeConfigured = true;
+            if (!names.add(configuredFeature.name())) {
+                throw new ConfigException("Duplicate configured provider identity at " + featuresConfig.key()
+                                                  + ": type \"" + OBSERVE
+                                                  + "\", name \"" + configuredFeature.name() + "\"");
+            }
+            if (configuredFeature.enabled()) {
+                features.add(featureProvider.create(configuredFeature.config(),
+                                                    configuredFeature.name(),
+                                                    serviceRegistry));
+            }
+        }
+
+        if (discoverFeatures && !observeConfigured) {
+            features.add(featureProvider.create(featuresConfig.get(OBSERVE), OBSERVE, serviceRegistry));
+        }
+
+        var observers = new ArrayList<Service.QualifiedInstance<Observer>>();
+        for (ObserveFeature feature : features) {
+            int ordinal = 0;
+            for (Observer observer : feature.observers()) {
+                String identity = lengthPrefixed(feature.name())
+                        + lengthPrefixed(observer.type())
+                        + lengthPrefixed(observer.name())
+                        + lengthPrefixed(Integer.toString(ordinal++));
+                observers.add(Service.QualifiedInstance.create(observer,
+                                                               Qualifier.createNamed(identity)));
+            }
+        }
+        return new Graph(List.copyOf(features), List.copyOf(observers));
+    }
+
+    private static List<ConfiguredFeature> configuredFeatures(Config featuresConfig) {
+        List<Config> featureConfigs = featuresConfig.asNodeList().orElseGet(List::of);
+        var result = new ArrayList<ConfiguredFeature>(featureConfigs.size());
+        boolean isList = featuresConfig.isList();
+
+        for (Config featureConfig : featureConfigs) {
+            if (isList) {
+                result.add(configuredListFeature(featureConfig));
+            } else {
+                String name = featureConfig.name();
+                String type = featureConfig.get("type").asString().orElse(name);
+                boolean enabled = !featureConfig.isObject()
+                        || featureConfig.get("enabled").asBoolean().orElse(true);
+                result.add(new ConfiguredFeature(type, name, featureConfig, enabled));
+            }
+        }
+        return result;
+    }
+
+    private static ConfiguredFeature configuredListFeature(Config featureConfig) {
+        String type = featureConfig.get("type").asString().orElse(null);
+        String name = featureConfig.get("name").asString().orElse(type);
+        boolean enabled = featureConfig.get("enabled").asBoolean().orElse(true);
+        Config usedConfig = featureConfig;
+
+        if (type == null) {
+            List<Config> nested = featureConfig.asNodeList().orElseGet(List::of);
+            if (nested.size() != 1) {
+                throw new ConfigException("Service provider configuration defined as a list must have a single node that is "
+                                                  + "the type, with children containing the provider configuration. Failed on: "
+                                                  + featureConfig.key());
+            }
+            usedConfig = nested.getFirst();
+            name = usedConfig.name();
+            type = usedConfig.get("type").asString().orElse(name);
+            enabled = usedConfig.get("enabled").asBoolean().orElse(enabled);
+        }
+        return new ConfiguredFeature(type, name, usedConfig, enabled);
+    }
+
+    private static String lengthPrefixed(String value) {
+        return value.length() + ":" + value;
+    }
+
+    private record Graph(List<ObserveFeature> features, List<Service.QualifiedInstance<Observer>> observers) {
+    }
+
+    private record ConfiguredFeature(String type, String name, Config config, boolean enabled) {
+    }
+}

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveServices.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveServices.java
@@ -29,6 +29,7 @@ import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.webserver.observe.spi.Observer;
+import io.helidon.webserver.spi.ServerFeatureProvider;
 
 @Service.Singleton
 class ObserveServices {
@@ -37,8 +38,10 @@ class ObserveServices {
     private final LazyValue<Graph> graph;
 
     @Service.Inject
-    ObserveServices(Supplier<Config> config, ServiceRegistry serviceRegistry) {
-        this.graph = LazyValue.create(() -> createGraph(config.get(), serviceRegistry));
+    ObserveServices(Supplier<Config> config,
+                    Supplier<List<ServerFeatureProvider<ObserveFeature>>> featureProviders,
+                    ServiceRegistry serviceRegistry) {
+        this.graph = LazyValue.create(() -> createGraph(config.get(), featureProviders, serviceRegistry));
     }
 
     List<ObserveFeature> features() {
@@ -49,7 +52,9 @@ class ObserveServices {
         return graph.get().observers();
     }
 
-    private static Graph createGraph(Config rootConfig, ServiceRegistry serviceRegistry) {
+    private static Graph createGraph(Config rootConfig,
+                                     Supplier<List<ServerFeatureProvider<ObserveFeature>>> featureProviders,
+                                     ServiceRegistry serviceRegistry) {
         Config serverConfig = rootConfig.get("server");
         Config featuresConfig = serverConfig.get("features");
         List<ConfiguredFeature> configuredFeatures = configuredFeatures(featuresConfig);
@@ -57,7 +62,12 @@ class ObserveServices {
                 .asBoolean()
                 .orElse(true);
 
-        var featureProvider = new ObserveFeatureProvider();
+        LazyValue<ServerFeatureProvider<ObserveFeature>> featureProvider = LazyValue.create(() -> featureProviders.get()
+                .stream()
+                .filter(provider -> OBSERVE.equals(provider.configKey()))
+                .findFirst()
+                .orElseThrow(() -> new ConfigException("No server feature provider is available for type \""
+                                                               + OBSERVE + "\"")));
         var features = new ArrayList<ObserveFeature>();
         boolean observeConfigured = false;
         Set<String> names = new HashSet<>();
@@ -73,14 +83,14 @@ class ObserveServices {
                                                   + "\", name \"" + configuredFeature.name() + "\"");
             }
             if (configuredFeature.enabled()) {
-                features.add(featureProvider.create(configuredFeature.config(),
-                                                    configuredFeature.name(),
-                                                    serviceRegistry));
+                features.add(featureProvider.get().create(configuredFeature.config(),
+                                                          configuredFeature.name(),
+                                                          serviceRegistry));
             }
         }
 
         if (discoverFeatures && !observeConfigured) {
-            features.add(featureProvider.create(featuresConfig.get(OBSERVE), OBSERVE, serviceRegistry));
+            features.add(featureProvider.get().create(featuresConfig.get(OBSERVE), OBSERVE, serviceRegistry));
         }
 
         var observers = new ArrayList<Service.QualifiedInstance<Observer>>();

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveServices.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveServices.java
@@ -19,7 +19,6 @@ package io.helidon.webserver.observe;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -62,7 +61,7 @@ class ObserveServices {
         boolean discoverFeatures = serverConfig.get("features-discover-services")
                 .asBoolean()
                 .orElse(true);
-        Optional<ObserveFeature> activeFeature = serviceRegistry.firstActive(ObserveFeature.class);
+        List<ObserveFeature> activeFeatures = serviceRegistry.allActive(ObserveFeature.class);
 
         LazyValue<ServerFeatureProvider<ObserveFeature>> featureProvider = LazyValue.create(() -> featureProviders.get()
                 .stream()
@@ -84,7 +83,7 @@ class ObserveServices {
                                                   + ": type \"" + OBSERVE
                                                   + "\", name \"" + configuredFeature.name() + "\"");
             }
-            if (activeFeature.filter(feature -> sameIdentity(feature, configuredFeature.name())).isPresent()) {
+            if (activeFeatures.stream().anyMatch(feature -> sameIdentity(feature, configuredFeature.name()))) {
                 continue;
             }
             if (configuredFeature.enabled()) {
@@ -96,7 +95,7 @@ class ObserveServices {
 
         if (discoverFeatures
                 && !observeConfigured
-                && activeFeature.filter(feature -> sameIdentity(feature, OBSERVE)).isEmpty()) {
+                && activeFeatures.stream().noneMatch(feature -> sameIdentity(feature, OBSERVE))) {
             features.add(featureProvider.get().create(featuresConfig.get(OBSERVE), OBSERVE, serviceRegistry));
         }
 

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserverServicesFactory.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserverServicesFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe;
+
+import java.util.List;
+
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.observe.spi.Observer;
+
+@Service.Singleton
+@Service.RunLevel(Service.RunLevel.SERVER)
+class ObserverServicesFactory implements Service.ServicesFactory<Observer> {
+    private final ObserveServices observeServices;
+
+    @Service.Inject
+    ObserverServicesFactory(ObserveServices observeServices) {
+        this.observeServices = observeServices;
+    }
+
+    @Override
+    public List<Service.QualifiedInstance<Observer>> services() {
+        return observeServices.observers();
+    }
+}

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/spi/ObserveProvider.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/spi/ObserveProvider.java
@@ -19,7 +19,9 @@ package io.helidon.webserver.observe.spi;
 import io.helidon.config.ConfiguredProvider;
 
 /**
- * {@link java.util.ServiceLoader} provider interface for observability services.
+ * Provider interface for observability services. Registry-managed applications discover providers through the owning
+ * {@link io.helidon.service.registry.ServiceRegistry}; direct construction and backward compatibility use
+ * {@link java.util.ServiceLoader}.
  */
 public interface ObserveProvider extends ConfiguredProvider<Observer> {
     /**

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/spi/Observer.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/spi/Observer.java
@@ -43,9 +43,9 @@ public interface Observer extends NamedService {
     ObserverConfigBase prototype();
 
     /**
-     * Type of this observer, to make sure we do not configure an observer both from {@link java.util.ServiceLoader} and
-     * using programmatic approach.
-     * If it is desired to have more than one observer of the same type, always use programmatic approach
+     * Type of this observer, to make sure we do not configure an observer both through provider discovery and using a
+     * programmatic approach.
+     * If it is desired to have more than one observer of the same type, always use a programmatic approach.
      *
      * @return type of this observer, should match {@link io.helidon.webserver.observe.spi.ObserveProvider#type()}
      */

--- a/webserver/observe/observe/src/main/java/module-info.java
+++ b/webserver/observe/observe/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module io.helidon.webserver.observe {
     requires static io.helidon.config.metadata;
 
     requires io.helidon.http;
+    requires io.helidon.service.registry;
     requires io.helidon.webserver;
 
     requires transitive io.helidon.builder.api;

--- a/webserver/observe/observe/src/main/resources/META-INF/helidon/io.helidon.webserver.observe/service.loader
+++ b/webserver/observe/observe/src/main/resources/META-INF/helidon/io.helidon.webserver.observe/service.loader
@@ -1,0 +1,2 @@
+# List of service contracts we want to support either from service registry, or from service loader
+io.helidon.webserver.observe.spi.ObserveProvider

--- a/webserver/observe/observe/src/main/resources/META-INF/helidon/manifest
+++ b/webserver/observe/observe/src/main/resources/META-INF/helidon/manifest
@@ -1,0 +1,2 @@
+#HELIDON MANIFEST#
+META-INF/helidon/io.helidon.webserver.observe/service.loader

--- a/webserver/observe/observe/src/test/java/io/helidon/webserver/observe/ObserveServicesTest.java
+++ b/webserver/observe/observe/src/test/java/io/helidon/webserver/observe/ObserveServicesTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.observe.spi.ObserveProvider;
+import io.helidon.webserver.observe.spi.Observer;
+import io.helidon.webserver.spi.ServerFeature;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.sameInstance;
+
+class ObserveServicesTest {
+    @Test
+    void factoriesExposeTheSameConfiguredGraph() {
+        Config config = Config.just(ConfigSources.create(Map.of("server.features.observe.observers.test.value", "configured")));
+        var provider = new TestObserveProvider();
+        ServiceRegistryManager manager = registry(provider);
+        try {
+            ServiceRegistry serviceRegistry = manager.registry();
+            var services = new ObserveServices(() -> config, serviceRegistry);
+            var featureProducts = new ObserveFeatureServicesFactory(services).services();
+            var observerProducts = new ObserverServicesFactory(services).services();
+
+            assertThat(featureProducts, hasSize(1));
+            assertThat(observerProducts, hasSize(1));
+            ObserveFeature feature = featureProducts.getFirst().get();
+            Observer observer = observerProducts.getFirst().get();
+            assertThat(feature, instanceOf(ServerFeature.class));
+            assertThat(feature.observers(), contains(sameInstance(observer)));
+            assertThat(provider.registry, sameInstance(serviceRegistry));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void discoveryFlagsAreHonored() {
+        var provider = new TestObserveProvider();
+        ServiceRegistryManager manager = registry(provider);
+        try {
+            ServiceRegistry serviceRegistry = manager.registry();
+            Config noFeatureDiscovery = Config.just(ConfigSources.create(Map.of("server.features-discover-services", "false")));
+            var noFeatures = new ObserveServices(() -> noFeatureDiscovery, serviceRegistry);
+            assertThat(new ObserveFeatureServicesFactory(noFeatures).services(), empty());
+            assertThat(new ObserverServicesFactory(noFeatures).services(), empty());
+
+            Config noObserverDiscovery = Config.just(
+                    ConfigSources.create(Map.of("server.features.observe.observers-discover-services", "false")));
+            var noObservers = new ObserveServices(() -> noObserverDiscovery, serviceRegistry);
+            assertThat(new ObserveFeatureServicesFactory(noObservers).services(), hasSize(1));
+            assertThat(new ObserverServicesFactory(noObservers).services(), empty());
+            assertThat(provider.createCount, is(0));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void featureListOrderAndObserverIdentityArePreserved() {
+        ConfigNode.ListNode featureNodes = ConfigNode.ListNode.builder()
+                .addObject(ConfigNode.ObjectNode.builder()
+                                   .addValue("type", "observe")
+                                   .addValue("name", "first")
+                                   .build())
+                .addObject(ConfigNode.ObjectNode.builder()
+                                   .addValue("type", "observe")
+                                   .addValue("name", "second")
+                                   .build())
+                .build();
+        ConfigNode.ObjectNode configNode = ConfigNode.ObjectNode.builder()
+                .addObject("server", ConfigNode.ObjectNode.builder()
+                        .addList("features", featureNodes)
+                        .build())
+                .build();
+        Config config = Config.just(ConfigSources.create(configNode));
+        var provider = new TestObserveProvider();
+        ServiceRegistryManager manager = registry(provider);
+        try {
+            var services = new ObserveServices(() -> config, manager.registry());
+            List<ObserveFeature> features = new ObserveFeatureServicesFactory(services)
+                    .services()
+                    .stream()
+                    .map(it -> it.get())
+                    .toList();
+            var observerProducts = new ObserverServicesFactory(services).services();
+            List<Observer> observers = observerProducts
+                    .stream()
+                    .map(it -> it.get())
+                    .toList();
+
+            assertThat(features.stream().map(ObserveFeature::name).toList(), contains("first", "second"));
+            assertThat(observers, hasSize(2));
+            assertThat(features.get(0).observers().getFirst(), sameInstance(observers.get(0)));
+            assertThat(features.get(1).observers().getFirst(), sameInstance(observers.get(1)));
+            assertThat(observers.get(0) == observers.get(1), is(false));
+            assertThat(observerProducts.get(0).qualifiers(), not(is(observerProducts.get(1).qualifiers())));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private static ServiceRegistryManager registry(ObserveProvider provider) {
+        return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                     .discoverServices(false)
+                                                     .discoverServicesFromServiceLoader(false)
+                                                     .putContractInstance(ObserveProvider.class, provider)
+                                                     .build());
+    }
+
+    private static final class TestObserveProvider implements ObserveProvider {
+        private ServiceRegistry registry;
+        private int createCount;
+
+        @Override
+        public String configKey() {
+            return "test";
+        }
+
+        @Override
+        public Observer create(Config config, String name) {
+            throw new AssertionError("Managed observer creation must use the owning registry");
+        }
+
+        @Override
+        public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+            registry = serviceRegistry;
+            createCount++;
+            return new TestObserver(name);
+        }
+    }
+
+    private static final class TestObserver implements Observer {
+        private final ObserverConfigBase config;
+
+        private TestObserver(String name) {
+            config = ObserverConfigBase.builder()
+                    .name(name)
+                    .buildPrototype();
+        }
+
+        @Override
+        public ObserverConfigBase prototype() {
+            return config;
+        }
+
+        @Override
+        public String type() {
+            return "test";
+        }
+
+        @Override
+        public void register(ServerFeature.ServerFeatureContext featureContext,
+                             List<HttpRouting.Builder> observeEndpointRouting,
+                             UnaryOperator<String> endpointFunction) {
+        }
+    }
+}

--- a/webserver/observe/observe/src/test/java/io/helidon/webserver/observe/ObserveServicesTest.java
+++ b/webserver/observe/observe/src/test/java/io/helidon/webserver/observe/ObserveServicesTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
+import io.helidon.common.types.TypeName;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.config.spi.ConfigNode;
@@ -30,6 +31,7 @@ import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
 import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.spi.ServerFeatureProvider;
 
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +45,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.sameInstance;
 
 class ObserveServicesTest {
+    private static final TypeName OBSERVE_FEATURE_PROVIDER = TypeName.builder(TypeName.create(ServerFeatureProvider.class))
+            .typeArguments(List.of(TypeName.create(ObserveFeature.class)))
+            .build();
+
     @Test
     void factoriesExposeTheSameConfiguredGraph() {
         Config config = Config.just(ConfigSources.create(Map.of("server.features.observe.observers.test.value", "configured")));
@@ -50,7 +56,7 @@ class ObserveServicesTest {
         ServiceRegistryManager manager = registry(provider);
         try {
             ServiceRegistry serviceRegistry = manager.registry();
-            var services = new ObserveServices(() -> config, serviceRegistry);
+            var services = observeServices(config, serviceRegistry);
             var featureProducts = new ObserveFeatureServicesFactory(services).services();
             var observerProducts = new ObserverServicesFactory(services).services();
 
@@ -73,13 +79,13 @@ class ObserveServicesTest {
         try {
             ServiceRegistry serviceRegistry = manager.registry();
             Config noFeatureDiscovery = Config.just(ConfigSources.create(Map.of("server.features-discover-services", "false")));
-            var noFeatures = new ObserveServices(() -> noFeatureDiscovery, serviceRegistry);
+            var noFeatures = observeServices(noFeatureDiscovery, serviceRegistry);
             assertThat(new ObserveFeatureServicesFactory(noFeatures).services(), empty());
             assertThat(new ObserverServicesFactory(noFeatures).services(), empty());
 
             Config noObserverDiscovery = Config.just(
                     ConfigSources.create(Map.of("server.features.observe.observers-discover-services", "false")));
-            var noObservers = new ObserveServices(() -> noObserverDiscovery, serviceRegistry);
+            var noObservers = observeServices(noObserverDiscovery, serviceRegistry);
             assertThat(new ObserveFeatureServicesFactory(noObservers).services(), hasSize(1));
             assertThat(new ObserverServicesFactory(noObservers).services(), empty());
             assertThat(provider.createCount, is(0));
@@ -109,7 +115,7 @@ class ObserveServicesTest {
         var provider = new TestObserveProvider();
         ServiceRegistryManager manager = registry(provider);
         try {
-            var services = new ObserveServices(() -> config, manager.registry());
+            var services = observeServices(config, manager.registry());
             List<ObserveFeature> features = new ObserveFeatureServicesFactory(services)
                     .services()
                     .stream()
@@ -130,6 +136,38 @@ class ObserveServicesTest {
         } finally {
             manager.shutdown();
         }
+    }
+
+    @Test
+    void higherWeightRegistryFeatureProviderIsSelected() {
+        var observerProvider = new TestObserveProvider();
+        var featureProvider = new TestObserveFeatureProvider();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class,
+                                                                                                     Config.empty())
+                                                                                .putContractInstance(ObserveProvider.class,
+                                                                                                     observerProvider)
+                                                                                .putContractInstance(OBSERVE_FEATURE_PROVIDER,
+                                                                                                     featureProvider)
+                                                                                .build());
+        try {
+            ServiceRegistry serviceRegistry = manager.registry();
+            var services = serviceRegistry.get(ObserveServices.class);
+
+            List<ObserveFeature> features = services.features();
+
+            assertThat(features, hasSize(1));
+            assertThat(featureProvider.createCount, is(1));
+            assertThat(featureProvider.registry, sameInstance(serviceRegistry));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private static ObserveServices observeServices(Config config, ServiceRegistry serviceRegistry) {
+        return new ObserveServices(() -> config,
+                                   () -> List.of(new ObserveFeatureProvider()),
+                                   serviceRegistry);
     }
 
     private static ServiceRegistryManager registry(ObserveProvider provider) {
@@ -159,6 +197,29 @@ class ObserveServicesTest {
             registry = serviceRegistry;
             createCount++;
             return new TestObserver(name);
+        }
+    }
+
+    private static final class TestObserveFeatureProvider implements ServerFeatureProvider<ObserveFeature> {
+        private final ObserveFeatureProvider delegate = new ObserveFeatureProvider();
+        private ServiceRegistry registry;
+        private int createCount;
+
+        @Override
+        public String configKey() {
+            return ObserveFeature.OBSERVE_ID;
+        }
+
+        @Override
+        public ObserveFeature create(Config config, String name) {
+            throw new AssertionError("Managed feature creation must use the owning registry");
+        }
+
+        @Override
+        public ObserveFeature create(Config config, String name, ServiceRegistry serviceRegistry) {
+            registry = serviceRegistry;
+            createCount++;
+            return delegate.create(config, name, serviceRegistry);
         }
     }
 

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.observe.tracing;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
@@ -69,6 +71,9 @@ public class TracingObserveProvider implements ObserveProvider {
 
     @Override
     public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serviceRegistry);
         Config tracingConfig = config.root().get("tracing");
         TracingObserverConfig observerConfig = TracingObserverConfig.builder()
                 .tracer(serviceRegistry.get(Tracer.class))

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
@@ -19,15 +19,19 @@ package io.helidon.webserver.observe.tracing;
 import io.helidon.common.Api;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.Services;
 import io.helidon.tracing.Tracer;
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 import io.helidon.webserver.observe.spi.Observer;
+import io.helidon.webserver.observe.tracing.spi.TracingSemanticConventionsProvider;
 
 /**
  * {@link java.util.ServiceLoader} provider implementation for tracing observe provider.
  */
+@Service.Singleton
 public class TracingObserveProvider implements ObserveProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
@@ -61,5 +65,19 @@ public class TracingObserveProvider implements ObserveProvider {
                 .config(config) // update with server.features.observe.tracing
                 .name(name)
                 .build();
+    }
+
+    @Override
+    public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+        Config tracingConfig = config.root().get("tracing");
+        TracingObserverConfig observerConfig = TracingObserverConfig.builder()
+                .tracer(serviceRegistry.get(Tracer.class))
+                .config(tracingConfig) // read from root `tracing`
+                .config(config) // update with server.features.observe.tracing
+                .name(name)
+                .buildPrototype();
+
+        return TracingObserver.create(observerConfig,
+                                      serviceRegistry.supply(TracingSemanticConventionsProvider.class));
     }
 }

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserveProvider.java
@@ -31,7 +31,8 @@ import io.helidon.webserver.observe.spi.Observer;
 import io.helidon.webserver.observe.tracing.spi.TracingSemanticConventionsProvider;
 
 /**
- * {@link java.util.ServiceLoader} provider implementation for tracing observe provider.
+ * Tracing observe provider implementation, discoverable through
+ * {@link io.helidon.service.registry.ServiceRegistry} and {@link java.util.ServiceLoader}.
  */
 @Service.Singleton
 public class TracingObserveProvider implements ObserveProvider {

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import io.helidon.builder.api.RuntimeType;
@@ -64,9 +65,16 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
     private static final String CONTENT_READ_SPAN_NAME = "content-read";
     private static final String CONTENT_WRITE_SPAN_NAME = "content-write";
     private final TracingObserverConfig config;
+    private final Supplier<TracingSemanticConventionsProvider> tracingSemanticConventionsProvider;
 
     private TracingObserver(TracingObserverConfig config) {
+        this(config, () -> Services.get(TracingSemanticConventionsProvider.class));
+    }
+
+    private TracingObserver(TracingObserverConfig config,
+                            Supplier<TracingSemanticConventionsProvider> tracingSemanticConventionsProvider) {
         this.config = config;
+        this.tracingSemanticConventionsProvider = tracingSemanticConventionsProvider;
     }
 
     /**
@@ -112,6 +120,11 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
         return new TracingObserver(config);
     }
 
+    static TracingObserver create(TracingObserverConfig config,
+                                  Supplier<TracingSemanticConventionsProvider> tracingSemanticConventionsProvider) {
+        return new TracingObserver(config, tracingSemanticConventionsProvider);
+    }
+
     /**
      * Create a new Tracing observer customizing its configuration.
      *
@@ -139,7 +152,9 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
             for (String socket : sockets) {
                 featureContext.socket(socket)
                         .httpRouting()
-                        .addFeature(new TracingFeature(config, DEFAULT_SOCKET_NAME.equals(socket) ? "" : socket));
+                        .addFeature(new TracingFeature(config,
+                                                       DEFAULT_SOCKET_NAME.equals(socket) ? "" : socket,
+                                                       tracingSemanticConventionsProvider));
             }
         }
     }
@@ -167,13 +182,14 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
                       TracingConfig envConfig,
                       boolean waitTracingEnabled,
                       List<PathTracingConfig> pathConfigs,
-                      String socketTag) {
+                      String socketTag,
+                      Supplier<TracingSemanticConventionsProvider> tracingSemanticConventionsProvider) {
             this.tracer = tracer;
             this.envConfig = envConfig;
             this.waitTracingEnabled = waitTracingEnabled;
             this.pathConfigs = pathConfigs;
             this.socketTag = socketTag;
-            this.tracingSemanticConventionsProvider = Services.get(TracingSemanticConventionsProvider.class);
+            this.tracingSemanticConventionsProvider = tracingSemanticConventionsProvider.get();
 
         }
 
@@ -603,10 +619,14 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
     private static class TracingFeature implements HttpFeature, Weighted {
         private final TracingObserverConfig config;
         private final String socketTag;
+        private final Supplier<TracingSemanticConventionsProvider> tracingSemanticConventionsProvider;
 
-        TracingFeature(TracingObserverConfig config, String socketTag) {
+        TracingFeature(TracingObserverConfig config,
+                       String socketTag,
+                       Supplier<TracingSemanticConventionsProvider> tracingSemanticConventionsProvider) {
             this.config = config;
             this.socketTag = socketTag;
+            this.tracingSemanticConventionsProvider = tracingSemanticConventionsProvider;
         }
 
         @Override
@@ -620,7 +640,8 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
                                                 config.envConfig(),
                                                 config.waitTracingEnabled(),
                                                 config.pathConfigs(),
-                                                socketTag));
+                                                socketTag,
+                                                tracingSemanticConventionsProvider));
         }
     }
 }

--- a/webserver/observe/tracing/src/test/java/io/helidon/webserver/observe/tracing/TracingObserverSupportTest.java
+++ b/webserver/observe/tracing/src/test/java/io/helidon/webserver/observe/tracing/TracingObserverSupportTest.java
@@ -16,20 +16,53 @@
 
 package io.helidon.webserver.observe.tracing;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.uri.UriPath;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.Tracer;
+import io.helidon.webserver.http.Filter;
+import io.helidon.webserver.http.FilterChain;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.RoutingRequest;
+import io.helidon.webserver.http.RoutingResponse;
 import io.helidon.webserver.observe.spi.Observer;
+import io.helidon.webserver.observe.tracing.spi.TracingSemanticConventionsProvider;
+import io.helidon.webserver.spi.ServerFeature;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import static io.helidon.webserver.WebServer.DEFAULT_SOCKET_NAME;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 @Testing.Test(perMethod = true)
 class TracingObserverSupportTest {
@@ -65,16 +98,82 @@ class TracingObserverSupportTest {
     }
 
     @Test
-    void observeProviderUsesRegistryTracer() {
-        Tracer tracer = mock(Tracer.class);
-        Services.set(Tracer.class, tracer);
+    void managedObserveProviderUsesOwningRegistryDependencies() {
+        Tracer globalTracer = mock(Tracer.class);
+        Tracer owningTracer = mock(Tracer.class);
+        TracingSemanticConventionsProvider globalSemantics = mock(TracingSemanticConventionsProvider.class);
+        TracingSemanticConventionsProvider owningSemantics = mock(TracingSemanticConventionsProvider.class);
+        ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+        AtomicInteger semanticsSupplierCalls = new AtomicInteger();
 
-        Observer observer = new TracingObserveProvider().create(Config.empty(), "test");
+        Services.set(Tracer.class, globalTracer);
+        Services.set(TracingSemanticConventionsProvider.class, globalSemantics);
+        when(serviceRegistry.get(Tracer.class)).thenReturn(owningTracer);
+        when(serviceRegistry.supply(TracingSemanticConventionsProvider.class))
+                .thenReturn(() -> {
+                    semanticsSupplierCalls.incrementAndGet();
+                    return owningSemantics;
+                });
+
+        Observer observer = new TracingObserveProvider().create(Config.empty(),
+                                                                "test",
+                                                                serviceRegistry);
 
         assertThat("Tracing provider observer type", observer.type(), is("tracing"));
         assertThat("Tracing provider tracer",
                    ((TracingObserver) observer).prototype().tracer(),
+                   sameInstance(owningTracer));
+
+        Filter filter = registerFilter((TracingObserver) observer);
+
+        assertThat("Semantic conventions supplier calls", semanticsSupplierCalls.get(), is(1));
+
+        invoke(filter, owningTracer, owningSemantics);
+
+        verify(owningSemantics).create(any(), anyString(), any(), any());
+        verify(globalTracer, never()).extract(any());
+        verifyZeroInteractions(globalSemantics);
+    }
+
+    @Test
+    void disabledManagedObserverDoesNotResolveSemanticConventions() {
+        Tracer tracer = mock(Tracer.class);
+        ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+        AtomicInteger semanticsSupplierCalls = new AtomicInteger();
+        when(serviceRegistry.get(Tracer.class)).thenReturn(tracer);
+        when(serviceRegistry.supply(TracingSemanticConventionsProvider.class))
+                .thenReturn(() -> {
+                    semanticsSupplierCalls.incrementAndGet();
+                    return mock(TracingSemanticConventionsProvider.class);
+                });
+        Observer observer = new TracingObserveProvider().create(config(Map.of("enabled", "false")),
+                                                                "test",
+                                                                serviceRegistry);
+        ServerFeature.ServerFeatureContext featureContext = mock(ServerFeature.ServerFeatureContext.class);
+
+        observer.register(featureContext, List.of(), endpoint -> endpoint);
+
+        assertThat("Semantic conventions supplier calls", semanticsSupplierCalls.get(), is(0));
+        verifyZeroInteractions(featureContext);
+    }
+
+    @Test
+    void directObserveProviderUsesGlobalRegistryDependencies() {
+        Tracer tracer = mock(Tracer.class);
+        TracingSemanticConventionsProvider semanticConventionsProvider = mock(TracingSemanticConventionsProvider.class);
+        Services.set(Tracer.class, tracer);
+        Services.set(TracingSemanticConventionsProvider.class, semanticConventionsProvider);
+
+        Observer observer = new TracingObserveProvider().create(Config.empty(), "test");
+
+        assertThat("Tracing provider tracer",
+                   ((TracingObserver) observer).prototype().tracer(),
                    sameInstance(tracer));
+
+        Filter filter = registerFilter((TracingObserver) observer);
+        invoke(filter, tracer, semanticConventionsProvider);
+
+        verify(semanticConventionsProvider).create(any(), anyString(), any(), any());
     }
 
     @Test
@@ -95,5 +194,58 @@ class TracingObserverSupportTest {
         } finally {
             manager.shutdown();
         }
+    }
+
+    private static Config config(Map<String, String> values) {
+        return Config.just(ConfigSources.create(values));
+    }
+
+    private static Filter registerFilter(TracingObserver observer) {
+        ServerFeature.ServerFeatureContext featureContext = mock(ServerFeature.ServerFeatureContext.class);
+        ServerFeature.SocketBuilders socketBuilders = mock(ServerFeature.SocketBuilders.class);
+        HttpRouting.Builder routing = mock(HttpRouting.Builder.class);
+        when(featureContext.sockets()).thenReturn(Set.of());
+        when(featureContext.socket(DEFAULT_SOCKET_NAME)).thenReturn(socketBuilders);
+        when(socketBuilders.httpRouting()).thenReturn(routing);
+
+        observer.register(featureContext, List.of(), endpoint -> endpoint);
+
+        ArgumentCaptor<HttpFeature> featureCaptor = ArgumentCaptor.forClass(HttpFeature.class);
+        verify(routing).addFeature(featureCaptor.capture());
+        featureCaptor.getValue().setup(routing);
+
+        ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+        verify(routing).addFilter(filterCaptor.capture());
+        return filterCaptor.getValue();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void invoke(Filter filter,
+                               Tracer tracer,
+                               TracingSemanticConventionsProvider semanticConventionsProvider) {
+        FilterChain chain = mock(FilterChain.class);
+        RoutingRequest request = mock(RoutingRequest.class);
+        RoutingResponse response = mock(RoutingResponse.class);
+        HttpPrologue prologue = mock(HttpPrologue.class);
+        TracingSemanticConventions semanticConventions = mock(TracingSemanticConventions.class);
+        Span.Builder spanBuilder = mock(Span.Builder.class, RETURNS_SELF);
+        Span span = mock(Span.class);
+        SpanContext spanContext = mock(SpanContext.class);
+        Scope scope = mock(Scope.class);
+
+        when(request.context()).thenReturn(Context.create());
+        when(request.prologue()).thenReturn(prologue);
+        when(prologue.method()).thenReturn(Method.GET);
+        when(prologue.uriPath()).thenReturn(UriPath.create("/test"));
+        when(tracer.extract(any())).thenReturn(Optional.empty());
+        when(semanticConventionsProvider.create(any(), anyString(), same(request), same(response)))
+                .thenReturn(semanticConventions);
+        when(semanticConventions.spanName()).thenReturn("test-span");
+        when(tracer.spanBuilder("test-span")).thenReturn(spanBuilder);
+        when(spanBuilder.start()).thenReturn(span);
+        when(span.context()).thenReturn(spanContext);
+        when(span.activate()).thenReturn(scope);
+
+        filter.filter(chain, request, response);
     }
 }

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
@@ -20,13 +20,16 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.testing.junit5.TestJunitExtension;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.WebServerService__ServiceDescriptor;
 import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.spi.ServerFeatureProvider;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -114,7 +117,12 @@ abstract class JunitExtensionBase extends TestJunitExtension implements AfterAll
     }
 
     static void setupWebServerFromRegistry(WebServerConfig.Builder serverBuilder) {
-        Object o = GlobalServiceRegistry.registry()
+        var serviceRegistry = GlobalServiceRegistry.registry();
+        serverBuilder.serviceRegistry(serviceRegistry);
+        Set<String> providedServerFeatureTypes = new HashSet<>();
+        serviceRegistry.all(ServerFeatureProvider.class)
+                .forEach(provider -> providedServerFeatureTypes.add(provider.configKey()));
+        Object o = serviceRegistry
                 .get(WebServerService__ServiceDescriptor.INSTANCE)
                 .orElseThrow(() -> {
                     return new IllegalStateException("Could not discover WebServerService in service registry, both "
@@ -124,9 +132,11 @@ abstract class JunitExtensionBase extends TestJunitExtension implements AfterAll
         // the service is package local
         Class<?> clazz = o.getClass();
         try {
-            Method method = clazz.getDeclaredMethod("updateServerBuilder", WebServerConfig.BuilderBase.class);
+            Method method = clazz.getDeclaredMethod("updateServerBuilder",
+                                                    WebServerConfig.BuilderBase.class,
+                                                    Set.class);
             method.setAccessible(true);
-            method.invoke(o, serverBuilder);
+            method.invoke(o, serverBuilder, providedServerFeatureTypes);
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to get service registry specific method on WebServerService", e);
         }

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.service.registry.Lookup;
@@ -42,6 +43,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import static io.helidon.webserver.testing.junit5.Junit5Util.withStaticMethods;
 
 abstract class JunitExtensionBase extends TestJunitExtension implements AfterAllCallback {
+    private static final TypeName SERVER_FEATURE_PROVIDER = TypeName.create(ServerFeatureProvider.class);
+
     private Class<?> testClass;
 
     JunitExtensionBase() {
@@ -144,37 +147,48 @@ abstract class JunitExtensionBase extends TestJunitExtension implements AfterAll
         }
     }
 
-    private static List<ServerFeature> registryServerFeatures(ServiceRegistry serviceRegistry) {
-        Set<String> providerTypes = new HashSet<>();
-        serviceRegistry.all(ServerFeatureProvider.class)
-                .forEach(provider -> providerTypes.add(provider.configKey()));
-
-        Lookup featureLookup = Lookup.create(ServerFeature.class);
-        Set<TypeName> factoryServiceTypes = new HashSet<>();
-        for (ServiceInfo serviceInfo : serviceRegistry.lookupServices(featureLookup)) {
-            // Config-backed factory products must be recreated from the final test server configuration.
-            if (!serviceInfo.serviceType().equals(serviceInfo.providedType())) {
-                factoryServiceTypes.add(serviceInfo.serviceType());
-            }
-        }
-
-        List<ServerFeature> result = new ArrayList<>();
-        List<ServiceInstance<ServerFeature>> featureInstances = serviceRegistry.lookupInstances(featureLookup);
-        for (ServiceInstance<ServerFeature> featureInstance : featureInstances) {
-            ServerFeature feature = featureInstance.get();
-            if (!factoryServiceTypes.contains(featureInstance.serviceType()) || !providerTypes.contains(feature.type())) {
-                result.add(feature);
-            }
-        }
-        return result;
-    }
-
     void testClass(Class<?> testClass) {
         this.testClass = testClass;
     }
 
     Class<?> testClass() {
         return testClass;
+    }
+
+    private static List<ServerFeature> registryServerFeatures(ServiceRegistry serviceRegistry) {
+        List<ServiceInfo> providerServices = serviceRegistry.lookupServices(Lookup.create(ServerFeatureProvider.class));
+        Lookup featureLookup = Lookup.create(ServerFeature.class);
+        List<ServiceInfo> featureServices = serviceRegistry.lookupServices(featureLookup);
+        Set<TypeName> providerBackedFactoryTypes = new HashSet<>();
+        for (ServiceInfo serviceInfo : featureServices) {
+            // Config-backed factory products must be recreated from the final test server configuration.
+            if (!serviceInfo.serviceType().equals(serviceInfo.providedType())
+                    && hasProviderFor(serviceInfo, providerServices)) {
+                providerBackedFactoryTypes.add(serviceInfo.serviceType());
+            }
+        }
+
+        List<ServerFeature> result = new ArrayList<>();
+        for (ServiceInfo featureService : featureServices) {
+            if (!providerBackedFactoryTypes.contains(featureService.serviceType())) {
+                Lookup serviceLookup = Lookup.builder(featureLookup)
+                        .serviceType(featureService.serviceType())
+                        .build();
+                List<ServiceInstance<ServerFeature>> featureInstances = serviceRegistry.lookupInstances(serviceLookup);
+                for (ServiceInstance<ServerFeature> featureInstance : featureInstances) {
+                    result.add(featureInstance.get());
+                }
+            }
+        }
+        return result;
+    }
+
+    private static boolean hasProviderFor(ServiceInfo factoryService, List<ServiceInfo> providerServices) {
+        ResolvedType providerContract = ResolvedType.create(TypeName.builder(SERVER_FEATURE_PROVIDER)
+                                                                    .addTypeArgument(factoryService.providedType())
+                                                                    .build());
+        return providerServices.stream()
+                .anyMatch(serviceInfo -> serviceInfo.contracts().contains(providerContract));
     }
 
     private void callAfterStop() {

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
@@ -34,6 +34,7 @@ import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.testing.junit5.TestJunitExtension;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.WebServerService__ServiceDescriptor;
+import io.helidon.webserver.spi.ConfiguredServerFeatureFactory;
 import io.helidon.webserver.spi.ServerFeature;
 import io.helidon.webserver.spi.ServerFeatureProvider;
 
@@ -44,6 +45,7 @@ import static io.helidon.webserver.testing.junit5.Junit5Util.withStaticMethods;
 
 abstract class JunitExtensionBase extends TestJunitExtension implements AfterAllCallback {
     private static final TypeName SERVER_FEATURE_PROVIDER = TypeName.create(ServerFeatureProvider.class);
+    private static final ResolvedType CONFIGURED_FEATURE_FACTORY = ResolvedType.create(ConfiguredServerFeatureFactory.class);
 
     private Class<?> testClass;
 
@@ -163,6 +165,7 @@ abstract class JunitExtensionBase extends TestJunitExtension implements AfterAll
         for (ServiceInfo serviceInfo : featureServices) {
             // Config-backed factory products must be recreated from the final test server configuration.
             if (!serviceInfo.serviceType().equals(serviceInfo.providedType())
+                    && serviceInfo.factoryContracts().contains(CONFIGURED_FEATURE_FACTORY)
                     && hasProviderFor(serviceInfo, providerServices)) {
                 providerBackedFactoryTypes.add(serviceInfo.serviceType());
             }

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
@@ -20,13 +20,21 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import io.helidon.common.types.TypeName;
 import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.ServiceInfo;
+import io.helidon.service.registry.ServiceInstance;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.testing.junit5.TestJunitExtension;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.WebServerService__ServiceDescriptor;
 import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.spi.ServerFeatureProvider;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -126,15 +134,40 @@ abstract class JunitExtensionBase extends TestJunitExtension implements AfterAll
         // the service is package local
         Class<?> clazz = o.getClass();
         try {
-            Method method = clazz.getDeclaredMethod("updateServerBuilder", WebServerConfig.BuilderBase.class);
+            Method method = clazz.getDeclaredMethod("updateServerBuilder",
+                                                    WebServerConfig.BuilderBase.class,
+                                                    List.class);
             method.setAccessible(true);
-            method.invoke(o, serverBuilder);
+            method.invoke(o, serverBuilder, registryServerFeatures(serviceRegistry));
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to get service registry specific method on WebServerService", e);
         }
     }
 
+    private static List<ServerFeature> registryServerFeatures(ServiceRegistry serviceRegistry) {
+        Set<String> providerTypes = new HashSet<>();
+        serviceRegistry.all(ServerFeatureProvider.class)
+                .forEach(provider -> providerTypes.add(provider.configKey()));
 
+        Lookup featureLookup = Lookup.create(ServerFeature.class);
+        Set<TypeName> factoryServiceTypes = new HashSet<>();
+        for (ServiceInfo serviceInfo : serviceRegistry.lookupServices(featureLookup)) {
+            // Config-backed factory products must be recreated from the final test server configuration.
+            if (!serviceInfo.serviceType().equals(serviceInfo.providedType())) {
+                factoryServiceTypes.add(serviceInfo.serviceType());
+            }
+        }
+
+        List<ServerFeature> result = new ArrayList<>();
+        List<ServiceInstance<ServerFeature>> featureInstances = serviceRegistry.lookupInstances(featureLookup);
+        for (ServiceInstance<ServerFeature> featureInstance : featureInstances) {
+            ServerFeature feature = featureInstance.get();
+            if (!factoryServiceTypes.contains(featureInstance.serviceType()) || !providerTypes.contains(feature.type())) {
+                result.add(feature);
+            }
+        }
+        return result;
+    }
 
     void testClass(Class<?> testClass) {
         this.testClass = testClass;

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
@@ -20,16 +20,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.testing.junit5.TestJunitExtension;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.WebServerService__ServiceDescriptor;
 import io.helidon.webserver.spi.ServerFeature;
-import io.helidon.webserver.spi.ServerFeatureProvider;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -119,9 +116,6 @@ abstract class JunitExtensionBase extends TestJunitExtension implements AfterAll
     static void setupWebServerFromRegistry(WebServerConfig.Builder serverBuilder) {
         var serviceRegistry = GlobalServiceRegistry.registry();
         serverBuilder.serviceRegistry(serviceRegistry);
-        Set<String> providedServerFeatureTypes = new HashSet<>();
-        serviceRegistry.all(ServerFeatureProvider.class)
-                .forEach(provider -> providedServerFeatureTypes.add(provider.configKey()));
         Object o = serviceRegistry
                 .get(WebServerService__ServiceDescriptor.INSTANCE)
                 .orElseThrow(() -> {
@@ -132,11 +126,9 @@ abstract class JunitExtensionBase extends TestJunitExtension implements AfterAll
         // the service is package local
         Class<?> clazz = o.getClass();
         try {
-            Method method = clazz.getDeclaredMethod("updateServerBuilder",
-                                                    WebServerConfig.BuilderBase.class,
-                                                    Set.class);
+            Method method = clazz.getDeclaredMethod("updateServerBuilder", WebServerConfig.BuilderBase.class);
             method.setAccessible(true);
-            method.invoke(o, serverBuilder, providedServerFeatureTypes);
+            method.invoke(o, serverBuilder);
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to get service registry specific method on WebServerService", e);
         }

--- a/webserver/testing/junit5/junit5/src/test/java/io/helidon/webserver/testing/junit5/JunitExtensionBaseTest.java
+++ b/webserver/testing/junit5/junit5/src/test/java/io/helidon/webserver/testing/junit5/JunitExtensionBaseTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.testing.junit5;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Isolated
+class JunitExtensionBaseTest {
+    @Test
+    void registryFeatureTakesPrecedenceOverMatchingProvider() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        AtomicInteger providerCreateCount = new AtomicInteger();
+        TestFeature registryFeature = new TestFeature();
+        ServerFeatureProvider<TestFeature> provider = new ServerFeatureProvider<>() {
+            @Override
+            public String configKey() {
+                return TestFeature.TYPE;
+            }
+
+            @Override
+            public TestFeature create(Config config, String name) {
+                providerCreateCount.incrementAndGet();
+                return new TestFeature();
+            }
+        };
+        Config config = Config.just(ConfigSources.create(Map.of("server.features.registry-feature.enabled", "true")));
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class, config)
+                                                                                .putContractInstance(ServerFeature.class,
+                                                                                                     registryFeature)
+                                                                                .putContractInstance(ServerFeatureProvider.class,
+                                                                                                     provider)
+                                                                                .build());
+        try {
+            GlobalServiceRegistry.registry(manager.registry());
+            WebServerConfig.Builder builder = WebServer.builder()
+                    .config(config.get("server"));
+
+            JunitExtensionBase.setupWebServerFromRegistry(builder);
+            WebServerConfig serverConfig = builder.buildPrototype();
+
+            assertThat(serverConfig.features(), hasItem(sameInstance(registryFeature)));
+            assertThat(providerCreateCount.get(), is(0));
+        } finally {
+            manager.shutdown();
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
+    private static final class TestFeature implements ServerFeature {
+        private static final String TYPE = "registry-feature";
+
+        @Override
+        public void setup(ServerFeatureContext featureContext) {
+        }
+
+        @Override
+        public String type() {
+            return TYPE;
+        }
+
+        @Override
+        public String name() {
+            return TYPE;
+        }
+    }
+}

--- a/webserver/testing/junit5/junit5/src/test/java/io/helidon/webserver/testing/junit5/JunitExtensionBaseTest.java
+++ b/webserver/testing/junit5/junit5/src/test/java/io/helidon/webserver/testing/junit5/JunitExtensionBaseTest.java
@@ -37,6 +37,7 @@ import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.spi.ConfiguredServerFeatureFactory;
 import io.helidon.webserver.spi.ServerFeature;
 import io.helidon.webserver.spi.ServerFeatureProvider;
 
@@ -51,6 +52,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Isolated
 class JunitExtensionBaseTest {
     private static final AtomicInteger FACTORY_CREATE_COUNT = new AtomicInteger();
+    private static final AtomicInteger UNRELATED_FACTORY_CREATE_COUNT = new AtomicInteger();
     private static final AtomicInteger PROVIDER_CREATE_COUNT = new AtomicInteger();
 
     @Test
@@ -138,6 +140,45 @@ class JunitExtensionBaseTest {
         }
     }
 
+    @Test
+    void unrelatedFactoryFeatureIsPreservedWithMatchingProvider() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        UNRELATED_FACTORY_CREATE_COUNT.set(0);
+        PROVIDER_CREATE_COUNT.set(0);
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class,
+                                                                                                     Config.empty())
+                                                                                .addServiceDescriptor(
+                                                                                        UnrelatedFeatureFactoryDescriptor.INSTANCE)
+                                                                                .addServiceDescriptor(
+                                                                                        TestFeatureProviderDescriptor.INSTANCE)
+                                                                                .build());
+        try {
+            GlobalServiceRegistry.registry(manager.registry());
+            WebServerConfig.Builder builder = WebServer.builder()
+                    .config(Config.empty());
+
+            JunitExtensionBase.setupWebServerFromRegistry(builder);
+
+            assertThat(UNRELATED_FACTORY_CREATE_COUNT.get(), is(1));
+            assertThat(PROVIDER_CREATE_COUNT.get(), is(0));
+
+            WebServerConfig serverConfig = builder.buildPrototype();
+            TestFeature feature = serverConfig.features()
+                    .stream()
+                    .filter(TestFeature.class::isInstance)
+                    .map(TestFeature.class::cast)
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(PROVIDER_CREATE_COUNT.get(), is(0));
+            assertThat(feature.value(), is("unrelated"));
+        } finally {
+            manager.shutdown();
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
     private static final class TestFeature implements ServerFeature {
         private static final String TYPE = "registry-feature";
         private final String value;
@@ -169,11 +210,21 @@ class JunitExtensionBaseTest {
         }
     }
 
-    private static final class TestFeatureFactory implements Service.ServicesFactory<TestFeature> {
+    private static final class TestFeatureFactory
+            implements Service.ServicesFactory<TestFeature>, ConfiguredServerFeatureFactory {
         @Override
         public List<Service.QualifiedInstance<TestFeature>> services() {
             FACTORY_CREATE_COUNT.incrementAndGet();
             return List.of(Service.QualifiedInstance.create(new TestFeature("registry"),
+                                                            Qualifier.createNamed(TestFeature.TYPE)));
+        }
+    }
+
+    private static final class UnrelatedFeatureFactory implements Service.ServicesFactory<TestFeature> {
+        @Override
+        public List<Service.QualifiedInstance<TestFeature>> services() {
+            UNRELATED_FACTORY_CREATE_COUNT.incrementAndGet();
+            return List.of(Service.QualifiedInstance.create(new TestFeature("unrelated"),
                                                             Qualifier.createNamed(TestFeature.TYPE)));
         }
     }
@@ -196,12 +247,10 @@ class JunitExtensionBaseTest {
         private static final TypeName SERVICE_TYPE = TypeName.create(TestFeatureFactory.class);
         private static final TypeName PROVIDED_TYPE = TypeName.create(TestFeature.class);
         private static final TypeName DESCRIPTOR_TYPE = TypeName.create(TestFeatureFactoryDescriptor.class);
-        private static final TypeName FACTORY_CONTRACT = TypeName.builder(TypeName.create(Service.ServicesFactory.class))
-                .addTypeArgument(PROVIDED_TYPE)
-                .build();
         private static final Set<ResolvedType> CONTRACTS = Set.of(ResolvedType.create(PROVIDED_TYPE),
                                                                   ResolvedType.create(ServerFeature.class));
-        private static final Set<ResolvedType> FACTORY_CONTRACTS = Set.of(ResolvedType.create(FACTORY_CONTRACT));
+        private static final Set<ResolvedType> FACTORY_CONTRACTS = Set.of(
+                ResolvedType.create(ConfiguredServerFeatureFactory.class));
 
         @Override
         public Object instantiate(DependencyContext ctx, InterceptionMetadata interceptionMetadata) {
@@ -231,6 +280,43 @@ class JunitExtensionBaseTest {
         @Override
         public Set<ResolvedType> factoryContracts() {
             return FACTORY_CONTRACTS;
+        }
+
+        @Override
+        public FactoryType factoryType() {
+            return FactoryType.SERVICES;
+        }
+    }
+
+    private static final class UnrelatedFeatureFactoryDescriptor
+            implements ServiceDescriptor<UnrelatedFeatureFactory> {
+        private static final UnrelatedFeatureFactoryDescriptor INSTANCE = new UnrelatedFeatureFactoryDescriptor();
+        private static final TypeName SERVICE_TYPE = TypeName.create(UnrelatedFeatureFactory.class);
+        private static final TypeName DESCRIPTOR_TYPE = TypeName.create(UnrelatedFeatureFactoryDescriptor.class);
+
+        @Override
+        public Object instantiate(DependencyContext ctx, InterceptionMetadata interceptionMetadata) {
+            return new UnrelatedFeatureFactory();
+        }
+
+        @Override
+        public TypeName serviceType() {
+            return SERVICE_TYPE;
+        }
+
+        @Override
+        public TypeName providedType() {
+            return TestFeatureFactoryDescriptor.PROVIDED_TYPE;
+        }
+
+        @Override
+        public TypeName descriptorType() {
+            return DESCRIPTOR_TYPE;
+        }
+
+        @Override
+        public Set<ResolvedType> contracts() {
+            return TestFeatureFactoryDescriptor.CONTRACTS;
         }
 
         @Override

--- a/webserver/testing/junit5/junit5/src/test/java/io/helidon/webserver/testing/junit5/JunitExtensionBaseTest.java
+++ b/webserver/testing/junit5/junit5/src/test/java/io/helidon/webserver/testing/junit5/JunitExtensionBaseTest.java
@@ -16,12 +16,22 @@
 
 package io.helidon.webserver.testing.junit5;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.helidon.common.types.ResolvedType;
+import io.helidon.common.types.TypeName;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
+import io.helidon.service.registry.DependencyContext;
+import io.helidon.service.registry.FactoryType;
 import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.InterceptionMetadata;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceDescriptor;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
@@ -40,6 +50,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Isolated
 class JunitExtensionBaseTest {
+    private static final AtomicInteger FACTORY_CREATE_COUNT = new AtomicInteger();
+    private static final AtomicInteger PROVIDER_CREATE_COUNT = new AtomicInteger();
+
     @Test
     void registryFeatureTakesPrecedenceOverMatchingProvider() {
         ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
@@ -81,8 +94,61 @@ class JunitExtensionBaseTest {
         }
     }
 
+    @Test
+    void configBackedFeatureIsCreatedFromFinalConfigOnly() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        FACTORY_CREATE_COUNT.set(0);
+        PROVIDER_CREATE_COUNT.set(0);
+        Config registryConfig = Config.just(ConfigSources.create(Map.of(
+                "server.features.registry-feature.value", "registry")));
+        Config finalConfig = Config.just(ConfigSources.create(Map.of(
+                "server.features.registry-feature.value", "final")));
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class,
+                                                                                                     registryConfig)
+                                                                                .addServiceDescriptor(
+                                                                                        TestFeatureFactoryDescriptor.INSTANCE)
+                                                                                .addServiceDescriptor(
+                                                                                        TestFeatureProviderDescriptor.INSTANCE)
+                                                                                .build());
+        try {
+            GlobalServiceRegistry.registry(manager.registry());
+            WebServerConfig.Builder builder = WebServer.builder()
+                    .config(finalConfig.get("server"));
+
+            JunitExtensionBase.setupWebServerFromRegistry(builder);
+
+            assertThat(FACTORY_CREATE_COUNT.get(), is(0));
+            assertThat(PROVIDER_CREATE_COUNT.get(), is(0));
+
+            WebServerConfig serverConfig = builder.buildPrototype();
+            TestFeature feature = serverConfig.features()
+                    .stream()
+                    .filter(TestFeature.class::isInstance)
+                    .map(TestFeature.class::cast)
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(FACTORY_CREATE_COUNT.get(), is(0));
+            assertThat(PROVIDER_CREATE_COUNT.get(), is(1));
+            assertThat(feature.value(), is("final"));
+        } finally {
+            manager.shutdown();
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
     private static final class TestFeature implements ServerFeature {
         private static final String TYPE = "registry-feature";
+        private final String value;
+
+        private TestFeature() {
+            this("explicit");
+        }
+
+        private TestFeature(String value) {
+            this.value = value;
+        }
 
         @Override
         public void setup(ServerFeatureContext featureContext) {
@@ -96,6 +162,111 @@ class JunitExtensionBaseTest {
         @Override
         public String name() {
             return TYPE;
+        }
+
+        private String value() {
+            return value;
+        }
+    }
+
+    private static final class TestFeatureFactory implements Service.ServicesFactory<TestFeature> {
+        @Override
+        public List<Service.QualifiedInstance<TestFeature>> services() {
+            FACTORY_CREATE_COUNT.incrementAndGet();
+            return List.of(Service.QualifiedInstance.create(new TestFeature("registry"),
+                                                            Qualifier.createNamed(TestFeature.TYPE)));
+        }
+    }
+
+    private static final class TestFeatureProvider implements ServerFeatureProvider<TestFeature> {
+        @Override
+        public String configKey() {
+            return TestFeature.TYPE;
+        }
+
+        @Override
+        public TestFeature create(Config config, String name) {
+            PROVIDER_CREATE_COUNT.incrementAndGet();
+            return new TestFeature(config.get("value").asString().orElse("missing"));
+        }
+    }
+
+    private static final class TestFeatureFactoryDescriptor implements ServiceDescriptor<TestFeatureFactory> {
+        private static final TestFeatureFactoryDescriptor INSTANCE = new TestFeatureFactoryDescriptor();
+        private static final TypeName SERVICE_TYPE = TypeName.create(TestFeatureFactory.class);
+        private static final TypeName PROVIDED_TYPE = TypeName.create(TestFeature.class);
+        private static final TypeName DESCRIPTOR_TYPE = TypeName.create(TestFeatureFactoryDescriptor.class);
+        private static final TypeName FACTORY_CONTRACT = TypeName.builder(TypeName.create(Service.ServicesFactory.class))
+                .addTypeArgument(PROVIDED_TYPE)
+                .build();
+        private static final Set<ResolvedType> CONTRACTS = Set.of(ResolvedType.create(PROVIDED_TYPE),
+                                                                  ResolvedType.create(ServerFeature.class));
+        private static final Set<ResolvedType> FACTORY_CONTRACTS = Set.of(ResolvedType.create(FACTORY_CONTRACT));
+
+        @Override
+        public Object instantiate(DependencyContext ctx, InterceptionMetadata interceptionMetadata) {
+            return new TestFeatureFactory();
+        }
+
+        @Override
+        public TypeName serviceType() {
+            return SERVICE_TYPE;
+        }
+
+        @Override
+        public TypeName providedType() {
+            return PROVIDED_TYPE;
+        }
+
+        @Override
+        public TypeName descriptorType() {
+            return DESCRIPTOR_TYPE;
+        }
+
+        @Override
+        public Set<ResolvedType> contracts() {
+            return CONTRACTS;
+        }
+
+        @Override
+        public Set<ResolvedType> factoryContracts() {
+            return FACTORY_CONTRACTS;
+        }
+
+        @Override
+        public FactoryType factoryType() {
+            return FactoryType.SERVICES;
+        }
+    }
+
+    private static final class TestFeatureProviderDescriptor implements ServiceDescriptor<TestFeatureProvider> {
+        private static final TestFeatureProviderDescriptor INSTANCE = new TestFeatureProviderDescriptor();
+        private static final TypeName SERVICE_TYPE = TypeName.create(TestFeatureProvider.class);
+        private static final TypeName DESCRIPTOR_TYPE = TypeName.create(TestFeatureProviderDescriptor.class);
+        private static final Set<ResolvedType> CONTRACTS = Set.of(
+                ResolvedType.create(ServerFeatureProvider.class),
+                ResolvedType.create(TypeName.builder(TypeName.create(ServerFeatureProvider.class))
+                                            .addTypeArgument(TypeName.create(TestFeature.class))
+                                            .build()));
+
+        @Override
+        public Object instantiate(DependencyContext ctx, InterceptionMetadata interceptionMetadata) {
+            return new TestFeatureProvider();
+        }
+
+        @Override
+        public TypeName serviceType() {
+            return SERVICE_TYPE;
+        }
+
+        @Override
+        public TypeName descriptorType() {
+            return DESCRIPTOR_TYPE;
+        }
+
+        @Override
+        public Set<ResolvedType> contracts() {
+            return CONTRACTS;
         }
     }
 }

--- a/webserver/tests/observe/observe/pom.xml
+++ b/webserver/tests/observe/observe/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>helidon-webserver-observe-log</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-tracing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-encryption</artifactId>
             <scope>test</scope>

--- a/webserver/tests/observe/observe/pom.xml
+++ b/webserver/tests/observe/observe/pom.xml
@@ -77,4 +77,34 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/ObserveRegistryBootstrapTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-registry-bootstrap</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/ObserveRegistryBootstrapTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveRegistryBootstrapTest.java
+++ b/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveRegistryBootstrapTest.java
@@ -237,6 +237,67 @@ class ObserveRegistryBootstrapTest {
         }
     }
 
+    @Test
+    void matchingManualFeatureSuppressesAutomaticGraphWhenNotFirst() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        var provider = new CountingObserveProvider();
+        InfoObserver observer = InfoObserver.builder()
+                .name("manual")
+                .endpoint("manual")
+                .putValue("source", "manual")
+                .build();
+        ObserveFeature customFeature = ObserveFeature.builder()
+                .name("custom")
+                .endpoint("/custom-observe")
+                .observersDiscoverServices(false)
+                .build();
+        ObserveFeature defaultFeature = ObserveFeature.builder()
+                .name("observe")
+                .endpoint("/manual-default-observe")
+                .observersDiscoverServices(false)
+                .addObserver(observer)
+                .build();
+        Config config = Config.just(ConfigSources.create(Map.of(
+                "declarative.ignore-incubating", "true",
+                "server.port", "0")));
+        ServiceRegistryConfig registryConfig = ServiceRegistryConfig.builder()
+                .putContractInstance(Config.class, config)
+                .putContractInstance(ObserveProvider.class, provider)
+                .putContractInstance(Observer.class, observer)
+                .discoverServicesFromServiceLoader(false)
+                .build();
+        ServiceRegistryManager manager = null;
+        WebServer server = null;
+
+        try {
+            manager = ServiceRegistryManager.create(registryConfig);
+            ServiceRegistry registry = manager.registry();
+            GlobalServiceRegistry.registry(registry);
+            Services.set(ObserveFeature.class, customFeature, defaultFeature);
+            Services.set(ServerFeature.class, customFeature, defaultFeature);
+            server = registry.get(WebServer.class).start();
+
+            assertThat(provider.createCount, is(0));
+            List<ObserveFeature> features = registry.all(ObserveFeature.class);
+            assertThat(features, hasSize(2));
+            assertThat(features.get(0), sameInstance(customFeature));
+            assertThat(features.get(1), sameInstance(defaultFeature));
+
+            ClientResponseTyped<JsonObject> response = client(server).get("/manual-default-observe/manual/source")
+                    .request(JsonObject.class);
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().stringValue("value").orElseThrow(), is("manual"));
+        } finally {
+            if (server != null) {
+                server.stop();
+            }
+            if (manager != null) {
+                manager.shutdown();
+            }
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
     private static ServiceRegistryConfig registryConfig(Config config) {
         return ServiceRegistryConfig.builder()
                 .putContractInstance(Config.class, config)

--- a/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveRegistryBootstrapTest.java
+++ b/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveRegistryBootstrapTest.java
@@ -188,6 +188,55 @@ class ObserveRegistryBootstrapTest {
         }
     }
 
+    @Test
+    void defaultManualFeatureSuppressesAutomaticGraph() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        var provider = new CountingObserveProvider();
+        InfoObserver observer = InfoObserver.builder()
+                .name("manual")
+                .endpoint("manual")
+                .putValue("source", "manual")
+                .build();
+        ObserveFeature feature = ObserveFeature.builder()
+                .name("observe")
+                .endpoint("/manual-default-observe")
+                .observersDiscoverServices(false)
+                .addObserver(observer)
+                .build();
+        Config config = Config.just(ConfigSources.create(Map.of(
+                "declarative.ignore-incubating", "true",
+                "server.port", "0")));
+        ServiceRegistryConfig registryConfig = ServiceRegistryConfig.builder()
+                .putContractInstance(Config.class, config)
+                .putContractInstance(ObserveProvider.class, provider)
+                .putContractInstance(Observer.class, observer)
+                .putContractInstance(ObserveFeature.class, feature)
+                .putContractInstance(ServerFeature.class, feature)
+                .discoverServicesFromServiceLoader(false)
+                .build();
+        ServiceRegistryManager manager = null;
+
+        try {
+            manager = ServiceRegistryManager.start(registryConfig);
+            ServiceRegistry registry = manager.registry();
+            WebServer server = registry.get(WebServer.class);
+
+            assertThat(provider.createCount, is(0));
+            assertThat(registry.all(ObserveFeature.class), contains(sameInstance(feature)));
+            assertThat(registry.all(Observer.class), contains(sameInstance(observer)));
+
+            ClientResponseTyped<JsonObject> response = client(server).get("/manual-default-observe/manual/source")
+                    .request(JsonObject.class);
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().stringValue("value").orElseThrow(), is("manual"));
+        } finally {
+            if (manager != null) {
+                manager.shutdown();
+            }
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
     private static ServiceRegistryConfig registryConfig(Config config) {
         return ServiceRegistryConfig.builder()
                 .putContractInstance(Config.class, config)
@@ -244,5 +293,28 @@ class ObserveRegistryBootstrapTest {
 
     private static void assertStatus(ClientResponseTyped<String> response, Status expectedStatus) {
         assertThat(response.status(), is(expectedStatus));
+    }
+
+    private static final class CountingObserveProvider implements ObserveProvider {
+        private int createCount;
+
+        @Override
+        public String configKey() {
+            return "counting";
+        }
+
+        @Override
+        public Observer create(Config config, String name) {
+            throw new AssertionError("Managed observer creation must use the owning registry");
+        }
+
+        @Override
+        public Observer create(Config config, String name, ServiceRegistry serviceRegistry) {
+            createCount++;
+            return InfoObserver.builder()
+                    .name(name)
+                    .endpoint(name)
+                    .build();
+        }
     }
 }

--- a/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveRegistryBootstrapTest.java
+++ b/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveRegistryBootstrapTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.observe;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.observe.ObserveFeature;
+import io.helidon.webserver.observe.info.InfoObserver;
+import io.helidon.webserver.observe.spi.ObserveProvider;
+import io.helidon.webserver.observe.spi.Observer;
+import io.helidon.webserver.spi.ServerFeature;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static java.util.Map.entry;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+@Isolated
+class ObserveRegistryBootstrapTest {
+    private static final String ENDPOINT = "/registry-observe";
+
+    @Test
+    void managerStartDiscoversFeatureAndObservers() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        ServiceRegistryManager manager = null;
+
+        try {
+            manager = ServiceRegistryManager.start(registryConfig(automaticConfig("bootstrap")));
+            ServiceRegistry registry = manager.registry();
+            WebServer server = registry.get(WebServer.class);
+            WebClient client = client(server);
+
+            assertThat(server.isRunning(), is(true));
+
+            var features = registry.all(ObserveFeature.class);
+            var observers = registry.all(Observer.class);
+            assertThat(features, hasSize(1));
+            assertThat(observers, hasSize(6));
+            assertThat(observerTypes(observers),
+                       containsInAnyOrder("config", "health", "info", "log", "metrics", "tracing"));
+
+            ObserveFeature feature = features.getFirst();
+            assertThat(feature.prototype().observers(), hasSize(6));
+            for (Observer featureObserver : feature.prototype().observers()) {
+                assertThat("Registry does not expose the feature's " + featureObserver.type() + " observer",
+                           observers,
+                           hasItem(sameInstance(featureObserver)));
+            }
+
+            assertConfigEndpoint(client, "bootstrap");
+            assertStatus(client.get(ENDPOINT + "/health").request(String.class), Status.NO_CONTENT_204);
+            assertStatus(client.get(ENDPOINT + "/metrics").request(String.class), Status.OK_200);
+            assertStatus(client.get(ENDPOINT + "/info").request(String.class), Status.OK_200);
+            assertStatus(client.get(ENDPOINT + "/log/loggers").request(String.class), Status.OK_200);
+
+        } finally {
+            if (manager != null) {
+                manager.shutdown();
+            }
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
+    @Test
+    void legacyObserveProvidersAreBridgedIntoRegistry() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .discoverServices(false)
+                                                                                .discoverServicesFromServiceLoader(true)
+                                                                                .build());
+        try {
+            List<String> providerTypes = manager.registry()
+                    .all(ObserveProvider.class)
+                    .stream()
+                    .map(ObserveProvider::configKey)
+                    .toList();
+
+            assertThat(providerTypes,
+                       containsInAnyOrder("config", "health", "info", "log", "metrics", "tracing"));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void managedConfigObserverUsesOwningRegistry() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        ServiceRegistryManager globalManager = ServiceRegistryManager.create(registryConfig(isolatedConfig("global")));
+        ServiceRegistryManager ownerManager = ServiceRegistryManager.create(registryConfig(isolatedConfig("owner")));
+        WebServer server = null;
+
+        try {
+            GlobalServiceRegistry.registry(globalManager.registry());
+            assertThat(Services.get(Config.class).get("registry.marker").asString().orElseThrow(), is("global"));
+
+            ServiceRegistry ownerRegistry = ownerManager.registry();
+            server = ownerRegistry.get(WebServer.class).start();
+            var observers = ownerRegistry.all(Observer.class);
+
+            assertThat(observerTypes(observers), contains("config"));
+            assertConfigEndpoint(client(server), "owner");
+        } finally {
+            if (server != null) {
+                server.stop();
+            }
+            ownerManager.shutdown();
+            globalManager.shutdown();
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
+    @Test
+    void discoveryCanBeDisabledForManualFeatureAndObserver() {
+        ServiceRegistry previousGlobal = GlobalServiceRegistry.registry();
+        InfoObserver observer = InfoObserver.builder()
+                .name("manual")
+                .endpoint("manual")
+                .putValue("source", "manual")
+                .build();
+        ObserveFeature feature = ObserveFeature.builder()
+                .name("manual-observe")
+                .endpoint("/manual-observe")
+                .observersDiscoverServices(false)
+                .addObserver(observer)
+                .build();
+        ServiceRegistryConfig registryConfig = ServiceRegistryConfig.builder()
+                .putContractInstance(Config.class, manualConfig())
+                .putContractInstance(Observer.class, observer)
+                .putContractInstance(ObserveFeature.class, feature)
+                .putContractInstance(ServerFeature.class, feature)
+                .discoverServicesFromServiceLoader(false)
+                .build();
+        ServiceRegistryManager manager = null;
+
+        try {
+            manager = ServiceRegistryManager.start(registryConfig);
+            ServiceRegistry registry = manager.registry();
+            WebServer server = registry.get(WebServer.class);
+
+            assertThat(registry.all(ObserveFeature.class), contains(sameInstance(feature)));
+            assertThat(registry.all(Observer.class), contains(sameInstance(observer)));
+
+            ClientResponseTyped<JsonObject> response = client(server).get("/manual-observe/manual/source")
+                    .request(JsonObject.class);
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().stringValue("value").orElseThrow(), is("manual"));
+        } finally {
+            if (manager != null) {
+                manager.shutdown();
+            }
+            GlobalServiceRegistry.registry(previousGlobal);
+        }
+    }
+
+    private static ServiceRegistryConfig registryConfig(Config config) {
+        return ServiceRegistryConfig.builder()
+                .putContractInstance(Config.class, config)
+                .build();
+    }
+
+    private static Config automaticConfig(String marker) {
+        return Config.just(ConfigSources.create(Map.ofEntries(
+                entry("declarative.ignore-incubating", "true"),
+                entry("server.port", "0"),
+                entry("server.features.observe.endpoint", ENDPOINT),
+                entry("server.features.observe.observers.config.permit-all", "true"),
+                entry("server.features.observe.observers.config.unsafe-values", "true"),
+                entry("server.features.observe.observers.log.permit-all", "true"),
+                entry("registry.marker", marker))));
+    }
+
+    private static Config isolatedConfig(String marker) {
+        return Config.just(ConfigSources.create(Map.ofEntries(
+                entry("declarative.ignore-incubating", "true"),
+                entry("server.port", "0"),
+                entry("server.features.observe.endpoint", ENDPOINT),
+                entry("server.features.observe.observers-discover-services", "false"),
+                entry("server.features.observe.observers.config.permit-all", "true"),
+                entry("server.features.observe.observers.config.unsafe-values", "true"),
+                entry("registry.marker", marker))));
+    }
+
+    private static Config manualConfig() {
+        return Config.just(ConfigSources.create(Map.of(
+                "declarative.ignore-incubating", "true",
+                "server.port", "0",
+                "server.features-discover-services", "false")));
+    }
+
+    private static WebClient client(WebServer server) {
+        return WebClient.builder()
+                .baseUri(URI.create("http://localhost:" + server.port()))
+                .build();
+    }
+
+    private static Set<String> observerTypes(List<Observer> observers) {
+        return observers.stream()
+                .map(Observer::type)
+                .collect(Collectors.toSet());
+    }
+
+    private static void assertConfigEndpoint(WebClient client, String expectedMarker) {
+        ClientResponseTyped<JsonObject> response = client.get(ENDPOINT + "/config/values/registry.marker")
+                .request(JsonObject.class);
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity().stringValue("value").orElseThrow(), is(expectedMarker));
+    }
+
+    private static void assertStatus(ClientResponseTyped<String> response, Status expectedStatus) {
+        assertThat(response.status(), is(expectedStatus));
+    }
+}

--- a/webserver/tests/observe/observe/src/test/resources/application.yaml
+++ b/webserver/tests/observe/observe/src/test/resources/application.yaml
@@ -34,6 +34,7 @@ unsafe-config-observer:
 server:
   features:
     observe:
+      enabled: false
       endpoint: "/observe"
 
 app:

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -51,6 +51,7 @@ import io.helidon.common.tls.Tls;
 import io.helidon.common.tls.TlsMaterial;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
+import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceRegistry;
@@ -79,20 +80,28 @@ class LoomServer implements WebServer, Resumable {
     private volatile boolean alreadyStarted = false;
 
     @Service.Inject
-    LoomServer(WebServerService service, Supplier<MetricsFactory> metricsFactory, ServiceRegistry serviceRegistry) {
+    LoomServer(WebServerService service,
+               Supplier<MetricsFactory> metricsFactory,
+               Supplier<MeterRegistry> meterRegistry,
+               ServiceRegistry serviceRegistry) {
         // only for service registry
         this(WebServerConfig.builder()
                      .serviceRegistry(serviceRegistry)
                      .update(service::updateServerBuilder)
                      .buildPrototype(),
-             metricsFactory);
+             metricsFactory,
+             meterRegistry);
     }
 
     LoomServer(WebServerConfig serverConfig) {
-        this(serverConfig, () -> Services.get(MetricsFactory.class));
+        this(serverConfig,
+             () -> Services.get(MetricsFactory.class),
+             () -> Services.get(MeterRegistry.class));
     }
 
-    private LoomServer(WebServerConfig serverConfig, Supplier<MetricsFactory> metricsFactory) {
+    private LoomServer(WebServerConfig serverConfig,
+                       Supplier<MetricsFactory> metricsFactory,
+                       Supplier<MeterRegistry> meterRegistry) {
         this.registerShutdownHook = serverConfig.shutdownHook();
         this.context = serverConfig.serverContext()
                 .orElseGet(() -> Context.builder()
@@ -128,6 +137,7 @@ class LoomServer implements WebServer, Resumable {
                                                serverConfig.contentEncoding().orElseGet(ContentEncodingContext::create),
                                                serverConfig.directHandlers().orElseGet(DirectHandlers::create),
                                                metricsFactory,
+                                               meterRegistry,
                                                this::fatalListenerFailure));
         });
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -53,6 +53,7 @@ import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.Services;
 import io.helidon.spi.HelidonShutdownHandler;
 import io.helidon.webserver.http.DirectHandlers;
@@ -78,9 +79,10 @@ class LoomServer implements WebServer, Resumable {
     private volatile boolean alreadyStarted = false;
 
     @Service.Inject
-    LoomServer(WebServerService service, Supplier<MetricsFactory> metricsFactory) {
+    LoomServer(WebServerService service, Supplier<MetricsFactory> metricsFactory, ServiceRegistry serviceRegistry) {
         // only for service registry
         this(WebServerConfig.builder()
+                     .serviceRegistry(serviceRegistry)
                      .update(service::updateServerBuilder)
                      .buildPrototype(),
              metricsFactory);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 import io.helidon.Main;
 import io.helidon.common.SerializationConfig;
@@ -50,7 +51,9 @@ import io.helidon.common.tls.Tls;
 import io.helidon.common.tls.TlsMaterial;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.Services;
 import io.helidon.spi.HelidonShutdownHandler;
 import io.helidon.webserver.http.DirectHandlers;
 import io.helidon.webserver.spi.ServerFeature;
@@ -75,14 +78,19 @@ class LoomServer implements WebServer, Resumable {
     private volatile boolean alreadyStarted = false;
 
     @Service.Inject
-    LoomServer(WebServerService service) {
+    LoomServer(WebServerService service, Supplier<MetricsFactory> metricsFactory) {
         // only for service registry
         this(WebServerConfig.builder()
                      .update(service::updateServerBuilder)
-                     .buildPrototype());
+                     .buildPrototype(),
+             metricsFactory);
     }
 
     LoomServer(WebServerConfig serverConfig) {
+        this(serverConfig, () -> Services.get(MetricsFactory.class));
+    }
+
+    private LoomServer(WebServerConfig serverConfig, Supplier<MetricsFactory> metricsFactory) {
         this.registerShutdownHook = serverConfig.shutdownHook();
         this.context = serverConfig.serverContext()
                 .orElseGet(() -> Context.builder()
@@ -117,6 +125,7 @@ class LoomServer implements WebServer, Resumable {
                                                serverConfig.mediaContext().orElseGet(MediaContext::create),
                                                serverConfig.contentEncoding().orElseGet(ContentEncodingContext::create),
                                                serverConfig.directHandlers().orElseGet(DirectHandlers::create),
+                                               metricsFactory,
                                                this::fatalListenerFailure));
         });
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 import io.helidon.common.concurrency.limits.FixedLimit;
 import io.helidon.common.concurrency.limits.Limit;
@@ -89,6 +90,28 @@ class ServerListener implements TransportBindingContext, ListenerContext {
                    ContentEncodingContext defaultContentEncodingContext,
                    DirectHandlers defaultDirectHandlers,
                    FatalListenerFailureHandler fatalListenerFailureHandler) {
+        this(socketName,
+             listenerConfig,
+             router,
+             serverContext,
+             idleConnectionTimer,
+             defaultMediaContext,
+             defaultContentEncodingContext,
+             defaultDirectHandlers,
+             () -> Services.get(MetricsFactory.class),
+             fatalListenerFailureHandler);
+    }
+
+    ServerListener(String socketName,
+                   ListenerConfig listenerConfig,
+                   Router router,
+                   Context serverContext,
+                   Timer idleConnectionTimer,
+                   MediaContext defaultMediaContext,
+                   ContentEncodingContext defaultContentEncodingContext,
+                   DirectHandlers defaultDirectHandlers,
+                   Supplier<MetricsFactory> metricsFactory,
+                   FatalListenerFailureHandler fatalListenerFailureHandler) {
 
         List<ProtocolConfig> protocolConfigs = listenerConfig.protocols();
         if (listenerConfig.maxConcurrentRequests() == -1) {
@@ -100,7 +123,7 @@ class ServerListener implements TransportBindingContext, ListenerContext {
                     .build();
         }
 
-        InitializationContext limitContext = limitContext(socketName);
+        InitializationContext limitContext = limitContext(socketName, metricsFactory);
         if (listenerConfig.maxConnections() == -1 || listenerConfig.maxConnections() == 0) {
             this.connectionLimit = FixedLimit.create();
         } else {
@@ -346,12 +369,11 @@ class ServerListener implements TransportBindingContext, ListenerContext {
         }
     }
 
-    private static InitializationContext limitContext(String socketName) {
+    private static InitializationContext limitContext(String socketName, Supplier<MetricsFactory> metricsFactory) {
         if (WebServer.DEFAULT_SOCKET_NAME.equals(socketName)) {
             return InitializationContext.create(socketName);
         }
-        // we access service registry here, but this was already the case, it was just hidden behind a static method
-        Tag socketNameTag = Services.get(MetricsFactory.class).tagCreate("socketName", socketName);
+        Tag socketNameTag = metricsFactory.get().tagCreate("socketName", socketName);
         return InitializationContext.create(socketName, List.of(socketNameTag));
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -44,6 +44,7 @@ import io.helidon.common.tls.Tls;
 import io.helidon.common.tls.TlsMaterial;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
+import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.service.registry.Services;
@@ -99,6 +100,7 @@ class ServerListener implements TransportBindingContext, ListenerContext {
              defaultContentEncodingContext,
              defaultDirectHandlers,
              () -> Services.get(MetricsFactory.class),
+             () -> Services.get(MeterRegistry.class),
              fatalListenerFailureHandler);
     }
 
@@ -111,6 +113,7 @@ class ServerListener implements TransportBindingContext, ListenerContext {
                    ContentEncodingContext defaultContentEncodingContext,
                    DirectHandlers defaultDirectHandlers,
                    Supplier<MetricsFactory> metricsFactory,
+                   Supplier<MeterRegistry> meterRegistry,
                    FatalListenerFailureHandler fatalListenerFailureHandler) {
 
         List<ProtocolConfig> protocolConfigs = listenerConfig.protocols();
@@ -123,7 +126,7 @@ class ServerListener implements TransportBindingContext, ListenerContext {
                     .build();
         }
 
-        InitializationContext limitContext = limitContext(socketName, metricsFactory);
+        InitializationContext limitContext = limitContext(socketName, metricsFactory, meterRegistry);
         if (listenerConfig.maxConnections() == -1 || listenerConfig.maxConnections() == 0) {
             this.connectionLimit = FixedLimit.create();
         } else {
@@ -369,12 +372,14 @@ class ServerListener implements TransportBindingContext, ListenerContext {
         }
     }
 
-    private static InitializationContext limitContext(String socketName, Supplier<MetricsFactory> metricsFactory) {
+    private static InitializationContext limitContext(String socketName,
+                                                      Supplier<MetricsFactory> metricsFactory,
+                                                      Supplier<MeterRegistry> meterRegistry) {
         if (WebServer.DEFAULT_SOCKET_NAME.equals(socketName)) {
-            return InitializationContext.create(socketName);
+            return InitializationContext.create(socketName, List.of(), meterRegistry);
         }
         Tag socketNameTag = metricsFactory.get().tagCreate("socketName", socketName);
-        return InitializationContext.create(socketName, List.of(socketNameTag));
+        return InitializationContext.create(socketName, List.of(socketNameTag), meterRegistry);
     }
 
     private List<TransportBinding> planTransportBindings(List<ProtocolConfig> protocolConfigs) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
@@ -23,12 +23,10 @@ import java.net.StandardSocketOptions;
 import java.net.UnixDomainSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.helidon.builder.api.Prototype;
@@ -119,21 +117,19 @@ class WebServerConfigSupport {
             }
 
             List<ServerFeature> features = target.features();
-            List<ServerFeature> uniqueFeatures = new ArrayList<>();
-            Set<FeatureId> registeredFeatures = new HashSet<>();
+            Map<FeatureId, ServerFeature> uniqueFeatures = new LinkedHashMap<>();
             for (ServerFeature feature : features) {
-                if (registeredFeatures.add(new FeatureId(feature.type(), feature.name()))) {
-                    uniqueFeatures.add(feature);
-                } else {
+                FeatureId featureId = new FeatureId(feature.type(), feature.name());
+                if (uniqueFeatures.put(featureId, feature) != null) {
                     if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
                         LOGGER.log(System.Logger.Level.DEBUG, "Feature (type, name): ("
                                 + feature.type() + ", " + feature.name()
-                                + ") is already registered with server, and will be ignored (probably one registered through "
-                                + "builder, the other through service loader. Builder wins.");
+                                + ") is already registered with server; the last registration wins (typically an explicit "
+                                + "builder registration replacing a discovered feature).");
                     }
                 }
             }
-            target.features(uniqueFeatures);
+            target.features(new ArrayList<>(uniqueFeatures.values()));
 
             Optional<HttpRouting.Builder> routing = target.routing();
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
@@ -23,10 +23,12 @@ import java.net.StandardSocketOptions;
 import java.net.UnixDomainSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import io.helidon.builder.api.Prototype;
@@ -117,19 +119,21 @@ class WebServerConfigSupport {
             }
 
             List<ServerFeature> features = target.features();
-            Map<FeatureId, ServerFeature> uniqueFeatures = new LinkedHashMap<>();
+            List<ServerFeature> uniqueFeatures = new ArrayList<>();
+            Set<FeatureId> registeredFeatures = new HashSet<>();
             for (ServerFeature feature : features) {
-                FeatureId featureId = new FeatureId(feature.type(), feature.name());
-                if (uniqueFeatures.put(featureId, feature) != null) {
+                if (registeredFeatures.add(new FeatureId(feature.type(), feature.name()))) {
+                    uniqueFeatures.add(feature);
+                } else {
                     if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
                         LOGGER.log(System.Logger.Level.DEBUG, "Feature (type, name): ("
                                 + feature.type() + ", " + feature.name()
-                                + ") is already registered with server; the last registration wins (typically an explicit "
-                                + "builder registration replacing a discovered feature).");
+                                + ") is already registered with server, and will be ignored (probably one registered through "
+                                + "builder, the other through service loader. Builder wins.");
                     }
                 }
             }
-            target.features(new ArrayList<>(uniqueFeatures.values()));
+            target.features(uniqueFeatures);
 
             Optional<HttpRouting.Builder> routing = target.routing();
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerService.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerService.java
@@ -18,6 +18,7 @@ package io.helidon.webserver;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.helidon.common.Builder;
 import io.helidon.config.Config;
@@ -80,6 +81,11 @@ class WebServerService {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     void updateServerBuilder(WebServerConfig.BuilderBase<?, ?> builder) {
+        updateServerBuilder(builder, Set.of());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void updateServerBuilder(WebServerConfig.BuilderBase<?, ?> builder, Set<String> excludedServerFeatureTypes) {
         if (builder.config().isEmpty()) {
             config.map(it -> it.get("server")).ifPresent(builder::config);
         }
@@ -107,7 +113,9 @@ class WebServerService {
         if (builder.requestedUriDiscoveryContext().isEmpty()) {
             requestedUriDiscoveryContext.ifPresent(builder::requestedUriDiscoveryContext);
         }
-        serverFeatures.forEach(builder::addFeature);
+        serverFeatures.stream()
+                .filter(feature -> !excludedServerFeatureTypes.contains(feature.type()))
+                .forEach(builder::addFeature);
         HttpRouting.Builder defaultRoutingBuilder = builder.routing()
                 .orElseGet(HttpRouting::builder);
         builder.routing(defaultRoutingBuilder);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerService.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerService.java
@@ -80,6 +80,11 @@ class WebServerService {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     void updateServerBuilder(WebServerConfig.BuilderBase<?, ?> builder) {
+        updateServerBuilder(builder, serverFeatures);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void updateServerBuilder(WebServerConfig.BuilderBase<?, ?> builder, List<ServerFeature> selectedServerFeatures) {
         if (builder.config().isEmpty()) {
             config.map(it -> it.get("server")).ifPresent(builder::config);
         }
@@ -107,7 +112,7 @@ class WebServerService {
         if (builder.requestedUriDiscoveryContext().isEmpty()) {
             requestedUriDiscoveryContext.ifPresent(builder::requestedUriDiscoveryContext);
         }
-        serverFeatures.forEach(builder::addFeature);
+        selectedServerFeatures.forEach(builder::addFeature);
         HttpRouting.Builder defaultRoutingBuilder = builder.routing()
                 .orElseGet(HttpRouting::builder);
         builder.routing(defaultRoutingBuilder);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerService.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerService.java
@@ -18,6 +18,7 @@ package io.helidon.webserver;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import io.helidon.common.Builder;
 import io.helidon.config.Config;
@@ -29,6 +30,7 @@ import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaContextConfig;
 import io.helidon.http.media.MediaSupport;
 import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInstance;
 import io.helidon.webserver.http.DirectHandlers;
 import io.helidon.webserver.http.HttpFeature;
 import io.helidon.webserver.http.HttpRouting;
@@ -44,7 +46,7 @@ Combines configuration done by hand with services discovered using the registry.
 @Service.Singleton
 class WebServerService {
     private final Optional<Config> config;
-    private final List<ServerFeature> serverFeatures;
+    private final Supplier<List<ServiceInstance<ServerFeature>>> serverFeatures;
     private final List<HttpFeature> httpFeatures;
     private final List<ProtocolConfig> protocolConfigs;
     private final List<ContentEncoding> contentEncodings;
@@ -56,7 +58,7 @@ class WebServerService {
 
     @Service.Inject
     WebServerService(Optional<Config> config,
-                     List<ServerFeature> serverFeatures,
+                     Supplier<List<ServiceInstance<ServerFeature>>> serverFeatures,
                      List<HttpFeature> httpFeatures,
                      List<ProtocolConfig> protocolConfigs,
                      List<ContentEncoding> contentEncodings,
@@ -80,7 +82,10 @@ class WebServerService {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     void updateServerBuilder(WebServerConfig.BuilderBase<?, ?> builder) {
-        updateServerBuilder(builder, serverFeatures);
+        updateServerBuilder(builder, serverFeatures.get()
+                .stream()
+                .map(ServiceInstance::get)
+                .toList());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerService.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerService.java
@@ -18,7 +18,6 @@ package io.helidon.webserver;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import io.helidon.common.Builder;
 import io.helidon.config.Config;
@@ -81,11 +80,6 @@ class WebServerService {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     void updateServerBuilder(WebServerConfig.BuilderBase<?, ?> builder) {
-        updateServerBuilder(builder, Set.of());
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    void updateServerBuilder(WebServerConfig.BuilderBase<?, ?> builder, Set<String> excludedServerFeatureTypes) {
         if (builder.config().isEmpty()) {
             config.map(it -> it.get("server")).ifPresent(builder::config);
         }
@@ -113,9 +107,7 @@ class WebServerService {
         if (builder.requestedUriDiscoveryContext().isEmpty()) {
             requestedUriDiscoveryContext.ifPresent(builder::requestedUriDiscoveryContext);
         }
-        serverFeatures.stream()
-                .filter(feature -> !excludedServerFeatureTypes.contains(feature.type()))
-                .forEach(builder::addFeature);
+        serverFeatures.forEach(builder::addFeature);
         HttpRouting.Builder defaultRoutingBuilder = builder.routing()
                 .orElseGet(HttpRouting::builder);
         builder.routing(defaultRoutingBuilder);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/spi/ConfiguredServerFeatureFactory.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/spi/ConfiguredServerFeatureFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.spi;
+
+import io.helidon.common.Api;
+
+/**
+ * Marker for a registry factory whose server features must be recreated from the final server configuration.
+ */
+@Api.Internal
+public interface ConfiguredServerFeatureFactory {
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/LoomServerRegistryTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/LoomServerRegistryTest.java
@@ -18,19 +18,31 @@ package io.helidon.webserver;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
+import io.helidon.metrics.api.Gauge;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.webserver.spi.ServerFeature;
 import io.helidon.webserver.spi.ServerFeatureProvider;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class LoomServerRegistryTest {
     @Test
@@ -63,6 +75,32 @@ class LoomServerRegistryTest {
         }
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void managedLimitReceivesOwningMeterRegistry() {
+        Config config = Config.just(ConfigSources.create(Map.of("server.concurrency-limit.fixed.enable-metrics", "true")));
+        MeterRegistry meterRegistry = mock(MeterRegistry.class);
+        MetricsFactory metricsFactory = mock(MetricsFactory.class);
+        Gauge.Builder<Integer> gaugeBuilder = mock(Gauge.Builder.class, RETURNS_SELF);
+        Timer.Builder timerBuilder = mock(Timer.Builder.class, RETURNS_SELF);
+        when(meterRegistry.metricsFactory()).thenReturn(metricsFactory);
+        when(metricsFactory.gaugeBuilder(anyString(), ArgumentMatchers.<Supplier<Integer>>any()))
+                .thenReturn(gaugeBuilder);
+        when(metricsFactory.timerBuilder(anyString())).thenReturn(timerBuilder);
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class, config)
+                                                                                .putContractInstance(MeterRegistry.class,
+                                                                                                     meterRegistry)
+                                                                                .build());
+        try {
+            manager.registry().get(WebServer.class);
+
+            verify(meterRegistry, atLeastOnce()).metricsFactory();
+        } finally {
+            manager.shutdown();
+        }
+    }
+
     private static final class TestFeature implements ServerFeature {
         private final AtomicBoolean setup = new AtomicBoolean();
 
@@ -85,4 +123,5 @@ class LoomServerRegistryTest {
             return setup.get();
         }
     }
+
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/LoomServerRegistryTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/LoomServerRegistryTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class LoomServerRegistryTest {
+    @Test
+    void managedServerUsesOwningRegistryFeatureProvider() {
+        TestFeature feature = new TestFeature();
+        ServerFeatureProvider<TestFeature> provider = new ServerFeatureProvider<>() {
+            @Override
+            public String configKey() {
+                return "owning-registry";
+            }
+
+            @Override
+            public TestFeature create(Config config, String name) {
+                return feature;
+            }
+        };
+        Config config = Config.just(ConfigSources.create(Map.of("server.features.owning-registry.enabled", "true")));
+        ServiceRegistryManager manager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                .putContractInstance(Config.class, config)
+                                                                                .putContractInstance(ServerFeatureProvider.class,
+                                                                                                     provider)
+                                                                                .build());
+        try {
+            WebServer server = manager.registry().get(WebServer.class);
+
+            assertThat(server.prototype().features(), hasItem(feature));
+            assertThat(feature.setup(), is(true));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private static final class TestFeature implements ServerFeature {
+        private final AtomicBoolean setup = new AtomicBoolean();
+
+        @Override
+        public void setup(ServerFeatureContext featureContext) {
+            setup.set(true);
+        }
+
+        @Override
+        public String type() {
+            return "owning-registry";
+        }
+
+        @Override
+        public String name() {
+            return type();
+        }
+
+        private boolean setup() {
+            return setup.get();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #12321

Remove static service lookups from registry-managed paths by supplying dependencies from the owning registry while preserving direct-construction fallbacks. This also provides registry-based observability discovery with ServiceLoader compatibility and clarifies the related configuration and lifecycle contracts.
