### PR TITLE
Correct JPMS module names (27.x)

### DIFF
--- a/dbclient/metrics-hikari/src/main/java/module-info.java
+++ b/dbclient/metrics-hikari/src/main/java/module-info.java
@@ -24,7 +24,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Description("Hikari connection pool metrics support")
 @Features.Flavor(HelidonFlavor.SE)
 @Features.Path({"DbClient", "Metrics-Hikari"})
-module helidon.dbclient.metrics.hikari {
+module io.helidon.dbclient.metrics.hikari {
 
     requires transitive io.helidon.common.features.api;
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -192,8 +192,6 @@
                     </fileExcludes>
                     <moduleIncludes>
                         <include>io.helidon*</include>
-                        <!-- See https://github.com/helidon-io/helidon/issues/8163 -->
-                        <include>helidon.*</include>
                     </moduleIncludes>
                     <moduleExcludes/>
                     <packageIncludes>

--- a/docs/src/main/asciidoc/se/guides/dbclient.adoc
+++ b/docs/src/main/asciidoc/se/guides/dbclient.adoc
@@ -227,6 +227,11 @@ Navigate to the `helidon-quickstart-se` directory and open the `pom.xml` file to
 <6> Support for metrics.
 <7> Support for Helidon JSON mapping.
 
+NOTE: In Helidon 27, the JPMS module name of `helidon-dbclient-metrics-hikari` is
+`io.helidon.dbclient.metrics.hikari`. Applications upgrading from Helidon 4 that declare
+`requires helidon.dbclient.metrics.hikari;` must change the declaration to
+`requires io.helidon.dbclient.metrics.hikari;`. Maven coordinates and Java packages are unchanged.
+
 === Configure the DB Client
 
 To configure the application, Helidon uses the `application.yaml`. The DB Client configuration can be joined in the same

--- a/webserver/tests/upgrade/src/main/java/module-info.java
+++ b/webserver/tests/upgrade/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 /**
  * Integration test for routing composition.
  */
-module helidon.tests.integration.webserver.upgrade {
+module io.helidon.tests.integration.webserver.upgrade {
 
     requires io.helidon.logging.common;
     requires io.helidon.http;


### PR DESCRIPTION
Resolves #8163

Renames the remaining JPMS module descriptors to use `io.helidon.*`, removes the temporary aggregated-Javadoc allowance, and documents the DBClient module-name migration. Helidon examples use the unchanged Maven coordinate on the classpath and require no corresponding change.
