### PR TITLE
4.x: Upgrade OCI SDK to 3.95.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -142,7 +142,7 @@
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
         <version.lib.netty>4.1.137.Final</version.lib.netty>
-        <version.lib.oci>3.86.2</version.lib.oci>
+        <version.lib.oci>3.95.0</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>
         <!-- Force upgrade of okio for dependency convergence: make the OTel otlp exporter use the release langchain4j uses -->


### PR DESCRIPTION
### Description

Upgrade OCI SDK to 3.95.0
