### PR TITLE
Close HTTP/1.1 connections after Connection: close (27.x)

### DIFF
--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/KeepAliveTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/KeepAliveTest.java
@@ -18,8 +18,14 @@ package io.helidon.webserver.tests;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
 
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
@@ -28,11 +34,15 @@ import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
 import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.noHeader;
@@ -44,9 +54,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @ServerTest
 class KeepAliveTest {
     private final Http1Client webClient;
+    private final URI uri;
 
-    KeepAliveTest(Http1Client client) {
+    KeepAliveTest(Http1Client client, URI uri) {
         this.webClient = client;
+        this.uri = uri;
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.writeQueueLength(2);
+        server.smartAsyncWrites(true);
     }
 
     @SetUpRoute
@@ -71,7 +89,19 @@ class KeepAliveTest {
                 res.status(INTERNAL_SERVER_ERROR_500)
                         .send(e.getMessage());
             }
-        });
+        }).get("/request-close", (_, res) -> res.send("done"))
+                .get("/response-close", (_, res) -> res.header(HeaderValues.CONNECTION_CLOSE)
+                        .send("done"))
+                .get("/request-close-stream", (_, res) -> sendStreamingResponse(res))
+                .get("/response-close-stream", (_, res) -> {
+                    res.header(HeaderValues.CONNECTION_CLOSE);
+                    sendStreamingResponse(res);
+                })
+                .route(Method.PUT, "/response-close-entity", (req, res) -> {
+                    req.content().as(String.class);
+                    res.header(HeaderValues.CONNECTION_CLOSE)
+                            .send("done");
+                });
     }
 
     @RepeatedTest(100)
