### PR TITLE
Limit JSON parser nesting depth (27.x)

### DIFF
--- a/docs/src/main/asciidoc/se/json/json.adoc
+++ b/docs/src/main/asciidoc/se/json/json.adoc
@@ -518,6 +518,10 @@ The JSON module (`helidon-json`) provides fundamental JSON parsing and generatio
 
 link:{json-base-url}/io/helidon/json/JsonParser.html[`JsonParser`] is a streaming JSON parser that provides efficient, low-level access to JSON data without loading the entire document into memory. It's designed for processing large JSON documents or streaming data sources.
 
+When decoding JSON or Smile input, materializing or skipping nested objects and arrays beyond
+`JsonParser.MAX_NESTING_DEPTH` (1,000) throws a `JsonException`. The root object or array counts as one structure.
+Direct Smile token iteration enforces the same limit.
+
 ==== What it's used for
 
 * Parsing large JSON documents efficiently

--- a/json/json/src/main/java/io/helidon/json/JsonParser.java
+++ b/json/json/src/main/java/io/helidon/json/JsonParser.java
@@ -37,6 +37,12 @@ import static io.helidon.json.JsonParserArray.WHITESPACE_CHARS;
 public interface JsonParser {
 
     /**
+     * Maximum number of nested JSON object and array structures supported by this parser.
+     * The root object or array counts as one structure.
+     */
+    int MAX_NESTING_DEPTH = 1_000;
+
+    /**
      * Create a new JSON parser from a JSON string.
      * <p>
      * This method creates an in-memory parser that processes the entire JSON string

--- a/json/json/src/main/java/io/helidon/json/JsonParserArray.java
+++ b/json/json/src/main/java/io/helidon/json/JsonParserArray.java
@@ -2226,24 +2226,12 @@ class JsonParserArray extends JsonParserBase {
     }
 
     private void skipObject() {
-        byte b = nextToken();
-        if (b == '}') {
-            return;
-        }
-        if (b == '"') {
-            skipString();
-            b = nextToken();
-        } else {
-            throw createException("Key name start expected", b);
-        }
-        if (b != ':') {
-            throw createException("Colon expected after the key", b);
-        }
-        nextToken();
-        skip();
-        b = nextToken();
-        while (b == ',') {
-            b = nextToken();
+        enterStructure();
+        try {
+            byte b = nextToken();
+            if (b == '}') {
+                return;
+            }
             if (b == '"') {
                 skipString();
                 b = nextToken();
@@ -2256,31 +2244,51 @@ class JsonParserArray extends JsonParserBase {
             nextToken();
             skip();
             b = nextToken();
-        }
+            while (b == ',') {
+                b = nextToken();
+                if (b == '"') {
+                    skipString();
+                    b = nextToken();
+                } else {
+                    throw createException("Key name start expected", b);
+                }
+                if (b != ':') {
+                    throw createException("Colon expected after the key", b);
+                }
+                nextToken();
+                skip();
+                b = nextToken();
+            }
 
-        if (b == '}') {
-            return;
+            if (b != '}') {
+                throw createException("Comma or the end of the object expected", b);
+            }
+        } finally {
+            exitStructure();
         }
-        throw createException("Comma or the end of the object expected", b);
     }
 
     private void skipArray() {
-        byte b = nextToken();
-        if (b == ']') {
-            return;
-        }
-        skip(); // Skip the first array value
-        b = nextToken();
-        while (b == ',') {
-            nextToken();
-            skip();
+        enterStructure();
+        try {
+            byte b = nextToken();
+            if (b == ']') {
+                return;
+            }
+            skip(); // Skip the first array value
             b = nextToken();
-        }
+            while (b == ',') {
+                nextToken();
+                skip();
+                b = nextToken();
+            }
 
-        if (b == ']') {
-            return;
+            if (b != ']') {
+                throw createException("Comma or the end of the array expected", b);
+            }
+        } finally {
+            exitStructure();
         }
-        throw createException("Comma or the end of the array expected", b);
     }
 
 }

--- a/json/json/src/main/java/io/helidon/json/JsonParserBase.java
+++ b/json/json/src/main/java/io/helidon/json/JsonParserBase.java
@@ -25,6 +25,8 @@ import java.util.List;
  */
 public abstract class JsonParserBase implements JsonParser {
 
+    private int nestingDepth;
+
     /**
      * Protected default constructor for subclasses.
      */
@@ -52,45 +54,50 @@ public abstract class JsonParserBase implements JsonParser {
         if (currentByte() != '{') {
             throw createException("Object start expected", currentByte());
         }
-        byte b = nextToken();
-        if (b == '}') {
-            return JsonObject.EMPTY_OBJECT;
-        }
-        LinkedHashMap<String, JsonValue> values = new LinkedHashMap<>();
-        while (hasNext()) {
-            String key;
-            if (b == '"') {
-                key = readString();
-            } else {
-                throw createException("Key name start expected", b);
-            }
-            b = nextToken();
-            if (b != ':') {
-                throw createException("Colon expected", b);
-            }
-            b = nextToken();
-            JsonValue value = switch (b) {
-            case '"' -> readJsonString();
-            case '{' -> readJsonObject();
-            case '[' -> readJsonArray();
-            case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> readJsonNumber();
-            case 'n' -> {
-                checkNull();
-                yield JsonNull.instance();
-            }
-            case 't', 'f' -> JsonBoolean.create(readBoolean());
-            default -> throw createException("Unexpected json value type", b);
-            };
-            values.put(key, value);
-            b = nextToken();
+        enterStructure();
+        try {
+            byte b = nextToken();
             if (b == '}') {
-                return JsonObject.createFromOwnedMap(values);
-            } else if (b != ',') {
-                throw createException("Comma or object end expected", b);
+                return JsonObject.EMPTY_OBJECT;
             }
-            b = nextToken();
+            LinkedHashMap<String, JsonValue> values = new LinkedHashMap<>();
+            while (hasNext()) {
+                String key;
+                if (b == '"') {
+                    key = readString();
+                } else {
+                    throw createException("Key name start expected", b);
+                }
+                b = nextToken();
+                if (b != ':') {
+                    throw createException("Colon expected", b);
+                }
+                b = nextToken();
+                JsonValue value = switch (b) {
+                case '"' -> readJsonString();
+                case '{' -> readJsonObject();
+                case '[' -> readJsonArray();
+                case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> readJsonNumber();
+                case 'n' -> {
+                    checkNull();
+                    yield JsonNull.instance();
+                }
+                case 't', 'f' -> JsonBoolean.create(readBoolean());
+                default -> throw createException("Unexpected json value type", b);
+                };
+                values.put(key, value);
+                b = nextToken();
+                if (b == '}') {
+                    return JsonObject.createFromOwnedMap(values);
+                } else if (b != ',') {
+                    throw createException("Comma or object end expected", b);
+                }
+                b = nextToken();
+            }
+            throw createException("Unexpected end of the object. Possibly incomplete JSON");
+        } finally {
+            exitStructure();
         }
-        throw createException("Unexpected end of the object. Possibly incomplete JSON");
     }
 
     @Override
@@ -98,55 +105,77 @@ public abstract class JsonParserBase implements JsonParser {
         if (currentByte() != '[') {
             throw createException("Array start expected", currentByte());
         }
-        byte b = nextToken();
-        if (b == ']') {
-            return JsonArray.EMPTY_ARRAY;
-        }
-        List<JsonValue> values = new ArrayList<>();
-        while (hasNext()) {
-            switch (b) {
-            case '"':
-                values.add(readJsonString());
-                break;
-            case '{':
-                values.add(readJsonObject());
-                break;
-            case '[':
-                values.add(readJsonArray());
-                break;
-            case '-':
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                values.add(readJsonNumber());
-                break;
-            case 'n':
-                checkNull();
-                values.add(JsonNull.instance());
-                break;
-            case 't':
-            case 'f':
-                values.add(JsonBoolean.create(readBoolean()));
-                break;
-            default:
-                throw createException("Invalid JSON value type", b);
-            }
-            b = nextToken();
+        enterStructure();
+        try {
+            byte b = nextToken();
             if (b == ']') {
-                return JsonArray.createFromOwnedList(values);
-            } else if (b != ',') {
-                throw createException("Comma or array end expected", b);
+                return JsonArray.EMPTY_ARRAY;
             }
-            b = nextToken();
+            List<JsonValue> values = new ArrayList<>();
+            while (hasNext()) {
+                switch (b) {
+                case '"':
+                    values.add(readJsonString());
+                    break;
+                case '{':
+                    values.add(readJsonObject());
+                    break;
+                case '[':
+                    values.add(readJsonArray());
+                    break;
+                case '-':
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                    values.add(readJsonNumber());
+                    break;
+                case 'n':
+                    checkNull();
+                    values.add(JsonNull.instance());
+                    break;
+                case 't':
+                case 'f':
+                    values.add(JsonBoolean.create(readBoolean()));
+                    break;
+                default:
+                    throw createException("Invalid JSON value type", b);
+                }
+                b = nextToken();
+                if (b == ']') {
+                    return JsonArray.createFromOwnedList(values);
+                } else if (b != ',') {
+                    throw createException("Comma or array end expected", b);
+                }
+                b = nextToken();
+            }
+            throw createException("Unexpected end of the array. Possibly incomplete JSON");
+        } finally {
+            exitStructure();
         }
-        throw createException("Unexpected end of the array. Possibly incomplete JSON");
+    }
+
+    /**
+     * Records entry into an object or array structure.
+     */
+    final void enterStructure() {
+        if (nestingDepth >= MAX_NESTING_DEPTH) {
+            throw createException("Maximum JSON nesting depth exceeded");
+        }
+        nestingDepth++;
+    }
+
+    /**
+     * Records exit from an object or array structure.
+     */
+    final void exitStructure() {
+        nestingDepth--;
     }
 
 }

--- a/json/json/src/main/java/io/helidon/json/JsonParserStream.java
+++ b/json/json/src/main/java/io/helidon/json/JsonParserStream.java
@@ -2358,24 +2358,12 @@ final class JsonParserStream extends JsonParserBase {
     }
 
     private void skipObject() {
-        byte b = nextToken();
-        if (b == '}') {
-            return;
-        }
-        if (b == '"') {
-            skipString();
-            b = nextToken();
-        } else {
-            throw createException("Key name start expected", b);
-        }
-        if (b != ':') {
-            throw createException("Colon expected after the key", b);
-        }
-        nextToken();
-        skip();
-        b = nextToken();
-        while (b == ',') {
-            b = nextToken();
+        enterStructure();
+        try {
+            byte b = nextToken();
+            if (b == '}') {
+                return;
+            }
             if (b == '"') {
                 skipString();
                 b = nextToken();
@@ -2388,31 +2376,51 @@ final class JsonParserStream extends JsonParserBase {
             nextToken();
             skip();
             b = nextToken();
-        }
+            while (b == ',') {
+                b = nextToken();
+                if (b == '"') {
+                    skipString();
+                    b = nextToken();
+                } else {
+                    throw createException("Key name start expected", b);
+                }
+                if (b != ':') {
+                    throw createException("Colon expected after the key", b);
+                }
+                nextToken();
+                skip();
+                b = nextToken();
+            }
 
-        if (b == '}') {
-            return;
+            if (b != '}') {
+                throw createException("Comma or the end of the object expected", b);
+            }
+        } finally {
+            exitStructure();
         }
-        throw createException("Comma or the end of the object expected", b);
     }
 
     private void skipArray() {
-        byte b = nextToken();
-        if (b == ']') {
-            return;
-        }
-        skip(); // Skip the first array value
-        b = nextToken();
-        while (b == ',') {
-            nextToken();
-            skip();
+        enterStructure();
+        try {
+            byte b = nextToken();
+            if (b == ']') {
+                return;
+            }
+            skip(); // Skip the first array value
             b = nextToken();
-        }
+            while (b == ',') {
+                nextToken();
+                skip();
+                b = nextToken();
+            }
 
-        if (b == ']') {
-            return;
+            if (b != ']') {
+                throw createException("Comma or the end of the array expected", b);
+            }
+        } finally {
+            exitStructure();
         }
-        throw createException("Comma or the end of the array expected", b);
     }
 
     private boolean expectedNext(char c) {

--- a/json/json/src/test/java/io/helidon/json/NestingDepthTest.java
+++ b/json/json/src/test/java/io/helidon/json/NestingDepthTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.json;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class NestingDepthTest {
+
+    @ParameterizedTest
+    @EnumSource(ParserMethod.class)
+    void readJsonArrayAllowsMaximumDepth(ParserMethod parserMethod) {
+        JsonParser parser = parserMethod.createParser(nestedArrays(JsonParser.MAX_NESTING_DEPTH));
+        JsonArray array = parser.readJsonArray();
+
+        assertThat(array.type(), is(JsonValueType.ARRAY));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ParserMethod.class)
+    void readJsonObjectAllowsMaximumDepth(ParserMethod parserMethod) {
+        JsonParser parser = parserMethod.createParser(nestedObjects(JsonParser.MAX_NESTING_DEPTH));
+        JsonObject object = parser.readJsonObject();
+
+        assertThat(object.type(), is(JsonValueType.OBJECT));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ParserMethod.class)
+    void readJsonArrayRejectsExcessiveDepth(ParserMethod parserMethod) {
+        JsonParser parser = parserMethod.createParser(nestedArrays(JsonParser.MAX_NESTING_DEPTH + 1));
+        JsonException exception = assertThrows(JsonException.class, parser::readJsonArray);
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ParserMethod.class)
+    void readJsonObjectRejectsExcessiveDepth(ParserMethod parserMethod) {
+        JsonParser parser = parserMethod.createParser(nestedObjects(JsonParser.MAX_NESTING_DEPTH + 1));
+        JsonException exception = assertThrows(JsonException.class, parser::readJsonObject);
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ParserMethod.class)
+    void skipArrayRejectsExcessiveDepth(ParserMethod parserMethod) {
+        JsonParser parser = parserMethod.createParser(nestedArrays(JsonParser.MAX_NESTING_DEPTH + 1));
+        JsonException exception = assertThrows(JsonException.class, parser::skip);
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ParserMethod.class)
+    void skipObjectRejectsExcessiveDepth(ParserMethod parserMethod) {
+        JsonParser parser = parserMethod.createParser(nestedObjects(JsonParser.MAX_NESTING_DEPTH + 1));
+        JsonException exception = assertThrows(JsonException.class, parser::skip);
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ParserMethod.class)
+    void failedReadDoesNotRetainNestingDepth(ParserMethod parserMethod) {
+        JsonParser parser = parserMethod.createParser(nestedArrays(JsonParser.MAX_NESTING_DEPTH + 1));
+
+        assertThrows(JsonException.class, parser::readJsonArray);
+
+        parser.skip();
+    }
+
+    private static String nestedArrays(int depth) {
+        StringBuilder json = new StringBuilder(depth * 2 + 1);
+        for (int i = 0; i < depth; i++) {
+            json.append('[');
+        }
+        json.append('0');
+        for (int i = 0; i < depth; i++) {
+            json.append(']');
+        }
+        return json.toString();
+    }
+
+    private static String nestedObjects(int depth) {
+        StringBuilder json = new StringBuilder(depth * 6 + 1);
+        for (int i = 0; i < depth; i++) {
+            json.append("{\"a\":");
+        }
+        json.append('0');
+        for (int i = 0; i < depth; i++) {
+            json.append('}');
+        }
+        return json.toString();
+    }
+}

--- a/json/smile/src/main/java/io/helidon/json/smile/SmileInputStreamParser.java
+++ b/json/smile/src/main/java/io/helidon/json/smile/SmileInputStreamParser.java
@@ -34,6 +34,7 @@ import io.helidon.json.JsonException;
 import io.helidon.json.JsonNull;
 import io.helidon.json.JsonNumber;
 import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
 import io.helidon.json.JsonParserBase;
 import io.helidon.json.JsonString;
 import io.helidon.json.JsonValue;
@@ -68,6 +69,8 @@ final class SmileInputStreamParser extends JsonParserBase {
 
     private static final int SHARED_TABLE_SIZE_MAX = 1024;
     private static final int SHARED_TABLE_SIZE_INIT = 24;
+    private static final int STRUCTURE_STACK_SIZE_INIT = 64;
+    private static final int STRUCTURE_STACK_DEPTH_MAX = JsonParser.MAX_NESTING_DEPTH;
     private static final int FNV_OFFSET_BASIS = 0x811c9dc5;
     private static final int FNV_PRIME = 0x01000193;
 
@@ -166,7 +169,7 @@ final class SmileInputStreamParser extends JsonParserBase {
     private boolean keyExpected = false;
     private byte forcedEvent = -1;
 
-    private final boolean[] structureStack = new boolean[64];
+    private boolean[] structureStack = new boolean[STRUCTURE_STACK_SIZE_INIT];
     private int stackDepth = 0;
 
     /** The JSON-like translation of the current Smile token (e.g. '{', '[', '"', '1', 't', …). */
@@ -480,11 +483,9 @@ final class SmileInputStreamParser extends JsonParserBase {
         if (rawByte >= (SmileConstants.TOKEN_START_ARRAY & 0xFF)
                 && rawByte <= (SmileConstants.TOKEN_END_OBJECT & 0xFF)) {
             if (translatedToken == Bytes.BRACE_OPEN_BYTE) {
-                structureStack[++stackDepth] = true;
-                inObject = true;
+                pushStructure(true);
             } else if (translatedToken == Bytes.SQUARE_BRACKET_OPEN_BYTE) {
-                structureStack[++stackDepth] = false;
-                inObject = false;
+                pushStructure(false);
             } else if (translatedToken == Bytes.SQUARE_BRACKET_CLOSE_BYTE
                     || translatedToken == Bytes.BRACE_CLOSE_BYTE) {
                 validateStructureClose(translatedToken);
@@ -2138,6 +2139,20 @@ final class SmileInputStreamParser extends JsonParserBase {
         if (token == Bytes.SQUARE_BRACKET_CLOSE_BYTE && inObject) {
             throw createException("Unexpected end-array token while in an object");
         }
+    }
+
+    private void pushStructure(boolean object) {
+        int nextDepth = stackDepth + 1;
+        if (nextDepth > STRUCTURE_STACK_DEPTH_MAX) {
+            throw createException("Maximum JSON nesting depth exceeded");
+        }
+        if (nextDepth == structureStack.length) {
+            structureStack = Arrays.copyOf(structureStack,
+                                           Math.min(structureStack.length * 2, STRUCTURE_STACK_DEPTH_MAX + 1));
+        }
+        structureStack[nextDepth] = object;
+        stackDepth = nextDepth;
+        inObject = object;
     }
 
     private void validateSmileString(byte[] source, int start, int length, boolean asciiToken) {

--- a/json/smile/src/main/java/io/helidon/json/smile/SmileParser.java
+++ b/json/smile/src/main/java/io/helidon/json/smile/SmileParser.java
@@ -43,7 +43,8 @@ import io.helidon.json.Parsers;
 import static io.helidon.json.Parsers.translateHex;
 
 /**
- * Smile binary JSON parser implementation.
+ * Smile binary JSON parser implementation. Supports up to {@link JsonParser#MAX_NESTING_DEPTH}
+ * nested object and array structures, including the root structure.
  *
  * <p>This class is not thread safe.
  */
@@ -55,6 +56,8 @@ public final class SmileParser extends JsonParserBase {
 
     private static final int SHARED_TABLE_SIZE_MAX = 1024;
     private static final int SHARED_TABLE_SIZE_INIT = 24;
+    private static final int STRUCTURE_STACK_SIZE_INIT = 64;
+    private static final int STRUCTURE_STACK_DEPTH_MAX = JsonParser.MAX_NESTING_DEPTH;
     private static final int FNV_OFFSET_BASIS = 0x811c9dc5;
     private static final int FNV_PRIME = 0x01000193;
 
@@ -134,7 +137,7 @@ public final class SmileParser extends JsonParserBase {
     private boolean keyExpected = false;
     private byte forcedEvent = -1;
 
-    private final boolean[] structureStack = new boolean[64];
+    private boolean[] structureStack = new boolean[STRUCTURE_STACK_SIZE_INIT];
     private int stackDepth = 0;
 
     private byte currentToken;
@@ -246,11 +249,9 @@ public final class SmileParser extends JsonParserBase {
         if (currentByte >= (SmileConstants.TOKEN_START_ARRAY & 0xFF)
                 && currentByte <= (SmileConstants.TOKEN_END_OBJECT & 0xFF)) {
             if (currentToken == Bytes.BRACE_OPEN_BYTE) {
-                structureStack[++stackDepth] = true;
-                inObject = true;
+                pushStructure(true);
             } else if (currentToken == Bytes.SQUARE_BRACKET_OPEN_BYTE) {
-                structureStack[++stackDepth] = false;
-                inObject = false;
+                pushStructure(false);
             } else if (currentToken == Bytes.SQUARE_BRACKET_CLOSE_BYTE
                     || currentToken == Bytes.BRACE_CLOSE_BYTE) {
                 validateStructureClose(currentToken);
@@ -1810,6 +1811,20 @@ public final class SmileParser extends JsonParserBase {
         if (token == Bytes.SQUARE_BRACKET_CLOSE_BYTE && inObject) {
             throw createException("Unexpected end-array token while in an object");
         }
+    }
+
+    private void pushStructure(boolean object) {
+        int nextDepth = stackDepth + 1;
+        if (nextDepth > STRUCTURE_STACK_DEPTH_MAX) {
+            throw createException("Maximum JSON nesting depth exceeded");
+        }
+        if (nextDepth == structureStack.length) {
+            structureStack = Arrays.copyOf(structureStack,
+                                           Math.min(structureStack.length * 2, STRUCTURE_STACK_DEPTH_MAX + 1));
+        }
+        structureStack[nextDepth] = object;
+        stackDepth = nextDepth;
+        inObject = object;
     }
 
     private void validateSmileString(byte[] source, int start, int length, boolean asciiToken) {

--- a/json/smile/src/test/java/io/helidon/json/smile/SmileParserTestBase.java
+++ b/json/smile/src/test/java/io/helidon/json/smile/SmileParserTestBase.java
@@ -36,6 +36,7 @@ import io.helidon.json.JsonValueType;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -47,6 +48,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * <p>Spec-trace comments quote exact Smile spec section titles and then paraphrase the exercised rule.</p>
  */
 abstract class SmileParserTestBase {
+
+    private static final int MAX_NESTING_DEPTH = JsonParser.MAX_NESTING_DEPTH;
 
     @FunctionalInterface
     protected interface JsonGeneratorWriter {
@@ -285,6 +288,73 @@ abstract class SmileParserTestBase {
 
         assertThat(result.keys().isEmpty(), is(true));
         assertThat(parser.hasNext(), is(false));
+    }
+
+    @Test
+    public void testReadJsonArrayAllowsDepthBeyondInitialStructureStack() {
+        JsonParser parser = createParser(nestedArrays(65));
+        JsonArray result = parser.readJsonArray();
+
+        assertThat(nestedArrayDepth(result), is(65));
+        assertThat(parser.hasNext(), is(false));
+    }
+
+    @Test
+    public void testReadJsonArrayAllowsMaximumDepth() {
+        JsonParser parser = createParser(nestedArrays(MAX_NESTING_DEPTH));
+        JsonArray result = parser.readJsonArray();
+
+        assertThat(nestedArrayDepth(result), is(MAX_NESTING_DEPTH));
+        assertThat(parser.hasNext(), is(false));
+    }
+
+    @Test
+    public void testReadJsonArrayRejectsExcessiveDepth() {
+        JsonParser parser = createParser(nestedArrays(MAX_NESTING_DEPTH + 1));
+
+        JsonException exception = assertThrows(JsonException.class, parser::readJsonArray);
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
+    }
+
+    @Test
+    public void testReadJsonObjectRejectsExcessiveDepth() {
+        JsonParser parser = createParser(nestedObjects(MAX_NESTING_DEPTH + 1));
+
+        JsonException exception = assertThrows(JsonException.class, parser::readJsonObject);
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
+    }
+
+    @Test
+    public void testSkipArrayRejectsExcessiveDepth() {
+        JsonParser parser = createParser(nestedArrays(MAX_NESTING_DEPTH + 1));
+
+        JsonException exception = assertThrows(JsonException.class, parser::skip);
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
+    }
+
+    @Test
+    public void testSkipObjectRejectsExcessiveDepth() {
+        JsonParser parser = createParser(nestedObjects(MAX_NESTING_DEPTH + 1));
+
+        JsonException exception = assertThrows(JsonException.class, parser::skip);
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
+    }
+
+    @Test
+    public void testTokenIterationRejectsExcessiveDepth() {
+        JsonParser parser = createParser(nestedArrays(MAX_NESTING_DEPTH + 1));
+
+        JsonException exception = assertThrows(JsonException.class, () -> {
+            while (parser.hasNext()) {
+                parser.nextToken();
+            }
+        });
+
+        assertThat(exception.getMessage(), containsString("Maximum JSON nesting depth exceeded"));
     }
 
     /*
@@ -1399,6 +1469,52 @@ abstract class SmileParserTestBase {
         byte[] smileData = new byte[] {0x3A, 0x29, 0x0A, 0x03, (byte) 0xFA, 0x30, (byte) 0xFE};
         JsonParser parser = createParser(smileData);
         assertThrows(JsonException.class, parser::readJsonObject);
+    }
+
+    private static byte[] nestedArrays(int depth) {
+        byte[] smileData = new byte[SmileConstants.HEADER_LENGTH + depth + 1 + depth];
+        int index = writeHeader(smileData);
+        for (int i = 0; i < depth; i++) {
+            smileData[index++] = SmileConstants.TOKEN_START_ARRAY;
+        }
+        smileData[index++] = SmileConstants.TOKEN_NULL;
+        for (int i = 0; i < depth; i++) {
+            smileData[index++] = SmileConstants.TOKEN_END_ARRAY;
+        }
+        return smileData;
+    }
+
+    private static byte[] nestedObjects(int depth) {
+        byte[] smileData = new byte[SmileConstants.HEADER_LENGTH + depth * 4 + 1];
+        int index = writeHeader(smileData);
+        for (int i = 0; i < depth; i++) {
+            smileData[index++] = SmileConstants.TOKEN_START_OBJECT;
+            smileData[index++] = (byte) SmileConstants.KEY_SHORT_ASCII_PREFIX;
+            smileData[index++] = (byte) 'a';
+        }
+        smileData[index++] = SmileConstants.TOKEN_NULL;
+        for (int i = 0; i < depth; i++) {
+            smileData[index++] = SmileConstants.TOKEN_END_OBJECT;
+        }
+        return smileData;
+    }
+
+    private static int writeHeader(byte[] smileData) {
+        smileData[0] = SmileConstants.HEADER_0;
+        smileData[1] = SmileConstants.HEADER_1;
+        smileData[2] = SmileConstants.HEADER_2;
+        smileData[3] = 0;
+        return SmileConstants.HEADER_LENGTH;
+    }
+
+    private static int nestedArrayDepth(JsonArray array) {
+        int depth = 1;
+        JsonValue value = array.get(0, JsonNull.instance());
+        while (value.type() == JsonValueType.ARRAY) {
+            depth++;
+            value = value.asArray().get(0, JsonNull.instance());
+        }
+        return depth;
     }
 
     private static int fnv1aHashUtf8(String value) {


### PR DESCRIPTION
### Description

Carries the JSON and Smile parser nesting-depth limit from Helidon 4.x commit [`04047a8e`](https://github.com/helidon-io/helidon/commit/04047a8eb152b1cf06a3b302b471589e91cd885a) to `main`.

- Rejects more than 1,000 nested object and array structures during JSON reads and skips.
- Applies the same boundary to Smile reads, skips, and direct token iteration.
- Preserves the optimized JSON object and array construction already present on `main`.
- Adds boundary, excessive-depth, stack-growth, and parser-state cleanup coverage.

### Release Note

____
Helidon JSON and Smile input parsers now reject more than 1,000 nested object and array structures with a `JsonException`. The root object or array counts as one structure.
____

### Documentation

The JSON guide documents the input-decoding limit and its boundary semantics.
