### PR TITLE
Propagate idle socket monitor failures as I/O errors

### DIFF
--- a/common/socket/src/main/java/io/helidon/common/socket/IdleInputStream.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/IdleInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.common.socket;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -165,15 +166,34 @@ class IdleInputStream extends InputStream {
         }
     }
 
-    private void endIdle() {
+    private void endIdle() throws IOException {
         try {
             cancelled = true;
             idlingThread.get();
             idlingThread = null;
             cancelled = false;
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException e) {
             closed = true;
-            throw new RuntimeException("Exception in socket monitor thread.", e);
+            Thread.currentThread().interrupt();
+            var interrupted = new InterruptedIOException("Interrupted while waiting for socket monitor thread.");
+            interrupted.initCause(e);
+            throw interrupted;
+        } catch (ExecutionException e) {
+            closed = true;
+            Throwable cause = e.getCause();
+            if (cause instanceof UncheckedIOException unchecked) {
+                throw unchecked.getCause();
+            }
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            }
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new IOException("Exception in socket monitor thread.", cause);
         }
     }
 }

--- a/common/socket/src/test/java/io/helidon/common/socket/PlainSocketIdleTest.java
+++ b/common/socket/src/test/java/io/helidon/common/socket/PlainSocketIdleTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.socket;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.Socket;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlainSocketIdleTest {
+
+    @Test
+    void idleMonitorIoFailurePropagatesWithoutAdditionalWrapping() throws Exception {
+        var monitorReadStarted = new CountDownLatch(1);
+        var expected = new IOException("Expected monitor failure");
+        InputStream inputStream = mock(InputStream.class);
+        doAnswer(_ -> {
+            monitorReadStarted.countDown();
+            throw expected;
+        }).when(inputStream).read();
+        PlainSocket socket = socket(inputStream);
+
+        try {
+            socket.idle();
+            assertThat("Socket monitor did not start", monitorReadStarted.await(10, TimeUnit.SECONDS), is(true));
+
+            UncheckedIOException actual = assertThrows(UncheckedIOException.class, socket::get);
+
+            assertThat(actual.getCause(), sameInstance(expected));
+        } finally {
+            socket.close();
+        }
+    }
+
+    @Test
+    void interruptedIdleWaitRestoresFlagAndPropagatesAsIo() throws Exception {
+        var monitorReadStarted = new CountDownLatch(1);
+        var releaseMonitor = new CountDownLatch(1);
+        InputStream inputStream = mock(InputStream.class);
+        doAnswer(_ -> {
+            monitorReadStarted.countDown();
+            try {
+                releaseMonitor.await();
+                return -1;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException(e);
+            }
+        }).when(inputStream).read();
+        doAnswer(_ -> {
+            releaseMonitor.countDown();
+            return null;
+        }).when(inputStream).close();
+        PlainSocket socket = socket(inputStream);
+        UncheckedIOException actual;
+        boolean interrupted;
+
+        try {
+            socket.idle();
+            assertThat("Socket monitor did not start", monitorReadStarted.await(10, TimeUnit.SECONDS), is(true));
+
+            Thread.currentThread().interrupt();
+            actual = assertThrows(UncheckedIOException.class, socket::get);
+            interrupted = Thread.currentThread().isInterrupted();
+        } finally {
+            Thread.interrupted();
+            socket.close();
+        }
+
+        assertThat("Interrupted status was not restored", interrupted, is(true));
+        assertThat(actual.getCause(), instanceOf(InterruptedIOException.class));
+        assertThat(actual.getCause().getCause(), instanceOf(InterruptedException.class));
+    }
+
+    private static PlainSocket socket(InputStream inputStream) throws IOException {
+        Socket delegate = mock(Socket.class);
+        when(delegate.getInputStream()).thenReturn(inputStream);
+        when(delegate.getOutputStream()).thenReturn(OutputStream.nullOutputStream());
+        when(delegate.getSoTimeout()).thenReturn(30_000);
+        return PlainSocket.client(delegate, "test");
+    }
+}


### PR DESCRIPTION
Resolves #12339

Propagate asynchronous idle socket monitor I/O failures through the `InputStream` exception boundary so `PlainSocket` exposes the existing `UncheckedIOException` contract without an additional raw `RuntimeException` wrapper.

Restore the thread interrupt flag when waiting for the monitor is interrupted and expose that path using `InterruptedIOException`.

Add deterministic regression coverage for both monitor failure paths in a new test file. This fixes the intermittent `Http1ClientTest.testReadTimeoutPerRequest` failure observed in #12337 without changing the existing test.
