### PR TITLE
Support Alt-Svc in WebClient

### DIFF
--- a/docs/config/io.helidon.webclient.api.ClientAltSvcConfig.md
+++ b/docs/config/io.helidon.webclient.api.ClientAltSvcConfig.md
@@ -1,0 +1,58 @@
+# io.<wbr>helidon.<wbr>webclient.<wbr>api.<wbr>Client<wbr>AltSvc<wbr>Config
+
+## Description
+
+Preview client policy for accepting and using HTTP <code>Alt-<wbr>Svc</code> response advertisements
+
+## Configuration options
+
+
+<table>
+<thead>
+<tr>
+<th>Key</th>
+<th>Type</th>
+<th>Default</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>protocols</code>
+</td>
+<td>
+<code>List&lt;<wbr>String&gt;</code>
+</td>
+<td>
+</td>
+<td>Allowed alternative service protocol identifiers</td>
+</tr>
+<tr>
+<td>
+<code>enabled</code>
+</td>
+<td>
+<code>Boolean</code>
+</td>
+<td>
+<code>true</code>
+</td>
+<td>Whether alternative service handling is enabled</td>
+</tr>
+</tbody>
+</table>
+
+
+
+## Usages
+
+- <a href="io.helidon.webclient.api.WebClient.md#alt-svc"><code>clients.<wbr>alt-<wbr>svc</code></a>
+- <a href="io.helidon.webclient.api.WebClient.md#alt-svc"><code>security.<wbr>providers.<wbr>idcs-<wbr>role-<wbr>mapper.<wbr>oidc-<wbr>config.<wbr>webclient.<wbr>alt-<wbr>svc</code></a>
+- <a href="io.helidon.webclient.api.WebClient.md#alt-svc"><code>security.<wbr>providers.<wbr>oidc.<wbr>webclient.<wbr>alt-<wbr>svc</code></a>
+- <a href="io.helidon.webclient.api.WebClient.md#alt-svc"><code>server.<wbr>features.<wbr>security.<wbr>security.<wbr>providers.<wbr>idcs-<wbr>role-<wbr>mapper.<wbr>oidc-<wbr>config.<wbr>webclient.<wbr>alt-<wbr>svc</code></a>
+- <a href="io.helidon.webclient.api.WebClient.md#alt-svc"><code>server.<wbr>features.<wbr>security.<wbr>security.<wbr>providers.<wbr>oidc.<wbr>webclient.<wbr>alt-<wbr>svc</code></a>
+
+---
+
+See the [manifest](manifest.md) for all available types.

--- a/docs/config/io.helidon.webclient.api.HttpClientConfig.md
+++ b/docs/config/io.helidon.webclient.api.HttpClientConfig.md
@@ -369,6 +369,20 @@ This can be used by any HTTP client version, and does not act as a factory, for 
 </tr>
 <tr>
 <td>
+<a id="alt-svc"></a>
+<a href="io.helidon.webclient.api.ClientAltSvcConfig.md">
+<code>alt-<wbr>svc</code>
+</a>
+</td>
+<td>
+<code>Client<wbr>AltSvc<wbr>Config</code>
+</td>
+<td>
+</td>
+<td>Client policy for accepting and using HTTP <code>Alt-<wbr>Svc</code> response advertisements</td>
+</tr>
+<tr>
+<td>
 <code>properties</code>
 </td>
 <td>

--- a/docs/config/io.helidon.webclient.api.WebClient.md
+++ b/docs/config/io.helidon.webclient.api.WebClient.md
@@ -406,6 +406,20 @@ WebClient configuration
 </tr>
 <tr>
 <td>
+<a id="alt-svc"></a>
+<a href="io.helidon.webclient.api.ClientAltSvcConfig.md">
+<code>alt-<wbr>svc</code>
+</a>
+</td>
+<td>
+<code>Client<wbr>AltSvc<wbr>Config</code>
+</td>
+<td>
+</td>
+<td>Client policy for accepting and using HTTP <code>Alt-<wbr>Svc</code> response advertisements</td>
+</tr>
+<tr>
+<td>
 <code>properties</code>
 </td>
 <td>

--- a/docs/config/io.helidon.webclient.grpc.GrpcClient.md
+++ b/docs/config/io.helidon.webclient.grpc.GrpcClient.md
@@ -334,6 +334,20 @@ Configuration of a grpc client
 </td>
 <td>Buffer size used when writing data to the underlying socket on a client TCP connection</td>
 </tr>
+<tr>
+<td>
+<a id="alt-svc"></a>
+<a href="io.helidon.webclient.api.ClientAltSvcConfig.md">
+<code>alt-<wbr>svc</code>
+</a>
+</td>
+<td>
+<code>Client<wbr>AltSvc<wbr>Config</code>
+</td>
+<td>
+</td>
+<td>Client policy for accepting and using HTTP <code>Alt-<wbr>Svc</code> response advertisements</td>
+</tr>
 </tbody>
 </table>
 

--- a/docs/config/io.helidon.webclient.http1.Http1Client.md
+++ b/docs/config/io.helidon.webclient.http1.Http1Client.md
@@ -260,6 +260,20 @@ HTTP/1.1
 </tr>
 <tr>
 <td>
+<a id="alt-svc"></a>
+<a href="io.helidon.webclient.api.ClientAltSvcConfig.md">
+<code>alt-<wbr>svc</code>
+</a>
+</td>
+<td>
+<code>Client<wbr>AltSvc<wbr>Config</code>
+</td>
+<td>
+</td>
+<td>Client policy for accepting and using HTTP <code>Alt-<wbr>Svc</code> response advertisements</td>
+</tr>
+<tr>
+<td>
 <code>redirect-<wbr>sensitive-<wbr>headers</code>
 </td>
 <td>

--- a/docs/config/io.helidon.webclient.jsonrpc.JsonRpcClient.md
+++ b/docs/config/io.helidon.webclient.jsonrpc.JsonRpcClient.md
@@ -275,6 +275,20 @@ Configuration of a JSON-RPC client
 </tr>
 <tr>
 <td>
+<a id="alt-svc"></a>
+<a href="io.helidon.webclient.api.ClientAltSvcConfig.md">
+<code>alt-<wbr>svc</code>
+</a>
+</td>
+<td>
+<code>Client<wbr>AltSvc<wbr>Config</code>
+</td>
+<td>
+</td>
+<td>Client policy for accepting and using HTTP <code>Alt-<wbr>Svc</code> response advertisements</td>
+</tr>
+<tr>
+<td>
 <code>redirect-<wbr>sensitive-<wbr>headers</code>
 </td>
 <td>

--- a/docs/config/io.helidon.webclient.websocket.WsClient.md
+++ b/docs/config/io.helidon.webclient.websocket.WsClient.md
@@ -275,6 +275,20 @@ WebSocket full webclient configuration
 </tr>
 <tr>
 <td>
+<a id="alt-svc"></a>
+<a href="io.helidon.webclient.api.ClientAltSvcConfig.md">
+<code>alt-<wbr>svc</code>
+</a>
+</td>
+<td>
+<code>Client<wbr>AltSvc<wbr>Config</code>
+</td>
+<td>
+</td>
+<td>Client policy for accepting and using HTTP <code>Alt-<wbr>Svc</code> response advertisements</td>
+</tr>
+<tr>
+<td>
 <code>redirect-<wbr>sensitive-<wbr>headers</code>
 </td>
 <td>

--- a/docs/config/manifest.md
+++ b/docs/config/manifest.md
@@ -102,6 +102,7 @@ See the [root type](config_reference.md).
 - [io.<wbr>helidon.<wbr>tracing.<wbr>Extended<wbr>Tracer<wbr>Config](io.helidon.tracing.ExtendedTracerConfig.md)
 - [io.<wbr>helidon.<wbr>tracing.<wbr>Tracer](io.helidon.tracing.Tracer.md)
 - [io.<wbr>helidon.<wbr>tracing.<wbr>providers.<wbr>opentelemetry.<wbr>Open<wbr>Telemetry<wbr>Tracer](io.helidon.tracing.providers.opentelemetry.OpenTelemetryTracer.md)
+- [io.<wbr>helidon.<wbr>webclient.<wbr>api.<wbr>Client<wbr>AltSvc<wbr>Config](io.helidon.webclient.api.ClientAltSvcConfig.md)
 - [io.<wbr>helidon.<wbr>webclient.<wbr>api.<wbr>Http<wbr>Client<wbr>Config](io.helidon.webclient.api.HttpClientConfig.md)
 - [io.<wbr>helidon.<wbr>webclient.<wbr>api.<wbr>Http<wbr>Config<wbr>Base](io.helidon.webclient.api.HttpConfigBase.md)
 - [io.<wbr>helidon.<wbr>webclient.<wbr>api.<wbr>Proxy](io.helidon.webclient.api.Proxy.md)

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -86,10 +86,11 @@ authority. WebClient does not support `h2c` alternatives. It also does not
 upgrade a plain `http` origin to TLS-based HTTP/2 because the RFC 8164
 `/.well-known/http-opportunistic` opt-in is not implemented.
 
-Alternative-service routing preserves the configured proxy policy and never
-bypasses a selected proxy. The current HTTP/2 provider uses alternatives only
-for a direct route that is not pinned to a resolved address; otherwise,
-WebClient continues with the selected route.
+Alternative-service routing never bypasses the configured proxy policy. The
+current HTTP/2 provider uses alternatives only when proxying is disabled. When
+any proxy policy is configured, including a `no-proxy` exception that selected
+a direct route for the origin, WebClient ignores the advertisement and
+continues with the selected route.
 
 WebClient honors the configured TLS policy as-is when connecting to an
 alternative. This includes custom TLS managers, custom SSL contexts, disabled

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -69,6 +69,44 @@ WebClient client = WebClient.builder()
     .build();
 ```
 
+### Alt-Svc Discovery
+
+WebClient uses alternative services only when the optional common
+`ClientAltSvcConfig` (`alt-svc`) configuration is present. Within a present
+configuration, `enabled` defaults to `true`; setting it to `false` provides an
+explicit override without removing the configuration. An empty `protocols`
+list allows every available client protocol provider that supports Alt-Svc.
+Otherwise, the list is an exact, case-sensitive ALPN protocol filter. The
+HTTP/2 protocol ID is `h2`.
+
+Initial client support accepts advertisements only from `https` origins and
+only for alternatives on the same host; the alternative port may differ. Using
+an alternative changes the connection endpoint, not the request scheme or
+authority. WebClient does not support `h2c` alternatives. It also does not
+upgrade a plain `http` origin to TLS-based HTTP/2 because the RFC 8164
+`/.well-known/http-opportunistic` opt-in is not implemented.
+
+Alternative-service routing preserves the configured proxy policy and never
+bypasses a selected proxy. The current HTTP/2 provider uses alternatives only
+for a direct route that is not pinned to a resolved address; otherwise,
+WebClient continues with the selected route.
+
+WebClient honors the configured TLS policy as-is when connecting to an
+alternative. This includes custom TLS managers, custom SSL contexts, disabled
+endpoint identification, and `trust-all`. An unsafe or permissive TLS
+configuration therefore makes Alt-Svc steering equally unsafe or permissive.
+Configure TLS trust and endpoint identification according to the security
+requirements of the application.
+
+The HTTP/2 provider accounts for `Age` and apparent age derived from `Date`,
+honors `ma`, `clear`, and `persist`, and falls back to the origin if an
+advertised endpoint cannot be established. Advertisement freshness controls
+creation of new connections; an already-opening or reusable connection can
+continue after the advertisement expires. Discovery state belongs to the
+HTTP/2 connection cache. Shared connection caches share that state; disabling
+connection-cache sharing isolates it. `persist` does not make discovery state
+durable across a process or beyond that cache lifecycle.
+
 ### Creating the Request
 
 WebClient offers a set of request methods that are used to specify the type of
@@ -172,6 +210,13 @@ rules on which specific protocol will be used:
   configuration](#setting-protocol-configuration) on how to customize `HTTP/2`.
   In such a case, `prior-knowledge` will be used and fail if it is unable to
   switch to `HTTP/2`.
+- When the common `alt-svc` configuration is present, enabled, and allows the
+  exact `h2` protocol ID, an `https` origin can advertise a same-host TLS HTTP/2
+  alternative. A later generic WebClient request can use that alternative
+  while retaining the original request authority. WebClient adds `Alt-Used`
+  only to the request sent to the alternative. See [Alt-Svc
+  Discovery](#alt-svc-discovery) for current limitations and TLS, proxy, and
+  lifecycle behavior.
 
 ### Adding Media Support
 
@@ -320,17 +365,20 @@ client:
         name-format: "wc.counter.%1$s.error"
         description: "Counter of failed PUT, POST and DELETE requests"
     tracing:
-  protocol-configs: # <5>
+  alt-svc: # <5>
+    enabled: true
+    protocols: ["h2"]
+  protocol-configs: # <6>
     http_1_1:
       max-header-size: 20000
       validate-request-headers: true
     h2:
       prior-knowledge: true
-  proxy: # <6>
+  proxy: # <7>
     host: "hostName"
     port: 80
     no-proxy: ["localhost:8080", ".helidon.io", "192.168.1.1"]
-  tls: # <7>
+  tls: # <8>
     trust:
       keystore:
         passphrase: "password"
@@ -342,9 +390,10 @@ client:
 2. Cookie management
 3. Default client headers
 4. Client service configuration
-5. Protocol configuration
-6. Proxy configuration
-7. TLS configuration
+5. Opt-in alternative service configuration
+6. Protocol configuration
+7. Proxy configuration
+8. TLS configuration
 <!--@mdc :: -->
 
 ## Examples

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -94,9 +94,10 @@ continues with the selected route. WebClient uses the system proxy policy by
 default; configure `proxy.type` as `none`, or use `Proxy.noProxy()`
 programmatically, to use an advertised alternative.
 
-Requests with caller-supplied connections or explicit transport addresses,
-including client `base-address` and Unix domain socket transports, do not learn
-or use alternative services.
+Requests with caller-supplied connections or Unix domain socket transport
+addresses do not learn or use alternative services. An `InetSocketAddress`
+supplied through client `base-address` or request `address` updates the request
+URI host and port, so Alt-Svc applies to that resulting origin.
 
 WebClient honors the configured TLS policy as-is when connecting to an
 alternative. This includes custom TLS managers, custom SSL contexts, disabled

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -94,6 +94,10 @@ continues with the selected route. WebClient uses the system proxy policy by
 default; configure `proxy.type` as `none`, or use `Proxy.noProxy()`
 programmatically, to use an advertised alternative.
 
+Requests with caller-supplied connections or explicit transport addresses,
+including client `base-address` and Unix domain socket transports, do not learn
+or use alternative services.
+
 WebClient honors the configured TLS policy as-is when connecting to an
 alternative. This includes custom TLS managers, custom SSL contexts, disabled
 endpoint identification, and `trust-all`. An unsafe or permissive TLS

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -71,13 +71,13 @@ WebClient client = WebClient.builder()
 
 ### Alt-Svc Discovery
 
-WebClient uses alternative services only when the optional common
-`ClientAltSvcConfig` (`alt-svc`) configuration is present. Within a present
-configuration, `enabled` defaults to `true`; setting it to `false` provides an
-explicit override without removing the configuration. An empty `protocols`
-list allows every available client protocol provider that supports Alt-Svc.
-Otherwise, the list is an exact, case-sensitive ALPN protocol filter. The
-HTTP/2 protocol ID is `h2`.
+Client Alt-Svc support is a preview feature. WebClient uses alternative
+services only when the optional common `ClientAltSvcConfig` (`alt-svc`)
+configuration is present. Within a present configuration, `enabled` defaults
+to `true`; setting it to `false` provides an explicit override without removing
+the configuration. An empty `protocols` list allows every available client
+protocol provider that supports Alt-Svc. Otherwise, the list is an exact,
+case-sensitive ALPN protocol filter. The HTTP/2 protocol ID is `h2`.
 
 Initial client support accepts advertisements only from `https` origins and
 only for alternatives on the same host; the alternative port may differ. Using

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -90,7 +90,9 @@ Alternative-service routing never bypasses the configured proxy policy. The
 current HTTP/2 provider uses alternatives only when proxying is disabled. When
 any proxy policy is configured, including a `no-proxy` exception that selected
 a direct route for the origin, WebClient ignores the advertisement and
-continues with the selected route.
+continues with the selected route. WebClient uses the system proxy policy by
+default; configure `proxy.type` as `none`, or use `Proxy.noProxy()`
+programmatically, to use an advertised alternative.
 
 WebClient honors the configured TLS policy as-is when connecting to an
 alternative. This includes custom TLS managers, custom SSL contexts, disabled
@@ -393,7 +395,8 @@ client:
 4. Client service configuration
 5. Opt-in alternative service configuration
 6. Protocol configuration
-7. Proxy configuration
+7. Proxy configuration; any configured proxy policy disables current Alt-Svc
+   alternative use
 8. TLS configuration
 <!--@mdc :: -->
 

--- a/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
@@ -196,6 +196,7 @@ enum HeaderNameEnum implements HeaderName {
         static final String AGE_NAME = "Age";
         static final String ALLOW_NAME = "Allow";
         static final String ALT_SVC_NAME = "Alt-Svc";
+        static final String ALT_USED_NAME = "Alt-Used";
         static final String CACHE_CONTROL_NAME = "Cache-Control";
         static final String CONNECTION_NAME = "Connection";
         static final String CONTENT_DISPOSITION_NAME = "Content-Disposition";

--- a/http/http/src/main/java/io/helidon/http/HeaderNames.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNames.java
@@ -439,6 +439,18 @@ public final class HeaderNames {
     public static final HeaderName ALT_SVC = HeaderNameEnum.ALT_SVC;
     /**
      * The {@value} header name.
+     * Identifies the alternative service used for a request.
+     */
+    public static final String ALT_USED_NAME = Strings.ALT_USED_NAME;
+    /**
+     * The {@value #ALT_USED_NAME} header name.
+     * Identifies the alternative service used for a request.
+     * <p>
+     * This infrequently used header is not part of the indexed known-header set.
+     */
+    public static final HeaderName ALT_USED = create(ALT_USED_NAME);
+    /**
+     * The {@value} header name.
      * Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds.
      */
     public static final String CACHE_CONTROL_NAME = Strings.CACHE_CONTROL_NAME;

--- a/http/http/src/main/java/io/helidon/http/HeaderNames.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNames.java
@@ -448,7 +448,7 @@ public final class HeaderNames {
      * <p>
      * This infrequently used header is not part of the indexed known-header set.
      */
-    public static final HeaderName ALT_USED = create(ALT_USED_NAME);
+    public static final HeaderName ALT_USED = createNonIndexed(ALT_USED_NAME);
     /**
      * The {@value} header name.
      * Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds.

--- a/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
+++ b/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf;
@@ -40,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class HeaderNamesTest {
     private static final Class<HeaderNames> clazz = HeaderNames.class;
     private static final List<HeaderName> NON_INDEXED_HEADERS = List.of(HeaderNames.ACCEPT_CHARSET,
+                                                                        HeaderNames.ALT_USED,
                                                                         HeaderNames.PUBLIC_KEY_PINS,
                                                                         HeaderNames.SET_COOKIE2,
                                                                         HeaderNames.TSV,

--- a/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
+++ b/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf;

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -168,6 +168,15 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/../../../webclient/http2/src/test/resources</directory>
+                <includes>
+                    <include>client.p12</include>
+                    <include>server.p12</include>
+                </includes>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -273,16 +273,18 @@ public class WebClientConnectionTargetBenchmark {
         ACTIVE,
         DIRECT_H2_ALTERNATIVE_REPEATED_AD,
         ACTIVE_REPEATED_AD,
+        EXPIRED_ESTABLISHED_REUSE,
         DISABLED_CAPTURE;
 
         private boolean headOnly() {
-            return this == ACTIVE || this == ACTIVE_REPEATED_AD;
+            return this == ACTIVE || this == ACTIVE_REPEATED_AD || this == EXPIRED_ESTABLISHED_REUSE;
         }
 
         private boolean configuresAltSvc() {
             return this == ENABLED_NO_ENTRY
                     || this == ACTIVE
                     || this == ACTIVE_REPEATED_AD
+                    || this == EXPIRED_ESTABLISHED_REUSE
                     || this == DISABLED_CAPTURE;
         }
 
@@ -434,9 +436,10 @@ public class WebClientConnectionTargetBenchmark {
         private String originAuthority;
         private String alternativeAuthority;
         private String altSvcValue;
+        private String expiredAltSvcValue;
         private String expectedProtocol;
         private volatile ExpectedRequest expectedRequest;
-        private volatile boolean advertise;
+        private volatile String responseAltSvc;
 
         @Setup(Level.Trial)
         public void setup() {
@@ -473,6 +476,7 @@ public class WebClientConnectionTargetBenchmark {
             originUri = "https://" + originAuthority + PATH;
             alternativeUri = "https://" + alternativeAuthority + PATH;
             altSvcValue = "h2=\":%d\"; ma=3600".formatted(server.port(ALTERNATIVE_SOCKET));
+            expiredAltSvcValue = "h2=\":%d\"; ma=0".formatted(server.port(ALTERNATIVE_SOCKET));
 
             var builder = WebClient.builder()
                     .shareConnectionCache(false)
@@ -505,6 +509,13 @@ public class WebClientConnectionTargetBenchmark {
                     primeOrigin(true);
                     primeActiveAlternative(true);
                 }
+                case EXPIRED_ESTABLISHED_REUSE -> {
+                    primeOrigin(true);
+                    primeActiveAlternative(false);
+                    primeActiveAlternative(expiredAltSvcValue);
+                    // The ma=0 response is setup-only; measured responses do not mutate Alt-Svc state.
+                    responseAltSvc = null;
+                }
                 case DISABLED_CAPTURE -> {
                     primeAlternative(false, true);
                     primeAlternative(false, true);
@@ -514,11 +525,18 @@ public class WebClientConnectionTargetBenchmark {
 
         @TearDown(Level.Trial)
         public void tearDown() {
-            if (webClient != null) {
-                webClient.closeResource();
-            }
-            if (server != null) {
-                server.stop();
+            try {
+                if (webClient != null) {
+                    // Re-check the final protocol, physical socket, authority, and Alt-Used expectation.
+                    request();
+                }
+            } finally {
+                if (webClient != null) {
+                    webClient.closeResource();
+                }
+                if (server != null) {
+                    server.stop();
+                }
             }
         }
 
@@ -564,7 +582,7 @@ public class WebClientConnectionTargetBenchmark {
             prime(originUri,
                   new ExpectedRequest(SocketKind.ORIGIN, originAuthority, ""),
                   Http1Client.PROTOCOL_ID,
-                  advertiseAltSvc);
+                  advertiseAltSvc ? altSvcValue : null);
         }
 
         private void primeAlternative(boolean synthetic, boolean advertiseAltSvc) {
@@ -573,23 +591,27 @@ public class WebClientConnectionTargetBenchmark {
             prime(alternativeUri,
                   new ExpectedRequest(SocketKind.ALTERNATIVE, expectedAuthority, expectedAltUsed),
                   Http2Client.PROTOCOL_ID,
-                  advertiseAltSvc);
+                  advertiseAltSvc ? altSvcValue : null);
         }
 
         private void primeActiveAlternative(boolean advertiseAltSvc) {
+            primeActiveAlternative(advertiseAltSvc ? altSvcValue : null);
+        }
+
+        private void primeActiveAlternative(String advertisedAltSvc) {
             prime(originUri,
                   new ExpectedRequest(SocketKind.ALTERNATIVE, originAuthority, alternativeAuthority),
                   Http2Client.PROTOCOL_ID,
-                  advertiseAltSvc);
+                  advertisedAltSvc);
         }
 
         private void prime(String uri,
                            ExpectedRequest requestExpectation,
                            String protocol,
-                           boolean advertiseAltSvc) {
+                           String advertisedAltSvc) {
             requestUri = uri;
             expectedProtocol = protocol;
-            advertise = advertiseAltSvc;
+            responseAltSvc = advertisedAltSvc;
             expectedRequest = requestExpectation;
             request();
         }
@@ -631,9 +653,10 @@ public class WebClientConnectionTargetBenchmark {
                 response.status(WRONG_ALT_USED).send(BODY);
                 return;
             }
-            if (advertise) {
-                // Repeated-ad rows emit this same value on every measured response.
-                response.header(HeaderNames.ALT_SVC, altSvcValue);
+            String advertisedAltSvc = responseAltSvc;
+            if (advertisedAltSvc != null) {
+                // Repeated-ad rows leave this enabled; the expiration row clears its setup-only ma=0 response.
+                response.header(HeaderNames.ALT_SVC, advertisedAltSvc);
             }
             response.send(BODY);
         }

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetBenchmark.java
@@ -17,13 +17,26 @@
 package io.helidon.webclient.benchmark.jmh;
 
 import java.net.InetAddress;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.Keys;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
+import io.helidon.http.Status;
 import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http1.Http1Config;
+import io.helidon.webserver.http1.Http1ConnectionSelector;
 import io.helidon.webserver.http1.Http1Route;
 import io.helidon.webserver.http2.Http2Config;
 import io.helidon.webserver.http2.Http2ConnectionSelector;
@@ -50,6 +63,13 @@ public class WebClientConnectionTargetBenchmark {
     private static final int REQUESTS_PER_INVOCATION = 16;
     private static final int TARGETS_PER_THREAD = 4;
     private static final String PATH = "/target";
+    private static final String BODY = "ok";
+    private static final String ALTERNATIVE_SOCKET = "alt-svc-h2";
+    private static final String CLIENT_ALT_SVC_CONFIG = "io.helidon.webclient.api.ClientAltSvcConfig";
+    private static final HeaderName ALT_USED = HeaderNames.create("Alt-Used");
+    private static final Status WRONG_SOCKET = Status.create(590, "Wrong benchmark socket");
+    private static final Status WRONG_AUTHORITY = Status.create(591, "Wrong benchmark authority");
+    private static final Status WRONG_ALT_USED = Status.create(592, "Wrong benchmark Alt-Used");
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
@@ -131,6 +151,15 @@ public class WebClientConnectionTargetBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void altSvcMatched(AltSvcMatchedState state, Blackhole blackhole) {
+        // One request loop keeps the base/head and scenario comparisons mechanically identical.
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            blackhole.consume(state.request());
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http2DistinctTargetPerThread(Http2State state, ThreadParams threadParams, Blackhole blackhole) {
         int targetIndex = threadParams.getThreadIndex() * TARGETS_PER_THREAD;
         for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
@@ -174,6 +203,28 @@ public class WebClientConnectionTargetBenchmark {
         return Math.max(prefilledTargetCount, benchmarkParams.getThreads() * TARGETS_PER_THREAD);
     }
 
+    private static Tls clientTls() {
+        return Tls.builder()
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+    }
+
+    private static Tls serverTls() {
+        Keys keys = Keys.builder()
+                .keystore(store -> store
+                        .keystore(Resource.create("server.p12"))
+                        .passphrase("password"))
+                .build();
+        return Tls.builder()
+                .privateKey(keys)
+                .privateKeyCertChain(keys)
+                .build();
+    }
+
     private static InetAddress resolve(String host, ProxyMode proxyMode) {
         boolean proxyHost = "proxy.invalid".equals(host);
         if (proxyMode == ProxyMode.HTTP_FORWARD && !proxyHost) {
@@ -207,6 +258,49 @@ public class WebClientConnectionTargetBenchmark {
                         .build();
             };
         }
+    }
+
+    public enum ExpectedImplementation {
+        BASE,
+        HEAD
+    }
+
+    public enum AltSvcScenario {
+        TLS_H1,
+        TLS_H2,
+        DIRECT_H2_ALTERNATIVE,
+        ENABLED_NO_ENTRY,
+        ACTIVE,
+        DIRECT_H2_ALTERNATIVE_REPEATED_AD,
+        ACTIVE_REPEATED_AD,
+        DISABLED_CAPTURE;
+
+        private boolean headOnly() {
+            return this == ACTIVE || this == ACTIVE_REPEATED_AD;
+        }
+
+        private boolean configuresAltSvc() {
+            return this == ENABLED_NO_ENTRY
+                    || this == ACTIVE
+                    || this == ACTIVE_REPEATED_AD
+                    || this == DISABLED_CAPTURE;
+        }
+
+        private boolean altSvcEnabled() {
+            return this != DISABLED_CAPTURE;
+        }
+
+        private boolean syntheticAlternative() {
+            return this == DIRECT_H2_ALTERNATIVE || this == DIRECT_H2_ALTERNATIVE_REPEATED_AD;
+        }
+    }
+
+    private enum SocketKind {
+        ORIGIN,
+        ALTERNATIVE
+    }
+
+    private record ExpectedRequest(SocketKind socket, String authority, String altUsed) {
     }
 
     @State(Scope.Benchmark)
@@ -307,7 +401,8 @@ public class WebClientConnectionTargetBenchmark {
                     if (i == 0
                             && proxyMode == ProxyMode.HTTP_FORWARD
                             && !Http1Client.PROTOCOL_ID.equals(response.protocolId())) {
-                        throw new IllegalStateException("Unexpected HTTP forward proxy protocol: " + response.protocolId());
+                        throw new IllegalStateException(
+                                "Unexpected HTTP forward proxy protocol: " + response.protocolId());
                     }
                 }
             }
@@ -320,6 +415,227 @@ public class WebClientConnectionTargetBenchmark {
 
         private String targetUri(int index) {
             return targetUris[index];
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class AltSvcMatchedState {
+        @Param({"BASE", "HEAD"})
+        public ExpectedImplementation expectedImplementation;
+
+        @Param({"TLS_H1", "TLS_H2"})
+        public AltSvcScenario scenario;
+
+        private WebServer server;
+        private WebClient webClient;
+        private String originUri;
+        private String alternativeUri;
+        private String requestUri;
+        private String originAuthority;
+        private String alternativeAuthority;
+        private String altSvcValue;
+        private String expectedProtocol;
+        private volatile ExpectedRequest expectedRequest;
+        private volatile boolean advertise;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            Class<?> altSvcConfigClass = expectedAltSvcConfigClass();
+            if (scenario.headOnly() && expectedImplementation != ExpectedImplementation.HEAD) {
+                throw new IllegalStateException("Scenario " + scenario + " requires the HEAD implementation");
+            }
+
+            Tls serverTls = serverTls();
+            server = WebServer.builder()
+                    .host("localhost")
+                    .port(-1)
+                    .tls(serverTls)
+                    .protocolsDiscoverServices(false)
+                    .addConnectionSelector(Http1ConnectionSelector.builder()
+                                                   .config(Http1Config.create())
+                                                   .build())
+                    .putSocket(ALTERNATIVE_SOCKET, socket -> socket
+                            .host("localhost")
+                            .port(-1)
+                            .tls(serverTls)
+                            .protocolsDiscoverServices(false)
+                            .addConnectionSelector(Http2ConnectionSelector.builder()
+                                                           .http2Config(Http2Config.create())
+                                                           .build()))
+                    .routing(HttpRouting.builder().get(PATH, this::originResponse))
+                    .routing(ALTERNATIVE_SOCKET,
+                             HttpRouting.builder().get(PATH, this::alternativeResponse))
+                    .build()
+                    .start();
+
+            originAuthority = "localhost:" + server.port();
+            alternativeAuthority = "localhost:" + server.port(ALTERNATIVE_SOCKET);
+            originUri = "https://" + originAuthority + PATH;
+            alternativeUri = "https://" + alternativeAuthority + PATH;
+            altSvcValue = "h2=\":%d\"; ma=3600".formatted(server.port(ALTERNATIVE_SOCKET));
+
+            var builder = WebClient.builder()
+                    .shareConnectionCache(false)
+                    .servicesDiscoverServices(false)
+                    .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                    .proxy(Proxy.noProxy())
+                    .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                    .tls(clientTls());
+            if (scenario.syntheticAlternative()) {
+                // Synthetic transport control, not an Alt-Svc implementation path: its setup defaults reproduce
+                // the logical origin authority and Alt-Used value while the URI connects directly to the H2 socket.
+                builder.addHeader(HeaderNames.HOST, originAuthority)
+                        .addHeader("Alt-Used", alternativeAuthority);
+            }
+            if (scenario.configuresAltSvc()) {
+                configureAltSvc(builder, altSvcConfigClass, scenario.altSvcEnabled());
+            }
+            webClient = builder.build();
+
+            switch (scenario) {
+                case TLS_H1, ENABLED_NO_ENTRY -> primeOrigin(false);
+                case TLS_H2 -> primeAlternative(false, false);
+                case DIRECT_H2_ALTERNATIVE -> primeAlternative(true, false);
+                case ACTIVE -> {
+                    primeOrigin(true);
+                    primeActiveAlternative(false);
+                }
+                case DIRECT_H2_ALTERNATIVE_REPEATED_AD -> primeAlternative(true, true);
+                case ACTIVE_REPEATED_AD -> {
+                    primeOrigin(true);
+                    primeActiveAlternative(true);
+                }
+                case DISABLED_CAPTURE -> {
+                    primeAlternative(false, true);
+                    primeAlternative(false, true);
+                }
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            if (webClient != null) {
+                webClient.closeResource();
+            }
+            if (server != null) {
+                server.stop();
+            }
+        }
+
+        private static void configureAltSvc(Object webClientBuilder,
+                                            Class<?> altSvcConfigClass,
+                                            boolean enabled) {
+            if (altSvcConfigClass == null) {
+                return;
+            }
+            try {
+                Object altSvcBuilder = altSvcConfigClass.getMethod("builder").invoke(null);
+                altSvcBuilder.getClass().getMethod("enabled", boolean.class).invoke(altSvcBuilder, enabled);
+                altSvcBuilder.getClass()
+                        .getMethod("addProtocol", String.class)
+                        .invoke(altSvcBuilder, Http2Client.PROTOCOL_ID);
+                Object altSvcConfig = altSvcBuilder.getClass().getMethod("build").invoke(altSvcBuilder);
+                webClientBuilder.getClass()
+                        .getMethod("altSvc", altSvcConfigClass)
+                        .invoke(webClientBuilder, altSvcConfig);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Cannot configure the HEAD Alt-Svc API", e);
+            }
+        }
+
+        private Class<?> expectedAltSvcConfigClass() {
+            try {
+                Class<?> configClass = Class.forName(CLIENT_ALT_SVC_CONFIG);
+                if (expectedImplementation == ExpectedImplementation.BASE) {
+                    throw new IllegalStateException("BASE benchmark classpath contains " + CLIENT_ALT_SVC_CONFIG);
+                }
+                return configClass;
+            } catch (ClassNotFoundException e) {
+                if (expectedImplementation == ExpectedImplementation.HEAD) {
+                    throw new IllegalStateException("HEAD benchmark classpath does not contain "
+                                                            + CLIENT_ALT_SVC_CONFIG,
+                                                    e);
+                }
+                return null;
+            }
+        }
+
+        private void primeOrigin(boolean advertiseAltSvc) {
+            prime(originUri,
+                  new ExpectedRequest(SocketKind.ORIGIN, originAuthority, ""),
+                  Http1Client.PROTOCOL_ID,
+                  advertiseAltSvc);
+        }
+
+        private void primeAlternative(boolean synthetic, boolean advertiseAltSvc) {
+            String expectedAuthority = synthetic ? originAuthority : alternativeAuthority;
+            String expectedAltUsed = synthetic ? alternativeAuthority : "";
+            prime(alternativeUri,
+                  new ExpectedRequest(SocketKind.ALTERNATIVE, expectedAuthority, expectedAltUsed),
+                  Http2Client.PROTOCOL_ID,
+                  advertiseAltSvc);
+        }
+
+        private void primeActiveAlternative(boolean advertiseAltSvc) {
+            prime(originUri,
+                  new ExpectedRequest(SocketKind.ALTERNATIVE, originAuthority, alternativeAuthority),
+                  Http2Client.PROTOCOL_ID,
+                  advertiseAltSvc);
+        }
+
+        private void prime(String uri,
+                           ExpectedRequest requestExpectation,
+                           String protocol,
+                           boolean advertiseAltSvc) {
+            requestUri = uri;
+            expectedProtocol = protocol;
+            advertise = advertiseAltSvc;
+            expectedRequest = requestExpectation;
+            request();
+        }
+
+        private int request() {
+            var request = webClient.get(requestUri);
+            try (var response = request.request()) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != Status.OK_200_CODE) {
+                    throw new IllegalStateException("Unexpected " + scenario + " status: " + response.status());
+                }
+                if (!expectedProtocol.equals(response.protocolId())) {
+                    throw new IllegalStateException("Unexpected " + scenario + " protocol: " + response.protocolId());
+                }
+                return status;
+            }
+        }
+
+        private void originResponse(ServerRequest request, ServerResponse response) {
+            respond(request, response, SocketKind.ORIGIN);
+        }
+
+        private void alternativeResponse(ServerRequest request, ServerResponse response) {
+            respond(request, response, SocketKind.ALTERNATIVE);
+        }
+
+        private void respond(ServerRequest request, ServerResponse response, SocketKind actualSocket) {
+            ExpectedRequest expectation = expectedRequest;
+            if (expectation == null || expectation.socket() != actualSocket) {
+                response.status(WRONG_SOCKET).send(BODY);
+                return;
+            }
+            if (!expectation.authority().equals(request.requestedUri().authority())) {
+                response.status(WRONG_AUTHORITY).send(BODY);
+                return;
+            }
+            if (!expectation.altUsed().equals(request.headers().first(ALT_USED).orElse(""))) {
+                response.status(WRONG_ALT_USED).send(BODY);
+                return;
+            }
+            if (advertise) {
+                // Repeated-ad rows emit this same value on every measured response.
+                response.header(HeaderNames.ALT_SVC, altSvcValue);
+            }
+            response.send(BODY);
         }
     }
 }

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
@@ -149,6 +149,7 @@ class WebClientConnectionTargetJmhRunnerTest {
                 "ACTIVE",
                 "DIRECT_H2_ALTERNATIVE_REPEATED_AD",
                 "ACTIVE_REPEATED_AD",
+                "EXPIRED_ESTABLISHED_REUSE",
                 "DISABLED_CAPTURE"
         };
     }

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/WebClientConnectionTargetJmhRunnerTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webclient.benchmark.jmh;
 
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
@@ -33,43 +35,62 @@ class WebClientConnectionTargetJmhRunnerTest {
     void runExactBenchmark() throws RunnerException {
         String benchmark = WebClientConnectionTargetBenchmark.class.getName();
         boolean contention = Boolean.getBoolean("webclient.target.jmh.contention");
-        String include = contention
-                ? "^" + benchmark
-                        + "\\.(http1DistinctTargetPerThread|http1RotatingTargetsPerThread"
-                        + "|http2DistinctTargetPerThread|http2RotatingTargetsPerThread)$"
-                : System.getProperty("webclient.target.jmh.include",
-                                     "^" + benchmark + "\\.(http1CacheHit|http1OneOff|http2CacheHit)$");
+        boolean altSvcMatched = Boolean.getBoolean("webclient.target.jmh.altSvcMatched");
+        if (contention && altSvcMatched) {
+            throw new IllegalArgumentException("Contention and matched Alt-Svc modes are mutually exclusive");
+        }
+        String include = include(benchmark, contention, altSvcMatched);
+        WebClientConnectionTargetBenchmark.ExpectedImplementation expectedImplementation = altSvcMatched
+                ? expectedImplementation()
+                : WebClientConnectionTargetBenchmark.ExpectedImplementation.BASE;
         String[] targetCounts = contention
                 ? new String[] {"64"}
                 : System.getProperty("webclient.target.jmh.targetCounts", "1,64").split(",");
         String[] proxyModes = System.getProperty("webclient.target.jmh.proxyModes", "NONE").split(",");
         int[] threadCounts = contention
                 ? new int[] {1, 2, 4, 8, 16}
-                : new int[] {Integer.getInteger("webclient.target.jmh.threads", 1)};
-        int forks = contention ? 3 : Integer.getInteger("webclient.target.jmh.forks", 1);
+                : altSvcMatched
+                        ? threadCounts("webclient.target.jmh.altSvcMatchedThreads", "1,8")
+                        : new int[] {Integer.getInteger("webclient.target.jmh.threads", 1)};
+        int forks = contention
+                ? 3
+                : altSvcMatched
+                        ? Integer.getInteger("webclient.target.jmh.altSvcMatchedForks", 3)
+                        : Integer.getInteger("webclient.target.jmh.forks", 1);
         String contentionResultPrefix = System.getProperty("webclient.target.jmh.contentionResultPrefix",
                                                            "target/webclient-target-cache-contention");
+        String altSvcMatchedResultPrefix = System.getProperty("webclient.target.jmh.altSvcMatchedResultPrefix",
+                                                              "target/webclient-alt-svc-matched");
 
         for (int threadCount : threadCounts) {
             String result = contention
                     ? contentionResultPrefix + "-" + threadCount + "-threads.json"
-                    : System.getProperty("webclient.target.jmh.result", "target/webclient-target-cache.json");
+                    : altSvcMatched
+                            ? altSvcMatchedResultPrefix + "-" + expectedImplementation.name().toLowerCase(Locale.ROOT)
+                                    + "-" + threadCount + "-threads.json"
+                            : System.getProperty("webclient.target.jmh.result", "target/webclient-target-cache.json");
             var optionsBuilder = new OptionsBuilder()
                     .include(include)
-                    .param("prefilledTargetCount", targetCounts)
-                    .param("proxyMode", proxyModes)
                     .threads(threadCount)
                     .forks(forks)
                     .mode(Mode.valueOf(System.getProperty("webclient.target.jmh.mode", "AverageTime")))
                     .warmupIterations(Integer.getInteger("webclient.target.jmh.warmupIterations", 3))
                     .warmupTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.warmupMillis", 500)))
                     .measurementIterations(Integer.getInteger("webclient.target.jmh.measurementIterations", 5))
-                    .measurementTime(TimeValue.milliseconds(Long.getLong("webclient.target.jmh.measurementMillis", 1000)))
+                    .measurementTime(
+                            TimeValue.milliseconds(Long.getLong("webclient.target.jmh.measurementMillis", 1000)))
                     .timeUnit(TimeUnit.MICROSECONDS)
                     .addProfiler(GCProfiler.class)
                     .shouldFailOnError(true)
                     .resultFormat(ResultFormatType.JSON)
                     .result(result);
+            if (altSvcMatched) {
+                optionsBuilder.param("expectedImplementation", expectedImplementation.name())
+                        .param("scenario", scenarios(expectedImplementation));
+            } else {
+                optionsBuilder.param("prefilledTargetCount", targetCounts)
+                        .param("proxyMode", proxyModes);
+            }
             String jvmArgument = System.getProperty("webclient.target.jmh.jvmArgument");
             if (jvmArgument != null) {
                 optionsBuilder.jvmArgsAppend(jvmArgument);
@@ -77,5 +98,64 @@ class WebClientConnectionTargetJmhRunnerTest {
             Options options = optionsBuilder.build();
             new Runner(options).run();
         }
+    }
+
+    private static String include(String benchmark, boolean contention, boolean altSvcMatched) {
+        if (contention) {
+            return "^" + benchmark
+                    + "\\.(http1DistinctTargetPerThread|http1RotatingTargetsPerThread"
+                    + "|http2DistinctTargetPerThread|http2RotatingTargetsPerThread)$";
+        }
+        if (altSvcMatched) {
+            return "^" + benchmark + "\\.altSvcMatched$";
+        }
+        return System.getProperty("webclient.target.jmh.include",
+                                  "^" + benchmark + "\\.(http1CacheHit|http1OneOff|http2CacheHit)$");
+    }
+
+    private static WebClientConnectionTargetBenchmark.ExpectedImplementation expectedImplementation() {
+        String value = System.getProperty("webclient.target.jmh.altSvcExpected");
+        if (value == null) {
+            throw new IllegalArgumentException("Matched Alt-Svc mode requires webclient.target.jmh.altSvcExpected");
+        }
+        try {
+            return WebClientConnectionTargetBenchmark.ExpectedImplementation.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("webclient.target.jmh.altSvcExpected must be BASE or HEAD", e);
+        }
+    }
+
+    private static String[] scenarios(
+            WebClientConnectionTargetBenchmark.ExpectedImplementation expectedImplementation) {
+        String configured = System.getProperty("webclient.target.jmh.altSvcMatchedScenarios");
+        if (configured != null) {
+            return configured.split(",");
+        }
+        if (expectedImplementation == WebClientConnectionTargetBenchmark.ExpectedImplementation.BASE) {
+            return new String[] {
+                    "TLS_H1",
+                    "TLS_H2",
+                    "DIRECT_H2_ALTERNATIVE",
+                    "ENABLED_NO_ENTRY",
+                    "DIRECT_H2_ALTERNATIVE_REPEATED_AD",
+                    "DISABLED_CAPTURE"
+            };
+        }
+        return new String[] {
+                "TLS_H1",
+                "TLS_H2",
+                "DIRECT_H2_ALTERNATIVE",
+                "ENABLED_NO_ENTRY",
+                "ACTIVE",
+                "DIRECT_H2_ALTERNATIVE_REPEATED_AD",
+                "ACTIVE_REPEATED_AD",
+                "DISABLED_CAPTURE"
+        };
+    }
+
+    private static int[] threadCounts(String property, String defaultValue) {
+        return Arrays.stream(System.getProperty(property, defaultValue).split(","))
+                .mapToInt(Integer::parseInt)
+                .toArray();
     }
 }

--- a/webclient/README.md
+++ b/webclient/README.md
@@ -33,10 +33,10 @@ in such a case we use `prior-knowledge` and fail if we cannot switch to HTTP/2.
 
 When using TLS, the client will use ALPN (protocol negotiation) to use appropriate HTTP version (either 1.1, or 2).
 
-Client Alt-Svc use is opt-in through the optional common `ClientAltSvcConfig` (`alt-svc`) configuration. Within a
-present configuration, `enabled` defaults to `true`; an empty `protocols` list allows every available supporting
-provider, while a non-empty list is an exact, case-sensitive ALPN protocol filter. The current HTTP/2 provider uses the
-`h2` protocol ID.
+Client Alt-Svc support is a preview feature and is opt-in through the optional common `ClientAltSvcConfig` (`alt-svc`)
+configuration. Within a present configuration, `enabled` defaults to `true`; an empty `protocols` list allows every
+available supporting provider, while a non-empty list is an exact, case-sensitive ALPN protocol filter. The current
+HTTP/2 provider uses the `h2` protocol ID.
 
 Initial Alt-Svc support accepts advertisements only from HTTPS origins and only for alternatives on the same host,
 although the port may differ. Using an alternative changes only the connection endpoint; the request scheme and

--- a/webclient/README.md
+++ b/webclient/README.md
@@ -46,9 +46,10 @@ supported. Plain HTTP origins cannot be upgraded to TLS-based HTTP/2 until the R
 
 Alt-Svc never bypasses the configured proxy policy. The current HTTP/2 provider uses alternatives only when proxying is
 disabled. When any proxy policy is configured, including a `no-proxy` exception that selected a direct origin route,
-WebClient ignores the advertisement. The configured TLS policy is honored as-is for the alternative, including an
-explicit `SSLContext`, a custom TLS manager, disabled endpoint identification, and `trust-all`. An unsafe or permissive
-TLS policy makes Alt-Svc steering equally unsafe or permissive.
+WebClient ignores the advertisement. WebClient uses the system proxy policy by default, so configure `proxy.type` as
+`none`, or use `Proxy.noProxy()` programmatically, to use an advertised alternative. The configured TLS policy is
+honored as-is for the alternative, including an explicit `SSLContext`, a custom TLS manager, disabled endpoint
+identification, and `trust-all`. An unsafe or permissive TLS policy makes Alt-Svc steering equally unsafe or permissive.
 
 The HTTP/2 provider applies `ma`, `Age`, `Date`, `clear`, and `persist` to its connection-cache discovery state. Shared
 connection caches share that state; disabling connection-cache sharing isolates it. `persist` does not make discovery

--- a/webclient/README.md
+++ b/webclient/README.md
@@ -33,9 +33,28 @@ in such a case we use `prior-knowledge` and fail if we cannot switch to HTTP/2.
 
 When using TLS, the client will use ALPN (protocol negotiation) to use appropriate HTTP version (either 1.1, or 2).
 
-Once (and if) HTTP/3 is supported, it cannot follow the same approach (as it is UDP and not TCP based). For such cases, we
-plan to support `Alt-Svc` header, with which the server can tell us to use a different protocol version, and the next request
-to the same authority would switch to that version.
+Client Alt-Svc use is opt-in through the optional common `ClientAltSvcConfig` (`alt-svc`) configuration. Within a
+present configuration, `enabled` defaults to `true`; an empty `protocols` list allows every available supporting
+provider, while a non-empty list is an exact, case-sensitive ALPN protocol filter. The current HTTP/2 provider uses the
+`h2` protocol ID.
+
+Initial Alt-Svc support accepts advertisements only from HTTPS origins and only for alternatives on the same host,
+although the port may differ. Using an alternative changes only the connection endpoint; the request scheme and
+authority remain unchanged, and WebClient adds `Alt-Used` only to the alternative request. `h2c` alternatives are not
+supported. Plain HTTP origins cannot be upgraded to TLS-based HTTP/2 until the RFC 8164
+`/.well-known/http-opportunistic` opt-in is implemented.
+
+Alt-Svc never bypasses a selected proxy. The current HTTP/2 provider uses alternatives only for a direct route that is
+not pinned to a resolved address. The configured TLS policy is honored as-is for the alternative, including an explicit
+`SSLContext`, a custom TLS manager, disabled endpoint identification, and `trust-all`. An unsafe or permissive TLS
+policy makes Alt-Svc steering equally unsafe or permissive.
+
+The HTTP/2 provider applies `ma`, `Age`, `Date`, `clear`, and `persist` to its connection-cache discovery state. Shared
+connection caches share that state; disabling connection-cache sharing isolates it. `persist` does not make discovery
+state durable across a process or beyond the cache lifecycle.
+
+HTTP/3 cannot use TCP ALPN or an HTTP/1.1 upgrade because it runs over QUIC. The common client policy, response
+notification, and parsed `Alt-Svc` model can also support an HTTP/3 provider.
 
 To provide HTTP version support extension, the implementation must provide `webclient.spi.HttpClientSpiProvider`.
 

--- a/webclient/README.md
+++ b/webclient/README.md
@@ -44,10 +44,11 @@ authority remain unchanged, and WebClient adds `Alt-Used` only to the alternativ
 supported. Plain HTTP origins cannot be upgraded to TLS-based HTTP/2 until the RFC 8164
 `/.well-known/http-opportunistic` opt-in is implemented.
 
-Alt-Svc never bypasses a selected proxy. The current HTTP/2 provider uses alternatives only for a direct route that is
-not pinned to a resolved address. The configured TLS policy is honored as-is for the alternative, including an explicit
-`SSLContext`, a custom TLS manager, disabled endpoint identification, and `trust-all`. An unsafe or permissive TLS
-policy makes Alt-Svc steering equally unsafe or permissive.
+Alt-Svc never bypasses the configured proxy policy. The current HTTP/2 provider uses alternatives only when proxying is
+disabled. When any proxy policy is configured, including a `no-proxy` exception that selected a direct origin route,
+WebClient ignores the advertisement. The configured TLS policy is honored as-is for the alternative, including an
+explicit `SSLContext`, a custom TLS manager, disabled endpoint identification, and `trust-all`. An unsafe or permissive
+TLS policy makes Alt-Svc steering equally unsafe or permissive.
 
 The HTTP/2 provider applies `ma`, `Age`, `Date`, `clear`, and `persist` to its connection-cache discovery state. Shared
 connection caches share that state; disabling connection-cache sharing isolates it. `persist` does not make discovery

--- a/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
@@ -422,6 +422,7 @@ public final class AltSvcHeader {
         int emptyElements = initialEmptyElements;
         boolean quoted = false;
         boolean escaped = false;
+        boolean malformed = emptyElements > MAX_EMPTY_LIST_ELEMENTS;
         boolean tooMany = false;
         boolean clear = false;
         for (int index = 0; index <= value.length(); index++) {
@@ -448,9 +449,11 @@ public final class AltSvcHeader {
 
             String element = trimOws(value.substring(elementStart, index));
             if (element.isEmpty()) {
-                emptyElements++;
+                if (emptyElements <= MAX_EMPTY_LIST_ELEMENTS) {
+                    emptyElements++;
+                }
                 if (emptyElements > MAX_EMPTY_LIST_ELEMENTS) {
-                    return new AlternativeListResult(clear, true, tooMany, emptyElements);
+                    malformed = true;
                 }
             } else if ("clear".equals(element)) {
                 clear = true;
@@ -461,7 +464,7 @@ public final class AltSvcHeader {
             }
             elementStart = index + 1;
         }
-        return new AlternativeListResult(clear, false, tooMany, emptyElements);
+        return new AlternativeListResult(clear, malformed, tooMany, emptyElements);
     }
 
     private static Optional<List<String>> splitValues(String value, char delimiter) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
@@ -149,15 +149,16 @@ public final class AltSvcHeader {
     }
 
     private static GrammarResult parseGrammarSnapshot(List<String> fieldLines) {
+        if (fieldLines.size() == 1 && "clear".equals(trimOws(fieldLines.getFirst()))) {
+            return CLEAR_GRAMMAR;
+        }
+
         List<String> encodedAlternatives = new ArrayList<>();
         boolean malformed = false;
         boolean tooMany = false;
         int emptyElements = 0;
         for (String headerValue : fieldLines) {
             AlternativeListResult result = splitAlternatives(headerValue, encodedAlternatives, emptyElements);
-            if (result.clear()) {
-                return CLEAR_GRAMMAR;
-            }
             malformed |= result.malformed();
             tooMany |= result.tooMany();
             emptyElements = result.emptyElements();
@@ -422,7 +423,6 @@ public final class AltSvcHeader {
         int emptyElements = initialEmptyElements;
         boolean quoted = false;
         boolean escaped = false;
-        boolean clear = false;
         boolean tooMany = false;
         for (int index = 0; index <= value.length(); index++) {
             if (index < value.length()) {
@@ -443,17 +443,15 @@ public final class AltSvcHeader {
                     continue;
                 }
             } else if (quoted || escaped) {
-                return new AlternativeListResult(false, true, tooMany, emptyElements);
+                return new AlternativeListResult(true, tooMany, emptyElements);
             }
 
             String element = trimOws(value.substring(elementStart, index));
             if (element.isEmpty()) {
                 emptyElements++;
                 if (emptyElements > MAX_EMPTY_LIST_ELEMENTS) {
-                    return new AlternativeListResult(false, true, tooMany, emptyElements);
+                    return new AlternativeListResult(true, tooMany, emptyElements);
                 }
-            } else if ("clear".equals(element)) {
-                clear = true;
             } else if (result.size() == MAX_ALTERNATIVES) {
                 tooMany = true;
             } else {
@@ -461,7 +459,7 @@ public final class AltSvcHeader {
             }
             elementStart = index + 1;
         }
-        return new AlternativeListResult(clear, false, tooMany, emptyElements);
+        return new AlternativeListResult(false, tooMany, emptyElements);
     }
 
     private static Optional<List<String>> splitValues(String value, char delimiter) {
@@ -669,7 +667,7 @@ public final class AltSvcHeader {
     private record AlternativeTemplate(String protocolId, String host, int port, long maxAge, boolean persist) {
     }
 
-    private record AlternativeListResult(boolean clear, boolean malformed, boolean tooMany, int emptyElements) {
+    private record AlternativeListResult(boolean malformed, boolean tooMany, int emptyElements) {
     }
 
     private record DateMemo(String value, Instant parsedDate) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
@@ -1,0 +1,686 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.Api;
+import io.helidon.common.uri.UriValidator;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.DateTime;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HttpToken;
+
+/**
+ * Parsed, protocol-neutral {@code Alt-Svc} response header.
+ */
+@Api.Internal
+public final class AltSvcHeader {
+    private static final long DEFAULT_MAX_AGE_SECONDS = Duration.ofHours(24).toSeconds();
+    private static final int MAX_ALTERNATIVES = 32;
+    private static final int MAX_EMPTY_LIST_ELEMENTS = 32;
+    private static final int MAX_PROTOCOL_ID_LENGTH = 0xFF;
+    private static final int MAX_ENCODED_PROTOCOL_ID_LENGTH = MAX_PROTOCOL_ID_LENGTH * 3;
+    private static final AltSvcHeader CLEAR = new AltSvcHeader(true, List.of());
+    private static final GrammarResult CLEAR_GRAMMAR = new GrammarResult(true, false, List.of());
+    private static final GrammarResult MALFORMED_GRAMMAR = new GrammarResult(false, true, List.of());
+
+    private static volatile GrammarMemo grammarMemo;
+    private static volatile DateMemo dateMemo;
+
+    private final boolean clear;
+    private final List<Alternative> alternatives;
+
+    private AltSvcHeader(boolean clear, List<Alternative> alternatives) {
+        this.clear = clear;
+        this.alternatives = List.copyOf(alternatives);
+    }
+
+    /**
+     * Parse all {@code Alt-Svc} field lines as one atomic update.
+     * Up to {@value #MAX_EMPTY_LIST_ELEMENTS} empty comma-list elements are ignored across all field lines, as required
+     * by RFC 9110's list-extension rules. Additional empty elements make the update malformed.
+     *
+     * @param headers response headers
+     * @param receivedAt time the response headers were received
+     * @return parsed update, or empty when the field is absent or malformed
+     */
+    public static Optional<AltSvcHeader> parse(ClientResponseHeaders headers, Instant receivedAt) {
+        ClientResponseHeaders checkedHeaders = Objects.requireNonNull(headers, "headers");
+        Instant responseTime = Objects.requireNonNull(receivedAt, "receivedAt");
+        if (!checkedHeaders.contains(HeaderNames.ALT_SVC)) {
+            return Optional.empty();
+        }
+
+        Header header = checkedHeaders.get(HeaderNames.ALT_SVC);
+        GrammarResult grammar = parseGrammar(header);
+        if (grammar.clear()) {
+            return Optional.of(CLEAR);
+        }
+        if (grammar.malformed()) {
+            return Optional.empty();
+        }
+
+        long responseAge = responseAge(checkedHeaders, responseTime);
+        List<AlternativeTemplate> templates = grammar.templates();
+        if (templates.size() == 1) {
+            AlternativeTemplate template = templates.getFirst();
+            long freshFor = template.maxAge() > responseAge ? template.maxAge() - responseAge : 0;
+            Alternative alternative = new Alternative(template.protocolId(),
+                                                       template.host(),
+                                                       template.port(),
+                                                       expirationTime(responseTime, freshFor),
+                                                       template.persist());
+            return Optional.of(new AltSvcHeader(false, List.of(alternative)));
+        }
+        List<Alternative> alternatives = new ArrayList<>(templates.size());
+        for (int index = 0; index < templates.size(); index++) {
+            AlternativeTemplate template = templates.get(index);
+            long freshFor = template.maxAge() > responseAge ? template.maxAge() - responseAge : 0;
+            alternatives.add(new Alternative(template.protocolId(),
+                                             template.host(),
+                                             template.port(),
+                                             expirationTime(responseTime, freshFor),
+                                             template.persist()));
+        }
+        return Optional.of(new AltSvcHeader(false, alternatives));
+    }
+
+    /**
+     * Whether this update clears alternatives previously learned for the origin.
+     *
+     * @return whether this is a clear update
+     */
+    public boolean clear() {
+        return clear;
+    }
+
+    /**
+     * Alternatives in received field order.
+     *
+     * @return immutable alternatives
+     */
+    public List<Alternative> alternatives() {
+        return alternatives;
+    }
+
+    private static GrammarResult parseGrammar(Header header) {
+        GrammarMemo memo = grammarMemo;
+        List<String> fieldLineSnapshot;
+        if (header.valueCount() == 1) {
+            String fieldLine = header.get();
+            if (memo != null && memo.fieldLines().size() == 1 && memo.fieldLines().getFirst().equals(fieldLine)) {
+                return memo.result();
+            }
+            fieldLineSnapshot = List.of(fieldLine);
+        } else {
+            List<String> fieldLines = header.allValues();
+            if (memo != null && memo.fieldLines().equals(fieldLines)) {
+                return memo.result();
+            }
+            fieldLineSnapshot = List.copyOf(fieldLines);
+        }
+
+        GrammarResult result = parseGrammarSnapshot(fieldLineSnapshot);
+        grammarMemo = new GrammarMemo(fieldLineSnapshot, result);
+        return result;
+    }
+
+    private static GrammarResult parseGrammarSnapshot(List<String> fieldLines) {
+        List<String> encodedAlternatives = new ArrayList<>();
+        boolean malformed = false;
+        boolean tooMany = false;
+        int emptyElements = 0;
+        for (String headerValue : fieldLines) {
+            AlternativeListResult result = splitAlternatives(headerValue, encodedAlternatives, emptyElements);
+            if (result.clear()) {
+                return CLEAR_GRAMMAR;
+            }
+            malformed |= result.malformed();
+            tooMany |= result.tooMany();
+            emptyElements = result.emptyElements();
+        }
+        if (malformed || tooMany || encodedAlternatives.isEmpty()) {
+            return MALFORMED_GRAMMAR;
+        }
+
+        List<AlternativeTemplate> alternatives = new ArrayList<>(encodedAlternatives.size());
+        for (String encodedAlternative : encodedAlternatives) {
+            Optional<AlternativeTemplate> alternative = parseAlternative(encodedAlternative);
+            if (alternative.isEmpty()) {
+                return MALFORMED_GRAMMAR;
+            }
+            alternatives.add(alternative.get());
+        }
+        return new GrammarResult(false, false, List.copyOf(alternatives));
+    }
+
+    private static long responseAge(ClientResponseHeaders headers, Instant receivedAt) {
+        long responseAge = 0;
+        if (headers.contains(HeaderNames.AGE)) {
+            long parsedAge = parseDeltaSeconds(headers.get(HeaderNames.AGE).get());
+            if (parsedAge >= 0) {
+                responseAge = parsedAge;
+            }
+        }
+        if (headers.contains(HeaderNames.DATE)) {
+            Instant responseDate = parseDate(headers.get(HeaderNames.DATE).get());
+            if (responseDate != null && responseDate.isBefore(receivedAt)) {
+                responseAge = Math.max(responseAge, elapsedSeconds(responseDate, receivedAt));
+            }
+        }
+        return responseAge;
+    }
+
+    private static Instant parseDate(String value) {
+        DateMemo memo = dateMemo;
+        if (memo != null && memo.value().equals(value)) {
+            return memo.parsedDate();
+        }
+
+        Instant parsedDate;
+        try {
+            parsedDate = DateTime.parse(value).toInstant();
+        } catch (DateTimeParseException _) {
+            parsedDate = null;
+        }
+        dateMemo = new DateMemo(value, parsedDate);
+        return parsedDate;
+    }
+
+    private static long elapsedSeconds(Instant start, Instant end) {
+        try {
+            return Duration.between(start, end).toSeconds();
+        } catch (ArithmeticException _) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    private static Optional<AlternativeTemplate> parseAlternative(String alternative) {
+        String trimmed = trimOws(alternative);
+        if (trimmed.isEmpty()) {
+            return Optional.empty();
+        }
+
+        int equals = trimmed.indexOf('=');
+        if (equals < 1) {
+            return Optional.empty();
+        }
+        Optional<String> protocolId = decodeProtocolId(trimmed.substring(0, equals));
+        if (protocolId.isEmpty()) {
+            return Optional.empty();
+        }
+
+        int quoteStart = equals + 1;
+        Optional<QuotedValue> quotedAuthority = parseQuotedValue(trimmed, quoteStart);
+        if (quotedAuthority.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<AlternativeAuthority> authority = parseAuthority(quotedAuthority.get().value());
+        if (authority.isEmpty()) {
+            return Optional.empty();
+        }
+
+        long maxAge = DEFAULT_MAX_AGE_SECONDS;
+        boolean persist = false;
+        String parameterText = trimOws(trimmed.substring(quotedAuthority.get().endIndex() + 1));
+        if (!parameterText.isEmpty()) {
+            if (parameterText.charAt(0) != ';') {
+                return Optional.empty();
+            }
+            Optional<List<String>> parameters = splitValues(parameterText.substring(1), ';');
+            if (parameters.isEmpty()) {
+                return Optional.empty();
+            }
+            boolean maxAgeSeen = false;
+            for (String parameter : parameters.get()) {
+                String value = trimOws(parameter);
+                int parameterEquals = value.indexOf('=');
+                if (parameterEquals < 1 || parameterEquals + 1 >= value.length()) {
+                    return Optional.empty();
+                }
+                String name = value.substring(0, parameterEquals);
+                String parameterValue = value.substring(parameterEquals + 1);
+                Optional<String> decodedParameter = parseParameterValue(parameterValue);
+                if (!validToken(name) || decodedParameter.isEmpty()) {
+                    return Optional.empty();
+                }
+                String decodedValue = decodedParameter.get();
+                if ("ma".equalsIgnoreCase(name)) {
+                    if (maxAgeSeen) {
+                        return Optional.empty();
+                    }
+                    maxAge = parseDeltaSeconds(decodedValue);
+                    if (maxAge < 0) {
+                        return Optional.empty();
+                    }
+                    maxAgeSeen = true;
+                } else if ("persist".equalsIgnoreCase(name) && "1".equals(decodedValue)) {
+                    persist = true;
+                }
+            }
+        }
+
+        AlternativeAuthority parsedAuthority = authority.get();
+        return Optional.of(new AlternativeTemplate(protocolId.get(),
+                                                   parsedAuthority.host(),
+                                                   parsedAuthority.port(),
+                                                   maxAge,
+                                                   persist));
+    }
+
+    private static Optional<String> decodeProtocolId(String encodedProtocolId) {
+        if (encodedProtocolId.length() > MAX_ENCODED_PROTOCOL_ID_LENGTH || !validToken(encodedProtocolId)) {
+            return Optional.empty();
+        }
+        byte[] protocolId = new byte[Math.min(encodedProtocolId.length(), MAX_PROTOCOL_ID_LENGTH)];
+        int protocolIdLength = 0;
+        for (int index = 0; index < encodedProtocolId.length(); index++) {
+            if (protocolIdLength == MAX_PROTOCOL_ID_LENGTH) {
+                return Optional.empty();
+            }
+            char character = encodedProtocolId.charAt(index);
+            int decodedByte = character;
+            if (character == '%') {
+                if (index + 2 >= encodedProtocolId.length()) {
+                    return Optional.empty();
+                }
+                char highCharacter = encodedProtocolId.charAt(index + 1);
+                char lowCharacter = encodedProtocolId.charAt(index + 2);
+                if (!uppercaseHex(highCharacter) || !uppercaseHex(lowCharacter)) {
+                    return Optional.empty();
+                }
+                int highNibble = Character.digit(highCharacter, 16);
+                int lowNibble = Character.digit(lowCharacter, 16);
+                decodedByte = (highNibble << 4) | lowNibble;
+                if (decodedByte != '%' && tokenByte(decodedByte)) {
+                    return Optional.empty();
+                }
+                index += 2;
+            }
+            protocolId[protocolIdLength++] = (byte) decodedByte;
+        }
+        if (protocolIdLength == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(new String(protocolId, 0, protocolIdLength, StandardCharsets.ISO_8859_1));
+    }
+
+    private static boolean uppercaseHex(char character) {
+        return character >= '0' && character <= '9' || character >= 'A' && character <= 'F';
+    }
+
+    private static boolean tokenByte(int value) {
+        return (value >= '0' && value <= '9')
+                || (value >= 'A' && value <= 'Z')
+                || (value >= 'a' && value <= 'z')
+                || switch (value) {
+                    case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' -> true;
+                    default -> false;
+                };
+    }
+
+    private static Optional<AlternativeAuthority> parseAuthority(String authority) {
+        if (authority.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String host;
+        String portPart;
+        if (authority.startsWith(":")) {
+            host = null;
+            portPart = authority.substring(1);
+        } else if (authority.startsWith("[")) {
+            int closingBracket = authority.indexOf(']');
+            if (closingBracket < 0
+                    || closingBracket + 2 > authority.length()
+                    || authority.charAt(closingBracket + 1) != ':') {
+                return Optional.empty();
+            }
+            host = authority.substring(1, closingBracket);
+            if (host.isEmpty()) {
+                return Optional.empty();
+            }
+            if (!validHost(authority.substring(0, closingBracket + 1))) {
+                return Optional.empty();
+            }
+            portPart = authority.substring(closingBracket + 2);
+        } else {
+            int colon = authority.lastIndexOf(':');
+            if (colon < 1 || colon + 1 >= authority.length()) {
+                return Optional.empty();
+            }
+            host = authority.substring(0, colon);
+            if (host.indexOf(':') >= 0 || containsWhitespace(host) || !validHost(host)) {
+                return Optional.empty();
+            }
+            portPart = authority.substring(colon + 1);
+        }
+
+        long port = parseDeltaSeconds(portPart);
+        if (port < 1 || port > 65535) {
+            return Optional.empty();
+        }
+        return Optional.of(new AlternativeAuthority(host, (int) port));
+    }
+
+    private static boolean validHost(String host) {
+        try {
+            UriValidator.validateHost(host);
+            return true;
+        } catch (IllegalArgumentException _) {
+            return false;
+        }
+    }
+
+    private static boolean containsWhitespace(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            if (Character.isWhitespace(value.charAt(index))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Optional<String> parseParameterValue(String value) {
+        if (!value.startsWith("\"")) {
+            return validToken(value) ? Optional.of(value) : Optional.empty();
+        }
+        Optional<QuotedValue> quotedValue = parseQuotedValue(value, 0);
+        if (quotedValue.isEmpty() || quotedValue.get().endIndex() + 1 != value.length()) {
+            return Optional.empty();
+        }
+        return Optional.of(quotedValue.get().value());
+    }
+
+    private static AlternativeListResult splitAlternatives(String value,
+                                                           List<String> result,
+                                                           int initialEmptyElements) {
+        int elementStart = 0;
+        int emptyElements = initialEmptyElements;
+        boolean quoted = false;
+        boolean escaped = false;
+        boolean clear = false;
+        boolean tooMany = false;
+        for (int index = 0; index <= value.length(); index++) {
+            if (index < value.length()) {
+                char character = value.charAt(index);
+                if (escaped) {
+                    escaped = false;
+                    continue;
+                }
+                if (quoted && character == '\\') {
+                    escaped = true;
+                    continue;
+                }
+                if (character == '"') {
+                    quoted = !quoted;
+                    continue;
+                }
+                if (character != ',' || quoted) {
+                    continue;
+                }
+            } else if (quoted || escaped) {
+                return new AlternativeListResult(false, true, tooMany, emptyElements);
+            }
+
+            String element = trimOws(value.substring(elementStart, index));
+            if (element.isEmpty()) {
+                emptyElements++;
+                if (emptyElements > MAX_EMPTY_LIST_ELEMENTS) {
+                    return new AlternativeListResult(false, true, tooMany, emptyElements);
+                }
+            } else if ("clear".equals(element)) {
+                clear = true;
+            } else if (result.size() == MAX_ALTERNATIVES) {
+                tooMany = true;
+            } else {
+                result.add(element);
+            }
+            elementStart = index + 1;
+        }
+        return new AlternativeListResult(clear, false, tooMany, emptyElements);
+    }
+
+    private static Optional<List<String>> splitValues(String value, char delimiter) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean quoted = false;
+        boolean escaped = false;
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            if (escaped) {
+                current.append(character);
+                escaped = false;
+                continue;
+            }
+            if (quoted && character == '\\') {
+                current.append(character);
+                escaped = true;
+                continue;
+            }
+            if (character == '"') {
+                quoted = !quoted;
+            }
+            if (character == delimiter && !quoted) {
+                result.add(trimOws(current.toString()));
+                current.setLength(0);
+            } else {
+                current.append(character);
+            }
+        }
+        if (quoted || escaped) {
+            return Optional.empty();
+        }
+        result.add(trimOws(current.toString()));
+        for (String item : result) {
+            if (item.isEmpty()) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(result);
+    }
+
+    private static String trimOws(String value) {
+        int start = 0;
+        int end = value.length();
+        while (start < end && ows(value.charAt(start))) {
+            start++;
+        }
+        while (end > start && ows(value.charAt(end - 1))) {
+            end--;
+        }
+        return start == 0 && end == value.length() ? value : value.substring(start, end);
+    }
+
+    private static boolean ows(char character) {
+        return character == ' ' || character == '\t';
+    }
+
+    private static Optional<QuotedValue> parseQuotedValue(String value, int quoteStart) {
+        if (quoteStart >= value.length() || value.charAt(quoteStart) != '"') {
+            return Optional.empty();
+        }
+        StringBuilder result = new StringBuilder();
+        boolean escaped = false;
+        for (int index = quoteStart + 1; index < value.length(); index++) {
+            char character = value.charAt(index);
+            if (escaped) {
+                if (!quotedPair(character)) {
+                    return Optional.empty();
+                }
+                result.append(character);
+                escaped = false;
+            } else if (character == '\\') {
+                escaped = true;
+            } else if (character == '"') {
+                return Optional.of(new QuotedValue(result.toString(), index));
+            } else if (!quotedText(character)) {
+                return Optional.empty();
+            } else {
+                result.append(character);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean quotedText(char character) {
+        return character == '\t'
+                || character == ' '
+                || character == '!'
+                || (character >= 0x23 && character <= 0x5B)
+                || (character >= 0x5D && character <= 0x7E)
+                || (character >= 0x80 && character <= 0xFF);
+    }
+
+    private static boolean quotedPair(char character) {
+        return character == '\t'
+                || character == ' '
+                || (character >= 0x21 && character <= 0x7E)
+                || (character >= 0x80 && character <= 0xFF);
+    }
+
+    private static boolean validToken(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        try {
+            HttpToken.validate(value);
+            return true;
+        } catch (IllegalArgumentException _) {
+            return false;
+        }
+    }
+
+    private static long parseDeltaSeconds(String value) {
+        if (value.isEmpty()) {
+            return -1;
+        }
+        long result = 0;
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            if (character < '0' || character > '9') {
+                return -1;
+            }
+            int digit = character - '0';
+            if (result > (Long.MAX_VALUE - digit) / 10) {
+                return Long.MAX_VALUE;
+            }
+            result = result * 10 + digit;
+        }
+        return result;
+    }
+
+    private static Instant expirationTime(Instant receivedAt, long freshFor) {
+        long maximumFreshness = Instant.MAX.getEpochSecond() - receivedAt.getEpochSecond();
+        return receivedAt.plusSeconds(Math.min(freshFor, maximumFreshness));
+    }
+
+    /**
+     * One parsed alternative service.
+     */
+    @Api.Internal
+    public static final class Alternative {
+        private final String protocolId;
+        private final String host;
+        private final int port;
+        private final Instant expirationTime;
+        private final boolean persist;
+
+        private Alternative(String protocolId, String host, int port, Instant expirationTime, boolean persist) {
+            this.protocolId = protocolId;
+            this.host = host;
+            this.port = port;
+            this.expirationTime = expirationTime;
+            this.persist = persist;
+        }
+
+        /**
+         * Percent-decoded ALPN protocol identifier, mapped one octet to each ISO-8859-1 character.
+         *
+         * @return protocol identifier
+         */
+        public String protocolId() {
+            return protocolId;
+        }
+
+        /**
+         * Alternative host without IPv6 brackets, or empty to retain the origin host.
+         *
+         * @return optional alternative host
+         */
+        public Optional<String> host() {
+            return Optional.ofNullable(host);
+        }
+
+        /**
+         * Alternative port.
+         *
+         * @return alternative port
+         */
+        public int port() {
+            return port;
+        }
+
+        /**
+         * Time at which this alternative expires after accounting for response age.
+         *
+         * @return expiration time
+         */
+        public Instant expirationTime() {
+            return expirationTime;
+        }
+
+        /**
+         * Whether this alternative can persist across network changes.
+         *
+         * @return whether the alternative is persistent
+         */
+        public boolean persist() {
+            return persist;
+        }
+    }
+
+    private record AlternativeAuthority(String host, int port) {
+    }
+
+    private record AlternativeTemplate(String protocolId, String host, int port, long maxAge, boolean persist) {
+    }
+
+    private record AlternativeListResult(boolean clear, boolean malformed, boolean tooMany, int emptyElements) {
+    }
+
+    private record DateMemo(String value, Instant parsedDate) {
+    }
+
+    private record GrammarMemo(List<String> fieldLines, GrammarResult result) {
+    }
+
+    private record GrammarResult(boolean clear, boolean malformed, List<AlternativeTemplate> templates) {
+    }
+
+    private record QuotedValue(String value, int endIndex) {
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
@@ -311,7 +311,7 @@ public final class AltSvcHeader {
                 }
                 char highCharacter = encodedProtocolId.charAt(index + 1);
                 char lowCharacter = encodedProtocolId.charAt(index + 2);
-                if (!uppercaseHex(highCharacter) || !uppercaseHex(lowCharacter)) {
+                if (!hexDigit(highCharacter) || !hexDigit(lowCharacter)) {
                     return Optional.empty();
                 }
                 int highNibble = Character.digit(highCharacter, 16);
@@ -330,8 +330,10 @@ public final class AltSvcHeader {
         return Optional.of(new String(protocolId, 0, protocolIdLength, StandardCharsets.ISO_8859_1));
     }
 
-    private static boolean uppercaseHex(char character) {
-        return character >= '0' && character <= '9' || character >= 'A' && character <= 'F';
+    private static boolean hexDigit(char character) {
+        return character >= '0' && character <= '9'
+                || character >= 'A' && character <= 'F'
+                || character >= 'a' && character <= 'f';
     }
 
     private static boolean tokenByte(int value) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
@@ -59,7 +59,7 @@ public final class AltSvcHeader {
     }
 
     /**
-     * Parse all {@code Alt-Svc} field lines as one atomic update.
+     * Create an {@code Alt-Svc} update by parsing all field lines atomically.
      * Up to {@value #MAX_EMPTY_LIST_ELEMENTS} empty comma-list elements are ignored across all field lines, as required
      * by RFC 9110's list-extension rules. Additional empty elements make the update malformed.
      *
@@ -67,7 +67,7 @@ public final class AltSvcHeader {
      * @param receivedAt time the response headers were received
      * @return parsed update, or empty when the field is absent or malformed
      */
-    public static Optional<AltSvcHeader> parse(ClientResponseHeaders headers, Instant receivedAt) {
+    public static Optional<AltSvcHeader> create(ClientResponseHeaders headers, Instant receivedAt) {
         ClientResponseHeaders checkedHeaders = Objects.requireNonNull(headers, "headers");
         Instant responseTime = Objects.requireNonNull(receivedAt, "receivedAt");
         if (!checkedHeaders.contains(HeaderNames.ALT_SVC)) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
@@ -149,16 +149,15 @@ public final class AltSvcHeader {
     }
 
     private static GrammarResult parseGrammarSnapshot(List<String> fieldLines) {
-        if (fieldLines.size() == 1 && "clear".equals(trimOws(fieldLines.getFirst()))) {
-            return CLEAR_GRAMMAR;
-        }
-
         List<String> encodedAlternatives = new ArrayList<>();
         boolean malformed = false;
         boolean tooMany = false;
         int emptyElements = 0;
         for (String headerValue : fieldLines) {
             AlternativeListResult result = splitAlternatives(headerValue, encodedAlternatives, emptyElements);
+            if (result.clear()) {
+                return CLEAR_GRAMMAR;
+            }
             malformed |= result.malformed();
             tooMany |= result.tooMany();
             emptyElements = result.emptyElements();
@@ -424,6 +423,7 @@ public final class AltSvcHeader {
         boolean quoted = false;
         boolean escaped = false;
         boolean tooMany = false;
+        boolean clear = false;
         for (int index = 0; index <= value.length(); index++) {
             if (index < value.length()) {
                 char character = value.charAt(index);
@@ -443,15 +443,17 @@ public final class AltSvcHeader {
                     continue;
                 }
             } else if (quoted || escaped) {
-                return new AlternativeListResult(true, tooMany, emptyElements);
+                return new AlternativeListResult(clear, true, tooMany, emptyElements);
             }
 
             String element = trimOws(value.substring(elementStart, index));
             if (element.isEmpty()) {
                 emptyElements++;
                 if (emptyElements > MAX_EMPTY_LIST_ELEMENTS) {
-                    return new AlternativeListResult(true, tooMany, emptyElements);
+                    return new AlternativeListResult(clear, true, tooMany, emptyElements);
                 }
+            } else if ("clear".equals(element)) {
+                clear = true;
             } else if (result.size() == MAX_ALTERNATIVES) {
                 tooMany = true;
             } else {
@@ -459,7 +461,7 @@ public final class AltSvcHeader {
             }
             elementStart = index + 1;
         }
-        return new AlternativeListResult(false, tooMany, emptyElements);
+        return new AlternativeListResult(clear, false, tooMany, emptyElements);
     }
 
     private static Optional<List<String>> splitValues(String value, char delimiter) {
@@ -667,7 +669,7 @@ public final class AltSvcHeader {
     private record AlternativeTemplate(String protocolId, String host, int port, long maxAge, boolean persist) {
     }
 
-    private record AlternativeListResult(boolean malformed, boolean tooMany, int emptyElements) {
+    private record AlternativeListResult(boolean clear, boolean malformed, boolean tooMany, int emptyElements) {
     }
 
     private record DateMemo(String value, Instant parsedDate) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/AltSvcHeader.java
@@ -180,7 +180,9 @@ public final class AltSvcHeader {
     private static long responseAge(ClientResponseHeaders headers, Instant receivedAt) {
         long responseAge = 0;
         if (headers.contains(HeaderNames.AGE)) {
-            long parsedAge = parseDeltaSeconds(headers.get(HeaderNames.AGE).get());
+            String age = headers.get(HeaderNames.AGE).get();
+            int comma = age.indexOf(',');
+            long parsedAge = parseDeltaSeconds(comma < 0 ? age : trimOws(age.substring(0, comma)));
             if (parsedAge >= 0) {
                 responseAge = parsedAge;
             }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientAltSvcConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientAltSvcConfigBlueprint.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.util.Set;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
+
+/**
+ * Client policy for accepting and using HTTP {@code Alt-Svc} response advertisements.
+ * <p>
+ * Alternative service handling is opt-in through {@link HttpClientConfig#altSvc()}. Supporting client protocols use
+ * this policy only for HTTPS origins and same-host alternative authorities. Clear-text HTTP origins, including an
+ * opportunistic transition from HTTP to TLS, and cross-host alternatives are not supported.
+ * <p>
+ * The client applies its configured TLS settings without additional restrictions when connecting to an alternative
+ * service. Unsafe TLS settings, such as trusting all certificates, therefore make alternative service handling
+ * correspondingly unsafe. Helidon honors the configured TLS policy and does not require its built-in trust manager.
+ */
+@Api.Preview
+@Prototype.Blueprint(decorator = ClientAltSvcConfigSupport.BuilderDecorator.class)
+@Prototype.Configured(root = false)
+interface ClientAltSvcConfigBlueprint {
+    /**
+     * Whether alternative service handling is enabled.
+     * <p>
+     * This option defaults to {@code true}. Setting it to {@code false} disables alternative service handling even when
+     * this configuration is present.
+     *
+     * @return whether alternative service handling is enabled
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(true)
+    boolean enabled();
+
+    /**
+     * Allowed alternative service protocol identifiers.
+     * <p>
+     * An empty set permits every available client protocol that supports alternative services. A non-empty set is an
+     * exact, case-sensitive allow-list of opaque ALPN protocol identifiers; it is not validated against the protocols
+     * currently provided by the client. Each Java character in the range {@code U+0000} through {@code U+00FF} maps
+     * one-to-one to an identifier byte. Each identifier must contain between {@code 1} and {@code 255} bytes, inclusive,
+     * when this policy is enabled.
+     *
+     * @return allowed alternative service protocol identifiers
+     */
+    @Option.Configured
+    @Option.Singular
+    Set<String> protocols();
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientAltSvcConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientAltSvcConfigBlueprint.java
@@ -23,7 +23,7 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.common.Api;
 
 /**
- * Client policy for accepting and using HTTP {@code Alt-Svc} response advertisements.
+ * Preview client policy for accepting and using HTTP {@code Alt-Svc} response advertisements.
  * <p>
  * Alternative service handling is opt-in through {@link HttpClientConfig#altSvc()}. Supporting client protocols use
  * this policy only for HTTPS origins and same-host alternative authorities. Clear-text HTTP origins, including an

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientAltSvcConfigSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientAltSvcConfigSupport.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import io.helidon.builder.api.Prototype;
+
+final class ClientAltSvcConfigSupport {
+    private ClientAltSvcConfigSupport() {
+    }
+
+    static final class BuilderDecorator implements Prototype.BuilderDecorator<ClientAltSvcConfig.BuilderBase<?, ?>> {
+        @Override
+        public void decorate(ClientAltSvcConfig.BuilderBase<?, ?> target) {
+            if (!target.enabled()) {
+                return;
+            }
+
+            for (String protocol : target.protocols()) {
+                if (protocol.isEmpty()) {
+                    throw new IllegalArgumentException("Client Alt-Svc protocol cannot be empty when enabled.");
+                }
+                for (int index = 0; index < protocol.length(); index++) {
+                    if (protocol.charAt(index) > 0xFF) {
+                        throw new IllegalArgumentException(
+                                "Client Alt-Svc protocol contains a character outside the byte range when enabled.");
+                    }
+                }
+                if (protocol.length() > 0xFF) {
+                    throw new IllegalArgumentException(
+                            "Client Alt-Svc protocol exceeds the 255-byte ALPN limit when enabled.");
+                }
+            }
+        }
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnectionTarget.java
@@ -612,6 +612,21 @@ public final class ClientConnectionTarget {
         return route;
     }
 
+    private static UriAuthority altSvcOriginAuthority(UriAuthority originAuthority) {
+        if (originAuthority == null) {
+            return null;
+        }
+        UriHost host = originAuthority.host();
+        if (host.kind() != UriHost.Kind.DNS) {
+            return originAuthority;
+        }
+        String canonicalHost = host.value().toLowerCase(Locale.ROOT);
+        if (host.value().equals(canonicalHost)) {
+            return originAuthority;
+        }
+        return UriAuthority.create(UriHost.create(canonicalHost), originAuthority.port());
+    }
+
     /**
      * DNS-free identity used to look up a logical WebClient connection target before selecting its proxy route.
      */
@@ -645,6 +660,32 @@ public final class ClientConnectionTarget {
          */
         public boolean currentTlsGeneration() {
             return tlsGeneration == connectionKey.tls().generation();
+        }
+
+        /**
+         * Create the canonical origin identity used for Alt-Svc discovery.
+         * <p>
+         * URI schemes and DNS host names are compared without regard to case. All connection policy, transport, local
+         * address, authority, TLS identity, and TLS generation partitions are retained.
+         * <p>
+         * This key is only an Alt-Svc identity. Callers must retain and use the request's original lookup key for
+         * routing, physical target creation, and connection-pool identity.
+         *
+         * @return canonical Alt-Svc origin key
+         */
+        @Api.Internal
+        public LookupKey altSvcOriginKey() {
+            ConnectionKey canonicalConnectionKey = connectionKey.altSvcOriginKey();
+            UriAuthority canonicalOriginAuthority = altSvcOriginAuthority(originAuthorityOverride);
+            if (connectionKey == canonicalConnectionKey && originAuthorityOverride == canonicalOriginAuthority) {
+                return this;
+            }
+            return new LookupKey(canonicalConnectionKey,
+                                 scheme,
+                                 canonicalOriginAuthority,
+                                 transportAddress,
+                                 localAddress,
+                                 tlsGeneration);
         }
 
         @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -617,7 +617,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                                                       CompletableFuture<WebClientServiceRequest> whenSent,
                                                       CompletableFuture<WebClientServiceResponse> whenComplete,
                                                       ClientUri usedUri) {
-        return invokeServices(httpCallChain, whenSent, whenComplete, usedUri, protocolId, null);
+        return invokeServices(null, httpCallChain, whenSent, whenComplete, usedUri, protocolId, null);
     }
 
     /**
@@ -634,7 +634,8 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                                                       CompletableFuture<WebClientServiceRequest> whenSent,
                                                       CompletableFuture<WebClientServiceResponse> whenComplete,
                                                       ClientUri usedUri) {
-        return invokeServices(httpCallChain,
+        return invokeServices(null,
+                              httpCallChain,
                               whenSent,
                               whenComplete,
                               usedUri,
@@ -642,7 +643,29 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                               Objects.requireNonNull(httpCallChain));
     }
 
-    private WebClientServiceResponse invokeServices(WebClientService.Chain httpCallChain,
+    /**
+     * Invoke configured client services and publish applicable transport response context before they unwind.
+     *
+     * @param webClient client that owns the transport protocols
+     * @param httpCallChain invocation of the HTTP request (the actual network call)
+     * @param whenSent completable future to be completed when the request is sent over the network
+     * @param whenComplete completable future to be completed when the request/response interaction finishes
+     * @param usedUri URI configured on the request, combined with the base URI of the client
+     * @return web client service response
+     */
+    @Api.Internal
+    protected WebClientServiceResponse invokeServices(WebClient webClient,
+                                                      WebClientService.TransportChain httpCallChain,
+                                                      CompletableFuture<WebClientServiceRequest> whenSent,
+                                                      CompletableFuture<WebClientServiceResponse> whenComplete,
+                                                      ClientUri usedUri) {
+        WebClient client = Objects.requireNonNull(webClient, "webClient");
+        WebClientService.TransportChain chain = Objects.requireNonNull(httpCallChain, "httpCallChain");
+        return invokeServices(client, chain, whenSent, whenComplete, usedUri, null, chain);
+    }
+
+    private WebClientServiceResponse invokeServices(WebClient webClient,
+                                                    WebClientService.Chain httpCallChain,
                                                     CompletableFuture<WebClientServiceRequest> whenSent,
                                                     CompletableFuture<WebClientServiceResponse> whenComplete,
                                                     ClientUri usedUri,
@@ -665,7 +688,14 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
 
         WebClientService.Chain last = request -> {
             ClientRequestHeaderSupport.validate(request.headers());
-            return httpCallChain.proceed(request);
+            WebClientServiceResponse response = httpCallChain.proceed(request);
+            if (webClient != null && wireProtocolChain instanceof WebClientService.TransportChain transportChain) {
+                Optional<WebClientProtocolResponse> protocolResponse = transportChain.protocolResponse(response);
+                if (protocolResponse.isPresent()) {
+                    webClient.responseReceived(protocolResponse.get());
+                }
+            }
+            return response;
         };
 
         List<WebClientService> services = clientConfig.services();

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
@@ -18,6 +18,7 @@ package io.helidon.webclient.api;
 
 import java.net.UnixDomainSocketAddress;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 import javax.net.ssl.SNIServerName;
@@ -26,6 +27,7 @@ import javax.net.ssl.SSLParameters;
 import io.helidon.common.Api;
 import io.helidon.common.tls.Tls;
 import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.webclient.spi.DnsResolver;
 
@@ -391,6 +393,28 @@ public final class ConnectionKey {
         return SniSupport.serverNamesOverride(sni);
     }
 
+    ConnectionKey altSvcOriginKey() {
+        String canonicalScheme = scheme.toLowerCase(Locale.ROOT);
+        String canonicalHost = canonicalDnsHost(host);
+        String canonicalTlsPeerHost = canonicalDnsHost(tlsPeerHost);
+        SniSupport.State canonicalSni = canonicalSni(sni);
+        if (scheme.equals(canonicalScheme)
+                && host.equals(canonicalHost)
+                && tlsPeerHost.equals(canonicalTlsPeerHost)
+                && sni.equals(canonicalSni)) {
+            return this;
+        }
+        return new ConnectionKey(canonicalScheme,
+                                 canonicalHost,
+                                 port,
+                                 tls,
+                                 dnsResolver,
+                                 dnsAddressLookup,
+                                 proxy,
+                                 transport,
+                                 new SniSupport.Selection(canonicalTlsPeerHost, tlsPeerPort, canonicalSni));
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -441,6 +465,32 @@ public final class ConnectionKey {
                 .scheme(scheme)
                 .host(host)
                 .port(port);
+    }
+
+    private static String canonicalDnsHost(String host) {
+        String canonical = host.toLowerCase(Locale.ROOT);
+        if (host.equals(canonical)) {
+            return host;
+        }
+        if (host.indexOf(':') >= 0) {
+            return host;
+        }
+        try {
+            return UriHost.create(host).kind() == UriHost.Kind.DNS ? canonical : host;
+        } catch (IllegalArgumentException _) {
+            return host;
+        }
+    }
+
+    private static SniSupport.State canonicalSni(SniSupport.State sni) {
+        if (sni.kind() != SniSupport.Kind.HOST && sni.kind() != SniSupport.Kind.EMPTY) {
+            return sni;
+        }
+        String canonicalHost = canonicalDnsHost(sni.host());
+        if (sni.host().equals(canonicalHost)) {
+            return sni;
+        }
+        return new SniSupport.State(sni.kind(), canonicalHost);
     }
 
     private record Transport(String type, String value) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.media.type.ParserMode;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.uri.UriFragment;
@@ -79,6 +80,18 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      */
     @Option.Configured
     Optional<SniConfig> sni();
+
+    /**
+     * Client policy for accepting and using HTTP {@code Alt-Svc} response advertisements.
+     * <p>
+     * Alternative service handling is disabled when this configuration is absent. Configure an empty
+     * {@link ClientAltSvcConfig} to opt in with its defaults.
+     *
+     * @return alternative service policy, or empty if alternative service handling is disabled
+     */
+    @Api.Preview
+    @Option.Configured
+    Optional<ClientAltSvcConfig> altSvc();
 
     /**
      * Base query used by the client in all requests.

--- a/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -41,6 +42,7 @@ import io.helidon.webclient.spi.ProtocolConfig;
  */
 @SuppressWarnings("rawtypes")
 class LoomClient implements WebClient {
+    private static final System.Logger LOGGER = System.getLogger(LoomClient.class.getName());
     static final LazyValue<ExecutorService> EXECUTOR =
             LazyValue.create(() -> Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
                                                                             .name("helidon-client-", 0)
@@ -163,6 +165,20 @@ class LoomClient implements WebClient {
             throw new IllegalStateException("TCP protocol IDs are not available during WebClient construction");
         }
         return protocolIds;
+    }
+
+    @Override
+    public void responseReceived(WebClientProtocolResponse response) {
+        WebClientProtocolResponse checkedResponse = Objects.requireNonNull(response, "response");
+        for (ProtocolSpi protocol : protocols) {
+            try {
+                protocol.spi().responseReceived(checkedResponse);
+            } catch (RuntimeException failure) {
+                LOGGER.log(System.Logger.Level.WARNING,
+                           "HTTP protocol response notification failed for " + protocol.id(),
+                           failure);
+            }
+        }
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
@@ -42,11 +42,11 @@ import io.helidon.webclient.spi.ProtocolConfig;
  */
 @SuppressWarnings("rawtypes")
 class LoomClient implements WebClient {
-    private static final System.Logger LOGGER = System.getLogger(LoomClient.class.getName());
     static final LazyValue<ExecutorService> EXECUTOR =
             LazyValue.create(() -> Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
                                                                             .name("helidon-client-", 0)
                                                                             .factory()));
+    private static final System.Logger LOGGER = System.getLogger(LoomClient.class.getName());
     private static final List<HttpClientSpiProvider> PROVIDERS =
             HelidonServiceLoader.create(ServiceLoader.load(HttpClientSpiProvider.class))
                     .asList();

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -30,6 +30,7 @@ import java.util.Base64;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -894,7 +895,11 @@ public class Proxy {
          * @return updated builder instance
          */
         public Builder config(Config config) {
-            config.get("type").asString().map(ProxyType::valueOf).ifPresent(this::type);
+            config.get("type")
+                    .asString()
+                    .map(it -> it.toUpperCase(Locale.ROOT))
+                    .map(ProxyType::valueOf)
+                    .ifPresent(this::type);
 
             if (this.type != ProxyType.SYSTEM && this.type != ProxyType.NONE) {
                 config.get("host").asString().ifPresent(this::host);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ProxyRoute.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ProxyRoute.java
@@ -180,6 +180,16 @@ public final class ProxyRoute {
     }
 
     /**
+     * Whether this direct route is bound to the address that matched an IP-based {@code no-proxy} rule.
+     *
+     * @return whether the route is address-bound
+     */
+    @Api.Internal
+    public boolean addressBound() {
+        return noProxyAddress != null;
+    }
+
+    /**
      * Whether HTTP/1.1 must use absolute-form request targets on this route.
      *
      * @return whether this is an HTTP forward-proxy route

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -146,11 +146,22 @@ public class TcpClientConnection implements ClientConnection {
                                        closeConsumer);
     }
 
-    static TcpClientConnection create(WebClient webClient,
-                                      ResolvedClientTarget resolvedTarget,
-                                      List<String> tcpProtocolIds,
-                                      Function<TcpClientConnection, Boolean> releaseFunction,
-                                      Consumer<TcpClientConnection> closeConsumer) {
+    /**
+     * Create a TCP connection from a resolved physical target.
+     *
+     * @param webClient webclient, may be used to create proxy connections
+     * @param resolvedTarget resolved physical target
+     * @param tcpProtocolIds protocol IDs for ALPN
+     * @param releaseFunction release callback
+     * @param closeConsumer close callback
+     * @return a new unconnected TCP connection
+     */
+    @Api.Internal
+    public static TcpClientConnection create(WebClient webClient,
+                                             ResolvedClientTarget resolvedTarget,
+                                             List<String> tcpProtocolIds,
+                                             Function<TcpClientConnection, Boolean> releaseFunction,
+                                             Consumer<TcpClientConnection> closeConsumer) {
         ResolvedClientTarget target = Objects.requireNonNull(resolvedTarget, "resolvedTarget");
         return new TcpClientConnection(webClient,
                                        target.logicalTarget().connectionKey(),

--- a/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
@@ -17,6 +17,7 @@
 package io.helidon.webclient.api;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
@@ -116,6 +117,16 @@ public interface WebClient extends RuntimeType.Api<WebClientConfig>, HttpClient<
     @Api.Internal
     default List<String> tcpProtocolIds() {
         return List.of();
+    }
+
+    /**
+     * Notify active HTTP protocols about a response received by this client.
+     *
+     * @param response received protocol response
+     */
+    @Api.Internal
+    default void responseReceived(WebClientProtocolResponse response) {
+        Objects.requireNonNull(response, "response");
     }
 
     /**

--- a/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/WebClient.java
@@ -120,7 +120,11 @@ public interface WebClient extends RuntimeType.Api<WebClientConfig>, HttpClient<
     }
 
     /**
-     * Notify active HTTP protocols about a response received by this client.
+     * Notify active HTTP protocol implementations about a transport response received by this client.
+     * <p>
+     * This notification lets one protocol observe response metadata produced by another protocol without creating
+     * dependencies between protocol modules. For example, a protocol may use an {@code Alt-Svc} response header to
+     * discover an alternative service.
      *
      * @param response received protocol response
      */

--- a/webclient/api/src/main/java/io/helidon/webclient/api/WebClientProtocolResponse.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/WebClientProtocolResponse.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.helidon.common.Api;
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.Value;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HttpMediaType;
+import io.helidon.http.Status;
+
+/**
+ * Protocol-neutral context for a response received by a WebClient transport.
+ */
+@Api.Internal
+public final class WebClientProtocolResponse {
+    private final ResolvedClientTarget target;
+    private final boolean explicitConnection;
+    private final String protocolId;
+    private final Status status;
+    private final ClientResponseHeaders headers;
+    private final Instant receivedAt;
+    private final UriAuthority alternativeAuthority;
+
+    private WebClientProtocolResponse(ResolvedClientTarget target,
+                                      boolean explicitConnection,
+                                      String protocolId,
+                                      Status status,
+                                      ClientResponseHeaders headers,
+                                      Instant receivedAt,
+                                      UriAuthority alternativeAuthority) {
+        this.target = Objects.requireNonNull(target, "target");
+        this.explicitConnection = explicitConnection;
+        this.protocolId = requireProtocolId(protocolId);
+        this.status = Objects.requireNonNull(status, "status");
+        this.headers = new SparseClientResponseHeaders(Objects.requireNonNull(headers, "headers"));
+        this.receivedAt = Objects.requireNonNull(receivedAt, "receivedAt");
+        this.alternativeAuthority = alternativeAuthority;
+    }
+
+    /**
+     * Create response context for a request sent to its direct route.
+     *
+     * @param target resolved physical and logical target
+     * @param explicitConnection whether the request used a caller-supplied or otherwise out-of-band connection
+     * @param protocolId actual response protocol identifier
+     * @param status response status
+     * @param headers response headers
+     * @param receivedAt time the response headers were received
+     * @return response context
+     */
+    public static WebClientProtocolResponse create(ResolvedClientTarget target,
+                                                   boolean explicitConnection,
+                                                   String protocolId,
+                                                   Status status,
+                                                   ClientResponseHeaders headers,
+                                                   Instant receivedAt) {
+        return new WebClientProtocolResponse(target,
+                                             explicitConnection,
+                                             protocolId,
+                                             status,
+                                             headers,
+                                             receivedAt,
+                                             null);
+    }
+
+    /**
+     * Create response context for a request sent to an alternative service.
+     *
+     * @param target resolved physical and logical target
+     * @param explicitConnection whether the request used a caller-supplied or otherwise out-of-band connection
+     * @param protocolId actual response protocol identifier
+     * @param status response status
+     * @param headers response headers
+     * @param receivedAt time the response headers were received
+     * @param alternativeAuthority alternative authority used for the request
+     * @return response context
+     */
+    public static WebClientProtocolResponse createAlternative(ResolvedClientTarget target,
+                                                              boolean explicitConnection,
+                                                              String protocolId,
+                                                              Status status,
+                                                              ClientResponseHeaders headers,
+                                                              Instant receivedAt,
+                                                              UriAuthority alternativeAuthority) {
+        return new WebClientProtocolResponse(target,
+                                             explicitConnection,
+                                             protocolId,
+                                             status,
+                                             headers,
+                                             receivedAt,
+                                             Objects.requireNonNull(alternativeAuthority, "alternativeAuthority"));
+    }
+
+    /**
+     * Exact resolved target used for this response.
+     *
+     * @return resolved target
+     */
+    public ResolvedClientTarget target() {
+        return target;
+    }
+
+    /**
+     * Whether the request used a caller-supplied or otherwise out-of-band connection.
+     *
+     * @return whether the request used an explicit connection
+     */
+    public boolean explicitConnection() {
+        return explicitConnection;
+    }
+
+    /**
+     * Actual protocol selected for this response.
+     *
+     * @return protocol identifier
+     */
+    public String protocolId() {
+        return protocolId;
+    }
+
+    /**
+     * Response status.
+     *
+     * @return response status
+     */
+    public Status status() {
+        return status;
+    }
+
+    /**
+     * Full immutable snapshot of response headers.
+     *
+     * @return response headers
+     */
+    public ClientResponseHeaders headers() {
+        return headers;
+    }
+
+    /**
+     * Whether this response used TLS for an HTTPS target.
+     *
+     * @return whether the response is secure
+     */
+    public boolean secure() {
+        ClientConnectionTarget logicalTarget = target.logicalTarget();
+        return "https".equals(logicalTarget.scheme()) && logicalTarget.connectionKey().tls().enabled();
+    }
+
+    /**
+     * Time the response headers were received.
+     *
+     * @return receipt time
+     */
+    public Instant receivedAt() {
+        return receivedAt;
+    }
+
+    /**
+     * Alternative authority used for this request, if any.
+     *
+     * @return alternative authority
+     */
+    public Optional<UriAuthority> alternativeAuthority() {
+        return Optional.ofNullable(alternativeAuthority);
+    }
+
+    private static String requireProtocolId(String protocolId) {
+        String id = Objects.requireNonNull(protocolId, "protocolId");
+        if (id.isEmpty()) {
+            throw new IllegalArgumentException("Protocol identifier must not be empty");
+        }
+        return id;
+    }
+
+    private static final class SparseClientResponseHeaders implements ClientResponseHeaders {
+        private final Header[] headers;
+
+        private SparseClientResponseHeaders(ClientResponseHeaders source) {
+            Header[] copied = new Header[source.size()];
+            int index = 0;
+            for (Header header : source) {
+                if (index == copied.length) {
+                    copied = Arrays.copyOf(copied, Math.max(1, index * 2));
+                }
+                copied[index++] = new SnapshotHeader(header);
+            }
+            this.headers = index == copied.length ? copied : Arrays.copyOf(copied, index);
+        }
+
+        @Override
+        public List<String> all(HeaderName name, Supplier<List<String>> defaultSupplier) {
+            Header header = findOrNull(name);
+            return header == null ? defaultSupplier.get() : header.allValues();
+        }
+
+        @Override
+        public boolean contains(HeaderName name) {
+            return findOrNull(name) != null;
+        }
+
+        @Override
+        public boolean contains(Header headerWithValue) {
+            Header header = findOrNull(headerWithValue.headerName());
+            if (header == null) {
+                return false;
+            }
+            if (headerWithValue.valueCount() == 1 && header.valueCount() == 1) {
+                return headerWithValue.get().equals(header.get());
+            }
+            return headerWithValue.allValues().equals(header.allValues());
+        }
+
+        @Override
+        public Header get(HeaderName name) {
+            Header header = findOrNull(name);
+            if (header == null) {
+                throw new NoSuchElementException("Header " + name + " is not present in these headers");
+            }
+            return header;
+        }
+
+        @Override
+        public int size() {
+            return headers.length;
+        }
+
+        @Override
+        public List<HttpMediaType> acceptedTypes() {
+            Header accept = findOrNull(HeaderNames.ACCEPT);
+            if (accept == null) {
+                return List.of();
+            }
+
+            List<String> accepts = accept.allValues(true);
+            List<HttpMediaType> mediaTypes = new ArrayList<>(accepts.size());
+            for (String value : accepts) {
+                mediaTypes.add(HttpMediaType.create(value));
+            }
+            mediaTypes.sort(null);
+            return List.copyOf(mediaTypes);
+        }
+
+        @Override
+        public Iterator<Header> iterator() {
+            return new Iterator<>() {
+                private int index;
+
+                @Override
+                public boolean hasNext() {
+                    return index < headers.length;
+                }
+
+                @Override
+                public Header next() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
+                    return headers[index++];
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            for (Header header : headers) {
+                for (String value : header.allValues()) {
+                    builder.append(header.name())
+                            .append(": ");
+                    if (header.sensitive()) {
+                        builder.append("*".repeat(value.length()));
+                    } else {
+                        builder.append(value);
+                    }
+                    if (header.sensitive() || header.changing()) {
+                        builder.append(" (");
+                        if (header.sensitive()) {
+                            builder.append("sensitive");
+                            if (header.changing()) {
+                                builder.append(", ");
+                            }
+                        }
+                        if (header.changing()) {
+                            builder.append("changing");
+                        }
+                        builder.append(")");
+                    }
+                    builder.append("\n");
+                }
+            }
+            return builder.toString();
+        }
+
+        private Header findOrNull(HeaderName name) {
+            String lowerCase = Objects.requireNonNull(name, "name").lowerCase();
+            for (Header header : headers) {
+                HeaderName candidate = header.headerName();
+                if (candidate == name || candidate.lowerCase().equals(lowerCase)) {
+                    return header;
+                }
+            }
+            return null;
+        }
+    }
+
+    private static final class SnapshotHeader implements Header {
+        private static final String[] QUALIFIER = new String[] {"http", "header"};
+
+        private final HeaderName headerName;
+        private final String name;
+        private final String firstValue;
+        private final boolean sensitive;
+        private final boolean changing;
+        private volatile List<String> values;
+
+        private SnapshotHeader(Header source) {
+            this.headerName = source.headerName();
+            this.name = source.name();
+            this.firstValue = source.get();
+            if (source.valueCount() > 1) {
+                this.values = List.copyOf(source.allValues());
+            }
+            this.sensitive = source.sensitive();
+            this.changing = source.changing();
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public HeaderName headerName() {
+            return headerName;
+        }
+
+        @Override
+        public String get() {
+            return firstValue;
+        }
+
+        @Override
+        public String getString() {
+            return get();
+        }
+
+        @Override
+        public List<String> allValues() {
+            List<String> result = values;
+            if (result == null) {
+                result = List.of(firstValue);
+                values = result;
+            }
+            return result;
+        }
+
+        @Override
+        public int valueCount() {
+            List<String> result = values;
+            return result == null ? 1 : result.size();
+        }
+
+        @Override
+        public boolean sensitive() {
+            return sensitive;
+        }
+
+        @Override
+        public boolean changing() {
+            return changing;
+        }
+
+        @Override
+        public <N> Value<N> as(Class<N> type) {
+            return value().as(type);
+        }
+
+        @Override
+        public <N> Value<N> as(GenericType<N> type) {
+            return value().as(type);
+        }
+
+        @Override
+        public <N> Value<N> as(Function<? super String, ? extends N> mapper) {
+            return value().as(mapper);
+        }
+
+        @Override
+        public Optional<String> asOptional() {
+            return Optional.of(get());
+        }
+
+        @Override
+        public Value<Boolean> asBoolean() {
+            return value().asBoolean();
+        }
+
+        @Override
+        public Value<String> asString() {
+            return value();
+        }
+
+        @Override
+        public Value<Integer> asInt() {
+            return value().asInt();
+        }
+
+        @Override
+        public Value<Long> asLong() {
+            return value().asLong();
+        }
+
+        @Override
+        public Value<Double> asDouble() {
+            return value().asDouble();
+        }
+
+        private Value<String> value() {
+            return Value.create(name, get(), QUALIFIER);
+        }
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/HttpClientSpi.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/HttpClientSpi.java
@@ -16,10 +16,14 @@
 
 package io.helidon.webclient.spi;
 
+import java.util.Objects;
+
+import io.helidon.common.Api;
 import io.helidon.webclient.api.ClientRequest;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.ReleasableResource;
+import io.helidon.webclient.api.WebClientProtocolResponse;
 
 /**
  * Integration for HTTP versions to provide a single API.
@@ -69,6 +73,16 @@ public interface HttpClientSpi extends ReleasableResource {
      */
     ClientRequest<?> clientRequest(FullClientRequest<?> clientRequest,
                                    ClientUri clientUri);
+
+    /**
+     * Notification invoked after the WebClient receives a protocol response.
+     *
+     * @param response received protocol response
+     */
+    @Api.Internal
+    default void responseReceived(WebClientProtocolResponse response) {
+        Objects.requireNonNull(response, "response");
+    }
 
     /**
      * For TCP based protocols, we can do ALPN negotiation, obtain a connection, and then let the client handle the protocol.

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/HttpClientSpi.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/HttpClientSpi.java
@@ -75,7 +75,11 @@ public interface HttpClientSpi extends ReleasableResource {
                                    ClientUri clientUri);
 
     /**
-     * Notification invoked after the WebClient receives a protocol response.
+     * Notification invoked after the WebClient receives a transport response, regardless of the protocol that produced
+     * it.
+     * <p>
+     * An implementation may inspect response metadata relevant to its protocol. For example, it may learn about an
+     * alternative service from an {@code Alt-Svc} response header received over another protocol.
      *
      * @param response received protocol response
      */

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/WebClientService.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/WebClientService.java
@@ -16,8 +16,11 @@
 
 package io.helidon.webclient.spi;
 
+import java.util.Optional;
+
 import io.helidon.common.Api;
 import io.helidon.config.NamedService;
+import io.helidon.webclient.api.WebClientProtocolResponse;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 
@@ -71,5 +74,19 @@ public interface WebClientService extends NamedService {
          * @return protocol identifier
          */
         String protocolId();
+    }
+
+    /**
+     * Terminal service chain that can expose transport response context after an invocation.
+     */
+    @Api.Internal
+    interface TransportChain extends WireProtocolChain {
+        /**
+         * Create protocol response context for the completed response when applicable.
+         *
+         * @param response completed service response
+         * @return protocol response context, or empty when no protocol notification is needed
+         */
+        Optional<WebClientProtocolResponse> protocolResponse(WebClientServiceResponse response);
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
@@ -134,8 +134,15 @@ class AltSvcHeaderTest {
         assertThat(AltSvcHeader.create(responseHeaders("h%3=\":443\""), RECEIVED_AT).isEmpty(), is(true));
         assertThat(AltSvcHeader.create(responseHeaders("h%GG=\":443\""), RECEIVED_AT).isEmpty(), is(true));
         assertThat(AltSvcHeader.create(responseHeaders("h%32=\":443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.create(responseHeaders("h%3a=\":443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.create(responseHeaders("%ff=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+
+        AltSvcHeader lowercaseHex = AltSvcHeader.create(
+                responseHeaders("h2=\":8443\", foo%3abar%ff=\":9443\""),
+                RECEIVED_AT).orElseThrow();
+        assertThat(lowercaseHex.alternatives(), hasSize(2));
+        assertThat(lowercaseHex.alternatives().get(0).protocolId(), is("h2"));
+        String lowercaseProtocolId = lowercaseHex.alternatives().get(1).protocolId();
+        assertThat(lowercaseProtocolId.substring(0, 7), is("foo:bar"));
+        assertThat((int) lowercaseProtocolId.charAt(7), is(255));
     }
 
     @Test

--- a/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
@@ -383,7 +383,8 @@ class AltSvcHeaderTest {
 
         String flood = ",".repeat(33) + "h3=\":443\"";
         assertThat(AltSvcHeader.create(responseHeaders(flood), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.create(responseHeaders(flood + ",clear"), RECEIVED_AT).isEmpty(), is(true));
+        assertClear(responseHeaders(",".repeat(33) + "clear"));
+        assertClear(responseHeaders(flood + ",clear"));
         assertThat(AltSvcHeader.create(responseHeaders(",".repeat(16) + "h3=\":443\"",
                                                      ",".repeat(17) + "h2=\":8443\""),
                                       RECEIVED_AT).isEmpty(),

--- a/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
@@ -205,6 +205,17 @@ class AltSvcHeaderTest {
     }
 
     @Test
+    void usesFirstMemberOfListBasedAge() {
+        AltSvcHeader.Alternative alternative = AltSvcHeader.create(
+                        timedResponseHeaders("h3=\":443\"; ma=60", "50, 10", "not a date"), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+
+        assertThat(alternative.expirationTime(), is(RECEIVED_AT.plusSeconds(10)));
+    }
+
+    @Test
     void materializesMemoizedGrammarForEachResponse() {
         String value = "h3=\":443\"; ma=120; persist=1";
         Instant laterReceivedAt = RECEIVED_AT.plusSeconds(150);

--- a/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
@@ -38,19 +38,19 @@ class AltSvcHeaderTest {
 
     @Test
     void distinguishesAbsentMalformedAndClearUpdates() {
-        assertThat(AltSvcHeader.parse(responseHeaders(), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("CLEAR"), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=:443"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders(), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("CLEAR"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=:443"), RECEIVED_AT).isEmpty(), is(true));
 
-        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders(" \tclear\t "), RECEIVED_AT).orElseThrow();
+        AltSvcHeader clear = AltSvcHeader.create(responseHeaders(" \tclear\t "), RECEIVED_AT).orElseThrow();
         assertThat(clear.clear(), is(true));
         assertThat(clear.alternatives(), is(empty()));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\"unterminated", "clear"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\"unterminated", "clear"), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
     void parsesEveryFieldLineAndQuotedCommaAtomically() {
-        AltSvcHeader parsed = AltSvcHeader.parse(
+        AltSvcHeader parsed = AltSvcHeader.create(
                 responseHeaders("h3=\":443\"; ma=60; persist=1",
                                 "w%3Dx%3Ay#z=\"other.example:8443\"; note=\"a,b\""),
                 RECEIVED_AT).orElseThrow();
@@ -73,7 +73,7 @@ class AltSvcHeaderTest {
 
     @Test
     void ignoresBoundedEmptyCommaListElements() {
-        AltSvcHeader parsed = AltSvcHeader.parse(
+        AltSvcHeader parsed = AltSvcHeader.create(
                 responseHeaders(", , h3=\":443\",,\t,", ", h2=\":8443\", ,"),
                 RECEIVED_AT).orElseThrow();
 
@@ -84,18 +84,18 @@ class AltSvcHeaderTest {
 
     @Test
     void requiresClearAsCompleteFieldValue() {
-        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders(" \tclear\t "), RECEIVED_AT).orElseThrow();
+        AltSvcHeader clear = AltSvcHeader.create(responseHeaders(" \tclear\t "), RECEIVED_AT).orElseThrow();
 
         assertThat(clear.clear(), is(true));
         assertThat(clear.alternatives(), is(empty()));
-        assertThat(AltSvcHeader.parse(responseHeaders(",, \tclear\t, ,"), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h2=\":8443\", clear"), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("clear", "h2=\":8443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders(",, \tclear\t, ,"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h2=\":8443\", clear"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("clear", "h2=\":8443\""), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
     void preservesUnsupportedAlternativesAndDoesNotDecodeAuthority() {
-        AltSvcHeader.Alternative alternative = AltSvcHeader.parse(
+        AltSvcHeader.Alternative alternative = AltSvcHeader.create(
                         responseHeaders("unrelated=\"%68ost.example:9443\""),
                         RECEIVED_AT)
                 .orElseThrow()
@@ -109,7 +109,7 @@ class AltSvcHeaderTest {
 
     @Test
     void mapsDecodedProtocolOctetsWithoutTextTranscoding() {
-        AltSvcHeader.Alternative alternative = AltSvcHeader.parse(responseHeaders("%00%FF=\":443\""), RECEIVED_AT)
+        AltSvcHeader.Alternative alternative = AltSvcHeader.create(responseHeaders("%00%FF=\":443\""), RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
@@ -118,31 +118,31 @@ class AltSvcHeaderTest {
         assertThat((int) alternative.protocolId().charAt(0), is(0));
         assertThat((int) alternative.protocolId().charAt(1), is(255));
 
-        AltSvcHeader.Alternative percent = AltSvcHeader.parse(responseHeaders("x%25y=\":443\""), RECEIVED_AT)
+        AltSvcHeader.Alternative percent = AltSvcHeader.create(responseHeaders("x%25y=\":443\""), RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
         assertThat(percent.protocolId(), is("x%y"));
 
-        assertThat(AltSvcHeader.parse(responseHeaders("h%=\":443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h%3=\":443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h%GG=\":443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h%32=\":443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h%3a=\":443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("%ff=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h%=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h%3=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h%GG=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h%32=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h%3a=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("%ff=\":443\""), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
     void enforcesDecodedProtocolLength() {
-        assertThat(AltSvcHeader.parse(responseHeaders("a".repeat(255) + "=\":443\""), RECEIVED_AT).isPresent(),
+        assertThat(AltSvcHeader.create(responseHeaders("a".repeat(255) + "=\":443\""), RECEIVED_AT).isPresent(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("a".repeat(256) + "=\":443\""), RECEIVED_AT).isEmpty(),
+        assertThat(AltSvcHeader.create(responseHeaders("a".repeat(256) + "=\":443\""), RECEIVED_AT).isEmpty(),
                    is(true));
     }
 
     @Test
     void validatesPortOnlyDnsAndIpv6Authorities() {
-        AltSvcHeader parsed = AltSvcHeader.parse(
+        AltSvcHeader parsed = AltSvcHeader.create(
                 responseHeaders("h3=\":443\", h2=\"other.example:8443\", h3-29=\"[2001:db8::1]:9443\","
                                         + " h3-v1=\"[v1.fe80]:10443\""),
                 RECEIVED_AT).orElseThrow();
@@ -152,15 +152,15 @@ class AltSvcHeaderTest {
         assertThat(parsed.alternatives().get(2).host().orElseThrow(), is("2001:db8::1"));
         assertThat(parsed.alternatives().get(3).host().orElseThrow(), is("v1.fe80"));
         assertThat(parsed.alternatives().get(3).port(), is(10443));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\"2001:db8::1:443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\"[2001:db8::1]443\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":0\""), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":65536\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\"2001:db8::1:443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\"[2001:db8::1]443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":0\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":65536\""), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
     void appliesDefaultMaxAgeAndSaturatedAge() {
-        AltSvcHeader.Alternative defaultAge = AltSvcHeader.parse(responseHeaders("h3=\":443\""), RECEIVED_AT)
+        AltSvcHeader.Alternative defaultAge = AltSvcHeader.create(responseHeaders("h3=\":443\""), RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
@@ -168,13 +168,13 @@ class AltSvcHeaderTest {
 
         WritableHeaders<?> agedHeaders = altSvcHeaders("h3=\":443\"; ma=60");
         agedHeaders.add(HeaderValues.create(HeaderNames.AGE, "999999999999999999999999999999"));
-        AltSvcHeader.Alternative expired = AltSvcHeader.parse(ClientResponseHeaders.create(agedHeaders), RECEIVED_AT)
+        AltSvcHeader.Alternative expired = AltSvcHeader.create(ClientResponseHeaders.create(agedHeaders), RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
         assertThat(expired.expirationTime(), is(RECEIVED_AT));
 
-        AltSvcHeader.Alternative saturated = AltSvcHeader.parse(
+        AltSvcHeader.Alternative saturated = AltSvcHeader.create(
                         responseHeaders("h3=\":443\"; ma=999999999999999999999999999999"),
                         RECEIVED_AT)
                 .orElseThrow()
@@ -190,7 +190,7 @@ class AltSvcHeaderTest {
         headers.add(HeaderValues.create(HeaderNames.AGE, "30"));
         headers.add(HeaderValues.create(HeaderNames.DATE, "Sun, 23 Aug 2026 00:00:00 GMT"));
 
-        AltSvcHeader.Alternative alternative = AltSvcHeader.parse(ClientResponseHeaders.create(headers), RECEIVED_AT)
+        AltSvcHeader.Alternative alternative = AltSvcHeader.create(ClientResponseHeaders.create(headers), RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
@@ -203,13 +203,13 @@ class AltSvcHeaderTest {
         String value = "h3=\":443\"; ma=120; persist=1";
         Instant laterReceivedAt = RECEIVED_AT.plusSeconds(150);
 
-        AltSvcHeader.Alternative first = AltSvcHeader.parse(
+        AltSvcHeader.Alternative first = AltSvcHeader.create(
                         timedResponseHeaders(value, "45", "Sun, 23 Aug 2026 00:01:00 GMT"),
                         RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
-        AltSvcHeader.Alternative second = AltSvcHeader.parse(
+        AltSvcHeader.Alternative second = AltSvcHeader.create(
                         timedResponseHeaders(value, "20", "Sun, 23 Aug 2026 00:03:30 GMT"),
                         laterReceivedAt)
                 .orElseThrow()
@@ -229,11 +229,11 @@ class AltSvcHeaderTest {
         Instant laterReceivedAt = RECEIVED_AT.plusSeconds(90);
         Instant expectedExpiration = Instant.parse("2026-08-23T00:05:00Z");
 
-        AltSvcHeader.Alternative first = AltSvcHeader.parse(timedResponseHeaders(value, "0", date), RECEIVED_AT)
+        AltSvcHeader.Alternative first = AltSvcHeader.create(timedResponseHeaders(value, "0", date), RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
-        AltSvcHeader.Alternative second = AltSvcHeader.parse(timedResponseHeaders(value, "0", date), laterReceivedAt)
+        AltSvcHeader.Alternative second = AltSvcHeader.create(timedResponseHeaders(value, "0", date), laterReceivedAt)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
@@ -246,12 +246,12 @@ class AltSvcHeaderTest {
     void memoizedInvalidDateStillHonorsAge() {
         String value = "h3=\":443\"; ma=120";
 
-        AltSvcHeader.Alternative first = AltSvcHeader.parse(
+        AltSvcHeader.Alternative first = AltSvcHeader.create(
                         timedResponseHeaders(value, "10", "not a date"), RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
                 .getFirst();
-        AltSvcHeader.Alternative second = AltSvcHeader.parse(
+        AltSvcHeader.Alternative second = AltSvcHeader.create(
                         timedResponseHeaders(value, "85", "not a date"), RECEIVED_AT)
                 .orElseThrow()
                 .alternatives()
@@ -264,25 +264,25 @@ class AltSvcHeaderTest {
     @Test
     void memoizesExactMalformedAndClearGrammar() {
         ClientResponseHeaders malformed = responseHeaders("h3=:443");
-        assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(malformed, RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(malformed, RECEIVED_AT).isEmpty(), is(true));
 
         ClientResponseHeaders clearHeaders = responseHeaders(" \tclear\t ");
-        AltSvcHeader firstClear = AltSvcHeader.parse(clearHeaders, RECEIVED_AT).orElseThrow();
-        AltSvcHeader secondClear = AltSvcHeader.parse(clearHeaders, RECEIVED_AT).orElseThrow();
+        AltSvcHeader firstClear = AltSvcHeader.create(clearHeaders, RECEIVED_AT).orElseThrow();
+        AltSvcHeader secondClear = AltSvcHeader.create(clearHeaders, RECEIVED_AT).orElseThrow();
         assertThat(firstClear.clear(), is(true));
         assertThat(secondClear.clear(), is(true));
     }
 
     @Test
     void changingOneFieldLineReplacesTheGrammarMemo() {
-        AltSvcHeader initial = AltSvcHeader.parse(
+        AltSvcHeader initial = AltSvcHeader.create(
                 responseHeaders("h3=\":443\"", "h2=\":8443\""),
                 RECEIVED_AT).orElseThrow();
-        AltSvcHeader changed = AltSvcHeader.parse(
+        AltSvcHeader changed = AltSvcHeader.create(
                 responseHeaders("h3=\":443\"", "h2=\"other.example:9443\""),
                 RECEIVED_AT).orElseThrow();
-        AltSvcHeader restored = AltSvcHeader.parse(
+        AltSvcHeader restored = AltSvcHeader.create(
                 responseHeaders("h3=\":443\"", "h2=\":8443\""),
                 RECEIVED_AT).orElseThrow();
 
@@ -295,17 +295,17 @@ class AltSvcHeaderTest {
     @Test
     void preservesFieldLineBoundariesAcrossMemoReplacement() {
         ClientResponseHeaders malformed = responseHeaders("h3=\"unterminated", "clear");
-        assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(malformed, RECEIVED_AT).isEmpty(), is(true));
 
-        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders("clear"), RECEIVED_AT).orElseThrow();
+        AltSvcHeader clear = AltSvcHeader.create(responseHeaders("clear"), RECEIVED_AT).orElseThrow();
         assertThat(clear.clear(), is(true));
 
-        assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(malformed, RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
     void decodesAndValidatesQuotedParameterValues() {
-        AltSvcHeader.Alternative alternative = AltSvcHeader.parse(
+        AltSvcHeader.Alternative alternative = AltSvcHeader.create(
                         responseHeaders("h3=\":443\"; ma=\"6\\0\"; persist=\"1\"; note=\"a\\\"b\""),
                         RECEIVED_AT)
                 .orElseThrow()
@@ -316,17 +316,17 @@ class AltSvcHeaderTest {
         assertThat(alternative.persist(), is(true));
 
         String rawNull = "h3=\":443\"; note=\"a" + '\0' + "b\"";
-        assertThat(AltSvcHeader.parse(responseHeaders(rawNull), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; note=\"a\rb\""), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders(rawNull), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\"; note=\"a\rb\""), RECEIVED_AT)
                            .isEmpty(),
                    is(true));
         String escapedNull = "h3=\":443\"; note=\"a\\" + '\0' + "b\"";
-        assertThat(AltSvcHeader.parse(responseHeaders(escapedNull), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders(escapedNull), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
     void rejectsMalformedMembersAndDuplicateMaxAgeAsOneUpdate() {
-        AltSvcHeader.Alternative withOws = AltSvcHeader.parse(
+        AltSvcHeader.Alternative withOws = AltSvcHeader.create(
                         responseHeaders(" \th3=\":443\" \t;\t ma=60\t "),
                         RECEIVED_AT)
                 .orElseThrow()
@@ -335,50 +335,50 @@ class AltSvcHeaderTest {
         assertThat(withOws.protocolId(), is("h3"));
         assertThat(withOws.expirationTime(), is(RECEIVED_AT.plusSeconds(60)));
 
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=:8443"), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2 =\":8443\""), RECEIVED_AT).isEmpty(),
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\", h2=:8443"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\", h2 =\":8443\""), RECEIVED_AT).isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2= \"other.example:8443\""), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\", h2= \"other.example:8443\""), RECEIVED_AT)
                            .isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=\":8443\"; ma =60"), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\", h2=\":8443\"; ma =60"), RECEIVED_AT)
                            .isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"\u000B, h2=\":8443\""), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\"\u000B, h2=\":8443\""), RECEIVED_AT)
                            .isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=\"bad/path:8443\""), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\", h2=\"bad/path:8443\""), RECEIVED_AT)
                            .isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=\"[not-an-ip]:8443\""), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\", h2=\"[not-an-ip]:8443\""), RECEIVED_AT)
                            .isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=\"bücher.example:8443\""), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\", h2=\"bücher.example:8443\""), RECEIVED_AT)
                            .isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; ma=60; MA=30"), RECEIVED_AT).isEmpty(),
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\"; ma=60; MA=30"), RECEIVED_AT).isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; broken"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\"; broken"), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
     void keepsEmptyParameterElementsMalformed() {
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\";; ma=60"), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; ma=60;; persist=1"), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\";; ma=60"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\"; ma=60;; persist=1"), RECEIVED_AT)
                            .isEmpty(),
                    is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; ma=60;"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("h3=\":443\"; ma=60;"), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
     void boundsIgnoredEmptyElements() {
         String accepted = ",".repeat(32) + "h3=\":443\"";
-        assertThat(AltSvcHeader.parse(responseHeaders(accepted), RECEIVED_AT).isPresent(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders(accepted), RECEIVED_AT).isPresent(), is(true));
 
         String flood = ",".repeat(33) + "h3=\":443\"";
-        assertThat(AltSvcHeader.parse(responseHeaders(flood), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders(flood + ",clear"), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.parse(responseHeaders(",".repeat(16) + "h3=\":443\"",
+        assertThat(AltSvcHeader.create(responseHeaders(flood), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders(flood + ",clear"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders(",".repeat(16) + "h3=\":443\"",
                                                      ",".repeat(17) + "h2=\":8443\""),
                                       RECEIVED_AT).isEmpty(),
                    is(true));
@@ -390,16 +390,16 @@ class AltSvcHeaderTest {
         for (int index = 0; index < 32; index++) {
             alternatives.add("h" + index + "=\":" + (8000 + index) + "\"");
         }
-        assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT)
+        assertThat(AltSvcHeader.create(responseHeaders(String.join(",", alternatives)), RECEIVED_AT)
                            .orElseThrow()
                            .alternatives(),
                    hasSize(32));
 
         alternatives.add("h32=\":8032\"");
-        assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
+        assertThat(AltSvcHeader.create(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
                    is(true));
         alternatives.add("clear");
-        assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
+        assertThat(AltSvcHeader.create(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
                    is(true));
     }
 

--- a/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.WritableHeaders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+class AltSvcHeaderTest {
+    private static final Instant RECEIVED_AT = Instant.parse("2026-08-23T00:01:30Z");
+
+    @Test
+    void distinguishesAbsentMalformedAndClearUpdates() {
+        assertThat(AltSvcHeader.parse(responseHeaders(), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("CLEAR"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=:443"), RECEIVED_AT).isEmpty(), is(true));
+
+        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders("h3=\"unterminated", "clear"), RECEIVED_AT)
+                .orElseThrow();
+        assertThat(clear.clear(), is(true));
+        assertThat(clear.alternatives(), is(empty()));
+    }
+
+    @Test
+    void parsesEveryFieldLineAndQuotedCommaAtomically() {
+        AltSvcHeader parsed = AltSvcHeader.parse(
+                responseHeaders("h3=\":443\"; ma=60; persist=1",
+                                "w%3Dx%3Ay#z=\"other.example:8443\"; note=\"a,b\""),
+                RECEIVED_AT).orElseThrow();
+
+        assertThat(parsed.clear(), is(false));
+        assertThat(parsed.alternatives(), hasSize(2));
+        AltSvcHeader.Alternative first = parsed.alternatives().get(0);
+        assertThat(first.protocolId(), is("h3"));
+        assertThat(first.host().isEmpty(), is(true));
+        assertThat(first.port(), is(443));
+        assertThat(first.expirationTime(), is(RECEIVED_AT.plusSeconds(60)));
+        assertThat(first.persist(), is(true));
+
+        AltSvcHeader.Alternative second = parsed.alternatives().get(1);
+        assertThat(second.protocolId(), is("w=x:y#z"));
+        assertThat(second.host().orElseThrow(), is("other.example"));
+        assertThat(second.port(), is(8443));
+        assertThat(second.persist(), is(false));
+    }
+
+    @Test
+    void ignoresBoundedEmptyCommaListElements() {
+        AltSvcHeader parsed = AltSvcHeader.parse(
+                responseHeaders(", , h3=\":443\",,\t,", ", h2=\":8443\", ,"),
+                RECEIVED_AT).orElseThrow();
+
+        assertThat(parsed.alternatives(), hasSize(2));
+        assertThat(parsed.alternatives().get(0).protocolId(), is("h3"));
+        assertThat(parsed.alternatives().get(1).protocolId(), is("h2"));
+    }
+
+    @Test
+    void ignoresEmptyElementsAroundClear() {
+        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders(",, \tclear\t, ,"), RECEIVED_AT).orElseThrow();
+
+        assertThat(clear.clear(), is(true));
+        assertThat(clear.alternatives(), is(empty()));
+    }
+
+    @Test
+    void preservesUnsupportedAlternativesAndDoesNotDecodeAuthority() {
+        AltSvcHeader.Alternative alternative = AltSvcHeader.parse(
+                        responseHeaders("unrelated=\"%68ost.example:9443\""),
+                        RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+
+        assertThat(alternative.protocolId(), is("unrelated"));
+        assertThat(alternative.host().orElseThrow(), is("%68ost.example"));
+        assertThat(alternative.port(), is(9443));
+    }
+
+    @Test
+    void mapsDecodedProtocolOctetsWithoutTextTranscoding() {
+        AltSvcHeader.Alternative alternative = AltSvcHeader.parse(responseHeaders("%00%FF=\":443\""), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+
+        assertThat(alternative.protocolId().length(), is(2));
+        assertThat((int) alternative.protocolId().charAt(0), is(0));
+        assertThat((int) alternative.protocolId().charAt(1), is(255));
+
+        AltSvcHeader.Alternative percent = AltSvcHeader.parse(responseHeaders("x%25y=\":443\""), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+        assertThat(percent.protocolId(), is("x%y"));
+
+        assertThat(AltSvcHeader.parse(responseHeaders("h%=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h%3=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h%GG=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h%32=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h%3a=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("%ff=\":443\""), RECEIVED_AT).isEmpty(), is(true));
+    }
+
+    @Test
+    void enforcesDecodedProtocolLength() {
+        assertThat(AltSvcHeader.parse(responseHeaders("a".repeat(255) + "=\":443\""), RECEIVED_AT).isPresent(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("a".repeat(256) + "=\":443\""), RECEIVED_AT).isEmpty(),
+                   is(true));
+    }
+
+    @Test
+    void validatesPortOnlyDnsAndIpv6Authorities() {
+        AltSvcHeader parsed = AltSvcHeader.parse(
+                responseHeaders("h3=\":443\", h2=\"other.example:8443\", h3-29=\"[2001:db8::1]:9443\","
+                                        + " h3-v1=\"[v1.fe80]:10443\""),
+                RECEIVED_AT).orElseThrow();
+
+        assertThat(parsed.alternatives().get(0).host().isEmpty(), is(true));
+        assertThat(parsed.alternatives().get(1).host().orElseThrow(), is("other.example"));
+        assertThat(parsed.alternatives().get(2).host().orElseThrow(), is("2001:db8::1"));
+        assertThat(parsed.alternatives().get(3).host().orElseThrow(), is("v1.fe80"));
+        assertThat(parsed.alternatives().get(3).port(), is(10443));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\"2001:db8::1:443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\"[2001:db8::1]443\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":0\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":65536\""), RECEIVED_AT).isEmpty(), is(true));
+    }
+
+    @Test
+    void appliesDefaultMaxAgeAndSaturatedAge() {
+        AltSvcHeader.Alternative defaultAge = AltSvcHeader.parse(responseHeaders("h3=\":443\""), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+        assertThat(defaultAge.expirationTime(), is(RECEIVED_AT.plus(Duration.ofHours(24))));
+
+        WritableHeaders<?> agedHeaders = altSvcHeaders("h3=\":443\"; ma=60");
+        agedHeaders.add(HeaderValues.create(HeaderNames.AGE, "999999999999999999999999999999"));
+        AltSvcHeader.Alternative expired = AltSvcHeader.parse(ClientResponseHeaders.create(agedHeaders), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+        assertThat(expired.expirationTime(), is(RECEIVED_AT));
+
+        AltSvcHeader.Alternative saturated = AltSvcHeader.parse(
+                        responseHeaders("h3=\":443\"; ma=999999999999999999999999999999"),
+                        RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+        long maximumFreshness = Duration.between(RECEIVED_AT, Instant.MAX).toSeconds();
+        assertThat(saturated.expirationTime(), is(RECEIVED_AT.plusSeconds(maximumFreshness)));
+    }
+
+    @Test
+    void accountsForTheGreaterOfAgeAndDate() {
+        WritableHeaders<?> headers = altSvcHeaders("h3=\":443\"; ma=120");
+        headers.add(HeaderValues.create(HeaderNames.AGE, "30"));
+        headers.add(HeaderValues.create(HeaderNames.DATE, "Sun, 23 Aug 2026 00:00:00 GMT"));
+
+        AltSvcHeader.Alternative alternative = AltSvcHeader.parse(ClientResponseHeaders.create(headers), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+
+        assertThat(alternative.expirationTime(), is(RECEIVED_AT.plusSeconds(30)));
+    }
+
+    @Test
+    void materializesMemoizedGrammarForEachResponse() {
+        String value = "h3=\":443\"; ma=120; persist=1";
+        Instant laterReceivedAt = RECEIVED_AT.plusSeconds(150);
+
+        AltSvcHeader.Alternative first = AltSvcHeader.parse(
+                        timedResponseHeaders(value, "45", "Sun, 23 Aug 2026 00:01:00 GMT"),
+                        RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+        AltSvcHeader.Alternative second = AltSvcHeader.parse(
+                        timedResponseHeaders(value, "20", "Sun, 23 Aug 2026 00:03:30 GMT"),
+                        laterReceivedAt)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+
+        assertThat(first.expirationTime(), is(RECEIVED_AT.plusSeconds(75)));
+        assertThat(second.expirationTime(), is(laterReceivedAt.plusSeconds(90)));
+        assertThat(first.persist(), is(true));
+        assertThat(second.persist(), is(true));
+    }
+
+    @Test
+    void recomputesAgeForAMemoizedDate() {
+        String value = "h3=\":443\"; ma=300";
+        String date = "Sun, 23 Aug 2026 00:00:00 GMT";
+        Instant laterReceivedAt = RECEIVED_AT.plusSeconds(90);
+        Instant expectedExpiration = Instant.parse("2026-08-23T00:05:00Z");
+
+        AltSvcHeader.Alternative first = AltSvcHeader.parse(timedResponseHeaders(value, "0", date), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+        AltSvcHeader.Alternative second = AltSvcHeader.parse(timedResponseHeaders(value, "0", date), laterReceivedAt)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+
+        assertThat(first.expirationTime(), is(expectedExpiration));
+        assertThat(second.expirationTime(), is(expectedExpiration));
+    }
+
+    @Test
+    void memoizedInvalidDateStillHonorsAge() {
+        String value = "h3=\":443\"; ma=120";
+
+        AltSvcHeader.Alternative first = AltSvcHeader.parse(
+                        timedResponseHeaders(value, "10", "not a date"), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+        AltSvcHeader.Alternative second = AltSvcHeader.parse(
+                        timedResponseHeaders(value, "85", "not a date"), RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+
+        assertThat(first.expirationTime(), is(RECEIVED_AT.plusSeconds(110)));
+        assertThat(second.expirationTime(), is(RECEIVED_AT.plusSeconds(35)));
+    }
+
+    @Test
+    void memoizesExactMalformedAndClearGrammar() {
+        ClientResponseHeaders malformed = responseHeaders("h3=:443");
+        assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
+
+        ClientResponseHeaders clearHeaders = responseHeaders(", clear,");
+        AltSvcHeader firstClear = AltSvcHeader.parse(clearHeaders, RECEIVED_AT).orElseThrow();
+        AltSvcHeader secondClear = AltSvcHeader.parse(clearHeaders, RECEIVED_AT).orElseThrow();
+        assertThat(firstClear.clear(), is(true));
+        assertThat(secondClear.clear(), is(true));
+    }
+
+    @Test
+    void changingOneFieldLineReplacesTheGrammarMemo() {
+        AltSvcHeader initial = AltSvcHeader.parse(
+                responseHeaders("h3=\":443\"", "h2=\":8443\""),
+                RECEIVED_AT).orElseThrow();
+        AltSvcHeader changed = AltSvcHeader.parse(
+                responseHeaders("h3=\":443\"", "h2=\"other.example:9443\""),
+                RECEIVED_AT).orElseThrow();
+        AltSvcHeader restored = AltSvcHeader.parse(
+                responseHeaders("h3=\":443\"", "h2=\":8443\""),
+                RECEIVED_AT).orElseThrow();
+
+        assertThat(initial.alternatives().get(1).port(), is(8443));
+        assertThat(changed.alternatives().get(1).host().orElseThrow(), is("other.example"));
+        assertThat(changed.alternatives().get(1).port(), is(9443));
+        assertThat(restored.alternatives().get(1).port(), is(8443));
+    }
+
+    @Test
+    void preservesFieldLineBoundariesAcrossMemoReplacement() {
+        AltSvcHeader clear = AltSvcHeader.parse(
+                responseHeaders("h3=\"unterminated", "clear"),
+                RECEIVED_AT).orElseThrow();
+        assertThat(clear.clear(), is(true));
+
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\"unterminated,clear"), RECEIVED_AT).isEmpty(), is(true));
+
+        AltSvcHeader restored = AltSvcHeader.parse(
+                responseHeaders("h3=\"unterminated", "clear"),
+                RECEIVED_AT).orElseThrow();
+        assertThat(restored.clear(), is(true));
+    }
+
+    @Test
+    void decodesAndValidatesQuotedParameterValues() {
+        AltSvcHeader.Alternative alternative = AltSvcHeader.parse(
+                        responseHeaders("h3=\":443\"; ma=\"6\\0\"; persist=\"1\"; note=\"a\\\"b\""),
+                        RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+
+        assertThat(alternative.expirationTime(), is(RECEIVED_AT.plusSeconds(60)));
+        assertThat(alternative.persist(), is(true));
+
+        String rawNull = "h3=\":443\"; note=\"a" + '\0' + "b\"";
+        assertThat(AltSvcHeader.parse(responseHeaders(rawNull), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; note=\"a\rb\""), RECEIVED_AT)
+                           .isEmpty(),
+                   is(true));
+        String escapedNull = "h3=\":443\"; note=\"a\\" + '\0' + "b\"";
+        assertThat(AltSvcHeader.parse(responseHeaders(escapedNull), RECEIVED_AT).isEmpty(), is(true));
+    }
+
+    @Test
+    void rejectsMalformedMembersAndDuplicateMaxAgeAsOneUpdate() {
+        AltSvcHeader.Alternative withOws = AltSvcHeader.parse(
+                        responseHeaders(" \th3=\":443\" \t;\t ma=60\t "),
+                        RECEIVED_AT)
+                .orElseThrow()
+                .alternatives()
+                .getFirst();
+        assertThat(withOws.protocolId(), is("h3"));
+        assertThat(withOws.expirationTime(), is(RECEIVED_AT.plusSeconds(60)));
+
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=:8443"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2 =\":8443\""), RECEIVED_AT).isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2= \"other.example:8443\""), RECEIVED_AT)
+                           .isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=\":8443\"; ma =60"), RECEIVED_AT)
+                           .isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"\u000B, h2=\":8443\""), RECEIVED_AT)
+                           .isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=\"bad/path:8443\""), RECEIVED_AT)
+                           .isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=\"[not-an-ip]:8443\""), RECEIVED_AT)
+                           .isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\", h2=\"bücher.example:8443\""), RECEIVED_AT)
+                           .isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; ma=60; MA=30"), RECEIVED_AT).isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; broken"), RECEIVED_AT).isEmpty(), is(true));
+    }
+
+    @Test
+    void keepsEmptyParameterElementsMalformed() {
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\";; ma=60"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; ma=60;; persist=1"), RECEIVED_AT)
+                           .isEmpty(),
+                   is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\":443\"; ma=60;"), RECEIVED_AT).isEmpty(), is(true));
+    }
+
+    @Test
+    void boundsIgnoredEmptyElements() {
+        String accepted = ",".repeat(32) + "h3=\":443\"";
+        assertThat(AltSvcHeader.parse(responseHeaders(accepted), RECEIVED_AT).isPresent(), is(true));
+
+        String flood = ",".repeat(33) + "h3=\":443\"";
+        assertThat(AltSvcHeader.parse(responseHeaders(flood), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders(flood + ",clear"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders(",".repeat(16) + "h3=\":443\"",
+                                                     ",".repeat(17) + "h2=\":8443\""),
+                                      RECEIVED_AT).isEmpty(),
+                   is(true));
+    }
+
+    @Test
+    void boundsTheAtomicAlternativeSetAcrossFieldLines() {
+        List<String> alternatives = new ArrayList<>();
+        for (int index = 0; index < 32; index++) {
+            alternatives.add("h" + index + "=\":" + (8000 + index) + "\"");
+        }
+        assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT)
+                           .orElseThrow()
+                           .alternatives(),
+                   hasSize(32));
+
+        alternatives.add("h32=\":8032\"");
+        assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
+                   is(true));
+        alternatives.add("clear");
+        assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT)
+                           .orElseThrow()
+                           .clear(),
+                   is(true));
+    }
+
+    private static ClientResponseHeaders responseHeaders(String... altSvcValues) {
+        return ClientResponseHeaders.create(altSvcHeaders(altSvcValues));
+    }
+
+    private static ClientResponseHeaders timedResponseHeaders(String altSvcValue, String age, String date) {
+        WritableHeaders<?> headers = altSvcHeaders(altSvcValue);
+        headers.add(HeaderValues.create(HeaderNames.AGE, age));
+        headers.add(HeaderValues.create(HeaderNames.DATE, date));
+        return ClientResponseHeaders.create(headers);
+    }
+
+    private static WritableHeaders<?> altSvcHeaders(String... values) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        for (String value : values) {
+            headers.add(HeaderValues.create(HeaderNames.ALT_SVC, value));
+        }
+        return headers;
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
@@ -45,7 +45,6 @@ class AltSvcHeaderTest {
         AltSvcHeader clear = AltSvcHeader.create(responseHeaders(" \tclear\t "), RECEIVED_AT).orElseThrow();
         assertThat(clear.clear(), is(true));
         assertThat(clear.alternatives(), is(empty()));
-        assertThat(AltSvcHeader.create(responseHeaders("h3=\"unterminated", "clear"), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
@@ -83,14 +82,21 @@ class AltSvcHeaderTest {
     }
 
     @Test
-    void requiresClearAsCompleteFieldValue() {
-        AltSvcHeader clear = AltSvcHeader.create(responseHeaders(" \tclear\t "), RECEIVED_AT).orElseThrow();
+    void clearInvalidatesMixedAlternatives() {
+        assertClear(responseHeaders(",, \tclear\t, ,"));
+        assertClear(responseHeaders("h2=\":8443\", clear"));
+        assertClear(responseHeaders("clear", "h2=\":8443\""));
+        assertClear(responseHeaders("h3=\"unterminated", "clear"));
 
-        assertThat(clear.clear(), is(true));
-        assertThat(clear.alternatives(), is(empty()));
-        assertThat(AltSvcHeader.create(responseHeaders(",, \tclear\t, ,"), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.create(responseHeaders("h2=\":8443\", clear"), RECEIVED_AT).isEmpty(), is(true));
-        assertThat(AltSvcHeader.create(responseHeaders("clear", "h2=\":8443\""), RECEIVED_AT).isEmpty(), is(true));
+        AltSvcHeader clearProtocol = AltSvcHeader.create(responseHeaders("clear=\":8443\""), RECEIVED_AT).orElseThrow();
+        assertThat(clearProtocol.clear(), is(false));
+        assertThat(clearProtocol.alternatives(), hasSize(1));
+        assertThat(AltSvcHeader.create(responseHeaders("h2=\":8443\"; note=clear"), RECEIVED_AT)
+                           .orElseThrow()
+                           .clear(),
+                   is(false));
+        assertThat(AltSvcHeader.create(responseHeaders("\"clear\""), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.create(responseHeaders("clear; foo=bar"), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
@@ -295,12 +301,12 @@ class AltSvcHeaderTest {
     @Test
     void preservesFieldLineBoundariesAcrossMemoReplacement() {
         ClientResponseHeaders malformed = responseHeaders("h3=\"unterminated", "clear");
-        assertThat(AltSvcHeader.create(malformed, RECEIVED_AT).isEmpty(), is(true));
+        assertClear(malformed);
 
         AltSvcHeader clear = AltSvcHeader.create(responseHeaders("clear"), RECEIVED_AT).orElseThrow();
         assertThat(clear.clear(), is(true));
 
-        assertThat(AltSvcHeader.create(malformed, RECEIVED_AT).isEmpty(), is(true));
+        assertClear(malformed);
     }
 
     @Test
@@ -399,8 +405,7 @@ class AltSvcHeaderTest {
         assertThat(AltSvcHeader.create(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
                    is(true));
         alternatives.add("clear");
-        assertThat(AltSvcHeader.create(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
-                   is(true));
+        assertClear(responseHeaders(String.join(",", alternatives)));
     }
 
     private static ClientResponseHeaders responseHeaders(String... altSvcValues) {
@@ -420,5 +425,11 @@ class AltSvcHeaderTest {
             headers.add(HeaderValues.create(HeaderNames.ALT_SVC, value));
         }
         return headers;
+    }
+
+    private static void assertClear(ClientResponseHeaders headers) {
+        AltSvcHeader clear = AltSvcHeader.create(headers, RECEIVED_AT).orElseThrow();
+        assertThat(clear.clear(), is(true));
+        assertThat(clear.alternatives(), is(empty()));
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/AltSvcHeaderTest.java
@@ -42,10 +42,10 @@ class AltSvcHeaderTest {
         assertThat(AltSvcHeader.parse(responseHeaders("CLEAR"), RECEIVED_AT).isEmpty(), is(true));
         assertThat(AltSvcHeader.parse(responseHeaders("h3=:443"), RECEIVED_AT).isEmpty(), is(true));
 
-        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders("h3=\"unterminated", "clear"), RECEIVED_AT)
-                .orElseThrow();
+        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders(" \tclear\t "), RECEIVED_AT).orElseThrow();
         assertThat(clear.clear(), is(true));
         assertThat(clear.alternatives(), is(empty()));
+        assertThat(AltSvcHeader.parse(responseHeaders("h3=\"unterminated", "clear"), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
@@ -83,11 +83,14 @@ class AltSvcHeaderTest {
     }
 
     @Test
-    void ignoresEmptyElementsAroundClear() {
-        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders(",, \tclear\t, ,"), RECEIVED_AT).orElseThrow();
+    void requiresClearAsCompleteFieldValue() {
+        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders(" \tclear\t "), RECEIVED_AT).orElseThrow();
 
         assertThat(clear.clear(), is(true));
         assertThat(clear.alternatives(), is(empty()));
+        assertThat(AltSvcHeader.parse(responseHeaders(",, \tclear\t, ,"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("h2=\":8443\", clear"), RECEIVED_AT).isEmpty(), is(true));
+        assertThat(AltSvcHeader.parse(responseHeaders("clear", "h2=\":8443\""), RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
@@ -264,7 +267,7 @@ class AltSvcHeaderTest {
         assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
         assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
 
-        ClientResponseHeaders clearHeaders = responseHeaders(", clear,");
+        ClientResponseHeaders clearHeaders = responseHeaders(" \tclear\t ");
         AltSvcHeader firstClear = AltSvcHeader.parse(clearHeaders, RECEIVED_AT).orElseThrow();
         AltSvcHeader secondClear = AltSvcHeader.parse(clearHeaders, RECEIVED_AT).orElseThrow();
         assertThat(firstClear.clear(), is(true));
@@ -291,17 +294,13 @@ class AltSvcHeaderTest {
 
     @Test
     void preservesFieldLineBoundariesAcrossMemoReplacement() {
-        AltSvcHeader clear = AltSvcHeader.parse(
-                responseHeaders("h3=\"unterminated", "clear"),
-                RECEIVED_AT).orElseThrow();
+        ClientResponseHeaders malformed = responseHeaders("h3=\"unterminated", "clear");
+        assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
+
+        AltSvcHeader clear = AltSvcHeader.parse(responseHeaders("clear"), RECEIVED_AT).orElseThrow();
         assertThat(clear.clear(), is(true));
 
-        assertThat(AltSvcHeader.parse(responseHeaders("h3=\"unterminated,clear"), RECEIVED_AT).isEmpty(), is(true));
-
-        AltSvcHeader restored = AltSvcHeader.parse(
-                responseHeaders("h3=\"unterminated", "clear"),
-                RECEIVED_AT).orElseThrow();
-        assertThat(restored.clear(), is(true));
+        assertThat(AltSvcHeader.parse(malformed, RECEIVED_AT).isEmpty(), is(true));
     }
 
     @Test
@@ -400,9 +399,7 @@ class AltSvcHeaderTest {
         assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
                    is(true));
         alternatives.add("clear");
-        assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT)
-                           .orElseThrow()
-                           .clear(),
+        assertThat(AltSvcHeader.parse(responseHeaders(String.join(",", alternatives)), RECEIVED_AT).isEmpty(),
                    is(true));
     }
 

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientAltSvcConfigTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientAltSvcConfigTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClientAltSvcConfigTest {
+    @Test
+    void defaultsEnableAllAvailableProtocols() {
+        ClientAltSvcConfig config = ClientAltSvcConfig.create();
+
+        assertThat(config.enabled(), is(true));
+        assertThat(config.protocols().isEmpty(), is(true));
+    }
+
+    @Test
+    void acceptsOpaqueAndUnavailableProtocolIdentifiers() {
+        ClientAltSvcConfig config = ClientAltSvcConfig.builder()
+                .addProtocol("h2")
+                .addProtocol("H2")
+                .addProtocol("future-protocol")
+                .addProtocol("h\u00ff")
+                .build();
+
+        assertThat(config.protocols(), containsInAnyOrder("h2", "H2", "future-protocol", "h\u00ff"));
+    }
+
+    @Test
+    void rejectsInvalidProtocolIdentifiersWhenEnabled() {
+        var empty = assertThrows(IllegalArgumentException.class,
+                                 () -> ClientAltSvcConfig.builder().addProtocol("").build());
+        var tooLong = assertThrows(IllegalArgumentException.class,
+                                   () -> ClientAltSvcConfig.builder().addProtocol("h".repeat(256)).build());
+        var outsideByteRange = assertThrows(IllegalArgumentException.class,
+                                            () -> ClientAltSvcConfig.builder().addProtocol("h\u0100").build());
+
+        assertThat(empty.getMessage(), containsString("cannot be empty"));
+        assertThat(tooLong.getMessage(), containsString("255-byte ALPN limit"));
+        assertThat(outsideByteRange.getMessage(), containsString("outside the byte range"));
+    }
+
+    @Test
+    void disabledPolicyOverridesUnusedProtocolValidation() {
+        ClientAltSvcConfig config = ClientAltSvcConfig.builder()
+                .enabled(false)
+                .addProtocol("")
+                .addProtocol("h\u0100")
+                .build();
+
+        assertThat(config.enabled(), is(false));
+        assertThat(config.protocols(), containsInAnyOrder("", "h\u0100"));
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientConnectionTargetTest.java
@@ -762,6 +762,177 @@ class ClientConnectionTargetTest {
     }
 
     @Test
+    void canonicalizesAltSvcLookupOriginDnsCaseInBothDirections() {
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        ClientUri mixedCaseUri = ClientUri.create(URI.create("HTTPS://Example.COM:443/path"));
+        ClientUri lowerCaseUri = ClientUri.create(URI.create("https://example.com:443/path"));
+        ConnectionKey mixedCaseKey = ConnectionKey.create(mixedCaseUri,
+                                                          TLS,
+                                                          resolver,
+                                                          DnsAddressLookup.IPV4,
+                                                          Proxy.noProxy());
+        ConnectionKey lowerCaseKey = ConnectionKey.create(lowerCaseUri,
+                                                          TLS,
+                                                          resolver,
+                                                          DnsAddressLookup.IPV4,
+                                                          Proxy.noProxy());
+        ClientRequestHeaders mixedCaseHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        mixedCaseHeaders.set(HeaderNames.HOST, "Alt-Origin.Example:9443");
+        ClientRequestHeaders lowerCaseHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        lowerCaseHeaders.set(HeaderNames.HOST, "alt-origin.example:9443");
+        ClientConnectionTarget.LookupKey mixedCase = ClientConnectionTarget.lookupKey(mixedCaseKey,
+                                                                                       mixedCaseUri,
+                                                                                       mixedCaseHeaders);
+        ClientConnectionTarget.LookupKey lowerCase = ClientConnectionTarget.lookupKey(lowerCaseKey,
+                                                                                       lowerCaseUri,
+                                                                                       lowerCaseHeaders);
+
+        assertThat(mixedCase, not(lowerCase));
+        assertThat(mixedCase.altSvcOriginKey(), is(lowerCase.altSvcOriginKey()));
+        assertThat(lowerCase.altSvcOriginKey(), is(mixedCase.altSvcOriginKey()));
+        assertThat(mixedCase.altSvcOriginKey().hashCode(), is(lowerCase.altSvcOriginKey().hashCode()));
+        assertThat(lowerCase.altSvcOriginKey(), sameInstance(lowerCase));
+    }
+
+    @Test
+    void altSvcLookupOriginRetainsConnectionAndTargetPartitions() {
+        DnsResolver resolver = (_, _) -> InetAddress.getLoopbackAddress();
+        DnsResolver otherResolver = (_, _) -> InetAddress.ofLiteral("127.0.0.2");
+        Tls tls = Tls.builder().build();
+        ClientUri uri = ClientUri.create(URI.create("https://origin.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           tls,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey, uri, headers);
+        ClientConnectionTarget.LookupKey base = target.lookupKey().altSvcOriginKey();
+
+        ClientUri otherPortUri = ClientUri.create(URI.create("https://origin.example:8443/path"));
+        ConnectionKey otherPortKey = ConnectionKey.create(otherPortUri,
+                                                          tls,
+                                                          resolver,
+                                                          DnsAddressLookup.IPV4,
+                                                          Proxy.noProxy());
+        ClientConnectionTarget.LookupKey otherPort = ClientConnectionTarget.lookupKey(otherPortKey,
+                                                                                       otherPortUri,
+                                                                                       headers)
+                .altSvcOriginKey();
+        ClientUri otherSchemeUri = ClientUri.create(URI.create("http://origin.example:443/path"));
+        ConnectionKey otherSchemeKey = ConnectionKey.create(otherSchemeUri,
+                                                            tls,
+                                                            resolver,
+                                                            DnsAddressLookup.IPV4,
+                                                            Proxy.noProxy());
+        ClientConnectionTarget.LookupKey otherScheme = ClientConnectionTarget.lookupKey(otherSchemeKey,
+                                                                                         otherSchemeUri,
+                                                                                         headers)
+                .altSvcOriginKey();
+        ConnectionKey otherTlsKey = ConnectionKey.create(uri,
+                                                         Tls.builder().build(),
+                                                         resolver,
+                                                         DnsAddressLookup.IPV4,
+                                                         Proxy.noProxy());
+        ClientConnectionTarget.LookupKey otherTls = ClientConnectionTarget.lookupKey(otherTlsKey, uri, headers)
+                .altSvcOriginKey();
+        ConnectionKey otherResolverKey = ConnectionKey.create(uri,
+                                                              tls,
+                                                              otherResolver,
+                                                              DnsAddressLookup.IPV4,
+                                                              Proxy.noProxy());
+        ClientConnectionTarget.LookupKey otherDnsResolver = ClientConnectionTarget.lookupKey(otherResolverKey,
+                                                                                              uri,
+                                                                                              headers)
+                .altSvcOriginKey();
+        ConnectionKey otherLookupKey = ConnectionKey.create(uri,
+                                                            tls,
+                                                            resolver,
+                                                            DnsAddressLookup.IPV6,
+                                                            Proxy.noProxy());
+        ClientConnectionTarget.LookupKey otherDnsLookup = ClientConnectionTarget.lookupKey(otherLookupKey, uri, headers)
+                .altSvcOriginKey();
+        Proxy proxy = Proxy.builder().host("proxy.example").port(8181).build();
+        ConnectionKey otherProxyKey = ConnectionKey.create(uri,
+                                                           tls,
+                                                           resolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+        ClientConnectionTarget.LookupKey otherProxy = ClientConnectionTarget.lookupKey(otherProxyKey, uri, headers)
+                .altSvcOriginKey();
+        ClientRequestHeaders otherAuthorityHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+        otherAuthorityHeaders.set(HeaderNames.HOST, "other.example:9443");
+        ClientConnectionTarget.LookupKey otherAuthority = ClientConnectionTarget.lookupKey(connectionKey,
+                                                                                            uri,
+                                                                                            otherAuthorityHeaders)
+                .altSvcOriginKey();
+        ClientConnectionTarget.LookupKey localBind = ClientConnectionTarget.create(
+                connectionKey,
+                target.scheme(),
+                target.originAuthority(),
+                target.proxyRoute(),
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
+                target.tlsGeneration()).lookupKey().altSvcOriginKey();
+        UnixDomainSocketAddress firstUnixAddress = UnixDomainSocketAddress.of("alt-svc-origin-first.sock");
+        ConnectionKey firstUnixKey = ConnectionKey.createUnixDomainSocket(uri,
+                                                                           tls,
+                                                                           resolver,
+                                                                           DnsAddressLookup.IPV4,
+                                                                           firstUnixAddress);
+        ClientConnectionTarget.LookupKey firstUnix = ClientConnectionTarget.createUnixDomainSocket(firstUnixKey,
+                                                                                                     uri,
+                                                                                                     headers,
+                                                                                                     firstUnixAddress)
+                .lookupKey()
+                .altSvcOriginKey();
+        UnixDomainSocketAddress secondUnixAddress = UnixDomainSocketAddress.of("alt-svc-origin-second.sock");
+        ConnectionKey secondUnixKey = ConnectionKey.createUnixDomainSocket(uri,
+                                                                            tls,
+                                                                            resolver,
+                                                                            DnsAddressLookup.IPV4,
+                                                                            secondUnixAddress);
+        ClientConnectionTarget.LookupKey secondUnix = ClientConnectionTarget.createUnixDomainSocket(secondUnixKey,
+                                                                                                      uri,
+                                                                                                      headers,
+                                                                                                      secondUnixAddress)
+                .lookupKey()
+                .altSvcOriginKey();
+
+        assertThat(base, not(otherPort));
+        assertThat(base, not(otherScheme));
+        assertThat(base, not(otherTls));
+        assertThat(base, not(otherDnsResolver));
+        assertThat(base, not(otherDnsLookup));
+        assertThat(base, not(otherProxy));
+        assertThat(base, not(otherAuthority));
+        assertThat(base, not(localBind));
+        assertThat(base, not(firstUnix));
+        assertThat(firstUnix, not(secondUnix));
+    }
+
+    @Test
+    void altSvcLookupOriginRetainsCapturedTlsGeneration() {
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientUri uri = ClientUri.create(URI.create("https://origin.example/path"));
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           tls,
+                                                           (_, _) -> InetAddress.getLoopbackAddress(),
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientConnectionTarget.LookupKey beforeReload = ClientConnectionTarget.lookupKey(connectionKey, uri, headers)
+                .altSvcOriginKey();
+
+        tls.reload(TlsMaterial.builder().trustAll(true).build());
+        ClientConnectionTarget.LookupKey afterReload = ClientConnectionTarget.lookupKey(connectionKey, uri, headers)
+                .altSvcOriginKey();
+
+        assertThat(beforeReload, not(afterReload));
+        assertThat(beforeReload.currentTlsGeneration(), is(false));
+        assertThat(afterReload.currentTlsGeneration(), is(true));
+    }
+
+    @Test
     void createsTargetFromLookupKeyOnCacheMiss() {
         AtomicInteger resolutions = new AtomicInteger();
         Proxy proxy = Proxy.builder()

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ConnectionKeySniTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ConnectionKeySniTest.java
@@ -16,8 +16,10 @@
 
 package io.helidon.webclient.api;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIServerName;
@@ -38,6 +40,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ConnectionKeySniTest {
@@ -340,6 +343,139 @@ class ConnectionKeySniTest {
 
         assertThat(key.tlsPeerHost(), is("[::1]"));
         assertThat(key.serverNamesOverride(), is(empty()));
+    }
+
+    @Test
+    void altSvcOriginKeyCanonicalizesDnsCaseWithoutChangingConnectionIdentity() {
+        AtomicReference<String> resolvedHost = new AtomicReference<>();
+        DnsResolver resolver = (host, _) -> {
+            resolvedHost.set(host);
+            return InetAddress.getLoopbackAddress();
+        };
+        ConnectionKey mixedCase = ConnectionKey.create("HTTPS",
+                                                       "Example.COM.",
+                                                       443,
+                                                       TLS,
+                                                       resolver,
+                                                       DNS_LOOKUP,
+                                                       NO_PROXY);
+        ConnectionKey lowerCase = ConnectionKey.create("https",
+                                                       "example.com.",
+                                                       443,
+                                                       TLS,
+                                                       resolver,
+                                                       DNS_LOOKUP,
+                                                       NO_PROXY);
+
+        assertThat(mixedCase, not(lowerCase));
+        assertThat(mixedCase.scheme(), is("HTTPS"));
+        assertThat(mixedCase.host(), is("Example.COM."));
+        assertThat(mixedCase.tlsPeerHost(), is("Example.COM."));
+        assertThat(mixedCase.altSvcOriginKey(), is(lowerCase));
+        assertThat(lowerCase.altSvcOriginKey(), is(mixedCase.altSvcOriginKey()));
+        assertThat(mixedCase.altSvcOriginKey().hashCode(), is(lowerCase.hashCode()));
+        assertThat(lowerCase.altSvcOriginKey(), sameInstance(lowerCase));
+
+        ClientConnectionTarget.create(mixedCase, "https").resolve();
+        assertThat(resolvedHost.get(), is("Example.COM."));
+    }
+
+    @Test
+    void altSvcOriginKeyDoesNotBroadenHostNormalization() {
+        ConnectionKey trailingDot = ConnectionKey.create("https",
+                                                         "Example.COM.",
+                                                         443,
+                                                         TLS,
+                                                         DNS_RESOLVER,
+                                                         DNS_LOOKUP,
+                                                         NO_PROXY);
+        ConnectionKey noTrailingDot = ConnectionKey.create("https",
+                                                           "example.com",
+                                                           443,
+                                                           TLS,
+                                                           DNS_RESOLVER,
+                                                           DNS_LOOKUP,
+                                                           NO_PROXY);
+        ConnectionKey unicode = ConnectionKey.create("https",
+                                                     "B\u00dcCHER.example",
+                                                     443,
+                                                     TLS,
+                                                     DNS_RESOLVER,
+                                                     DNS_LOOKUP,
+                                                     NO_PROXY);
+        ConnectionKey punycode = ConnectionKey.create("https",
+                                                      "xn--bcher-kva.example",
+                                                      443,
+                                                      TLS,
+                                                      DNS_RESOLVER,
+                                                      DNS_LOOKUP,
+                                                      NO_PROXY);
+        ConnectionKey upperIpv6 = ConnectionKey.create("https",
+                                                       "[2001:DB8::1]",
+                                                       443,
+                                                       TLS,
+                                                       DNS_RESOLVER,
+                                                       DNS_LOOKUP,
+                                                       NO_PROXY);
+        ConnectionKey lowerIpv6 = ConnectionKey.create("https",
+                                                       "[2001:db8::1]",
+                                                       443,
+                                                       TLS,
+                                                       DNS_RESOLVER,
+                                                       DNS_LOOKUP,
+                                                       NO_PROXY);
+
+        assertThat(trailingDot.altSvcOriginKey(), not(noTrailingDot.altSvcOriginKey()));
+        assertThat(unicode.altSvcOriginKey(), not(punycode.altSvcOriginKey()));
+        assertThat(upperIpv6.altSvcOriginKey(), sameInstance(upperIpv6));
+        assertThat(upperIpv6.altSvcOriginKey(), not(lowerIpv6.altSvcOriginKey()));
+    }
+
+    @Test
+    void altSvcOriginKeyPreservesEffectiveSniPartitions() {
+        ClientRequestHeaders headers = emptyHeaders();
+        ConnectionKey defaults = key("https://Service.EXAMPLE:443", null, TLS, headers).altSvcOriginKey();
+        ConnectionKey uriHost = key("https://Service.EXAMPLE:443",
+                                    SniConfig.create(),
+                                    TLS,
+                                    headers).altSvcOriginKey();
+        ConnectionKey lowerUriHost = key("https://service.example:443",
+                                         SniConfig.create(),
+                                         TLS,
+                                         headers);
+        ConnectionKey explicit = key("https://Service.EXAMPLE:443",
+                                     explicit("SERVICE.EXAMPLE"),
+                                     TLS,
+                                     headers).altSvcOriginKey();
+        ConnectionKey otherExplicit = key("https://Service.EXAMPLE:443",
+                                          explicit("other.example"),
+                                          TLS,
+                                          headers).altSvcOriginKey();
+        ConnectionKey emptySni = key("https://Service.EXAMPLE:443",
+                                     explicit("127.0.0.1"),
+                                     TLS,
+                                     headers).altSvcOriginKey();
+        ConnectionKey ipv6 = key("https://Service.EXAMPLE:443",
+                                 explicit("[2001:DB8::1]"),
+                                 TLS,
+                                 headers).altSvcOriginKey();
+        ConnectionKey disabled = key("https://Service.EXAMPLE:443",
+                                     SniConfig.builder().mode(SniMode.DISABLED).build(),
+                                     TLS,
+                                     headers).altSvcOriginKey();
+
+        assertThat(uriHost, is(explicit));
+        assertThat(uriHost, is(lowerUriHost));
+        assertThat(uriHost.hashCode(), is(explicit.hashCode()));
+        assertThat(lowerUriHost.altSvcOriginKey(), sameInstance(lowerUriHost));
+        assertThat(serverName(uriHost), is("service.example"));
+        assertThat(defaults, not(uriHost));
+        assertThat(otherExplicit, not(uriHost));
+        assertThat(emptySni, not(disabled));
+        assertThat(emptySni.serverNamesOverride(), is(empty()));
+        assertThat(ipv6.tlsPeerHost(), is("2001:db8::1"));
+        assertThat(ipv6.serverNamesOverride(), is(empty()));
+        assertThat(disabled.serverNamesOverride(), is(empty()));
     }
 
     private static ConnectionKey key(String uri,

--- a/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientConfigTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientConfigTest.java
@@ -27,8 +27,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 class HttpClientConfigTest {
+
+    @Test
+    void altSvcIsDisabledByDefault() {
+        assertThat(HttpClientConfig.create().altSvc().isEmpty(), is(true));
+    }
 
     @Test
     void testUnixBaseAddressKeepsConfiguredPath() {
@@ -39,5 +45,28 @@ class HttpClientConfigTest {
                 .orElseThrow();
 
         assertThat(socketAddress.getPath(), is(Path.of("/tmp/client.sock")));
+    }
+
+    @Test
+    void programmaticAltSvcConfigurationOptsInWithDefaults() {
+        HttpClientConfig config = HttpClientConfig.builder()
+                .altSvc(ClientAltSvcConfig.create())
+                .build();
+
+        ClientAltSvcConfig altSvc = config.altSvc().orElseThrow();
+        assertThat(altSvc.enabled(), is(true));
+        assertThat(altSvc.protocols().isEmpty(), is(true));
+    }
+
+    @Test
+    void parsesAltSvcConfiguration() {
+        Config config = Config.just(ConfigSources.create(Map.of("alt-svc.enabled", "false",
+                                                               "alt-svc.protocols.0", "h2",
+                                                               "alt-svc.protocols.1", "future-protocol")));
+
+        ClientAltSvcConfig altSvc = HttpClientConfig.create(config).altSvc().orElseThrow();
+
+        assertThat(altSvc.enabled(), is(false));
+        assertThat(altSvc.protocols(), containsInAnyOrder("h2", "future-protocol"));
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ProxyTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.net.InetSocketAddress;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +36,18 @@ class ProxyTest {
     void defaultProxy() {
         Proxy proxy = Proxy.create();
         assertThat(proxy.type(), is(Proxy.ProxyType.SYSTEM));
+    }
+
+    @Test
+    void configuredProxyTypeIgnoresCase() {
+        for (Proxy.ProxyType type : Proxy.ProxyType.values()) {
+            assertThat("exact " + type,
+                       configuredProxy(type.name()).type(),
+                       is(type));
+            assertThat("lowercase " + type,
+                       configuredProxy(type.name().toLowerCase(Locale.ROOT)).type(),
+                       is(type));
+        }
     }
 
     @Test
@@ -69,5 +86,11 @@ class ProxyTest {
 
     private InetSocketAddress address(String host, int port) {
         return new InetSocketAddress(host, port);
+    }
+
+    private Proxy configuredProxy(String type) {
+        Config config = Config.just(ConfigSources.create(Map.of("type", type,
+                                                                "host", "proxy.example")));
+        return Proxy.create(config);
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/TestHttpClientSpiProvider.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/TestHttpClientSpiProvider.java
@@ -34,6 +34,14 @@ public class TestHttpClientSpiProvider implements HttpClientSpiProvider<Protocol
         }
 
         @Override
+        public void responseReceived(WebClientProtocolResponse response) {
+            protocolResponse = response;
+            if (failResponseNotification) {
+                throw new IllegalStateException("deliberate response notification failure");
+            }
+        }
+
+        @Override
         public boolean isTcp() {
             return false;
         }
@@ -44,6 +52,8 @@ public class TestHttpClientSpiProvider implements HttpClientSpiProvider<Protocol
     };
 
     private static volatile IllegalStateException constructionFailure;
+    private static volatile WebClientProtocolResponse protocolResponse;
+    private static volatile boolean failResponseNotification;
 
     @Override
     public String protocolId() {
@@ -82,9 +92,19 @@ public class TestHttpClientSpiProvider implements HttpClientSpiProvider<Protocol
 
     static void reset() {
         constructionFailure = null;
+        protocolResponse = null;
+        failResponseNotification = false;
     }
 
     static IllegalStateException constructionFailure() {
         return constructionFailure;
+    }
+
+    static WebClientProtocolResponse protocolResponse() {
+        return protocolResponse;
+    }
+
+    static void failResponseNotification() {
+        failResponseNotification = true;
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/TestHttpClientSpiProvider.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/TestHttpClientSpiProvider.java
@@ -55,6 +55,14 @@ public class TestHttpClientSpiProvider implements HttpClientSpiProvider<Protocol
     private static volatile WebClientProtocolResponse protocolResponse;
     private static volatile boolean failResponseNotification;
 
+    static WebClientProtocolResponse protocolResponse() {
+        return protocolResponse;
+    }
+
+    static void failResponseNotification() {
+        failResponseNotification = true;
+    }
+
     @Override
     public String protocolId() {
         return PROTOCOL_ID;
@@ -98,13 +106,5 @@ public class TestHttpClientSpiProvider implements HttpClientSpiProvider<Protocol
 
     static IllegalStateException constructionFailure() {
         return constructionFailure;
-    }
-
-    static WebClientProtocolResponse protocolResponse() {
-        return protocolResponse;
-    }
-
-    static void failResponseNotification() {
-        failResponseNotification = true;
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/TransportResponseDispatchTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/TransportResponseDispatchTest.java
@@ -126,14 +126,6 @@ class TransportResponseDispatchTest {
                   Map.of());
         }
 
-        private WebClientServiceResponse invoke(WebClient client, WebClientService.TransportChain transport) {
-            return invokeServices(client,
-                                  transport,
-                                  new CompletableFuture<>(),
-                                  new CompletableFuture<>(),
-                                  resolvedUri());
-        }
-
         @Override
         protected HttpClientResponse doSubmit(Object entity) {
             throw new UnsupportedOperationException();
@@ -142,6 +134,14 @@ class TransportResponseDispatchTest {
         @Override
         protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
             throw new UnsupportedOperationException();
+        }
+
+        private WebClientServiceResponse invoke(WebClient client, WebClientService.TransportChain transport) {
+            return invokeServices(client,
+                                  transport,
+                                  new CompletableFuture<>(),
+                                  new CompletableFuture<>(),
+                                  resolvedUri());
         }
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/TransportResponseDispatchTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/TransportResponseDispatchTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.spi.WebClientService;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+@Isolated
+class TransportResponseDispatchTest {
+
+    @Test
+    void publishesAfterNetworkProceedAndBeforeServicesUnwind() {
+        TestHttpClientSpiProvider.reset();
+        WebClientProtocolResponse protocolResponse = protocolResponse();
+        AtomicBoolean networkProceeded = new AtomicBoolean();
+        AtomicBoolean serviceObservedPublication = new AtomicBoolean();
+        HttpClientConfig requestConfig = HttpClientConfig.builder()
+                .addService((chain, request) -> {
+                    WebClientServiceResponse response = chain.proceed(request);
+                    serviceObservedPublication.set(TestHttpClientSpiProvider.protocolResponse() == protocolResponse);
+                    return response;
+                })
+                .build();
+        DispatchRequest request = new DispatchRequest(requestConfig);
+        WebClient client = WebClient.builder()
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(TestHttpClientSpiProvider.PROTOCOL_ID))
+                .build();
+        try {
+            WebClientService.TransportChain transport = new WebClientService.TransportChain() {
+                @Override
+                public String protocolId() {
+                    return "http/1.1";
+                }
+
+                @Override
+                public WebClientServiceResponse proceed(WebClientServiceRequest serviceRequest) {
+                    networkProceeded.set(true);
+                    return response(serviceRequest);
+                }
+
+                @Override
+                public Optional<WebClientProtocolResponse> protocolResponse(WebClientServiceResponse response) {
+                    assertThat(networkProceeded.get(), is(true));
+                    return Optional.of(protocolResponse);
+                }
+            };
+
+            WebClientServiceResponse response = request.invoke(client, transport);
+
+            assertThat(response.status(), sameInstance(Status.OK_200));
+            assertThat(TestHttpClientSpiProvider.protocolResponse(), sameInstance(protocolResponse));
+            assertThat(serviceObservedPublication.get(), is(true));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    private static WebClientServiceResponse response(WebClientServiceRequest request) {
+        return WebClientServiceResponse.builder()
+                .serviceRequest(request)
+                .whenComplete(new CompletableFuture<>())
+                .connection(() -> { })
+                .status(Status.OK_200)
+                .headers(ClientResponseHeaders.create(WritableHeaders.create()))
+                .build();
+    }
+
+    private static WebClientProtocolResponse protocolResponse() {
+        ClientUri uri = ClientUri.create(URI.create("http://origin.example"));
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           Tls.builder().enabled(false).build(),
+                                                           (_, _) -> InetAddress.getLoopbackAddress(),
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ResolvedClientTarget target = ClientConnectionTarget.create(connectionKey, "http").resolve();
+        return WebClientProtocolResponse.create(target,
+                                                false,
+                                                "http/1.1",
+                                                Status.OK_200,
+                                                ClientResponseHeaders.create(WritableHeaders.create()),
+                                                Instant.parse("2026-08-23T00:01:30Z"));
+    }
+
+    private static final class DispatchRequest extends ClientRequestBase<DispatchRequest, HttpClientResponse> {
+        private DispatchRequest(HttpClientConfig config) {
+            super(config,
+                  WebClientCookieManager.builder().build(),
+                  "http/1.1",
+                  Method.GET,
+                  ClientUri.create(URI.create("http://origin.example")),
+                  Map.of());
+        }
+
+        private WebClientServiceResponse invoke(WebClient client, WebClientService.TransportChain transport) {
+            return invokeServices(client,
+                                  transport,
+                                  new CompletableFuture<>(),
+                                  new CompletableFuture<>(),
+                                  resolvedUri());
+        }
+
+        @Override
+        protected HttpClientResponse doSubmit(Object entity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected HttpClientResponse doOutputStream(OutputStreamHandler outputStreamHandler) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/WebClientProtocolInventoryTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/WebClientProtocolInventoryTest.java
@@ -15,14 +15,25 @@
  */
 package io.helidon.webclient.api;
 
+import java.net.InetAddress;
+import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 
+import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
+@Isolated
 class WebClientProtocolInventoryTest {
 
     @Test
@@ -40,5 +51,42 @@ class WebClientProtocolInventoryTest {
         } finally {
             client.closeResource();
         }
+    }
+
+    @Test
+    void synchronouslyDispatchesAndIsolatesProtocolNotificationFailures() {
+        TestHttpClientSpiProvider.reset();
+        WebClient client = WebClient.builder()
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(TestHttpClientSpiProvider.PROTOCOL_ID))
+                .build();
+        try {
+            WebClientProtocolResponse response = protocolResponse();
+
+            client.responseReceived(response);
+
+            assertThat(TestHttpClientSpiProvider.protocolResponse(), sameInstance(response));
+            TestHttpClientSpiProvider.failResponseNotification();
+            client.responseReceived(response);
+            assertThat(TestHttpClientSpiProvider.protocolResponse(), sameInstance(response));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    private static WebClientProtocolResponse protocolResponse() {
+        ClientUri uri = ClientUri.create(URI.create("http://origin.example"));
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           Tls.builder().enabled(false).build(),
+                                                           (_, _) -> InetAddress.getLoopbackAddress(),
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ResolvedClientTarget target = ClientConnectionTarget.create(connectionKey, "http").resolve();
+        return WebClientProtocolResponse.create(target,
+                                                false,
+                                                "http/1.1",
+                                                Status.OK_200,
+                                                ClientResponseHeaders.create(WritableHeaders.create()),
+                                                Instant.parse("2026-08-23T00:01:30Z"));
     }
 }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/WebClientProtocolResponseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/WebClientProtocolResponseTest.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.Value;
+import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsConfig;
+import io.helidon.common.tls.TlsManager;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.HttpMediaType;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WebClientProtocolResponseTest {
+    private static final Instant RECEIVED_AT = Instant.parse("2026-08-23T00:01:30Z");
+
+    @Test
+    void retainsExactContextAndCopiesHeaders() {
+        ResolvedClientTarget target = resolvedTarget("https://origin.example/path", null, null);
+        WritableHeaders<?> mutableHeaders = WritableHeaders.create();
+        mutableHeaders.add(HeaderValues.create(HeaderNames.ALT_SVC, "h3=\":443\""));
+        ClientResponseHeaders responseHeaders = ClientResponseHeaders.create(mutableHeaders);
+
+        WebClientProtocolResponse response = WebClientProtocolResponse.create(target,
+                                                                              false,
+                                                                              "h2",
+                                                                              Status.OK_200,
+                                                                              responseHeaders,
+                                                                              RECEIVED_AT);
+        mutableHeaders.set(HeaderValues.create(HeaderNames.ALT_SVC, "clear"));
+
+        assertThat(response.target(), sameInstance(target));
+        assertThat(response.explicitConnection(), is(false));
+        assertThat(response.protocolId(), is("h2"));
+        assertThat(response.status(), sameInstance(Status.OK_200));
+        assertThat(response.headers().first(HeaderNames.ALT_SVC).orElseThrow(), is("h3=\":443\""));
+        assertThat(response.receivedAt(), is(RECEIVED_AT));
+        assertThat(response.alternativeAuthority().isEmpty(), is(true));
+        assertThat(response.secure(), is(true));
+    }
+
+    @Test
+    void snapshotsAllHeadersAndTheirState() {
+        HeaderName customName = HeaderNames.create("X-Custom-Response");
+        HeaderName customLookup = HeaderNames.create("x-CUSTOM-response");
+        WritableHeaders<?> mutableHeaders = WritableHeaders.create();
+        mutableHeaders.add(HeaderValues.create(HeaderNames.ACCEPT,
+                                               "text/plain;q=0.5, application/json"));
+        mutableHeaders.add(HeaderValues.create(HeaderNames.CACHE_CONTROL,
+                                               true,
+                                               false,
+                                               "no-cache"));
+        mutableHeaders.add(HeaderValues.create(customName, false, true, "first"));
+        mutableHeaders.add(HeaderValues.create(customName, false, true, "second"));
+        ClientResponseHeaders original = ClientResponseHeaders.create(mutableHeaders);
+        List<String> originalIteration = original.stream().map(Header::name).toList();
+
+        ClientResponseHeaders snapshot = WebClientProtocolResponse.create(
+                        resolvedTarget("https://origin.example/path", null, null),
+                        false,
+                        "h2",
+                        Status.OK_200,
+                        original,
+                        RECEIVED_AT)
+                .headers();
+
+        mutableHeaders.remove(HeaderNames.ACCEPT);
+        mutableHeaders.set(HeaderValues.create(HeaderNames.CACHE_CONTROL, "public"));
+        mutableHeaders.add(HeaderValues.create(customName, "third"));
+
+        assertThat(snapshot.size(), is(3));
+        assertThat(snapshot.stream().map(Header::name).toList(), is(originalIteration));
+        assertThat(snapshot.contains(HeaderNames.ACCEPT), is(true));
+        assertThat(snapshot.get(HeaderNames.CACHE_CONTROL).get(), is("no-cache"));
+        assertThat(snapshot.get(HeaderNames.CACHE_CONTROL).changing(), is(true));
+        assertThat(snapshot.get(HeaderNames.CACHE_CONTROL).sensitive(), is(false));
+
+        Header custom = snapshot.get(customLookup);
+        assertThat(custom.name(), is("X-Custom-Response"));
+        assertThat(custom.headerName().defaultCase(), is("X-Custom-Response"));
+        assertThat(custom.get(), is("first"));
+        assertThat(custom.allValues(), contains("first", "second"));
+        assertThat(custom.values(), is("first, second"));
+        assertThat(snapshot.value(customLookup).orElseThrow(), is("first,second"));
+        assertThat(custom.changing(), is(false));
+        assertThat(custom.sensitive(), is(true));
+        assertThat(snapshot.contains(HeaderValues.create(customLookup, "first", "second")), is(true));
+        assertThat(snapshot.contains(HeaderValues.create(customLookup, "second", "first")), is(false));
+
+        Iterator<Header> exhausted = snapshot.iterator();
+        exhausted.forEachRemaining(_ -> { });
+        assertThrows(NoSuchElementException.class, exhausted::next);
+
+        List<HttpMediaType> acceptedTypes = snapshot.acceptedTypes();
+        assertThat(acceptedTypes.stream().map(HttpMediaType::text).toList(),
+                   contains("application/json", "text/plain; q=0.5"));
+        assertThrows(UnsupportedOperationException.class, () -> custom.allValues().add("fourth"));
+        assertThrows(UnsupportedOperationException.class,
+                     () -> snapshot.all(customLookup, List::of).add("fourth"));
+        assertThrows(UnsupportedOperationException.class,
+                     () -> acceptedTypes.add(HttpMediaType.create("application/xml")));
+    }
+
+    @Test
+    void snapshotsSingleValueWithoutReadingItsValueList() {
+        HeaderName name = HeaderNames.create("X-Single-Value");
+        Header source = new ThrowingAllValuesHeader(HeaderValues.create(name, true, true, "single"));
+        WritableHeaders<?> mutableHeaders = WritableHeaders.create();
+        mutableHeaders.set(source);
+
+        Header snapshot = WebClientProtocolResponse.create(
+                        resolvedTarget("https://origin.example/path", null, null),
+                        false,
+                        "h2",
+                        Status.OK_200,
+                        ClientResponseHeaders.create(mutableHeaders),
+                        RECEIVED_AT)
+                .headers()
+                .get(name);
+
+        assertThat(snapshot.get(), is("single"));
+        assertThat(snapshot.allValues(), contains("single"));
+        assertThat(snapshot.valueCount(), is(1));
+        assertThat(snapshot.changing(), is(true));
+        assertThat(snapshot.sensitive(), is(true));
+    }
+
+    @Test
+    void missingHeaderUsesTheExpectedContract() {
+        ClientResponseHeaders headers = response(resolvedTarget("https://origin.example/path", null, null)).headers();
+        HeaderName missing = HeaderNames.create("X-Missing");
+
+        assertThat(headers.contains(missing), is(false));
+        assertThat(headers.all(missing, () -> List.of("default")), contains("default"));
+        NoSuchElementException exception = assertThrows(NoSuchElementException.class, () -> headers.get(missing));
+        assertThat(exception.getMessage(), is("Header " + missing + " is not present in these headers"));
+    }
+
+    @Test
+    void carriesTheAlternativeAuthorityUsedForTheRequest() {
+        ResolvedClientTarget target = resolvedTarget("https://origin.example/path", null, null);
+        UriAuthority alternative = UriAuthority.create("alt.example:8443");
+
+        WebClientProtocolResponse response = WebClientProtocolResponse.createAlternative(
+                target,
+                true,
+                "h3",
+                Status.OK_200,
+                ClientResponseHeaders.create(WritableHeaders.create()),
+                RECEIVED_AT,
+                alternative);
+
+        assertThat(response.alternativeAuthority().orElseThrow(), sameInstance(alternative));
+        assertThat(response.explicitConnection(), is(true));
+    }
+
+    @Test
+    void secureUsesHttpsAndConfiguredTlsOnly() {
+        ResolvedClientTarget differentOrigin = resolvedTarget("https://route.example/path", "origin.example", null);
+        ResolvedClientTarget staleTls = resolvedTarget("https://origin.example/path", null, 1L);
+        ResolvedClientTarget clearText = resolvedTarget("http://origin.example/path", null, null);
+        Tls disabledTls = Tls.builder().enabled(false).build();
+
+        assertThat(response(differentOrigin).secure(), is(true));
+        assertThat(response(staleTls).secure(), is(true));
+        assertThat(response(clearText).secure(), is(false));
+        assertThat(response(resolvedTarget("https://origin.example/path", disabledTls)).secure(), is(false));
+    }
+
+    @Test
+    void secureHonorsUserConfiguredTlsPolicy() {
+        Tls trustAll = Tls.builder().trustAll(true).build();
+        Tls endpointIdentificationDisabled = Tls.builder()
+                .endpointIdentificationAlgorithm(Tls.ENDPOINT_IDENTIFICATION_NONE)
+                .build();
+        Tls explicitContext = Tls.builder()
+                .sslContext(defaultSslContext())
+                .build();
+        Tls customManager = Tls.builder()
+                .manager(new TestTlsManager())
+                .build();
+
+        assertThat(response(resolvedTarget("https://origin.example/path", trustAll)).secure(), is(true));
+        assertThat(response(resolvedTarget("https://origin.example/path", endpointIdentificationDisabled)).secure(),
+                   is(true));
+        assertThat(response(resolvedTarget("https://origin.example/path", explicitContext)).secure(), is(true));
+        assertThat(response(resolvedTarget("https://origin.example/path", customManager)).secure(), is(true));
+    }
+
+    private static WebClientProtocolResponse response(ResolvedClientTarget target) {
+        return WebClientProtocolResponse.create(target,
+                                                false,
+                                                "h2",
+                                                Status.OK_200,
+                                                ClientResponseHeaders.create(WritableHeaders.create()),
+                                                RECEIVED_AT);
+    }
+
+    private static ResolvedClientTarget resolvedTarget(String uriText,
+                                                       String originHost,
+                                                       Long tlsGeneration) {
+        ClientUri uri = ClientUri.create(URI.create(uriText));
+        Tls tls = Tls.builder().enabled("https".equals(uri.scheme())).build();
+        return resolvedTarget(uri, tls, originHost, tlsGeneration);
+    }
+
+    private static ResolvedClientTarget resolvedTarget(String uriText, Tls tls) {
+        return resolvedTarget(ClientUri.create(URI.create(uriText)), tls, null, null);
+    }
+
+    private static ResolvedClientTarget resolvedTarget(ClientUri uri,
+                                                       Tls tls,
+                                                       String originHost,
+                                                       Long tlsGeneration) {
+        ConnectionKey connectionKey = ConnectionKey.create(uri,
+                                                           tls,
+                                                           (_, _) -> InetAddress.getLoopbackAddress(),
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        if (originHost != null) {
+            headers.set(HeaderNames.HOST, originHost);
+        }
+        ClientConnectionTarget logicalTarget = ClientConnectionTarget.create(connectionKey, uri, headers);
+        if (tlsGeneration != null) {
+            logicalTarget = ClientConnectionTarget.create(connectionKey,
+                                                          logicalTarget.scheme(),
+                                                          logicalTarget.originAuthority(),
+                                                          logicalTarget.proxyRoute(),
+                                                          tlsGeneration);
+        }
+        return ResolvedClientTarget.direct(logicalTarget,
+                                           logicalTarget.originAuthority(),
+                                           new InetSocketAddress(InetAddress.getLoopbackAddress(), uri.port()),
+                                           0);
+    }
+
+    private static SSLContext defaultSslContext() {
+        try {
+            return SSLContext.getDefault();
+        } catch (GeneralSecurityException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static final class ThrowingAllValuesHeader implements Header {
+        private final Header delegate;
+
+        private ThrowingAllValuesHeader(Header delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public HeaderName headerName() {
+            return delegate.headerName();
+        }
+
+        @Override
+        public String get() {
+            return delegate.get();
+        }
+
+        @Override
+        public List<String> allValues() {
+            throw new AssertionError("Single-value snapshot must not read allValues()");
+        }
+
+        @Override
+        public int valueCount() {
+            return delegate.valueCount();
+        }
+
+        @Override
+        public boolean sensitive() {
+            return delegate.sensitive();
+        }
+
+        @Override
+        public boolean changing() {
+            return delegate.changing();
+        }
+
+        @Override
+        public <N> Value<N> as(Class<N> type) {
+            return delegate.as(type);
+        }
+
+        @Override
+        public <N> Value<N> as(GenericType<N> type) {
+            return delegate.as(type);
+        }
+
+        @Override
+        public <N> Value<N> as(Function<? super String, ? extends N> mapper) {
+            return delegate.as(mapper);
+        }
+
+        @Override
+        public Optional<String> asOptional() {
+            return delegate.asOptional();
+        }
+
+        @Override
+        public Value<Boolean> asBoolean() {
+            return delegate.asBoolean();
+        }
+
+        @Override
+        public Value<String> asString() {
+            return delegate.asString();
+        }
+
+        @Override
+        public Value<Integer> asInt() {
+            return delegate.asInt();
+        }
+
+        @Override
+        public Value<Long> asLong() {
+            return delegate.asLong();
+        }
+
+        @Override
+        public Value<Double> asDouble() {
+            return delegate.asDouble();
+        }
+    }
+
+    private static final class TestTlsManager implements TlsManager {
+        private final SSLContext sslContext = defaultSslContext();
+
+        @Override
+        public void init(TlsConfig tls) {
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            return sslContext;
+        }
+
+        @Override
+        public Optional<X509KeyManager> keyManager() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<X509TrustManager> trustManager() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public String type() {
+            return "test";
+        }
+    }
+}

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -401,12 +401,6 @@ abstract class Http1CallChainBase implements WebClientService.TransportChain {
         }
     }
 
-    private WebClientProtocolResponse takeProtocolResponse() {
-        WebClientProtocolResponse response = pendingProtocolResponse;
-        pendingProtocolResponse = null;
-        return response;
-    }
-
     Http1ConnectionListener sendListener() {
         return sendListener;
     }
@@ -477,6 +471,12 @@ abstract class Http1CallChainBase implements WebClientService.TransportChain {
 
     Http1ConnectionListener recvListener() {
         return recvListener;
+    }
+
+    private WebClientProtocolResponse takeProtocolResponse() {
+        WebClientProtocolResponse response = pendingProtocolResponse;
+        pendingProtocolResponse = null;
+        return response;
     }
 
     static boolean statusAllowsEntity(Status responseStatus) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -473,12 +473,6 @@ abstract class Http1CallChainBase implements WebClientService.TransportChain {
         return recvListener;
     }
 
-    private WebClientProtocolResponse takeProtocolResponse() {
-        WebClientProtocolResponse response = pendingProtocolResponse;
-        pendingProtocolResponse = null;
-        return response;
-    }
-
     static boolean statusAllowsEntity(Status responseStatus) {
         int statusCode = responseStatus.code();
         return responseStatus.family() != Status.Family.INFORMATIONAL
@@ -598,6 +592,12 @@ abstract class Http1CallChainBase implements WebClientService.TransportChain {
         String rawFragment = fragment.rawValue();
         int fragmentLength = requestTarget.endsWith(rawFragment) ? rawFragment.length() : fragment.value().length();
         return requestTarget.substring(0, requestTarget.length() - fragmentLength - 1);
+    }
+
+    private WebClientProtocolResponse takeProtocolResponse() {
+        WebClientProtocolResponse response = pendingProtocolResponse;
+        pendingProtocolResponse = null;
+        return response;
     }
 
     private ClientConnection obtainConnection(ClientConnectionTarget connectionTarget,

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -22,6 +22,7 @@ import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -50,6 +51,7 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.http.encoding.ContentDecoder;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.http1.Http1ConnectionListener;
+import io.helidon.webclient.api.ClientAltSvcConfig;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientRequestBase;
@@ -59,11 +61,12 @@ import io.helidon.webclient.api.HttpClientConfig;
 import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.ProxyRoute;
 import io.helidon.webclient.api.TcpClientConnection;
+import io.helidon.webclient.api.WebClientProtocolResponse;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
 
-abstract class Http1CallChainBase implements WebClientService.Chain {
+abstract class Http1CallChainBase implements WebClientService.TransportChain {
     private static final Supplier<IllegalArgumentException> INVALID_SIZE_EXCEPTION_SUPPLIER =
             () -> new IllegalArgumentException("Chunk size is invalid");
 
@@ -79,9 +82,12 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     private final Http1ClientImpl http1Client;
     private final Http1ConnectionListener sendListener;
     private final Http1ConnectionListener recvListener;
+    private final boolean explicitConnectionRequest;
+    private final boolean altSvcEnabled;
 
     private ClientConnection effectiveConnection;
     private boolean forwardProxy;
+    private WebClientProtocolResponse pendingProtocolResponse;
 
     Http1CallChainBase(Http1ClientImpl http1Client,
                        Http1ClientRequestImpl clientRequest,
@@ -97,6 +103,11 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         this.whenComplete = whenComplete;
         this.sendListener = http1Client.sendListener();
         this.recvListener = http1Client.recvListener();
+        this.explicitConnectionRequest = clientRequest.connection().isPresent()
+                && !clientRequest.ownsExplicitConnection();
+        this.altSvcEnabled = clientConfig.altSvc()
+                .map(ClientAltSvcConfig::enabled)
+                .orElse(false);
     }
 
     static WebClientServiceResponse createServiceResponse(Http1ClientImpl http1Client,
@@ -258,6 +269,23 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         return doProceed(effectiveConnection, serviceRequest, headers, writer, reader, writeBuffer);
     }
 
+    @Override
+    public String protocolId() {
+        return Http1Client.PROTOCOL_ID;
+    }
+
+    @Override
+    public Optional<WebClientProtocolResponse> protocolResponse(WebClientServiceResponse response) {
+        return Optional.ofNullable(takeProtocolResponse());
+    }
+
+    void publishProtocolResponse() {
+        WebClientProtocolResponse response = takeProtocolResponse();
+        if (response != null) {
+            http1Client.webClient().responseReceived(response);
+        }
+    }
+
     abstract WebClientServiceResponse doProceed(ClientConnection connection,
                                                 WebClientServiceRequest request,
                                                 ClientRequestHeaders headers,
@@ -343,6 +371,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                 ? readResponseHead(connection, reader, Http1CallChainBase::isPreContinueInterimResponse)
                 : readResponseHead(connection, reader);
 
+        captureProtocolResponse(connection, responseHead.status(), responseHead.headers());
         return createServiceResponse(http1Client,
                                      serviceRequest,
                                      connection,
@@ -350,6 +379,32 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                                      responseHead.status(),
                                      responseHead.headers(),
                                      whenComplete);
+    }
+
+    void captureProtocolResponse(ClientConnection connection,
+                                 Status status,
+                                 ClientResponseHeaders headers) {
+        // One terminal callback is available per chain; nested redirect chains publish their own responses.
+        if (altSvcEnabled
+                && pendingProtocolResponse == null
+                && headers.contains(HeaderNames.ALT_SVC)
+                && connection instanceof TcpClientConnection tcpConnection) {
+            var target = tcpConnection.resolvedTarget().orElse(null);
+            if (target != null) {
+                pendingProtocolResponse = WebClientProtocolResponse.create(target,
+                                                                           explicitConnectionRequest,
+                                                                           protocolId(),
+                                                                           status,
+                                                                           headers,
+                                                                           Instant.now());
+            }
+        }
+    }
+
+    private WebClientProtocolResponse takeProtocolResponse() {
+        WebClientProtocolResponse response = pendingProtocolResponse;
+        pendingProtocolResponse = null;
+        return response;
     }
 
     Http1ConnectionListener sendListener() {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -108,9 +108,11 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
         ResponseHead responseHead = readResponseHead(connection, reader);
         Status responseStatus = responseHead.status();
         ClientResponseHeaders responseHeaders = responseHead.headers();
+        captureProtocolResponse(connection, responseStatus, responseHeaders);
 
         if (originalRequest().followRedirects()
                 && RedirectionProcessor.redirectionStatusCode(responseStatus)) {
+            publishProtocolResponse();
             checkRedirectHeaders(responseHeaders);
             URI newUri = URI.create(responseHeaders.get(HeaderNames.LOCATION).get());
             ClientUri redirectUri = ClientUri.create(newUri);
@@ -480,8 +482,10 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
 
                 if (responseStatus.code() != Status.CONTINUE_100.code()) {
                     ClientResponseHeaders responseHeaders = responseHead.headers();
+                    callChain.captureProtocolResponse(connection, responseStatus, responseHeaders);
 
                     if (RedirectionProcessor.redirectionStatusCode(responseStatus) && originalRequest.followRedirects()) {
+                        callChain.publishProtocolResponse();
                         // redirect as needed
                         // Discard any remaining data from the response
                         reader.skip(reader.available());

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -314,7 +314,11 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         // will create a copy, so we could invoke this method multiple times
         ClientUri resolvedUri = resolvedUri();
 
-        WebClientServiceResponse serviceResponse = invokeServices(callChain, whenSent, whenComplete, resolvedUri);
+        WebClientServiceResponse serviceResponse = invokeServices(http1Client.webClient(),
+                                                                  callChain,
+                                                                  whenSent,
+                                                                  whenComplete,
+                                                                  resolvedUri);
 
         CompletableFuture<Void> complete = new CompletableFuture<>();
         complete.thenAccept(ignored -> serviceResponse.whenComplete().complete(serviceResponse))

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/AlternativeConnectionException.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/AlternativeConnectionException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.util.Objects;
+
+final class AlternativeConnectionException extends RuntimeException {
+    private final Http2AltSvcCache.Selection selection;
+    private final Reason reason;
+
+    AlternativeConnectionException(Http2AltSvcCache.Selection selection, Reason reason, Throwable cause) {
+        super("HTTP/2 alternative connection failed before creating a request stream",
+              Objects.requireNonNull(cause, "cause"));
+        this.selection = Objects.requireNonNull(selection, "selection");
+        this.reason = Objects.requireNonNull(reason, "reason");
+    }
+
+    Http2AltSvcCache.Selection selection() {
+        return selection;
+    }
+
+    Reason reason() {
+        return reason;
+    }
+
+    enum Reason {
+        STALE,
+        PRE_SEND_FAILURE
+    }
+}

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
@@ -32,6 +32,7 @@ final class Http1FallbackHandler {
     private final Function<Http1ClientRequest, Http1ClientResponse> responseFunction;
     private final boolean upgradeFailureResponseAllowed;
     private volatile String actualProtocolId = Http2Client.PROTOCOL_ID;
+    private volatile boolean explicitConnection;
 
     Http1FallbackHandler(CompletableFuture<WebClientServiceRequest> whenSent,
                          Function<Http1ClientRequest, Http1ClientResponse> responseFunction,
@@ -69,6 +70,14 @@ final class Http1FallbackHandler {
 
     boolean upgradeFailureResponseAllowed() {
         return upgradeFailureResponseAllowed;
+    }
+
+    void explicitConnection(boolean explicitConnection) {
+        this.explicitConnection = explicitConnection;
+    }
+
+    boolean explicitConnection() {
+        return explicitConnection;
     }
 
     String actualProtocolId() {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackHandler.java
@@ -72,6 +72,11 @@ final class Http1FallbackHandler {
         return upgradeFailureResponseAllowed;
     }
 
+    static void copyFinalHeaders(Http1ClientRequest request, WebClientServiceRequest serviceRequest) {
+        request.headers().clear();
+        request.headers(serviceRequest.headers());
+    }
+
     void explicitConnection(boolean explicitConnection) {
         this.explicitConnection = explicitConnection;
     }
@@ -82,10 +87,5 @@ final class Http1FallbackHandler {
 
     String actualProtocolId() {
         return actualProtocolId;
-    }
-
-    static void copyFinalHeaders(Http1ClientRequest request, WebClientServiceRequest serviceRequest) {
-        request.headers().clear();
-        request.headers(serviceRequest.headers());
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackService.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackService.java
@@ -26,6 +26,22 @@ import io.helidon.webclient.spi.WebClientService;
 final class Http1FallbackService implements WebClientService {
     private static final Object CONTEXT_KEY = new Object();
 
+    static WebClientProtocolResponse response(WebClientProtocolResponse response) {
+        boolean explicitConnection = Contexts.context()
+                .flatMap(context -> context.get(CONTEXT_KEY, FallbackContext.class))
+                .map(fallback -> fallback.fallbackHandler().explicitConnection())
+                .orElse(response.explicitConnection());
+        if (explicitConnection == response.explicitConnection()) {
+            return response;
+        }
+        return WebClientProtocolResponse.create(response.target(),
+                                                explicitConnection,
+                                                response.protocolId(),
+                                                response.status(),
+                                                response.headers(),
+                                                response.receivedAt());
+    }
+
     @Override
     public WebClientServiceResponse handle(Chain chain, WebClientServiceRequest clientRequest) {
         clientRequest.context()
@@ -47,22 +63,6 @@ final class Http1FallbackService implements WebClientService {
         Context context = Context.create(serviceRequest.context());
         context.register(CONTEXT_KEY, new FallbackContext(serviceRequest, fallbackHandler));
         return context;
-    }
-
-    static WebClientProtocolResponse response(WebClientProtocolResponse response) {
-        boolean explicitConnection = Contexts.context()
-                .flatMap(context -> context.get(CONTEXT_KEY, FallbackContext.class))
-                .map(fallback -> fallback.fallbackHandler().explicitConnection())
-                .orElse(response.explicitConnection());
-        if (explicitConnection == response.explicitConnection()) {
-            return response;
-        }
-        return WebClientProtocolResponse.create(response.target(),
-                                                explicitConnection,
-                                                response.protocolId(),
-                                                response.status(),
-                                                response.headers(),
-                                                response.receivedAt());
     }
 
     private record FallbackContext(WebClientServiceRequest serviceRequest,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackService.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http1FallbackService.java
@@ -17,6 +17,8 @@
 package io.helidon.webclient.http2;
 
 import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.webclient.api.WebClientProtocolResponse;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
@@ -45,6 +47,22 @@ final class Http1FallbackService implements WebClientService {
         Context context = Context.create(serviceRequest.context());
         context.register(CONTEXT_KEY, new FallbackContext(serviceRequest, fallbackHandler));
         return context;
+    }
+
+    static WebClientProtocolResponse response(WebClientProtocolResponse response) {
+        boolean explicitConnection = Contexts.context()
+                .flatMap(context -> context.get(CONTEXT_KEY, FallbackContext.class))
+                .map(fallback -> fallback.fallbackHandler().explicitConnection())
+                .orElse(response.explicitConnection());
+        if (explicitConnection == response.explicitConnection()) {
+            return response;
+        }
+        return WebClientProtocolResponse.create(response.target(),
+                                                explicitConnection,
+                                                response.protocolId(),
+                                                response.status(),
+                                                response.headers(),
+                                                response.receivedAt());
     }
 
     private record FallbackContext(WebClientServiceRequest serviceRequest,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -87,16 +87,13 @@ final class Http2AltSvcCache implements AutoCloseable {
 
     boolean available(ClientConnectionTarget target,
                       boolean explicitConnection,
-                      Predicate<Selection> established,
-                      Predicate<Generation> establishedGeneration) {
-        return select(target, explicitConnection, established, establishedGeneration) != null;
+                      Predicate<Selection> established) {
+        return select(target, explicitConnection, established) != null;
     }
 
     Candidate selectRoute(ClientConnectionTarget.LookupKey lookupKey,
-                          boolean explicitConnection,
-                          Predicate<Generation> established) {
+                          boolean explicitConnection) {
         Objects.requireNonNull(lookupKey, "lookupKey");
-        Objects.requireNonNull(established, "established");
         if (explicitConnection) {
             return null;
         }
@@ -121,21 +118,11 @@ final class Http2AltSvcCache implements AutoCloseable {
                         continue;
                     }
                     Candidate candidate = state.candidate;
-                    if (fresh(state, now)) {
-                        if (stable(version) && current(candidate)) {
-                            return candidate;
-                        }
-                        slowPath = true;
-                        break;
+                    if (stable(version) && current(candidate)) {
+                        return candidate;
                     }
-                    boolean generationEstablished = established.test(state.generation);
-                    if (stable(version)) {
-                        if (generationEstablished && current(candidate)) {
-                            return candidate;
-                        }
-                        slowPath = true;
-                        break;
-                    }
+                    slowPath = true;
+                    break;
                 }
                 if (!slowPath && stable(version)) {
                     return null;
@@ -144,22 +131,14 @@ final class Http2AltSvcCache implements AutoCloseable {
                 return null;
             }
         }
-        return selectRouteSlow(originKey, established);
+        return selectRouteSlow(originKey);
     }
 
     Selection select(ClientConnectionTarget target,
                      boolean explicitConnection,
                      Predicate<Selection> established) {
-        return select(target, explicitConnection, established, _ -> false);
-    }
-
-    Selection select(ClientConnectionTarget target,
-                     boolean explicitConnection,
-                     Predicate<Selection> established,
-                     Predicate<Generation> establishedGeneration) {
         Objects.requireNonNull(target, "target");
         Objects.requireNonNull(established, "established");
-        Objects.requireNonNull(establishedGeneration, "establishedGeneration");
         if (explicitConnection) {
             return null;
         }
@@ -208,20 +187,14 @@ final class Http2AltSvcCache implements AutoCloseable {
                         }
                     } else {
                         boolean exactEstablished = established.test(selection);
-                        if (stable(version) && exactEstablished && current(selection)) {
-                            return selection;
-                        }
                         if (stable(version)) {
-                            boolean anyEstablished = establishedGeneration.test(state.generation);
-                            if (stable(version) && anyEstablished) {
-                                return null;
-                            }
+                            return exactEstablished && current(selection) ? selection : null;
                         }
                     }
                 }
             }
         }
-        return selectSlow(target, routeKey, established, establishedGeneration);
+        return selectSlow(target, routeKey, established);
     }
 
     void record(ClientConnectionTarget target,
@@ -507,112 +480,58 @@ final class Http2AltSvcCache implements AutoCloseable {
         return normalized.toLowerCase(Locale.ROOT);
     }
 
-    private Candidate selectRouteSlow(ClientConnectionTarget.LookupKey originKey,
-                                      Predicate<Generation> established) {
+    private Candidate selectRouteSlow(ClientConnectionTarget.LookupKey originKey) {
         if (!originKey.currentTlsGeneration()) {
             removeStale(originKey);
             return null;
         }
 
-        while (true) {
-            List<OriginRouteKey> indexedRoutes;
-            lock.lock();
-            try {
-                if (closed) {
-                    return null;
-                }
-                indexedRoutes = lookupIndex.get(originKey);
-                if (indexedRoutes == null) {
-                    return null;
-                }
-            } finally {
-                lock.unlock();
+        lock.lock();
+        try {
+            if (closed) {
+                return null;
             }
-
-            boolean retry = false;
+            List<OriginRouteKey> indexedRoutes = lookupIndex.get(originKey);
+            if (indexedRoutes == null) {
+                return null;
+            }
             for (int index = indexedRoutes.size() - 1; index >= 0; index--) {
                 OriginRouteKey routeKey = indexedRoutes.get(index);
-                RouteState state;
-                boolean freshAdvertisement;
-                lock.lock();
-                try {
-                    if (closed) {
-                        return null;
+                RouteState state = routes.get(routeKey);
+                if (state == null) {
+                    beginMutation();
+                    try {
+                        removeIndexLocked(routeKey);
+                    } finally {
+                        endMutation();
                     }
-                    state = routes.get(routeKey);
-                    if (state == null) {
-                        beginMutation();
-                        try {
-                            removeIndexLocked(routeKey);
-                        } finally {
-                            endMutation();
-                        }
-                        continue;
-                    }
-                    Instant now = clock.instant();
-                    if (expiredNegative(state, now)) {
-                        beginMutation();
-                        try {
-                            state.negativeUntil = null;
-                        } finally {
-                            endMutation();
-                        }
-                    } else if (negative(state, now)) {
-                        continue;
-                    }
-                    freshAdvertisement = fresh(state, now);
-                } finally {
-                    lock.unlock();
+                    continue;
                 }
-
+                Instant now = clock.instant();
+                if (expiredNegative(state, now)) {
+                    beginMutation();
+                    try {
+                        state.negativeUntil = null;
+                    } finally {
+                        endMutation();
+                    }
+                } else if (negative(state, now)) {
+                    continue;
+                }
                 Candidate candidate = state.candidate;
-                if (freshAdvertisement) {
-                    return current(candidate) ? candidate : null;
+                if (current(candidate)) {
+                    return candidate;
                 }
-                boolean generationEstablished = established.test(state.generation);
-                List<Generation> invalidations = new ArrayList<>();
-                boolean stateChanged;
-                lock.lock();
-                try {
-                    stateChanged = routes.get(routeKey) != state;
-                    if (!stateChanged) {
-                        Instant now = clock.instant();
-                        stateChanged = negative(state, now) || fresh(state, now);
-                        if (!stateChanged) {
-                            if (generationEstablished && current(candidate)) {
-                                return candidate;
-                            }
-                            beginMutation();
-                            try {
-                                removeWithTombstone(routeKey,
-                                                    state,
-                                                    state.observedAt,
-                                                    invalidations);
-                            } finally {
-                                endMutation();
-                            }
-                        }
-                    }
-                } finally {
-                    lock.unlock();
-                    notifyInvalidations(invalidations);
-                }
-                if (stateChanged) {
-                    retry = true;
-                    break;
-                }
-            }
-            if (retry) {
-                continue;
             }
             return null;
+        } finally {
+            lock.unlock();
         }
     }
 
     private Selection selectSlow(ClientConnectionTarget target,
                                  OriginRouteKey suppliedRouteKey,
-                                 Predicate<Selection> established,
-                                 Predicate<Generation> establishedGeneration) {
+                                 Predicate<Selection> established) {
         OriginRouteKey routeKey = suppliedRouteKey == null ? originRouteKey(target) : suppliedRouteKey;
         while (true) {
             RouteState state;
@@ -664,8 +583,6 @@ final class Http2AltSvcCache implements AutoCloseable {
                 return current(selection) ? selection : null;
             }
             boolean exactEstablished = established.test(selection);
-            boolean anyEstablished = !exactEstablished && establishedGeneration.test(state.generation);
-            List<Generation> invalidations = new ArrayList<>();
             lock.lock();
             try {
                 if (routes.get(routeKey) != state) {
@@ -681,19 +598,9 @@ final class Http2AltSvcCache implements AutoCloseable {
                 if (exactEstablished && current(selection)) {
                     return selection;
                 }
-                if (anyEstablished) {
-                    return null;
-                }
-                beginMutation();
-                try {
-                    removeWithTombstone(routeKey, state, state.observedAt, invalidations);
-                } finally {
-                    endMutation();
-                }
                 return null;
             } finally {
                 lock.unlock();
-                notifyInvalidations(invalidations);
             }
         }
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -740,31 +740,49 @@ final class Http2AltSvcCache implements AutoCloseable {
         routes.put(routeKey, updated);
         insertionOrder.put(routeKey, updated);
         addIndexLocked(routeKey);
-        enforceCapacityLocked(invalidations);
+        enforceCapacityLocked(invalidations, false);
         Selection selection = updated.selection(target);
         if (selection != null && routes.get(routeKey) == updated) {
             publishSelectionMemoLocked(target, routeKey, updated, selection);
         }
     }
 
-    private void enforceCapacityLocked(List<Generation> invalidations) {
+    private void enforceCapacityLocked(List<Generation> invalidations, boolean evictRouteFirst) {
         while (insertionOrder.size() + tombstones.size() > MAX_ENTRIES) {
-            Map.Entry<OriginRouteKey, Instant> tombstone = tombstones.firstEntry();
-            if (tombstone != null) {
-                tombstones.remove(tombstone.getKey(), tombstone.getValue());
+            if (!evictRouteFirst && removeOldestTombstoneLocked()) {
                 continue;
             }
-            Map.Entry<OriginRouteKey, RouteState> removed = insertionOrder.firstEntry();
-            if (removed == null) {
-                throw new IllegalStateException("HTTP/2 Alt-Svc indexes are empty above capacity");
+            if (removeOldestRouteLocked(invalidations)) {
+                continue;
             }
-            invalidate(removed.getValue(), invalidations);
-            insertionOrder.remove(removed.getKey(), removed.getValue());
-            routes.remove(removed.getKey(), removed.getValue());
-            removeIndexLocked(removed.getKey());
-            removeAdvertisedHost(removed.getValue().advertisedHost);
-            clearSelectionMemosLocked(removed.getValue());
+            if (removeOldestTombstoneLocked()) {
+                continue;
+            }
+            throw new IllegalStateException("HTTP/2 Alt-Svc indexes are empty above capacity");
         }
+    }
+
+    private boolean removeOldestTombstoneLocked() {
+        Map.Entry<OriginRouteKey, Instant> tombstone = tombstones.firstEntry();
+        if (tombstone != null) {
+            tombstones.remove(tombstone.getKey(), tombstone.getValue());
+            return true;
+        }
+        return false;
+    }
+
+    private boolean removeOldestRouteLocked(List<Generation> invalidations) {
+        Map.Entry<OriginRouteKey, RouteState> removed = insertionOrder.firstEntry();
+        if (removed == null) {
+            return false;
+        }
+        invalidate(removed.getValue(), invalidations);
+        insertionOrder.remove(removed.getKey(), removed.getValue());
+        routes.remove(removed.getKey(), removed.getValue());
+        removeIndexLocked(removed.getKey());
+        removeAdvertisedHost(removed.getValue().advertisedHost);
+        clearSelectionMemosLocked(removed.getValue());
+        return true;
     }
 
     private void removeWithTombstone(OriginRouteKey routeKey,
@@ -799,7 +817,7 @@ final class Http2AltSvcCache implements AutoCloseable {
         }
         tombstones.remove(routeKey);
         tombstones.put(routeKey, observedAt);
-        enforceCapacityLocked(invalidations);
+        enforceCapacityLocked(invalidations, true);
     }
 
     private void invalidate(RouteState state, List<Generation> invalidations) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -55,6 +55,8 @@ final class Http2AltSvcCache implements AutoCloseable {
     private final ConcurrentMap<String, Integer> advertisedHostCounts = new ConcurrentHashMap<>();
     // Mutated only while holding lock.
     private final LinkedHashMap<OriginRouteKey, RouteState> insertionOrder = new LinkedHashMap<>();
+    // Mutated only while holding lock. Active routes and tombstones share MAX_ENTRIES.
+    private final LinkedHashMap<OriginRouteKey, Instant> tombstones = new LinkedHashMap<>();
     // Even values are stable; every locked mutation spans the adjacent odd value.
     private volatile long mutationVersion;
     // Mutated only while holding lock, then published through mutationVersion.
@@ -63,6 +65,7 @@ final class Http2AltSvcCache implements AutoCloseable {
     private volatile List<SelectionMemo> selectionMemos = List.of();
     private long nextGeneration;
     private long networkGeneration;
+    private Instant networkChangedAt = Instant.MIN;
     private volatile boolean closed;
 
     private Http2AltSvcCache(Clock clock, Consumer<Generation> invalidationListener) {
@@ -224,9 +227,11 @@ final class Http2AltSvcCache implements AutoCloseable {
     void record(ClientConnectionTarget target,
                 AltSvcHeader header,
                 boolean secureOrigin,
-                boolean explicitConnection) {
+                boolean explicitConnection,
+                Instant observedAt) {
         Objects.requireNonNull(target, "target");
         Objects.requireNonNull(header, "header");
+        Objects.requireNonNull(observedAt, "observedAt");
         if (!target.currentTlsGeneration()) {
             removeStale(target);
             return;
@@ -254,7 +259,14 @@ final class Http2AltSvcCache implements AutoCloseable {
                         : normalizeHost(target.originAuthority().host().value());
                 alternative = selectAlternative(originHost, header, now);
             }
-            if (alternative == null && previous == null) {
+            boolean withdrawal = alternative == null;
+            Instant latestObservation = previous == null ? tombstones.get(routeKey) : previous.observedAt;
+            // Equal-time withdrawals win; advertisements must be strictly newer than state and network barriers.
+            if (observedAt.isBefore(networkChangedAt)
+                    || (!withdrawal && observedAt.equals(networkChangedAt))
+                    || (latestObservation != null
+                            && (observedAt.isBefore(latestObservation)
+                                    || (!withdrawal && observedAt.equals(latestObservation))))) {
                 return;
             }
             if (alternative != null
@@ -262,7 +274,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                     && previous.alternative.sameAuthority(alternative)) {
                 beginMutation();
                 try {
-                    previous.refresh(alternative);
+                    previous.refresh(alternative, observedAt);
                     Selection selection = previous.selection(target);
                     if (selection == null) {
                         selection = previous.addSelection(clock,
@@ -281,7 +293,7 @@ final class Http2AltSvcCache implements AutoCloseable {
             beginMutation();
             try {
                 if (alternative == null) {
-                    remove(routeKey, previous, invalidations);
+                    removeWithTombstone(routeKey, previous, observedAt, invalidations);
                 } else {
                     Generation generation = nextGeneration(alternative.expirationTime);
                     RouteState updated = new RouteState(previous == null ? originHost : previous.originHost,
@@ -290,6 +302,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                                                                 : previous.advertisedHost,
                                                         routeKey,
                                                         alternative,
+                                                        observedAt,
                                                         generation,
                                                         selection(target, routeKey, alternative, generation),
                                                         null);
@@ -315,6 +328,7 @@ final class Http2AltSvcCache implements AutoCloseable {
             return;
         }
 
+        Instant observedAt = clock.instant();
         List<Generation> invalidations = new ArrayList<>();
         lock.lock();
         try {
@@ -324,14 +338,19 @@ final class Http2AltSvcCache implements AutoCloseable {
             }
             beginMutation();
             try {
+                Instant eventAt = latest(state.observedAt, observedAt);
                 Generation generation = nextGeneration(state.alternative.expirationTime);
-                RouteState updated = routeState(selection.routeKey,
-                                                selection.originTarget,
-                                                state.originHost,
-                                                state.advertisedHost,
-                                                state.alternative,
-                                                generation,
-                                                clock.instant().plus(NEGATIVE_CACHE_TTL));
+                RouteState updated = new RouteState(state.originHost,
+                                                    state.advertisedHost,
+                                                    selection.routeKey,
+                                                    state.alternative,
+                                                    eventAt,
+                                                    generation,
+                                                    selection(selection.originTarget,
+                                                              selection.routeKey,
+                                                              state.alternative,
+                                                              generation),
+                                                    eventAt.plus(NEGATIVE_CACHE_TTL));
                 put(selection.routeKey, selection.originTarget, state, updated, invalidations);
             } finally {
                 endMutation();
@@ -344,6 +363,7 @@ final class Http2AltSvcCache implements AutoCloseable {
 
     void recordMisdirected(Selection selection) {
         Objects.requireNonNull(selection, "selection");
+        Instant observedAt = clock.instant();
         List<Generation> invalidations = new ArrayList<>();
         lock.lock();
         try {
@@ -351,7 +371,10 @@ final class Http2AltSvcCache implements AutoCloseable {
             if (matches(selection, state)) {
                 beginMutation();
                 try {
-                    remove(selection.routeKey, state, invalidations);
+                    removeWithTombstone(selection.routeKey,
+                                        state,
+                                        latest(state.observedAt, observedAt),
+                                        invalidations);
                 } finally {
                     endMutation();
                 }
@@ -363,6 +386,7 @@ final class Http2AltSvcCache implements AutoCloseable {
     }
 
     void networkChanged() {
+        Instant observedAt = clock.instant();
         List<Generation> invalidations = new ArrayList<>();
         lock.lock();
         try {
@@ -371,6 +395,7 @@ final class Http2AltSvcCache implements AutoCloseable {
             }
             beginMutation();
             try {
+                networkChangedAt = latest(networkChangedAt, observedAt);
                 networkGeneration++;
                 var iterator = insertionOrder.entrySet().iterator();
                 while (iterator.hasNext()) {
@@ -383,6 +408,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                                                         state.originHost,
                                                         state.advertisedHost,
                                                         state.alternative,
+                                                        latest(state.observedAt, networkChangedAt),
                                                         nextGeneration(state.alternative.expirationTime),
                                                         null);
                         entry.setValue(updated);
@@ -394,6 +420,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                         removeIndexLocked(routeKey);
                         removeAdvertisedHost(state.advertisedHost);
                         clearSelectionMemosLocked(state);
+                        putTombstoneLocked(routeKey, networkChangedAt, invalidations);
                     }
                 }
             } finally {
@@ -420,6 +447,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                 routes.clear();
                 lookupIndex.clear();
                 insertionOrder.clear();
+                tombstones.clear();
                 advertisedHostCounts.clear();
                 selectionMemos = List.of();
             } finally {
@@ -441,6 +469,10 @@ final class Http2AltSvcCache implements AutoCloseable {
 
     private static boolean fresh(RouteState state, Instant now) {
         return state.alternative.expirationTime.isAfter(now);
+    }
+
+    private static Instant latest(Instant first, Instant second) {
+        return first.isAfter(second) ? first : second;
     }
 
     private static boolean eligible(ClientConnectionTarget target) {
@@ -552,7 +584,10 @@ final class Http2AltSvcCache implements AutoCloseable {
                             }
                             beginMutation();
                             try {
-                                remove(routeKey, state, invalidations);
+                                removeWithTombstone(routeKey,
+                                                    state,
+                                                    state.observedAt,
+                                                    invalidations);
                             } finally {
                                 endMutation();
                             }
@@ -651,7 +686,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                 }
                 beginMutation();
                 try {
-                    remove(routeKey, state, invalidations);
+                    removeWithTombstone(routeKey, state, state.observedAt, invalidations);
                 } finally {
                     endMutation();
                 }
@@ -701,13 +736,27 @@ final class Http2AltSvcCache implements AutoCloseable {
         if (previous == null) {
             addAdvertisedHost(updated.advertisedHost);
         }
+        tombstones.remove(routeKey);
         routes.put(routeKey, updated);
         insertionOrder.put(routeKey, updated);
         addIndexLocked(routeKey);
-        while (insertionOrder.size() > MAX_ENTRIES) {
+        enforceCapacityLocked(invalidations);
+        Selection selection = updated.selection(target);
+        if (selection != null && routes.get(routeKey) == updated) {
+            publishSelectionMemoLocked(target, routeKey, updated, selection);
+        }
+    }
+
+    private void enforceCapacityLocked(List<Generation> invalidations) {
+        while (insertionOrder.size() + tombstones.size() > MAX_ENTRIES) {
+            Map.Entry<OriginRouteKey, Instant> tombstone = tombstones.firstEntry();
+            if (tombstone != null) {
+                tombstones.remove(tombstone.getKey(), tombstone.getValue());
+                continue;
+            }
             Map.Entry<OriginRouteKey, RouteState> removed = insertionOrder.firstEntry();
             if (removed == null) {
-                throw new IllegalStateException("HTTP/2 Alt-Svc insertion index is empty above capacity");
+                throw new IllegalStateException("HTTP/2 Alt-Svc indexes are empty above capacity");
             }
             invalidate(removed.getValue(), invalidations);
             insertionOrder.remove(removed.getKey(), removed.getValue());
@@ -716,15 +765,21 @@ final class Http2AltSvcCache implements AutoCloseable {
             removeAdvertisedHost(removed.getValue().advertisedHost);
             clearSelectionMemosLocked(removed.getValue());
         }
-        Selection selection = updated.selection(target);
-        if (selection != null) {
-            publishSelectionMemoLocked(target, routeKey, updated, selection);
+    }
+
+    private void removeWithTombstone(OriginRouteKey routeKey,
+                                     RouteState expected,
+                                     Instant observedAt,
+                                     List<Generation> invalidations) {
+        removeDiscardingHistory(routeKey, expected, invalidations);
+        if (expected == null || routes.get(routeKey) == null) {
+            putTombstoneLocked(routeKey, observedAt, invalidations);
         }
     }
 
-    private void remove(OriginRouteKey routeKey,
-                        RouteState expected,
-                        List<Generation> invalidations) {
+    private void removeDiscardingHistory(OriginRouteKey routeKey,
+                                         RouteState expected,
+                                         List<Generation> invalidations) {
         if (expected != null && routes.get(routeKey) == expected) {
             invalidate(expected, invalidations);
             routes.remove(routeKey, expected);
@@ -735,37 +790,35 @@ final class Http2AltSvcCache implements AutoCloseable {
         }
     }
 
+    private void putTombstoneLocked(OriginRouteKey routeKey,
+                                    Instant observedAt,
+                                    List<Generation> invalidations) {
+        Instant previous = tombstones.get(routeKey);
+        if (previous != null && !observedAt.isAfter(previous)) {
+            return;
+        }
+        tombstones.remove(routeKey);
+        tombstones.put(routeKey, observedAt);
+        enforceCapacityLocked(invalidations);
+    }
+
     private void invalidate(RouteState state, List<Generation> invalidations) {
         state.generation.current = false;
         invalidations.add(state.generation);
     }
 
     private RouteState routeState(OriginRouteKey routeKey,
-                                  ClientConnectionTarget target,
                                   String originHost,
                                   String advertisedHost,
                                   Alternative alternative,
+                                  Instant observedAt,
                                   Generation generation,
                                   Instant negativeUntil) {
         return new RouteState(originHost,
                               advertisedHost,
                               routeKey,
                               alternative,
-                              generation,
-                              selection(target, routeKey, alternative, generation),
-                              negativeUntil);
-    }
-
-    private RouteState routeState(OriginRouteKey routeKey,
-                                  String originHost,
-                                  String advertisedHost,
-                                  Alternative alternative,
-                                  Generation generation,
-                                  Instant negativeUntil) {
-        return new RouteState(originHost,
-                              advertisedHost,
-                              routeKey,
-                              alternative,
+                              observedAt,
                               generation,
                               negativeUntil);
     }
@@ -902,7 +955,7 @@ final class Http2AltSvcCache implements AutoCloseable {
             if (state != null) {
                 beginMutation();
                 try {
-                    remove(routeKey, state, invalidations);
+                    removeDiscardingHistory(routeKey, state, invalidations);
                 } finally {
                     endMutation();
                 }
@@ -922,7 +975,10 @@ final class Http2AltSvcCache implements AutoCloseable {
                 beginMutation();
                 try {
                     for (OriginRouteKey routeKey : routeKeys) {
-                        remove(routeKey, routes.get(routeKey), invalidations);
+                        RouteState state = routes.get(routeKey);
+                        if (state != null) {
+                            removeDiscardingHistory(routeKey, state, invalidations);
+                        }
                     }
                 } finally {
                     endMutation();
@@ -1091,12 +1147,14 @@ final class Http2AltSvcCache implements AutoCloseable {
         private final Candidate candidate;
         private List<Selection> selections;
         private Alternative alternative;
+        private Instant observedAt;
         private Instant negativeUntil;
 
         private RouteState(String originHost,
                            String advertisedHost,
                            OriginRouteKey routeKey,
                            Alternative alternative,
+                           Instant observedAt,
                            Generation generation,
                            Selection selection,
                            Instant negativeUntil) {
@@ -1104,6 +1162,7 @@ final class Http2AltSvcCache implements AutoCloseable {
             this.advertisedHost = Objects.requireNonNull(advertisedHost, "advertisedHost");
             this.routeKey = Objects.requireNonNull(routeKey, "routeKey");
             this.alternative = Objects.requireNonNull(alternative, "alternative");
+            this.observedAt = Objects.requireNonNull(observedAt, "observedAt");
             this.generation = Objects.requireNonNull(generation, "generation");
             this.candidate = new Candidate(routeKey, generation);
             this.selections = List.of(Objects.requireNonNull(selection, "selection"));
@@ -1114,12 +1173,14 @@ final class Http2AltSvcCache implements AutoCloseable {
                            String advertisedHost,
                            OriginRouteKey routeKey,
                            Alternative alternative,
+                           Instant observedAt,
                            Generation generation,
                            Instant negativeUntil) {
             this.originHost = Objects.requireNonNull(originHost, "originHost");
             this.advertisedHost = Objects.requireNonNull(advertisedHost, "advertisedHost");
             this.routeKey = Objects.requireNonNull(routeKey, "routeKey");
             this.alternative = Objects.requireNonNull(alternative, "alternative");
+            this.observedAt = Objects.requireNonNull(observedAt, "observedAt");
             this.generation = Objects.requireNonNull(generation, "generation");
             this.candidate = new Candidate(routeKey, generation);
             this.selections = List.of();
@@ -1161,8 +1222,9 @@ final class Http2AltSvcCache implements AutoCloseable {
             return selection;
         }
 
-        private void refresh(Alternative alternative) {
+        private void refresh(Alternative alternative, Instant observedAt) {
             this.alternative = alternative;
+            this.observedAt = observedAt;
             generation.establishUntil = alternative.expirationTime;
             negativeUntil = null;
         }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -35,6 +35,7 @@ import io.helidon.common.uri.UriAuthority;
 import io.helidon.common.uri.UriHost;
 import io.helidon.webclient.api.AltSvcHeader;
 import io.helidon.webclient.api.ClientConnectionTarget;
+import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.ProxyRoute;
 
 final class Http2AltSvcCache implements AutoCloseable {
@@ -446,6 +447,7 @@ final class Http2AltSvcCache implements AutoCloseable {
         return target.currentTlsGeneration()
                 && "https".equals(target.scheme())
                 && target.connectionKey().tls().enabled()
+                && target.connectionKey().proxy().type() == Proxy.ProxyType.NONE
                 && target.transportAddress().isEmpty()
                 && target.proxyRoute().direct()
                 && !target.proxyRoute().addressBound();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -234,12 +234,10 @@ final class Http2AltSvcCache implements AutoCloseable {
             }
             boolean withdrawal = alternative == null;
             Instant latestObservation = previous == null ? tombstones.get(routeKey) : previous.observedAt;
-            // Equal-time withdrawals win; advertisements must be strictly newer than state and network barriers.
-            if (observedAt.isBefore(networkChangedAt)
-                    || (!withdrawal && observedAt.equals(networkChangedAt))
-                    || (latestObservation != null
-                            && (observedAt.isBefore(latestObservation)
-                                    || (!withdrawal && observedAt.equals(latestObservation))))) {
+            // Withdrawals always win; advertisements must be strictly newer than state and network barriers.
+            if (!withdrawal
+                    && (!observedAt.isAfter(networkChangedAt)
+                            || (latestObservation != null && !observedAt.isAfter(latestObservation)))) {
                 return;
             }
             if (alternative != null

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -1151,7 +1151,6 @@ final class Http2AltSvcCache implements AutoCloseable {
             this.alternative = alternative;
             this.observedAt = observedAt;
             generation.establishUntil = alternative.expirationTime;
-            negativeUntil = null;
         }
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -234,11 +234,17 @@ final class Http2AltSvcCache implements AutoCloseable {
             }
             boolean withdrawal = alternative == null;
             Instant latestObservation = previous == null ? tombstones.get(routeKey) : previous.observedAt;
-            // Withdrawals always win; advertisements must be strictly newer than state and network barriers.
-            if (!withdrawal
-                    && (!observedAt.isAfter(networkChangedAt)
-                            || (latestObservation != null && !observedAt.isAfter(latestObservation)))) {
-                return;
+            if (withdrawal) {
+                // Withdrawals win ties but cannot discard a newer advertisement.
+                if (previous != null && observedAt.isBefore(previous.alternativeObservedAt)) {
+                    return;
+                }
+            } else {
+                // Advertisements must be strictly newer than state and network barriers.
+                if (!observedAt.isAfter(networkChangedAt)
+                        || (latestObservation != null && !observedAt.isAfter(latestObservation))) {
+                    return;
+                }
             }
             if (alternative != null
                     && previous != null
@@ -273,6 +279,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                                                                 : previous.advertisedHost,
                                                         routeKey,
                                                         alternative,
+                                                        observedAt,
                                                         observedAt,
                                                         generation,
                                                         selection(target, routeKey, alternative, generation),
@@ -316,6 +323,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                                                     selection.routeKey,
                                                     state.alternative,
                                                     eventAt,
+                                                    state.alternativeObservedAt,
                                                     generation,
                                                     selection(selection.originTarget,
                                                               selection.routeKey,
@@ -375,10 +383,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                     RouteState state = entry.getValue();
                     invalidate(state, invalidations);
                     if (state.alternative.persist && routeKey.originKey.currentTlsGeneration()) {
-                        RouteState updated = routeState(routeKey,
-                                                        state.originHost,
-                                                        state.advertisedHost,
-                                                        state.alternative,
+                        RouteState updated = routeState(state,
                                                         latest(state.observedAt, networkChangedAt),
                                                         nextGeneration(state.alternative.expirationTime),
                                                         null);
@@ -731,18 +736,16 @@ final class Http2AltSvcCache implements AutoCloseable {
         invalidations.add(state.generation);
     }
 
-    private RouteState routeState(OriginRouteKey routeKey,
-                                  String originHost,
-                                  String advertisedHost,
-                                  Alternative alternative,
+    private RouteState routeState(RouteState state,
                                   Instant observedAt,
                                   Generation generation,
                                   Instant negativeUntil) {
-        return new RouteState(originHost,
-                              advertisedHost,
-                              routeKey,
-                              alternative,
+        return new RouteState(state.originHost,
+                              state.advertisedHost,
+                              state.routeKey,
+                              state.alternative,
                               observedAt,
+                              state.alternativeObservedAt,
                               generation,
                               negativeUntil);
     }
@@ -1072,6 +1075,7 @@ final class Http2AltSvcCache implements AutoCloseable {
         private List<Selection> selections;
         private Alternative alternative;
         private Instant observedAt;
+        private Instant alternativeObservedAt;
         private Instant negativeUntil;
 
         private RouteState(String originHost,
@@ -1079,6 +1083,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                            OriginRouteKey routeKey,
                            Alternative alternative,
                            Instant observedAt,
+                           Instant alternativeObservedAt,
                            Generation generation,
                            Selection selection,
                            Instant negativeUntil) {
@@ -1087,6 +1092,7 @@ final class Http2AltSvcCache implements AutoCloseable {
             this.routeKey = Objects.requireNonNull(routeKey, "routeKey");
             this.alternative = Objects.requireNonNull(alternative, "alternative");
             this.observedAt = Objects.requireNonNull(observedAt, "observedAt");
+            this.alternativeObservedAt = Objects.requireNonNull(alternativeObservedAt, "alternativeObservedAt");
             this.generation = Objects.requireNonNull(generation, "generation");
             this.candidate = new Candidate(routeKey, generation);
             this.selections = List.of(Objects.requireNonNull(selection, "selection"));
@@ -1098,6 +1104,7 @@ final class Http2AltSvcCache implements AutoCloseable {
                            OriginRouteKey routeKey,
                            Alternative alternative,
                            Instant observedAt,
+                           Instant alternativeObservedAt,
                            Generation generation,
                            Instant negativeUntil) {
             this.originHost = Objects.requireNonNull(originHost, "originHost");
@@ -1105,6 +1112,7 @@ final class Http2AltSvcCache implements AutoCloseable {
             this.routeKey = Objects.requireNonNull(routeKey, "routeKey");
             this.alternative = Objects.requireNonNull(alternative, "alternative");
             this.observedAt = Objects.requireNonNull(observedAt, "observedAt");
+            this.alternativeObservedAt = Objects.requireNonNull(alternativeObservedAt, "alternativeObservedAt");
             this.generation = Objects.requireNonNull(generation, "generation");
             this.candidate = new Candidate(routeKey, generation);
             this.selections = List.of();
@@ -1149,6 +1157,7 @@ final class Http2AltSvcCache implements AutoCloseable {
         private void refresh(Alternative alternative, Instant observedAt) {
             this.alternative = alternative;
             this.observedAt = observedAt;
+            this.alternativeObservedAt = observedAt;
             generation.establishUntil = alternative.expirationTime;
         }
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -1,0 +1,1184 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
+import io.helidon.webclient.api.AltSvcHeader;
+import io.helidon.webclient.api.ClientConnectionTarget;
+import io.helidon.webclient.api.ProxyRoute;
+
+final class Http2AltSvcCache implements AutoCloseable {
+    private static final System.Logger LOGGER = System.getLogger(Http2AltSvcCache.class.getName());
+    private static final Duration NEGATIVE_CACHE_TTL = Duration.ofMinutes(5);
+    private static final int MAX_ENTRIES = 1_000;
+    private static final int MAX_SELECTION_MEMOS = 4;
+
+    private final Clock clock;
+    private final Consumer<Generation> invalidationListener;
+    private final ReentrantLock lock = new ReentrantLock();
+    // Concurrent readers use only published state and immutable lookup lists.
+    private final ConcurrentMap<OriginRouteKey, RouteState> routes = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ClientConnectionTarget.LookupKey, List<OriginRouteKey>> lookupIndex =
+            new ConcurrentHashMap<>();
+    // Mutated under lock. Add before publishing a route; remove after unpublishing it.
+    private final ConcurrentMap<String, Integer> advertisedHostCounts = new ConcurrentHashMap<>();
+    // Mutated only while holding lock.
+    private final LinkedHashMap<OriginRouteKey, RouteState> insertionOrder = new LinkedHashMap<>();
+    // Even values are stable; every locked mutation spans the adjacent odd value.
+    private volatile long mutationVersion;
+    // Mutated only while holding lock, then published through mutationVersion.
+    private long nextMutationVersion;
+    // Small raw-target memo. Common and alternating case variants avoid canonical-key allocation and map hashing.
+    private volatile List<SelectionMemo> selectionMemos = List.of();
+    private long nextGeneration;
+    private long networkGeneration;
+    private volatile boolean closed;
+
+    private Http2AltSvcCache(Clock clock, Consumer<Generation> invalidationListener) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.invalidationListener = Objects.requireNonNull(invalidationListener, "invalidationListener");
+    }
+
+    static Http2AltSvcCache create(Consumer<Generation> invalidationListener) {
+        return new Http2AltSvcCache(Clock.systemUTC(), invalidationListener);
+    }
+
+    static Http2AltSvcCache create(Clock clock, Consumer<Generation> invalidationListener) {
+        return new Http2AltSvcCache(clock, invalidationListener);
+    }
+
+    boolean mayContain(String host) {
+        return !advertisedHostCounts.isEmpty() && advertisedHostCounts.containsKey(normalizeHost(host));
+    }
+
+    boolean available(ClientConnectionTarget target,
+                      boolean explicitConnection,
+                      Predicate<Selection> established,
+                      Predicate<Generation> establishedGeneration) {
+        return select(target, explicitConnection, established, establishedGeneration) != null;
+    }
+
+    Candidate selectRoute(ClientConnectionTarget.LookupKey lookupKey,
+                          boolean explicitConnection,
+                          Predicate<Generation> established) {
+        Objects.requireNonNull(lookupKey, "lookupKey");
+        Objects.requireNonNull(established, "established");
+        if (explicitConnection) {
+            return null;
+        }
+
+        ClientConnectionTarget.LookupKey originKey = lookupKey.altSvcOriginKey();
+        long version = mutationVersion;
+        if ((version & 1) == 0 && !closed && originKey.currentTlsGeneration()) {
+            List<OriginRouteKey> indexedRoutes = lookupIndex.get(originKey);
+            if (indexedRoutes == null && stable(version)) {
+                return null;
+            }
+            Instant now = clock.instant();
+            if (indexedRoutes != null) {
+                boolean slowPath = false;
+                for (int index = indexedRoutes.size() - 1; index >= 0; index--) {
+                    RouteState state = routes.get(indexedRoutes.get(index));
+                    if (state == null || expiredNegative(state, now)) {
+                        slowPath = true;
+                        break;
+                    }
+                    if (negative(state, now)) {
+                        continue;
+                    }
+                    Candidate candidate = state.candidate;
+                    if (fresh(state, now)) {
+                        if (stable(version) && current(candidate)) {
+                            return candidate;
+                        }
+                        slowPath = true;
+                        break;
+                    }
+                    boolean generationEstablished = established.test(state.generation);
+                    if (stable(version)) {
+                        if (generationEstablished && current(candidate)) {
+                            return candidate;
+                        }
+                        slowPath = true;
+                        break;
+                    }
+                }
+                if (!slowPath && stable(version)) {
+                    return null;
+                }
+            } else if (stable(version)) {
+                return null;
+            }
+        }
+        return selectRouteSlow(originKey, established);
+    }
+
+    Selection select(ClientConnectionTarget target,
+                     boolean explicitConnection,
+                     Predicate<Selection> established) {
+        return select(target, explicitConnection, established, _ -> false);
+    }
+
+    Selection select(ClientConnectionTarget target,
+                     boolean explicitConnection,
+                     Predicate<Selection> established,
+                     Predicate<Generation> establishedGeneration) {
+        Objects.requireNonNull(target, "target");
+        Objects.requireNonNull(established, "established");
+        Objects.requireNonNull(establishedGeneration, "establishedGeneration");
+        if (explicitConnection) {
+            return null;
+        }
+        if (!target.currentTlsGeneration()) {
+            removeStale(target);
+            return null;
+        }
+        if (!eligible(target)) {
+            return null;
+        }
+        if (routes.isEmpty()) {
+            return null;
+        }
+
+        long version = mutationVersion;
+        OriginRouteKey routeKey = null;
+        if ((version & 1) == 0 && !closed) {
+            SelectionMemo memo = selectionMemo(target);
+            RouteState state;
+            Selection selection = null;
+            if (memo != null) {
+                routeKey = memo.routeKey;
+                state = memo.state;
+                selection = memo.selection;
+            } else {
+                routeKey = originRouteKey(target);
+                state = routes.get(routeKey);
+            }
+            if (state == null && stable(version)) {
+                return null;
+            }
+            Instant now = clock.instant();
+            if (state != null && negative(state, now)) {
+                if (stable(version)) {
+                    return null;
+                }
+            }
+            if (state != null && !expiredNegative(state, now)) {
+                if (selection == null) {
+                    selection = state.selection(target);
+                }
+                if (selection != null) {
+                    if (fresh(state, now)) {
+                        if (stable(version) && current(selection)) {
+                            return selection;
+                        }
+                    } else {
+                        boolean exactEstablished = established.test(selection);
+                        if (stable(version) && exactEstablished && current(selection)) {
+                            return selection;
+                        }
+                        if (stable(version)) {
+                            boolean anyEstablished = establishedGeneration.test(state.generation);
+                            if (stable(version) && anyEstablished) {
+                                return null;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return selectSlow(target, routeKey, established, establishedGeneration);
+    }
+
+    void record(ClientConnectionTarget target,
+                AltSvcHeader header,
+                boolean secureOrigin,
+                boolean explicitConnection) {
+        Objects.requireNonNull(target, "target");
+        Objects.requireNonNull(header, "header");
+        if (!target.currentTlsGeneration()) {
+            removeStale(target);
+            return;
+        }
+        if (!secureOrigin || explicitConnection || !eligible(target)) {
+            return;
+        }
+
+        Instant now = clock.instant();
+        List<Generation> invalidations = null;
+        lock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            SelectionMemo memo = selectionMemo(target);
+            boolean memoized = memo != null && memo.state.generation.current;
+            OriginRouteKey routeKey = memoized ? memo.routeKey : originRouteKey(target);
+            RouteState previous = memoized ? memo.state : routes.get(routeKey);
+            Alternative alternative = null;
+            String originHost = null;
+            if (!header.clear()) {
+                originHost = memoized
+                        ? previous.originHost
+                        : normalizeHost(target.originAuthority().host().value());
+                alternative = selectAlternative(originHost, header, now);
+            }
+            if (alternative == null && previous == null) {
+                return;
+            }
+            if (alternative != null
+                    && previous != null
+                    && previous.alternative.sameAuthority(alternative)) {
+                beginMutation();
+                try {
+                    previous.refresh(alternative);
+                    Selection selection = previous.selection(target);
+                    if (selection == null) {
+                        selection = previous.addSelection(clock,
+                                                          target,
+                                                          alternative,
+                                                          networkGeneration,
+                                                          MAX_SELECTION_MEMOS);
+                    }
+                    publishSelectionMemoLocked(target, routeKey, previous, selection);
+                } finally {
+                    endMutation();
+                }
+                return;
+            }
+            invalidations = new ArrayList<>();
+            beginMutation();
+            try {
+                if (alternative == null) {
+                    remove(routeKey, previous, invalidations);
+                } else {
+                    Generation generation = nextGeneration(alternative.expirationTime);
+                    RouteState updated = new RouteState(previous == null ? originHost : previous.originHost,
+                                                        previous == null
+                                                                ? normalizeHost(target.connectionKey().host())
+                                                                : previous.advertisedHost,
+                                                        routeKey,
+                                                        alternative,
+                                                        generation,
+                                                        selection(target, routeKey, alternative, generation),
+                                                        null);
+                    put(routeKey, target, previous, updated, invalidations);
+                }
+            } finally {
+                endMutation();
+            }
+        } finally {
+            lock.unlock();
+            notifyInvalidations(invalidations);
+        }
+    }
+
+    boolean current(Selection selection) {
+        Objects.requireNonNull(selection, "selection");
+        return selection.generation.current && selection.originTarget.currentTlsGeneration();
+    }
+
+    void recordFailure(Selection selection) {
+        Objects.requireNonNull(selection, "selection");
+        if (!current(selection) || !selection.establishAllowed()) {
+            return;
+        }
+
+        List<Generation> invalidations = new ArrayList<>();
+        lock.lock();
+        try {
+            RouteState state = routes.get(selection.routeKey);
+            if (!matches(selection, state)) {
+                return;
+            }
+            beginMutation();
+            try {
+                Generation generation = nextGeneration(state.alternative.expirationTime);
+                RouteState updated = routeState(selection.routeKey,
+                                                selection.originTarget,
+                                                state.originHost,
+                                                state.advertisedHost,
+                                                state.alternative,
+                                                generation,
+                                                clock.instant().plus(NEGATIVE_CACHE_TTL));
+                put(selection.routeKey, selection.originTarget, state, updated, invalidations);
+            } finally {
+                endMutation();
+            }
+        } finally {
+            lock.unlock();
+            notifyInvalidations(invalidations);
+        }
+    }
+
+    void recordMisdirected(Selection selection) {
+        Objects.requireNonNull(selection, "selection");
+        List<Generation> invalidations = new ArrayList<>();
+        lock.lock();
+        try {
+            RouteState state = routes.get(selection.routeKey);
+            if (matches(selection, state)) {
+                beginMutation();
+                try {
+                    remove(selection.routeKey, state, invalidations);
+                } finally {
+                    endMutation();
+                }
+            }
+        } finally {
+            lock.unlock();
+            notifyInvalidations(invalidations);
+        }
+    }
+
+    void networkChanged() {
+        List<Generation> invalidations = new ArrayList<>();
+        lock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            beginMutation();
+            try {
+                networkGeneration++;
+                var iterator = insertionOrder.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    Map.Entry<OriginRouteKey, RouteState> entry = iterator.next();
+                    OriginRouteKey routeKey = entry.getKey();
+                    RouteState state = entry.getValue();
+                    invalidate(state, invalidations);
+                    if (state.alternative.persist && routeKey.originKey.currentTlsGeneration()) {
+                        RouteState updated = routeState(routeKey,
+                                                        state.originHost,
+                                                        state.advertisedHost,
+                                                        state.alternative,
+                                                        nextGeneration(state.alternative.expirationTime),
+                                                        null);
+                        entry.setValue(updated);
+                        routes.put(routeKey, updated);
+                        clearSelectionMemosLocked(state);
+                    } else {
+                        iterator.remove();
+                        routes.remove(routeKey, state);
+                        removeIndexLocked(routeKey);
+                        removeAdvertisedHost(state.advertisedHost);
+                        clearSelectionMemosLocked(state);
+                    }
+                }
+            } finally {
+                endMutation();
+            }
+        } finally {
+            lock.unlock();
+            notifyInvalidations(invalidations);
+        }
+    }
+
+    @Override
+    public void close() {
+        List<Generation> invalidations = new ArrayList<>();
+        lock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            beginMutation();
+            try {
+                closed = true;
+                insertionOrder.values().forEach(state -> invalidate(state, invalidations));
+                routes.clear();
+                lookupIndex.clear();
+                insertionOrder.clear();
+                advertisedHostCounts.clear();
+                selectionMemos = List.of();
+            } finally {
+                endMutation();
+            }
+        } finally {
+            lock.unlock();
+            notifyInvalidations(invalidations);
+        }
+    }
+
+    private static boolean negative(RouteState state, Instant now) {
+        return state.negativeUntil != null && state.negativeUntil.isAfter(now);
+    }
+
+    private static boolean expiredNegative(RouteState state, Instant now) {
+        return state.negativeUntil != null && !state.negativeUntil.isAfter(now);
+    }
+
+    private static boolean fresh(RouteState state, Instant now) {
+        return state.alternative.expirationTime.isAfter(now);
+    }
+
+    private static boolean eligible(ClientConnectionTarget target) {
+        return target.currentTlsGeneration()
+                && "https".equals(target.scheme())
+                && target.connectionKey().tls().enabled()
+                && target.transportAddress().isEmpty()
+                && target.proxyRoute().direct()
+                && !target.proxyRoute().addressBound();
+    }
+
+    private static boolean matches(Selection selection, RouteState state) {
+        return state != null
+                && state.generation == selection.generation
+                && state.routeKey.equals(selection.routeKey);
+    }
+
+    private static OriginRouteKey originRouteKey(ClientConnectionTarget target) {
+        return new OriginRouteKey(target.lookupKey().altSvcOriginKey(), target.proxyRoute());
+    }
+
+    private static boolean sameHost(String first, String second) {
+        return normalizeHost(first).equals(normalizeHost(second));
+    }
+
+    private static String normalizeHost(String host) {
+        String normalized = Objects.requireNonNull(host, "host").trim();
+        if (normalized.startsWith("[") && normalized.endsWith("]")) {
+            normalized = normalized.substring(1, normalized.length() - 1);
+        }
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private Candidate selectRouteSlow(ClientConnectionTarget.LookupKey originKey,
+                                      Predicate<Generation> established) {
+        if (!originKey.currentTlsGeneration()) {
+            removeStale(originKey);
+            return null;
+        }
+
+        while (true) {
+            List<OriginRouteKey> indexedRoutes;
+            lock.lock();
+            try {
+                if (closed) {
+                    return null;
+                }
+                indexedRoutes = lookupIndex.get(originKey);
+                if (indexedRoutes == null) {
+                    return null;
+                }
+            } finally {
+                lock.unlock();
+            }
+
+            boolean retry = false;
+            for (int index = indexedRoutes.size() - 1; index >= 0; index--) {
+                OriginRouteKey routeKey = indexedRoutes.get(index);
+                RouteState state;
+                boolean freshAdvertisement;
+                lock.lock();
+                try {
+                    if (closed) {
+                        return null;
+                    }
+                    state = routes.get(routeKey);
+                    if (state == null) {
+                        beginMutation();
+                        try {
+                            removeIndexLocked(routeKey);
+                        } finally {
+                            endMutation();
+                        }
+                        continue;
+                    }
+                    Instant now = clock.instant();
+                    if (expiredNegative(state, now)) {
+                        beginMutation();
+                        try {
+                            state.negativeUntil = null;
+                        } finally {
+                            endMutation();
+                        }
+                    } else if (negative(state, now)) {
+                        continue;
+                    }
+                    freshAdvertisement = fresh(state, now);
+                } finally {
+                    lock.unlock();
+                }
+
+                Candidate candidate = state.candidate;
+                if (freshAdvertisement) {
+                    return current(candidate) ? candidate : null;
+                }
+                boolean generationEstablished = established.test(state.generation);
+                List<Generation> invalidations = new ArrayList<>();
+                boolean stateChanged;
+                lock.lock();
+                try {
+                    stateChanged = routes.get(routeKey) != state;
+                    if (!stateChanged) {
+                        Instant now = clock.instant();
+                        stateChanged = negative(state, now) || fresh(state, now);
+                        if (!stateChanged) {
+                            if (generationEstablished && current(candidate)) {
+                                return candidate;
+                            }
+                            beginMutation();
+                            try {
+                                remove(routeKey, state, invalidations);
+                            } finally {
+                                endMutation();
+                            }
+                        }
+                    }
+                } finally {
+                    lock.unlock();
+                    notifyInvalidations(invalidations);
+                }
+                if (stateChanged) {
+                    retry = true;
+                    break;
+                }
+            }
+            if (retry) {
+                continue;
+            }
+            return null;
+        }
+    }
+
+    private Selection selectSlow(ClientConnectionTarget target,
+                                 OriginRouteKey suppliedRouteKey,
+                                 Predicate<Selection> established,
+                                 Predicate<Generation> establishedGeneration) {
+        OriginRouteKey routeKey = suppliedRouteKey == null ? originRouteKey(target) : suppliedRouteKey;
+        while (true) {
+            RouteState state;
+            Selection selection;
+            boolean freshAdvertisement;
+            lock.lock();
+            try {
+                if (closed || !target.currentTlsGeneration() || !eligible(target)) {
+                    return null;
+                }
+                state = routes.get(routeKey);
+                if (state == null) {
+                    return null;
+                }
+                Instant now = clock.instant();
+                if (negative(state, now)) {
+                    return null;
+                }
+                if (expiredNegative(state, now)) {
+                    beginMutation();
+                    try {
+                        state.negativeUntil = null;
+                    } finally {
+                        endMutation();
+                    }
+                }
+                selection = state.selection(target);
+                if (selection == null) {
+                    beginMutation();
+                    try {
+                        selection = state.addSelection(clock,
+                                                       target,
+                                                       state.alternative,
+                                                       networkGeneration,
+                                                       MAX_SELECTION_MEMOS);
+                        publishSelectionMemoLocked(target, routeKey, state, selection);
+                    } finally {
+                        endMutation();
+                    }
+                } else {
+                    publishSelectionMemoLocked(target, routeKey, state, selection);
+                }
+                freshAdvertisement = fresh(state, now);
+            } finally {
+                lock.unlock();
+            }
+
+            if (freshAdvertisement) {
+                return current(selection) ? selection : null;
+            }
+            boolean exactEstablished = established.test(selection);
+            boolean anyEstablished = !exactEstablished && establishedGeneration.test(state.generation);
+            List<Generation> invalidations = new ArrayList<>();
+            lock.lock();
+            try {
+                if (routes.get(routeKey) != state) {
+                    continue;
+                }
+                Instant now = clock.instant();
+                if (negative(state, now)) {
+                    return null;
+                }
+                if (fresh(state, now)) {
+                    continue;
+                }
+                if (exactEstablished && current(selection)) {
+                    return selection;
+                }
+                if (anyEstablished) {
+                    return null;
+                }
+                beginMutation();
+                try {
+                    remove(routeKey, state, invalidations);
+                } finally {
+                    endMutation();
+                }
+                return null;
+            } finally {
+                lock.unlock();
+                notifyInvalidations(invalidations);
+            }
+        }
+    }
+
+    private Alternative selectAlternative(String originHost, AltSvcHeader header, Instant now) {
+        Alternative firstFresh = null;
+        Alternative firstExpired = null;
+        for (AltSvcHeader.Alternative candidate : header.alternatives()) {
+            if (!"h2".equals(candidate.protocolId())) {
+                continue;
+            }
+            String host = candidate.host().orElse(originHost);
+            if (!sameHost(host, originHost)) {
+                continue;
+            }
+            Alternative alternative = new Alternative(host,
+                                                       candidate.port(),
+                                                       candidate.expirationTime(),
+                                                       candidate.persist());
+            if (alternative.expirationTime.isAfter(now)) {
+                if (firstFresh == null) {
+                    firstFresh = alternative;
+                }
+            } else if (firstExpired == null) {
+                firstExpired = alternative;
+            }
+        }
+        return firstFresh == null ? firstExpired : firstFresh;
+    }
+
+    private void put(OriginRouteKey routeKey,
+                     ClientConnectionTarget target,
+                     RouteState previous,
+                     RouteState updated,
+                     List<Generation> invalidations) {
+        if (previous != null && previous.generation != updated.generation) {
+            invalidate(previous, invalidations);
+            clearSelectionMemosLocked(previous);
+        }
+        if (previous == null) {
+            addAdvertisedHost(updated.advertisedHost);
+        }
+        routes.put(routeKey, updated);
+        insertionOrder.put(routeKey, updated);
+        addIndexLocked(routeKey);
+        while (insertionOrder.size() > MAX_ENTRIES) {
+            Map.Entry<OriginRouteKey, RouteState> removed = insertionOrder.firstEntry();
+            if (removed == null) {
+                throw new IllegalStateException("HTTP/2 Alt-Svc insertion index is empty above capacity");
+            }
+            invalidate(removed.getValue(), invalidations);
+            insertionOrder.remove(removed.getKey(), removed.getValue());
+            routes.remove(removed.getKey(), removed.getValue());
+            removeIndexLocked(removed.getKey());
+            removeAdvertisedHost(removed.getValue().advertisedHost);
+            clearSelectionMemosLocked(removed.getValue());
+        }
+        Selection selection = updated.selection(target);
+        if (selection != null) {
+            publishSelectionMemoLocked(target, routeKey, updated, selection);
+        }
+    }
+
+    private void remove(OriginRouteKey routeKey,
+                        RouteState expected,
+                        List<Generation> invalidations) {
+        if (expected != null && routes.get(routeKey) == expected) {
+            invalidate(expected, invalidations);
+            routes.remove(routeKey, expected);
+            insertionOrder.remove(routeKey, expected);
+            removeIndexLocked(routeKey);
+            removeAdvertisedHost(expected.advertisedHost);
+            clearSelectionMemosLocked(expected);
+        }
+    }
+
+    private void invalidate(RouteState state, List<Generation> invalidations) {
+        state.generation.current = false;
+        invalidations.add(state.generation);
+    }
+
+    private RouteState routeState(OriginRouteKey routeKey,
+                                  ClientConnectionTarget target,
+                                  String originHost,
+                                  String advertisedHost,
+                                  Alternative alternative,
+                                  Generation generation,
+                                  Instant negativeUntil) {
+        return new RouteState(originHost,
+                              advertisedHost,
+                              routeKey,
+                              alternative,
+                              generation,
+                              selection(target, routeKey, alternative, generation),
+                              negativeUntil);
+    }
+
+    private RouteState routeState(OriginRouteKey routeKey,
+                                  String originHost,
+                                  String advertisedHost,
+                                  Alternative alternative,
+                                  Generation generation,
+                                  Instant negativeUntil) {
+        return new RouteState(originHost,
+                              advertisedHost,
+                              routeKey,
+                              alternative,
+                              generation,
+                              negativeUntil);
+    }
+
+    private Selection selection(ClientConnectionTarget target,
+                                OriginRouteKey routeKey,
+                                Alternative alternative,
+                                Generation generation) {
+        return new Selection(clock,
+                             target,
+                             routeKey,
+                             alternative.host,
+                             alternative.port,
+                             generation,
+                             networkGeneration);
+    }
+
+    private SelectionMemo selectionMemo(ClientConnectionTarget target) {
+        for (SelectionMemo memo : selectionMemos) {
+            if (memo.target.equals(target)) {
+                return memo;
+            }
+        }
+        return null;
+    }
+
+    private void publishSelectionMemoLocked(ClientConnectionTarget target,
+                                            OriginRouteKey routeKey,
+                                            RouteState state,
+                                            Selection selection) {
+        List<SelectionMemo> current = selectionMemos;
+        if (!current.isEmpty()) {
+            SelectionMemo first = current.getFirst();
+            if (first.state == state && first.selection == selection && first.target.equals(target)) {
+                return;
+            }
+        }
+        var updated = new ArrayList<SelectionMemo>(Math.min(MAX_SELECTION_MEMOS, current.size() + 1));
+        updated.add(new SelectionMemo(target, routeKey, state, selection));
+        for (SelectionMemo memo : current) {
+            if (updated.size() == MAX_SELECTION_MEMOS) {
+                break;
+            }
+            if (!memo.target.equals(target) && memo.selection != selection) {
+                updated.add(memo);
+            }
+        }
+        selectionMemos = List.copyOf(updated);
+    }
+
+    private void clearSelectionMemosLocked(RouteState state) {
+        List<SelectionMemo> current = selectionMemos;
+        if (current.isEmpty()) {
+            return;
+        }
+        var updated = new ArrayList<SelectionMemo>(current.size());
+        for (SelectionMemo memo : current) {
+            if (memo.state != state) {
+                updated.add(memo);
+            }
+        }
+        if (updated.size() != current.size()) {
+            selectionMemos = updated.isEmpty() ? List.of() : List.copyOf(updated);
+        }
+    }
+
+    private void addIndexLocked(OriginRouteKey routeKey) {
+        List<OriginRouteKey> indexedRoutes = lookupIndex.get(routeKey.originKey);
+        if (indexedRoutes == null) {
+            lookupIndex.put(routeKey.originKey, List.of(routeKey));
+            return;
+        }
+        if (indexedRoutes.getLast().equals(routeKey)) {
+            return;
+        }
+        var updatedRoutes = new ArrayList<>(indexedRoutes);
+        updatedRoutes.remove(routeKey);
+        updatedRoutes.add(routeKey);
+        lookupIndex.put(routeKey.originKey, List.copyOf(updatedRoutes));
+    }
+
+    private void removeIndexLocked(OriginRouteKey routeKey) {
+        List<OriginRouteKey> indexedRoutes = lookupIndex.get(routeKey.originKey);
+        if (indexedRoutes == null || !indexedRoutes.contains(routeKey)) {
+            return;
+        }
+        if (indexedRoutes.size() == 1) {
+            lookupIndex.remove(routeKey.originKey, indexedRoutes);
+            return;
+        }
+        var updatedRoutes = new ArrayList<>(indexedRoutes);
+        updatedRoutes.remove(routeKey);
+        lookupIndex.replace(routeKey.originKey, indexedRoutes, List.copyOf(updatedRoutes));
+    }
+
+    private void addAdvertisedHost(String host) {
+        Integer count = advertisedHostCounts.get(host);
+        advertisedHostCounts.put(host, count == null ? 1 : count + 1);
+    }
+
+    private void removeAdvertisedHost(String host) {
+        Integer count = advertisedHostCounts.get(host);
+        if (count == null) {
+            throw new IllegalStateException("HTTP/2 Alt-Svc host index does not contain " + host);
+        }
+        if (count == 1) {
+            advertisedHostCounts.remove(host, count);
+        } else {
+            advertisedHostCounts.put(host, count - 1);
+        }
+    }
+
+    private void notifyInvalidations(List<Generation> invalidations) {
+        if (invalidations == null) {
+            return;
+        }
+        for (Generation invalidation : invalidations) {
+            try {
+                invalidationListener.accept(invalidation);
+            } catch (RuntimeException e) {
+                LOGGER.log(System.Logger.Level.WARNING,
+                           "Failed to retire invalidated HTTP/2 alternative " + invalidation,
+                           e);
+            }
+        }
+    }
+
+    private void removeStale(ClientConnectionTarget target) {
+        OriginRouteKey routeKey = originRouteKey(target);
+        List<Generation> invalidations = new ArrayList<>();
+        lock.lock();
+        try {
+            RouteState state = routes.get(routeKey);
+            if (state != null) {
+                beginMutation();
+                try {
+                    remove(routeKey, state, invalidations);
+                } finally {
+                    endMutation();
+                }
+            }
+        } finally {
+            lock.unlock();
+            notifyInvalidations(invalidations);
+        }
+    }
+
+    private void removeStale(ClientConnectionTarget.LookupKey lookupKey) {
+        List<Generation> invalidations = new ArrayList<>();
+        lock.lock();
+        try {
+            List<OriginRouteKey> routeKeys = lookupIndex.get(lookupKey);
+            if (routeKeys != null) {
+                beginMutation();
+                try {
+                    for (OriginRouteKey routeKey : routeKeys) {
+                        remove(routeKey, routes.get(routeKey), invalidations);
+                    }
+                } finally {
+                    endMutation();
+                }
+            }
+        } finally {
+            lock.unlock();
+            notifyInvalidations(invalidations);
+        }
+    }
+
+    private Generation nextGeneration(Instant establishUntil) {
+        return new Generation(++nextGeneration, establishUntil);
+    }
+
+    private void beginMutation() {
+        nextMutationVersion++;
+        mutationVersion = nextMutationVersion;
+    }
+
+    private void endMutation() {
+        nextMutationVersion++;
+        mutationVersion = nextMutationVersion;
+    }
+
+    private boolean stable(long version) {
+        return version == mutationVersion;
+    }
+
+    private boolean current(Candidate candidate) {
+        return candidate.generation.current && candidate.routeKey.originKey.currentTlsGeneration();
+    }
+
+    static final class Candidate {
+        private final OriginRouteKey routeKey;
+        private final Generation generation;
+
+        private Candidate(OriginRouteKey routeKey, Generation generation) {
+            this.routeKey = Objects.requireNonNull(routeKey, "routeKey");
+            this.generation = Objects.requireNonNull(generation, "generation");
+        }
+
+        ProxyRoute proxyRoute() {
+            return routeKey.proxyRoute;
+        }
+
+        @Override
+        public String toString() {
+            return "Http2AltSvcCache.Candidate[routeKey=" + routeKey
+                    + ", generation=" + generation
+                    + ']';
+        }
+    }
+
+    static final class Selection {
+        private final Clock clock;
+        private final ClientConnectionTarget originTarget;
+        private final OriginRouteKey routeKey;
+        private final String host;
+        private final int port;
+        private final UriAuthority authority;
+        private final Generation generation;
+        private final long networkGeneration;
+
+        private Selection(Clock clock,
+                          ClientConnectionTarget originTarget,
+                          OriginRouteKey routeKey,
+                          String host,
+                          int port,
+                          Generation generation,
+                          long networkGeneration) {
+            this.clock = clock;
+            this.originTarget = originTarget;
+            this.routeKey = routeKey;
+            this.host = host;
+            this.port = port;
+            this.authority = UriAuthority.create(UriHost.create(host), port);
+            this.generation = generation;
+            this.networkGeneration = networkGeneration;
+        }
+
+        ClientConnectionTarget originTarget() {
+            return originTarget;
+        }
+
+        String host() {
+            return host;
+        }
+
+        int port() {
+            return port;
+        }
+
+        UriAuthority authority() {
+            return authority;
+        }
+
+        long networkGeneration() {
+            return networkGeneration;
+        }
+
+        boolean establishAllowed() {
+            return generation.establishUntil.isAfter(clock.instant());
+        }
+
+        boolean sameRouteGeneration(Selection other) {
+            return other != null
+                    && generation == other.generation
+                    && routeKey.equals(other.routeKey);
+        }
+
+        boolean sameGeneration(Generation other) {
+            return generation == other;
+        }
+
+        @Override
+        public String toString() {
+            return "Http2AltSvcCache.Selection[originTarget=" + originTarget
+                    + ", authority=" + host + ':' + port
+                    + ", routeKey=" + routeKey
+                    + ", generation=" + generation
+                    + ", networkGeneration=" + networkGeneration
+                    + ", establishUntil=" + generation.establishUntil
+                    + ']';
+        }
+    }
+
+    private record SelectionMemo(ClientConnectionTarget target,
+                                 OriginRouteKey routeKey,
+                                 RouteState state,
+                                 Selection selection) {
+        private SelectionMemo {
+            Objects.requireNonNull(target, "target");
+            Objects.requireNonNull(routeKey, "routeKey");
+            Objects.requireNonNull(state, "state");
+            Objects.requireNonNull(selection, "selection");
+        }
+    }
+
+    private record Alternative(String host, int port, Instant expirationTime, boolean persist) {
+        private Alternative {
+            host = normalizeHost(host);
+            if (port < 1 || port > 65_535) {
+                throw new IllegalArgumentException("Invalid alternative port: " + port);
+            }
+            Objects.requireNonNull(expirationTime, "expirationTime");
+        }
+
+        private boolean sameAuthority(Alternative other) {
+            return host.equals(other.host) && port == other.port;
+        }
+    }
+
+    private record OriginRouteKey(ClientConnectionTarget.LookupKey originKey, ProxyRoute proxyRoute) {
+        private OriginRouteKey {
+            Objects.requireNonNull(originKey, "originKey");
+            Objects.requireNonNull(proxyRoute, "proxyRoute");
+        }
+    }
+
+    private static final class RouteState {
+        private final String originHost;
+        private final String advertisedHost;
+        private final OriginRouteKey routeKey;
+        private final Generation generation;
+        private final Candidate candidate;
+        private List<Selection> selections;
+        private Alternative alternative;
+        private Instant negativeUntil;
+
+        private RouteState(String originHost,
+                           String advertisedHost,
+                           OriginRouteKey routeKey,
+                           Alternative alternative,
+                           Generation generation,
+                           Selection selection,
+                           Instant negativeUntil) {
+            this.originHost = Objects.requireNonNull(originHost, "originHost");
+            this.advertisedHost = Objects.requireNonNull(advertisedHost, "advertisedHost");
+            this.routeKey = Objects.requireNonNull(routeKey, "routeKey");
+            this.alternative = Objects.requireNonNull(alternative, "alternative");
+            this.generation = Objects.requireNonNull(generation, "generation");
+            this.candidate = new Candidate(routeKey, generation);
+            this.selections = List.of(Objects.requireNonNull(selection, "selection"));
+            this.negativeUntil = negativeUntil;
+        }
+
+        private RouteState(String originHost,
+                           String advertisedHost,
+                           OriginRouteKey routeKey,
+                           Alternative alternative,
+                           Generation generation,
+                           Instant negativeUntil) {
+            this.originHost = Objects.requireNonNull(originHost, "originHost");
+            this.advertisedHost = Objects.requireNonNull(advertisedHost, "advertisedHost");
+            this.routeKey = Objects.requireNonNull(routeKey, "routeKey");
+            this.alternative = Objects.requireNonNull(alternative, "alternative");
+            this.generation = Objects.requireNonNull(generation, "generation");
+            this.candidate = new Candidate(routeKey, generation);
+            this.selections = List.of();
+            this.negativeUntil = negativeUntil;
+        }
+
+        private Selection selection(ClientConnectionTarget target) {
+            for (Selection selection : selections) {
+                if (selection.originTarget.equals(target)) {
+                    return selection;
+                }
+            }
+            return null;
+        }
+
+        private Selection addSelection(Clock clock,
+                                       ClientConnectionTarget target,
+                                       Alternative alternative,
+                                       long networkGeneration,
+                                       int maximumSelections) {
+            Selection selection = new Selection(clock,
+                                                target,
+                                                routeKey,
+                                                alternative.host,
+                                                alternative.port,
+                                                generation,
+                                                networkGeneration);
+            var updated = new ArrayList<Selection>(Math.min(maximumSelections, selections.size() + 1));
+            updated.add(selection);
+            for (Selection existing : selections) {
+                if (updated.size() == maximumSelections) {
+                    break;
+                }
+                if (!existing.originTarget.equals(target)) {
+                    updated.add(existing);
+                }
+            }
+            selections = List.copyOf(updated);
+            return selection;
+        }
+
+        private void refresh(Alternative alternative) {
+            this.alternative = alternative;
+            generation.establishUntil = alternative.expirationTime;
+            negativeUntil = null;
+        }
+    }
+
+    static final class Generation {
+        private final long id;
+        private volatile boolean current = true;
+        private volatile Instant establishUntil;
+
+        private Generation(long id, Instant establishUntil) {
+            this.id = id;
+            this.establishUntil = establishUntil;
+        }
+
+        @Override
+        public String toString() {
+            return Long.toString(id);
+        }
+    }
+}

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -324,7 +324,7 @@ final class Http2AltSvcCache implements AutoCloseable {
 
     void recordFailure(Selection selection) {
         Objects.requireNonNull(selection, "selection");
-        if (!current(selection) || !selection.establishAllowed()) {
+        if (!current(selection)) {
             return;
         }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2AltSvcCache.java
@@ -450,6 +450,7 @@ final class Http2AltSvcCache implements AutoCloseable {
         return target.currentTlsGeneration()
                 && "https".equals(target.scheme())
                 && target.connectionKey().tls().enabled()
+                && sameHost(target.originAuthority().host().value(), target.connectionKey().tlsPeerHost())
                 && target.connectionKey().proxy().type() == Proxy.ProxyType.NONE
                 && target.transportAddress().isEmpty()
                 && target.proxyRoute().direct()

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -478,6 +478,17 @@ abstract class Http2CallChainBase implements WebClientService.TransportChain {
         return ContentDecoder.NO_OP;
     }
 
+    private static String requestTarget(ClientUri uri) {
+        String requestTarget = uri.pathWithQueryAndFragment();
+        var fragment = uri.fragment();
+        if (!fragment.hasValue()) {
+            return requestTarget;
+        }
+        String rawFragment = fragment.rawValue();
+        int fragmentLength = requestTarget.endsWith(rawFragment) ? rawFragment.length() : fragment.value().length();
+        return requestTarget.substring(0, requestTarget.length() - fragmentLength - 1);
+    }
+
     private ClientConnectionTarget connectionTarget(ClientUri uri,
                                                     ClientRequestHeaders headers,
                                                     ConnectionKey connectionKey,
@@ -575,17 +586,6 @@ abstract class Http2CallChainBase implements WebClientService.TransportChain {
                 failedStream.close();
             }
         }
-    }
-
-    private static String requestTarget(ClientUri uri) {
-        String requestTarget = uri.pathWithQueryAndFragment();
-        var fragment = uri.fragment();
-        if (!fragment.hasValue()) {
-            return requestTarget;
-        }
-        String rawFragment = fragment.rawValue();
-        int fragmentLength = requestTarget.endsWith(rawFragment) ? rawFragment.length() : fragment.value().length();
-        return requestTarget.substring(0, requestTarget.length() - fragmentLength - 1);
     }
 
     private static final class LogHeaderConsumer implements Consumer<Header> {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.net.SocketAddress;
 import java.net.UnixDomainSocketAddress;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -36,6 +37,7 @@ import io.helidon.http.HeaderValues;
 import io.helidon.http.LogFormatter;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
 import io.helidon.http.encoding.ContentDecoder;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.http2.Http2Exception;
@@ -50,6 +52,7 @@ import io.helidon.webclient.api.ProxyRoute;
 import io.helidon.webclient.api.ReleasableResource;
 import io.helidon.webclient.api.ResolvedClientTarget;
 import io.helidon.webclient.api.TcpClientConnection;
+import io.helidon.webclient.api.WebClientProtocolResponse;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 import io.helidon.webclient.spi.WebClientService;
@@ -57,7 +60,7 @@ import io.helidon.webclient.spi.WebClientService;
 import static io.helidon.http.HeaderNames.CONTENT_ENCODING;
 import static io.helidon.webclient.api.ClientRequestBase.USER_AGENT_HEADER;
 
-abstract class Http2CallChainBase implements WebClientService.WireProtocolChain {
+abstract class Http2CallChainBase implements WebClientService.TransportChain {
     private final Http2ClientImpl http2Client;
     private final HttpClientConfig clientConfig;
     private final Http2ClientRequestImpl clientRequest;
@@ -67,6 +70,11 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
     private HttpClientResponse response;
     private ClientRequestHeaders requestHeaders;
     private Status responseStatus;
+    private ResolvedClientTarget responseTarget;
+    private Http2AltSvcCache.Selection selectedAlternative;
+    private WebClientProtocolResponse pendingProtocolResponse;
+    private boolean explicitConnectionRequest;
+    private ClientConnectionTarget.LookupKey connectionLookupKey;
 
     Http2CallChainBase(Http2ClientImpl http2Client,
                        Http2ClientRequestImpl clientRequest,
@@ -111,6 +119,8 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
     public WebClientServiceResponse proceed(WebClientServiceRequest serviceRequest) {
         ClientUri uri = serviceRequest.uri();
         requestHeaders = serviceRequest.headers();
+        explicitConnectionRequest = clientRequest.connection().isPresent() && !clientRequest.ownsExplicitConnection();
+        http1FallbackHandler.explicitConnection(explicitConnectionRequest);
 
         clientRequest.sanitizeRedirectHeaders(uri, requestHeaders);
         boolean originAuthorityOverride = requestHeaders.contains(Http2Headers.AUTHORITY_NAME)
@@ -120,84 +130,65 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
         requestHeaders.setIfAbsent(USER_AGENT_HEADER);
 
         ConnectionKey connectionKey = Http2ConnectionKeys.create(uri, clientRequest, clientConfig, requestHeaders);
-        boolean ownsExplicitConnection = Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest);
-        ClientConnection explicitConnection = clientRequest.connection().orElse(null);
-        ClientConnectionTarget explicitTarget = null;
-        if (explicitConnection != null) {
-            clientRequest.clearSelectedProxyRoute();
-            if (explicitConnection instanceof TcpClientConnection tcpConnection) {
-                ResolvedClientTarget resolvedTarget = tcpConnection.resolvedTarget().orElse(null);
-                Optional<ProxyRoute> matchingRoute = ClientConnectionTarget.matchingRoute(explicitConnection,
-                                                                                           connectionKey,
-                                                                                           uri,
-                                                                                           requestHeaders);
-                if (matchingRoute.isPresent()) {
-                    clientRequest.selectedProxyRoute(matchingRoute.get());
-                    if (resolvedTarget != null) {
-                        explicitTarget = resolvedTarget.logicalTarget();
-                    }
-                }
-            }
-        }
-        if (ownsExplicitConnection && explicitConnection != null && explicitTarget == null) {
-            clientRequest.clearConnection();
-            explicitConnection.closeResource();
-            explicitConnection = null;
-        }
-        ClientConnectionTarget connectionTarget;
-        ClientConnectionTarget.LookupKey connectionLookupKey = null;
-        if (explicitTarget != null) {
-            connectionTarget = explicitTarget;
-        } else {
-            SocketAddress address = clientRequest.address().orElse(null);
-            if (address instanceof UnixDomainSocketAddress udsAddress) {
-                clientRequest.clearSelectedProxyRoute();
-                connectionTarget = ClientConnectionTarget.createUnixDomainSocket(connectionKey,
-                                                                                   uri,
-                                                                                   requestHeaders,
-                                                                                   udsAddress);
+        ClientConnectionTarget connectionTarget = connectionTarget(uri,
+                                                                    requestHeaders,
+                                                                    connectionKey,
+                                                                    originAuthorityOverride);
+        ClientConnectionTarget.LookupKey connectionLookupKey = this.connectionLookupKey;
+
+        Http2ConnectionCache cache = http2Client.connectionCache();
+        Http2AltSvcCache.Selection alternative = null;
+        if (http2Client.altSvcEnabled()) {
+            if (connectionLookupKey == null) {
+                alternative = cache.currentAlternative(connectionTarget, explicitConnectionRequest);
             } else {
-                ProxyRoute selectedProxyRoute = clientRequest.selectedProxyRoute().orElse(null);
-                if (explicitConnection == null
-                        && selectedProxyRoute == null
-                        && connectionKey.proxy().ipNoProxyConfigured()) {
-                    connectionLookupKey = originAuthorityOverride
-                            ? ClientConnectionTarget.lookupKey(connectionKey, uri, requestHeaders)
-                            : ClientConnectionTarget.lookupKey(connectionKey, uri.scheme());
-                    connectionTarget = null;
-                    clientRequest.clearSelectedProxyRoute();
-                } else {
-                    if (originAuthorityOverride) {
-                        connectionTarget = selectedProxyRoute == null
-                                ? ClientConnectionTarget.create(connectionKey, uri, requestHeaders)
-                                : ClientConnectionTarget.create(connectionKey, uri, requestHeaders, selectedProxyRoute);
-                    } else {
-                        connectionTarget = selectedProxyRoute == null
-                                ? ClientConnectionTarget.create(connectionKey, uri.scheme())
-                                : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
-                    }
-                    if (explicitConnection == null || clientRequest.selectedProxyRoute().isPresent()) {
+                Http2AltSvcCache.Candidate candidate = cache.currentAlternative(connectionLookupKey,
+                                                                                 explicitConnectionRequest);
+                if (candidate != null) {
+                    ClientConnectionTarget candidateTarget = originAuthorityOverride
+                            ? ClientConnectionTarget.create(connectionKey,
+                                                            uri,
+                                                            requestHeaders,
+                                                            candidate.proxyRoute())
+                            : ClientConnectionTarget.create(connectionKey, uri.scheme(), candidate.proxyRoute());
+                    alternative = cache.currentAlternative(candidateTarget, explicitConnectionRequest);
+                    if (alternative != null) {
+                        connectionTarget = candidateTarget;
+                        connectionLookupKey = null;
                         clientRequest.selectedProxyRoute(connectionTarget.proxyRoute());
                     }
                 }
             }
         }
 
-        Http2ConnectionAttemptResult result = connectionLookupKey == null
-                ? http2Client.connectionCache()
-                        .newStream(http2Client,
-                                   connectionTarget,
-                                   clientRequest,
-                                   uri,
-                                   serviceRequest,
-                                   http1FallbackHandler)
-                : http2Client.connectionCache()
-                        .newStream(http2Client,
-                                   connectionLookupKey,
-                                   clientRequest,
-                                   uri,
-                                   serviceRequest,
-                                   http1FallbackHandler);
+        Http2ConnectionAttemptResult result;
+        if (alternative == null) {
+            result = newOriginStream(cache,
+                                     connectionTarget,
+                                     connectionLookupKey,
+                                     uri,
+                                     serviceRequest);
+        } else {
+            try {
+                result = cache.newAlternativeStream(http2Client,
+                                                    alternative,
+                                                    clientRequest,
+                                                    http1FallbackHandler);
+            } catch (AlternativeConnectionException e) {
+                if (e.reason() == AlternativeConnectionException.Reason.PRE_SEND_FAILURE) {
+                    cache.recordAlternativeFailure(e.selection());
+                }
+                try {
+                    result = newOriginStream(cache, connectionTarget, null, uri, serviceRequest);
+                } catch (RuntimeException | Error originFailure) {
+                    originFailure.addSuppressed(e);
+                    throw originFailure;
+                }
+            }
+        }
+
+        responseTarget = result.resolvedTarget().orElse(null);
+        selectedAlternative = result.alternative().orElse(null);
 
         try {
             if (connectionLookupKey != null) {
@@ -206,7 +197,20 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
             if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
                 // ALPN, prior knowledge, or upgrade success
                 this.stream = result.stream();
-                return doProceed(serviceRequest, requestHeaders, result.stream());
+                ClientRequestHeaders transportHeaders = requestHeaders;
+                if (selectedAlternative != null) {
+                    transportHeaders = ClientRequestHeaders.create(WritableHeaders.create(requestHeaders));
+                    transportHeaders.set(HeaderValues.create(HeaderNames.ALT_USED,
+                                                             selectedAlternative.authority().toString()));
+                    requestHeaders = transportHeaders;
+                }
+                try {
+                    return doProceed(serviceRequest, transportHeaders, result.stream());
+                } finally {
+                    if (selectedAlternative != null) {
+                        transportHeaders.remove(HeaderNames.ALT_USED);
+                    }
+                }
             } else {
                 // upgrade failed
                 this.response = result.response();
@@ -220,7 +224,12 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
                     && !clientRequest().outputStreamRedirect()
                     && (clientRequest.connection().isEmpty()
                             || Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest))) {
-                http2Client.connectionCache().remove(result.connectionTarget(), resultHandler);
+                Http2AltSvcCache.Selection failedAlternative = result.alternative().orElse(null);
+                if (failedAlternative == null) {
+                    cache.remove(result.connectionTarget(), resultHandler);
+                } else {
+                    cache.removeAlternative(failedAlternative);
+                }
                 closeFailedStream(result);
             }
             throw e;
@@ -230,17 +239,90 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
         }
     }
 
-    private void closeFailedStream(Http2ConnectionAttemptResult result) {
-        if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
-            Http2ClientStream failedStream = result.stream();
-            try {
-                failedStream.cancel();
-            } catch (RuntimeException ignored) {
-                // Preserve the original request failure; close still releases the reserved stream slot.
-            } finally {
-                failedStream.close();
+    private ClientConnectionTarget connectionTarget(ClientUri uri,
+                                                    ClientRequestHeaders headers,
+                                                    ConnectionKey connectionKey,
+                                                    boolean originAuthorityOverride) {
+        connectionLookupKey = null;
+        boolean ownsExplicitConnection = Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest);
+        ClientConnection explicitConnection = clientRequest.connection().orElse(null);
+        ClientConnectionTarget explicitTarget = null;
+        if (explicitConnection != null) {
+            clientRequest.clearSelectedProxyRoute();
+            if (explicitConnection instanceof TcpClientConnection tcpConnection) {
+                ResolvedClientTarget resolvedTarget = tcpConnection.resolvedTarget().orElse(null);
+                Optional<ProxyRoute> matchingRoute = ClientConnectionTarget.matchingRoute(explicitConnection,
+                                                                                           connectionKey,
+                                                                                           uri,
+                                                                                           headers);
+                if (matchingRoute.isPresent()) {
+                    clientRequest.selectedProxyRoute(matchingRoute.get());
+                    if (resolvedTarget != null) {
+                        explicitTarget = resolvedTarget.logicalTarget();
+                    }
+                }
             }
         }
+        if (ownsExplicitConnection && explicitConnection != null && explicitTarget == null) {
+            clientRequest.clearConnection();
+            explicitConnection.closeResource();
+            explicitConnection = null;
+        }
+        if (explicitTarget != null) {
+            return explicitTarget;
+        }
+
+        SocketAddress address = clientRequest.address().orElse(null);
+        if (address instanceof UnixDomainSocketAddress udsAddress) {
+            clientRequest.clearSelectedProxyRoute();
+            return ClientConnectionTarget.createUnixDomainSocket(connectionKey, uri, headers, udsAddress);
+        }
+
+        ProxyRoute selectedProxyRoute = clientRequest.selectedProxyRoute().orElse(null);
+        if (explicitConnection == null
+                && selectedProxyRoute == null
+                && connectionKey.proxy().ipNoProxyConfigured()) {
+            connectionLookupKey = originAuthorityOverride
+                    ? ClientConnectionTarget.lookupKey(connectionKey, uri, headers)
+                    : ClientConnectionTarget.lookupKey(connectionKey, uri.scheme());
+            clientRequest.clearSelectedProxyRoute();
+            return null;
+        }
+
+        ClientConnectionTarget connectionTarget;
+        if (originAuthorityOverride) {
+            connectionTarget = selectedProxyRoute == null
+                    ? ClientConnectionTarget.create(connectionKey, uri, headers)
+                    : ClientConnectionTarget.create(connectionKey, uri, headers, selectedProxyRoute);
+        } else {
+            connectionTarget = selectedProxyRoute == null
+                    ? ClientConnectionTarget.create(connectionKey, uri.scheme())
+                    : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
+        }
+        if (explicitConnection == null || clientRequest.selectedProxyRoute().isPresent()) {
+            clientRequest.selectedProxyRoute(connectionTarget.proxyRoute());
+        }
+        return connectionTarget;
+    }
+
+    private Http2ConnectionAttemptResult newOriginStream(Http2ConnectionCache cache,
+                                                         ClientConnectionTarget connectionTarget,
+                                                         ClientConnectionTarget.LookupKey connectionLookupKey,
+                                                         ClientUri uri,
+                                                         WebClientServiceRequest serviceRequest) {
+        return connectionLookupKey == null
+                ? cache.newStream(http2Client,
+                                  connectionTarget,
+                                  clientRequest,
+                                  uri,
+                                  serviceRequest,
+                                  http1FallbackHandler)
+                : cache.newStream(http2Client,
+                                  connectionLookupKey,
+                                  clientRequest,
+                                  uri,
+                                  serviceRequest,
+                                  http1FallbackHandler);
     }
 
     ClientRequestHeaders requestHeaders() {
@@ -265,6 +347,28 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
     @Override
     public String protocolId() {
         return response == null ? http1FallbackHandler.actualProtocolId() : response.protocolId();
+    }
+
+    @Override
+    public Optional<WebClientProtocolResponse> protocolResponse(WebClientServiceResponse response) {
+        if (this.response != null) {
+            return Optional.empty();
+        }
+        Optional<WebClientProtocolResponse> result = Optional.ofNullable(pendingProtocolResponse);
+        pendingProtocolResponse = null;
+        if (result.isPresent() && !http2Client.responseNotificationsManagedByWebClient()) {
+            http2Client.publishResponse(result.get());
+            return Optional.empty();
+        }
+        return result;
+    }
+
+    void publishProtocolResponse() {
+        WebClientProtocolResponse response = pendingProtocolResponse;
+        pendingProtocolResponse = null;
+        if (response != null) {
+            http2Client.publishResponse(response);
+        }
     }
 
     CompletableFuture<WebClientServiceResponse> whenComplete() {
@@ -317,6 +421,7 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
 
         ClientResponseHeaders responseHeaders = ClientResponseHeaders.create(headers.httpHeaders());
         this.responseStatus = headers.status();
+        captureProtocolResponse(responseStatus, responseHeaders);
 
         WebClientServiceResponse.Builder builder = WebClientServiceResponse.builder();
 
@@ -343,6 +448,36 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
 
         response.set(serviceResponse);
         return serviceResponse;
+    }
+
+    protected void captureProtocolResponse(Status status, ClientResponseHeaders headers) {
+        if (!http2Client.altSvcNotificationsEnabled() || pendingProtocolResponse != null) {
+            return;
+        }
+
+        Http2AltSvcCache.Selection alternative = selectedAlternative;
+        if (alternative != null) {
+            boolean misdirected = status.code() == Status.MISDIRECTED_REQUEST_421_CODE;
+            if (misdirected) {
+                http2Client.connectionCache().recordAlternativeMisdirected(alternative);
+            }
+            if (!misdirected && responseTarget != null && headers.contains(HeaderNames.ALT_SVC)) {
+                pendingProtocolResponse = WebClientProtocolResponse.createAlternative(responseTarget,
+                                                                                      explicitConnectionRequest,
+                                                                                      protocolId(),
+                                                                                      status,
+                                                                                      headers,
+                                                                                      Instant.now(),
+                                                                                      alternative.authority());
+            }
+        } else if (responseTarget != null && headers.contains(HeaderNames.ALT_SVC)) {
+            pendingProtocolResponse = WebClientProtocolResponse.create(responseTarget,
+                                                                       explicitConnectionRequest,
+                                                                       protocolId(),
+                                                                       status,
+                                                                       headers,
+                                                                       Instant.now());
+        }
     }
 
     static Http2Headers readHeaders(Http2ClientStream stream) {
@@ -504,6 +639,19 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
                     entityProcessedRunnable.run();
                     finished = true;
                 }
+            }
+        }
+    }
+
+    private void closeFailedStream(Http2ConnectionAttemptResult result) {
+        if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
+            Http2ClientStream failedStream = result.stream();
+            try {
+                failedStream.cancel();
+            } catch (RuntimeException ignored) {
+                // Preserve the original request failure; close still releases the reserved stream slot.
+            } finally {
+                failedStream.close();
             }
         }
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -115,6 +115,49 @@ abstract class Http2CallChainBase implements WebClientService.TransportChain {
         return serviceResponse;
     }
 
+    static Http2Headers readHeaders(Http2ClientStream stream) {
+        return readHeaders(stream, null);
+    }
+
+    static Http2Headers readHeaders(Http2ClientStream stream, Duration readTimeout) {
+        try {
+            return readTimeout == null ? stream.readHeaders() : stream.readHeaders(readTimeout);
+        } catch (Http2Exception e) {
+            resetAndClose(stream, e);
+            throw e;
+        }
+    }
+
+    static Status waitFor100Continue(Http2ClientStream stream) {
+        return waitFor100Continue(stream, null);
+    }
+
+    static Status waitFor100Continue(Http2ClientStream stream, Duration readContinueTimeout) {
+        try {
+            return stream.waitFor100Continue(readContinueTimeout);
+        } catch (Http2Exception e) {
+            resetAndClose(stream, e);
+            throw e;
+        }
+    }
+
+    protected static Http2Headers prepareHeaders(Method method, ClientRequestHeaders headers, ClientUri uri) {
+        Http2Headers h2Headers = Http2Headers.create(headers);
+        h2Headers.method(method);
+        if (!Method.CONNECT.equals(method)) {
+            h2Headers.path(requestTarget(uri));
+            h2Headers.scheme(uri.scheme());
+        }
+
+        return h2Headers;
+    }
+
+    static void alignHostHeader(ClientUri uri, ClientRequestHeaders requestHeaders) {
+        requestHeaders.first(Http2Headers.AUTHORITY_NAME)
+                .ifPresentOrElse(authority -> requestHeaders.set(HeaderValues.create(HeaderNames.HOST, authority)),
+                                 () -> requestHeaders.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority())));
+    }
+
     @Override
     public WebClientServiceResponse proceed(WebClientServiceRequest serviceRequest) {
         ClientUri uri = serviceRequest.uri();
@@ -237,92 +280,6 @@ abstract class Http2CallChainBase implements WebClientService.TransportChain {
             closeFailedStream(result);
             throw e;
         }
-    }
-
-    private ClientConnectionTarget connectionTarget(ClientUri uri,
-                                                    ClientRequestHeaders headers,
-                                                    ConnectionKey connectionKey,
-                                                    boolean originAuthorityOverride) {
-        connectionLookupKey = null;
-        boolean ownsExplicitConnection = Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest);
-        ClientConnection explicitConnection = clientRequest.connection().orElse(null);
-        ClientConnectionTarget explicitTarget = null;
-        if (explicitConnection != null) {
-            clientRequest.clearSelectedProxyRoute();
-            if (explicitConnection instanceof TcpClientConnection tcpConnection) {
-                ResolvedClientTarget resolvedTarget = tcpConnection.resolvedTarget().orElse(null);
-                Optional<ProxyRoute> matchingRoute = ClientConnectionTarget.matchingRoute(explicitConnection,
-                                                                                           connectionKey,
-                                                                                           uri,
-                                                                                           headers);
-                if (matchingRoute.isPresent()) {
-                    clientRequest.selectedProxyRoute(matchingRoute.get());
-                    if (resolvedTarget != null) {
-                        explicitTarget = resolvedTarget.logicalTarget();
-                    }
-                }
-            }
-        }
-        if (ownsExplicitConnection && explicitConnection != null && explicitTarget == null) {
-            clientRequest.clearConnection();
-            explicitConnection.closeResource();
-            explicitConnection = null;
-        }
-        if (explicitTarget != null) {
-            return explicitTarget;
-        }
-
-        SocketAddress address = clientRequest.address().orElse(null);
-        if (address instanceof UnixDomainSocketAddress udsAddress) {
-            clientRequest.clearSelectedProxyRoute();
-            return ClientConnectionTarget.createUnixDomainSocket(connectionKey, uri, headers, udsAddress);
-        }
-
-        ProxyRoute selectedProxyRoute = clientRequest.selectedProxyRoute().orElse(null);
-        if (explicitConnection == null
-                && selectedProxyRoute == null
-                && connectionKey.proxy().ipNoProxyConfigured()) {
-            connectionLookupKey = originAuthorityOverride
-                    ? ClientConnectionTarget.lookupKey(connectionKey, uri, headers)
-                    : ClientConnectionTarget.lookupKey(connectionKey, uri.scheme());
-            clientRequest.clearSelectedProxyRoute();
-            return null;
-        }
-
-        ClientConnectionTarget connectionTarget;
-        if (originAuthorityOverride) {
-            connectionTarget = selectedProxyRoute == null
-                    ? ClientConnectionTarget.create(connectionKey, uri, headers)
-                    : ClientConnectionTarget.create(connectionKey, uri, headers, selectedProxyRoute);
-        } else {
-            connectionTarget = selectedProxyRoute == null
-                    ? ClientConnectionTarget.create(connectionKey, uri.scheme())
-                    : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
-        }
-        if (explicitConnection == null || clientRequest.selectedProxyRoute().isPresent()) {
-            clientRequest.selectedProxyRoute(connectionTarget.proxyRoute());
-        }
-        return connectionTarget;
-    }
-
-    private Http2ConnectionAttemptResult newOriginStream(Http2ConnectionCache cache,
-                                                         ClientConnectionTarget connectionTarget,
-                                                         ClientConnectionTarget.LookupKey connectionLookupKey,
-                                                         ClientUri uri,
-                                                         WebClientServiceRequest serviceRequest) {
-        return connectionLookupKey == null
-                ? cache.newStream(http2Client,
-                                  connectionTarget,
-                                  clientRequest,
-                                  uri,
-                                  serviceRequest,
-                                  http1FallbackHandler)
-                : cache.newStream(http2Client,
-                                  connectionLookupKey,
-                                  clientRequest,
-                                  uri,
-                                  serviceRequest,
-                                  http1FallbackHandler);
     }
 
     ClientRequestHeaders requestHeaders() {
@@ -480,59 +437,6 @@ abstract class Http2CallChainBase implements WebClientService.TransportChain {
         }
     }
 
-    static Http2Headers readHeaders(Http2ClientStream stream) {
-        return readHeaders(stream, null);
-    }
-
-    static Http2Headers readHeaders(Http2ClientStream stream, Duration readTimeout) {
-        try {
-            return readTimeout == null ? stream.readHeaders() : stream.readHeaders(readTimeout);
-        } catch (Http2Exception e) {
-            resetAndClose(stream, e);
-            throw e;
-        }
-    }
-
-    static Status waitFor100Continue(Http2ClientStream stream) {
-        return waitFor100Continue(stream, null);
-    }
-
-    static Status waitFor100Continue(Http2ClientStream stream, Duration readContinueTimeout) {
-        try {
-            return stream.waitFor100Continue(readContinueTimeout);
-        } catch (Http2Exception e) {
-            resetAndClose(stream, e);
-            throw e;
-        }
-    }
-
-    private static void resetAndClose(Http2ClientStream stream, Http2Exception e) {
-        stream.close();
-        stream.reset(e.code());
-    }
-
-    private static ContentDecoder contentDecoder(ClientResponseHeaders responseHeaders, HttpClientConfig clientConfig) {
-        ContentEncodingContext encodingSupport = clientConfig.contentEncoding();
-        if (encodingSupport.contentDecodingEnabled() && responseHeaders.contains(CONTENT_ENCODING)) {
-            String contentEncoding = responseHeaders.get(CONTENT_ENCODING).get();
-            if (encodingSupport.contentDecodingSupported(contentEncoding)) {
-                return encodingSupport.decoder(contentEncoding);
-            }
-        }
-        return ContentDecoder.NO_OP;
-    }
-
-    protected static Http2Headers prepareHeaders(Method method, ClientRequestHeaders headers, ClientUri uri) {
-        Http2Headers h2Headers = Http2Headers.create(headers);
-        h2Headers.method(method);
-        if (!Method.CONNECT.equals(method)) {
-            h2Headers.path(requestTarget(uri));
-            h2Headers.scheme(uri.scheme());
-        }
-
-        return h2Headers;
-    }
-
     protected HttpClientConfig clientConfig() {
         return clientConfig;
     }
@@ -558,10 +462,119 @@ abstract class Http2CallChainBase implements WebClientService.TransportChain {
         }
     }
 
-    static void alignHostHeader(ClientUri uri, ClientRequestHeaders requestHeaders) {
-        requestHeaders.first(Http2Headers.AUTHORITY_NAME)
-                .ifPresentOrElse(authority -> requestHeaders.set(HeaderValues.create(HeaderNames.HOST, authority)),
-                                 () -> requestHeaders.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority())));
+    private static void resetAndClose(Http2ClientStream stream, Http2Exception e) {
+        stream.close();
+        stream.reset(e.code());
+    }
+
+    private static ContentDecoder contentDecoder(ClientResponseHeaders responseHeaders, HttpClientConfig clientConfig) {
+        ContentEncodingContext encodingSupport = clientConfig.contentEncoding();
+        if (encodingSupport.contentDecodingEnabled() && responseHeaders.contains(CONTENT_ENCODING)) {
+            String contentEncoding = responseHeaders.get(CONTENT_ENCODING).get();
+            if (encodingSupport.contentDecodingSupported(contentEncoding)) {
+                return encodingSupport.decoder(contentEncoding);
+            }
+        }
+        return ContentDecoder.NO_OP;
+    }
+
+    private ClientConnectionTarget connectionTarget(ClientUri uri,
+                                                    ClientRequestHeaders headers,
+                                                    ConnectionKey connectionKey,
+                                                    boolean originAuthorityOverride) {
+        connectionLookupKey = null;
+        boolean ownsExplicitConnection = Http2ClientConnectionHandler.ownsExplicitConnection(clientRequest);
+        ClientConnection explicitConnection = clientRequest.connection().orElse(null);
+        ClientConnectionTarget explicitTarget = null;
+        if (explicitConnection != null) {
+            clientRequest.clearSelectedProxyRoute();
+            if (explicitConnection instanceof TcpClientConnection tcpConnection) {
+                ResolvedClientTarget resolvedTarget = tcpConnection.resolvedTarget().orElse(null);
+                Optional<ProxyRoute> matchingRoute = ClientConnectionTarget.matchingRoute(explicitConnection,
+                                                                                           connectionKey,
+                                                                                           uri,
+                                                                                           headers);
+                if (matchingRoute.isPresent()) {
+                    clientRequest.selectedProxyRoute(matchingRoute.get());
+                    if (resolvedTarget != null) {
+                        explicitTarget = resolvedTarget.logicalTarget();
+                    }
+                }
+            }
+        }
+        if (ownsExplicitConnection && explicitConnection != null && explicitTarget == null) {
+            clientRequest.clearConnection();
+            explicitConnection.closeResource();
+            explicitConnection = null;
+        }
+        if (explicitTarget != null) {
+            return explicitTarget;
+        }
+
+        SocketAddress address = clientRequest.address().orElse(null);
+        if (address instanceof UnixDomainSocketAddress udsAddress) {
+            clientRequest.clearSelectedProxyRoute();
+            return ClientConnectionTarget.createUnixDomainSocket(connectionKey, uri, headers, udsAddress);
+        }
+
+        ProxyRoute selectedProxyRoute = clientRequest.selectedProxyRoute().orElse(null);
+        if (explicitConnection == null
+                && selectedProxyRoute == null
+                && connectionKey.proxy().ipNoProxyConfigured()) {
+            connectionLookupKey = originAuthorityOverride
+                    ? ClientConnectionTarget.lookupKey(connectionKey, uri, headers)
+                    : ClientConnectionTarget.lookupKey(connectionKey, uri.scheme());
+            clientRequest.clearSelectedProxyRoute();
+            return null;
+        }
+
+        ClientConnectionTarget connectionTarget;
+        if (originAuthorityOverride) {
+            connectionTarget = selectedProxyRoute == null
+                    ? ClientConnectionTarget.create(connectionKey, uri, headers)
+                    : ClientConnectionTarget.create(connectionKey, uri, headers, selectedProxyRoute);
+        } else {
+            connectionTarget = selectedProxyRoute == null
+                    ? ClientConnectionTarget.create(connectionKey, uri.scheme())
+                    : ClientConnectionTarget.create(connectionKey, uri.scheme(), selectedProxyRoute);
+        }
+        if (explicitConnection == null || clientRequest.selectedProxyRoute().isPresent()) {
+            clientRequest.selectedProxyRoute(connectionTarget.proxyRoute());
+        }
+        return connectionTarget;
+    }
+
+    private Http2ConnectionAttemptResult newOriginStream(Http2ConnectionCache cache,
+                                                         ClientConnectionTarget connectionTarget,
+                                                         ClientConnectionTarget.LookupKey connectionLookupKey,
+                                                         ClientUri uri,
+                                                         WebClientServiceRequest serviceRequest) {
+        return connectionLookupKey == null
+                ? cache.newStream(http2Client,
+                                  connectionTarget,
+                                  clientRequest,
+                                  uri,
+                                  serviceRequest,
+                                  http1FallbackHandler)
+                : cache.newStream(http2Client,
+                                  connectionLookupKey,
+                                  clientRequest,
+                                  uri,
+                                  serviceRequest,
+                                  http1FallbackHandler);
+    }
+
+    private void closeFailedStream(Http2ConnectionAttemptResult result) {
+        if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
+            Http2ClientStream failedStream = result.stream();
+            try {
+                failedStream.cancel();
+            } catch (RuntimeException ignored) {
+                // Preserve the original request failure; close still releases the reserved stream slot.
+            } finally {
+                failedStream.close();
+            }
+        }
     }
 
     private static String requestTarget(ClientUri uri) {
@@ -639,19 +652,6 @@ abstract class Http2CallChainBase implements WebClientService.TransportChain {
                     entityProcessedRunnable.run();
                     finished = true;
                 }
-            }
-        }
-    }
-
-    private void closeFailedStream(Http2ConnectionAttemptResult result) {
-        if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2) {
-            Http2ClientStream failedStream = result.stream();
-            try {
-                failedStream.cancel();
-            } catch (RuntimeException ignored) {
-                // Preserve the original request failure; close still releases the reserved stream slot.
-            } finally {
-                failedStream.close();
             }
         }
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -94,6 +94,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                                                  Http2ClientStream stream) {
         boolean interrupted = false;
         ClientOutputStream outputStream = new ClientOutputStream(client,
+                                                                 this,
                                                                  stream,
                                                                  headers,
                                                                  clientConfig(),
@@ -115,15 +116,22 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             //This is a fallback mechanism to correctly handle such a situations.
             redirectedResponse = outputStream.response;
             stream(outputStream.stream);
-            return outputStream.serviceResponse();
+            WebClientServiceResponse serviceResponse = outputStream.serviceResponse();
+            if (redirectedResponse == null) {
+                captureProtocolResponse(serviceResponse.status(), serviceResponse.headers());
+            }
+            return serviceResponse;
         } else if (!outputStream.closed()) {
             throw new IllegalStateException("Output stream was not closed in handler");
         }
 
         Http2Headers responseHeaders = readHeaders(outputStream.stream);
+        ClientResponseHeaders clientResponseHeaders = ClientResponseHeaders.create(responseHeaders.httpHeaders());
+        captureProtocolResponse(responseHeaders.status(), clientResponseHeaders);
 
         if (clientRequest().followRedirects()
                 && RedirectionProcessor.redirectionStatusCode(responseHeaders.status())) {
+            publishProtocolResponse();
             checkRedirectHeaders(responseHeaders);
             URI newUri = URI.create(responseHeaders.httpHeaders().get(HeaderNames.LOCATION).get());
             ClientUri redirectUri = ClientUri.create(newUri);
@@ -180,7 +188,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                                      outputStream.stream,
                                      whenComplete(),
                                      responseHeaders.status(),
-                                     ClientResponseHeaders.create(responseHeaders.httpHeaders()));
+                                     clientResponseHeaders);
     }
 
     @Override
@@ -320,6 +328,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
         private final HttpClientConfig clientConfig;
         private final WritableHeaders<?> headers;
         private final long contentLength;
+        private final Http2CallOutputStreamChain callChain;
 
         private long bytesWritten;
         private boolean hasEntity;
@@ -334,6 +343,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
         private WebClientServiceResponse serviceResponse;
 
         private ClientOutputStream(Http2ClientImpl client,
+                                   Http2CallOutputStreamChain callChain,
                                    Http2ClientStream stream,
                                    WritableHeaders<?> headers,
                                    HttpClientConfig clientConfig,
@@ -342,6 +352,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                                    CompletableFuture<WebClientServiceRequest> whenSent,
                                    CompletableFuture<WebClientServiceResponse> whenComplete) {
             this.client = client;
+            this.callChain = callChain;
             this.stream = stream;
             this.headers = headers;
             this.clientConfig = clientConfig;
@@ -448,8 +459,12 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 if (status != Status.CONTINUE_100) {
                     Http2Headers responseHeaders = readHeaders(stream);
                     Status responseStatus = responseHeaders.status();
+                    ClientResponseHeaders clientResponseHeaders = ClientResponseHeaders.create(
+                            responseHeaders.httpHeaders());
+                    callChain.captureProtocolResponse(responseStatus, clientResponseHeaders);
 
                     if (RedirectionProcessor.redirectionStatusCode(responseStatus) && originalRequest.followRedirects()) {
+                        callChain.publishProtocolResponse();
                         checkRedirectHeaders(responseHeaders);
                         redirect(responseStatus, responseHeaders.httpHeaders());
                     } else {
@@ -460,8 +475,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                                                                      stream,
                                                                      whenComplete,
                                                                      responseHeaders.status(),
-                                                                     ClientResponseHeaders.create(
-                                                                             responseHeaders.httpHeaders()));
+                                                                     clientResponseHeaders);
                         //we are not sending anything by this OS, we need to interrupt it.
                         throw new OutputStreamInterruptedException();
                     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -218,25 +218,6 @@ public class Http2ClientConnection {
         return create(connection, http2Client, sendSettings, _ -> { });
     }
 
-    private static <T extends Http2ClientConnection> T create(T connection,
-                                                              Http2ClientImpl http2Client,
-                                                              boolean sendSettings,
-                                                              Consumer<T> beforeStart) {
-        Http2ClientConnection rawConnection = connection;
-        boolean success = false;
-        try {
-            beforeStart.accept(connection);
-            rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
-            rawConnection.awaitInitialSettings();
-            success = true;
-        } finally {
-            if (!success) {
-                rawConnection.close();
-            }
-        }
-        return connection;
-    }
-
     static Http2Settings settings(Http2ClientProtocolConfig config) {
         Http2Settings.Builder b = Http2Settings.builder();
         if (config.maxHeaderListSize() > 0) {
@@ -246,45 +227,6 @@ public class Http2ClientConnection {
                 .add(Http2Setting.MAX_FRAME_SIZE, (long) config.maxFrameSize())
                 .add(Http2Setting.ENABLE_PUSH, false)
                 .build();
-    }
-
-    private static Http2Settings mergeSettings(Http2Settings currentSettings, Http2Settings receivedSettings) {
-        Http2Settings.Builder builder = Http2Settings.builder();
-        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.HEADER_TABLE_SIZE);
-        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.ENABLE_PUSH);
-        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_CONCURRENT_STREAMS);
-        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.INITIAL_WINDOW_SIZE);
-        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_FRAME_SIZE);
-        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_HEADER_LIST_SIZE);
-        return builder.build();
-    }
-
-    private static <T> void mergeSetting(Http2Settings.Builder builder,
-                                         Http2Settings currentSettings,
-                                         Http2Settings receivedSettings,
-                                         Http2Setting<T> setting) {
-        if (receivedSettings.hasValue(setting)) {
-            builder.add(setting, receivedSettings.value(setting));
-        } else if (currentSettings.hasValue(setting)) {
-            builder.add(setting, currentSettings.value(setting));
-        }
-    }
-
-    private static boolean clientStreamId(int streamId) {
-        return streamId > 0 && streamId % 2 == 1;
-    }
-
-    private static boolean endOfHeaders(Http2FrameHeader frameHeader) {
-        return switch (frameHeader.type()) {
-        case HEADERS -> frameHeader.flags(Http2FrameTypes.HEADERS).endOfHeaders();
-        case CONTINUATION -> frameHeader.flags(Http2FrameTypes.CONTINUATION).endOfHeaders();
-        default -> false;
-        };
-    }
-
-    private static BufferData pingData(long pingId) {
-        return BufferData.create(Long.BYTES)
-                .writeInt64(pingId);
     }
 
     Optional<ResolvedClientTarget> resolvedTarget() {
@@ -519,6 +461,104 @@ public class Http2ClientConnection {
     @Api.Internal
     public void closeNow() {
         closeConnection(new IllegalStateException("HTTP/2 connection is closed"));
+    }
+
+    boolean handle(Http2FrameHeader frameHeader, BufferData data) {
+        int streamId = frameHeader.streamId();
+        validateFrameStreamId(frameHeader, streamId);
+        validateHeaderContinuation(frameHeader, streamId);
+
+        return switch (frameHeader.type()) {
+        case GO_AWAY -> handleGoAwayFrame(streamId, frameHeader, data);
+        case SETTINGS -> handleSettingsFrame(streamId, frameHeader, data);
+        case WINDOW_UPDATE -> handleWindowUpdateFrame(streamId, frameHeader, data);
+        case PING -> handlePingFrame(streamId, frameHeader, data);
+        case RST_STREAM -> {
+            handleRstStreamFrame(streamId, data);
+            yield true;
+        }
+        case DATA -> {
+            handleDataFrame(streamId, frameHeader, data);
+            yield true;
+        }
+        case HEADERS, CONTINUATION -> handleHeadersFrame(streamId, frameHeader, data);
+        default -> {
+            LOGGER.log(WARNING, "Unsupported frame type!! " + frameHeader.type());
+            yield true;
+        }
+        };
+    }
+
+    /**
+     * Hook invoked on the connection thread once an inbound header block has
+     * been decoded and survived the post-decode stream-membership check, but
+     * before it is logged and delivered to the stream. Production code leaves
+     * this empty; tests can override it to force close timing in the narrow
+     * post-decode/pre-delivery window.
+     *
+     * @param stream live stream about to receive the decoded headers
+     * @param headers decoded headers
+     * @param endOfStream whether the block also closes the remote side
+     */
+    void beforeDeliverInboundHeaders(Http2ClientStream stream, Http2Headers headers, boolean endOfStream) {
+    }
+
+    private static <T extends Http2ClientConnection> T create(T connection,
+                                                              Http2ClientImpl http2Client,
+                                                              boolean sendSettings,
+                                                              Consumer<T> beforeStart) {
+        Http2ClientConnection rawConnection = connection;
+        boolean success = false;
+        try {
+            beforeStart.accept(connection);
+            rawConnection.start(http2Client.protocolConfig(), http2Client.webClient().executor(), sendSettings);
+            rawConnection.awaitInitialSettings();
+            success = true;
+        } finally {
+            if (!success) {
+                rawConnection.close();
+            }
+        }
+        return connection;
+    }
+
+    private static Http2Settings mergeSettings(Http2Settings currentSettings, Http2Settings receivedSettings) {
+        Http2Settings.Builder builder = Http2Settings.builder();
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.HEADER_TABLE_SIZE);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.ENABLE_PUSH);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_CONCURRENT_STREAMS);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.INITIAL_WINDOW_SIZE);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_FRAME_SIZE);
+        mergeSetting(builder, currentSettings, receivedSettings, Http2Setting.MAX_HEADER_LIST_SIZE);
+        return builder.build();
+    }
+
+    private static <T> void mergeSetting(Http2Settings.Builder builder,
+                                         Http2Settings currentSettings,
+                                         Http2Settings receivedSettings,
+                                         Http2Setting<T> setting) {
+        if (receivedSettings.hasValue(setting)) {
+            builder.add(setting, receivedSettings.value(setting));
+        } else if (currentSettings.hasValue(setting)) {
+            builder.add(setting, currentSettings.value(setting));
+        }
+    }
+
+    private static boolean clientStreamId(int streamId) {
+        return streamId > 0 && streamId % 2 == 1;
+    }
+
+    private static boolean endOfHeaders(Http2FrameHeader frameHeader) {
+        return switch (frameHeader.type()) {
+        case HEADERS -> frameHeader.flags(Http2FrameTypes.HEADERS).endOfHeaders();
+        case CONTINUATION -> frameHeader.flags(Http2FrameTypes.CONTINUATION).endOfHeaders();
+        default -> false;
+        };
+    }
+
+    private static BufferData pingData(long pingId) {
+        return BufferData.create(Long.BYTES)
+                .writeInt64(pingId);
     }
 
     private void close(RuntimeException failure) {
@@ -839,32 +879,6 @@ public class Http2ClientConnection {
         return handle(frameHeader, data);
     }
 
-    boolean handle(Http2FrameHeader frameHeader, BufferData data) {
-        int streamId = frameHeader.streamId();
-        validateFrameStreamId(frameHeader, streamId);
-        validateHeaderContinuation(frameHeader, streamId);
-
-        return switch (frameHeader.type()) {
-        case GO_AWAY -> handleGoAwayFrame(streamId, frameHeader, data);
-        case SETTINGS -> handleSettingsFrame(streamId, frameHeader, data);
-        case WINDOW_UPDATE -> handleWindowUpdateFrame(streamId, frameHeader, data);
-        case PING -> handlePingFrame(streamId, frameHeader, data);
-        case RST_STREAM -> {
-            handleRstStreamFrame(streamId, data);
-            yield true;
-        }
-        case DATA -> {
-            handleDataFrame(streamId, frameHeader, data);
-            yield true;
-        }
-        case HEADERS, CONTINUATION -> handleHeadersFrame(streamId, frameHeader, data);
-        default -> {
-            LOGGER.log(WARNING, "Unsupported frame type!! " + frameHeader.type());
-            yield true;
-        }
-        };
-    }
-
     private BufferData readFrameData(Http2FrameHeader frameHeader) {
         if (frameHeader.length() == 0) {
             return BufferData.empty();
@@ -931,20 +945,6 @@ public class Http2ClientConnection {
 
     private Http2Headers decodeInboundHeaders(Http2ClientStream stream, Http2FrameData... headerFrames) {
         return decodeInboundHeaders(stream, stream.inboundHeaderDecodeBasis(), headerFrames);
-    }
-
-    /**
-     * Hook invoked on the connection thread once an inbound header block has
-     * been decoded and survived the post-decode stream-membership check, but
-     * before it is logged and delivered to the stream. Production code leaves
-     * this empty; tests can override it to force close timing in the narrow
-     * post-decode/pre-delivery window.
-     *
-     * @param stream live stream about to receive the decoded headers
-     * @param headers decoded headers
-     * @param endOfStream whether the block also closes the remote side
-     */
-    void beforeDeliverInboundHeaders(Http2ClientStream stream, Http2Headers headers, boolean endOfStream) {
     }
 
     /**

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -67,6 +68,8 @@ import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.http.http2.StreamFlowControl;
 import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ResolvedClientTarget;
+import io.helidon.webclient.api.TcpClientConnection;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.TRACE;
@@ -96,6 +99,7 @@ public class Http2ClientConnection {
     private final PendingInboundHeaders pendingInboundHeaders;
     private final Http2ClientProtocolConfig protocolConfig;
     private final ClientConnection connection;
+    private final ResolvedClientTarget resolvedTarget;
     private final SocketContext ctx;
     private final Http2ConnectionWriter writer;
     private final DataReader reader;
@@ -152,6 +156,9 @@ public class Http2ClientConnection {
                 .blockTimeout(protocolConfig.flowControlBlockTimeout())
                 .build();
         this.connection = connection;
+        this.resolvedTarget = connection instanceof TcpClientConnection tcpConnection
+                ? tcpConnection.resolvedTarget().orElse(null)
+                : null;
         this.ctx = connection.helidonSocket();
         this.dataWriter = connection.writer();
         this.reader = connection.reader();
@@ -278,6 +285,10 @@ public class Http2ClientConnection {
     private static BufferData pingData(long pingId) {
         return BufferData.create(Long.BYTES)
                 .writeInt64(pingId);
+    }
+
+    Optional<ResolvedClientTarget> resolvedTarget() {
+        return Optional.ofNullable(resolvedTarget);
     }
 
     Http2ConnectionWriter writer() {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -273,20 +273,6 @@ class Http2ClientConnectionHandler {
         toRetire.forEach(Http2ClientConnection::retire);
     }
 
-    private boolean containsGeneration(Http2AltSvcCache.Generation generation) {
-        lifecycleLock.lock();
-        try {
-            for (ConnectionRoute route : allConnections.values()) {
-                if (route.matches(generation)) {
-                    return true;
-                }
-            }
-            return false;
-        } finally {
-            lifecycleLock.unlock();
-        }
-    }
-
     void close() {
         // this is to prevent concurrent modification (connections remove themselves from the map)
         Set<Http2ClientConnection> toClose = new HashSet<>();
@@ -562,6 +548,20 @@ class Http2ClientConnectionHandler {
         if (!clientConnection.helidonSocket().protocolNegotiated()
                 || !Http2Client.PROTOCOL_ID.equals(clientConnection.helidonSocket().protocol())) {
             throw new IllegalStateException("HTTP/2 alternative did not negotiate h2");
+        }
+    }
+
+    private boolean containsGeneration(Http2AltSvcCache.Generation generation) {
+        lifecycleLock.lock();
+        try {
+            for (ConnectionRoute route : allConnections.values()) {
+                if (route.matches(generation)) {
+                    return true;
+                }
+            }
+            return false;
+        } finally {
+            lifecycleLock.unlock();
         }
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -103,6 +103,37 @@ class Http2ClientConnectionHandler {
         this.currentAlternative = Objects.requireNonNull(currentAlternative, "currentAlternative");
     }
 
+    static boolean ownsExplicitConnection(Http2ClientRequestImpl request) {
+        return request.ownsExplicitConnection();
+    }
+
+    static Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
+                                              ClientConnectionTarget requestTarget,
+                                              Http2ClientRequestImpl request,
+                                              WebClientServiceRequest serviceRequest,
+                                              Http1FallbackHandler http1FallbackHandler,
+                                              Http2ClientConnectionHandler resultHandler) {
+        return http1(http2Client,
+                     requestTarget,
+                     request,
+                     serviceRequest,
+                     http1FallbackHandler,
+                     resultHandler,
+                     null);
+    }
+
+    static boolean http1FallbackAllowed(Http2ClientRequestImpl request) {
+        return request.tcpProtocolIds().contains(Http1Client.PROTOCOL_ID);
+    }
+
+    static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri,
+                                                             Http2ClientRequestImpl request,
+                                                             Http1FallbackHandler http1FallbackHandler) {
+        IllegalArgumentException failure = unsupportedHttp1Fallback(uri, request);
+        http1FallbackHandler.completeSentExceptionally(failure);
+        return failure;
+    }
+
     boolean acquire() {
         lifecycleLock.lock();
         try {
@@ -417,6 +448,107 @@ class Http2ClientConnectionHandler {
         }
     }
 
+    private static AlternativeConnectionException staleAlternative(Http2AltSvcCache.Selection selection,
+                                                                    String message) {
+        return new AlternativeConnectionException(selection,
+                                                  AlternativeConnectionException.Reason.STALE,
+                                                  new IllegalStateException(message));
+    }
+
+    private static Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
+                                                       ClientConnectionTarget requestTarget,
+                                                       Http2ClientRequestImpl request,
+                                                       WebClientServiceRequest serviceRequest,
+                                                       Http1FallbackHandler http1FallbackHandler,
+                                                       Http2ClientConnectionHandler resultHandler,
+                                                       ResolvedClientTarget resolvedTarget) {
+        try {
+            Http1ClientRequest http1Request = http1Request(http2Client.http1FallbackClient(),
+                                                           requestTarget,
+                                                           request,
+                                                           serviceRequest.uri());
+            Http1ClientResponse fallbackResponse = http1FallbackHandler.apply(http1Request, serviceRequest);
+            return new Http2ConnectionAttemptResult(Result.HTTP_1,
+                                                    null,
+                                                    fallbackResponse,
+                                                    resultHandler,
+                                                    requestTarget,
+                                                    resolvedTarget,
+                                                    null);
+        } catch (RuntimeException | Error e) {
+            http1FallbackHandler.completeSentExceptionally(e);
+            throw e;
+        }
+    }
+
+    private static Http1ClientRequest http1Request(Http1Client http1Client,
+                                                  ClientConnectionTarget requestTarget,
+                                                  Http2ClientRequestImpl request,
+                                                  ClientUri initialUri) {
+        Http1ClientRequest http1Request = http1Client.method(request.method())
+                .uri(initialUri)
+                .keepAlive(request.keepAlive())
+                .headers(request.headers())
+                .skipUriEncoding(request.skipUriEncoding())
+                .tls(request.tls())
+                .readTimeout(request.readTimeout())
+                .readContinueTimeout(request.readContinueTimeout())
+                .proxy(request.proxy())
+                .maxRedirects(request.maxRedirects())
+                .followRedirects(request.followRedirects());
+        request.connection().ifPresent(http1Request::connection);
+        request.address().ifPresent(http1Request::address);
+        request.sni().ifPresent(http1Request::sni);
+        request.sendExpectContinue().ifPresent(http1Request::sendExpectContinue);
+        // This is a manual HTTP/2-to-HTTP/1 request copy used for h2c probing/fallback. Properties carry internal
+        // redirect state, including whether a previous redirect already crossed an origin boundary.
+        request.properties().forEach(http1Request::property);
+        if (requestTarget.transportAddress().isEmpty()
+                && http1Request instanceof FullClientRequest<?> fullClientRequest) {
+            fullClientRequest.selectedProxyRoute(requestTarget.proxyRoute());
+        }
+        return http1Request;
+    }
+
+    private static ResolvedClientTarget resolvedTarget(ClientConnection clientConnection) {
+        return clientConnection instanceof TcpClientConnection tcpConnection
+                ? tcpConnection.resolvedTarget().orElse(null)
+                : null;
+    }
+
+    private static void closeClientConnection(ClientConnection clientConnection) {
+        try {
+            clientConnection.closeResource();
+        } catch (RuntimeException e) {
+            LOGGER.log(DEBUG, "Failed to close internally created HTTP/2 probe connection", e);
+        }
+    }
+
+    private static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri, Http2ClientRequestImpl request) {
+        return new IllegalArgumentException("Cannot handle request to " + uri
+                                                   + ", negotiated HTTP/1.1 fallback is not enabled. HTTP versions supported: "
+                                                   + request.tcpProtocolIds());
+    }
+
+    private static IllegalStateException unsupportedUpgradeFallback(Http2ClientRequestImpl request,
+                                                                    HttpClientResponse response) {
+        return new IllegalStateException("Cannot use failed h2c upgrade response as HTTP/1.1 fallback for "
+                                                 + request.method()
+                                                 + " request with an entity. Status: "
+                                                 + response.status());
+    }
+
+    private static List<String> alpnProtocolIds(Http2ClientRequestImpl request) {
+        return request.priorKnowledge() ? List.of(Http2Client.PROTOCOL_ID) : request.tcpProtocolIds();
+    }
+
+    private static void requireHttp2(ClientConnection clientConnection) {
+        if (!clientConnection.helidonSocket().protocolNegotiated()
+                || !Http2Client.PROTOCOL_ID.equals(clientConnection.helidonSocket().protocol())) {
+            throw new IllegalStateException("HTTP/2 alternative did not negotiate h2");
+        }
+    }
+
     private Http2ConnectionAttemptResult alternativeHttp2(Http2ClientImpl http2Client,
                                                           Http2AltSvcCache.Selection selection,
                                                           Http2ClientRequestImpl request) {
@@ -526,13 +658,6 @@ class Http2ClientConnectionHandler {
         } finally {
             lifecycleLock.unlock();
         }
-    }
-
-    private static AlternativeConnectionException staleAlternative(Http2AltSvcCache.Selection selection,
-                                                                    String message) {
-        return new AlternativeConnectionException(selection,
-                                                  AlternativeConnectionException.Reason.STALE,
-                                                  new IllegalStateException(message));
     }
 
     private ExistingStream existingStream(Http2ClientImpl http2Client,
@@ -862,10 +987,6 @@ class Http2ClientConnectionHandler {
         }
     }
 
-    static boolean ownsExplicitConnection(Http2ClientRequestImpl request) {
-        return request.ownsExplicitConnection();
-    }
-
     private String settingsForUpgrade(Http2ClientProtocolConfig protocolConfig) {
         Http2Settings settings = Http2ClientConnection.settings(protocolConfig);
         BufferData settingsFrameData = settings.toFrameData(null, 0, Http2Flag.SettingsFlags.create(0))
@@ -873,76 +994,6 @@ class Http2ClientConnectionHandler {
         byte[] b = new byte[settingsFrameData.available()];
         settingsFrameData.read(b);
         return Base64.getUrlEncoder().encodeToString(b);
-    }
-
-    static Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
-                                              ClientConnectionTarget requestTarget,
-                                              Http2ClientRequestImpl request,
-                                              WebClientServiceRequest serviceRequest,
-                                              Http1FallbackHandler http1FallbackHandler,
-                                              Http2ClientConnectionHandler resultHandler) {
-        return http1(http2Client,
-                     requestTarget,
-                     request,
-                     serviceRequest,
-                     http1FallbackHandler,
-                     resultHandler,
-                     null);
-    }
-
-    private static Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
-                                                       ClientConnectionTarget requestTarget,
-                                                       Http2ClientRequestImpl request,
-                                                       WebClientServiceRequest serviceRequest,
-                                                       Http1FallbackHandler http1FallbackHandler,
-                                                       Http2ClientConnectionHandler resultHandler,
-                                                       ResolvedClientTarget resolvedTarget) {
-        try {
-            Http1ClientRequest http1Request = http1Request(http2Client.http1FallbackClient(),
-                                                           requestTarget,
-                                                           request,
-                                                           serviceRequest.uri());
-            Http1ClientResponse fallbackResponse = http1FallbackHandler.apply(http1Request, serviceRequest);
-            return new Http2ConnectionAttemptResult(Result.HTTP_1,
-                                                    null,
-                                                    fallbackResponse,
-                                                    resultHandler,
-                                                    requestTarget,
-                                                    resolvedTarget,
-                                                    null);
-        } catch (RuntimeException | Error e) {
-            http1FallbackHandler.completeSentExceptionally(e);
-            throw e;
-        }
-    }
-
-    private static Http1ClientRequest http1Request(Http1Client http1Client,
-                                                  ClientConnectionTarget requestTarget,
-                                                  Http2ClientRequestImpl request,
-                                                  ClientUri initialUri) {
-        Http1ClientRequest http1Request = http1Client.method(request.method())
-                .uri(initialUri)
-                .keepAlive(request.keepAlive())
-                .headers(request.headers())
-                .skipUriEncoding(request.skipUriEncoding())
-                .tls(request.tls())
-                .readTimeout(request.readTimeout())
-                .readContinueTimeout(request.readContinueTimeout())
-                .proxy(request.proxy())
-                .maxRedirects(request.maxRedirects())
-                .followRedirects(request.followRedirects());
-        request.connection().ifPresent(http1Request::connection);
-        request.address().ifPresent(http1Request::address);
-        request.sni().ifPresent(http1Request::sni);
-        request.sendExpectContinue().ifPresent(http1Request::sendExpectContinue);
-        // This is a manual HTTP/2-to-HTTP/1 request copy used for h2c probing/fallback. Properties carry internal
-        // redirect state, including whether a previous redirect already crossed an origin boundary.
-        request.properties().forEach(http1Request::property);
-        if (requestTarget.transportAddress().isEmpty()
-                && http1Request instanceof FullClientRequest<?> fullClientRequest) {
-            fullClientRequest.selectedProxyRoute(requestTarget.proxyRoute());
-        }
-        return http1Request;
     }
 
     private Http2ClientConnection createConnection(Http2ClientImpl http2Client,
@@ -1150,50 +1201,6 @@ class Http2ClientConnectionHandler {
         toRetire.forEach(Http2ClientConnection::retire);
     }
 
-    private static ResolvedClientTarget resolvedTarget(ClientConnection clientConnection) {
-        return clientConnection instanceof TcpClientConnection tcpConnection
-                ? tcpConnection.resolvedTarget().orElse(null)
-                : null;
-    }
-
-    private static void closeClientConnection(ClientConnection clientConnection) {
-        try {
-            clientConnection.closeResource();
-        } catch (RuntimeException e) {
-            LOGGER.log(DEBUG, "Failed to close internally created HTTP/2 probe connection", e);
-        }
-    }
-
-    static boolean http1FallbackAllowed(Http2ClientRequestImpl request) {
-        return request.tcpProtocolIds().contains(Http1Client.PROTOCOL_ID);
-    }
-
-    private static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri, Http2ClientRequestImpl request) {
-        return new IllegalArgumentException("Cannot handle request to " + uri
-                                                   + ", negotiated HTTP/1.1 fallback is not enabled. HTTP versions supported: "
-                                                   + request.tcpProtocolIds());
-    }
-
-    static IllegalArgumentException unsupportedHttp1Fallback(ClientUri uri,
-                                                             Http2ClientRequestImpl request,
-                                                             Http1FallbackHandler http1FallbackHandler) {
-        IllegalArgumentException failure = unsupportedHttp1Fallback(uri, request);
-        http1FallbackHandler.completeSentExceptionally(failure);
-        return failure;
-    }
-
-    private static IllegalStateException unsupportedUpgradeFallback(Http2ClientRequestImpl request,
-                                                                    HttpClientResponse response) {
-        return new IllegalStateException("Cannot use failed h2c upgrade response as HTTP/1.1 fallback for "
-                                                 + request.method()
-                                                 + " request with an entity. Status: "
-                                                 + response.status());
-    }
-
-    private static List<String> alpnProtocolIds(Http2ClientRequestImpl request) {
-        return request.priorKnowledge() ? List.of(Http2Client.PROTOCOL_ID) : request.tcpProtocolIds();
-    }
-
     private ClientConnection connectAlternative(WebClient webClient, ResolvedClientTarget resolvedTarget) {
         return TcpClientConnection.create(webClient,
                                           resolvedTarget,
@@ -1201,13 +1208,6 @@ class Http2ClientConnectionHandler {
                                           _ -> false,
                                           this::removeClientConnection)
                 .connect();
-    }
-
-    private static void requireHttp2(ClientConnection clientConnection) {
-        if (!clientConnection.helidonSocket().protocolNegotiated()
-                || !Http2Client.PROTOCOL_ID.equals(clientConnection.helidonSocket().protocol())) {
-            throw new IllegalStateException("HTTP/2 alternative did not negotiate h2");
-        }
     }
 
     private ClientConnection connectClient(WebClient webClient,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -24,10 +24,13 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Header;
@@ -41,12 +44,14 @@ import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.ResolvedClientTarget;
 import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.UnixDomainSocketClientConnection;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
+import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.http1.UpgradeResponse;
 import io.helidon.webclient.http2.Http2ConnectionAttemptResult.Result;
 
@@ -67,7 +72,7 @@ class Http2ClientConnectionHandler {
     private final Map<ClientConnection, Http2ClientConnection> h2ConnByConn =
             Collections.synchronizedMap(new IdentityHashMap<>());
 
-    private final Map<Http2ClientConnection, ClientConnectionTarget> allConnections =
+    private final Map<Http2ClientConnection, ConnectionRoute> allConnections =
             Collections.synchronizedMap(new IdentityHashMap<>());
     private final Set<Http2ClientConnection> pendingUpgradedConnections =
             Collections.newSetFromMap(new IdentityHashMap<>());
@@ -76,18 +81,26 @@ class Http2ClientConnectionHandler {
     private final AtomicReference<Http2ClientConnection> activeConnection = new AtomicReference<>();
     private final ReentrantLock lock = new ReentrantLock();
     private final ReentrantLock lifecycleLock = new ReentrantLock();
+    private final AtomicBoolean directHttp2Supported = new AtomicBoolean();
     private final AtomicReference<Result> result = new AtomicReference<>(Result.UNKNOWN);
     private final int connectionCacheSize;
+    private final Predicate<Http2AltSvcCache.Selection> currentAlternative;
     private boolean closed;
     private boolean retired;
     private boolean connectionsRetired;
     private int leases;
 
     Http2ClientConnectionHandler(int connectionCacheSize) {
+        this(connectionCacheSize, _ -> true);
+    }
+
+    Http2ClientConnectionHandler(int connectionCacheSize,
+                                 Predicate<Http2AltSvcCache.Selection> currentAlternative) {
         if (connectionCacheSize < 1) {
             throw new IllegalArgumentException("Connection cache size must be greater than zero");
         }
         this.connectionCacheSize = connectionCacheSize;
+        this.currentAlternative = Objects.requireNonNull(currentAlternative, "currentAlternative");
     }
 
     boolean acquire() {
@@ -101,6 +114,14 @@ class Http2ClientConnectionHandler {
         } finally {
             lifecycleLock.unlock();
         }
+    }
+
+    boolean directHttp2Supported() {
+        return directHttp2Supported.get();
+    }
+
+    void markDirectHttp2Supported() {
+        directHttp2Supported.set(true);
     }
 
     void release() {
@@ -141,6 +162,82 @@ class Http2ClientConnectionHandler {
         if (retireConnections) {
             retireConnections();
         }
+    }
+
+    boolean hasAlternative(Http2AltSvcCache.Selection selection) {
+        lifecycleLock.lock();
+        try {
+            for (Http2ClientConnection connection : selectableConnections) {
+                ConnectionRoute route = allConnections.get(connection);
+                if (route != null && route.matches(selection)) {
+                    return true;
+                }
+            }
+            return false;
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    boolean hasAlternative(Http2AltSvcCache.Generation generation) {
+        lifecycleLock.lock();
+        try {
+            for (Http2ClientConnection connection : selectableConnections) {
+                ConnectionRoute route = allConnections.get(connection);
+                if (route != null && route.matches(generation)) {
+                    return true;
+                }
+            }
+            return false;
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    void retire(Http2AltSvcCache.Selection selection) {
+        Set<Http2ClientConnection> toRetire = new HashSet<>();
+        lock.lock();
+        try {
+            lifecycleLock.lock();
+            try {
+                for (Http2ClientConnection connection : List.copyOf(allConnections.keySet())) {
+                    ConnectionRoute route = allConnections.get(connection);
+                    if (route != null && route.matches(selection)) {
+                        allConnections.remove(connection, route);
+                        removeSelectableConnection(connection);
+                        toRetire.add(connection);
+                    }
+                }
+            } finally {
+                lifecycleLock.unlock();
+            }
+        } finally {
+            lock.unlock();
+        }
+        toRetire.forEach(Http2ClientConnection::retire);
+    }
+
+    void retire(Http2AltSvcCache.Generation generation) {
+        Set<Http2ClientConnection> toRetire = new HashSet<>();
+        lock.lock();
+        try {
+            lifecycleLock.lock();
+            try {
+                for (Http2ClientConnection connection : List.copyOf(allConnections.keySet())) {
+                    ConnectionRoute route = allConnections.get(connection);
+                    if (route != null && route.matches(generation)) {
+                        allConnections.remove(connection, route);
+                        removeSelectableConnection(connection);
+                        toRetire.add(connection);
+                    }
+                }
+            } finally {
+                lifecycleLock.unlock();
+            }
+        } finally {
+            lock.unlock();
+        }
+        toRetire.forEach(Http2ClientConnection::retire);
     }
 
     void close() {
@@ -192,7 +289,6 @@ class Http2ClientConnectionHandler {
                 return http1(http2Client,
                              requestTarget,
                              request,
-                             initialUri,
                              serviceRequest,
                              http1FallbackHandler,
                              this);
@@ -206,7 +302,6 @@ class Http2ClientConnectionHandler {
                     yield http1(http2Client,
                                 requestTarget,
                                 request,
-                                initialUri,
                                 serviceRequest,
                                 http1FallbackHandler,
                                 this);
@@ -225,6 +320,20 @@ class Http2ClientConnectionHandler {
         }
     }
 
+    Http2ConnectionAttemptResult newAlternativeStream(Http2ClientImpl http2Client,
+                                                      Http2AltSvcCache.Selection selection,
+                                                      Http2ClientRequestImpl request,
+                                                      Http1FallbackHandler http1FallbackHandler) {
+        try {
+            return alternativeHttp2(http2Client, selection, request);
+        } catch (AlternativeConnectionException e) {
+            throw e;
+        } catch (RuntimeException | Error e) {
+            http1FallbackHandler.completeSentExceptionally(e);
+            throw e;
+        }
+    }
+
     Http2ConnectionAttemptResult reuseStream(Http2ClientImpl http2Client,
                                              Http2ClientRequestImpl request) {
         if (result.get() != Result.HTTP_2) {
@@ -236,7 +345,7 @@ class Http2ClientConnectionHandler {
             throw new IllegalStateException("Interrupted", e);
         }
         try {
-            ExistingStream existingStream = existingStream(http2Client, request);
+            ExistingStream existingStream = existingStream(http2Client, request, null);
             if (existingStream == null) {
                 return null;
             }
@@ -244,7 +353,9 @@ class Http2ClientConnectionHandler {
                                                     existingStream.stream(),
                                                     null,
                                                     this,
-                                                    existingStream.connectionTarget());
+                                                    existingStream.route().logicalTarget(),
+                                                    existingStream.route().physicalTarget,
+                                                    null);
         } finally {
             lock.unlock();
         }
@@ -263,7 +374,7 @@ class Http2ClientConnectionHandler {
         }
         try {
             // read/write lock to obtain a stream or create a new connection
-            ExistingStream existingStream = existingStream(http2Client, request);
+            ExistingStream existingStream = existingStream(http2Client, request, null);
             if (existingStream == null) {
                 Http2ClientConnection connection;
                 try {
@@ -284,26 +395,156 @@ class Http2ClientConnectionHandler {
                 result.set(Result.HTTP_2);
                 // we must assume that a new connection can handle a new stream
                 Http2ClientStream stream = createStreamOnNewConnection(http2Client, connection, request);
-                return new Http2ConnectionAttemptResult(Result.HTTP_2, stream, null, this, requestTarget);
+                ConnectionRoute route = connectionRoute(connection, requestTarget);
+                return new Http2ConnectionAttemptResult(Result.HTTP_2,
+                                                        stream,
+                                                        null,
+                                                        this,
+                                                        requestTarget,
+                                                        route.physicalTarget,
+                                                        null);
             }
 
             return new Http2ConnectionAttemptResult(Result.HTTP_2,
                                                     existingStream.stream(),
                                                     null,
                                                     this,
-                                                    existingStream.connectionTarget());
+                                                    existingStream.route().logicalTarget(),
+                                                    existingStream.route().physicalTarget,
+                                                    null);
         } finally {
             lock.unlock();
         }
     }
 
-    private ExistingStream existingStream(Http2ClientImpl http2Client, Http2ClientRequestImpl request) {
+    private Http2ConnectionAttemptResult alternativeHttp2(Http2ClientImpl http2Client,
+                                                          Http2AltSvcCache.Selection selection,
+                                                          Http2ClientRequestImpl request) {
+        try {
+            lock.lockInterruptibly();
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Interrupted", e);
+        }
+        try {
+            ensureAlternativeCurrent(selection);
+            ExistingStream existingStream = existingStream(http2Client, request, selection);
+            if (existingStream != null) {
+                try {
+                    ensureAlternativeCurrent(selection);
+                } catch (RuntimeException | Error e) {
+                    try {
+                        existingStream.stream().close();
+                    } catch (RuntimeException | Error closeFailure) {
+                        if (closeFailure != e) {
+                            e.addSuppressed(closeFailure);
+                        }
+                    }
+                    throw e;
+                }
+                return new Http2ConnectionAttemptResult(Result.HTTP_2,
+                                                        existingStream.stream(),
+                                                        null,
+                                                        this,
+                                                        existingStream.route().logicalTarget(),
+                                                        existingStream.route().physicalTarget,
+                                                        selection);
+            }
+            ensureAlternativeCanEstablish(selection);
+
+            ClientConnection clientConnection = null;
+            Http2ClientConnection connection = null;
+            try {
+                ResolvedClientTarget resolvedTarget = selection.originTarget()
+                        .resolve(selection.host(), selection.port(), selection.networkGeneration());
+                clientConnection = connectAlternative(http2Client.webClient(), resolvedTarget);
+                requireHttp2(clientConnection);
+                connection = createHttp2Connection(http2Client, clientConnection, true);
+                ensureAlternativeCurrent(selection);
+                activateConnection(selection.originTarget(), clientConnection, connection, selection);
+                ensureAlternativeCurrent(selection);
+            } catch (AlternativeConnectionException e) {
+                if (connection != null) {
+                    discardConnection(connection);
+                } else if (clientConnection != null) {
+                    closeClientConnection(clientConnection);
+                }
+                throw e;
+            } catch (RuntimeException e) {
+                if (connection != null) {
+                    discardConnection(connection);
+                } else if (clientConnection != null) {
+                    closeClientConnection(clientConnection);
+                }
+                AlternativeConnectionException.Reason reason = alternativeAvailable(selection)
+                        ? AlternativeConnectionException.Reason.PRE_SEND_FAILURE
+                        : AlternativeConnectionException.Reason.STALE;
+                throw new AlternativeConnectionException(selection, reason, e);
+            }
+
+            Http2ClientStream stream;
+            try {
+                stream = createStreamOnNewConnection(http2Client, connection, request);
+            } catch (RuntimeException e) {
+                AlternativeConnectionException.Reason reason = alternativeAvailable(selection)
+                        ? AlternativeConnectionException.Reason.PRE_SEND_FAILURE
+                        : AlternativeConnectionException.Reason.STALE;
+                throw new AlternativeConnectionException(selection, reason, e);
+            }
+            ConnectionRoute route = connectionRoute(connection, selection.originTarget());
+            return new Http2ConnectionAttemptResult(Result.HTTP_2,
+                                                    stream,
+                                                    null,
+                                                    this,
+                                                    route.logicalTarget(),
+                                                    route.physicalTarget,
+                                                    selection);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void ensureAlternativeCanEstablish(Http2AltSvcCache.Selection selection) {
+        ensureAlternativeCurrent(selection);
+        if (!selection.establishAllowed()) {
+            throw staleAlternative(selection, "Expired HTTP/2 alternative has no reusable connection");
+        }
+    }
+
+    private void ensureAlternativeCurrent(Http2AltSvcCache.Selection selection) {
+        if (!alternativeAvailable(selection)) {
+            throw staleAlternative(selection, "HTTP/2 alternative route selection is stale");
+        }
+    }
+
+    private boolean alternativeAvailable(Http2AltSvcCache.Selection selection) {
+        if (!currentAlternative.test(selection)) {
+            return false;
+        }
+        lifecycleLock.lock();
+        try {
+            return !closed && !retired;
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private static AlternativeConnectionException staleAlternative(Http2AltSvcCache.Selection selection,
+                                                                    String message) {
+        return new AlternativeConnectionException(selection,
+                                                  AlternativeConnectionException.Reason.STALE,
+                                                  new IllegalStateException(message));
+    }
+
+    private ExistingStream existingStream(Http2ClientImpl http2Client,
+                                          Http2ClientRequestImpl request,
+                                          Http2AltSvcCache.Selection selectedAlternative) {
         Http2ClientProtocolConfig protocolConfig = http2Client.protocolConfig();
         Http2ClientConnection connection = activeConnection.get();
         if (connection != null) {
-            ClientConnectionTarget connectionTarget = allConnections.get(connection);
-            if (connectionTarget != null
-                    && (request.priorKnowledge() || !connectionTarget.proxyRoute().forwardProxy())) {
+            ConnectionRoute route = allConnections.get(connection);
+            if (route != null
+                    && route.matches(selectedAlternative)
+                    && (request.priorKnowledge() || !route.logicalTarget().proxyRoute().forwardProxy())) {
                 if (connection.closed(protocolConfig)) {
                     discardConnection(connection);
                 } else {
@@ -312,7 +553,7 @@ class Http2ClientConnectionHandler {
                                                                     http2Client.sendListener(),
                                                                     http2Client.recvListener());
                     if (stream != null) {
-                        return new ExistingStream(stream, connectionTarget);
+                        return new ExistingStream(stream, route);
                     }
                 }
             }
@@ -329,11 +570,11 @@ class Http2ClientConnectionHandler {
             if (candidate == connection) {
                 continue;
             }
-            ClientConnectionTarget connectionTarget = allConnections.get(candidate);
-            if (connectionTarget == null) {
+            ConnectionRoute route = allConnections.get(candidate);
+            if (route == null || !route.matches(selectedAlternative)) {
                 continue;
             }
-            if (!request.priorKnowledge() && connectionTarget.proxyRoute().forwardProxy()) {
+            if (!request.priorKnowledge() && route.logicalTarget().proxyRoute().forwardProxy()) {
                 continue;
             }
             if (candidate.closed(protocolConfig)) {
@@ -356,7 +597,7 @@ class Http2ClientConnectionHandler {
                 } finally {
                     lifecycleLock.unlock();
                 }
-                return new ExistingStream(stream, connectionTarget);
+                return new ExistingStream(stream, route);
             }
         }
         return null;
@@ -386,7 +627,7 @@ class Http2ClientConnectionHandler {
                         Http2ClientConnection connection = createHttp2Connection(http2Client,
                                                                                  clientConnection,
                                                                                  true);
-                        activateConnection(requestTarget, clientConnection, connection);
+                        activateConnection(requestTarget, clientConnection, connection, null);
                         return http2(http2Client,
                                      requestTarget,
                                      request,
@@ -426,7 +667,7 @@ class Http2ClientConnectionHandler {
                     Http2ClientConnection connection = createHttp2Connection(http2Client,
                                                                              clientConnection,
                                                                              true);
-                    activateConnection(requestTarget, clientConnection, connection);
+                    activateConnection(requestTarget, clientConnection, connection, null);
                     return http2(http2Client,
                                  requestTarget,
                                  request,
@@ -466,7 +707,7 @@ class Http2ClientConnectionHandler {
                 result.set(Result.HTTP_2);
                 ClientConnection connection = upgradeResponse.connection();
                 Http2ClientConnection conn = createUpgradedHttp2Connection(http2Client, connection);
-                activateConnection(requestTarget, connection, conn);
+                activateConnection(requestTarget, connection, conn, null);
                 return http2(http2Client,
                              requestTarget,
                              request,
@@ -516,10 +757,10 @@ class Http2ClientConnectionHandler {
             return http1(http2Client,
                          requestTarget,
                          request,
-                         initialUri,
                          serviceRequest,
                          http1FallbackHandler,
-                         this);
+                         this,
+                         resolvedTarget(clientConnection));
         } catch (RuntimeException | Error e) {
             closeClientConnection(clientConnection);
             throw e;
@@ -566,10 +807,10 @@ class Http2ClientConnectionHandler {
             return http1(http2Client,
                          requestTarget,
                          request,
-                         initialUri,
                          serviceRequest,
                          http1FallbackHandler,
-                         this);
+                         this,
+                         resolvedTarget(clientConnection));
         }
         return http2ExplicitConnection(http2Client, requestTarget, request, clientConnection);
     }
@@ -602,17 +843,20 @@ class Http2ClientConnectionHandler {
             }
             if (ownsExplicitConnection) {
                 result.set(Result.HTTP_2);
-                activateConnection(requestTarget, clientConnection, connection);
+                activateConnection(requestTarget, clientConnection, connection, null);
             }
 
-            return new Http2ConnectionAttemptResult(Result.HTTP_2,
-                                                    connection.createStream(request,
-                                                                            http2Client.clientConfig(),
-                                                                            http2Client.sendListener(),
-                                                                            http2Client.recvListener()),
-                                                    null,
-                                                    this,
-                                                    requestTarget);
+            return new Http2ConnectionAttemptResult(
+                    Result.HTTP_2,
+                    connection.createStream(request,
+                                            http2Client.clientConfig(),
+                                            http2Client.sendListener(),
+                                            http2Client.recvListener()),
+                    null,
+                    this,
+                    requestTarget,
+                    connection.resolvedTarget().orElse(null),
+                    null);
         } finally {
             lock.unlock();
         }
@@ -634,20 +878,38 @@ class Http2ClientConnectionHandler {
     static Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
                                               ClientConnectionTarget requestTarget,
                                               Http2ClientRequestImpl request,
-                                              ClientUri initialUri,
                                               WebClientServiceRequest serviceRequest,
                                               Http1FallbackHandler http1FallbackHandler,
                                               Http2ClientConnectionHandler resultHandler) {
+        return http1(http2Client,
+                     requestTarget,
+                     request,
+                     serviceRequest,
+                     http1FallbackHandler,
+                     resultHandler,
+                     null);
+    }
+
+    private static Http2ConnectionAttemptResult http1(Http2ClientImpl http2Client,
+                                                       ClientConnectionTarget requestTarget,
+                                                       Http2ClientRequestImpl request,
+                                                       WebClientServiceRequest serviceRequest,
+                                                       Http1FallbackHandler http1FallbackHandler,
+                                                       Http2ClientConnectionHandler resultHandler,
+                                                       ResolvedClientTarget resolvedTarget) {
         try {
             Http1ClientRequest http1Request = http1Request(http2Client.http1FallbackClient(),
                                                            requestTarget,
                                                            request,
-                                                           initialUri);
+                                                           serviceRequest.uri());
+            Http1ClientResponse fallbackResponse = http1FallbackHandler.apply(http1Request, serviceRequest);
             return new Http2ConnectionAttemptResult(Result.HTTP_1,
                                                     null,
-                                                    http1FallbackHandler.apply(http1Request, serviceRequest),
+                                                    fallbackResponse,
                                                     resultHandler,
-                                                    requestTarget);
+                                                    requestTarget,
+                                                    resolvedTarget,
+                                                    null);
         } catch (RuntimeException | Error e) {
             http1FallbackHandler.completeSentExceptionally(e);
             throw e;
@@ -751,7 +1013,7 @@ class Http2ClientConnectionHandler {
             }
 
             // only set these for requests that do not have an explicit connection defined
-            activateConnection(requestTarget, connection, usedConnection);
+            activateConnection(requestTarget, connection, usedConnection, null);
         }
 
         return usedConnection;
@@ -802,9 +1064,18 @@ class Http2ClientConnectionHandler {
         }
     }
 
+    private ConnectionRoute connectionRoute(Http2ClientConnection connection,
+                                            ClientConnectionTarget fallbackTarget) {
+        ConnectionRoute route = allConnections.get(connection);
+        return route == null
+                ? new ConnectionRoute(fallbackTarget, connection.resolvedTarget().orElse(null), null)
+                : route;
+    }
+
     private void activateConnection(ClientConnectionTarget connectionTarget,
                                     ClientConnection clientConnection,
-                                    Http2ClientConnection connection) {
+                                    Http2ClientConnection connection,
+                                    Http2AltSvcCache.Selection selectedAlternative) {
         Http2ClientConnection displacedConnection = null;
         boolean closeConnection;
         lifecycleLock.lock();
@@ -812,7 +1083,10 @@ class Http2ClientConnectionHandler {
             pendingUpgradedConnections.remove(connection);
             closeConnection = closed;
             if (!closeConnection) {
-                allConnections.put(connection, connectionTarget);
+                allConnections.put(connection,
+                                   ConnectionRoute.create(connectionTarget,
+                                                          clientConnection,
+                                                          selectedAlternative));
                 h2ConnByConn.put(clientConnection, connection);
                 boolean alreadySelectable = false;
                 for (Http2ClientConnection selectableConnection : selectableConnections) {
@@ -876,6 +1150,12 @@ class Http2ClientConnectionHandler {
         toRetire.forEach(Http2ClientConnection::retire);
     }
 
+    private static ResolvedClientTarget resolvedTarget(ClientConnection clientConnection) {
+        return clientConnection instanceof TcpClientConnection tcpConnection
+                ? tcpConnection.resolvedTarget().orElse(null)
+                : null;
+    }
+
     private static void closeClientConnection(ClientConnection clientConnection) {
         try {
             clientConnection.closeResource();
@@ -914,6 +1194,22 @@ class Http2ClientConnectionHandler {
         return request.priorKnowledge() ? List.of(Http2Client.PROTOCOL_ID) : request.tcpProtocolIds();
     }
 
+    private ClientConnection connectAlternative(WebClient webClient, ResolvedClientTarget resolvedTarget) {
+        return TcpClientConnection.create(webClient,
+                                          resolvedTarget,
+                                          List.of(Http2Client.PROTOCOL_ID),
+                                          _ -> false,
+                                          this::removeClientConnection)
+                .connect();
+    }
+
+    private static void requireHttp2(ClientConnection clientConnection) {
+        if (!clientConnection.helidonSocket().protocolNegotiated()
+                || !Http2Client.PROTOCOL_ID.equals(clientConnection.helidonSocket().protocol())) {
+            throw new IllegalStateException("HTTP/2 alternative did not negotiate h2");
+        }
+    }
+
     private ClientConnection connectClient(WebClient webClient,
                                            ClientConnectionTarget requestTarget,
                                            Http2ClientRequestImpl request,
@@ -950,7 +1246,46 @@ class Http2ClientConnectionHandler {
         }
     }
 
-    private record ExistingStream(Http2ClientStream stream, ClientConnectionTarget connectionTarget) {
+    private record ExistingStream(Http2ClientStream stream, ConnectionRoute route) {
+    }
+
+    private static final class ConnectionRoute {
+        private final ClientConnectionTarget logicalTarget;
+        private final ResolvedClientTarget physicalTarget;
+        private final Http2AltSvcCache.Selection selectedAlternative;
+
+        private ConnectionRoute(ClientConnectionTarget logicalTarget,
+                                ResolvedClientTarget physicalTarget,
+                                Http2AltSvcCache.Selection selectedAlternative) {
+            this.logicalTarget = Objects.requireNonNull(logicalTarget, "logicalTarget");
+            this.physicalTarget = selectedAlternative == null
+                    ? physicalTarget
+                    : Objects.requireNonNull(physicalTarget, "alternative physicalTarget");
+            this.selectedAlternative = selectedAlternative;
+        }
+
+        private static ConnectionRoute create(ClientConnectionTarget logicalTarget,
+                                              ClientConnection clientConnection,
+                                              Http2AltSvcCache.Selection selectedAlternative) {
+            return new ConnectionRoute(logicalTarget,
+                                       resolvedTarget(clientConnection),
+                                       selectedAlternative);
+        }
+
+        private ClientConnectionTarget logicalTarget() {
+            return logicalTarget;
+        }
+
+        private boolean matches(Http2AltSvcCache.Selection selection) {
+            if (selection == null) {
+                return selectedAlternative == null;
+            }
+            return selectedAlternative != null && selectedAlternative.sameRouteGeneration(selection);
+        }
+
+        private boolean matches(Http2AltSvcCache.Generation generation) {
+            return selectedAlternative != null && selectedAlternative.sameGeneration(generation);
+        }
     }
 
     private static class Http1FallbackResponse extends RuntimeException {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -69,11 +69,12 @@ class Http2ClientConnectionHandler {
     private static final HeaderName HTTP2_SETTINGS_HEADER = HeaderNames.create("HTTP2-Settings");
 
     // todo requires handling of timeouts and removal from this queue
-    private final Map<ClientConnection, Http2ClientConnection> h2ConnByConn =
-            Collections.synchronizedMap(new IdentityHashMap<>());
+    // Accessed only while holding lifecycleLock.
+    private final Map<ClientConnection, Http2ClientConnection> h2ConnByConn = new IdentityHashMap<>();
 
-    private final Map<Http2ClientConnection, ConnectionRoute> allConnections =
-            Collections.synchronizedMap(new IdentityHashMap<>());
+    // Accessed only while holding lifecycleLock.
+    private final Map<Http2ClientConnection, ConnectionRoute> allConnections = new IdentityHashMap<>();
+    // Accessed only while holding lifecycleLock.
     private final Set<Http2ClientConnection> pendingUpgradedConnections =
             Collections.newSetFromMap(new IdentityHashMap<>());
     // Creation ordered and compared by identity. Mutated only while holding lifecycleLock.
@@ -249,6 +250,9 @@ class Http2ClientConnectionHandler {
     }
 
     void retire(Http2AltSvcCache.Generation generation) {
+        if (!containsGeneration(generation)) {
+            return;
+        }
         Set<Http2ClientConnection> toRetire = new HashSet<>();
         lock.lock();
         try {
@@ -269,6 +273,20 @@ class Http2ClientConnectionHandler {
             lock.unlock();
         }
         toRetire.forEach(Http2ClientConnection::retire);
+    }
+
+    private boolean containsGeneration(Http2AltSvcCache.Generation generation) {
+        lifecycleLock.lock();
+        try {
+            for (ConnectionRoute route : allConnections.values()) {
+                if (route.matches(generation)) {
+                    return true;
+                }
+            }
+            return false;
+        } finally {
+            lifecycleLock.unlock();
+        }
     }
 
     void close() {
@@ -666,7 +684,7 @@ class Http2ClientConnectionHandler {
         Http2ClientProtocolConfig protocolConfig = http2Client.protocolConfig();
         Http2ClientConnection connection = activeConnection.get();
         if (connection != null) {
-            ConnectionRoute route = allConnections.get(connection);
+            ConnectionRoute route = connectionRoute(connection);
             if (route != null
                     && route.matches(selectedAlternative)
                     && (request.priorKnowledge() || !route.logicalTarget().proxyRoute().forwardProxy())) {
@@ -695,7 +713,7 @@ class Http2ClientConnectionHandler {
             if (candidate == connection) {
                 continue;
             }
-            ConnectionRoute route = allConnections.get(candidate);
+            ConnectionRoute route = connectionRoute(candidate);
             if (route == null || !route.matches(selectedAlternative)) {
                 continue;
             }
@@ -951,7 +969,7 @@ class Http2ClientConnectionHandler {
         }
         try {
             boolean ownsExplicitConnection = ownsExplicitConnection(request);
-            Http2ClientConnection connection = ownsExplicitConnection ? h2ConnByConn.get(clientConnection) : null;
+            Http2ClientConnection connection = ownsExplicitConnection ? http2Connection(clientConnection) : null;
             if (connection != null && connection.closed(http2Client.protocolConfig())) {
                 removeConnection(connection);
                 connection = null;
@@ -1117,10 +1135,28 @@ class Http2ClientConnectionHandler {
 
     private ConnectionRoute connectionRoute(Http2ClientConnection connection,
                                             ClientConnectionTarget fallbackTarget) {
-        ConnectionRoute route = allConnections.get(connection);
+        ConnectionRoute route = connectionRoute(connection);
         return route == null
                 ? new ConnectionRoute(fallbackTarget, connection.resolvedTarget().orElse(null), null)
                 : route;
+    }
+
+    private ConnectionRoute connectionRoute(Http2ClientConnection connection) {
+        lifecycleLock.lock();
+        try {
+            return allConnections.get(connection);
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private Http2ClientConnection http2Connection(ClientConnection connection) {
+        lifecycleLock.lock();
+        try {
+            return h2ConnByConn.get(connection);
+        } finally {
+            lifecycleLock.unlock();
+        }
     }
 
     private void activateConnection(ClientConnectionTarget connectionTarget,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnectionHandler.java
@@ -235,7 +235,6 @@ class Http2ClientConnectionHandler {
                 for (Http2ClientConnection connection : List.copyOf(allConnections.keySet())) {
                     ConnectionRoute route = allConnections.get(connection);
                     if (route != null && route.matches(selection)) {
-                        allConnections.remove(connection, route);
                         removeSelectableConnection(connection);
                         toRetire.add(connection);
                     }
@@ -261,7 +260,6 @@ class Http2ClientConnectionHandler {
                 for (Http2ClientConnection connection : List.copyOf(allConnections.keySet())) {
                     ConnectionRoute route = allConnections.get(connection);
                     if (route != null && route.matches(generation)) {
-                        allConnections.remove(connection, route);
                         removeSelectableConnection(connection);
                         toRetire.add(connection);
                     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -38,6 +38,7 @@ import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.ProxyRoute;
+import io.helidon.webclient.api.SniMode;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.api.WebClientConfig;
 import io.helidon.webclient.api.WebClientCookieManager;
@@ -132,6 +133,12 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
                 return SupportLevel.NOT_SUPPORTED;
             }
             ClientRequestHeaders headers = clientRequest.headers();
+            if (clientRequest.sni()
+                    .or(clientConfig::sni)
+                    .filter(sni -> sni.mode() == SniMode.HOST_HEADER)
+                    .isPresent()) {
+                connectionKey = Http2ConnectionKeys.create(clientUri, clientRequest, clientConfig, headers);
+            }
             Optional<ProxyRoute> selectedRoute = clientRequest.selectedProxyRoute();
             boolean alternativeAvailable;
             if (selectedRoute.isPresent()) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -189,7 +189,7 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
         }
 
         var receivedAt = response.receivedAt();
-        AltSvcHeader.parse(response.headers(), receivedAt)
+        AltSvcHeader.create(response.headers(), receivedAt)
                 .ifPresent(header -> connectionCache.recordAlternative(response.target().logicalTarget(),
                                                                         header,
                                                                         response.secure(),

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -183,8 +183,7 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
                 || !response.secure()
                 || !(Http1Client.PROTOCOL_ID.equals(response.protocolId())
                         || Http2Client.PROTOCOL_ID.equals(response.protocolId()))
-                || (response.status().code() == Status.MISDIRECTED_REQUEST_421_CODE
-                        && response.alternativeAuthority().isPresent())) {
+                || response.status().code() == Status.MISDIRECTED_REQUEST_421_CODE) {
             return;
         }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -17,20 +17,31 @@
 package io.helidon.webclient.http2;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.uri.UriQueryWriteable;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpLogConfig;
 import io.helidon.http.Method;
+import io.helidon.http.Status;
 import io.helidon.http.http2.Http2FrameListener;
+import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2LoggingFrameListener;
+import io.helidon.webclient.api.AltSvcHeader;
+import io.helidon.webclient.api.ClientAltSvcConfig;
+import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientRequest;
 import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.FullClientRequest;
+import io.helidon.webclient.api.ProxyRoute;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.api.WebClientConfig;
 import io.helidon.webclient.api.WebClientCookieManager;
+import io.helidon.webclient.api.WebClientProtocolResponse;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.spi.HttpClientSpi;
 
@@ -47,12 +58,29 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
     private final ReentrantLock lifecycleLock = new ReentrantLock();
     private final Http2FrameListener sendListener;
     private final Http2FrameListener recvListener;
+    private final boolean altSvcNotificationsEnabled;
+    private final boolean altSvcEnabled;
+    private final boolean responseNotificationsManagedByWebClient;
     private volatile boolean closed;
 
     Http2ClientImpl(WebClient webClient, Http2ClientConfig clientConfig) {
+        this(webClient, clientConfig, false);
+    }
+
+    Http2ClientImpl(WebClient webClient,
+                    Http2ClientConfig clientConfig,
+                    boolean responseNotificationsManagedByWebClient) {
         this.webClient = webClient;
         this.clientConfig = clientConfig;
         this.protocolConfig = clientConfig.protocolConfig();
+        Optional<ClientAltSvcConfig> altSvc = clientConfig.altSvc()
+                .filter(ClientAltSvcConfig::enabled);
+        this.altSvcNotificationsEnabled = altSvc.isPresent();
+        this.altSvcEnabled = altSvc
+                .map(config -> config.protocols().isEmpty()
+                        || config.protocols().contains(Http2Client.PROTOCOL_ID))
+                .orElse(false);
+        this.responseNotificationsManagedByWebClient = responseNotificationsManagedByWebClient;
         if (clientConfig.shareConnectionCache()) {
             this.connectionCache = Http2ConnectionCache.shared();
             this.clientCache = null;
@@ -93,11 +121,71 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
 
     @Override
     public SupportLevel supports(FullClientRequest<?> clientRequest, ClientUri clientUri) {
-        if (connectionCache.supports(Http2ConnectionKeys.create(clientUri, clientRequest, clientConfig))) {
+        ConnectionKey connectionKey = Http2ConnectionKeys.create(clientUri, clientRequest, clientConfig);
+        if (connectionCache.supports(connectionKey)) {
             return SupportLevel.SUPPORTED;
         }
 
+        if (altSvcEnabled) {
+            boolean explicitConnection = clientRequest.connection().isPresent();
+            if (!connectionCache.mayContainAlternative(connectionKey.host(), explicitConnection)) {
+                return SupportLevel.NOT_SUPPORTED;
+            }
+            ClientRequestHeaders headers = clientRequest.headers();
+            Optional<ProxyRoute> selectedRoute = clientRequest.selectedProxyRoute();
+            boolean alternativeAvailable;
+            if (selectedRoute.isPresent()) {
+                ClientConnectionTarget target = ClientConnectionTarget.create(connectionKey,
+                                                                                clientUri,
+                                                                                headers,
+                                                                                selectedRoute.get());
+                alternativeAvailable = connectionCache.alternativeAvailable(target, explicitConnection);
+            } else {
+                ClientConnectionTarget.LookupKey lookupKey = ClientConnectionTarget.lookupKey(connectionKey,
+                                                                                               clientUri,
+                                                                                               headers);
+                Http2AltSvcCache.Candidate candidate = connectionCache.currentAlternative(lookupKey,
+                                                                                           explicitConnection);
+                if (candidate == null) {
+                    alternativeAvailable = false;
+                } else {
+                    boolean originAuthorityOverride = headers.contains(Http2Headers.AUTHORITY_NAME)
+                            || headers.contains(HeaderNames.HOST);
+                    ClientConnectionTarget target = originAuthorityOverride
+                            ? ClientConnectionTarget.create(connectionKey,
+                                                            clientUri,
+                                                            headers,
+                                                            candidate.proxyRoute())
+                            : ClientConnectionTarget.create(connectionKey,
+                                                            clientUri.scheme(),
+                                                            candidate.proxyRoute());
+                    alternativeAvailable = connectionCache.alternativeAvailable(target, explicitConnection);
+                }
+            }
+            if (alternativeAvailable) {
+                return SupportLevel.SUPPORTED;
+            }
+        }
+
         return SupportLevel.NOT_SUPPORTED;
+    }
+
+    @Override
+    public void responseReceived(WebClientProtocolResponse response) {
+        if (!altSvcEnabled
+                || !response.secure()
+                || !(Http1Client.PROTOCOL_ID.equals(response.protocolId())
+                        || Http2Client.PROTOCOL_ID.equals(response.protocolId()))
+                || (response.status().code() == Status.MISDIRECTED_REQUEST_421_CODE
+                        && response.alternativeAuthority().isPresent())) {
+            return;
+        }
+
+        AltSvcHeader.parse(response.headers(), response.receivedAt())
+                .ifPresent(header -> connectionCache.recordAlternative(response.target().logicalTarget(),
+                                                                        header,
+                                                                        response.secure(),
+                                                                        response.explicitConnection()));
     }
 
     @Override
@@ -184,7 +272,19 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
                     .shareConnectionCache(false)
                     .build();
             try {
-                Http1Client http1Client = fallbackWebClient.client(Http1Client.PROTOCOL);
+                var provider = Http1Client.PROTOCOL.provider();
+                var configType = provider.configType();
+                var http1ProtocolConfig = fallbackWebClient.prototype()
+                        .protocolConfigs()
+                        .stream()
+                        .filter(config -> provider.protocolId().equals(config.type()))
+                        .filter(config -> configType.isAssignableFrom(config.getClass()))
+                        .map(configType::cast)
+                        .findFirst()
+                        .orElseGet(provider::defaultConfig);
+                WebClient forwardingWebClient = new Http2ResponseForwardingWebClient(fallbackWebClient,
+                                                                                      this::publishResponse);
+                Http1Client http1Client = provider.protocol(forwardingWebClient, http1ProtocolConfig);
                 fallbackResources = new Http1FallbackResources(fallbackWebClient, http1Client);
                 http1FallbackResources.set(fallbackResources);
                 return http1Client;
@@ -211,6 +311,26 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
 
     Http2ClientProtocolConfig protocolConfig() {
         return protocolConfig;
+    }
+
+    boolean altSvcEnabled() {
+        return altSvcEnabled;
+    }
+
+    boolean altSvcNotificationsEnabled() {
+        return altSvcNotificationsEnabled;
+    }
+
+    boolean responseNotificationsManagedByWebClient() {
+        return responseNotificationsManagedByWebClient;
+    }
+
+    void publishResponse(WebClientProtocolResponse response) {
+        if (responseNotificationsManagedByWebClient) {
+            webClient.responseReceived(response);
+        } else {
+            responseReceived(response);
+        }
     }
 
     Http2ConnectionCache connectionCache() {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -181,11 +181,13 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
             return;
         }
 
-        AltSvcHeader.parse(response.headers(), response.receivedAt())
+        var receivedAt = response.receivedAt();
+        AltSvcHeader.parse(response.headers(), receivedAt)
                 .ifPresent(header -> connectionCache.recordAlternative(response.target().logicalTarget(),
                                                                         header,
                                                                         response.secure(),
-                                                                        response.explicitConnection()));
+                                                                        response.explicitConnection(),
+                                                                        receivedAt));
     }
 
     @Override

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -271,7 +271,11 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         // will create a copy, so we could invoke this method multiple times
         ClientUri resolvedUri = resolvedUri();
 
-        WebClientServiceResponse serviceResponse = invokeServices(callChain, whenSent, whenComplete, resolvedUri);
+        WebClientServiceResponse serviceResponse = invokeServices(http2Client.webClient(),
+                                                                  callChain,
+                                                                  whenSent,
+                                                                  whenComplete,
+                                                                  resolvedUri);
 
         CompletableFuture<Void> complete = new CompletableFuture<>();
         complete.thenAccept(ignored -> serviceResponse.whenComplete().complete(serviceResponse))

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientSpiProvider.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientSpiProvider.java
@@ -54,6 +54,7 @@ public class Http2ClientSpiProvider implements HttpClientSpiProvider<Http2Client
                                            .from(client.prototype())
                                            .protocolConfig(config)
                                            .servicesDiscoverServices(false)
-                                           .buildPrototype());
+                                           .buildPrototype(),
+                                   true);
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionAttemptResult.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionAttemptResult.java
@@ -16,14 +16,79 @@
 
 package io.helidon.webclient.http2;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.ResolvedClientTarget;
 
-record Http2ConnectionAttemptResult(Result result,
-                                    Http2ClientStream stream,
-                                    HttpClientResponse response,
-                                    Http2ClientConnectionHandler handler,
-                                    ClientConnectionTarget connectionTarget) {
+final class Http2ConnectionAttemptResult {
+    private final Result result;
+    private final Http2ClientStream stream;
+    private final HttpClientResponse response;
+    private final Http2ClientConnectionHandler handler;
+    private final ClientConnectionTarget connectionTarget;
+    private final ResolvedClientTarget physicalTarget;
+    private final Http2AltSvcCache.Selection selectedAlternative;
+
+    Http2ConnectionAttemptResult(Result result,
+                                 Http2ClientStream stream,
+                                 HttpClientResponse response,
+                                 Http2ClientConnectionHandler handler,
+                                 ClientConnectionTarget connectionTarget) {
+        this(result, stream, response, handler, connectionTarget, null, null);
+    }
+
+    Http2ConnectionAttemptResult(Result result,
+                                 Http2ClientStream stream,
+                                 HttpClientResponse response,
+                                 Http2ClientConnectionHandler handler,
+                                 ClientConnectionTarget connectionTarget,
+                                 ResolvedClientTarget physicalTarget,
+                                 Http2AltSvcCache.Selection selectedAlternative) {
+        this.result = Objects.requireNonNull(result, "result");
+        this.stream = stream;
+        this.response = response;
+        this.handler = handler;
+        this.connectionTarget = Objects.requireNonNull(connectionTarget, "connectionTarget");
+        this.physicalTarget = selectedAlternative == null
+                ? physicalTarget
+                : Objects.requireNonNull(physicalTarget, "alternative physicalTarget");
+        this.selectedAlternative = selectedAlternative;
+        if (selectedAlternative != null && !selectedAlternative.originTarget().equals(connectionTarget)) {
+            throw new IllegalArgumentException("Alternative selection does not belong to the connection target");
+        }
+    }
+
+    Result result() {
+        return result;
+    }
+
+    Http2ClientStream stream() {
+        return stream;
+    }
+
+    HttpClientResponse response() {
+        return response;
+    }
+
+    Http2ClientConnectionHandler handler() {
+        return handler;
+    }
+
+    ClientConnectionTarget connectionTarget() {
+        return connectionTarget;
+    }
+
+    Optional<ResolvedClientTarget> resolvedTarget() {
+        return Optional.ofNullable(physicalTarget);
+    }
+
+    Optional<Http2AltSvcCache.Selection> alternative() {
+        return Optional.ofNullable(selectedAlternative);
+    }
+
     enum Result {
         HTTP_1,
         HTTP_2,

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -124,15 +124,6 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         markSupported(connectionTarget, handler);
     }
 
-    private void markSupported(ClientConnectionTarget connectionTarget,
-                               Http2ClientConnectionHandler expectedHandler) {
-        Http2ClientConnectionHandler handler = cache.get(connectionTarget);
-        if (handler == expectedHandler && handler != null) {
-            handler.markDirectHttp2Supported();
-            markSupported(connectionTarget.connectionKey());
-        }
-    }
-
     boolean alternativeAvailable(ClientConnectionTarget connectionTarget, boolean explicitConnection) {
         return altSvc.available(connectionTarget,
                                 explicitConnection,
@@ -308,6 +299,19 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         return result;
     }
 
+    private static IllegalStateException staleTlsGeneration() {
+        return new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
+    }
+
+    private void markSupported(ClientConnectionTarget connectionTarget,
+                               Http2ClientConnectionHandler expectedHandler) {
+        Http2ClientConnectionHandler handler = cache.get(connectionTarget);
+        if (handler == expectedHandler && handler != null) {
+            handler.markDirectHttp2Supported();
+            markSupported(connectionTarget.connectionKey());
+        }
+    }
+
     private Http2ClientConnectionHandler acquireHandler(Http2ClientImpl http2Client,
                                                         ClientConnectionTarget connectionTarget) {
         List<Http2ClientConnectionHandler> retiredHandlers = null;
@@ -382,10 +386,6 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                 }
             }
         }
-    }
-
-    private static IllegalStateException staleTlsGeneration() {
-        return new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
     }
 
     private void retireOldestTarget(List<Http2ClientConnectionHandler> retiredHandlers) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -51,8 +51,6 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
     private final ReentrantLock cacheLock = new ReentrantLock();
     private final Http2AltSvcCache altSvc;
     private final Predicate<Http2AltSvcCache.Selection> establishedAlternative = this::hasEstablishedAlternative;
-    private final Predicate<Http2AltSvcCache.Generation> establishedAlternativeGeneration =
-            this::hasEstablishedAlternative;
 
     private Http2ConnectionCache(boolean shared) {
         super(shared);
@@ -127,21 +125,19 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
     boolean alternativeAvailable(ClientConnectionTarget connectionTarget, boolean explicitConnection) {
         return altSvc.available(connectionTarget,
                                 explicitConnection,
-                                establishedAlternative,
-                                establishedAlternativeGeneration);
+                                establishedAlternative);
     }
 
     Http2AltSvcCache.Candidate currentAlternative(ClientConnectionTarget.LookupKey lookupKey,
                                                   boolean explicitConnection) {
-        return altSvc.selectRoute(lookupKey, explicitConnection, establishedAlternativeGeneration);
+        return altSvc.selectRoute(lookupKey, explicitConnection);
     }
 
     Http2AltSvcCache.Selection currentAlternative(ClientConnectionTarget connectionTarget,
                                                    boolean explicitConnection) {
         return altSvc.select(connectionTarget,
                              explicitConnection,
-                             establishedAlternative,
-                             establishedAlternativeGeneration);
+                             establishedAlternative);
     }
 
     void recordAlternative(ClientConnectionTarget connectionTarget,
@@ -420,22 +416,6 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
     private boolean hasEstablishedAlternative(Http2AltSvcCache.Selection selection) {
         Http2ClientConnectionHandler handler = cache.get(selection.originTarget());
         return handler != null && handler.hasAlternative(selection);
-    }
-
-    private boolean hasEstablishedAlternative(Http2AltSvcCache.Generation generation) {
-        List<Http2ClientConnectionHandler> handlers;
-        cacheLock.lock();
-        try {
-            handlers = List.copyOf(insertionOrder.values());
-        } finally {
-            cacheLock.unlock();
-        }
-        for (Http2ClientConnectionHandler handler : handlers) {
-            if (handler.hasAlternative(generation)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void retireAlternative(Http2AltSvcCache.Selection selection) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.http2;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -155,8 +156,9 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
     void recordAlternative(ClientConnectionTarget connectionTarget,
                            AltSvcHeader header,
                            boolean secureOrigin,
-                           boolean explicitConnection) {
-        altSvc.record(connectionTarget, header, secureOrigin, explicitConnection);
+                           boolean explicitConnection,
+                           Instant observedAt) {
+        altSvc.record(connectionTarget, header, secureOrigin, explicitConnection, observedAt);
     }
 
     void recordAlternativeFailure(Http2AltSvcCache.Selection selection) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ConnectionCache.java
@@ -24,8 +24,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 
 import io.helidon.common.LruCache;
+import io.helidon.webclient.api.AltSvcHeader;
 import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
@@ -46,9 +48,14 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
     private final Map<ClientConnectionTarget, Http2ClientConnectionHandler> insertionOrder = new LinkedHashMap<>();
     private final AtomicBoolean closed = new AtomicBoolean();
     private final ReentrantLock cacheLock = new ReentrantLock();
+    private final Http2AltSvcCache altSvc;
+    private final Predicate<Http2AltSvcCache.Selection> establishedAlternative = this::hasEstablishedAlternative;
+    private final Predicate<Http2AltSvcCache.Generation> establishedAlternativeGeneration =
+            this::hasEstablishedAlternative;
 
     private Http2ConnectionCache(boolean shared) {
         super(shared);
+        this.altSvc = Http2AltSvcCache.create(this::retireAlternative);
     }
 
     /**
@@ -86,8 +93,15 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
     }
 
     @Override
+    public void suspend() {
+        altSvc.networkChanged();
+        evict();
+    }
+
+    @Override
     public void closeResource() {
         if (!closed.getAndSet(true)) {
+            altSvc.close();
             evict();
         }
     }
@@ -96,8 +110,65 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         return http2Supported.get(ck).isPresent();
     }
 
+    boolean mayContainAlternative(String host, boolean explicitConnection) {
+        return !explicitConnection && altSvc.mayContain(host);
+    }
+
     void markSupported(ConnectionKey connectionKey) {
         http2Supported.put(connectionKey, true);
+    }
+
+    void markSupported(ClientConnectionTarget connectionTarget) {
+        Http2ClientConnectionHandler handler = cache.get(connectionTarget);
+        markSupported(connectionTarget, handler);
+    }
+
+    private void markSupported(ClientConnectionTarget connectionTarget,
+                               Http2ClientConnectionHandler expectedHandler) {
+        Http2ClientConnectionHandler handler = cache.get(connectionTarget);
+        if (handler == expectedHandler && handler != null) {
+            handler.markDirectHttp2Supported();
+            markSupported(connectionTarget.connectionKey());
+        }
+    }
+
+    boolean alternativeAvailable(ClientConnectionTarget connectionTarget, boolean explicitConnection) {
+        return altSvc.available(connectionTarget,
+                                explicitConnection,
+                                establishedAlternative,
+                                establishedAlternativeGeneration);
+    }
+
+    Http2AltSvcCache.Candidate currentAlternative(ClientConnectionTarget.LookupKey lookupKey,
+                                                  boolean explicitConnection) {
+        return altSvc.selectRoute(lookupKey, explicitConnection, establishedAlternativeGeneration);
+    }
+
+    Http2AltSvcCache.Selection currentAlternative(ClientConnectionTarget connectionTarget,
+                                                   boolean explicitConnection) {
+        return altSvc.select(connectionTarget,
+                             explicitConnection,
+                             establishedAlternative,
+                             establishedAlternativeGeneration);
+    }
+
+    void recordAlternative(ClientConnectionTarget connectionTarget,
+                           AltSvcHeader header,
+                           boolean secureOrigin,
+                           boolean explicitConnection) {
+        altSvc.record(connectionTarget, header, secureOrigin, explicitConnection);
+    }
+
+    void recordAlternativeFailure(Http2AltSvcCache.Selection selection) {
+        altSvc.recordFailure(selection);
+    }
+
+    void recordAlternativeMisdirected(Http2AltSvcCache.Selection selection) {
+        altSvc.recordMisdirected(selection);
+    }
+
+    void removeAlternative(Http2AltSvcCache.Selection selection) {
+        retireAlternative(selection);
     }
 
     void remove(ClientConnectionTarget connectionTarget, Http2ClientConnectionHandler expectedHandler) {
@@ -144,7 +215,7 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                     handler.release();
                 }
                 if (result != null) {
-                    markSupported(result.connectionTarget().connectionKey());
+                    markSupported(result.connectionTarget(), result.handler());
                     return result;
                 }
             }
@@ -156,6 +227,28 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
                          initialUri,
                          serviceRequest,
                          http1FallbackHandler);
+    }
+
+    Http2ConnectionAttemptResult newAlternativeStream(Http2ClientImpl http2Client,
+                                                      Http2AltSvcCache.Selection selection,
+                                                      Http2ClientRequestImpl request,
+                                                      Http1FallbackHandler http1FallbackHandler) {
+        if (closed.get()) {
+            throw new IllegalStateException("Connection cache is closed");
+        }
+        if (!altSvc.current(selection)) {
+            throw new AlternativeConnectionException(
+                    selection,
+                    AlternativeConnectionException.Reason.STALE,
+                    new IllegalStateException("HTTP/2 alternative route selection is stale"));
+        }
+
+        Http2ClientConnectionHandler handler = acquireHandler(http2Client, selection.originTarget());
+        try {
+            return handler.newAlternativeStream(http2Client, selection, request, http1FallbackHandler);
+        } finally {
+            handler.release();
+        }
     }
 
     Http2ConnectionAttemptResult newStream(Http2ClientImpl http2Client,
@@ -188,101 +281,12 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
             return Http2ClientConnectionHandler.http1(http2Client,
                                                        connectionTarget,
                                                        request,
-                                                       initialUri,
                                                        serviceRequest,
                                                        http1FallbackHandler,
                                                        null);
         }
 
-        List<Http2ClientConnectionHandler> retiredHandlers = null;
-        Http2ClientConnectionHandler handler;
-        while (true) {
-            if (closed.get()) {
-                throw new IllegalStateException("Connection cache is closed");
-            }
-            if (!connectionTarget.currentTlsGeneration()) {
-                throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
-            }
-            handler = cache.get(connectionTarget);
-            if (handler != null) {
-                if (handler.acquire()) {
-                    break;
-                }
-                continue;
-            }
-
-            cacheLock.lock();
-            try {
-                if (closed.get()) {
-                    throw new IllegalStateException("Connection cache is closed");
-                }
-                if (!connectionTarget.currentTlsGeneration()) {
-                    throw new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
-                }
-                handler = cache.get(connectionTarget);
-                if (handler != null) {
-                    if (handler.acquire()) {
-                        break;
-                    }
-                    continue;
-                }
-
-                var iterator = insertionOrder.entrySet().iterator();
-                while (iterator.hasNext()) {
-                    var entry = iterator.next();
-                    ClientConnectionTarget cachedTarget = entry.getKey();
-                    if (cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
-                            && !cachedTarget.currentTlsGeneration()) {
-                        iterator.remove();
-                        if (cache.remove(cachedTarget, entry.getValue())) {
-                            removeLookupHandler(cachedTarget, entry.getValue());
-                            if (retiredHandlers == null) {
-                                retiredHandlers = new ArrayList<>();
-                            }
-                            retiredHandlers.add(entry.getValue());
-                        }
-                    }
-                }
-
-                if (insertionOrder.size() >= MAX_TARGETS) {
-                    var evictionIterator = insertionOrder.entrySet().iterator();
-                    var evicted = evictionIterator.next();
-                    evictionIterator.remove();
-                    if (cache.remove(evicted.getKey(), evicted.getValue())) {
-                        removeLookupHandler(evicted.getKey(), evicted.getValue());
-                        if (retiredHandlers == null) {
-                            retiredHandlers = new ArrayList<>();
-                        }
-                        retiredHandlers.add(evicted.getValue());
-                    }
-                }
-
-                handler = new Http2ClientConnectionHandler(http2Client.clientConfig().connectionCacheSize());
-                if (!handler.acquire()) {
-                    throw new IllegalStateException("New HTTP/2 connection target could not be acquired");
-                }
-                insertionOrder.put(connectionTarget, handler);
-                cache.put(connectionTarget, handler);
-                if (connectionTarget.connectionKey().proxy().ipNoProxyConfigured()) {
-                    ClientConnectionTarget.LookupKey lookupKey = connectionTarget.lookupKey();
-                    List<Http2ClientConnectionHandler> handlers = lookupCache.get(lookupKey);
-                    if (handlers == null) {
-                        lookupCache.put(lookupKey, List.of(handler));
-                    } else {
-                        var updatedHandlers = new ArrayList<>(handlers);
-                        updatedHandlers.add(handler);
-                        lookupCache.put(lookupKey, List.copyOf(updatedHandlers));
-                    }
-                }
-                break;
-            } finally {
-                cacheLock.unlock();
-            }
-        }
-        if (retiredHandlers != null) {
-            retiredHandlers.forEach(Http2ClientConnectionHandler::retire);
-        }
-
+        Http2ClientConnectionHandler handler = acquireHandler(http2Client, connectionTarget);
         Http2ConnectionAttemptResult result;
         try {
             result = handler.newStream(http2Client,
@@ -297,14 +301,163 @@ public final class Http2ConnectionCache extends ClientConnectionCache {
         if (result.result() == Http2ConnectionAttemptResult.Result.HTTP_2
                 && (request.connection().isEmpty()
                         || Http2ClientConnectionHandler.ownsExplicitConnection(request))) {
-            markSupported(connectionTarget.connectionKey());
+            markSupported(connectionTarget, result.handler());
         }
         return result;
     }
 
+    private Http2ClientConnectionHandler acquireHandler(Http2ClientImpl http2Client,
+                                                        ClientConnectionTarget connectionTarget) {
+        List<Http2ClientConnectionHandler> retiredHandlers = null;
+        try {
+            while (true) {
+                if (closed.get()) {
+                    throw new IllegalStateException("Connection cache is closed");
+                }
+                if (!connectionTarget.currentTlsGeneration()) {
+                    throw staleTlsGeneration();
+                }
+                Http2ClientConnectionHandler handler = cache.get(connectionTarget);
+                if (handler != null) {
+                    if (handler.acquire()) {
+                        return handler;
+                    }
+                    continue;
+                }
+
+                cacheLock.lock();
+                try {
+                    if (closed.get()) {
+                        throw new IllegalStateException("Connection cache is closed");
+                    }
+                    if (!connectionTarget.currentTlsGeneration()) {
+                        throw staleTlsGeneration();
+                    }
+                    handler = cache.get(connectionTarget);
+                    if (handler != null) {
+                        if (handler.acquire()) {
+                            return handler;
+                        }
+                        continue;
+                    }
+
+                    retiredHandlers = new ArrayList<>();
+                    retireStaleTlsTargets(connectionTarget, retiredHandlers);
+                    retireOldestTarget(retiredHandlers);
+
+                    handler = new Http2ClientConnectionHandler(http2Client.clientConfig().connectionCacheSize(),
+                                                               altSvc::current);
+                    if (!handler.acquire()) {
+                        throw new IllegalStateException("New HTTP/2 connection target could not be acquired");
+                    }
+                    insertionOrder.put(connectionTarget, handler);
+                    cache.put(connectionTarget, handler);
+                    addLookupHandler(connectionTarget, handler);
+                    return handler;
+                } finally {
+                    cacheLock.unlock();
+                }
+            }
+        } finally {
+            if (retiredHandlers != null) {
+                retiredHandlers.forEach(Http2ClientConnectionHandler::retire);
+            }
+        }
+    }
+
+    private void retireStaleTlsTargets(ClientConnectionTarget connectionTarget,
+                                       List<Http2ClientConnectionHandler> retiredHandlers) {
+        var iterator = insertionOrder.entrySet().iterator();
+        while (iterator.hasNext()) {
+            var entry = iterator.next();
+            ClientConnectionTarget cachedTarget = entry.getKey();
+            if (cachedTarget.connectionKey().tls() == connectionTarget.connectionKey().tls()
+                    && !cachedTarget.currentTlsGeneration()) {
+                iterator.remove();
+                if (cache.remove(cachedTarget, entry.getValue())) {
+                    removeLookupHandler(cachedTarget, entry.getValue());
+                    retiredHandlers.add(entry.getValue());
+                }
+            }
+        }
+    }
+
+    private static IllegalStateException staleTlsGeneration() {
+        return new IllegalStateException("TLS configuration was reloaded before connection-pool acquisition");
+    }
+
+    private void retireOldestTarget(List<Http2ClientConnectionHandler> retiredHandlers) {
+        if (insertionOrder.size() < MAX_TARGETS) {
+            return;
+        }
+        var evictionIterator = insertionOrder.entrySet().iterator();
+        var evicted = evictionIterator.next();
+        evictionIterator.remove();
+        if (cache.remove(evicted.getKey(), evicted.getValue())) {
+            removeLookupHandler(evicted.getKey(), evicted.getValue());
+            retiredHandlers.add(evicted.getValue());
+        }
+    }
+
+    private void addLookupHandler(ClientConnectionTarget connectionTarget,
+                                  Http2ClientConnectionHandler handler) {
+        if (!connectionTarget.connectionKey().proxy().ipNoProxyConfigured()) {
+            return;
+        }
+        ClientConnectionTarget.LookupKey lookupKey = connectionTarget.lookupKey();
+        List<Http2ClientConnectionHandler> handlers = lookupCache.get(lookupKey);
+        if (handlers == null) {
+            lookupCache.put(lookupKey, List.of(handler));
+        } else {
+            var updatedHandlers = new ArrayList<>(handlers);
+            updatedHandlers.add(handler);
+            lookupCache.put(lookupKey, List.copyOf(updatedHandlers));
+        }
+    }
+
+    private boolean hasEstablishedAlternative(Http2AltSvcCache.Selection selection) {
+        Http2ClientConnectionHandler handler = cache.get(selection.originTarget());
+        return handler != null && handler.hasAlternative(selection);
+    }
+
+    private boolean hasEstablishedAlternative(Http2AltSvcCache.Generation generation) {
+        List<Http2ClientConnectionHandler> handlers;
+        cacheLock.lock();
+        try {
+            handlers = List.copyOf(insertionOrder.values());
+        } finally {
+            cacheLock.unlock();
+        }
+        for (Http2ClientConnectionHandler handler : handlers) {
+            if (handler.hasAlternative(generation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void retireAlternative(Http2AltSvcCache.Selection selection) {
+        Http2ClientConnectionHandler handler = cache.get(selection.originTarget());
+        if (handler != null) {
+            handler.retire(selection);
+        }
+    }
+
+    private void retireAlternative(Http2AltSvcCache.Generation generation) {
+        List<Http2ClientConnectionHandler> handlers;
+        cacheLock.lock();
+        try {
+            handlers = List.copyOf(insertionOrder.values());
+        } finally {
+            cacheLock.unlock();
+        }
+        handlers.forEach(handler -> handler.retire(generation));
+    }
+
     private void removeSupportIfUnused(ConnectionKey connectionKey) {
-        for (ClientConnectionTarget cachedTarget : cache.keySet()) {
-            if (connectionKey.equals(cachedTarget.connectionKey())) {
+        for (Map.Entry<ClientConnectionTarget, Http2ClientConnectionHandler> entry : cache.entrySet()) {
+            if (connectionKey.equals(entry.getKey().connectionKey())
+                    && entry.getValue().directHttp2Supported()) {
                 return;
             }
         }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ResponseForwardingWebClient.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ResponseForwardingWebClient.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+
+import io.helidon.http.Method;
+import io.helidon.webclient.api.HttpClientRequest;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.api.WebClientConfig;
+import io.helidon.webclient.api.WebClientCookieManager;
+import io.helidon.webclient.api.WebClientProtocolResponse;
+import io.helidon.webclient.spi.Protocol;
+import io.helidon.webclient.spi.ProtocolConfig;
+
+final class Http2ResponseForwardingWebClient implements WebClient {
+    private final WebClient delegate;
+    private final Consumer<WebClientProtocolResponse> responsePublisher;
+
+    Http2ResponseForwardingWebClient(WebClient delegate,
+                                     Consumer<WebClientProtocolResponse> responsePublisher) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.responsePublisher = Objects.requireNonNull(responsePublisher, "responsePublisher");
+    }
+
+    @Override
+    public HttpClientRequest method(Method method) {
+        return delegate.method(method);
+    }
+
+    @Override
+    public <T, C extends ProtocolConfig> T client(Protocol<T, C> protocol, C protocolConfig) {
+        return delegate.client(protocol, protocolConfig);
+    }
+
+    @Override
+    public <T, C extends ProtocolConfig> T client(Protocol<T, C> protocol) {
+        return delegate.client(protocol);
+    }
+
+    @Override
+    public List<String> tcpProtocolIds() {
+        return delegate.tcpProtocolIds();
+    }
+
+    @Override
+    public void responseReceived(WebClientProtocolResponse response) {
+        responsePublisher.accept(Http1FallbackService.response(response));
+    }
+
+    @Override
+    public ExecutorService executor() {
+        return delegate.executor();
+    }
+
+    @Override
+    public WebClientCookieManager cookieManager() {
+        return delegate.cookieManager();
+    }
+
+    @Override
+    public WebClientConfig prototype() {
+        return delegate.prototype();
+    }
+
+    @Override
+    public void releaseResource() {
+        delegate.releaseResource();
+    }
+
+    @Override
+    public void closeResource() {
+        delegate.closeResource();
+    }
+}

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -73,7 +73,7 @@ class Http2AltSvcCacheTest {
         cache.record(target,
                      header(clock, "h3=\":7443\", h2=\":8443\"; ma=60"),
                      true,
-                     false);
+                     false, clock.nextObservation());
 
         Http2AltSvcCache.Selection byTarget = cache.select(target, false, _ -> false);
         Http2AltSvcCache.Candidate byLookup = cache.selectRoute(target.lookupKey(), false, _ -> false);
@@ -102,7 +102,7 @@ class Http2AltSvcCacheTest {
 
         assertThat(upper, not(is(lower)));
 
-        cache.record(upper, header(clock, "h2=\":8443\"; ma=3600"), true, false);
+        cache.record(upper, header(clock, "h2=\":8443\"; ma=3600"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection upperSelection = cache.select(upper, false, _ -> false);
         Http2AltSvcCache.Selection lowerSelection = cache.select(lower, false, _ -> false);
 
@@ -114,13 +114,13 @@ class Http2AltSvcCacheTest {
         assertThat(cache.mayContain("EXAMPLE.COM"), is(true));
         assertThat(cache.selectRoute(lower.lookupKey(), false, _ -> false), notNullValue());
 
-        cache.record(lower, header(clock, "h2=\":8443\"; ma=7200"), true, false);
+        cache.record(lower, header(clock, "h2=\":8443\"; ma=7200"), true, false, clock.nextObservation());
 
         assertThat(cache.select(upper, false, _ -> false), sameInstance(upperSelection));
         assertThat(cache.select(lower, false, _ -> false), sameInstance(lowerSelection));
 
-        cache.record(upper, header(clock, "clear"), true, false);
-        cache.record(lower, header(clock, "h2=\":9443\"; ma=3600"), true, false);
+        cache.record(upper, header(clock, "clear"), true, false, clock.nextObservation());
+        cache.record(lower, header(clock, "h2=\":9443\"; ma=3600"), true, false, clock.nextObservation());
 
         Http2AltSvcCache.Selection reverse = cache.select(upper, false, _ -> false);
         assertThat(reverse.originTarget(), sameInstance(upper));
@@ -147,7 +147,7 @@ class Http2AltSvcCacheTest {
         ClientConnectionTarget upper = target(tls, "Example.COM");
         ClientConnectionTarget lower = target(tls, "example.com");
 
-        cache.record(upper, header(clock, "h2=\":8443\"; ma=3600; persist=1"), true, false);
+        cache.record(upper, header(clock, "h2=\":8443\"; ma=3600; persist=1"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection beforeNetworkChange = cache.select(lower, false, _ -> false);
 
         cache.networkChanged();
@@ -171,7 +171,7 @@ class Http2AltSvcCacheTest {
         ClientConnectionTarget upper = target(tls, "Example.COM");
         ClientConnectionTarget lower = target(tls, "example.com");
 
-        cache.record(upper, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        cache.record(upper, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection establishedUpper = cache.select(upper, false, _ -> false);
         clock.advance(Duration.ofSeconds(2));
 
@@ -196,7 +196,7 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "Origin.EXAMPLE");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false, clock.nextObservation());
         cache.recordFailure(cache.select(target, false, _ -> false));
 
         assertThat(cache.selectRoute(target.lookupKey(), false, _ -> true), nullValue());
@@ -219,29 +219,29 @@ class Http2AltSvcCacheTest {
         assertThat(cache.mayContain("origin.example"), is(false));
         assertThat(cache.mayContain("other.example"), is(false));
 
-        cache.record(first, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(first, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
 
         assertThat(cache.mayContain("origin.example"), is(true));
         assertThat(cache.mayContain("other.example"), is(false));
 
-        cache.record(first, header(clock, "h2=\":8443\"; ma=120"), true, false);
-        cache.record(first, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        cache.record(first, header(clock, "h2=\":8443\"; ma=120"), true, false, clock.nextObservation());
+        cache.record(first, header(clock, "h2=\":9443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection replacement = cache.select(first, false, _ -> false);
         cache.recordFailure(replacement);
 
         assertThat(cache.mayContain("origin.example"), is(true));
 
-        cache.record(first, header(clock, "clear"), true, false);
+        cache.record(first, header(clock, "clear"), true, false, clock.nextObservation());
 
         assertThat(cache.mayContain("origin.example"), is(false));
 
-        cache.record(first, header(clock, "h2=\":8443\"; ma=60"), true, false);
-        cache.record(second, header(clock, "h2=\":8443\"; ma=60"), true, false);
-        cache.record(first, header(clock, "clear"), true, false);
+        cache.record(first, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
+        cache.record(second, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
+        cache.record(first, header(clock, "clear"), true, false, clock.nextObservation());
 
         assertThat(cache.mayContain("origin.example"), is(true));
 
-        cache.record(second, header(clock, "clear"), true, false);
+        cache.record(second, header(clock, "clear"), true, false, clock.nextObservation());
 
         assertThat(cache.mayContain("origin.example"), is(false));
 
@@ -255,11 +255,11 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection selection = cache.select(target, false, _ -> false);
 
         clock.advance(Duration.ofSeconds(30));
-        cache.record(target, header(clock, "h2=\":8443\"; ma=120; persist=1"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=120; persist=1"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), sameInstance(selection));
         assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
@@ -272,7 +272,7 @@ class Http2AltSvcCacheTest {
         clock.advance(Duration.ofSeconds(61));
         assertThat(cache.select(target, false, _ -> false), sameInstance(selection));
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=0"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=0"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target,
                                 false,
@@ -296,32 +296,34 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection transientSelection = cache.select(target, false, _ -> false);
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60; persist=1"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60; persist=1"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), sameInstance(transientSelection));
 
         cache.networkChanged();
+        clock.advance(Duration.ofNanos(1));
 
         Http2AltSvcCache.Selection persistentSelection = cache.select(target, false, _ -> false);
         assertThat(persistentSelection, not(sameInstance(transientSelection)));
         assertThat(invalidations, hasSize(1));
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), sameInstance(persistentSelection));
         assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
 
         cache.networkChanged();
+        clock.advance(Duration.ofNanos(1));
 
         assertThat(cache.select(target, false, _ -> true), nullValue());
         assertThat(cache.mayContain(target.connectionKey().host()), is(false));
         assertThat(invalidations, hasSize(2));
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection revived = cache.select(target, false, _ -> false);
-        cache.record(target, header(clock, "h2=\":8443\"; ma=120"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=120"), true, false, clock.nextObservation());
 
         assertThat(revived, not(sameInstance(persistentSelection)));
         assertThat(cache.select(target, false, _ -> false), sameInstance(revived));
@@ -337,14 +339,15 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection failed = cache.select(target, false, _ -> false);
         cache.recordFailure(failed);
 
         assertThat(cache.select(target, false, _ -> true), nullValue());
         assertThat(invalidations, hasSize(1));
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=120"), true, false);
+        clock.advance(Duration.ofNanos(1));
+        cache.record(target, header(clock, "h2=\":8443\"; ma=120"), true, false, clock.nextObservation());
 
         Http2AltSvcCache.Selection retry = cache.select(target, false, _ -> false);
         assertThat(retry, not(sameInstance(failed)));
@@ -352,7 +355,7 @@ class Http2AltSvcCacheTest {
         assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
         assertThat(invalidations, hasSize(1));
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), sameInstance(retry));
         assertThat(invalidations, hasSize(1));
@@ -372,29 +375,29 @@ class Http2AltSvcCacheTest {
         assertThat(equalTarget, is(target));
         assertThat(equalTarget, not(sameInstance(target)));
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection first = cache.select(target, false, _ -> false);
-        cache.record(equalTarget, header(clock, "h2=\":8443\"; ma=120"), true, false);
+        cache.record(equalTarget, header(clock, "h2=\":8443\"; ma=120"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), sameInstance(first));
         assertThat(cache.selectRoute(equalTarget.lookupKey(), false, _ -> false), notNullValue());
 
-        cache.record(equalTarget, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        cache.record(equalTarget, header(clock, "h2=\":9443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection replacement = cache.select(target, false, _ -> false);
-        cache.record(equalTarget, header(clock, "h2=\":9443\"; ma=120"), true, false);
+        cache.record(equalTarget, header(clock, "h2=\":9443\"; ma=120"), true, false, clock.nextObservation());
 
         assertThat(replacement, not(sameInstance(first)));
         assertThat(cache.select(equalTarget, false, _ -> false), sameInstance(replacement));
         assertThat(invalidations, hasSize(1));
 
-        cache.record(equalTarget, header(clock, "clear"), true, false);
+        cache.record(equalTarget, header(clock, "clear"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> true), nullValue());
         assertThat(invalidations, hasSize(2));
 
-        cache.record(target, header(clock, "h2=\":10443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":10443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection revived = cache.select(target, false, _ -> false);
-        cache.record(target, header(clock, "h2=\":10443\"; ma=120"), true, false);
+        cache.record(target, header(clock, "h2=\":10443\"; ma=120"), true, false, clock.nextObservation());
 
         assertThat(revived, not(sameInstance(replacement)));
         assertThat(cache.select(target, false, _ -> false), sameInstance(revived));
@@ -417,26 +420,26 @@ class Http2AltSvcCacheTest {
         ClientConnectionTarget persistent = target(tls, "persistent.example");
         ClientConnectionTarget transientTarget = target(tls, "transient.example");
 
-        cache.record(unsupported, header(clock, "h2=\":8443\"; ma=60"), true, false);
-        cache.record(unsupported, header(clock, "H2=\":8443\"; ma=60"), true, false);
+        cache.record(unsupported, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
+        cache.record(unsupported, header(clock, "H2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         assertThat(cache.mayContain("unsupported.example"), is(false));
 
-        cache.record(misdirected, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(misdirected, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         cache.recordMisdirected(cache.select(misdirected, false, _ -> false));
         assertThat(cache.mayContain("misdirected.example"), is(false));
 
-        cache.record(expired, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        cache.record(expired, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
         clock.advance(Duration.ofSeconds(2));
         assertThat(cache.select(expired, false, _ -> false), nullValue());
         assertThat(cache.mayContain("expired.example"), is(false));
 
-        cache.record(staleTls, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(staleTls, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         reloadedTls.reload(TlsMaterial.builder().trustAll(true).build());
         assertThat(cache.select(staleTls, false, _ -> false), nullValue());
         assertThat(cache.mayContain("stale-tls.example"), is(false));
 
-        cache.record(persistent, header(clock, "h2=\":8443\"; ma=60; persist=1"), true, false);
-        cache.record(transientTarget, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(persistent, header(clock, "h2=\":8443\"; ma=60; persist=1"), true, false, clock.nextObservation());
+        cache.record(transientTarget, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         cache.networkChanged();
 
         assertThat(cache.mayContain("persistent.example"), is(true));
@@ -455,22 +458,22 @@ class Http2AltSvcCacheTest {
         AltSvcHeader advertisement = header(clock, "h2=\":8443\"; ma=60");
         ClientConnectionTarget target = target(tls, "origin.example");
 
-        cache.record(target, advertisement, false, false);
+        cache.record(target, advertisement, false, false, clock.nextObservation());
         assertThat(cache.select(target, false, _ -> false), nullValue());
 
-        cache.record(target, advertisement, true, true);
+        cache.record(target, advertisement, true, true, clock.nextObservation());
         assertThat(cache.select(target, false, _ -> false), nullValue());
 
-        cache.record(target, advertisement, true, false);
+        cache.record(target, advertisement, true, false, clock.nextObservation());
         assertThat(cache.select(target, true, _ -> true), nullValue());
 
         ClientConnectionTarget httpTarget = target(Tls.builder().enabled(false).build(), "http", "origin.example");
-        cache.record(httpTarget, advertisement, true, false);
+        cache.record(httpTarget, advertisement, true, false, clock.nextObservation());
         assertThat(cache.select(httpTarget, false, _ -> false), nullValue());
 
         Proxy proxy = Proxy.builder().host("proxy.example").port(8181).build();
         ClientConnectionTarget proxyTarget = target(tls, "https", "origin.example", proxy, DNS);
-        cache.record(proxyTarget, advertisement, true, false);
+        cache.record(proxyTarget, advertisement, true, false, clock.nextObservation());
         assertThat(cache.select(proxyTarget, false, _ -> false), nullValue());
 
         Proxy portScopedNoProxy = Proxy.builder()
@@ -485,7 +488,7 @@ class Http2AltSvcCacheTest {
                                                                  DNS);
         assertThat(portScopedNoProxyTarget.proxyRoute().direct(), is(true));
         assertThat(portScopedNoProxyTarget.proxyRoute().addressBound(), is(false));
-        cache.record(portScopedNoProxyTarget, advertisement, true, false);
+        cache.record(portScopedNoProxyTarget, advertisement, true, false, clock.nextObservation());
         assertThat(cache.select(portScopedNoProxyTarget, false, _ -> false), nullValue());
 
         Proxy noProxy = Proxy.builder()
@@ -498,12 +501,12 @@ class Http2AltSvcCacheTest {
                                                             "origin.example",
                                                             noProxy,
                                                             (_, _) -> InetAddress.ofLiteral("127.0.0.1"));
-        cache.record(addressBoundTarget, advertisement, true, false);
+        cache.record(addressBoundTarget, advertisement, true, false, clock.nextObservation());
         assertThat(addressBoundTarget.proxyRoute().addressBound(), is(true));
         assertThat(cache.select(addressBoundTarget, false, _ -> false), nullValue());
 
         ClientConnectionTarget udsTarget = udsTarget(tls, "origin.example");
-        cache.record(udsTarget, advertisement, true, false);
+        cache.record(udsTarget, advertisement, true, false, clock.nextObservation());
         assertThat(cache.select(udsTarget, false, _ -> false), nullValue());
 
         cache.close();
@@ -516,19 +519,19 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection first = cache.select(target, false, _ -> false);
 
-        cache.record(target, header(clock, "H2=\":9443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "H2=\":9443\"; ma=60"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), nullValue());
         assertThat(cache.current(first), is(false));
         assertThat(invalidations, hasSize(1));
         assertThat(first.sameGeneration(invalidations.getFirst()), is(true));
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection second = cache.select(target, false, _ -> false);
-        cache.record(target, header(clock, "h2=\"other.example:8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\"other.example:8443\"; ma=60"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), nullValue());
         assertThat(cache.current(second), is(false));
@@ -544,7 +547,7 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection fresh = cache.select(target, false, _ -> false);
         clock.advance(Duration.ofSeconds(2));
 
@@ -577,8 +580,8 @@ class Http2AltSvcCacheTest {
         ClientConnectionTarget expiredTarget = target(tls, "expired.example");
         ClientConnectionTarget freshTarget = target(tls, "fresh.example");
 
-        cache.record(expiredTarget, header(clock, "h2=\":8443\"; ma=1"), true, false);
-        cache.record(freshTarget, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        cache.record(expiredTarget, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
+        cache.record(freshTarget, header(clock, "h2=\":9443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection expired = cache.select(expiredTarget, false, _ -> false);
         Http2AltSvcCache.Selection fresh = cache.select(freshTarget, false, _ -> false);
         clock.advance(Duration.ofSeconds(2));
@@ -621,7 +624,7 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection stale = cache.select(target, false, _ -> false);
         clock.advance(Duration.ofSeconds(2));
 
@@ -645,7 +648,11 @@ class Http2AltSvcCacheTest {
             try {
                 assertThat(enteredEstablishedProbe.await(5, TimeUnit.SECONDS), is(true));
                 Future<?> replacementWrite = executor.submit(
-                        () -> cache.record(target, header(clock, "h2=\":9443\"; ma=60"), true, false));
+                        () -> cache.record(target,
+                                           header(clock, "h2=\":9443\"; ma=60"),
+                                           true,
+                                           false,
+                                           clock.nextObservation()));
                 assertThat(replacementWrite.get(5, TimeUnit.SECONDS), nullValue());
             } finally {
                 releaseEstablishedProbe.countDown();
@@ -667,7 +674,7 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection expired = cache.select(target, false, _ -> false);
         clock.advance(Duration.ofSeconds(2));
 
@@ -691,7 +698,11 @@ class Http2AltSvcCacheTest {
             try {
                 assertThat(enteredEstablishedProbe.await(5, TimeUnit.SECONDS), is(true));
                 Future<?> refreshWrite = executor.submit(
-                        () -> cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false));
+                        () -> cache.record(target,
+                                           header(clock, "h2=\":8443\"; ma=60"),
+                                           true,
+                                           false,
+                                           clock.nextObservation()));
                 assertThat(refreshWrite.get(5, TimeUnit.SECONDS), nullValue());
             } finally {
                 releaseEstablishedProbe.countDown();
@@ -714,7 +725,7 @@ class Http2AltSvcCacheTest {
         Tls tls = Tls.builder().trustAll(true).build();
         ClientConnectionTarget target = target(tls, "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection stale = cache.select(target, false, _ -> false);
         clock.advance(Duration.ofSeconds(2));
 
@@ -757,15 +768,15 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection first = cache.select(target, false, _ -> false);
-        cache.record(target, header(clock, "h2=\":8443\"; ma=120; persist=1"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=120; persist=1"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection extended = cache.select(target, false, _ -> false);
 
         assertThat(extended, sameInstance(first));
         assertThat(invalidations, is(empty()));
 
-        cache.record(target, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":9443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection replacement = cache.select(target, false, _ -> false);
 
         assertThat(replacement, not(sameInstance(first)));
@@ -773,7 +784,7 @@ class Http2AltSvcCacheTest {
         assertThat(cache.current(first), is(false));
         assertThat(invalidations, hasSize(1));
 
-        cache.record(target, header(clock, "h2=\":9443\"; ma=0"), true, false);
+        cache.record(target, header(clock, "h2=\":9443\"; ma=0"), true, false, clock.nextObservation());
 
         Http2AltSvcCache.Selection zeroAgeReuse = cache.select(
                 target,
@@ -785,9 +796,9 @@ class Http2AltSvcCacheTest {
         assertThat(cache.select(target, false, _ -> false), nullValue());
         assertThat(invalidations, hasSize(2));
 
-        cache.record(target, header(clock, "h2=\":10443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":10443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection beforeClear = cache.select(target, false, _ -> false);
-        cache.record(target, header(clock, "clear"), true, false);
+        cache.record(target, header(clock, "clear"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), nullValue());
         assertThat(cache.current(beforeClear), is(false));
@@ -803,7 +814,7 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection failed = cache.select(target, false, _ -> false);
         cache.recordFailure(failed);
 
@@ -829,9 +840,9 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection stale = cache.select(target, false, _ -> false);
-        cache.record(target, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":9443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection current = cache.select(target, false, _ -> false);
 
         cache.recordMisdirected(stale);
@@ -856,8 +867,12 @@ class Http2AltSvcCacheTest {
         ClientConnectionTarget persistentTarget = target(tls, "persistent.example");
         ClientConnectionTarget transientTarget = target(tls, "transient.example");
 
-        cache.record(persistentTarget, header(clock, "h2=\":8443\"; ma=60; persist=1"), true, false);
-        cache.record(transientTarget, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        cache.record(persistentTarget,
+                     header(clock, "h2=\":8443\"; ma=60; persist=1"),
+                     true,
+                     false,
+                     clock.nextObservation());
+        cache.record(transientTarget, header(clock, "h2=\":9443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection persistent = cache.select(persistentTarget, false, _ -> false);
         Http2AltSvcCache.Selection transientSelection = cache.select(transientTarget, false, _ -> false);
 
@@ -884,7 +899,7 @@ class Http2AltSvcCacheTest {
         Tls tls = Tls.builder().trustAll(true).build();
         ClientConnectionTarget target = target(tls, "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection selection = cache.select(target, false, _ -> false);
         tls.reload(TlsMaterial.builder().trustAll(true).build());
 
@@ -896,6 +911,276 @@ class Http2AltSvcCacheTest {
         ClientConnectionTarget currentTarget = target(tls, "origin.example");
         assertThat(currentTarget, is(not(target)));
         assertThat(cache.select(currentTarget, false, _ -> true), nullValue());
+
+        cache.close();
+    }
+
+    @Test
+    void newerAdvertisementWinsOverDelayedReplacement() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+        Instant older = START.plusSeconds(5);
+        Instant newer = START.plusSeconds(10);
+
+        cache.record(target, header(newer, "h2=\":9443\"; ma=60"), true, false, newer);
+        cache.record(target, header(older, "h2=\":8443\"; ma=60"), true, false, older);
+
+        assertThat(cache.select(target, false, _ -> false).port(), is(9443));
+
+        Instant latest = newer.plusSeconds(1);
+        cache.record(target, header(latest, "h2=\":10443\"; ma=60"), true, false, latest);
+
+        assertThat(cache.select(target, false, _ -> false).port(), is(10443));
+
+        cache.close();
+    }
+
+    @Test
+    void withdrawalWinsTiesAndRejectsDelayedAdvertisement() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+        Instant first = START.plusSeconds(5);
+
+        cache.record(target, header(first, "h2=\":8443\"; ma=60"), true, false, first);
+        cache.record(target, header(first, "h2=\":9443\"; ma=60"), true, false, first);
+
+        assertThat(cache.select(target, false, _ -> false).port(), is(8443));
+
+        cache.record(target, header(first, "H2=\":9443\"; ma=60"), true, false, first);
+        cache.record(target, header(first, "h2=\":10443\"; ma=60"), true, false, first);
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        Instant second = first.plusSeconds(1);
+        cache.record(target, header(second, "h2=\":10443\"; ma=60"), true, false, second);
+        cache.record(target, header(second, "clear"), true, false, second);
+        cache.record(target, header(first, "h2=\":11443\"; ma=60"), true, false, first);
+        cache.record(target, header(second, "h2=\":12443\"; ma=60"), true, false, second);
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        Instant third = second.plusSeconds(1);
+        cache.record(target, header(third, "h2=\":13443\"; ma=60"), true, false, third);
+
+        assertThat(cache.select(target, false, _ -> false).port(), is(13443));
+
+        cache.close();
+    }
+
+    @Test
+    void failureAndMisdirectedResponseRejectDelayedAdvertisements() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget failedTarget = target(tls, "failed.example");
+        ClientConnectionTarget misdirectedTarget = target(tls, "misdirected.example");
+
+        cache.record(failedTarget, header(START, "h2=\":8443\"; ma=3600"), true, false, START);
+        Http2AltSvcCache.Selection failed = cache.select(failedTarget, false, _ -> false);
+        clock.advance(Duration.ofSeconds(10));
+        cache.recordFailure(failed);
+
+        Instant delayedFailure = START.plusSeconds(5);
+        cache.record(failedTarget,
+                     header(delayedFailure, "h2=\":9443\"; ma=3600"),
+                     true,
+                     false,
+                     delayedFailure);
+        assertThat(cache.select(failedTarget, false, _ -> false), nullValue());
+
+        Instant afterFailure = clock.instant().plusSeconds(1);
+        cache.record(failedTarget,
+                     header(afterFailure, "h2=\":10443\"; ma=3600"),
+                     true,
+                     false,
+                     afterFailure);
+        assertThat(cache.select(failedTarget, false, _ -> false).port(), is(10443));
+
+        cache.record(misdirectedTarget,
+                     header(clock, "h2=\":8443\"; ma=3600"),
+                     true,
+                     false,
+                     clock.instant());
+        Http2AltSvcCache.Selection misdirected = cache.select(misdirectedTarget, false, _ -> false);
+        clock.advance(Duration.ofSeconds(10));
+        cache.recordMisdirected(misdirected);
+
+        Instant delayedMisdirected = clock.instant().minusSeconds(5);
+        cache.record(misdirectedTarget,
+                     header(delayedMisdirected, "h2=\":9443\"; ma=3600"),
+                     true,
+                     false,
+                     delayedMisdirected);
+        assertThat(cache.select(misdirectedTarget, false, _ -> false), nullValue());
+
+        Instant afterMisdirected = clock.instant().plusSeconds(1);
+        cache.record(misdirectedTarget,
+                     header(afterMisdirected, "h2=\":10443\"; ma=3600"),
+                     true,
+                     false,
+                     afterMisdirected);
+        assertThat(cache.select(misdirectedTarget, false, _ -> false).port(), is(10443));
+
+        cache.close();
+    }
+
+    @Test
+    void failureObservationSurvivesNaturalExpiry() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(START, "h2=\":8443\"; ma=1"), true, false, START);
+        Http2AltSvcCache.Selection selection = cache.select(target, false, _ -> false);
+        assertThat(selection, notNullValue());
+        clock.advance(Duration.ofMillis(500));
+        cache.recordFailure(selection);
+        clock.advance(Duration.ofMinutes(5));
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        Instant delayed = START.plusMillis(250);
+        cache.record(target, header(delayed, "h2=\":9443\"; ma=3600"), true, false, delayed);
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        Instant newer = START.plusMillis(750);
+        cache.record(target, header(newer, "h2=\":10443\"; ma=3600"), true, false, newer);
+
+        assertThat(cache.select(target, false, _ -> false).port(), is(10443));
+
+        cache.close();
+    }
+
+    @Test
+    void networkChangeOrdersKnownPersistentAndPreviouslyUnseenRoutes() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget transientTarget = target(tls, "transient.example");
+        ClientConnectionTarget persistentTarget = target(tls, "persistent.example");
+        ClientConnectionTarget unseenTarget = target(tls, "unseen.example");
+
+        cache.record(transientTarget, header(START, "h2=\":7443\"; ma=60"), true, false, START);
+        cache.record(persistentTarget,
+                     header(START, "h2=\":8443\"; ma=60; persist=1"),
+                     true,
+                     false,
+                     START);
+        clock.advance(Duration.ofSeconds(10));
+        cache.networkChanged();
+
+        Instant delayed = START.plusSeconds(5);
+        cache.record(transientTarget, header(delayed, "h2=\":9443\"; ma=60"), true, false, delayed);
+        cache.record(persistentTarget, header(delayed, "h2=\":9443\"; ma=60"), true, false, delayed);
+        cache.record(unseenTarget, header(delayed, "h2=\":9443\"; ma=60"), true, false, delayed);
+        Instant barrier = clock.instant();
+        cache.record(unseenTarget, header(barrier, "h2=\":10443\"; ma=60"), true, false, barrier);
+
+        assertThat(cache.select(transientTarget, false, _ -> false), nullValue());
+        assertThat(cache.select(persistentTarget, false, _ -> false).port(), is(8443));
+        assertThat(cache.select(unseenTarget, false, _ -> false), nullValue());
+
+        Instant newer = clock.instant().plusSeconds(1);
+        cache.record(transientTarget, header(newer, "h2=\":10443\"; ma=60"), true, false, newer);
+        cache.record(persistentTarget, header(newer, "h2=\":11443\"; ma=60"), true, false, newer);
+        cache.record(unseenTarget, header(newer, "h2=\":12443\"; ma=60"), true, false, newer);
+
+        assertThat(cache.select(transientTarget, false, _ -> false).port(), is(10443));
+        assertThat(cache.select(persistentTarget, false, _ -> false).port(), is(11443));
+        assertThat(cache.select(unseenTarget, false, _ -> false).port(), is(12443));
+
+        cache.close();
+    }
+
+    @Test
+    void caseVariantsShareObservationOrder() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget upper = target(tls, "Example.COM");
+        ClientConnectionTarget lower = target(tls, "example.com");
+        Instant older = START.plusSeconds(5);
+        Instant newer = START.plusSeconds(10);
+
+        cache.record(upper, header(newer, "h2=\":8443\"; ma=60"), true, false, newer);
+        cache.record(lower, header(older, "h2=\":9443\"; ma=60"), true, false, older);
+
+        assertThat(cache.select(lower, false, _ -> false).port(), is(8443));
+
+        cache.record(lower, header(newer, "clear"), true, false, newer);
+        cache.record(upper, header(newer, "h2=\":10443\"; ma=60"), true, false, newer);
+
+        assertThat(cache.select(upper, false, _ -> false), nullValue());
+
+        Instant latest = newer.plusSeconds(1);
+        cache.record(lower, header(latest, "h2=\":11443\"; ma=60"), true, false, latest);
+
+        assertThat(cache.select(upper, false, _ -> false).port(), is(11443));
+
+        cache.close();
+    }
+
+    @Test
+    void naturalExpiryRetainsOnlyTheAdvertisementObservation() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(START, "h2=\":8443\"; ma=1"), true, false, START);
+        clock.advance(Duration.ofSeconds(2));
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        Instant delayedNewer = START.plusMillis(500);
+        cache.record(target,
+                     header(delayedNewer, "h2=\":9443\"; ma=60"),
+                     true,
+                     false,
+                     delayedNewer);
+        cache.record(target,
+                     header(START, "h2=\":10443\"; ma=60"),
+                     true,
+                     false,
+                     START);
+
+        assertThat(cache.select(target, false, _ -> false).port(), is(9443));
+
+        cache.close();
+    }
+
+    @Test
+    void evictsOldestTombstoneBeforeActiveRoutesAtBound() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        AltSvcHeader clear = header(START, "clear");
+        ClientConnectionTarget first = null;
+        ClientConnectionTarget last = null;
+
+        for (int index = 0; index <= 1_000; index++) {
+            ClientConnectionTarget target = target(tls, "withdrawn-" + index + ".example");
+            if (index == 0) {
+                first = target;
+            }
+            if (index == 1_000) {
+                last = target;
+            }
+            cache.record(target, clear, true, false, START.plusSeconds(index));
+        }
+
+        cache.record(first, header(START, "h2=\":8443\"; ma=3600"), true, false, START);
+        Instant lastObservation = START.plusSeconds(1_000);
+        cache.record(last,
+                     header(lastObservation, "h2=\":9443\"; ma=3600"),
+                     true,
+                     false,
+                     lastObservation);
+
+        assertThat(cache.select(first, false, _ -> false), notNullValue());
+        assertThat(cache.select(last, false, _ -> false), nullValue());
 
         cache.close();
     }
@@ -914,14 +1199,14 @@ class Http2AltSvcCacheTest {
             if (index == 0) {
                 first = target;
             }
-            cache.record(target, advertisement, true, false);
+            cache.record(target, advertisement, true, false, clock.nextObservation());
         }
         Http2AltSvcCache.Selection firstSelection = cache.select(first, false, _ -> false);
         assertThat(firstSelection, notNullValue());
-        cache.record(first, advertisement, true, false);
+        cache.record(first, advertisement, true, false, clock.nextObservation());
 
         ClientConnectionTarget last = target(tls, "origin-1000.example");
-        cache.record(last, advertisement, true, false);
+        cache.record(last, advertisement, true, false, clock.nextObservation());
 
         assertThat(cache.select(first, false, _ -> false), nullValue());
         assertThat(cache.select(last, false, _ -> false), notNullValue());
@@ -930,9 +1215,9 @@ class Http2AltSvcCacheTest {
         assertThat(invalidations, hasSize(1));
         assertThat(firstSelection.sameGeneration(invalidations.getFirst()), is(true));
 
-        cache.record(first, advertisement, true, false);
+        cache.record(first, advertisement, true, false, clock.nextObservation());
         Http2AltSvcCache.Selection revived = cache.select(first, false, _ -> false);
-        cache.record(first, header(clock, "h2=\":8443\"; ma=120"), true, false);
+        cache.record(first, header(clock, "h2=\":8443\"; ma=120"), true, false, clock.nextObservation());
 
         assertThat(revived, not(sameInstance(firstSelection)));
         assertThat(cache.select(first, false, _ -> false), sameInstance(revived));
@@ -943,11 +1228,15 @@ class Http2AltSvcCacheTest {
     }
 
     private static AltSvcHeader header(Clock clock, String... values) {
+        return header(clock.instant(), values);
+    }
+
+    private static AltSvcHeader header(Instant observedAt, String... values) {
         WritableHeaders<?> headers = WritableHeaders.create();
         for (String value : values) {
             headers.add(HeaderValues.create(HeaderNames.ALT_SVC, value));
         }
-        return AltSvcHeader.parse(ClientResponseHeaders.create(headers), clock.instant()).orElseThrow();
+        return AltSvcHeader.parse(ClientResponseHeaders.create(headers), observedAt).orElseThrow();
     }
 
     private static ClientConnectionTarget target(Tls tls, String host) {
@@ -1027,6 +1316,12 @@ class Http2AltSvcCacheTest {
 
         private void advance(Duration duration) {
             instant = instant.plus(duration);
+        }
+
+        private Instant nextObservation() {
+            Instant observedAt = instant;
+            instant = instant.plusNanos(1);
+            return observedAt;
         }
     }
 }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -558,14 +558,9 @@ class Http2AltSvcCacheTest {
         assertThat(reuse.sameRouteGeneration(fresh), is(true));
         assertThat(reuse.establishAllowed(), is(false));
         cache.recordFailure(reuse);
-        assertThat(cache.current(reuse), is(true));
-        assertThat(cache.select(target,
-                                false,
-                                candidate -> candidate.sameRouteGeneration(reuse)),
-                   sameInstance(reuse));
 
-        assertThat(cache.select(target, false, _ -> false), nullValue());
         assertThat(cache.current(reuse), is(false));
+        assertThat(cache.select(target, false, _ -> true), nullValue());
         assertThat(invalidations, hasSize(1));
         assertThat(reuse.sameGeneration(invalidations.getFirst()), is(true));
 
@@ -1047,6 +1042,31 @@ class Http2AltSvcCacheTest {
         assertThat(cache.select(target, false, _ -> false), nullValue());
 
         Instant newer = START.plusMillis(750);
+        cache.record(target, header(newer, "h2=\":10443\"; ma=3600"), true, false, newer);
+
+        assertThat(cache.select(target, false, _ -> false).port(), is(10443));
+
+        cache.close();
+    }
+
+    @Test
+    void connectionFailureAfterAdvertisementExpiryRejectsOlderObservation() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(START, "h2=\":8443\"; ma=1"), true, false, START);
+        Http2AltSvcCache.Selection selection = cache.select(target, false, _ -> false);
+        Instant delayed = START.plusMillis(500);
+        AltSvcHeader delayedAdvertisement = header(delayed, "h2=\":9443\"; ma=3600");
+
+        clock.advance(Duration.ofSeconds(2));
+        cache.recordFailure(selection);
+        cache.record(target, delayedAdvertisement, true, false, delayed);
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        Instant newer = clock.instant().plusSeconds(1);
         cache.record(target, header(newer, "h2=\":10443\"; ma=3600"), true, false, newer);
 
         assertThat(cache.select(target, false, _ -> false).port(), is(10443));

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -1,0 +1,1017 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnixDomainSocketAddress;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsMaterial;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.api.AltSvcHeader;
+import io.helidon.webclient.api.ClientConnectionTarget;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.ConnectionKey;
+import io.helidon.webclient.api.DnsAddressLookup;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.spi.DnsResolver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+class Http2AltSvcCacheTest {
+    private static final Instant START = Instant.parse("2026-08-24T00:00:00Z");
+    private static final DnsResolver DNS = (_, _) -> InetAddress.getLoopbackAddress();
+
+    @Test
+    void selectsSameHostH2ByLookupAndExactTarget() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target,
+                     header(clock, "h3=\":7443\", h2=\":8443\"; ma=60"),
+                     true,
+                     false);
+
+        Http2AltSvcCache.Selection byTarget = cache.select(target, false, _ -> false);
+        Http2AltSvcCache.Candidate byLookup = cache.selectRoute(target.lookupKey(), false, _ -> false);
+
+        assertThat(byLookup, notNullValue());
+        assertThat(byLookup.proxyRoute(), is(target.proxyRoute()));
+        assertThat(byTarget.originTarget(), sameInstance(target));
+        assertThat(byTarget.host(), is("origin.example"));
+        assertThat(byTarget.port(), is(8443));
+        assertThat(byTarget.networkGeneration(), is(0L));
+        assertThat(byTarget.establishAllowed(), is(true));
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), sameInstance(byLookup));
+        assertThat(cache.select(target, false, _ -> false), sameInstance(byTarget));
+        assertThat(invalidations, is(empty()));
+
+        cache.close();
+    }
+
+    @Test
+    void sharesAdvertisementAcrossDnsCaseWithoutSharingRawTargetSelection() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget upper = target(tls, "Example.COM");
+        ClientConnectionTarget lower = target(tls, "example.com");
+
+        assertThat(upper, not(is(lower)));
+
+        cache.record(upper, header(clock, "h2=\":8443\"; ma=3600"), true, false);
+        Http2AltSvcCache.Selection upperSelection = cache.select(upper, false, _ -> false);
+        Http2AltSvcCache.Selection lowerSelection = cache.select(lower, false, _ -> false);
+
+        assertThat(upperSelection.originTarget(), sameInstance(upper));
+        assertThat(lowerSelection.originTarget(), sameInstance(lower));
+        assertThat(lowerSelection.sameRouteGeneration(upperSelection), is(true));
+        assertThat(cache.select(upper, false, _ -> false), sameInstance(upperSelection));
+        assertThat(cache.select(lower, false, _ -> false), sameInstance(lowerSelection));
+        assertThat(cache.mayContain("EXAMPLE.COM"), is(true));
+        assertThat(cache.selectRoute(lower.lookupKey(), false, _ -> false), notNullValue());
+
+        cache.record(lower, header(clock, "h2=\":8443\"; ma=7200"), true, false);
+
+        assertThat(cache.select(upper, false, _ -> false), sameInstance(upperSelection));
+        assertThat(cache.select(lower, false, _ -> false), sameInstance(lowerSelection));
+
+        cache.record(upper, header(clock, "clear"), true, false);
+        cache.record(lower, header(clock, "h2=\":9443\"; ma=3600"), true, false);
+
+        Http2AltSvcCache.Selection reverse = cache.select(upper, false, _ -> false);
+        assertThat(reverse.originTarget(), sameInstance(upper));
+        assertThat(reverse.port(), is(9443));
+
+        cache.recordFailure(reverse);
+
+        assertThat(cache.select(lower, false, _ -> true, _ -> true), nullValue());
+
+        clock.advance(Duration.ofMinutes(5));
+        Http2AltSvcCache.Selection retry = cache.select(lower, false, _ -> false);
+        cache.recordMisdirected(retry);
+
+        assertThat(cache.select(upper, false, _ -> true, _ -> true), nullValue());
+
+        cache.close();
+    }
+
+    @Test
+    void persistentMixedCaseAdvertisementGetsOneSharedNetworkGeneration() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget upper = target(tls, "Example.COM");
+        ClientConnectionTarget lower = target(tls, "example.com");
+
+        cache.record(upper, header(clock, "h2=\":8443\"; ma=3600; persist=1"), true, false);
+        Http2AltSvcCache.Selection beforeNetworkChange = cache.select(lower, false, _ -> false);
+
+        cache.networkChanged();
+
+        Http2AltSvcCache.Selection lowerSelection = cache.select(lower, false, _ -> false);
+        Http2AltSvcCache.Selection upperSelection = cache.select(upper, false, _ -> false);
+        assertThat(lowerSelection.networkGeneration(), is(1L));
+        assertThat(upperSelection.networkGeneration(), is(1L));
+        assertThat(lowerSelection.sameRouteGeneration(upperSelection), is(true));
+        assertThat(lowerSelection.sameRouteGeneration(beforeNetworkChange), is(false));
+
+        cache.close();
+    }
+
+    @Test
+    void expiredMixedCaseAdvertisementReusesOnlyTheExactRawTargetPool() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget upper = target(tls, "Example.COM");
+        ClientConnectionTarget lower = target(tls, "example.com");
+
+        cache.record(upper, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        Http2AltSvcCache.Selection establishedUpper = cache.select(upper, false, _ -> false);
+        clock.advance(Duration.ofSeconds(2));
+
+        assertThat(cache.select(lower, false, _ -> false, _ -> true), nullValue());
+        assertThat(invalidations, is(empty()));
+        assertThat(cache.select(upper,
+                                false,
+                                candidate -> candidate.sameRouteGeneration(establishedUpper),
+                                _ -> true),
+                   sameInstance(establishedUpper));
+
+        assertThat(cache.select(lower, false, _ -> false, _ -> false), nullValue());
+        assertThat(invalidations, hasSize(1));
+        assertThat(establishedUpper.sameGeneration(invalidations.getFirst()), is(true));
+
+        cache.close();
+    }
+
+    @Test
+    void lookupRecoversWhenSharedNegativeEntryExpires() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "Origin.EXAMPLE");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false);
+        cache.recordFailure(cache.select(target, false, _ -> false));
+
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> true), nullValue());
+
+        clock.advance(Duration.ofMinutes(5));
+
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+
+        cache.close();
+    }
+
+    @Test
+    void hostPresenceHintCountsLogicalRoutes() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget first = target(tls, "https", "origin.example", 443);
+        ClientConnectionTarget second = target(tls, "https", "origin.example", 444);
+
+        assertThat(cache.mayContain("origin.example"), is(false));
+        assertThat(cache.mayContain("other.example"), is(false));
+
+        cache.record(first, header(clock, "h2=\":8443\"; ma=60"), true, false);
+
+        assertThat(cache.mayContain("origin.example"), is(true));
+        assertThat(cache.mayContain("other.example"), is(false));
+
+        cache.record(first, header(clock, "h2=\":8443\"; ma=120"), true, false);
+        cache.record(first, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection replacement = cache.select(first, false, _ -> false);
+        cache.recordFailure(replacement);
+
+        assertThat(cache.mayContain("origin.example"), is(true));
+
+        cache.record(first, header(clock, "clear"), true, false);
+
+        assertThat(cache.mayContain("origin.example"), is(false));
+
+        cache.record(first, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(second, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(first, header(clock, "clear"), true, false);
+
+        assertThat(cache.mayContain("origin.example"), is(true));
+
+        cache.record(second, header(clock, "clear"), true, false);
+
+        assertThat(cache.mayContain("origin.example"), is(false));
+
+        cache.close();
+    }
+
+    @Test
+    void sameAuthorityRefreshPreservesSelectionAndIndexesWithoutInvalidation() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection selection = cache.select(target, false, _ -> false);
+
+        clock.advance(Duration.ofSeconds(30));
+        cache.record(target, header(clock, "h2=\":8443\"; ma=120; persist=1"), true, false);
+
+        assertThat(cache.select(target, false, _ -> false), sameInstance(selection));
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(selection.establishAllowed(), is(true));
+        assertThat(selection.authority().toString(), is("origin.example:8443"));
+        assertThat(selection.authority(), sameInstance(selection.authority()));
+        assertThat(cache.mayContain(target.connectionKey().host()), is(true));
+        assertThat(invalidations, is(empty()));
+
+        clock.advance(Duration.ofSeconds(61));
+        assertThat(cache.select(target, false, _ -> false), sameInstance(selection));
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=0"), true, false);
+
+        assertThat(cache.select(target,
+                                false,
+                                candidate -> candidate.sameRouteGeneration(selection)),
+                   sameInstance(selection));
+        assertThat(selection.establishAllowed(), is(false));
+        assertThat(cache.mayContain(target.connectionKey().host()), is(true));
+        assertThat(invalidations, is(empty()));
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(cache.mayContain(target.connectionKey().host()), is(false));
+        assertThat(invalidations, hasSize(1));
+
+        cache.close();
+    }
+
+    @Test
+    void sameAuthorityRefreshChangesPersistenceWithoutReplacingSelection() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection transientSelection = cache.select(target, false, _ -> false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60; persist=1"), true, false);
+
+        assertThat(cache.select(target, false, _ -> false), sameInstance(transientSelection));
+
+        cache.networkChanged();
+
+        Http2AltSvcCache.Selection persistentSelection = cache.select(target, false, _ -> false);
+        assertThat(persistentSelection, not(sameInstance(transientSelection)));
+        assertThat(invalidations, hasSize(1));
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+
+        assertThat(cache.select(target, false, _ -> false), sameInstance(persistentSelection));
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+
+        cache.networkChanged();
+
+        assertThat(cache.select(target, false, _ -> true), nullValue());
+        assertThat(cache.mayContain(target.connectionKey().host()), is(false));
+        assertThat(invalidations, hasSize(2));
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection revived = cache.select(target, false, _ -> false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=120"), true, false);
+
+        assertThat(revived, not(sameInstance(persistentSelection)));
+        assertThat(cache.select(target, false, _ -> false), sameInstance(revived));
+        assertThat(invalidations, hasSize(2));
+
+        cache.close();
+    }
+
+    @Test
+    void sameAuthorityRefreshClearsNegativeStateWithoutInvalidatingReplacement() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection failed = cache.select(target, false, _ -> false);
+        cache.recordFailure(failed);
+
+        assertThat(cache.select(target, false, _ -> true), nullValue());
+        assertThat(invalidations, hasSize(1));
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=120"), true, false);
+
+        Http2AltSvcCache.Selection retry = cache.select(target, false, _ -> false);
+        assertThat(retry, not(sameInstance(failed)));
+        assertThat(cache.current(retry), is(true));
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(invalidations, hasSize(1));
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+
+        assertThat(cache.select(target, false, _ -> false), sameInstance(retry));
+        assertThat(invalidations, hasSize(1));
+
+        cache.close();
+    }
+
+    @Test
+    void identityMemoFallsBackForEqualTargetAndTracksReplacementAndClear() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget target = target(tls, "origin.example");
+        ClientConnectionTarget equalTarget = target(tls, "origin.example");
+
+        assertThat(equalTarget, is(target));
+        assertThat(equalTarget, not(sameInstance(target)));
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection first = cache.select(target, false, _ -> false);
+        cache.record(equalTarget, header(clock, "h2=\":8443\"; ma=120"), true, false);
+
+        assertThat(cache.select(target, false, _ -> false), sameInstance(first));
+        assertThat(cache.selectRoute(equalTarget.lookupKey(), false, _ -> false), notNullValue());
+
+        cache.record(equalTarget, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection replacement = cache.select(target, false, _ -> false);
+        cache.record(equalTarget, header(clock, "h2=\":9443\"; ma=120"), true, false);
+
+        assertThat(replacement, not(sameInstance(first)));
+        assertThat(cache.select(equalTarget, false, _ -> false), sameInstance(replacement));
+        assertThat(invalidations, hasSize(1));
+
+        cache.record(equalTarget, header(clock, "clear"), true, false);
+
+        assertThat(cache.select(target, false, _ -> true), nullValue());
+        assertThat(invalidations, hasSize(2));
+
+        cache.record(target, header(clock, "h2=\":10443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection revived = cache.select(target, false, _ -> false);
+        cache.record(target, header(clock, "h2=\":10443\"; ma=120"), true, false);
+
+        assertThat(revived, not(sameInstance(replacement)));
+        assertThat(cache.select(target, false, _ -> false), sameInstance(revived));
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(invalidations, hasSize(2));
+
+        cache.close();
+    }
+
+    @Test
+    void hostPresenceHintTracksRemovalLifecycle() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget unsupported = target(tls, "unsupported.example");
+        ClientConnectionTarget misdirected = target(tls, "misdirected.example");
+        ClientConnectionTarget expired = target(tls, "expired.example");
+        Tls reloadedTls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget staleTls = target(reloadedTls, "stale-tls.example");
+        ClientConnectionTarget persistent = target(tls, "persistent.example");
+        ClientConnectionTarget transientTarget = target(tls, "transient.example");
+
+        cache.record(unsupported, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.record(unsupported, header(clock, "H2=\":8443\"; ma=60"), true, false);
+        assertThat(cache.mayContain("unsupported.example"), is(false));
+
+        cache.record(misdirected, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.recordMisdirected(cache.select(misdirected, false, _ -> false));
+        assertThat(cache.mayContain("misdirected.example"), is(false));
+
+        cache.record(expired, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        clock.advance(Duration.ofSeconds(2));
+        assertThat(cache.select(expired, false, _ -> false), nullValue());
+        assertThat(cache.mayContain("expired.example"), is(false));
+
+        cache.record(staleTls, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        reloadedTls.reload(TlsMaterial.builder().trustAll(true).build());
+        assertThat(cache.select(staleTls, false, _ -> false), nullValue());
+        assertThat(cache.mayContain("stale-tls.example"), is(false));
+
+        cache.record(persistent, header(clock, "h2=\":8443\"; ma=60; persist=1"), true, false);
+        cache.record(transientTarget, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        cache.networkChanged();
+
+        assertThat(cache.mayContain("persistent.example"), is(true));
+        assertThat(cache.mayContain("transient.example"), is(false));
+
+        cache.close();
+
+        assertThat(cache.mayContain("persistent.example"), is(false));
+    }
+
+    @Test
+    void rejectsInsecureExplicitAndIneligibleOrigins() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        AltSvcHeader advertisement = header(clock, "h2=\":8443\"; ma=60");
+        ClientConnectionTarget target = target(tls, "origin.example");
+
+        cache.record(target, advertisement, false, false);
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        cache.record(target, advertisement, true, true);
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        cache.record(target, advertisement, true, false);
+        assertThat(cache.select(target, true, _ -> true), nullValue());
+
+        ClientConnectionTarget httpTarget = target(Tls.builder().enabled(false).build(), "http", "origin.example");
+        cache.record(httpTarget, advertisement, true, false);
+        assertThat(cache.select(httpTarget, false, _ -> false), nullValue());
+
+        Proxy proxy = Proxy.builder().host("proxy.example").port(8181).build();
+        ClientConnectionTarget proxyTarget = target(tls, "https", "origin.example", proxy, DNS);
+        cache.record(proxyTarget, advertisement, true, false);
+        assertThat(cache.select(proxyTarget, false, _ -> false), nullValue());
+
+        Proxy noProxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        ClientConnectionTarget addressBoundTarget = target(tls,
+                                                            "https",
+                                                            "origin.example",
+                                                            noProxy,
+                                                            (_, _) -> InetAddress.ofLiteral("127.0.0.1"));
+        cache.record(addressBoundTarget, advertisement, true, false);
+        assertThat(addressBoundTarget.proxyRoute().addressBound(), is(true));
+        assertThat(cache.select(addressBoundTarget, false, _ -> false), nullValue());
+
+        ClientConnectionTarget udsTarget = udsTarget(tls, "origin.example");
+        cache.record(udsTarget, advertisement, true, false);
+        assertThat(cache.select(udsTarget, false, _ -> false), nullValue());
+
+        cache.close();
+    }
+
+    @Test
+    void replacesExistingStateForUnsupportedOrCrossHostAdvertisement() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection first = cache.select(target, false, _ -> false);
+
+        cache.record(target, header(clock, "H2=\":9443\"; ma=60"), true, false);
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(cache.current(first), is(false));
+        assertThat(invalidations, hasSize(1));
+        assertThat(first.sameGeneration(invalidations.getFirst()), is(true));
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection second = cache.select(target, false, _ -> false);
+        cache.record(target, header(clock, "h2=\"other.example:8443\"; ma=60"), true, false);
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(cache.current(second), is(false));
+        assertThat(invalidations, hasSize(2));
+
+        cache.close();
+    }
+
+    @Test
+    void expiredAdvertisementReusesOnlyExactEstablishedGeneration() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        Http2AltSvcCache.Selection fresh = cache.select(target, false, _ -> false);
+        clock.advance(Duration.ofSeconds(2));
+
+        Http2AltSvcCache.Selection reuse = cache.select(target,
+                                                        false,
+                                                        candidate -> candidate.sameRouteGeneration(fresh));
+
+        assertThat(reuse.sameRouteGeneration(fresh), is(true));
+        assertThat(reuse.establishAllowed(), is(false));
+        cache.recordFailure(reuse);
+        assertThat(cache.current(reuse), is(true));
+        assertThat(cache.select(target,
+                                false,
+                                candidate -> candidate.sameRouteGeneration(reuse)),
+                   sameInstance(reuse));
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(cache.current(reuse), is(false));
+        assertThat(invalidations, hasSize(1));
+        assertThat(reuse.sameGeneration(invalidations.getFirst()), is(true));
+
+        cache.close();
+    }
+
+    @Test
+    void expiredEstablishedProbeDoesNotBlockFreshUnrelatedSelection() throws Exception {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget expiredTarget = target(tls, "expired.example");
+        ClientConnectionTarget freshTarget = target(tls, "fresh.example");
+
+        cache.record(expiredTarget, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        cache.record(freshTarget, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection expired = cache.select(expiredTarget, false, _ -> false);
+        Http2AltSvcCache.Selection fresh = cache.select(freshTarget, false, _ -> false);
+        clock.advance(Duration.ofSeconds(2));
+
+        CountDownLatch enteredEstablishedProbe = new CountDownLatch(1);
+        CountDownLatch releaseEstablishedProbe = new CountDownLatch(1);
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<Http2AltSvcCache.Selection> expiredRead = executor.submit(() -> cache.select(
+                    expiredTarget,
+                    false,
+                    selection -> {
+                        enteredEstablishedProbe.countDown();
+                        try {
+                            releaseEstablishedProbe.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException("Interrupted while holding established probe", e);
+                        }
+                        return selection.sameRouteGeneration(expired);
+                    }));
+
+            try {
+                assertThat(enteredEstablishedProbe.await(5, TimeUnit.SECONDS), is(true));
+                Future<Http2AltSvcCache.Selection> freshRead = executor.submit(
+                        () -> cache.select(freshTarget, false, _ -> false));
+                assertThat(freshRead.get(5, TimeUnit.SECONDS), sameInstance(fresh));
+            } finally {
+                releaseEstablishedProbe.countDown();
+            }
+
+            assertThat(expiredRead.get(5, TimeUnit.SECONDS), sameInstance(expired));
+        } finally {
+            cache.close();
+        }
+    }
+
+    @Test
+    void replacementDuringEstablishedProbeCannotReturnStaleSelection() throws Exception {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        Http2AltSvcCache.Selection stale = cache.select(target, false, _ -> false);
+        clock.advance(Duration.ofSeconds(2));
+
+        CountDownLatch enteredEstablishedProbe = new CountDownLatch(1);
+        CountDownLatch releaseEstablishedProbe = new CountDownLatch(1);
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<Http2AltSvcCache.Selection> selectionRead = executor.submit(() -> cache.select(
+                    target,
+                    false,
+                    selection -> {
+                        enteredEstablishedProbe.countDown();
+                        try {
+                            releaseEstablishedProbe.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException("Interrupted while holding established probe", e);
+                        }
+                        return selection.sameRouteGeneration(stale);
+                    }));
+
+            try {
+                assertThat(enteredEstablishedProbe.await(5, TimeUnit.SECONDS), is(true));
+                Future<?> replacementWrite = executor.submit(
+                        () -> cache.record(target, header(clock, "h2=\":9443\"; ma=60"), true, false));
+                assertThat(replacementWrite.get(5, TimeUnit.SECONDS), nullValue());
+            } finally {
+                releaseEstablishedProbe.countDown();
+            }
+
+            Http2AltSvcCache.Selection replacement = cache.select(target, false, _ -> false);
+            assertThat(selectionRead.get(5, TimeUnit.SECONDS), sameInstance(replacement));
+            assertThat(cache.current(stale), is(false));
+            assertThat(cache.current(replacement), is(true));
+            assertThat(cache.select(target, false, _ -> false), sameInstance(replacement));
+        } finally {
+            cache.close();
+        }
+    }
+
+    @Test
+    void sameAuthorityRefreshDuringExpiredEstablishedProbeReturnsCoherentSelection() throws Exception {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        Http2AltSvcCache.Selection expired = cache.select(target, false, _ -> false);
+        clock.advance(Duration.ofSeconds(2));
+
+        CountDownLatch enteredEstablishedProbe = new CountDownLatch(1);
+        CountDownLatch releaseEstablishedProbe = new CountDownLatch(1);
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<Http2AltSvcCache.Selection> selectionRead = executor.submit(() -> cache.select(
+                    target,
+                    false,
+                    _ -> {
+                        enteredEstablishedProbe.countDown();
+                        try {
+                            releaseEstablishedProbe.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException("Interrupted while holding established probe", e);
+                        }
+                        return false;
+                    }));
+
+            try {
+                assertThat(enteredEstablishedProbe.await(5, TimeUnit.SECONDS), is(true));
+                Future<?> refreshWrite = executor.submit(
+                        () -> cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false));
+                assertThat(refreshWrite.get(5, TimeUnit.SECONDS), nullValue());
+            } finally {
+                releaseEstablishedProbe.countDown();
+            }
+
+            assertThat(selectionRead.get(5, TimeUnit.SECONDS), sameInstance(expired));
+            assertThat(expired.establishAllowed(), is(true));
+            assertThat(cache.current(expired), is(true));
+            assertThat(cache.select(target, false, _ -> false), sameInstance(expired));
+            assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        } finally {
+            cache.close();
+        }
+    }
+
+    @Test
+    void tlsReloadDuringEstablishedProbeCannotReturnStaleSelection() throws Exception {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget target = target(tls, "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=1"), true, false);
+        Http2AltSvcCache.Selection stale = cache.select(target, false, _ -> false);
+        clock.advance(Duration.ofSeconds(2));
+
+        CountDownLatch enteredEstablishedProbe = new CountDownLatch(1);
+        CountDownLatch releaseEstablishedProbe = new CountDownLatch(1);
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<Http2AltSvcCache.Selection> selectionRead = executor.submit(() -> cache.select(
+                    target,
+                    false,
+                    selection -> {
+                        enteredEstablishedProbe.countDown();
+                        try {
+                            releaseEstablishedProbe.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException("Interrupted while holding established probe", e);
+                        }
+                        return selection.sameRouteGeneration(stale);
+                    }));
+
+            try {
+                assertThat(enteredEstablishedProbe.await(5, TimeUnit.SECONDS), is(true));
+                tls.reload(TlsMaterial.builder().trustAll(true).build());
+            } finally {
+                releaseEstablishedProbe.countDown();
+            }
+
+            assertThat(selectionRead.get(5, TimeUnit.SECONDS), nullValue());
+            assertThat(cache.current(stale), is(false));
+            assertThat(cache.select(target, false, _ -> true), nullValue());
+        } finally {
+            cache.close();
+        }
+    }
+
+    @Test
+    void replacementClearAndZeroMaximumAgeInvalidateMatchingGeneration() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection first = cache.select(target, false, _ -> false);
+        cache.record(target, header(clock, "h2=\":8443\"; ma=120; persist=1"), true, false);
+        Http2AltSvcCache.Selection extended = cache.select(target, false, _ -> false);
+
+        assertThat(extended, sameInstance(first));
+        assertThat(invalidations, is(empty()));
+
+        cache.record(target, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection replacement = cache.select(target, false, _ -> false);
+
+        assertThat(replacement, not(sameInstance(first)));
+        assertThat(replacement.sameRouteGeneration(first), is(false));
+        assertThat(cache.current(first), is(false));
+        assertThat(invalidations, hasSize(1));
+
+        cache.record(target, header(clock, "h2=\":9443\"; ma=0"), true, false);
+
+        Http2AltSvcCache.Selection zeroAgeReuse = cache.select(
+                target,
+                false,
+                candidate -> candidate.sameRouteGeneration(replacement));
+        assertThat(cache.current(replacement), is(true));
+        assertThat(zeroAgeReuse, sameInstance(replacement));
+        assertThat(zeroAgeReuse.establishAllowed(), is(false));
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(invalidations, hasSize(2));
+
+        cache.record(target, header(clock, "h2=\":10443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection beforeClear = cache.select(target, false, _ -> false);
+        cache.record(target, header(clock, "clear"), true, false);
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(cache.current(beforeClear), is(false));
+        assertThat(invalidations, hasSize(3));
+
+        cache.close();
+    }
+
+    @Test
+    void preSendFailureIsNegativeForFiveMinutes() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false);
+        Http2AltSvcCache.Selection failed = cache.select(target, false, _ -> false);
+        cache.recordFailure(failed);
+
+        assertThat(cache.current(failed), is(false));
+        assertThat(cache.select(target, false, _ -> true), nullValue());
+        assertThat(invalidations, hasSize(1));
+
+        clock.advance(Duration.ofMinutes(5));
+        Http2AltSvcCache.Selection retry = cache.select(target, false, _ -> false);
+
+        assertThat(retry.sameRouteGeneration(failed), is(false));
+        assertThat(retry.establishAllowed(), is(true));
+        assertThat(cache.current(retry), is(true));
+        assertThat(cache.select(target, false, _ -> false), sameInstance(retry));
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+
+        cache.close();
+    }
+
+    @Test
+    void staleMisdirectedResponseCannotRemoveReplacement() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection stale = cache.select(target, false, _ -> false);
+        cache.record(target, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection current = cache.select(target, false, _ -> false);
+
+        cache.recordMisdirected(stale);
+        Http2AltSvcCache.Selection retained = cache.select(target, false, _ -> false);
+
+        assertThat(retained, sameInstance(current));
+
+        cache.recordMisdirected(current);
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(cache.current(current), is(false));
+
+        cache.close();
+    }
+
+    @Test
+    void networkChangeRetainsOnlyPersistentAdvertisementWithNewGeneration() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget persistentTarget = target(tls, "persistent.example");
+        ClientConnectionTarget transientTarget = target(tls, "transient.example");
+
+        cache.record(persistentTarget, header(clock, "h2=\":8443\"; ma=60; persist=1"), true, false);
+        cache.record(transientTarget, header(clock, "h2=\":9443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection persistent = cache.select(persistentTarget, false, _ -> false);
+        Http2AltSvcCache.Selection transientSelection = cache.select(transientTarget, false, _ -> false);
+
+        cache.networkChanged();
+
+        Http2AltSvcCache.Selection retained = cache.select(persistentTarget, false, _ -> false);
+        assertThat(retained.networkGeneration(), is(1L));
+        assertThat(retained.sameRouteGeneration(persistent), is(false));
+        assertThat(cache.select(transientTarget, false, _ -> false), nullValue());
+        assertThat(cache.current(persistent), is(false));
+        assertThat(cache.current(transientSelection), is(false));
+        assertThat(invalidations, hasSize(2));
+
+        cache.close();
+        assertThat(cache.current(retained), is(false));
+        assertThat(cache.select(persistentTarget, false, _ -> false), nullValue());
+    }
+
+    @Test
+    void tlsReloadInvalidatesCapturedTargetGeneration() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget target = target(tls, "origin.example");
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false);
+        Http2AltSvcCache.Selection selection = cache.select(target, false, _ -> false);
+        tls.reload(TlsMaterial.builder().trustAll(true).build());
+
+        assertThat(cache.current(selection), is(false));
+        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> true), nullValue());
+        assertThat(invalidations, hasSize(1));
+        assertThat(selection.sameGeneration(invalidations.getFirst()), is(true));
+
+        ClientConnectionTarget currentTarget = target(tls, "origin.example");
+        assertThat(currentTarget, is(not(target)));
+        assertThat(cache.select(currentTarget, false, _ -> true), nullValue());
+
+        cache.close();
+    }
+
+    @Test
+    void evictsOldestInsertedOriginAtBoundDespiteRead() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        Tls tls = Tls.builder().trustAll(true).build();
+        AltSvcHeader advertisement = header(clock, "h2=\":8443\"; ma=60");
+        ClientConnectionTarget first = null;
+
+        for (int index = 0; index < 1_000; index++) {
+            ClientConnectionTarget target = target(tls, "origin-" + index + ".example");
+            if (index == 0) {
+                first = target;
+            }
+            cache.record(target, advertisement, true, false);
+        }
+        Http2AltSvcCache.Selection firstSelection = cache.select(first, false, _ -> false);
+        assertThat(firstSelection, notNullValue());
+        cache.record(first, advertisement, true, false);
+
+        ClientConnectionTarget last = target(tls, "origin-1000.example");
+        cache.record(last, advertisement, true, false);
+
+        assertThat(cache.select(first, false, _ -> false), nullValue());
+        assertThat(cache.select(last, false, _ -> false), notNullValue());
+        assertThat(cache.mayContain(first.connectionKey().host()), is(false));
+        assertThat(cache.mayContain(last.connectionKey().host()), is(true));
+        assertThat(invalidations, hasSize(1));
+        assertThat(firstSelection.sameGeneration(invalidations.getFirst()), is(true));
+
+        cache.record(first, advertisement, true, false);
+        Http2AltSvcCache.Selection revived = cache.select(first, false, _ -> false);
+        cache.record(first, header(clock, "h2=\":8443\"; ma=120"), true, false);
+
+        assertThat(revived, not(sameInstance(firstSelection)));
+        assertThat(cache.select(first, false, _ -> false), sameInstance(revived));
+        assertThat(cache.mayContain(first.connectionKey().host()), is(true));
+        assertThat(invalidations, hasSize(2));
+
+        cache.close();
+    }
+
+    private static AltSvcHeader header(Clock clock, String... values) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        for (String value : values) {
+            headers.add(HeaderValues.create(HeaderNames.ALT_SVC, value));
+        }
+        return AltSvcHeader.parse(ClientResponseHeaders.create(headers), clock.instant()).orElseThrow();
+    }
+
+    private static ClientConnectionTarget target(Tls tls, String host) {
+        return target(tls, "https", host);
+    }
+
+    private static ClientConnectionTarget target(Tls tls, String scheme, String host) {
+        int port = "https".equals(scheme) ? 443 : 80;
+        return target(tls, scheme, host, port, Proxy.noProxy(), DNS);
+    }
+
+    private static ClientConnectionTarget target(Tls tls, String scheme, String host, int port) {
+        return target(tls, scheme, host, port, Proxy.noProxy(), DNS);
+    }
+
+    private static ClientConnectionTarget target(Tls tls,
+                                                  String scheme,
+                                                  String host,
+                                                  Proxy proxy,
+                                                  DnsResolver dnsResolver) {
+        int port = "https".equals(scheme) ? 443 : 80;
+        return target(tls, scheme, host, port, proxy, dnsResolver);
+    }
+
+    private static ClientConnectionTarget target(Tls tls,
+                                                  String scheme,
+                                                  String host,
+                                                  int port,
+                                                  Proxy proxy,
+                                                  DnsResolver dnsResolver) {
+        ConnectionKey connectionKey = ConnectionKey.create(scheme,
+                                                           host,
+                                                           port,
+                                                           tls,
+                                                           dnsResolver,
+                                                           DnsAddressLookup.IPV4,
+                                                           proxy);
+        return ClientConnectionTarget.create(connectionKey, scheme);
+    }
+
+    private static ClientConnectionTarget udsTarget(Tls tls, String host) {
+        ClientUri uri = ClientUri.create(URI.create("https://" + host));
+        UnixDomainSocketAddress address = UnixDomainSocketAddress.of(Path.of("alt-svc-test.sock"));
+        ConnectionKey connectionKey = ConnectionKey.createUnixDomainSocket(uri,
+                                                                           tls,
+                                                                           DNS,
+                                                                           DnsAddressLookup.IPV4,
+                                                                           address);
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        return ClientConnectionTarget.createUnixDomainSocket(connectionKey, uri, headers, address);
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            if (ZoneOffset.UTC.equals(zone)) {
+                return this;
+            }
+            return Clock.fixed(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        private void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+    }
+}

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -393,13 +393,13 @@ class Http2AltSvcCacheTest {
     }
 
     @Test
-    void sameAuthorityRefreshClearsNegativeStateWithoutInvalidatingReplacement() {
+    void sameAuthorityRefreshPreservesNegativeStateWithoutInvalidatingReplacement() {
         MutableClock clock = new MutableClock(START);
         List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
+        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection failed = cache.select(target, false, _ -> false);
         cache.recordFailure(failed);
 
@@ -407,17 +407,24 @@ class Http2AltSvcCacheTest {
         assertThat(invalidations, hasSize(1));
 
         clock.advance(Duration.ofNanos(1));
-        cache.record(target, header(clock, "h2=\":8443\"; ma=120"), true, false, clock.nextObservation());
+        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false, clock.nextObservation());
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), nullValue());
+        assertThat(invalidations, hasSize(1));
+
+        cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false, clock.nextObservation());
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(invalidations, hasSize(1));
+
+        clock.advance(Duration.ofMinutes(5));
 
         Http2AltSvcCache.Selection retry = cache.select(target, false, _ -> false);
         assertThat(retry, not(sameInstance(failed)));
         assertThat(cache.current(retry), is(true));
-        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
-        assertThat(invalidations, hasSize(1));
-
-        cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
-
         assertThat(cache.select(target, false, _ -> false), sameInstance(retry));
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
         assertThat(invalidations, hasSize(1));
 
         cache.close();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -539,6 +539,12 @@ class Http2AltSvcCacheTest {
         cache.record(httpTarget, advertisement, true, false, clock.nextObservation());
         assertThat(cache.select(httpTarget, false, _ -> false), nullValue());
 
+        ClientConnectionTarget unauthenticatedAuthority = targetWithAuthority(tls,
+                                                                               "gateway.example",
+                                                                               "origin.example");
+        cache.record(unauthenticatedAuthority, advertisement, true, false, clock.nextObservation());
+        assertThat(cache.select(unauthenticatedAuthority, false, _ -> false), nullValue());
+
         Proxy proxy = Proxy.builder().host("proxy.example").port(8181).build();
         ClientConnectionTarget proxyTarget = target(tls, "https", "origin.example", proxy, DNS);
         cache.record(proxyTarget, advertisement, true, false, clock.nextObservation());
@@ -1437,6 +1443,20 @@ class Http2AltSvcCacheTest {
                                                            DnsAddressLookup.IPV4,
                                                            proxy);
         return ClientConnectionTarget.create(connectionKey, scheme);
+    }
+
+    private static ClientConnectionTarget targetWithAuthority(Tls tls, String routingHost, String originAuthority) {
+        ConnectionKey connectionKey = ConnectionKey.create("https",
+                                                           routingHost,
+                                                           443,
+                                                           tls,
+                                                           DNS,
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientUri uri = ClientUri.create(URI.create("https://" + routingHost));
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.set(HeaderNames.HOST, originAuthority);
+        return ClientConnectionTarget.create(connectionKey, uri, ClientRequestHeaders.create(headers));
     }
 
     private static ClientConnectionTarget udsTarget(Tls tls, String host) {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.tls.Tls;
 import io.helidon.common.tls.TlsMaterial;
@@ -76,7 +77,7 @@ class Http2AltSvcCacheTest {
                      false, clock.nextObservation());
 
         Http2AltSvcCache.Selection byTarget = cache.select(target, false, _ -> false);
-        Http2AltSvcCache.Candidate byLookup = cache.selectRoute(target.lookupKey(), false, _ -> false);
+        Http2AltSvcCache.Candidate byLookup = cache.selectRoute(target.lookupKey(), false);
 
         assertThat(byLookup, notNullValue());
         assertThat(byLookup.proxyRoute(), is(target.proxyRoute()));
@@ -85,7 +86,7 @@ class Http2AltSvcCacheTest {
         assertThat(byTarget.port(), is(8443));
         assertThat(byTarget.networkGeneration(), is(0L));
         assertThat(byTarget.establishAllowed(), is(true));
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), sameInstance(byLookup));
+        assertThat(cache.selectRoute(target.lookupKey(), false), sameInstance(byLookup));
         assertThat(cache.select(target, false, _ -> false), sameInstance(byTarget));
         assertThat(invalidations, is(empty()));
 
@@ -112,7 +113,7 @@ class Http2AltSvcCacheTest {
         assertThat(cache.select(upper, false, _ -> false), sameInstance(upperSelection));
         assertThat(cache.select(lower, false, _ -> false), sameInstance(lowerSelection));
         assertThat(cache.mayContain("EXAMPLE.COM"), is(true));
-        assertThat(cache.selectRoute(lower.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(cache.selectRoute(lower.lookupKey(), false), notNullValue());
 
         cache.record(lower, header(clock, "h2=\":8443\"; ma=7200"), true, false, clock.nextObservation());
 
@@ -128,13 +129,13 @@ class Http2AltSvcCacheTest {
 
         cache.recordFailure(reverse);
 
-        assertThat(cache.select(lower, false, _ -> true, _ -> true), nullValue());
+        assertThat(cache.select(lower, false, _ -> true), nullValue());
 
         clock.advance(Duration.ofMinutes(5));
         Http2AltSvcCache.Selection retry = cache.select(lower, false, _ -> false);
         cache.recordMisdirected(retry);
 
-        assertThat(cache.select(upper, false, _ -> true, _ -> true), nullValue());
+        assertThat(cache.select(upper, false, _ -> true), nullValue());
 
         cache.close();
     }
@@ -175,17 +176,75 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache.Selection establishedUpper = cache.select(upper, false, _ -> false);
         clock.advance(Duration.ofSeconds(2));
 
-        assertThat(cache.select(lower, false, _ -> false, _ -> true), nullValue());
+        AtomicInteger exactEstablishedChecks = new AtomicInteger();
+        assertThat(cache.select(lower, false, _ -> {
+            exactEstablishedChecks.incrementAndGet();
+            return false;
+        }), nullValue());
+        assertThat(exactEstablishedChecks.get(), is(1));
         assertThat(invalidations, is(empty()));
         assertThat(cache.select(upper,
                                 false,
-                                candidate -> candidate.sameRouteGeneration(establishedUpper),
-                                _ -> true),
+                                candidate -> {
+                                    exactEstablishedChecks.incrementAndGet();
+                                    return candidate == establishedUpper;
+                                }),
                    sameInstance(establishedUpper));
+        assertThat(exactEstablishedChecks.get(), is(2));
 
-        assertThat(cache.select(lower, false, _ -> false, _ -> false), nullValue());
+        assertThat(cache.select(lower, false, _ -> false), nullValue());
+        assertThat(cache.selectRoute(lower.lookupKey(), false), notNullValue());
+        assertThat(cache.mayContain("EXAMPLE.COM"), is(true));
+        assertThat(invalidations, is(empty()));
+
+        cache.close();
+    }
+
+    @Test
+    void repeatedExpiredRouteLookupDoesNotProbeExactPoolsAndMetadataIsEvictable() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget expiredTarget = target(tls, "expired.example");
+
+        cache.record(expiredTarget, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
+        Http2AltSvcCache.Selection expiredSelection = cache.select(expiredTarget, false, _ -> false);
+        Http2AltSvcCache.Candidate expiredCandidate = cache.selectRoute(expiredTarget.lookupKey(), false);
+        clock.advance(Duration.ofSeconds(2));
+
+        AtomicInteger exactEstablishedChecks = new AtomicInteger();
+        for (int index = 0; index < 3; index++) {
+            assertThat(cache.selectRoute(expiredTarget.lookupKey(), false), sameInstance(expiredCandidate));
+        }
+        assertThat(exactEstablishedChecks.get(), is(0));
+
+        assertThat(cache.select(expiredTarget, false, candidate -> {
+            exactEstablishedChecks.incrementAndGet();
+            return candidate == expiredSelection;
+        }), sameInstance(expiredSelection));
+        assertThat(cache.select(expiredTarget, false, _ -> {
+            exactEstablishedChecks.incrementAndGet();
+            return false;
+        }), nullValue());
+        assertThat(exactEstablishedChecks.get(), is(2));
+        assertThat(cache.selectRoute(expiredTarget.lookupKey(), false), sameInstance(expiredCandidate));
+        assertThat(exactEstablishedChecks.get(), is(2));
+        assertThat(cache.current(expiredSelection), is(true));
+        assertThat(cache.mayContain("expired.example"), is(true));
+        assertThat(invalidations, is(empty()));
+
+        AltSvcHeader advertisement = header(clock, "h2=\":9443\"; ma=60");
+        for (int index = 0; index < 1_000; index++) {
+            ClientConnectionTarget target = target(tls, "capacity-" + index + ".example");
+            cache.record(target, advertisement, true, false, clock.nextObservation());
+        }
+
+        assertThat(cache.selectRoute(expiredTarget.lookupKey(), false), nullValue());
+        assertThat(cache.mayContain("expired.example"), is(false));
+        assertThat(cache.current(expiredSelection), is(false));
         assertThat(invalidations, hasSize(1));
-        assertThat(establishedUpper.sameGeneration(invalidations.getFirst()), is(true));
+        assertThat(expiredSelection.sameGeneration(invalidations.getFirst()), is(true));
 
         cache.close();
     }
@@ -199,11 +258,11 @@ class Http2AltSvcCacheTest {
         cache.record(target, header(clock, "h2=\":8443\"; ma=3600"), true, false, clock.nextObservation());
         cache.recordFailure(cache.select(target, false, _ -> false));
 
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> true), nullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), nullValue());
 
         clock.advance(Duration.ofMinutes(5));
 
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
 
         cache.close();
     }
@@ -262,7 +321,7 @@ class Http2AltSvcCacheTest {
         cache.record(target, header(clock, "h2=\":8443\"; ma=120; persist=1"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), sameInstance(selection));
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
         assertThat(selection.establishAllowed(), is(true));
         assertThat(selection.authority().toString(), is("origin.example:8443"));
         assertThat(selection.authority(), sameInstance(selection.authority()));
@@ -283,8 +342,9 @@ class Http2AltSvcCacheTest {
         assertThat(invalidations, is(empty()));
 
         assertThat(cache.select(target, false, _ -> false), nullValue());
-        assertThat(cache.mayContain(target.connectionKey().host()), is(false));
-        assertThat(invalidations, hasSize(1));
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
+        assertThat(cache.mayContain(target.connectionKey().host()), is(true));
+        assertThat(invalidations, is(empty()));
 
         cache.close();
     }
@@ -312,7 +372,7 @@ class Http2AltSvcCacheTest {
         cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), sameInstance(persistentSelection));
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
 
         cache.networkChanged();
         clock.advance(Duration.ofNanos(1));
@@ -352,7 +412,7 @@ class Http2AltSvcCacheTest {
         Http2AltSvcCache.Selection retry = cache.select(target, false, _ -> false);
         assertThat(retry, not(sameInstance(failed)));
         assertThat(cache.current(retry), is(true));
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
         assertThat(invalidations, hasSize(1));
 
         cache.record(target, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
@@ -380,7 +440,7 @@ class Http2AltSvcCacheTest {
         cache.record(equalTarget, header(clock, "h2=\":8443\"; ma=120"), true, false, clock.nextObservation());
 
         assertThat(cache.select(target, false, _ -> false), sameInstance(first));
-        assertThat(cache.selectRoute(equalTarget.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(cache.selectRoute(equalTarget.lookupKey(), false), notNullValue());
 
         cache.record(equalTarget, header(clock, "h2=\":9443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection replacement = cache.select(target, false, _ -> false);
@@ -401,7 +461,7 @@ class Http2AltSvcCacheTest {
 
         assertThat(revived, not(sameInstance(replacement)));
         assertThat(cache.select(target, false, _ -> false), sameInstance(revived));
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
         assertThat(invalidations, hasSize(2));
 
         cache.close();
@@ -431,7 +491,7 @@ class Http2AltSvcCacheTest {
         cache.record(expired, header(clock, "h2=\":8443\"; ma=1"), true, false, clock.nextObservation());
         clock.advance(Duration.ofSeconds(2));
         assertThat(cache.select(expired, false, _ -> false), nullValue());
-        assertThat(cache.mayContain("expired.example"), is(false));
+        assertThat(cache.mayContain("expired.example"), is(true));
 
         cache.record(staleTls, header(clock, "h2=\":8443\"; ma=60"), true, false, clock.nextObservation());
         reloadedTls.reload(TlsMaterial.builder().trustAll(true).build());
@@ -447,6 +507,7 @@ class Http2AltSvcCacheTest {
 
         cache.close();
 
+        assertThat(cache.mayContain("expired.example"), is(false));
         assertThat(cache.mayContain("persistent.example"), is(false));
     }
 
@@ -541,7 +602,7 @@ class Http2AltSvcCacheTest {
     }
 
     @Test
-    void expiredAdvertisementReusesOnlyExactEstablishedGeneration() {
+    void expiredAdvertisementReusesOnlyExactEstablishedSelection() {
         MutableClock clock = new MutableClock(START);
         List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
@@ -707,7 +768,7 @@ class Http2AltSvcCacheTest {
             assertThat(expired.establishAllowed(), is(true));
             assertThat(cache.current(expired), is(true));
             assertThat(cache.select(target, false, _ -> false), sameInstance(expired));
-            assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+            assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
         } finally {
             cache.close();
         }
@@ -757,7 +818,7 @@ class Http2AltSvcCacheTest {
     }
 
     @Test
-    void replacementClearAndZeroMaximumAgeInvalidateMatchingGeneration() {
+    void replacementAndClearInvalidateButZeroMaximumAgeRetainsGeneration() {
         MutableClock clock = new MutableClock(START);
         List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
@@ -789,7 +850,9 @@ class Http2AltSvcCacheTest {
         assertThat(zeroAgeReuse, sameInstance(replacement));
         assertThat(zeroAgeReuse.establishAllowed(), is(false));
         assertThat(cache.select(target, false, _ -> false), nullValue());
-        assertThat(invalidations, hasSize(2));
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
+        assertThat(cache.current(replacement), is(true));
+        assertThat(invalidations, hasSize(1));
 
         cache.record(target, header(clock, "h2=\":10443\"; ma=60"), true, false, clock.nextObservation());
         Http2AltSvcCache.Selection beforeClear = cache.select(target, false, _ -> false);
@@ -824,7 +887,7 @@ class Http2AltSvcCacheTest {
         assertThat(retry.establishAllowed(), is(true));
         assertThat(cache.current(retry), is(true));
         assertThat(cache.select(target, false, _ -> false), sameInstance(retry));
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> false), notNullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
 
         cache.close();
     }
@@ -899,7 +962,7 @@ class Http2AltSvcCacheTest {
         tls.reload(TlsMaterial.builder().trustAll(true).build());
 
         assertThat(cache.current(selection), is(false));
-        assertThat(cache.selectRoute(target.lookupKey(), false, _ -> true), nullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), nullValue());
         assertThat(invalidations, hasSize(1));
         assertThat(selection.sameGeneration(invalidations.getFirst()), is(true));
 
@@ -1144,15 +1207,21 @@ class Http2AltSvcCacheTest {
     }
 
     @Test
-    void naturalExpiryRetainsOnlyTheAdvertisementObservation() {
+    void naturalExpiryRetainsRouteWithoutBlockingNewerObservation() {
         MutableClock clock = new MutableClock(START);
-        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
         ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
 
         cache.record(target, header(START, "h2=\":8443\"; ma=1"), true, false, START);
+        Http2AltSvcCache.Selection expired = cache.select(target, false, _ -> false);
         clock.advance(Duration.ofSeconds(2));
 
         assertThat(cache.select(target, false, _ -> false), nullValue());
+        assertThat(cache.selectRoute(target.lookupKey(), false), notNullValue());
+        assertThat(cache.current(expired), is(true));
+        assertThat(cache.mayContain("origin.example"), is(true));
+        assertThat(invalidations, is(empty()));
 
         Instant delayedNewer = START.plusMillis(500);
         cache.record(target,
@@ -1167,6 +1236,8 @@ class Http2AltSvcCacheTest {
                      START);
 
         assertThat(cache.select(target, false, _ -> false).port(), is(9443));
+        assertThat(invalidations, hasSize(1));
+        assertThat(expired.sameGeneration(invalidations.getFirst()), is(true));
 
         cache.close();
     }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -1035,6 +1035,27 @@ class Http2AltSvcCacheTest {
     }
 
     @Test
+    void withdrawalObservedBeforeFailureWinsWhenRecordedAfterFailure() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+
+        cache.record(target, header(START, "h2=\":8443\"; ma=3600"), true, false, START);
+        Http2AltSvcCache.Selection selection = cache.select(target, false, _ -> false);
+        Instant withdrawalObservedAt = START.plusSeconds(5);
+        AltSvcHeader withdrawal = header(withdrawalObservedAt, "clear");
+
+        clock.advance(Duration.ofSeconds(10));
+        cache.recordFailure(selection);
+        cache.record(target, withdrawal, true, false, withdrawalObservedAt);
+        clock.advance(Duration.ofMinutes(5));
+
+        assertThat(cache.select(target, false, _ -> false), nullValue());
+
+        cache.close();
+    }
+
+    @Test
     void failureAndMisdirectedResponseRejectDelayedAdvertisements() {
         MutableClock clock = new MutableClock(START);
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -473,6 +473,21 @@ class Http2AltSvcCacheTest {
         cache.record(proxyTarget, advertisement, true, false);
         assertThat(cache.select(proxyTarget, false, _ -> false), nullValue());
 
+        Proxy portScopedNoProxy = Proxy.builder()
+                .host("proxy.example")
+                .port(8181)
+                .addNoProxy("origin.example:443")
+                .build();
+        ClientConnectionTarget portScopedNoProxyTarget = target(tls,
+                                                                 "https",
+                                                                 "origin.example",
+                                                                 portScopedNoProxy,
+                                                                 DNS);
+        assertThat(portScopedNoProxyTarget.proxyRoute().direct(), is(true));
+        assertThat(portScopedNoProxyTarget.proxyRoute().addressBound(), is(false));
+        cache.record(portScopedNoProxyTarget, advertisement, true, false);
+        assertThat(cache.select(portScopedNoProxyTarget, false, _ -> false), nullValue());
+
         Proxy noProxy = Proxy.builder()
                 .host("proxy.example")
                 .port(8181)

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -1008,6 +1008,30 @@ class Http2AltSvcCacheTest {
     }
 
     @Test
+    void newerAdvertisementWinsOverDelayedWithdrawal() {
+        MutableClock clock = new MutableClock(START);
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });
+        ClientConnectionTarget target = target(Tls.builder().trustAll(true).build(), "origin.example");
+        Instant withdrawalObservedAt = START.plusSeconds(5);
+        AltSvcHeader delayedWithdrawal = header(withdrawalObservedAt, "clear");
+        Instant advertisementObservedAt = START.plusSeconds(10);
+
+        cache.record(target,
+                     header(advertisementObservedAt, "h2=\":9443\"; ma=60"),
+                     true,
+                     false,
+                     advertisementObservedAt);
+        Http2AltSvcCache.Selection selection = cache.select(target, false, _ -> false);
+        cache.record(target, delayedWithdrawal, true, false, withdrawalObservedAt);
+
+        assertThat(cache.select(target, false, _ -> false), sameInstance(selection));
+        assertThat(selection.port(), is(9443));
+        assertThat(cache.current(selection), is(true));
+
+        cache.close();
+    }
+
+    @Test
     void withdrawalWinsTiesAndRejectsDelayedAdvertisement() {
         MutableClock clock = new MutableClock(START);
         Http2AltSvcCache cache = Http2AltSvcCache.create(clock, _ -> { });

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -1370,7 +1370,7 @@ class Http2AltSvcCacheTest {
         for (String value : values) {
             headers.add(HeaderValues.create(HeaderNames.ALT_SVC, value));
         }
-        return AltSvcHeader.parse(ClientResponseHeaders.create(headers), observedAt).orElseThrow();
+        return AltSvcHeader.create(ClientResponseHeaders.create(headers), observedAt).orElseThrow();
     }
 
     private static ClientConnectionTarget target(Tls tls, String host) {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcCacheTest.java
@@ -1186,6 +1186,49 @@ class Http2AltSvcCacheTest {
     }
 
     @Test
+    void newWithdrawalEvictsOldestActiveRouteAtBound() {
+        MutableClock clock = new MutableClock(START);
+        List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();
+        Http2AltSvcCache cache = Http2AltSvcCache.create(clock, invalidations::add);
+        Tls tls = Tls.builder().trustAll(true).build();
+        AltSvcHeader advertisement = header(START, "h2=\":8443\"; ma=3600");
+        ClientConnectionTarget first = null;
+        ClientConnectionTarget last = null;
+
+        for (int index = 0; index < 1_000; index++) {
+            ClientConnectionTarget target = target(tls, "active-" + index + ".example");
+            if (index == 0) {
+                first = target;
+            }
+            if (index == 999) {
+                last = target;
+            }
+            cache.record(target, advertisement, true, false, START.plusNanos(index + 1));
+        }
+
+        ClientConnectionTarget withdrawn = target(tls, "withdrawn.example");
+        Instant withdrawal = START.plusSeconds(10);
+        cache.record(withdrawn, header(withdrawal, "clear"), true, false, withdrawal);
+
+        assertThat(cache.select(first, false, _ -> false), nullValue());
+        assertThat(cache.select(last, false, _ -> false), notNullValue());
+        assertThat(invalidations, hasSize(1));
+
+        Instant delayed = withdrawal.minusSeconds(1);
+        cache.record(withdrawn, header(delayed, "h2=\":9443\"; ma=3600"), true, false, delayed);
+
+        assertThat(cache.select(withdrawn, false, _ -> false), nullValue());
+
+        Instant newer = withdrawal.plusSeconds(1);
+        cache.record(withdrawn, header(newer, "h2=\":10443\"; ma=3600"), true, false, newer);
+
+        assertThat(cache.select(withdrawn, false, _ -> false).port(), is(10443));
+        assertThat(invalidations, hasSize(1));
+
+        cache.close();
+    }
+
+    @Test
     void evictsOldestInsertedOriginAtBoundDespiteRead() {
         MutableClock clock = new MutableClock(START);
         List<Http2AltSvcCache.Generation> invalidations = new ArrayList<>();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
@@ -59,6 +59,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -251,6 +252,48 @@ class Http2AltSvcClientTest {
 
             assertThat(context.client.supports(context.request, context.uri),
                        is(HttpClientSpi.SupportLevel.SUPPORTED));
+        }
+    }
+
+    @Test
+    void misdirectedDirectResponseDoesNotInstallAlternative() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID,
+                                                                    false,
+                                                                    Status.MISDIRECTED_REQUEST_421));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @Test
+    void misdirectedDirectResponseDoesNotReplaceOrClearAlternative() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            Instant observation = Instant.now();
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID,
+                                                                    false,
+                                                                    Status.OK_200,
+                                                                    responseHeaders(),
+                                                                    observation));
+
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID,
+                                                                    false,
+                                                                    Status.MISDIRECTED_REQUEST_421,
+                                                                    responseHeaders("h2=\":9443\"; ma=3600"),
+                                                                    observation.plusNanos(1)));
+            Http2AltSvcCache.Selection selection = context.client.connectionCache()
+                    .currentAlternative(context.target, false);
+            assertThat(selection, notNullValue());
+            assertThat(selection.port(), is(8443));
+
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID,
+                                                                    false,
+                                                                    Status.MISDIRECTED_REQUEST_421,
+                                                                    responseHeaders("clear"),
+                                                                    observation.plusNanos(2)));
+            assertThat(context.client.connectionCache().currentAlternative(context.target, false),
+                       sameInstance(selection));
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
@@ -45,6 +45,8 @@ import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.ResolvedClientTarget;
+import io.helidon.webclient.api.SniConfig;
+import io.helidon.webclient.api.SniMode;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.api.WebClientProtocolResponse;
 import io.helidon.webclient.http1.Http1Client;
@@ -163,6 +165,15 @@ class Http2AltSvcClientTest {
 
             assertThat(context.client.supports(context.request, context.uri),
                        is(HttpClientSpi.SupportLevel.SUPPORTED));
+        }
+    }
+
+    @Test
+    void supportsAlternativeWithHostHeaderSni() {
+        try (TestContext context = TestContext.createHostHeaderSni(ClientAltSvcConfig.create())) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri), is(HttpClientSpi.SupportLevel.SUPPORTED));
         }
     }
 
@@ -332,6 +343,18 @@ class Http2AltSvcClientTest {
         }
 
         private TestContext(Optional<ClientAltSvcConfig> altSvc, Tls tls, String scheme) {
+            this(altSvc,
+                 tls,
+                 scheme,
+                 Optional.empty(),
+                 ClientRequestHeaders.create(WritableHeaders.create()));
+        }
+
+        private TestContext(Optional<ClientAltSvcConfig> altSvc,
+                            Tls tls,
+                            String scheme,
+                            Optional<SniConfig> sni,
+                            ClientRequestHeaders requestHeaders) {
             Http2ClientConfig.Builder configBuilder = Http2ClientConfig.builder()
                     .shareConnectionCache(false)
                     .dnsResolver((_, _) -> InetAddress.getLoopbackAddress())
@@ -341,16 +364,15 @@ class Http2AltSvcClientTest {
             Http2ClientConfig clientConfig = configBuilder.buildPrototype();
             client = new Http2ClientImpl(mock(WebClient.class), clientConfig);
             uri = ClientUri.create(URI.create(scheme + "://origin.example/resource"));
-            ClientRequestHeaders requestHeaders = ClientRequestHeaders.create(WritableHeaders.create());
             request = mock(FullClientRequest.class);
             when(request.address()).thenReturn(Optional.empty());
-            when(request.sni()).thenReturn(Optional.empty());
+            when(request.sni()).thenReturn(sni);
             when(request.tls()).thenReturn(tls);
             when(request.proxy()).thenReturn(Proxy.noProxy());
             when(request.headers()).thenReturn(requestHeaders);
             when(request.connection()).thenReturn(Optional.empty());
             when(request.selectedProxyRoute()).thenReturn(Optional.empty());
-            connectionKey = Http2ConnectionKeys.create(uri, request, clientConfig);
+            connectionKey = Http2ConnectionKeys.create(uri, request, clientConfig, requestHeaders);
             target = ClientConnectionTarget.create(connectionKey, uri, requestHeaders);
             resolvedTarget = target.resolve();
         }
@@ -369,6 +391,19 @@ class Http2AltSvcClientTest {
 
         private static TestContext createPlain(ClientAltSvcConfig altSvc) {
             return new TestContext(Optional.of(altSvc), Tls.builder().build(), "http");
+        }
+
+        private static TestContext createHostHeaderSni(ClientAltSvcConfig altSvc) {
+            WritableHeaders<?> headers = WritableHeaders.create();
+            headers.set(HeaderNames.HOST, "service.example");
+            SniConfig sni = SniConfig.builder()
+                    .mode(SniMode.HOST_HEADER)
+                    .build();
+            return new TestContext(Optional.of(altSvc),
+                                   Tls.builder().build(),
+                                   "https",
+                                   Optional.of(sni),
+                                   ClientRequestHeaders.create(headers));
         }
 
         private WebClientProtocolResponse directResponse(String protocolId,

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
@@ -167,6 +167,30 @@ class Http2AltSvcClientTest {
     }
 
     @Test
+    void responseObservationTimeOrdersDelayedCallbacks() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            Instant newer = Instant.now();
+            Instant older = newer.minusSeconds(1);
+
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID,
+                                                                    false,
+                                                                    Status.OK_200,
+                                                                    responseHeaders("h2=\":9443\"; ma=3600"),
+                                                                    newer));
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID,
+                                                                    false,
+                                                                    Status.OK_200,
+                                                                    responseHeaders("h2=\":8443\"; ma=3600"),
+                                                                    older));
+
+            Http2AltSvcCache.Selection selection = context.client.connectionCache()
+                    .currentAlternative(context.target, false);
+            assertThat(selection, notNullValue());
+            assertThat(selection.port(), is(9443));
+        }
+    }
+
+    @Test
     void ignoresAdvertisementFromExplicitConnection() {
         try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
             context.client.responseReceived(context.directResponse(Http2Client.PROTOCOL_ID, true, Status.OK_200));
@@ -249,8 +273,12 @@ class Http2AltSvcClientTest {
     }
 
     private static ClientResponseHeaders responseHeaders() {
+        return responseHeaders("h2=\":8443\"; ma=3600");
+    }
+
+    private static ClientResponseHeaders responseHeaders(String value) {
         WritableHeaders<?> headers = WritableHeaders.create();
-        headers.set(HeaderNames.ALT_SVC, "h2=\":8443\"; ma=3600");
+        headers.set(HeaderNames.ALT_SVC, value);
         return ClientResponseHeaders.create(headers);
     }
 
@@ -346,12 +374,24 @@ class Http2AltSvcClientTest {
         private WebClientProtocolResponse directResponse(String protocolId,
                                                          boolean explicitConnection,
                                                          Status status) {
+            return directResponse(protocolId,
+                                  explicitConnection,
+                                  status,
+                                  responseHeaders(),
+                                  Instant.now());
+        }
+
+        private WebClientProtocolResponse directResponse(String protocolId,
+                                                         boolean explicitConnection,
+                                                         Status status,
+                                                         ClientResponseHeaders headers,
+                                                         Instant receivedAt) {
             return WebClientProtocolResponse.create(resolvedTarget,
                                                     explicitConnection,
                                                     protocolId,
                                                     status,
-                                                    responseHeaders(),
-                                                    Instant.now());
+                                                    headers,
+                                                    receivedAt);
         }
 
         @Override

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
@@ -202,6 +202,28 @@ class Http2AltSvcClientTest {
     }
 
     @Test
+    void clearAfterEmptyElementBoundInvalidatesAlternative() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            Instant advertisementTime = Instant.now();
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID,
+                                                                    false,
+                                                                    Status.OK_200,
+                                                                    responseHeaders(),
+                                                                    advertisementTime));
+            assertThat(context.client.supports(context.request, context.uri), is(HttpClientSpi.SupportLevel.SUPPORTED));
+
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID,
+                                                                    false,
+                                                                    Status.OK_200,
+                                                                    responseHeaders(",".repeat(33) + "clear"),
+                                                                    advertisementTime.plusNanos(1)));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @Test
     void ignoresAdvertisementFromExplicitConnection() {
         try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
             context.client.responseReceived(context.directResponse(Http2Client.PROTOCOL_ID, true, Status.OK_200));

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
@@ -298,6 +298,22 @@ class Http2AltSvcClientTest {
     }
 
     @Test
+    void repeatedFallbackAdvertisementDoesNotClearFailureBackoff() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+            Http2AltSvcCache.Selection selection = context.client.connectionCache()
+                    .currentAlternative(context.target, false);
+            assertThat(selection, notNullValue());
+
+            context.client.connectionCache().recordAlternativeFailure(selection);
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @Test
     void misdirectedAlternativeDoesNotReadvertiseItself() {
         try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
             context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcClientTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsConfig;
+import io.helidon.common.tls.TlsManager;
+import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriHost;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.api.ClientAltSvcConfig;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientConnectionTarget;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.ConnectionKey;
+import io.helidon.webclient.api.FullClientRequest;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.ResolvedClientTarget;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.api.WebClientProtocolResponse;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.spi.HttpClientSpi;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class Http2AltSvcClientTest {
+    @Test
+    void ignoresAdvertisementWhenAltSvcIsAbsent() {
+        try (TestContext context = TestContext.create()) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @Test
+    void noEntrySkipsFinalTargetResolution() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            clearInvocations((Object) context.request);
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+            verify(context.request, never()).headers();
+            verify(context.request, never()).selectedProxyRoute();
+        }
+    }
+
+    @Test
+    void explicitConnectionSkipsAdvertisedHost() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+            when(context.request.connection()).thenReturn(Optional.of(mock(ClientConnection.class)));
+            clearInvocations((Object) context.request);
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+            verify(context.request, never()).headers();
+            verify(context.request, never()).selectedProxyRoute();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("tcpProtocolIds")
+    void learnsH2AlternativeFromHttpsResponse(String protocolId) {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            assertThat(context.client.connectionCache().supports(context.connectionKey), is(false));
+
+            context.client.responseReceived(context.directResponse(protocolId, false, Status.OK_200));
+
+            assertThat(context.client.connectionCache().supports(context.connectionKey), is(false));
+            assertThat(context.client.supports(context.request, context.uri), is(HttpClientSpi.SupportLevel.SUPPORTED));
+
+            when(context.request.selectedProxyRoute()).thenReturn(Optional.of(context.target.proxyRoute()));
+            assertThat(context.client.supports(context.request, context.uri), is(HttpClientSpi.SupportLevel.SUPPORTED));
+        }
+    }
+
+    @Test
+    void ignoresAdvertisementFromPlainHttpOrigin() {
+        try (TestContext context = TestContext.createPlain(ClientAltSvcConfig.create())) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @Test
+    void ignoresAdvertisementWhenDisabled() {
+        ClientAltSvcConfig altSvc = ClientAltSvcConfig.builder()
+                .enabled(false)
+                .build();
+        try (TestContext context = TestContext.create(altSvc)) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("disallowedProtocols")
+    void ignoresAdvertisementWhenH2IsNotAllowed(String protocol) {
+        ClientAltSvcConfig altSvc = ClientAltSvcConfig.builder()
+                .addProtocol(protocol)
+                .build();
+        try (TestContext context = TestContext.create(altSvc)) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @Test
+    void learnsAdvertisementWhenH2IsAllowed() {
+        ClientAltSvcConfig altSvc = ClientAltSvcConfig.builder()
+                .addProtocol(Http2Client.PROTOCOL_ID)
+                .build();
+        try (TestContext context = TestContext.create(altSvc)) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.SUPPORTED));
+        }
+    }
+
+    @Test
+    void ignoresAdvertisementFromExplicitConnection() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            context.client.responseReceived(context.directResponse(Http2Client.PROTOCOL_ID, true, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @Test
+    void ignoresAdvertisementFromUnsupportedResponseProtocol() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            context.client.responseReceived(context.directResponse("h3", false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("userConfiguredTls")
+    void learnsAdvertisementWithUserConfiguredTls(Tls tls) {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create(), tls)) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.SUPPORTED));
+        }
+    }
+
+    @Test
+    void misdirectedAlternativeDoesNotReadvertiseItself() {
+        try (TestContext context = TestContext.create(ClientAltSvcConfig.create())) {
+            context.client.responseReceived(context.directResponse(Http1Client.PROTOCOL_ID, false, Status.OK_200));
+            Http2AltSvcCache.Selection selection = context.client.connectionCache()
+                    .currentAlternative(context.target, false);
+            assertThat(selection, notNullValue());
+            context.client.connectionCache().recordAlternativeMisdirected(selection);
+
+            ResolvedClientTarget alternativeTarget = context.target.resolve(selection.host(), selection.port(), 0);
+            WebClientProtocolResponse response = WebClientProtocolResponse.createAlternative(
+                    alternativeTarget,
+                    false,
+                    Http2Client.PROTOCOL_ID,
+                    Status.MISDIRECTED_REQUEST_421,
+                    responseHeaders(),
+                    Instant.now(),
+                    UriAuthority.create(UriHost.create(selection.host()), selection.port()));
+
+            context.client.responseReceived(response);
+
+            assertThat(context.client.supports(context.request, context.uri),
+                       is(HttpClientSpi.SupportLevel.NOT_SUPPORTED));
+        }
+    }
+
+    private static Stream<String> tcpProtocolIds() {
+        return Stream.of(Http1Client.PROTOCOL_ID, Http2Client.PROTOCOL_ID);
+    }
+
+    private static Stream<String> disallowedProtocols() {
+        return Stream.of("H2", "h3");
+    }
+
+    private static Stream<Tls> userConfiguredTls() {
+        return Stream.of(Tls.builder().trustAll(true).build(),
+                         Tls.builder()
+                                 .endpointIdentificationAlgorithm(Tls.ENDPOINT_IDENTIFICATION_NONE)
+                                 .build(),
+                         Tls.builder().sslContext(defaultSslContext()).build(),
+                         Tls.builder().manager(new TestTlsManager()).build());
+    }
+
+    private static SSLContext defaultSslContext() {
+        try {
+            return SSLContext.getDefault();
+        } catch (GeneralSecurityException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static ClientResponseHeaders responseHeaders() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.set(HeaderNames.ALT_SVC, "h2=\":8443\"; ma=3600");
+        return ClientResponseHeaders.create(headers);
+    }
+
+    private static final class TestTlsManager implements TlsManager {
+        private final SSLContext sslContext = defaultSslContext();
+
+        @Override
+        public void init(TlsConfig tls) {
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            return sslContext;
+        }
+
+        @Override
+        public Optional<X509KeyManager> keyManager() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<X509TrustManager> trustManager() {
+            return Optional.empty();
+        }
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public String type() {
+            return "test";
+        }
+    }
+
+    private static final class TestContext implements AutoCloseable {
+        private final Http2ClientImpl client;
+        private final FullClientRequest<?> request;
+        private final ClientUri uri;
+        private final ConnectionKey connectionKey;
+        private final ClientConnectionTarget target;
+        private final ResolvedClientTarget resolvedTarget;
+
+        private TestContext(Optional<ClientAltSvcConfig> altSvc) {
+            this(altSvc, Tls.builder().build(), "https");
+        }
+
+        private TestContext(Optional<ClientAltSvcConfig> altSvc, Tls tls) {
+            this(altSvc, tls, "https");
+        }
+
+        private TestContext(Optional<ClientAltSvcConfig> altSvc, Tls tls, String scheme) {
+            Http2ClientConfig.Builder configBuilder = Http2ClientConfig.builder()
+                    .shareConnectionCache(false)
+                    .dnsResolver((_, _) -> InetAddress.getLoopbackAddress())
+                    .tls(tls)
+                    .protocolConfig(Http2ClientProtocolConfig.create());
+            altSvc.ifPresent(configBuilder::altSvc);
+            Http2ClientConfig clientConfig = configBuilder.buildPrototype();
+            client = new Http2ClientImpl(mock(WebClient.class), clientConfig);
+            uri = ClientUri.create(URI.create(scheme + "://origin.example/resource"));
+            ClientRequestHeaders requestHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+            request = mock(FullClientRequest.class);
+            when(request.address()).thenReturn(Optional.empty());
+            when(request.sni()).thenReturn(Optional.empty());
+            when(request.tls()).thenReturn(tls);
+            when(request.proxy()).thenReturn(Proxy.noProxy());
+            when(request.headers()).thenReturn(requestHeaders);
+            when(request.connection()).thenReturn(Optional.empty());
+            when(request.selectedProxyRoute()).thenReturn(Optional.empty());
+            connectionKey = Http2ConnectionKeys.create(uri, request, clientConfig);
+            target = ClientConnectionTarget.create(connectionKey, uri, requestHeaders);
+            resolvedTarget = target.resolve();
+        }
+
+        private static TestContext create() {
+            return new TestContext(Optional.empty());
+        }
+
+        private static TestContext create(ClientAltSvcConfig altSvc) {
+            return new TestContext(Optional.of(altSvc));
+        }
+
+        private static TestContext create(ClientAltSvcConfig altSvc, Tls tls) {
+            return new TestContext(Optional.of(altSvc), tls);
+        }
+
+        private static TestContext createPlain(ClientAltSvcConfig altSvc) {
+            return new TestContext(Optional.of(altSvc), Tls.builder().build(), "http");
+        }
+
+        private WebClientProtocolResponse directResponse(String protocolId,
+                                                         boolean explicitConnection,
+                                                         Status status) {
+            return WebClientProtocolResponse.create(resolvedTarget,
+                                                    explicitConnection,
+                                                    protocolId,
+                                                    status,
+                                                    responseHeaders(),
+                                                    Instant.now());
+        }
+
+        @Override
+        public void close() {
+            client.closeResource();
+        }
+    }
+}

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
@@ -546,6 +546,19 @@ class Http2AltSvcTest {
     }
 
     @Test
+    void mixedClearRetiresAlternative() {
+        WebClient client = client(clientTls(), true, false);
+
+        try {
+            assertOrigin(request(client, "/learn-clear"));
+            assertAlternative(request(client, "/mixed-clear"));
+            assertOrigin(request(client, "/after-mixed-clear"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
     void misdirectedResponseInvalidatesWithoutRelearning() {
         WebClient client = client(clientTls(), true, false);
 
@@ -778,6 +791,8 @@ class Http2AltSvcTest {
                                                    "h2=\":%1$d\"; ma=3600, h3=\":%1$d\"; ma=3600"
                                                            .formatted(redirectTargetPort));
         case "clear" -> response.header(HeaderNames.ALT_SVC, "clear");
+        case "mixed-clear" -> response.header(HeaderNames.ALT_SVC,
+                                                advertisement(alternativePort, 3600) + ", clear");
         case "zero-age" -> response.header(HeaderNames.ALT_SVC, advertisement(alternativePort, 0));
         case "misdirected" -> response
                 .status(Status.MISDIRECTED_REQUEST_421)

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
@@ -209,7 +209,7 @@ class Http2AltSvcTest {
     }
 
     @Test
-    void dnsFreeCandidateReconstructsTargetsWithAndWithoutAuthorityOverride() {
+    void configuredNoProxyPolicyDoesNotUseAlternativeWithAuthorityOverride() {
         Proxy proxy = Proxy.builder()
                 .host("unused-proxy.invalid")
                 .port(8181)
@@ -230,14 +230,14 @@ class Http2AltSvcTest {
 
         try {
             assertOrigin(request(client, "/learn"));
-            assertAlternative(request(client, "/reuse"));
+            assertOrigin(request(client, "/reuse"));
 
             String authority = "Alt-Origin.EXAMPLE:" + originPort;
             Observation learnedOverride = requestWithHost(client, "/learn", authority);
             Observation reusedOverride = requestWithHost(client, "/reuse", authority);
 
             assertThat(learnedOverride.responseProtocol(), is(Http1Client.PROTOCOL_ID));
-            assertThat(reusedOverride.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(reusedOverride.responseProtocol(), is(Http1Client.PROTOCOL_ID));
         } finally {
             client.closeResource();
         }
@@ -250,6 +250,7 @@ class Http2AltSvcTest {
                 .shareConnectionCache(false)
                 .servicesDiscoverServices(false)
                 .altSvc(ClientAltSvcConfig.create())
+                .proxy(Proxy.noProxy())
                 .tls(clientTls()));
 
         try {
@@ -282,6 +283,7 @@ class Http2AltSvcTest {
                 .baseUri("https://localhost:" + originPort)
                 .shareConnectionCache(false)
                 .servicesDiscoverServices(false)
+                .proxy(Proxy.noProxy())
                 .tls(tls));
         Http2ClientImpl http2Client = (Http2ClientImpl) client;
         ClientConnectionTarget originTarget = ClientConnectionTarget.create(
@@ -297,10 +299,11 @@ class Http2AltSvcTest {
         responseHeaders.set(HeaderNames.ALT_SVC, advertisement(staleReusePort, 3600));
 
         try (Http2AltSvcCache alternatives = Http2AltSvcCache.create(_ -> { })) {
+            Instant observedAt = Instant.now();
             AltSvcHeader advertisement = AltSvcHeader.parse(ClientResponseHeaders.create(responseHeaders),
-                                                             Instant.now())
+                                                             observedAt)
                     .orElseThrow();
-            alternatives.record(originTarget, advertisement, true, false);
+            alternatives.record(originTarget, advertisement, true, false, observedAt);
             Http2AltSvcCache.Selection selection = alternatives.select(originTarget, false, _ -> false);
 
             AtomicInteger phase = new AtomicInteger();
@@ -369,6 +372,7 @@ class Http2AltSvcTest {
                 .addProtocolConfig(Http1ClientProtocolConfig.builder()
                                            .defaultKeepAlive(false)
                                            .build())
+                .proxy(Proxy.noProxy())
                 .tls(clientTls())
                 .build();
 
@@ -406,6 +410,7 @@ class Http2AltSvcTest {
                 .shareConnectionCache(false)
                 .servicesDiscoverServices(false)
                 .altSvc(ClientAltSvcConfig.create())
+                .proxy(Proxy.noProxy())
                 .tls(clientTls()));
 
         try {
@@ -423,6 +428,7 @@ class Http2AltSvcTest {
                 .shareConnectionCache(false)
                 .servicesDiscoverServices(false)
                 .altSvc(ClientAltSvcConfig.create())
+                .proxy(Proxy.noProxy())
                 .tls(clientTls()));
 
         try {
@@ -658,6 +664,7 @@ class Http2AltSvcTest {
                 .baseUri("https://localhost:" + alternativePort)
                 .shareConnectionCache(false)
                 .servicesDiscoverServices(false)
+                .proxy(Proxy.noProxy())
                 .tls(clientTls());
         altSvc.ifPresent(configBuilder::altSvc);
         Http2ClientConfig clientConfig = configBuilder.buildPrototype();
@@ -701,6 +708,7 @@ class Http2AltSvcTest {
                 .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
                 .altSvc(altSvc)
                 .addProtocolConfig(Http2ClientProtocolConfig.create())
+                .proxy(Proxy.noProxy())
                 .tls(tls)
                 .build();
     }
@@ -712,6 +720,7 @@ class Http2AltSvcTest {
                 .servicesDiscoverServices(false)
                 .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
                 .addProtocolConfig(Http2ClientProtocolConfig.create())
+                .proxy(Proxy.noProxy())
                 .tls(tls)
                 .build();
     }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
@@ -34,8 +34,10 @@ import io.helidon.common.pki.Keys;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2Headers;
 import io.helidon.webclient.api.AltSvcHeader;
 import io.helidon.webclient.api.ClientAltSvcConfig;
 import io.helidon.webclient.api.ClientConnectionTarget;
@@ -277,7 +279,7 @@ class Http2AltSvcTest {
     }
 
     @Test
-    void staleReusableAlternativeReleasesReservedStream() {
+    void staleReusableAlternativeReleasesReservedStreamAndRemainsTrackedUntilClose() {
         Tls tls = clientTls();
         Http2Client client = Http2Client.create(builder -> builder
                 .baseUri("https://localhost:" + originPort)
@@ -349,8 +351,16 @@ class Http2AltSvcTest {
 
                 assertThat(currentChecks.get(), is(2));
                 assertThat(reservationAttempted.get(), is(true));
-                recovered.stream().close();
                 handler.retire(selection);
+                handler.close();
+
+                Http2Headers requestHeaders = Http2Headers.create(WritableHeaders.create())
+                        .method(Method.GET)
+                        .scheme("https")
+                        .path("/")
+                        .authority("localhost");
+                assertThrows(IllegalStateException.class,
+                             () -> recovered.stream().writeHeaders(requestHeaders, true));
             } finally {
                 handler.close();
             }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
@@ -300,7 +300,7 @@ class Http2AltSvcTest {
 
         try (Http2AltSvcCache alternatives = Http2AltSvcCache.create(_ -> { })) {
             Instant observedAt = Instant.now();
-            AltSvcHeader advertisement = AltSvcHeader.parse(ClientResponseHeaders.create(responseHeaders),
+            AltSvcHeader advertisement = AltSvcHeader.create(ClientResponseHeaders.create(responseHeaders),
                                                              observedAt)
                     .orElseThrow();
             alternatives.record(originTarget, advertisement, true, false, observedAt);

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2AltSvcTest.java
@@ -1,0 +1,892 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.http2;
+
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SSLParameters;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.Keys;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.api.AltSvcHeader;
+import io.helidon.webclient.api.ClientAltSvcConfig;
+import io.helidon.webclient.api.ClientConnectionTarget;
+import io.helidon.webclient.api.ConnectionKey;
+import io.helidon.webclient.api.DnsAddressLookup;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.api.WebClientProtocolResponse;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientProtocolConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http1.Http1Config;
+import io.helidon.webserver.http1.Http1ConnectionSelector;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2ConnectionSelector;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ServerTest
+class Http2AltSvcTest {
+    private static final String ALTERNATIVE_SOCKET = "alternative";
+    private static final String REDIRECT_TARGET_SOCKET = "redirect-target";
+    private static final String STALE_REUSE_SOCKET = "stale-reuse";
+    private static final String ZERO_STREAM_SOCKET = "zero-stream";
+    private static final String ABSENT_HEADER = "-";
+    private static final AtomicInteger ZERO_STREAM_REQUESTS = new AtomicInteger();
+
+    private static int originPort;
+    private static int alternativePort;
+    private static int redirectTargetPort;
+    private static int staleReusePort;
+    private static int zeroStreamPort;
+
+    Http2AltSvcTest(WebServer server) {
+        originPort = server.port();
+        alternativePort = server.port(ALTERNATIVE_SOCKET);
+        redirectTargetPort = server.port(REDIRECT_TARGET_SOCKET);
+        staleReusePort = server.port(STALE_REUSE_SOCKET);
+        zeroStreamPort = server.port(ZERO_STREAM_SOCKET);
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder serverBuilder) {
+        Tls serverTls = serverTls();
+        HttpRouting.Builder originRouting = HttpRouting.builder()
+                .get("/{operation}", Http2AltSvcTest::originResponse);
+        HttpRouting.Builder alternativeRouting = HttpRouting.builder()
+                .get("/{operation}", Http2AltSvcTest::alternativeResponse);
+        HttpRouting.Builder zeroStreamRouting = HttpRouting.builder()
+                .get("/{operation}", Http2AltSvcTest::zeroStreamResponse);
+        HttpRouting.Builder redirectTargetRouting = HttpRouting.builder()
+                .get("/{operation}", Http2AltSvcTest::redirectTargetResponse);
+        HttpRouting.Builder staleReuseRouting = HttpRouting.builder()
+                .get("/{operation}", Http2AltSvcTest::alternativeResponse);
+
+        serverBuilder
+                .host("localhost")
+                .port(-1)
+                .tls(serverTls)
+                .protocolsDiscoverServices(false)
+                .addConnectionSelector(Http1ConnectionSelector.builder()
+                                               .config(Http1Config.create())
+                                               .build())
+                .putSocket(ALTERNATIVE_SOCKET, socket -> socket
+                        .host("localhost")
+                        .port(-1)
+                        .tls(serverTls)
+                        .protocolsDiscoverServices(false)
+                        .addConnectionSelector(Http2ConnectionSelector.builder()
+                                                       .http2Config(Http2Config.create())
+                                                       .build()))
+                .putSocket(ZERO_STREAM_SOCKET, socket -> socket
+                        .host("localhost")
+                        .port(-1)
+                        .tls(serverTls)
+                        .protocolsDiscoverServices(false)
+                        .addConnectionSelector(Http2ConnectionSelector.builder()
+                                                       .http2Config(Http2Config.builder()
+                                                                            .maxConcurrentStreams(0)
+                                                                            .build())
+                                                       .build()))
+                .putSocket(REDIRECT_TARGET_SOCKET, socket -> socket
+                        .host("localhost")
+                        .port(-1)
+                        .tls(serverTls)
+                        .protocolsDiscoverServices(false)
+                        .addConnectionSelector(Http2ConnectionSelector.builder()
+                                                       .http2Config(Http2Config.create())
+                                                       .build()))
+                .putSocket(STALE_REUSE_SOCKET, socket -> socket
+                        .host("localhost")
+                        .port(-1)
+                        .tls(serverTls)
+                        .protocolsDiscoverServices(false)
+                        .addConnectionSelector(Http2ConnectionSelector.builder()
+                                                       .http2Config(Http2Config.builder()
+                                                                            .maxConcurrentStreams(1)
+                                                                            .build())
+                                                       .build()))
+                .routing(originRouting)
+                .routing(ALTERNATIVE_SOCKET, alternativeRouting)
+                .routing(ZERO_STREAM_SOCKET, zeroStreamRouting)
+                .routing(REDIRECT_TARGET_SOCKET, redirectTargetRouting)
+                .routing(STALE_REUSE_SOCKET, staleReuseRouting);
+    }
+
+    @Test
+    void learnsAndReusesAlternativeWithOriginIdentity() {
+        WebClient client = client(clientTls(), true, false);
+
+        try {
+            Observation learned = request(client, "/learn");
+            Observation firstAlternative = request(client, "/reuse");
+            Observation reusedAlternative = request(client, "/reuse");
+
+            assertOrigin(learned);
+            assertAlternative(firstAlternative);
+            assertAlternative(reusedAlternative);
+            assertThat(reusedAlternative.socketId(), is(firstAlternative.socketId()));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void dnsCaseVariantsShareAdvertisementButKeepConnectionPoolsDistinct() {
+        WebClient client = client(clientTls(), true, false);
+        String upperOrigin = "https://LOCALHOST:" + originPort;
+        String lowerOrigin = "https://localhost:" + originPort;
+
+        try {
+            Observation learned = requestUri(client, upperOrigin + "/learn");
+            Observation lowerAlternative = requestUri(client, lowerOrigin + "/reuse");
+            Observation upperAlternative = requestUri(client, upperOrigin + "/reuse");
+            Observation lowerReused = requestUri(client, lowerOrigin + "/reuse");
+            Observation upperReused = requestUri(client, upperOrigin + "/reuse");
+
+            assertThat(learned.responseProtocol(), is(Http1Client.PROTOCOL_ID));
+            assertThat(lowerAlternative.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(upperAlternative.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(lowerAlternative.socketId(), not(is(upperAlternative.socketId())));
+            assertThat(lowerReused.socketId(), is(lowerAlternative.socketId()));
+            assertThat(upperReused.socketId(), is(upperAlternative.socketId()));
+
+            Observation cleared = requestUri(client, lowerOrigin + "/clear");
+            assertThat(cleared.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(requestUri(client, upperOrigin + "/reuse").responseProtocol(), is(Http1Client.PROTOCOL_ID));
+            assertThat(requestUri(client, lowerOrigin + "/reuse").responseProtocol(), is(Http1Client.PROTOCOL_ID));
+
+            assertThat(requestUri(client, lowerOrigin + "/learn").responseProtocol(), is(Http1Client.PROTOCOL_ID));
+            Observation reverseAlternative = requestUri(client, upperOrigin + "/reuse");
+            assertThat(reverseAlternative.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(reverseAlternative.socketId(), not(is(upperAlternative.socketId())));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void dnsFreeCandidateReconstructsTargetsWithAndWithoutAuthorityOverride() {
+        Proxy proxy = Proxy.builder()
+                .host("unused-proxy.invalid")
+                .port(8181)
+                .addNoProxy("localhost")
+                .addNoProxy("127.0.0.1")
+                .build();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + originPort)
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                .altSvc(ClientAltSvcConfig.create())
+                .addProtocolConfig(Http2ClientProtocolConfig.create())
+                .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                .proxy(proxy)
+                .tls(clientTls())
+                .build();
+
+        try {
+            assertOrigin(request(client, "/learn"));
+            assertAlternative(request(client, "/reuse"));
+
+            String authority = "Alt-Origin.EXAMPLE:" + originPort;
+            Observation learnedOverride = requestWithHost(client, "/learn", authority);
+            Observation reusedOverride = requestWithHost(client, "/reuse", authority);
+
+            assertThat(learnedOverride.responseProtocol(), is(Http1Client.PROTOCOL_ID));
+            assertThat(reusedOverride.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void protocolSpecificClientLearnsWithPrivateCache() {
+        Http2Client client = Http2Client.create(builder -> builder
+                .baseUri("https://localhost:" + originPort)
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .altSvc(ClientAltSvcConfig.create())
+                .tls(clientTls()));
+
+        try {
+            assertOrigin(request(client, "/learn"));
+            assertAlternative(request(client, "/reuse"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void zeroStreamAlternativeFallsBackBeforeSendingRequest() {
+        ZERO_STREAM_REQUESTS.set(0);
+        WebClient client = client(clientTls(), true, false);
+
+        try {
+            assertOrigin(request(client, "/learn-zero-stream"));
+            assertOrigin(request(client, "/zero-stream-fallback"));
+            assertOrigin(request(client, "/zero-stream-fallback"));
+            assertThat(ZERO_STREAM_REQUESTS.get(), is(0));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void staleReusableAlternativeReleasesReservedStream() {
+        Tls tls = clientTls();
+        Http2Client client = Http2Client.create(builder -> builder
+                .baseUri("https://localhost:" + originPort)
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .tls(tls));
+        Http2ClientImpl http2Client = (Http2ClientImpl) client;
+        ClientConnectionTarget originTarget = ClientConnectionTarget.create(
+                ConnectionKey.create("https",
+                                     "localhost",
+                                     originPort,
+                                     tls,
+                                     (_, _) -> InetAddress.getLoopbackAddress(),
+                                     DnsAddressLookup.IPV4,
+                                     Proxy.noProxy()),
+                "https");
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+        responseHeaders.set(HeaderNames.ALT_SVC, advertisement(staleReusePort, 3600));
+
+        try (Http2AltSvcCache alternatives = Http2AltSvcCache.create(_ -> { })) {
+            AltSvcHeader advertisement = AltSvcHeader.parse(ClientResponseHeaders.create(responseHeaders),
+                                                             Instant.now())
+                    .orElseThrow();
+            alternatives.record(originTarget, advertisement, true, false);
+            Http2AltSvcCache.Selection selection = alternatives.select(originTarget, false, _ -> false);
+
+            AtomicInteger phase = new AtomicInteger();
+            AtomicInteger currentChecks = new AtomicInteger();
+            AtomicBoolean reservationAttempted = new AtomicBoolean();
+            Http2ClientConnectionHandler handler = new Http2ClientConnectionHandler(1, _ -> switch (phase.get()) {
+                case 0 -> true;
+                case 1 -> currentChecks.getAndIncrement() == 0;
+                case 2 -> currentChecks.getAndIncrement() == 0 || reservationAttempted.get();
+                default -> false;
+            });
+            Http2ClientRequestImpl request = mock(Http2ClientRequestImpl.class);
+            when(request.readTimeout()).thenAnswer(_ -> {
+                reservationAttempted.set(true);
+                return Duration.ofSeconds(1);
+            });
+            Http1FallbackHandler fallbackHandler = new Http1FallbackHandler(new CompletableFuture<>(), _ -> null, true);
+            try {
+                Http2ConnectionAttemptResult established = handler.newAlternativeStream(http2Client,
+                                                                                         selection,
+                                                                                         request,
+                                                                                         fallbackHandler);
+                established.stream().close();
+
+                phase.set(1);
+                currentChecks.set(0);
+                reservationAttempted.set(false);
+                AlternativeConnectionException stale = assertThrows(
+                        AlternativeConnectionException.class,
+                        () -> handler.newAlternativeStream(http2Client, selection, request, fallbackHandler));
+
+                assertThat(stale.reason(), is(AlternativeConnectionException.Reason.STALE));
+                assertThat(currentChecks.get(), is(2));
+                assertThat(reservationAttempted.get(), is(true));
+
+                phase.set(2);
+                currentChecks.set(0);
+                reservationAttempted.set(false);
+                Http2ConnectionAttemptResult recovered = handler.newAlternativeStream(http2Client,
+                                                                                       selection,
+                                                                                       request,
+                                                                                       fallbackHandler);
+
+                assertThat(currentChecks.get(), is(2));
+                assertThat(reservationAttempted.get(), is(true));
+                recovered.stream().close();
+                handler.retire(selection);
+            } finally {
+                handler.close();
+            }
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void privateHttp1FallbackUsesConfiguredKeepAlive() {
+        ZERO_STREAM_REQUESTS.set(0);
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + originPort)
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                .altSvc(ClientAltSvcConfig.create())
+                .addProtocolConfig(Http2ClientProtocolConfig.create())
+                .addProtocolConfig(Http1ClientProtocolConfig.builder()
+                                           .defaultKeepAlive(false)
+                                           .build())
+                .tls(clientTls())
+                .build();
+
+        try {
+            assertOrigin(request(client, "/learn-zero-stream"));
+
+            Observation firstFallback = request(client, "/configured-h1-keep-alive");
+            Observation secondFallback = request(client, "/configured-h1-keep-alive");
+
+            assertOrigin(firstFallback);
+            assertOrigin(secondFallback);
+            assertThat(secondFallback.socketId(), not(is(firstFallback.socketId())));
+            assertThat(ZERO_STREAM_REQUESTS.get(), is(0));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void http1OutputStreamRedirectPublishesFinalClearLast() {
+        WebClient client = client(clientTls(), true, false);
+
+        try {
+            assertOrigin(outputStream(client, "/h1-output-redirect"));
+            assertOrigin(request(client, "/reuse"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void privateHttp1FallbackOutputStreamRedirectPublishesFinalClearLast() {
+        Http2Client client = Http2Client.create(builder -> builder
+                .baseUri("https://localhost:" + originPort)
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .altSvc(ClientAltSvcConfig.create())
+                .tls(clientTls()));
+
+        try {
+            assertOrigin(outputStream(client, "/h1-output-redirect"));
+            assertOrigin(request(client, "/reuse"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void http2OutputStreamRedirectPublishesIntermediateAdvertisement() {
+        Http2Client client = Http2Client.create(builder -> builder
+                .baseUri("https://localhost:" + alternativePort)
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .altSvc(ClientAltSvcConfig.create())
+                .tls(clientTls()));
+
+        try {
+            Observation redirected = outputStream(client, "/h2-output-redirect");
+            assertThat(redirected.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(redirected.serverProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(redirected.authority(), is("localhost:" + alternativePort));
+            assertThat(redirected.altUsed(), is("localhost:" + redirectTargetPort));
+
+            Observation alternative = request(client, "/redirect-reuse");
+            assertThat(alternative.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(alternative.serverProtocol(), is(Http2Client.PROTOCOL_ID));
+            assertThat(alternative.authority(), is("localhost:" + alternativePort));
+            assertThat(alternative.altUsed(), is("localhost:" + redirectTargetPort));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void disabledAltSvcStaysOnOrigin() {
+        WebClient client = client(clientTls(), false, false);
+
+        try {
+            assertOrigin(request(client, "/learn"));
+            assertOrigin(request(client, "/reuse"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void absentAltSvcStaysOnOrigin() {
+        WebClient client = clientWithoutAltSvc(clientTls(), false);
+
+        try {
+            assertOrigin(request(client, "/learn"));
+            assertOrigin(request(client, "/reuse"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void absentAltSvcDoesNotDispatchProtocolResponse() {
+        CaptureResult result = captureProtocolResponse(Optional.empty());
+
+        assertThat(result.notificationCount(), is(0));
+        assertThat(result.h2SelectionEnabled(), is(false));
+        assertThat(result.h2AlternativeAvailable(), is(false));
+    }
+
+    @Test
+    void disabledAltSvcDoesNotDispatchProtocolResponse() {
+        ClientAltSvcConfig altSvc = ClientAltSvcConfig.builder()
+                .enabled(false)
+                .build();
+        CaptureResult result = captureProtocolResponse(Optional.of(altSvc));
+
+        assertThat(result.notificationCount(), is(0));
+        assertThat(result.h2SelectionEnabled(), is(false));
+        assertThat(result.h2AlternativeAvailable(), is(false));
+    }
+
+    @Test
+    void h3OnlyAltSvcDispatchesWithoutTeachingHttp2() {
+        ClientAltSvcConfig altSvc = ClientAltSvcConfig.builder()
+                .addProtocol("h3")
+                .build();
+        CaptureResult result = captureProtocolResponse(Optional.of(altSvc));
+
+        assertThat(result.notificationCount(), is(1));
+        assertThat(result.h2SelectionEnabled(), is(false));
+        assertThat(result.h2AlternativeAvailable(), is(false));
+    }
+
+    @Test
+    void addressBoundProxyBypassDoesNotUseAlternative() {
+        Proxy proxy = Proxy.builder()
+                .host("unused-proxy.invalid")
+                .port(8181)
+                .addNoProxy("127.0.0.1")
+                .build();
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + originPort)
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                .altSvc(ClientAltSvcConfig.create())
+                .addProtocolConfig(Http2ClientProtocolConfig.builder().build())
+                .dnsResolver((_, _) -> InetAddress.ofLiteral("127.0.0.1"))
+                .proxy(proxy)
+                .tls(clientTls())
+                .build();
+
+        try {
+            assertOrigin(request(client, "/learn"));
+            assertOrigin(request(client, "/reuse"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void clearRetiresAlternative() {
+        WebClient client = client(clientTls(), true, false);
+
+        try {
+            assertOrigin(request(client, "/learn-clear"));
+            assertAlternative(request(client, "/clear"));
+            assertOrigin(request(client, "/after-clear"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void misdirectedResponseInvalidatesWithoutRelearning() {
+        WebClient client = client(clientTls(), true, false);
+
+        try {
+            assertOrigin(request(client, "/learn-misdirected"));
+            Observation misdirected = request(client, "/misdirected");
+
+            assertAlternativeIdentity(misdirected);
+            assertThat(misdirected.status(), is(Status.MISDIRECTED_REQUEST_421));
+            assertOrigin(request(client, "/after-misdirected"));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void zeroMaximumAgeReusesEstablishedAlternative() {
+        WebClient client = client(clientTls(), true, false);
+
+        try {
+            assertOrigin(request(client, "/learn-zero-age"));
+            Observation zeroAge = request(client, "/zero-age");
+            Observation reused = request(client, "/after-zero-age");
+
+            assertAlternative(zeroAge);
+            assertAlternative(reused);
+            assertThat(reused.socketId(), is(zeroAge.socketId()));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void tlsReloadRequiresFreshOriginBootstrapAndAlternativeConnection() {
+        Tls tls = clientTls();
+        WebClient client = client(tls, true, false);
+
+        try {
+            assertOrigin(request(client, "/tls-reload"));
+            Observation firstAlternative = request(client, "/reuse");
+
+            tls.reload(clientTls());
+
+            assertOrigin(request(client, "/tls-reload"));
+            Observation reloadedAlternative = request(client, "/reuse");
+
+            assertAlternative(firstAlternative);
+            assertAlternative(reloadedAlternative);
+            assertThat(reloadedAlternative.socketId(), not(is(firstAlternative.socketId())));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
+    void privateCachesDoNotShareLearnedAlternative() {
+        Tls tls = clientTls();
+        WebClient learningClient = client(tls, true, false);
+        WebClient isolatedClient = client(tls, true, false);
+
+        try {
+            assertOrigin(request(learningClient, "/learn-private"));
+            assertOrigin(request(isolatedClient, "/private-isolation"));
+            assertAlternative(request(learningClient, "/private-isolation"));
+        } finally {
+            learningClient.closeResource();
+            isolatedClient.closeResource();
+        }
+    }
+
+    @Test
+    void sharedCacheSurvivesClosingLearningClient() {
+        Tls tls = clientTls();
+        WebClient learningClient = client(tls, true, true);
+        WebClient reusingClient = client(tls, true, true);
+
+        try {
+            assertOrigin(request(learningClient, "/learn-shared"));
+            learningClient.closeResource();
+
+            Observation firstAlternative = request(reusingClient, "/shared-reuse");
+            Observation reusedAlternative = request(reusingClient, "/shared-reuse");
+
+            assertAlternative(firstAlternative);
+            assertAlternative(reusedAlternative);
+            assertThat(reusedAlternative.socketId(), is(firstAlternative.socketId()));
+        } finally {
+            learningClient.closeResource();
+            reusingClient.closeResource();
+        }
+    }
+
+    @Test
+    void disabledAndRestrictedClientsDoNotConsumeSharedAlternative() {
+        Tls tls = clientTls();
+        WebClient learningClient = client(tls, true, true);
+        WebClient disabledClient = client(tls, false, true);
+        WebClient restrictedClient = client(tls,
+                                            ClientAltSvcConfig.builder().addProtocol("h3").build(),
+                                            true);
+
+        try {
+            assertOrigin(request(learningClient, "/learn-shared-policy"));
+            assertOrigin(request(disabledClient, "/shared-policy"));
+            assertOrigin(request(restrictedClient, "/shared-policy"));
+            assertAlternative(request(learningClient, "/shared-policy"));
+        } finally {
+            learningClient.closeResource();
+            disabledClient.closeResource();
+            restrictedClient.closeResource();
+        }
+    }
+
+    private static CaptureResult captureProtocolResponse(Optional<ClientAltSvcConfig> altSvc) {
+        Http2ClientConfig.Builder configBuilder = Http2ClientConfig.builder()
+                .baseUri("https://localhost:" + alternativePort)
+                .shareConnectionCache(false)
+                .servicesDiscoverServices(false)
+                .tls(clientTls());
+        altSvc.ifPresent(configBuilder::altSvc);
+        Http2ClientConfig clientConfig = configBuilder.buildPrototype();
+        WebClient webClient = WebClient.create(builder -> builder.from(clientConfig));
+        List<WebClientProtocolResponse> notifications = new ArrayList<>();
+        Http2ClientImpl client = new Http2ClientImpl(webClient, clientConfig) {
+            @Override
+            public void responseReceived(WebClientProtocolResponse response) {
+                notifications.add(response);
+                super.responseReceived(response);
+            }
+        };
+
+        try {
+            request(client, "/capture-policy");
+            boolean alternativeAvailable = notifications.stream()
+                    .findFirst()
+                    .map(response -> client.connectionCache()
+                            .currentAlternative(response.target().logicalTarget(), false) != null)
+                    .orElse(false);
+            return new CaptureResult(notifications.size(), client.altSvcEnabled(), alternativeAvailable);
+        } finally {
+            client.closeResource();
+            webClient.closeResource();
+        }
+    }
+
+    private static WebClient client(Tls tls, boolean altSvcEnabled, boolean shareConnectionCache) {
+        return client(tls,
+                      ClientAltSvcConfig.builder().enabled(altSvcEnabled).build(),
+                      shareConnectionCache);
+    }
+
+    private static WebClient client(Tls tls,
+                                    ClientAltSvcConfig altSvc,
+                                    boolean shareConnectionCache) {
+        return WebClient.builder()
+                .baseUri("https://localhost:" + originPort)
+                .shareConnectionCache(shareConnectionCache)
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                .altSvc(altSvc)
+                .addProtocolConfig(Http2ClientProtocolConfig.create())
+                .tls(tls)
+                .build();
+    }
+
+    private static WebClient clientWithoutAltSvc(Tls tls, boolean shareConnectionCache) {
+        return WebClient.builder()
+                .baseUri("https://localhost:" + originPort)
+                .shareConnectionCache(shareConnectionCache)
+                .servicesDiscoverServices(false)
+                .protocolPreference(List.of(Http2Client.PROTOCOL_ID, Http1Client.PROTOCOL_ID))
+                .addProtocolConfig(Http2ClientProtocolConfig.create())
+                .tls(tls)
+                .build();
+    }
+
+    private static Tls clientTls() {
+        return Tls.builder()
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+    }
+
+    private static Tls serverTls() {
+        Keys keys = Keys.builder()
+                .keystore(store -> store
+                        .keystore(Resource.create("server.p12"))
+                        .passphrase("password"))
+                .build();
+        SSLParameters sslParameters = new SSLParameters();
+        sslParameters.setSNIMatchers(List.of(SNIHostName.createSNIMatcher("localhost")));
+
+        return Tls.builder()
+                .privateKey(keys)
+                .privateKeyCertChain(keys)
+                .sslParameters(sslParameters)
+                .build();
+    }
+
+    private static void originResponse(ServerRequest request, ServerResponse response) {
+        String operation = request.path().pathParameters().get("operation");
+        switch (operation) {
+        case "learn", "learn-clear", "learn-misdirected", "learn-zero-age", "learn-private", "learn-shared",
+                "learn-shared-policy", "tls-reload" -> response.header(HeaderNames.ALT_SVC,
+                                                                         advertisement(alternativePort, 3600));
+        case "learn-zero-stream" -> response.header(HeaderNames.ALT_SVC, advertisement(zeroStreamPort, 3600));
+        case "h1-output-redirect" -> response
+                .status(Status.TEMPORARY_REDIRECT_307)
+                .header(HeaderNames.LOCATION, "/h1-output-final")
+                .header(HeaderNames.ALT_SVC, advertisement(alternativePort, 3600));
+        case "h1-output-final" -> response.header(HeaderNames.ALT_SVC, "clear");
+        case "configured-h1-keep-alive" -> response
+                .header(HeaderNames.ALT_SVC, advertisement(zeroStreamPort, 3600));
+        default -> {
+        }
+        }
+        sendObservation(request, response, Http1Client.PROTOCOL_ID);
+    }
+
+    private static void alternativeResponse(ServerRequest request, ServerResponse response) {
+        String operation = request.path().pathParameters().get("operation");
+        switch (operation) {
+        case "capture-policy" -> response.header(HeaderNames.ALT_SVC,
+                                                   "h2=\":%1$d\"; ma=3600, h3=\":%1$d\"; ma=3600"
+                                                           .formatted(redirectTargetPort));
+        case "clear" -> response.header(HeaderNames.ALT_SVC, "clear");
+        case "zero-age" -> response.header(HeaderNames.ALT_SVC, advertisement(alternativePort, 0));
+        case "misdirected" -> response
+                .status(Status.MISDIRECTED_REQUEST_421)
+                .header(HeaderNames.ALT_SVC, advertisement(alternativePort, 3600));
+        case "h2-output-redirect" -> response
+                .status(Status.TEMPORARY_REDIRECT_307)
+                .header(HeaderNames.LOCATION, "/h2-output-final")
+                .header(HeaderNames.ALT_SVC, advertisement(redirectTargetPort, 3600));
+        default -> {
+        }
+        }
+        sendObservation(request, response, Http2Client.PROTOCOL_ID);
+    }
+
+    private static void zeroStreamResponse(ServerRequest request, ServerResponse response) {
+        ZERO_STREAM_REQUESTS.incrementAndGet();
+        sendObservation(request, response, Http2Client.PROTOCOL_ID);
+    }
+
+    private static void redirectTargetResponse(ServerRequest request, ServerResponse response) {
+        sendObservation(request, response, Http2Client.PROTOCOL_ID);
+    }
+
+    private static void sendObservation(ServerRequest request, ServerResponse response, String serverProtocol) {
+        String altUsed = request.headers().first(HeaderNames.ALT_USED).orElse(ABSENT_HEADER);
+        String sniHost = request.sniRequestedHost().orElse(ABSENT_HEADER);
+        response.send(serverProtocol
+                              + "|" + request.requestedUri().authority()
+                              + "|" + altUsed
+                              + "|" + sniHost
+                              + "|" + request.socketId());
+    }
+
+    private static String advertisement(int port, long maxAgeSeconds) {
+        return "h2=\":%d\"; ma=%d".formatted(port, maxAgeSeconds);
+    }
+
+    private static Observation request(WebClient client, String path) {
+        try (HttpClientResponse response = client.get(path).request()) {
+            return observation(response);
+        }
+    }
+
+    private static Observation request(Http2Client client, String path) {
+        try (HttpClientResponse response = client.get(path).request()) {
+            return observation(response);
+        }
+    }
+
+    private static Observation requestUri(WebClient client, String uri) {
+        try (HttpClientResponse response = client.get().uri(uri).request()) {
+            return observation(response);
+        }
+    }
+
+    private static Observation requestWithHost(WebClient client, String path, String authority) {
+        try (HttpClientResponse response = client.get(path)
+                .header(HeaderNames.HOST, authority)
+                .request()) {
+            return observation(response);
+        }
+    }
+
+    private static Observation outputStream(WebClient client, String path) {
+        try (HttpClientResponse response = client.get(path).outputStream(OutputStream::close)) {
+            return observation(response);
+        }
+    }
+
+    private static Observation outputStream(Http2Client client, String path) {
+        try (HttpClientResponse response = client.get(path).outputStream(OutputStream::close)) {
+            return observation(response);
+        }
+    }
+
+    private static Observation observation(HttpClientResponse response) {
+        String[] fields = response.as(String.class).split("\\|", -1);
+        assertThat("server observation field count", fields.length, is(5));
+        return new Observation(response.status(),
+                               response.protocolId(),
+                               fields[0],
+                               fields[1],
+                               fields[2],
+                               fields[3],
+                               fields[4]);
+    }
+
+    private static void assertOrigin(Observation observation) {
+        assertThat(observation.status(), is(Status.OK_200));
+        assertThat(observation.responseProtocol(), is(Http1Client.PROTOCOL_ID));
+        assertThat(observation.serverProtocol(), is(Http1Client.PROTOCOL_ID));
+        assertThat(observation.authority(), is("localhost:" + originPort));
+        assertThat(observation.altUsed(), is(ABSENT_HEADER));
+    }
+
+    private static void assertAlternative(Observation observation) {
+        assertThat(observation.status(), is(Status.OK_200));
+        assertAlternativeIdentity(observation);
+    }
+
+    private static void assertAlternativeIdentity(Observation observation) {
+        assertThat(observation.responseProtocol(), is(Http2Client.PROTOCOL_ID));
+        assertThat(observation.serverProtocol(), is(Http2Client.PROTOCOL_ID));
+        assertThat(observation.authority(), is("localhost:" + originPort));
+        assertThat(observation.altUsed(), is("localhost:" + alternativePort));
+    }
+
+    private record CaptureResult(int notificationCount,
+                                 boolean h2SelectionEnabled,
+                                 boolean h2AlternativeAvailable) {
+    }
+
+    private record Observation(Status status,
+                               String responseProtocol,
+                               String serverProtocol,
+                               String authority,
+                               String altUsed,
+                               String sniHost,
+                               String socketId) {
+    }
+}

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -18,9 +18,11 @@ package io.helidon.webclient.http2;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -36,6 +38,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketContext;
+import io.helidon.common.tls.Tls;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
@@ -59,6 +62,12 @@ import io.helidon.http.http2.Http2Settings;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientConnectionTarget;
+import io.helidon.webclient.api.ConnectionKey;
+import io.helidon.webclient.api.DnsAddressLookup;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.ResolvedClientTarget;
+import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.WebClient;
 
 import org.junit.jupiter.api.Test;
@@ -2241,6 +2250,28 @@ class Http2ClientConnectionTest {
         }
     }
 
+    @Test
+    void retainsResolvedPhysicalTarget() {
+        Tls tls = Tls.builder().enabled(false).build();
+        ConnectionKey connectionKey = ConnectionKey.create("https",
+                                                           "origin.example",
+                                                           443,
+                                                           tls,
+                                                           (_, _) -> InetAddress.getLoopbackAddress(),
+                                                           DnsAddressLookup.IPV4,
+                                                           Proxy.noProxy());
+        ClientConnectionTarget logicalTarget = ClientConnectionTarget.create(connectionKey, "https");
+        ResolvedClientTarget resolvedTarget = logicalTarget.resolve("origin.example", 8443, 17);
+        TcpClientConnection tcpConnection = mock(TcpClientConnection.class);
+        when(tcpConnection.resolvedTarget()).thenReturn(Optional.of(resolvedTarget));
+
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext(tcpConnection)) {
+            Http2ClientConnection connection = new Http2ClientConnection(test.client, tcpConnection);
+
+            assertThat(connection.resolvedTarget(), is(Optional.of(resolvedTarget)));
+        }
+    }
+
     @FunctionalInterface
     private interface ConnectionFactory<T extends Http2ClientConnection> {
         T create(Http2ClientImpl client, ClientConnection clientConnection);
@@ -2264,6 +2295,10 @@ class Http2ClientConnectionTest {
         private final ClientConnection clientConnection;
 
         private MockedConnectionTestContext() {
+            this(mock(ClientConnection.class));
+        }
+
+        private MockedConnectionTestContext(ClientConnection clientConnection) {
             Http2ClientProtocolConfig protocolConfig = Http2ClientProtocolConfig.builder()
                     .ping(true)
                     .pingTimeout(Duration.ofMillis(100))
@@ -2274,7 +2309,7 @@ class Http2ClientConnectionTest {
                     .buildPrototype();
 
             this.client = mock(Http2ClientImpl.class);
-            this.clientConnection = mock(ClientConnection.class);
+            this.clientConnection = clientConnection;
             WebClient webClient = mock(WebClient.class);
 
             doAnswer(invocation -> {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -149,7 +149,7 @@ class Http2ConnectionCacheTest {
                 "https");
         WritableHeaders<?> responseHeaders = WritableHeaders.create();
         responseHeaders.add(HeaderValues.create(HeaderNames.ALT_SVC, "h2=\":8443\"; ma=0"));
-        AltSvcHeader advertisement = AltSvcHeader.parse(ClientResponseHeaders.create(responseHeaders), clock.instant())
+        AltSvcHeader advertisement = AltSvcHeader.create(ClientResponseHeaders.create(responseHeaders), clock.instant())
                 .orElseThrow();
         alternatives.record(originTarget, advertisement, true, false, clock.instant());
         Http2AltSvcCache.Selection selection = alternatives.select(originTarget, false, _ -> true);

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -25,6 +25,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
@@ -131,6 +137,76 @@ class Http2ConnectionCacheTest {
     void rejectsNonPositiveConnectionCacheSize() {
         assertThrows(IllegalArgumentException.class, () -> new Http2ClientConnectionHandler(0));
         assertThrows(IllegalArgumentException.class, () -> new Http2ClientConnectionHandler(-1));
+    }
+
+    @Test
+    void unrelatedInvalidationDoesNotWaitForHandlerSetup() throws Exception {
+        Clock clock = Clock.fixed(Instant.parse("2026-08-27T00:00:00Z"), ZoneOffset.UTC);
+        Http2ClientConnectionHandler handler = new Http2ClientConnectionHandler(1);
+        Http2AltSvcCache alternatives = Http2AltSvcCache.create(clock, handler::retire);
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget originTarget = ClientConnectionTarget.create(
+                ConnectionKey.create("https",
+                                     "origin.example",
+                                     443,
+                                     tls,
+                                     (_, _) -> InetAddress.getLoopbackAddress(),
+                                     DnsAddressLookup.IPV4,
+                                     Proxy.noProxy()),
+                "https");
+        Instant firstObservation = clock.instant();
+        WritableHeaders<?> firstHeaders = WritableHeaders.create();
+        firstHeaders.add(HeaderValues.create(HeaderNames.ALT_SVC, "h2=\":8443\"; ma=3600"));
+        AltSvcHeader firstAdvertisement = AltSvcHeader.create(ClientResponseHeaders.create(firstHeaders), firstObservation)
+                .orElseThrow();
+        alternatives.record(originTarget, firstAdvertisement, true, false, firstObservation);
+
+        CountDownLatch setupStarted = new CountDownLatch(1);
+        CountDownLatch releaseSetup = new CountDownLatch(1);
+        Http2ClientImpl http2Client = mock(Http2ClientImpl.class);
+        Http2ClientRequestImpl request = mock(Http2ClientRequestImpl.class);
+        WebClientServiceRequest serviceRequest = mock(WebClientServiceRequest.class);
+        Http1FallbackHandler fallbackHandler = new Http1FallbackHandler(new CompletableFuture<>(), _ -> null, true);
+        when(http2Client.protocolConfig()).thenReturn(Http2ClientProtocolConfig.create());
+        when(request.connection()).thenReturn(Optional.empty());
+        when(request.tls()).thenAnswer(_ -> {
+            setupStarted.countDown();
+            if (!releaseSetup.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out waiting to release handler setup");
+            }
+            throw new IllegalStateException("Expected test setup failure");
+        });
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<?> establishing = executor.submit(() -> handler.http2(http2Client,
+                                                                          originTarget,
+                                                                          request,
+                                                                          ClientUri.create(URI.create(
+                                                                                  "https://origin.example")),
+                                                                          serviceRequest,
+                                                                          fallbackHandler));
+            try {
+                assertThat(setupStarted.await(5, TimeUnit.SECONDS), is(true));
+                Instant replacementObservation = firstObservation.plusNanos(1);
+                WritableHeaders<?> replacementHeaders = WritableHeaders.create();
+                replacementHeaders.add(HeaderValues.create(HeaderNames.ALT_SVC, "h2=\":9443\"; ma=3600"));
+                AltSvcHeader replacement = AltSvcHeader.create(ClientResponseHeaders.create(replacementHeaders),
+                                                               replacementObservation)
+                        .orElseThrow();
+                Future<?> invalidation = executor.submit(() -> alternatives.record(originTarget,
+                                                                                     replacement,
+                                                                                     true,
+                                                                                     false,
+                                                                                     replacementObservation));
+
+                assertThat(invalidation.get(5, TimeUnit.SECONDS), nullValue());
+            } finally {
+                releaseSetup.countDown();
+            }
+            assertThrows(ExecutionException.class, () -> establishing.get(5, TimeUnit.SECONDS));
+        } finally {
+            alternatives.close();
+        }
     }
 
     @Test

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -18,6 +18,9 @@ package io.helidon.webclient.http2;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,9 +31,12 @@ import java.util.function.IntFunction;
 import io.helidon.common.context.Context;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.api.AltSvcHeader;
 import io.helidon.webclient.api.ClientConnectionTarget;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
@@ -128,6 +134,43 @@ class Http2ConnectionCacheTest {
     }
 
     @Test
+    void expiredAlternativeRaceDoesNotCompleteRequestAsFailed() {
+        Clock clock = Clock.fixed(Instant.parse("2026-08-24T00:00:00Z"), ZoneOffset.UTC);
+        Http2AltSvcCache alternatives = Http2AltSvcCache.create(clock, _ -> { });
+        Tls tls = Tls.builder().trustAll(true).build();
+        ClientConnectionTarget originTarget = ClientConnectionTarget.create(
+                ConnectionKey.create("https",
+                                     "origin.example",
+                                     443,
+                                     tls,
+                                     (_, _) -> InetAddress.getLoopbackAddress(),
+                                     DnsAddressLookup.IPV4,
+                                     Proxy.noProxy()),
+                "https");
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+        responseHeaders.add(HeaderValues.create(HeaderNames.ALT_SVC, "h2=\":8443\"; ma=0"));
+        AltSvcHeader advertisement = AltSvcHeader.parse(ClientResponseHeaders.create(responseHeaders), clock.instant())
+                .orElseThrow();
+        alternatives.record(originTarget, advertisement, true, false);
+        Http2AltSvcCache.Selection selection = alternatives.select(originTarget, false, _ -> true);
+        Http2ClientConnectionHandler handler = new Http2ClientConnectionHandler(1, alternatives::current);
+        Http2ClientImpl http2Client = mock(Http2ClientImpl.class);
+        Http2ClientRequestImpl request = mock(Http2ClientRequestImpl.class);
+        CompletableFuture<WebClientServiceRequest> whenSent = new CompletableFuture<>();
+        Http1FallbackHandler fallbackHandler = new Http1FallbackHandler(whenSent, _ -> null, true);
+        when(http2Client.protocolConfig()).thenReturn(Http2ClientProtocolConfig.create());
+
+        AlternativeConnectionException failure = assertThrows(
+                AlternativeConnectionException.class,
+                () -> handler.newAlternativeStream(http2Client, selection, request, fallbackHandler));
+
+        assertThat(failure.selection(), sameInstance(selection));
+        assertThat(failure.reason(), is(AlternativeConnectionException.Reason.STALE));
+        assertThat(whenSent.isDone(), is(false));
+        alternatives.close();
+    }
+
+    @Test
     void removingOneTargetRetainsSharedHttp2Support() {
         Tls tls = Tls.builder().enabled(false).build();
         Proxy proxy = Proxy.noProxy();
@@ -198,9 +241,25 @@ class Http2ConnectionCacheTest {
                                                                           serviceRequest,
                                                                           fallbackHandler)
                     .handler();
-            cache.markSupported(connectionKey);
+            cache.markSupported(firstTarget);
 
             assertThat(firstTarget, not(secondTarget));
+            assertThat(firstHandler, not(sameInstance(secondHandler)));
+            assertThat(cache.supports(connectionKey), is(true));
+
+            cache.remove(firstTarget, firstHandler);
+
+            assertThat(cache.supports(connectionKey), is(false));
+
+            firstHandler = cache.newStream(http2Client,
+                                           firstTarget,
+                                           request,
+                                           initialUri,
+                                           serviceRequest,
+                                           fallbackHandler)
+                    .handler();
+            cache.markSupported(secondTarget);
+
             assertThat(firstHandler, not(sameInstance(secondHandler)));
             assertThat(cache.supports(connectionKey), is(true));
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ConnectionCacheTest.java
@@ -151,7 +151,7 @@ class Http2ConnectionCacheTest {
         responseHeaders.add(HeaderValues.create(HeaderNames.ALT_SVC, "h2=\":8443\"; ma=0"));
         AltSvcHeader advertisement = AltSvcHeader.parse(ClientResponseHeaders.create(responseHeaders), clock.instant())
                 .orElseThrow();
-        alternatives.record(originTarget, advertisement, true, false);
+        alternatives.record(originTarget, advertisement, true, false, clock.instant());
         Http2AltSvcCache.Selection selection = alternatives.select(originTarget, false, _ -> true);
         Http2ClientConnectionHandler handler = new Http2ClientConnectionHandler(1, alternatives::current);
         Http2ClientImpl http2Client = mock(Http2ClientImpl.class);


### PR DESCRIPTION
Resolves #7278
Pre-requisite for https://github.com/helidon-io/helidon/issues/3686

This change adds preview, opt-in client Alt-Svc discovery to WebClient. Its primary intent is to let a generic WebClient learn an HTTP/2 alternative from a network response and route later requests to that endpoint without changing the request's logical origin, authority, or TLS identity. It also establishes protocol-neutral configuration, parsing, and response-notification foundations that can be reused by the HTTP/3 client.

### Configuration and protocol selection

The new optional `ClientAltSvcConfig` belongs to the common HTTP client configuration rather than an individual protocol configuration.

When the configuration is absent, Alt-Svc handling is disabled. Within a present configuration, `enabled` defaults to `true`. The optional `protocols` collection is an exact, case-sensitive ALPN allow-list; an empty collection permits every available protocol provider that supports Alt-Svc.

Protocol preference continues to control provider ordering. Alt-Svc discovery only makes an advertised protocol available for selection.

### HTTP/2 alternative routing

The HTTP/2 provider can learn an `h2` alternative from an HTTP/1.1 or HTTP/2 response and use it for a later request. The alternative changes only the physical connection endpoint:

- The original request URI and authority are preserved.
- TLS peer identity, SNI, and the configured TLS policy remain those of the logical origin.
- Alternative requests include the generated `Alt-Used` header.
- Connection pools remain partitioned by their concrete targets while compatible DNS-host casing shares advertisement state.
- Shared connection caches share Alt-Svc discovery state; private caches remain isolated.

The implementation preserves response ordering across redirects and HTTP/1.1 fallback, including output-stream and Expect/Continue flows.

### Advertisement lifecycle

The client parser handles multiple Alt-Svc field values, opaque protocol identifiers, percent escapes, `ma`, `persist`, `Age`, apparent age from `Date`, and the complete-field `clear` value.

Discovery state is bounded and tied to the connection-cache lifecycle. Replacement, `clear`, current-alternative `421` responses, TLS reload, network changes, and failed alternative establishment invalidate or suppress the appropriate generation. An expired advertisement cannot create a new alternative connection, but an already-opening or established compatible connection can remain reusable.

If an alternative fails before the request can have been processed, WebClient falls back to the origin. Failures after possible transmission are not automatically replayed.

### Security, proxy, and current scope

Initial client support is deliberately limited to:

- Alt-Svc response headers from `https` origins
- Same-host alternatives, optionally on a different port
- TLS HTTP/2 using ALPN `h2`
- Clients whose proxy type is explicitly `none`

Any configured proxy policy—including the default system proxy policy and configured no-proxy exceptions—causes the HTTP/2 provider to ignore the alternative rather than bypass that policy.

WebClient honors the configured TLS policy as-is, including custom TLS managers, custom SSL contexts, disabled endpoint identification, and `trust-all`. A permissive TLS configuration therefore makes Alt-Svc steering equally permissive.

This change does not support cleartext `h2c`, upgrading plain `http` origins, RFC 8164 opportunistic HTTP, cross-host alternatives, or the HTTP/2 ALTSVC frame.