@@ -95,6 +125,39 @@ class KeepAliveTest {
         try (HttpClientResponse response = testCall(webClient, true, "/close", INTERNAL_SERVER_ERROR_500)) {
             assertThat(response.headers(), noHeader(HeaderNames.CONNECTION));
         }
+    }
+
+    @Test
+    void requestConnectionCloseClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.GET, "/request-close", null, List.of("Connection: close"));
+    }
+
+    @Test
+    void requestConnectionCloseWithEntityClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.PUT, "/plain", "content", List.of("Connection: close"));
+    }
+
+    @Test
+    void responseConnectionCloseClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.GET, "/response-close", null, List.of());
+    }
+
+    @Test
+    void responseConnectionCloseWithEntityClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.PUT, "/response-close-entity", "content", List.of());
+    }
+
+    @Test
+    void requestConnectionCloseWithStreamingResponseClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.GET,
+                                 "/request-close-stream",
+                                 null,
+                                 List.of("Connection: close"));
+    }
+
+    @Test
+    void responseConnectionCloseWithStreamingResponseClosesSocket() throws Exception {
+        assertConnectionIsClosed(Method.GET, "/response-close-stream", null, List.of());
     }
 
     private static HttpClientResponse testCall(Http1Client client,
@@ -121,4 +184,23 @@ class KeepAliveTest {
 
         return response;
     }
+
+    private static void sendStreamingResponse(ServerResponse response) {
+        try (OutputStream outputStream = response.outputStream()) {
+            outputStream.write("first".getBytes(StandardCharsets.UTF_8));
+            outputStream.write("second".getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void assertConnectionIsClosed(Method method, String path, String payload, List<String> headers) throws Exception {
+        try (SocketHttpClient client = SocketHttpClient.create(uri.getHost(), uri.getPort(), Duration.ofSeconds(2))) {
+            String response = client.sendAndReceive(method, path, payload, headers);
+            assertThat(SocketHttpClient.statusFromResponse(response), is(OK_200));
+            assertThat(SocketHttpClient.headersFromResponse(response), hasHeader(HeaderValues.CONNECTION_CLOSE));
+            client.assertConnectionIsClosed();
+        }
+    }
+
 }

--- a/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketTest.java
+++ b/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketTest.java
@@ -28,6 +28,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Status;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
@@ -41,6 +44,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -184,6 +188,27 @@ class WebSocketTest {
         assertThat(listener.results().statusCode, is(1009));
         assertThat(listener.results().reason, is("Payload too large"));
         isNormalClose = false;
+    }
+
+    @Test
+    void rejectedUpgradeWithCloseClosesConnection() throws Exception {
+        isNormalClose = false;
+        try (SocketHttpClient socketClient = SocketHttpClient.create(port)) {
+            socketClient.requestRaw("""
+                                            GET /echo HTTP/1.1\r
+                                            Host: localhost:%d\r
+                                            Upgrade: websocket\r
+                                            Connection: Upgrade, close\r
+                                            Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
+                                            Sec-WebSocket-Version: 13\r
+                                            \r
+                                            """.formatted(port));
+
+            String response = socketClient.receive();
+            assertThat(SocketHttpClient.statusFromResponse(response), is(Status.BAD_REQUEST_400));
+            assertThat(SocketHttpClient.headersFromResponse(response), hasHeader(HeaderValues.CONNECTION_CLOSE));
+            socketClient.assertConnectionIsClosed();
+        }
     }
 
     private static class TestListener implements java.net.http.WebSocket.Listener {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -231,6 +231,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                     LimitAlgorithm.Outcome.Accepted accepted = (LimitAlgorithm.Outcome.Accepted) outcome;
                                     LimitAlgorithm.Token permit = accepted.token();
                                     ServerConnection routedUpgradeConnection = null;
+                                    boolean keepConnectionOpen = true;
                                     boolean permitCompleted = false;
                                     try {
                                         this.lastRequestTimestamp = DateTime.timestamp();
@@ -249,9 +250,13 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                             this.lastRequestTimestamp = DateTime.timestamp();
                                             break;
                                         case RESPONDED:
+                                            keepConnectionOpen = response.keepConnectionOpen();
                                             permit.success();
                                             permitCompleted = true;
                                             this.lastRequestTimestamp = DateTime.timestamp();
+                                            if (!keepConnectionOpen) {
+                                                flushBeforeClose();
+                                            }
                                             break;
                                         default:
                                             throw new IllegalStateException("Unknown routed upgrade result kind");
@@ -261,6 +266,9 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                             permit.dropped();
                                         }
                                         throw e;
+                                    }
+                                    if (!keepConnectionOpen) {
+                                        return;
                                     }
                                     if (routedUpgradeConnection != null) {
                                         handleUpgradeConnection(limit, routedUpgradeConnection);
@@ -283,16 +291,8 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                 LimitAlgorithm.Outcome outcome = limit.tryAcquireOutcome(true);
                 if (outcome.disposition() == LimitAlgorithm.Outcome.Disposition.ACCEPTED) {
                     LimitAlgorithm.Outcome.Accepted accepted = (LimitAlgorithm.Outcome.Accepted) outcome;
-                    LimitAlgorithm.Token permit = accepted.token();
-
-                    try {
-                        this.lastRequestTimestamp = DateTime.timestamp();
-                        route(prologue, headers, accepted);
-                        permit.success();
-                        this.lastRequestTimestamp = DateTime.timestamp();
-                    } catch (Throwable e) {
-                        permit.dropped();
-                        throw e;
+                    if (!routeWithPermit(prologue, headers, accepted)) {
+                        return;
                     }
                 } else {
                     throw tooManyConcurrentRequests(prologue, headers);
@@ -543,6 +543,37 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         UriValidator.validateNonIpLiteral(hostString);
     }
 
+    private boolean routeWithPermit(HttpPrologue prologue,
+                                    WritableHeaders<?> headers,
+                                    LimitAlgorithm.Outcome.Accepted accepted) {
+        LimitAlgorithm.Token permit = accepted.token();
+        boolean permitCompleted = false;
+        try {
+            this.lastRequestTimestamp = DateTime.timestamp();
+            boolean keepConnectionOpen = route(prologue, headers, accepted);
+            permit.success();
+            permitCompleted = true;
+            this.lastRequestTimestamp = DateTime.timestamp();
+            if (!keepConnectionOpen) {
+                flushBeforeClose();
+            }
+            return keepConnectionOpen;
+        } catch (Throwable e) {
+            if (!permitCompleted) {
+                permit.dropped();
+            }
+            throw e;
+        }
+    }
+
+    private void flushBeforeClose() {
+        try {
+            writer.flush();
+        } catch (RuntimeException e) {
+            throw new CloseConnectionException("Failed to flush closing response", e);
+        }
+    }
+
     private BufferData readEntityFromPipeline(HttpPrologue prologue, WritableHeaders<?> headers) {
         if (currentEntitySize == -1) {
             // chunked
@@ -596,9 +627,9 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         return buffer;
     }
 
-    private void route(HttpPrologue prologue,
-                       WritableHeaders<?> headers,
-                       LimitAlgorithm.Outcome limitOutcome) {
+    private boolean route(HttpPrologue prologue,
+                          WritableHeaders<?> headers,
+                          LimitAlgorithm.Outcome limitOutcome) {
         EntityStyle entity = EntityStyle.NONE;
 
         if (headers.contains(HeaderNames.TRANSFER_ENCODING)) {
@@ -631,7 +662,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
 
             routing.route(ctx, request, response);
             // we have handled a request without request entity
-            return;
+            return response.keepConnectionOpen();
         }
 
         boolean expectContinue = false;
@@ -703,6 +734,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                     .cause(e)
                     .build();
         }
+        return response.keepConnectionOpen();
     }
 
     private Http1ServerRequest createNoEntityRequest(HttpPrologue prologue,
@@ -736,7 +768,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     }
 
     private void consumeEntity(Http1ServerRequest request, Http1ServerResponse response, CountDownLatch entityReadLatch) {
-        if (response.headers().containsToken(HeaderValues.CONNECTION_CLOSE) || request.content().consumed()) {
+        if (!response.keepConnectionOpen() || request.content().consumed()) {
             // we do not care about request entity if connection is getting closed
             entityReadLatch.countDown();
             return;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -81,14 +81,15 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     private final ServerResponseHeaders headers;
     private final ServerResponseTrailers trailers;
     private final boolean keepAlive;
+    private final boolean validateHeaders;
 
+    private boolean keepConnectionOpen;
     private boolean streamingEntity;
     private boolean isSent;
     private ClosingBufferedOutputStream outputStream;
     private long bytesWritten;
     private String streamResult = "";
     private boolean isNoEntityStatus;
-    private final boolean validateHeaders;
 
     Http1ServerResponse(ConnectionContext ctx,
                         Http1ConnectionListener sendListener,
@@ -105,6 +106,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         this.headers = ServerResponseHeaders.create();
         this.trailers = ServerResponseTrailers.create();
         this.keepAlive = keepAlive;
+        this.keepConnectionOpen = keepAlive;
         this.validateHeaders = validateHeaders;
     }
 
@@ -332,6 +334,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             return false;
         }
         headers.clear();
+        keepConnectionOpen = keepAlive;
         streamingEntity = false;
         outputStream = null;
         return true;
@@ -493,6 +496,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         // give some space for code and headers + entity
         BufferData responseBuffer = BufferData.growing(256 + (headRequest || noEntityResponse ? 0 : length));
 
+        keepConnectionOpen = resolveKeepConnectionOpen();
         nonEntityBytes(headers, usedStatus, responseBuffer, keepAlive, validateHeaders);
         if (!headRequest && !noEntityResponse && forcedChunkedEncoding) {
             byte[] hex = Integer.toHexString(length).getBytes(StandardCharsets.US_ASCII);
@@ -548,6 +552,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             bos.checkResponseHeaders();     // headers can be augmented by encoders
         }
         OutputStream applicationOutputStream = applyStreamFilters(encodedOutputStream);
+        keepConnectionOpen = resolveKeepConnectionOpen();
         if (applicationOutputStream == outputStream) {
             outputStream.applicationFacing();
             return outputStream;
@@ -556,7 +561,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     }
 
     boolean keepConnectionOpen() {
-        return keepAlive && !headers.containsToken(HeaderValues.CONNECTION_CLOSE);
+        return keepConnectionOpen;
     }
 
     private static Status noEntityInternalError(Status status) {
@@ -584,6 +589,10 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             headers.remove(HeaderNames.TRANSFER_ENCODING);
             headers.remove(HeaderNames.TRAILER);
         }
+    }
+
+    private boolean resolveKeepConnectionOpen() {
+        return keepAlive && !headers.containsToken(HeaderValues.CONNECTION_CLOSE);
     }
 
     static class BlockingOutputStream extends OutputStream {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -21,12 +21,16 @@ import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.concurrency.limits.FixedLimit;
 import io.helidon.common.concurrency.limits.Limit;
 import io.helidon.common.concurrency.limits.LimitAlgorithm;
 import io.helidon.common.socket.HelidonSocket;
@@ -44,6 +48,7 @@ import io.helidon.webserver.Router;
 import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.DirectHandlers;
+import io.helidon.webserver.http.HttpRouting;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -51,6 +56,7 @@ import org.mockito.ArgumentCaptor;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -61,6 +67,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Http1ConnectionTest {
+    private static final byte[] CONNECTION_CLOSE_REQUEST = ("""
+            GET / HTTP/1.1\r
+            Host: localhost\r
+            Connection: close\r
+            \r
+            """).getBytes(StandardCharsets.UTF_8);
 
     @Test
     void rejectedHeadUsesParsedRequestMethod() throws InterruptedException {
@@ -126,26 +138,60 @@ class Http1ConnectionTest {
         }
     }
 
+    @Test
+    void gracefulCloseDoesNotInterruptClosingResponseFlush() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        BlockingDataWriter writer = new BlockingDataWriter();
+        Http1Connection connection = createConnection(DataReader.create(() -> CONNECTION_CLOSE_REQUEST),
+                                                      writer,
+                                                      DirectHandlers.create(),
+                                                      Router.builder()
+                                                              .addRouting(HttpRouting.builder()
+                                                                                  .get("/", (_, res) -> res.send("done")))
+                                                              .build());
+        try {
+            Future<?> connectionTask = executor.submit(() -> {
+                connection.handle(FixedLimit.create());
+                return null;
+            });
+
+            assertThat("Closing response did not reach the final flush",
+                       writer.flushStarted.await(10, TimeUnit.SECONDS),
+                       is(true));
+            connection.close(false);
+            writer.releaseFlush.countDown();
+            connectionTask.get(2, TimeUnit.SECONDS);
+
+            assertThat("Graceful close interrupted the final response flush", writer.interrupted, is(false));
+        } finally {
+            writer.releaseFlush.countDown();
+            executor.shutdownNow();
+        }
+    }
+
     private static Http1Connection createConnection(DataWriter dataWriter) {
-        return createConnection(mock(DataReader.class), dataWriter, DirectHandlers.create());
+        return createConnection(mock(DataReader.class), dataWriter, DirectHandlers.create(), Router.empty());
     }
 
     private static Http1Connection createConnection(DataReader dataReader,
                                                     DataWriter dataWriter,
-                                                    DirectHandlers directHandlers) {
+                                                    DirectHandlers directHandlers,
+                                                    Router router) {
         ListenerContext listenerContext = mock(ListenerContext.class);
         when(listenerContext.contentEncodingContext()).thenReturn(mock(ContentEncodingContext.class));
         when(listenerContext.config()).thenReturn(WebServer.builder().buildPrototype());
         when(listenerContext.directHandlers()).thenReturn(directHandlers);
 
+        PeerInfo peerInfo = mock(PeerInfo.class);
+        when(peerInfo.tlsCertificates()).thenReturn(Optional.empty());
+
         ConnectionContext ctx = mock(ConnectionContext.class);
         when(ctx.listenerContext()).thenReturn(listenerContext);
         when(ctx.dataWriter()).thenReturn(dataWriter);
         when(ctx.dataReader()).thenReturn(dataReader);
-        when(ctx.router()).thenReturn(Router.empty());
-        PeerInfo remotePeer = mock(PeerInfo.class);
-        when(remotePeer.tlsCertificates()).thenReturn(Optional.empty());
-        when(ctx.remotePeer()).thenReturn(remotePeer);
+        when(ctx.router()).thenReturn(router);
+        when(ctx.remotePeer()).thenReturn(peerInfo);
+        when(ctx.localPeer()).thenReturn(peerInfo);
 
         return new Http1Connection(ctx,
                                    Http1Config.builder()
@@ -166,7 +212,7 @@ class Http1ConnectionTest {
         Limit limit = mock(Limit.class);
         when(limit.tryAcquireOutcome(true)).thenReturn(LimitAlgorithm.Outcome.immediateRejection("test", "test"));
 
-        createConnection(reader, writer, directHandlers).handle(limit);
+        createConnection(reader, writer, directHandlers, Router.empty()).handle(limit);
 
         ArgumentCaptor<BufferData> responseBuffer = ArgumentCaptor.forClass(BufferData.class);
         verify(writer).write(responseBuffer.capture());
@@ -181,5 +227,38 @@ class Http1ConnectionTest {
                 .when(socket)
                 .write(any(BufferData.class));
         return SocketWriter.create(executor, socket, 2, true);
+    }
+
+    private static final class BlockingDataWriter implements DataWriter {
+        private final CountDownLatch flushStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseFlush = new CountDownLatch(1);
+        private volatile boolean interrupted;
+
+        @Override
+        public void write(BufferData... buffers) {
+        }
+
+        @Override
+        public void write(BufferData buffer) {
+        }
+
+        @Override
+        public void writeNow(BufferData... buffers) {
+        }
+
+        @Override
+        public void writeNow(BufferData buffer) {
+        }
+
+        @Override
+        public void flush() {
+            flushStarted.countDown();
+            try {
+                releaseFlush.await();
+            } catch (InterruptedException e) {
+                interrupted = true;
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #12325

Carries the HTTP/1.1 connection-close fix from #12326 to `main`. Ensures responses selecting `Connection: close` are fully flushed before the server closes the socket, without holding the request-limit permit. Includes request- and response-driven closure, entities, streaming responses, and rejected routed WebSocket upgrades.
