### PR TITLE
Avoid creating a global service registry during manager shutdown

### DIFF
--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistryManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,11 +221,7 @@ public final class ServiceRegistryManager {
                 return;
             }
 
-            ServiceRegistry global = GlobalServiceRegistry.registry();
-            if (global == registry) {
-                // this is the same instance, if we shut it down, global would stop working
-                GlobalServiceRegistry.unset(registry);
-            }
+            GlobalServiceRegistry.unset(registry);
             registry.shutdown();
             registry = null;
         } finally {

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/ServiceRegistryManagerShutdownTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/ServiceRegistryManagerShutdownTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ServiceRegistryManagerShutdownTest {
+
+    @Test
+    void shutdownDoesNotCreateGlobalRegistry() {
+        resetGlobalRegistry();
+        var manager = ServiceRegistryManager.create();
+
+        try {
+            manager.registry();
+            assertThat("Creating an independent registry must not configure the global registry",
+                       GlobalServiceRegistry.configured(),
+                       is(false));
+
+            manager.shutdown();
+
+            assertThat("Shutting down an independent registry must not configure the global registry",
+                       GlobalServiceRegistry.configured(),
+                       is(false));
+        } finally {
+            manager.shutdown();
+            resetGlobalRegistry();
+        }
+    }
+
+    private static void resetGlobalRegistry() {
+        var manager = ServiceRegistryManager.create();
+        GlobalServiceRegistry.registry(manager.registry());
+        manager.shutdown();
+    }
+}


### PR DESCRIPTION
Resolves #12333

Avoid calling the creating global-registry accessor during `ServiceRegistryManager` shutdown. Unregister the manager's exact registry directly so independently managed registries do not leak application-global state.

Add regression coverage for the create/shutdown lifecycle in a new test file without changing existing tests.

This also addresses the service-registry lifecycle failure observed in helidon-io/helidon-microprofile#85.
