### PR TITLE
Deprecate ConfigUserStore constructor

### DIFF
--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
@@ -35,7 +35,10 @@ public class ConfigUserStore implements SecureUserStore {
 
     /**
      * Create an empty configuration-backed user store.
+     *
+     * @deprecated Use {@link #create(Config)} instead.
      */
+    @Deprecated(forRemoval = true, since = "27.0.0")
     public ConfigUserStore() {
     }
 


### PR DESCRIPTION
Resolves #12113

Deprecates direct construction of `ConfigUserStore` in favor of the configuration factory.
