### PR TITLE
Allow MP Telemetry span to include response write

### DIFF
--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -480,19 +480,26 @@ naming convention unconditionally.
 
 When `telemetry.span.includes-response-write` is `false`, Helidon ends the
 span before serializing the response entity, preserving the behavior of earlier
-Helidon 4 releases. When it is `true`, Helidon ends the span after response
+Helidon 4 releases. When it is `true`, Helidon keeps the span open until response
 serialization and encoding have populated Helidon's response stream and Jersey
-has finished processing the response. The span remains open during response
+has finished processing the response. If an asynchronous resource method is
+still executing at that point, the span ends when the resource method returns.
+The span remains open during response
 filtering, but Helidon makes it current only during discrete, thread-owned
-phases: request filtering, resource-method execution, and entity
-materialization. This includes asynchronous JAX-RS responses. Spans started by
-writer interceptors, message-body writers, or streaming output are therefore
-children of the automatic span, without leaving its scope attached to a thread
-between phases. If response processing or writing fails, Helidon records the
-available failure and ends the automatic span when Jersey finishes processing
-the failed request. An application exception which Jersey successfully maps to
-a response is not itself treated as a response-writing failure; the resulting
-HTTP status determines the automatic span status.
+phases: request filtering, resource-method execution, exception mapping, and
+entity materialization. This includes asynchronous JAX-RS responses. Spans
+started by exception mappers, writer interceptors, message-body writers, or
+streaming output are therefore children of the automatic span, without leaving
+its scope attached to a thread between phases. Helidon does not force the
+automatic span to be current across arbitrary response filters because a
+request filter can establish a nested scope which its paired response filter
+must close in nesting order. The automatic span still remains open during that
+work. If response processing or writing fails, Helidon records the available
+failure and ends the automatic span after Jersey finishes processing the failed
+request and any still-running asynchronous resource method returns. An
+application exception which Jersey successfully maps to a response
+is not itself treated as a response-writing failure; the resulting HTTP status
+determines the automatic span status.
 
 This setting is deprecated for removal in a future major release. After its
 removal, automatic incoming REST spans will always include response preparation
@@ -503,7 +510,9 @@ server-side work of preparing the response. It does not measure the later
 WebServer socket commit, network delivery, or wait for the client to receive or
 acknowledge the response. A downstream transport failure after JAX-RS processing
 has finished might therefore not be recorded on the span, but it cannot leave
-the span unfinished.
+the span unfinished. For long-lived `ChunkedOutput` and server-sent event
+responses, the span covers initial JAX-RS response processing but not the later
+serialization and transmission of individual chunks or events.
 
 ### OpenTelemetry Java Agent
 

--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -467,12 +467,16 @@ When `telemetry.span.includes-response-write` is `false`, Helidon ends the
 span before serializing the response entity, preserving the behavior of earlier
 Helidon 4 releases. When it is `true`, Helidon ends the span after response
 serialization and encoding, when the last byte has been buffered for writing to
-the socket. The automatic span remains current while the response entity is
-written, so spans started by writer interceptors, message-body writers, or
-streaming output are children of the automatic span. If response writing fails,
-Helidon records the failure and ends the automatic span when Jersey finishes
-processing the failed request. This setting is deprecated for removal in a
-future major release.
+the socket. Helidon propagates the automatic span to the thread which processes
+the response, including asynchronous JAX-RS responses. The span remains current
+during response filtering and entity materialization, so spans started by writer
+interceptors, message-body writers, or streaming output are children of the
+automatic span. If response processing or writing fails, Helidon records the
+available failure and ends the automatic span when Jersey finishes processing
+the failed request. An application exception which Jersey successfully maps to
+a response is not itself treated as a response-writing failure; the resulting
+HTTP status determines the automatic span status. This setting is deprecated
+for removal in a future major release.
 
 For `telemetry.span.includes-response-write`, `true` measures the
 server-side work of preparing the response. It does not measure network delivery

--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -482,16 +482,21 @@ When `telemetry.span.includes-response-write` is `false`, Helidon ends the
 span before serializing the response entity, preserving the behavior of earlier
 Helidon 4 releases. When it is `true`, Helidon ends the span after response
 serialization and encoding have populated Helidon's response stream and Jersey
-has finished processing the response. Helidon propagates the automatic span to
-the thread which processes the response, including asynchronous JAX-RS
-responses. The span remains current during response filtering and entity
-materialization, so spans started by writer interceptors, message-body writers,
-or streaming output are children of the automatic span. If response processing
-or writing fails, Helidon records the available failure and ends the automatic
-span when Jersey finishes processing the failed request. An application
-exception which Jersey successfully maps to a response is not itself treated as
-a response-writing failure; the resulting HTTP status determines the automatic
-span status. This setting is deprecated for removal in a future major release.
+has finished processing the response. The span remains open during response
+filtering, but Helidon makes it current only during discrete, thread-owned
+phases: request filtering, resource-method execution, and entity
+materialization. This includes asynchronous JAX-RS responses. Spans started by
+writer interceptors, message-body writers, or streaming output are therefore
+children of the automatic span, without leaving its scope attached to a thread
+between phases. If response processing or writing fails, Helidon records the
+available failure and ends the automatic span when Jersey finishes processing
+the failed request. An application exception which Jersey successfully maps to
+a response is not itself treated as a response-writing failure; the resulting
+HTTP status determines the automatic span status.
+
+This setting is deprecated for removal in a future major release. After its
+removal, automatic incoming REST spans will always include response preparation
+through the end of Jersey response processing.
 
 For `telemetry.span.includes-response-write`, `true` measures the
 server-side work of preparing the response. It does not measure the later

--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -452,8 +452,23 @@ settings for automatic incoming REST request spans:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
+| `telemetry.span.full.url` | `Boolean` | `false` | **Deprecated.** Whether the span name uses the absolute request path instead of the matched JAX-RS route. |
 | `telemetry.span.name-includes-method` | `Boolean` | `false` | **Deprecated.** Whether the span name includes the HTTP request method. |
 | `telemetry.span.includes-response-write` | `Boolean` | `false` | **Deprecated.** Whether the span includes preparing and writing the response entity. |
+
+By default, Helidon uses the matched, low-cardinality JAX-RS route in the span
+name, such as `/greet/{name}`. Setting `telemetry.span.full.url` to `true`
+uses the resolved absolute request path instead, such as
+`http://localhost:8080/greet/Joe`. The absolute path does not include the query
+string. Because resolved paths can contain user-supplied path values and
+therefore create high-cardinality span names, leave this setting `false` unless
+compatibility with an application that expects the older full-URL naming format
+requires it. The setting is deprecated because a future major release will use
+low-cardinality route-based span names unconditionally.
+
+The `telemetry.span.full.url` and `telemetry.span.name-includes-method` settings
+are independent. For example, setting both to `true` produces a span name such
+as `GET http://localhost:8080/greet/Joe`.
 
 Earlier Helidon 4 releases used OpenTelemetry semantic conventions which did
 not include the HTTP method in automatic incoming REST span names. Setting
@@ -466,21 +481,24 @@ naming convention unconditionally.
 When `telemetry.span.includes-response-write` is `false`, Helidon ends the
 span before serializing the response entity, preserving the behavior of earlier
 Helidon 4 releases. When it is `true`, Helidon ends the span after response
-serialization and encoding, when the last byte has been buffered for writing to
-the socket. Helidon propagates the automatic span to the thread which processes
-the response, including asynchronous JAX-RS responses. The span remains current
-during response filtering and entity materialization, so spans started by writer
-interceptors, message-body writers, or streaming output are children of the
-automatic span. If response processing or writing fails, Helidon records the
-available failure and ends the automatic span when Jersey finishes processing
-the failed request. An application exception which Jersey successfully maps to
-a response is not itself treated as a response-writing failure; the resulting
-HTTP status determines the automatic span status. This setting is deprecated
-for removal in a future major release.
+serialization and encoding have populated Helidon's response stream and Jersey
+has finished processing the response. Helidon propagates the automatic span to
+the thread which processes the response, including asynchronous JAX-RS
+responses. The span remains current during response filtering and entity
+materialization, so spans started by writer interceptors, message-body writers,
+or streaming output are children of the automatic span. If response processing
+or writing fails, Helidon records the available failure and ends the automatic
+span when Jersey finishes processing the failed request. An application
+exception which Jersey successfully maps to a response is not itself treated as
+a response-writing failure; the resulting HTTP status determines the automatic
+span status. This setting is deprecated for removal in a future major release.
 
 For `telemetry.span.includes-response-write`, `true` measures the
-server-side work of preparing the response. It does not measure network delivery
-or wait for the client to receive or acknowledge the response.
+server-side work of preparing the response. It does not measure the later
+WebServer socket commit, network delivery, or wait for the client to receive or
+acknowledge the response. A downstream transport failure after JAX-RS processing
+has finished might therefore not be recorded on the span, but it cannot leave
+the span unfinished.
 
 ### OpenTelemetry Java Agent
 

--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -501,6 +501,10 @@ application exception which Jersey successfully maps to a response
 is not itself treated as a response-writing failure; the resulting HTTP status
 determines the automatic span status.
 
+This setting controls only automatic spans created by Helidon. When the
+OpenTelemetry Java Agent is present, the agent owns the automatic server span,
+so `telemetry.span.includes-response-write` has no effect.
+
 This setting is deprecated for removal in a future major release. After its
 removal, automatic incoming REST spans will always include response preparation
 through the end of Jersey response processing.

--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -467,8 +467,12 @@ When `telemetry.span.includes-response-write` is `false`, Helidon ends the
 span before serializing the response entity, preserving the behavior of earlier
 Helidon 4 releases. When it is `true`, Helidon ends the span after response
 serialization and encoding, when the last byte has been buffered for writing to
-the socket. This setting is also deprecated for removal in a future major
-release.
+the socket. The automatic span remains current while the response entity is
+written, so spans started by writer interceptors, message-body writers, or
+streaming output are children of the automatic span. If response writing fails,
+Helidon records the failure and ends the automatic span when Jersey finishes
+processing the failed request. This setting is deprecated for removal in a
+future major release.
 
 For `telemetry.span.includes-response-write`, `true` measures the
 server-side work of preparing the response. It does not measure network delivery

--- a/docs/mp/telemetry.md
+++ b/docs/mp/telemetry.md
@@ -54,7 +54,9 @@ telemetry.span.name-includes-method = true
 
 The ability to use the older format is deprecated, and you should plan for its
 removal in a future major release of Helidon. For that reason Helidon logs a
-warning message if you use the older REST span naming convention.
+warning message if you use the older REST span naming convention. See
+[Helidon automatic span compatibility](#helidon-automatic-span-compatibility)
+for details about this setting and the response-writing compatibility setting.
 
 ## Usage
 
@@ -442,6 +444,35 @@ use a different exporter set `otel.traces.exporter` in your configuration to the
 appropriate value. The `zipkin` value is deprecated because OpenTelemetry
 stopped publishing its Zipkin exporter in 1.65.0; use `otlp` for traces. See
 the [examples](#examples) section below.
+
+### Helidon Automatic Span Compatibility
+
+Helidon supports the following deprecated vendor-specific compatibility
+settings for automatic incoming REST request spans:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `telemetry.span.name-includes-method` | `Boolean` | `false` | **Deprecated.** Whether the span name includes the HTTP request method. |
+| `telemetry.span.includes-response-write` | `Boolean` | `false` | **Deprecated.** Whether the span includes preparing and writing the response entity. |
+
+Earlier Helidon 4 releases used OpenTelemetry semantic conventions which did
+not include the HTTP method in automatic incoming REST span names. Setting
+`telemetry.span.name-includes-method` to `true` selects the current convention,
+which includes the method. Leaving it unset or setting it to `false` preserves
+the older span names for compatibility and causes Helidon to log a warning. The
+setting is deprecated because a future major release will use the current span
+naming convention unconditionally.
+
+When `telemetry.span.includes-response-write` is `false`, Helidon ends the
+span before serializing the response entity, preserving the behavior of earlier
+Helidon 4 releases. When it is `true`, Helidon ends the span after response
+serialization and encoding, when the last byte has been buffered for writing to
+the socket. This setting is also deprecated for removal in a future major
+release.
+
+For `telemetry.span.includes-response-write`, `true` measures the
+server-side work of preparing the response. It does not measure network delivery
+or wait for the client to receive or acknowledge the response.
 
 ### OpenTelemetry Java Agent
 

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -248,6 +248,9 @@
                             <goal>test</goal>
                         </goals>
                         <configuration>
+                            <systemPropertyVariables>
+                                <io.opentelemetry.context.enableStrictContext>true</io.opentelemetry.context.enableStrictContext>
+                            </systemPropertyVariables>
                             <includes>
                                 <include>**/TestFilterSpanNesting.java</include>
                             </includes>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -195,6 +195,7 @@
                             </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/AgentDetectorTest.java</exclude>
+                                <exclude>**/AutoSpanIncludesWriteAgentTest.java</exclude>
                                 <exclude>**/TestSpanListenersWithInjection.java</exclude>
                                 <exclude>**/TestFilterSpanNesting.java</exclude>
                                 <exclude>**/PlainJerseyClientTest.java</exclude>
@@ -228,6 +229,7 @@
                         <configuration>
                             <includes>
                                 <include>**/AgentDetectorTest.java</include>
+                                <include>**/AutoSpanIncludesWriteAgentTest.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -198,7 +198,22 @@
                                 <exclude>**/TestSpanListenersWithInjection.java</exclude>
                                 <exclude>**/TestFilterSpanNesting.java</exclude>
                                 <exclude>**/PlainJerseyClientTest.java</exclude>
+                                <exclude>**/AutoSpanIncludesWriteAsyncTest.java</exclude>
                             </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>auto-span-async-context-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <io.opentelemetry.context.enableStrictContext>true</io.opentelemetry.context.enableStrictContext>
+                            </systemPropertyVariables>
+                            <includes>
+                                <include>**/AutoSpanIncludesWriteAsyncTest.java</include>
+                            </includes>
                         </configuration>
                     </execution>
                     <execution>

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -214,7 +214,7 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
                     request.setProperty(ServerSpanLifecycle.PROPERTY, lifecycle);
                 }
                 ServerSpanLifecycle finalLifecycle = lifecycle;
-                serverResponse.whenSent(() -> finalLifecycle.complete(span, scope, true));
+                serverResponse.whenSent(() -> finalLifecycle.responseSent(span, scope));
             } else {
                 span.end();
             }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -28,7 +28,6 @@ import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
-import io.helidon.webserver.http.ServerResponse;
 
 import io.opentelemetry.semconv.ServerAttributes;
 import jakarta.enterprise.inject.Instance;
@@ -93,9 +92,6 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
 
     @jakarta.ws.rs.core.Context
     private ResourceInfo resourceInfo;
-
-    @jakarta.ws.rs.core.Context
-    private ServerResponse serverResponse;
 
     @Inject
     HelidonTelemetryContainerFilter(io.helidon.tracing.Tracer helidonTracer,
@@ -207,19 +203,10 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
             if (response.getStatusInfo().getFamily().compareTo(Response.Status.Family.SERVER_ERROR) == 0) {
                 span.status(Span.Status.ERROR);
             }
-            if (autoSpanIncludesResponseWrite) {
-                ServerSpanLifecycle lifecycle = (ServerSpanLifecycle) request.getProperty(ServerSpanLifecycle.PROPERTY);
-                if (lifecycle == null) {
-                    lifecycle = new ServerSpanLifecycle();
-                    request.setProperty(ServerSpanLifecycle.PROPERTY, lifecycle);
-                }
-                ServerSpanLifecycle finalLifecycle = lifecycle;
-                serverResponse.whenSent(() -> finalLifecycle.responseSent(span, scope));
-            } else {
+            // Response-write-inclusive spans end at Jersey's FINISHED request event.
+            if (!autoSpanIncludesResponseWrite) {
                 span.end();
             }
-
-
         } finally {
             if (!autoSpanIncludesResponseWrite) {
                 request.removeProperty(SPAN);

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -28,6 +28,7 @@ import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
+import io.helidon.webserver.http.ServerResponse;
 
 import io.opentelemetry.semconv.ServerAttributes;
 import jakarta.enterprise.inject.Instance;
@@ -69,11 +70,15 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
     @Deprecated(forRemoval = true, since = "4.1")
     static final String SPAN_NAME_INCLUDES_METHOD = "telemetry.span.name-includes-method";
 
+    @Deprecated(forRemoval = true, since = "4.5.4")
+    static final String AUTO_SPAN_INCLUDES_RESPONSE_WRITE = "telemetry.span.includes-response-write";
+
     private static boolean spanNameFullUrl = false;
     private static AtomicBoolean spanNameWarningLogged = new AtomicBoolean();
 
     private final io.helidon.tracing.Tracer helidonTracer;
     private final boolean isAgentPresent;
+    private final boolean autoSpanIncludesResponseWrite;
 
     /*
      MP Telemetry 1.1 adopts OpenTelemetry 1.29 semantic conventions which require the route to be in the REST span name.
@@ -89,12 +94,17 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
     @jakarta.ws.rs.core.Context
     private ResourceInfo resourceInfo;
 
+    @jakarta.ws.rs.core.Context
+    private ServerResponse serverResponse;
+
     @Inject
     HelidonTelemetryContainerFilter(io.helidon.tracing.Tracer helidonTracer,
                                     org.eclipse.microprofile.config.Config mpConfig,
                                     Instance<HelidonTelemetryContainerFilterHelper> helpersInstance) {
         this.helidonTracer = helidonTracer;
         isAgentPresent = HelidonOpenTelemetry.AgentDetector.isAgentPresent(MpConfig.toHelidonConfig(mpConfig));
+        autoSpanIncludesResponseWrite = mpConfig.getOptionalValue(AUTO_SPAN_INCLUDES_RESPONSE_WRITE, Boolean.class)
+                .orElse(false);
 
         // @Deprecated(forRemoval = true) In 5.x remove the following.
         mpConfig.getOptionalValue(SPAN_NAME_FULL_URL, Boolean.class).ifPresent(e -> spanNameFullUrl = e);
@@ -192,7 +202,11 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
             if (response.getStatusInfo().getFamily().compareTo(Response.Status.Family.SERVER_ERROR) == 0) {
                 span.status(Span.Status.ERROR);
             }
-            span.end();
+            if (autoSpanIncludesResponseWrite) {
+                serverResponse.whenSent(span::end);
+            } else {
+                span.end();
+            }
 
 
         } finally {

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -164,10 +164,11 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
 
         Scope helidonScope = helidonSpan.activate();
 
-        requestContext.setProperty(SPAN, helidonSpan);
-        requestContext.setProperty(SPAN_SCOPE, helidonScope);
         if (autoSpanIncludesResponseWrite) {
-            requestContext.setProperty(ServerSpanLifecycle.PROPERTY, new ServerSpanLifecycle());
+            requestContext.setProperty(ServerSpanLifecycle.PROPERTY, new ServerSpanLifecycle(helidonSpan, helidonScope));
+        } else {
+            requestContext.setProperty(SPAN, helidonSpan);
+            requestContext.setProperty(SPAN_SCOPE, helidonScope);
         }
 
     }
@@ -189,21 +190,33 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         }
 
         try {
-            Span span = (Span) request.getProperty(SPAN);
+            ServerSpanLifecycle lifecycle = null;
+            Span span;
+            if (autoSpanIncludesResponseWrite) {
+                lifecycle = (ServerSpanLifecycle) request.getProperty(ServerSpanLifecycle.PROPERTY);
+                span = lifecycle == null ? null : lifecycle.span();
+            } else {
+                span = (Span) request.getProperty(SPAN);
+            }
             if (span == null) {
                 return;
             }
-            Scope scope = (Scope) request.getProperty(SPAN_SCOPE);
-            if (!autoSpanIncludesResponseWrite) {
-                scope.close();
+            if (autoSpanIncludesResponseWrite) {
+                lifecycle.closeRequestScopeIfCurrent();
+            } else {
+                ((Scope) request.getProperty(SPAN_SCOPE)).close();
             }
 
-            span.tag(HTTP_STATUS_CODE, response.getStatus());
+            if (autoSpanIncludesResponseWrite) {
+                lifecycle.responseStatus(response.getStatus());
+            } else {
+                span.tag(HTTP_STATUS_CODE, response.getStatus());
 
-            // OpenTelemetry semantic conventions dictate what the span status should be.
-            // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
-            if (response.getStatusInfo().getFamily().compareTo(Response.Status.Family.SERVER_ERROR) == 0) {
-                span.status(Span.Status.ERROR);
+                // OpenTelemetry semantic conventions dictate what the span status should be.
+                // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+                if (response.getStatusInfo().getFamily().compareTo(Response.Status.Family.SERVER_ERROR) == 0) {
+                    span.status(Span.Status.ERROR);
+                }
             }
             // Response-write-inclusive spans end at Jersey's FINISHED request event.
             if (!autoSpanIncludesResponseWrite) {

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -58,8 +58,8 @@ import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.NET_HO
 @Provider
 class HelidonTelemetryContainerFilter implements ContainerRequestFilter, ContainerResponseFilter {
     private static final System.Logger LOGGER = System.getLogger(HelidonTelemetryContainerFilter.class.getName());
-    private static final String SPAN = Span.class.getName();
-    private static final String SPAN_SCOPE = Scope.class.getName();
+    static final String SPAN = Span.class.getName();
+    static final String SPAN_SCOPE = Scope.class.getName();
     private static final String HTTP_TARGET = "http.target";
     private static final String HTTP_ROUTE = "http.route";
 
@@ -168,6 +168,9 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
 
         requestContext.setProperty(SPAN, helidonSpan);
         requestContext.setProperty(SPAN_SCOPE, helidonScope);
+        if (autoSpanIncludesResponseWrite) {
+            requestContext.setProperty(ServerSpanLifecycle.PROPERTY, new ServerSpanLifecycle());
+        }
 
     }
 
@@ -193,7 +196,9 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
                 return;
             }
             Scope scope = (Scope) request.getProperty(SPAN_SCOPE);
-            scope.close();
+            if (!autoSpanIncludesResponseWrite) {
+                scope.close();
+            }
 
             span.tag(HTTP_STATUS_CODE, response.getStatus());
 
@@ -203,15 +208,23 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
                 span.status(Span.Status.ERROR);
             }
             if (autoSpanIncludesResponseWrite) {
-                serverResponse.whenSent(span::end);
+                ServerSpanLifecycle lifecycle = (ServerSpanLifecycle) request.getProperty(ServerSpanLifecycle.PROPERTY);
+                if (lifecycle == null) {
+                    lifecycle = new ServerSpanLifecycle();
+                    request.setProperty(ServerSpanLifecycle.PROPERTY, lifecycle);
+                }
+                ServerSpanLifecycle finalLifecycle = lifecycle;
+                serverResponse.whenSent(() -> finalLifecycle.complete(span, scope, true));
             } else {
                 span.end();
             }
 
 
         } finally {
-            request.removeProperty(SPAN);
-            request.removeProperty(SPAN_SCOPE);
+            if (!autoSpanIncludesResponseWrite) {
+                request.removeProperty(SPAN);
+                request.removeProperty(SPAN_SCOPE);
+            }
         }
     }
 

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -27,6 +27,7 @@ import io.helidon.microprofile.telemetry.spi.HelidonTelemetryContainerFilterHelp
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.Tracer;
 import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
 
 import io.opentelemetry.semconv.ServerAttributes;
@@ -39,8 +40,10 @@ import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
+import org.eclipse.microprofile.config.Config;
 import org.glassfish.jersey.server.ExtendedUriInfo;
 import org.glassfish.jersey.server.model.Resource;
 
@@ -56,15 +59,8 @@ import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.NET_HO
  */
 @Provider
 class HelidonTelemetryContainerFilter implements ContainerRequestFilter, ContainerResponseFilter {
-    private static final System.Logger LOGGER = System.getLogger(HelidonTelemetryContainerFilter.class.getName());
     static final String SPAN = Span.class.getName();
     static final String SPAN_SCOPE = Scope.class.getName();
-    private static final String HTTP_TARGET = "http.target";
-    private static final String HTTP_ROUTE = "http.route";
-
-    private static final String SPAN_NAME_FULL_URL = "telemetry.span.full.url";
-
-    private static final String HELPER_START_SPAN_PROPERTY = HelidonTelemetryContainerFilterHelper.class + ".startSpan";
 
     @Deprecated(forRemoval = true, since = "4.1")
     static final String SPAN_NAME_INCLUDES_METHOD = "telemetry.span.name-includes-method";
@@ -72,10 +68,16 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
     @Deprecated(forRemoval = true, since = "4.5.4")
     static final String AUTO_SPAN_INCLUDES_RESPONSE_WRITE = "telemetry.span.includes-response-write";
 
-    private static boolean spanNameFullUrl = false;
-    private static AtomicBoolean spanNameWarningLogged = new AtomicBoolean();
+    private static final System.Logger LOGGER = System.getLogger(HelidonTelemetryContainerFilter.class.getName());
+    private static final String HTTP_TARGET = "http.target";
+    private static final String HTTP_ROUTE = "http.route";
+    private static final String SPAN_NAME_FULL_URL = "telemetry.span.full.url";
+    private static final String HELPER_START_SPAN_PROPERTY = HelidonTelemetryContainerFilterHelper.class + ".startSpan";
+    private static final AtomicBoolean SPAN_NAME_WARNING_LOGGED = new AtomicBoolean();
 
-    private final io.helidon.tracing.Tracer helidonTracer;
+    private static boolean spanNameFullUrl = false;
+
+    private final Tracer helidonTracer;
     private final boolean isAgentPresent;
     private final boolean autoSpanIncludesResponseWrite;
 
@@ -90,12 +92,12 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
 
     private final List<HelidonTelemetryContainerFilterHelper> helpers;
 
-    @jakarta.ws.rs.core.Context
+    @Context
     private ResourceInfo resourceInfo;
 
     @Inject
-    HelidonTelemetryContainerFilter(io.helidon.tracing.Tracer helidonTracer,
-                                    org.eclipse.microprofile.config.Config mpConfig,
+    HelidonTelemetryContainerFilter(Tracer helidonTracer,
+                                    Config mpConfig,
                                     Instance<HelidonTelemetryContainerFilterHelper> helpersInstance) {
         this.helidonTracer = helidonTracer;
         isAgentPresent = HelidonOpenTelemetry.AgentDetector.isAgentPresent(MpConfig.toHelidonConfig(mpConfig));
@@ -106,8 +108,8 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         mpConfig.getOptionalValue(SPAN_NAME_FULL_URL, Boolean.class).ifPresent(e -> spanNameFullUrl = e);
         Optional<Boolean> includeMethodConfig = mpConfig.getOptionalValue(SPAN_NAME_INCLUDES_METHOD, Boolean.class);
         restSpanNameIncludesMethod = includeMethodConfig.orElse(false);
-        if (!restSpanNameIncludesMethod && !spanNameWarningLogged.get()) {
-            spanNameWarningLogged.set(true);
+        if (!restSpanNameIncludesMethod && !SPAN_NAME_WARNING_LOGGED.get()) {
+            SPAN_NAME_WARNING_LOGGED.set(true);
             LOGGER.log(System.Logger.Level.WARNING,
                        String.format("""
                                Current OpenTelemetry semantic conventions include the HTTP method as part of REST span
@@ -215,6 +217,14 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         }
     }
 
+    private static Class<?> getRealClass(Class<?> object) {
+        Class<?> result = object;
+        while (result.isSynthetic()) {
+            result = result.getSuperclass();
+        }
+        return result;
+    }
+
     private Optional<SpanContext> parentSpanContext(ContainerRequestContext requestContext) {
         // Prefer the current span if there is one.
         return Span.current().map(Span::context)
@@ -287,11 +297,4 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         return path;
     }
 
-    private static Class<?> getRealClass(Class<?> object) {
-        Class<?> result = object;
-        while (result.isSynthetic()) {
-            result = result.getSuperclass();
-        }
-        return result;
-    }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+
+import org.glassfish.jersey.server.monitoring.ApplicationEvent;
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+
+/**
+ * Completes response-write-inclusive server spans after Jersey finishes processing a request.
+ */
+final class HelidonTelemetryRequestEventListener implements ApplicationEventListener {
+
+    @Override
+    public void onEvent(ApplicationEvent event) {
+    }
+
+    @Override
+    public RequestEventListener onRequest(RequestEvent requestEvent) {
+        return HelidonTelemetryRequestEventListener::onRequestEvent;
+    }
+
+    private static void onRequestEvent(RequestEvent event) {
+        ServerSpanLifecycle lifecycle = (ServerSpanLifecycle) event.getContainerRequest()
+                .getProperty(ServerSpanLifecycle.PROPERTY);
+        if (lifecycle == null) {
+            return;
+        }
+
+        switch (event.getType()) {
+        case ON_EXCEPTION:
+            lifecycle.failure(event.getException());
+            break;
+        case FINISHED:
+            Span span = (Span) event.getContainerRequest().getProperty(HelidonTelemetryContainerFilter.SPAN);
+            Scope scope = (Scope) event.getContainerRequest().getProperty(HelidonTelemetryContainerFilter.SPAN_SCOPE);
+            if (span != null && scope != null) {
+                lifecycle.complete(span, scope, event.isResponseWritten());
+            }
+            break;
+        default:
+            break;
+        }
+    }
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
@@ -18,16 +18,15 @@ package io.helidon.microprofile.telemetry;
 import java.util.Objects;
 
 import io.helidon.tracing.Scope;
-import io.helidon.tracing.Span;
 
-import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
 
 /**
- * Maintains response-write-inclusive server spans across Jersey request-processing phases and ends them at FINISHED.
+ * Maintains response-write-inclusive server spans across Jersey request-processing phases. FINISHED makes a span eligible
+ * to end; if an asynchronous resource method is still executing, the span ends when that method returns.
  */
 final class HelidonTelemetryRequestEventListener implements ApplicationEventListener {
 
@@ -39,46 +38,84 @@ final class HelidonTelemetryRequestEventListener implements ApplicationEventList
     @Override
     public RequestEventListener onRequest(RequestEvent requestEvent) {
         Objects.requireNonNull(requestEvent);
-        return HelidonTelemetryRequestEventListener::onRequestEvent;
+        return new RequestListener();
     }
 
-    private static void onRequestEvent(RequestEvent event) {
-        ContainerRequest request = event.getContainerRequest();
-        ServerSpanLifecycle lifecycle = (ServerSpanLifecycle) request.getProperty(ServerSpanLifecycle.PROPERTY);
-        if (lifecycle == null) {
-            return;
+    private static void close(Scope scope) {
+        if (scope != null) {
+            scope.close();
+        }
+    }
+
+    private static final class RequestListener implements RequestEventListener {
+        private volatile ServerSpanLifecycle lifecycle;
+        private Scope resourceScope;
+        private Scope exceptionMapperScope;
+        private volatile boolean initialized;
+
+        @Override
+        public void onEvent(RequestEvent event) {
+            initialize(event);
+            ServerSpanLifecycle currentLifecycle = lifecycle;
+            if (currentLifecycle == null) {
+                return;
+            }
+
+            switch (event.getType()) {
+            case REQUEST_FILTERED -> currentLifecycle.closeRequestScopeIfCurrent();
+            case RESOURCE_METHOD_START -> {
+                if (currentLifecycle.resourceMethodStarted()) {
+                    resourceScope = currentLifecycle.activate();
+                }
+            }
+            case RESOURCE_METHOD_FINISHED -> {
+                close(resourceScope);
+                resourceScope = null;
+                releaseIfFinished(currentLifecycle, currentLifecycle.resourceMethodFinished());
+            }
+            case RESP_FILTERS_START -> currentLifecycle.responseProcessingStarted();
+            case EXCEPTION_MAPPER_FOUND -> {
+                exceptionMapperScope = currentLifecycle.activate();
+            }
+            case EXCEPTION_MAPPING_FINISHED -> {
+                close(exceptionMapperScope);
+                exceptionMapperScope = null;
+            }
+            case ON_EXCEPTION -> currentLifecycle.responseFailure(event.getException());
+            case FINISHED -> {
+                currentLifecycle.closeRequestScopeIfCurrent();
+                if (event.getContainerResponse() != null) {
+                    currentLifecycle.responseStatus(event.getContainerResponse().getStatus());
+                }
+                releaseIfFinished(currentLifecycle, currentLifecycle.requestFinished(event.isResponseWritten()));
+            }
+            case START, MATCHING_START, LOCATOR_MATCHED, SUBRESOURCE_LOCATED, REQUEST_MATCHED, RESP_FILTERS_FINISHED -> {
+            }
+            default -> {
+            }
+            }
         }
 
-        Span span = (Span) request.getProperty(HelidonTelemetryContainerFilter.SPAN);
-        Scope scope = (Scope) request.getProperty(HelidonTelemetryContainerFilter.SPAN_SCOPE);
-        switch (event.getType()) {
-        case REQUEST_FILTERED -> {
-            if (scope != null) {
-                lifecycle.requestFiltered(scope);
+        private void releaseIfFinished(ServerSpanLifecycle currentLifecycle, boolean finished) {
+            if (finished && lifecycle == currentLifecycle) {
+                lifecycle = null;
             }
         }
-        case RESOURCE_METHOD_START -> {
-            if (span != null) {
-                lifecycle.resourceMethodStarted(span);
+
+        private static boolean initializes(RequestEvent.Type type) {
+            return switch (type) {
+            case REQUEST_FILTERED, RESOURCE_METHOD_START, RESOURCE_METHOD_FINISHED, RESP_FILTERS_START,
+                    RESP_FILTERS_FINISHED, ON_EXCEPTION, EXCEPTION_MAPPER_FOUND, EXCEPTION_MAPPING_FINISHED, FINISHED -> true;
+            case START, MATCHING_START, LOCATOR_MATCHED, SUBRESOURCE_LOCATED, REQUEST_MATCHED -> false;
+            };
+        }
+
+        private void initialize(RequestEvent event) {
+            if (initialized || !initializes(event.getType())) {
+                return;
             }
-        }
-        case RESOURCE_METHOD_FINISHED -> {
-            if (span != null) {
-                lifecycle.resourceMethodFinished(span);
-            }
-        }
-        case RESP_FILTERS_START -> lifecycle.responseProcessingStarted();
-        case ON_EXCEPTION -> lifecycle.responseFailure(event.getException());
-        case FINISHED -> {
-            if (span != null) {
-                lifecycle.requestFinished(span, event.isResponseWritten());
-            }
-        }
-        case START, MATCHING_START, LOCATOR_MATCHED, SUBRESOURCE_LOCATED, REQUEST_MATCHED, RESP_FILTERS_FINISHED,
-                EXCEPTION_MAPPER_FOUND, EXCEPTION_MAPPING_FINISHED -> {
-        }
-        default -> {
-        }
+            lifecycle = (ServerSpanLifecycle) event.getContainerRequest().getProperty(ServerSpanLifecycle.PROPERTY);
+            initialized = true;
         }
     }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import java.util.Objects;
+
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 
@@ -31,10 +33,12 @@ final class HelidonTelemetryRequestEventListener implements ApplicationEventList
 
     @Override
     public void onEvent(ApplicationEvent event) {
+        Objects.requireNonNull(event);
     }
 
     @Override
     public RequestEventListener onRequest(RequestEvent requestEvent) {
+        Objects.requireNonNull(requestEvent);
         return HelidonTelemetryRequestEventListener::onRequestEvent;
     }
 
@@ -48,45 +52,33 @@ final class HelidonTelemetryRequestEventListener implements ApplicationEventList
         Span span = (Span) request.getProperty(HelidonTelemetryContainerFilter.SPAN);
         Scope scope = (Scope) request.getProperty(HelidonTelemetryContainerFilter.SPAN_SCOPE);
         switch (event.getType()) {
-        case RESOURCE_METHOD_START:
-            lifecycle.resourceMethodStarted();
-            break;
-        case RESOURCE_METHOD_FINISHED:
-            if (span != null && scope != null) {
-                try {
-                    lifecycle.resourceMethodFinished(span, scope);
-                } finally {
-                    cleanupIfFinished(request, lifecycle);
-                }
+        case REQUEST_FILTERED -> {
+            if (scope != null) {
+                lifecycle.requestFiltered(scope);
             }
-            break;
-        case RESP_FILTERS_START:
-            if (span != null) {
-                lifecycle.responseProcessingStarted(span);
-            }
-            break;
-        case ON_EXCEPTION:
-            lifecycle.responseFailure(event.getException());
-            break;
-        case FINISHED:
-            if (span != null && scope != null) {
-                try {
-                    lifecycle.requestFinished(span, scope, event.isResponseWritten());
-                } finally {
-                    cleanupIfFinished(request, lifecycle);
-                }
-            }
-            break;
-        default:
-            break;
         }
-    }
-
-    static void cleanupIfFinished(ContainerRequest request, ServerSpanLifecycle lifecycle) {
-        if (lifecycle.isFinished()) {
-            request.removeProperty(HelidonTelemetryContainerFilter.SPAN);
-            request.removeProperty(HelidonTelemetryContainerFilter.SPAN_SCOPE);
-            request.removeProperty(ServerSpanLifecycle.PROPERTY);
+        case RESOURCE_METHOD_START -> {
+            if (span != null) {
+                lifecycle.resourceMethodStarted(span);
+            }
+        }
+        case RESOURCE_METHOD_FINISHED -> {
+            if (span != null) {
+                lifecycle.resourceMethodFinished(span);
+            }
+        }
+        case RESP_FILTERS_START -> lifecycle.responseProcessingStarted();
+        case ON_EXCEPTION -> lifecycle.responseFailure(event.getException());
+        case FINISHED -> {
+            if (span != null) {
+                lifecycle.requestFinished(span, event.isResponseWritten());
+            }
+        }
+        case START, MATCHING_START, LOCATOR_MATCHED, SUBRESOURCE_LOCATED, REQUEST_MATCHED, RESP_FILTERS_FINISHED,
+                EXCEPTION_MAPPER_FOUND, EXCEPTION_MAPPING_FINISHED -> {
+        }
+        default -> {
+        }
         }
     }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
@@ -25,7 +25,7 @@ import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
 
 /**
- * Maintains response-write-inclusive server spans across Jersey request-processing phases.
+ * Maintains response-write-inclusive server spans across Jersey request-processing phases and ends them at FINISHED.
  */
 final class HelidonTelemetryRequestEventListener implements ApplicationEventListener {
 
@@ -53,7 +53,11 @@ final class HelidonTelemetryRequestEventListener implements ApplicationEventList
             break;
         case RESOURCE_METHOD_FINISHED:
             if (span != null && scope != null) {
-                lifecycle.resourceMethodFinished(span, scope);
+                try {
+                    lifecycle.resourceMethodFinished(span, scope);
+                } finally {
+                    cleanupIfFinished(request, lifecycle);
+                }
             }
             break;
         case RESP_FILTERS_START:
@@ -66,11 +70,23 @@ final class HelidonTelemetryRequestEventListener implements ApplicationEventList
             break;
         case FINISHED:
             if (span != null && scope != null) {
-                lifecycle.requestFinished(span, scope, event.isResponseWritten());
+                try {
+                    lifecycle.requestFinished(span, scope, event.isResponseWritten());
+                } finally {
+                    cleanupIfFinished(request, lifecycle);
+                }
             }
             break;
         default:
             break;
+        }
+    }
+
+    static void cleanupIfFinished(ContainerRequest request, ServerSpanLifecycle lifecycle) {
+        if (lifecycle.isFinished()) {
+            request.removeProperty(HelidonTelemetryContainerFilter.SPAN);
+            request.removeProperty(HelidonTelemetryContainerFilter.SPAN_SCOPE);
+            request.removeProperty(ServerSpanLifecycle.PROPERTY);
         }
     }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
@@ -96,18 +96,18 @@ final class HelidonTelemetryRequestEventListener implements ApplicationEventList
             }
         }
 
-        private void releaseIfFinished(ServerSpanLifecycle currentLifecycle, boolean finished) {
-            if (finished && lifecycle == currentLifecycle) {
-                lifecycle = null;
-            }
-        }
-
         private static boolean initializes(RequestEvent.Type type) {
             return switch (type) {
             case REQUEST_FILTERED, RESOURCE_METHOD_START, RESOURCE_METHOD_FINISHED, RESP_FILTERS_START,
                     RESP_FILTERS_FINISHED, ON_EXCEPTION, EXCEPTION_MAPPER_FOUND, EXCEPTION_MAPPING_FINISHED, FINISHED -> true;
             case START, MATCHING_START, LOCATOR_MATCHED, SUBRESOURCE_LOCATED, REQUEST_MATCHED -> false;
             };
+        }
+
+        private void releaseIfFinished(ServerSpanLifecycle currentLifecycle, boolean finished) {
+            if (finished && lifecycle == currentLifecycle) {
+                lifecycle = null;
+            }
         }
 
         private void initialize(RequestEvent event) {

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryRequestEventListener.java
@@ -18,13 +18,14 @@ package io.helidon.microprofile.telemetry;
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 
+import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
 
 /**
- * Completes response-write-inclusive server spans after Jersey finishes processing a request.
+ * Maintains response-write-inclusive server spans across Jersey request-processing phases.
  */
 final class HelidonTelemetryRequestEventListener implements ApplicationEventListener {
 
@@ -38,21 +39,34 @@ final class HelidonTelemetryRequestEventListener implements ApplicationEventList
     }
 
     private static void onRequestEvent(RequestEvent event) {
-        ServerSpanLifecycle lifecycle = (ServerSpanLifecycle) event.getContainerRequest()
-                .getProperty(ServerSpanLifecycle.PROPERTY);
+        ContainerRequest request = event.getContainerRequest();
+        ServerSpanLifecycle lifecycle = (ServerSpanLifecycle) request.getProperty(ServerSpanLifecycle.PROPERTY);
         if (lifecycle == null) {
             return;
         }
 
+        Span span = (Span) request.getProperty(HelidonTelemetryContainerFilter.SPAN);
+        Scope scope = (Scope) request.getProperty(HelidonTelemetryContainerFilter.SPAN_SCOPE);
         switch (event.getType()) {
+        case RESOURCE_METHOD_START:
+            lifecycle.resourceMethodStarted();
+            break;
+        case RESOURCE_METHOD_FINISHED:
+            if (span != null && scope != null) {
+                lifecycle.resourceMethodFinished(span, scope);
+            }
+            break;
+        case RESP_FILTERS_START:
+            if (span != null) {
+                lifecycle.responseProcessingStarted(span);
+            }
+            break;
         case ON_EXCEPTION:
-            lifecycle.failure(event.getException());
+            lifecycle.responseFailure(event.getException());
             break;
         case FINISHED:
-            Span span = (Span) event.getContainerRequest().getProperty(HelidonTelemetryContainerFilter.SPAN);
-            Scope scope = (Scope) event.getContainerRequest().getProperty(HelidonTelemetryContainerFilter.SPAN_SCOPE);
             if (span != null && scope != null) {
-                lifecycle.complete(span, scope, event.isResponseWritten());
+                lifecycle.requestFinished(span, scope, event.isResponseWritten());
             }
             break;
         default:

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryWriterInterceptor.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryWriterInterceptor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.io.IOException;
+
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+
+/**
+ * Makes a response-write-inclusive automatic server span current during entity materialization.
+ */
+@Provider
+@Priority(Integer.MIN_VALUE)
+final class HelidonTelemetryWriterInterceptor implements WriterInterceptor {
+
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+        ServerSpanLifecycle lifecycle = (ServerSpanLifecycle) context.getProperty(ServerSpanLifecycle.PROPERTY);
+        Span span = (Span) context.getProperty(HelidonTelemetryContainerFilter.SPAN);
+        if (lifecycle == null || span == null) {
+            context.proceed();
+            return;
+        }
+
+        if (isCurrent(span)) {
+            proceed(context, lifecycle);
+            return;
+        }
+
+        try (Scope ignored = span.activate()) {
+            proceed(context, lifecycle);
+        }
+    }
+
+    private static void proceed(WriterInterceptorContext context, ServerSpanLifecycle lifecycle) throws IOException {
+        try {
+            context.proceed();
+        } catch (IOException | RuntimeException | Error e) {
+            lifecycle.writerFailure(e);
+            throw e;
+        }
+    }
+
+    private static boolean isCurrent(Span span) {
+        return Span.current()
+                .map(current -> current.context().spanId().equals(span.context().spanId()))
+                .orElse(false);
+    }
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryWriterInterceptor.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryWriterInterceptor.java
@@ -46,8 +46,11 @@ final class HelidonTelemetryWriterInterceptor implements WriterInterceptor {
             return;
         }
 
-        try (Scope ignored = span.activate()) {
+        Scope scope = span.activate();
+        try {
             proceed(context, lifecycle);
+        } finally {
+            scope.close();
         }
     }
 

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryWriterInterceptor.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryWriterInterceptor.java
@@ -18,7 +18,6 @@ package io.helidon.microprofile.telemetry;
 import java.io.IOException;
 
 import io.helidon.tracing.Scope;
-import io.helidon.tracing.Span;
 
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.ext.Provider;
@@ -35,22 +34,17 @@ final class HelidonTelemetryWriterInterceptor implements WriterInterceptor {
     @Override
     public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
         ServerSpanLifecycle lifecycle = (ServerSpanLifecycle) context.getProperty(ServerSpanLifecycle.PROPERTY);
-        Span span = (Span) context.getProperty(HelidonTelemetryContainerFilter.SPAN);
-        if (lifecycle == null || span == null) {
+        if (lifecycle == null) {
             context.proceed();
             return;
         }
 
-        if (isCurrent(span)) {
-            proceed(context, lifecycle);
-            return;
-        }
-
-        Scope scope = span.activate();
+        Scope scope = lifecycle.activate();
         try {
             proceed(context, lifecycle);
         } finally {
             scope.close();
+            context.removeProperty(ServerSpanLifecycle.PROPERTY);
         }
     }
 
@@ -61,11 +55,5 @@ final class HelidonTelemetryWriterInterceptor implements WriterInterceptor {
             lifecycle.writerFailure(e);
             throw e;
         }
-    }
-
-    private static boolean isCurrent(Span span) {
-        return Span.current()
-                .map(current -> current.context().spanId().equals(span.context().spanId()))
-                .orElse(false);
     }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
@@ -15,11 +15,15 @@
  */
 package io.helidon.microprofile.telemetry;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
+
+import io.opentelemetry.context.Context;
+
+import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_STATUS_CODE;
 
 final class ServerSpanLifecycle {
     static final String PROPERTY = ServerSpanLifecycle.class.getName();
@@ -31,83 +35,115 @@ final class ServerSpanLifecycle {
     private static final int REQUEST_FINISHED = 1 << 4;
     private static final int RESPONSE_WRITTEN = 1 << 5;
     private static final int SPAN_ENDED = 1 << 6;
+    private static final VarHandle STATE;
+    private static final VarHandle FAILURE;
 
-    private final AtomicInteger state = new AtomicInteger();
-    private final AtomicReference<Scope> resourceScope = new AtomicReference<>();
-    private final AtomicReference<Throwable> failure = new AtomicReference<>();
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            STATE = lookup.findVarHandle(ServerSpanLifecycle.class, "state", int.class);
+            FAILURE = lookup.findVarHandle(ServerSpanLifecycle.class, "failure", Throwable.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
-    void requestFiltered(Scope requestScope) {
-        int previous = state.getAndUpdate(value -> value | REQUEST_SCOPE_CLOSED);
+    private final Span span;
+    private final Scope requestScope;
+    private final Thread requestScopeOwner;
+    private final Context requestContext;
+    private volatile int state;
+    private volatile Throwable failure;
+
+    ServerSpanLifecycle(Span span, Scope requestScope) {
+        this.span = span;
+        this.requestScope = requestScope;
+        requestScopeOwner = Thread.currentThread();
+        requestContext = Context.current();
+    }
+
+    Span span() {
+        return span;
+    }
+
+    Scope activate() {
+        return span.activate();
+    }
+
+    void closeRequestScopeIfCurrent() {
+        if (Thread.currentThread() != requestScopeOwner || Context.current() != requestContext) {
+            return;
+        }
+
+        int previous = (int) STATE.getAndBitwiseOr(this, REQUEST_SCOPE_CLOSED);
         if ((previous & REQUEST_SCOPE_CLOSED) == 0) {
             requestScope.close();
         }
     }
 
-    void resourceMethodStarted(Span span) {
-        int previous = state.getAndUpdate(value -> value | RESOURCE_METHOD_STARTED);
-        if ((previous & RESOURCE_METHOD_STARTED) != 0) {
-            return;
-        }
-
-        Scope scope = span.activate();
-        resourceScope.set(scope);
-        if ((state.get() & RESOURCE_METHOD_FINISHED) != 0) {
-            closeResourceScope();
-        }
+    boolean resourceMethodStarted() {
+        int previous = (int) STATE.getAndBitwiseOr(this, RESOURCE_METHOD_STARTED);
+        return (previous & RESOURCE_METHOD_STARTED) == 0;
     }
 
-    void resourceMethodFinished(Span span) {
-        closeResourceScope();
-        state.getAndUpdate(value -> value | RESOURCE_METHOD_FINISHED);
-        tryEnd(span);
+    boolean resourceMethodFinished() {
+        STATE.getAndBitwiseOr(this, RESOURCE_METHOD_FINISHED);
+        return tryEnd();
     }
 
     void responseProcessingStarted() {
-        state.getAndUpdate(value -> value | RESPONSE_PROCESSING_STARTED);
+        STATE.getAndBitwiseOr(this, RESPONSE_PROCESSING_STARTED);
     }
 
     void responseFailure(Throwable throwable) {
-        if ((state.get() & RESPONSE_PROCESSING_STARTED) != 0 && throwable != null) {
-            failure.compareAndSet(null, throwable);
+        if (((int) STATE.getVolatile(this) & RESPONSE_PROCESSING_STARTED) != 0 && throwable != null) {
+            FAILURE.compareAndSet(this, null, throwable);
         }
     }
 
     void writerFailure(Throwable throwable) {
         if (throwable != null) {
-            failure.compareAndSet(null, throwable);
+            FAILURE.compareAndSet(this, null, throwable);
         }
     }
 
-    void requestFinished(Span span, boolean responseWritten) {
+    void responseStatus(int status) {
+        span.tag(HTTP_STATUS_CODE, status);
+        if (status >= 500 && status < 600) {
+            span.status(Span.Status.ERROR);
+        }
+    }
+
+    boolean requestFinished(boolean responseWritten) {
         int completion = REQUEST_FINISHED | (responseWritten ? RESPONSE_WRITTEN : 0);
-        state.getAndUpdate(value -> (value & REQUEST_FINISHED) == 0 ? value | completion : value);
-        tryEnd(span);
-    }
-
-    private void closeResourceScope() {
-        Scope scope = resourceScope.getAndSet(null);
-        if (scope != null) {
-            scope.close();
-        }
-    }
-
-    private void tryEnd(Span span) {
         while (true) {
-            int current = state.get();
-            if ((current & SPAN_ENDED) != 0
-                    || (current & REQUEST_FINISHED) == 0
-                    || ((current & RESOURCE_METHOD_STARTED) != 0 && (current & RESOURCE_METHOD_FINISHED) == 0)) {
-                return;
+            int current = (int) STATE.getVolatile(this);
+            if ((current & REQUEST_FINISHED) != 0 || STATE.compareAndSet(this, current, current | completion)) {
+                break;
             }
-            if (state.compareAndSet(current, current | SPAN_ENDED)) {
-                end(span, current);
-                return;
+        }
+        return tryEnd();
+    }
+
+    private boolean tryEnd() {
+        while (true) {
+            int current = (int) STATE.getVolatile(this);
+            if ((current & SPAN_ENDED) != 0) {
+                return true;
+            }
+            if ((current & REQUEST_FINISHED) == 0
+                    || ((current & RESOURCE_METHOD_STARTED) != 0 && (current & RESOURCE_METHOD_FINISHED) == 0)) {
+                return false;
+            }
+            if (STATE.compareAndSet(this, current, current | SPAN_ENDED)) {
+                end(current);
+                return true;
             }
         }
     }
 
-    private void end(Span span, int completionState) {
-        Throwable throwable = failure.get();
+    private void end(int completionState) {
+        Throwable throwable = (Throwable) FAILURE.getVolatile(this);
         if ((completionState & RESPONSE_WRITTEN) == 0 || throwable != null) {
             span.status(Span.Status.ERROR);
         }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
@@ -28,6 +28,7 @@ import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_S
 final class ServerSpanLifecycle {
     static final String PROPERTY = ServerSpanLifecycle.class.getName();
 
+    private static final int NO_RESPONSE_STATUS = -1;
     private static final int REQUEST_SCOPE_CLOSED = 1;
     private static final int RESOURCE_METHOD_STARTED = 1 << 1;
     private static final int RESOURCE_METHOD_FINISHED = 1 << 2;
@@ -54,6 +55,7 @@ final class ServerSpanLifecycle {
     private final Context requestContext;
     private volatile int state;
     private volatile Throwable failure;
+    private volatile int responseStatus = NO_RESPONSE_STATUS;
 
     ServerSpanLifecycle(Span span, Scope requestScope) {
         this.span = span;
@@ -108,10 +110,7 @@ final class ServerSpanLifecycle {
     }
 
     void responseStatus(int status) {
-        span.tag(HTTP_STATUS_CODE, status);
-        if (status >= 500 && status < 600) {
-            span.status(Span.Status.ERROR);
-        }
+        responseStatus = status;
     }
 
     boolean requestFinished(boolean responseWritten) {
@@ -144,7 +143,13 @@ final class ServerSpanLifecycle {
 
     private void end(int completionState) {
         Throwable throwable = (Throwable) FAILURE.getVolatile(this);
-        if ((completionState & RESPONSE_WRITTEN) == 0 || throwable != null) {
+        int finalResponseStatus = responseStatus;
+        if (finalResponseStatus != NO_RESPONSE_STATUS) {
+            span.tag(HTTP_STATUS_CODE, finalResponseStatus);
+        }
+        if ((completionState & RESPONSE_WRITTEN) == 0
+                || throwable != null
+                || (finalResponseStatus >= 500 && finalResponseStatus < 600)) {
             span.status(Span.Status.ERROR);
         }
         if (throwable == null) {

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
@@ -24,8 +24,8 @@ final class ServerSpanLifecycle {
     private boolean resourceMethodStarted;
     private boolean resourceMethodFinished;
     private boolean responseProcessingStarted;
-    private boolean responseCompleted;
-    private boolean responseSuccessful;
+    private boolean requestFinished;
+    private boolean responseWritten;
     private boolean requestScopeClosed;
     private boolean responseScopeClosed;
     private boolean spanEnded;
@@ -69,30 +69,14 @@ final class ServerSpanLifecycle {
         }
     }
 
-    void responseSent(Span span, Scope requestScope) {
-        responseCompleted(span, requestScope, true);
-    }
-
     void requestFinished(Span span, Scope requestScope, boolean responseWritten) {
-        boolean failed;
-        synchronized (this) {
-            failed = !responseWritten || failure != null;
-        }
-        if (failed) {
-            responseCompleted(span, requestScope, false);
-        } else {
-            responseProcessingFinished(span, requestScope);
-        }
-    }
-
-    private void responseCompleted(Span span, Scope requestScope, boolean successful) {
         Scope scopeToClose;
         boolean closeRequestScope;
         boolean endSpan;
         synchronized (this) {
-            if (!responseCompleted) {
-                responseCompleted = true;
-                responseSuccessful = successful;
+            if (!requestFinished) {
+                requestFinished = true;
+                this.responseWritten = responseWritten;
             }
             scopeToClose = claimResponseScope();
             closeRequestScope = !resourceMethodStarted && claimRequestScope();
@@ -108,22 +92,8 @@ final class ServerSpanLifecycle {
         }
     }
 
-    private void responseProcessingFinished(Span span, Scope requestScope) {
-        Scope scopeToClose;
-        boolean closeRequestScope;
-        synchronized (this) {
-            scopeToClose = claimResponseScope();
-            closeRequestScope = !resourceMethodStarted && claimRequestScope();
-        }
-        try {
-            if (scopeToClose != null) {
-                scopeToClose.close();
-            }
-        } finally {
-            if (closeRequestScope) {
-                requestScope.close();
-            }
-        }
+    synchronized boolean isFinished() {
+        return spanEnded && requestScopeClosed && (responseScope == null || responseScopeClosed);
     }
 
     private synchronized Scope claimResponseScope() {
@@ -143,7 +113,7 @@ final class ServerSpanLifecycle {
     }
 
     private boolean claimSpanEnd() {
-        if (spanEnded || !responseCompleted || (resourceMethodStarted && !resourceMethodFinished)) {
+        if (spanEnded || !requestFinished || (resourceMethodStarted && !resourceMethodFinished)) {
             return false;
         }
         spanEnded = true;
@@ -164,12 +134,12 @@ final class ServerSpanLifecycle {
 
     private void end(Span span) {
         Throwable throwable;
-        boolean successful;
+        boolean written;
         synchronized (this) {
             throwable = failure;
-            successful = responseSuccessful;
+            written = responseWritten;
         }
-        if (!successful || throwable != null) {
+        if (!written || throwable != null) {
             span.status(Span.Status.ERROR);
         }
         if (throwable == null) {

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
@@ -15,41 +15,173 @@
  */
 package io.helidon.microprofile.telemetry;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 
 final class ServerSpanLifecycle {
     static final String PROPERTY = ServerSpanLifecycle.class.getName();
 
-    private final AtomicBoolean completed = new AtomicBoolean();
-    private final AtomicReference<Throwable> failure = new AtomicReference<>();
+    private boolean resourceMethodStarted;
+    private boolean resourceMethodFinished;
+    private boolean responseProcessingStarted;
+    private boolean responseCompleted;
+    private boolean responseSuccessful;
+    private boolean requestScopeClosed;
+    private boolean responseScopeClosed;
+    private boolean spanEnded;
+    private Throwable failure;
+    private Scope responseScope;
 
-    void failure(Throwable throwable) {
-        if (throwable != null) {
-            failure.compareAndSet(null, throwable);
+    synchronized void resourceMethodStarted() {
+        resourceMethodStarted = true;
+    }
+
+    void resourceMethodFinished(Span span, Scope requestScope) {
+        boolean closeRequestScope;
+        boolean endSpan;
+        synchronized (this) {
+            resourceMethodFinished = true;
+            closeRequestScope = claimRequestScope();
+            endSpan = claimSpanEnd();
+        }
+        closeAndEnd(span, requestScope, closeRequestScope, endSpan);
+    }
+
+    void responseProcessingStarted(Span span) {
+        synchronized (this) {
+            responseProcessingStarted = true;
+            if (responseScope != null || isCurrent(span)) {
+                return;
+            }
+            responseScope = span.activate();
         }
     }
 
-    void complete(Span span, Scope scope, boolean responseWritten) {
-        if (!completed.compareAndSet(false, true)) {
-            return;
+    synchronized void responseFailure(Throwable throwable) {
+        if (responseProcessingStarted && throwable != null && failure == null) {
+            failure = throwable;
         }
-        Throwable throwable = failure.get();
-        if (!responseWritten || throwable != null) {
-            span.status(Span.Status.ERROR);
+    }
+
+    synchronized void writerFailure(Throwable throwable) {
+        if (throwable != null && failure == null) {
+            failure = throwable;
+        }
+    }
+
+    void responseSent(Span span, Scope requestScope) {
+        responseCompleted(span, requestScope, true);
+    }
+
+    void requestFinished(Span span, Scope requestScope, boolean responseWritten) {
+        boolean failed;
+        synchronized (this) {
+            failed = !responseWritten || failure != null;
+        }
+        if (failed) {
+            responseCompleted(span, requestScope, false);
+        } else {
+            responseProcessingFinished(span, requestScope);
+        }
+    }
+
+    private void responseCompleted(Span span, Scope requestScope, boolean successful) {
+        Scope scopeToClose;
+        boolean closeRequestScope;
+        boolean endSpan;
+        synchronized (this) {
+            if (!responseCompleted) {
+                responseCompleted = true;
+                responseSuccessful = successful;
+            }
+            scopeToClose = claimResponseScope();
+            closeRequestScope = !resourceMethodStarted && claimRequestScope();
+            endSpan = claimSpanEnd();
         }
 
         try {
-            scope.close();
+            if (scopeToClose != null) {
+                scopeToClose.close();
+            }
         } finally {
-            if (throwable == null) {
-                span.end();
-            } else {
-                span.end(throwable);
+            closeAndEnd(span, requestScope, closeRequestScope, endSpan);
+        }
+    }
+
+    private void responseProcessingFinished(Span span, Scope requestScope) {
+        Scope scopeToClose;
+        boolean closeRequestScope;
+        synchronized (this) {
+            scopeToClose = claimResponseScope();
+            closeRequestScope = !resourceMethodStarted && claimRequestScope();
+        }
+        try {
+            if (scopeToClose != null) {
+                scopeToClose.close();
+            }
+        } finally {
+            if (closeRequestScope) {
+                requestScope.close();
             }
         }
+    }
+
+    private synchronized Scope claimResponseScope() {
+        if (responseScopeClosed || responseScope == null) {
+            return null;
+        }
+        responseScopeClosed = true;
+        return responseScope;
+    }
+
+    private boolean claimRequestScope() {
+        if (requestScopeClosed) {
+            return false;
+        }
+        requestScopeClosed = true;
+        return true;
+    }
+
+    private boolean claimSpanEnd() {
+        if (spanEnded || !responseCompleted || (resourceMethodStarted && !resourceMethodFinished)) {
+            return false;
+        }
+        spanEnded = true;
+        return true;
+    }
+
+    private void closeAndEnd(Span span, Scope requestScope, boolean closeRequestScope, boolean endSpan) {
+        try {
+            if (closeRequestScope) {
+                requestScope.close();
+            }
+        } finally {
+            if (endSpan) {
+                end(span);
+            }
+        }
+    }
+
+    private void end(Span span) {
+        Throwable throwable;
+        boolean successful;
+        synchronized (this) {
+            throwable = failure;
+            successful = responseSuccessful;
+        }
+        if (!successful || throwable != null) {
+            span.status(Span.Status.ERROR);
+        }
+        if (throwable == null) {
+            span.end();
+        } else {
+            span.end(throwable);
+        }
+    }
+
+    private static boolean isCurrent(Span span) {
+        return Span.current()
+                .map(current -> current.context().spanId().equals(span.context().spanId()))
+                .orElse(false);
     }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
@@ -15,131 +15,100 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 
 final class ServerSpanLifecycle {
     static final String PROPERTY = ServerSpanLifecycle.class.getName();
 
-    private boolean resourceMethodStarted;
-    private boolean resourceMethodFinished;
-    private boolean responseProcessingStarted;
-    private boolean requestFinished;
-    private boolean responseWritten;
-    private boolean requestScopeClosed;
-    private boolean responseScopeClosed;
-    private boolean spanEnded;
-    private Throwable failure;
-    private Scope responseScope;
+    private static final int REQUEST_SCOPE_CLOSED = 1;
+    private static final int RESOURCE_METHOD_STARTED = 1 << 1;
+    private static final int RESOURCE_METHOD_FINISHED = 1 << 2;
+    private static final int RESPONSE_PROCESSING_STARTED = 1 << 3;
+    private static final int REQUEST_FINISHED = 1 << 4;
+    private static final int RESPONSE_WRITTEN = 1 << 5;
+    private static final int SPAN_ENDED = 1 << 6;
 
-    synchronized void resourceMethodStarted() {
-        resourceMethodStarted = true;
-    }
+    private final AtomicInteger state = new AtomicInteger();
+    private final AtomicReference<Scope> resourceScope = new AtomicReference<>();
+    private final AtomicReference<Throwable> failure = new AtomicReference<>();
 
-    void resourceMethodFinished(Span span, Scope requestScope) {
-        boolean closeRequestScope;
-        boolean endSpan;
-        synchronized (this) {
-            resourceMethodFinished = true;
-            closeRequestScope = claimRequestScope();
-            endSpan = claimSpanEnd();
+    void requestFiltered(Scope requestScope) {
+        int previous = state.getAndUpdate(value -> value | REQUEST_SCOPE_CLOSED);
+        if ((previous & REQUEST_SCOPE_CLOSED) == 0) {
+            requestScope.close();
         }
-        closeAndEnd(span, requestScope, closeRequestScope, endSpan);
     }
 
-    void responseProcessingStarted(Span span) {
-        synchronized (this) {
-            responseProcessingStarted = true;
-            if (responseScope != null || isCurrent(span)) {
+    void resourceMethodStarted(Span span) {
+        int previous = state.getAndUpdate(value -> value | RESOURCE_METHOD_STARTED);
+        if ((previous & RESOURCE_METHOD_STARTED) != 0) {
+            return;
+        }
+
+        Scope scope = span.activate();
+        resourceScope.set(scope);
+        if ((state.get() & RESOURCE_METHOD_FINISHED) != 0) {
+            closeResourceScope();
+        }
+    }
+
+    void resourceMethodFinished(Span span) {
+        closeResourceScope();
+        state.getAndUpdate(value -> value | RESOURCE_METHOD_FINISHED);
+        tryEnd(span);
+    }
+
+    void responseProcessingStarted() {
+        state.getAndUpdate(value -> value | RESPONSE_PROCESSING_STARTED);
+    }
+
+    void responseFailure(Throwable throwable) {
+        if ((state.get() & RESPONSE_PROCESSING_STARTED) != 0 && throwable != null) {
+            failure.compareAndSet(null, throwable);
+        }
+    }
+
+    void writerFailure(Throwable throwable) {
+        if (throwable != null) {
+            failure.compareAndSet(null, throwable);
+        }
+    }
+
+    void requestFinished(Span span, boolean responseWritten) {
+        int completion = REQUEST_FINISHED | (responseWritten ? RESPONSE_WRITTEN : 0);
+        state.getAndUpdate(value -> (value & REQUEST_FINISHED) == 0 ? value | completion : value);
+        tryEnd(span);
+    }
+
+    private void closeResourceScope() {
+        Scope scope = resourceScope.getAndSet(null);
+        if (scope != null) {
+            scope.close();
+        }
+    }
+
+    private void tryEnd(Span span) {
+        while (true) {
+            int current = state.get();
+            if ((current & SPAN_ENDED) != 0
+                    || (current & REQUEST_FINISHED) == 0
+                    || ((current & RESOURCE_METHOD_STARTED) != 0 && (current & RESOURCE_METHOD_FINISHED) == 0)) {
                 return;
             }
-            responseScope = span.activate();
-        }
-    }
-
-    synchronized void responseFailure(Throwable throwable) {
-        if (responseProcessingStarted && throwable != null && failure == null) {
-            failure = throwable;
-        }
-    }
-
-    synchronized void writerFailure(Throwable throwable) {
-        if (throwable != null && failure == null) {
-            failure = throwable;
-        }
-    }
-
-    void requestFinished(Span span, Scope requestScope, boolean responseWritten) {
-        Scope scopeToClose;
-        boolean closeRequestScope;
-        boolean endSpan;
-        synchronized (this) {
-            if (!requestFinished) {
-                requestFinished = true;
-                this.responseWritten = responseWritten;
-            }
-            scopeToClose = claimResponseScope();
-            closeRequestScope = !resourceMethodStarted && claimRequestScope();
-            endSpan = claimSpanEnd();
-        }
-
-        try {
-            if (scopeToClose != null) {
-                scopeToClose.close();
-            }
-        } finally {
-            closeAndEnd(span, requestScope, closeRequestScope, endSpan);
-        }
-    }
-
-    synchronized boolean isFinished() {
-        return spanEnded && requestScopeClosed && (responseScope == null || responseScopeClosed);
-    }
-
-    private synchronized Scope claimResponseScope() {
-        if (responseScopeClosed || responseScope == null) {
-            return null;
-        }
-        responseScopeClosed = true;
-        return responseScope;
-    }
-
-    private boolean claimRequestScope() {
-        if (requestScopeClosed) {
-            return false;
-        }
-        requestScopeClosed = true;
-        return true;
-    }
-
-    private boolean claimSpanEnd() {
-        if (spanEnded || !requestFinished || (resourceMethodStarted && !resourceMethodFinished)) {
-            return false;
-        }
-        spanEnded = true;
-        return true;
-    }
-
-    private void closeAndEnd(Span span, Scope requestScope, boolean closeRequestScope, boolean endSpan) {
-        try {
-            if (closeRequestScope) {
-                requestScope.close();
-            }
-        } finally {
-            if (endSpan) {
-                end(span);
+            if (state.compareAndSet(current, current | SPAN_ENDED)) {
+                end(span, current);
+                return;
             }
         }
     }
 
-    private void end(Span span) {
-        Throwable throwable;
-        boolean written;
-        synchronized (this) {
-            throwable = failure;
-            written = responseWritten;
-        }
-        if (!written || throwable != null) {
+    private void end(Span span, int completionState) {
+        Throwable throwable = failure.get();
+        if ((completionState & RESPONSE_WRITTEN) == 0 || throwable != null) {
             span.status(Span.Status.ERROR);
         }
         if (throwable == null) {
@@ -147,11 +116,5 @@ final class ServerSpanLifecycle {
         } else {
             span.end(throwable);
         }
-    }
-
-    private static boolean isCurrent(Span span) {
-        return Span.current()
-                .map(current -> current.context().spanId().equals(span.context().spanId()))
-                .orElse(false);
     }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/ServerSpanLifecycle.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+
+final class ServerSpanLifecycle {
+    static final String PROPERTY = ServerSpanLifecycle.class.getName();
+
+    private final AtomicBoolean completed = new AtomicBoolean();
+    private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    void failure(Throwable throwable) {
+        if (throwable != null) {
+            failure.compareAndSet(null, throwable);
+        }
+    }
+
+    void complete(Span span, Scope scope, boolean responseWritten) {
+        if (!completed.compareAndSet(false, true)) {
+            return;
+        }
+        Throwable throwable = failure.get();
+        if (!responseWritten || throwable != null) {
+            span.status(Span.Status.ERROR);
+        }
+
+        try {
+            scope.close();
+        } finally {
+            if (throwable == null) {
+                span.end();
+            } else {
+                span.end(throwable);
+            }
+        }
+    }
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
@@ -15,12 +15,15 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import io.helidon.config.mp.MpConfig;
 import io.helidon.tracing.Tracer;
+import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.ws.rs.RuntimeType;
 import jakarta.ws.rs.core.FeatureContext;
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.glassfish.jersey.internal.spi.AutoDiscoverable;
 
@@ -47,7 +50,7 @@ public class TelemetryAutoDiscoverable implements AutoDiscoverable {
     @Override
     public void configure(FeatureContext ctx) {
         ctx.register(HelidonTelemetryContainerFilter.class);
-        if (ctx.getConfiguration().getRuntimeType() == RuntimeType.SERVER && includesResponseWrite()) {
+        if (ctx.getConfiguration().getRuntimeType() == RuntimeType.SERVER && shouldRegisterResponseWriteProviders()) {
             ctx.register(HelidonTelemetryWriterInterceptor.class);
             ctx.register(new HelidonTelemetryRequestEventListener());
         }
@@ -69,11 +72,13 @@ public class TelemetryAutoDiscoverable implements AutoDiscoverable {
     }
 
     @SuppressWarnings("removal")
-    private static boolean includesResponseWrite() {
+    private static boolean shouldRegisterResponseWriteProviders() {
         try {
-            return ConfigProvider.getConfig()
-                    .getOptionalValue(HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, Boolean.class)
-                    .orElse(false);
+            Config mpConfig = ConfigProvider.getConfig();
+            return mpConfig.getOptionalValue(HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE,
+                                             Boolean.class)
+                    .orElse(false)
+                    && !HelidonOpenTelemetry.AgentDetector.isAgentPresent(MpConfig.toHelidonConfig(mpConfig));
         } catch (IllegalStateException e) {
             LOGGER.log(System.Logger.Level.TRACE,
                        "Skipping response-write-inclusive telemetry because MP Config is unavailable",

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
@@ -19,6 +19,7 @@ import io.helidon.tracing.Tracer;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.RuntimeType;
 import jakarta.ws.rs.core.FeatureContext;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.glassfish.jersey.internal.spi.AutoDiscoverable;
@@ -46,7 +47,7 @@ public class TelemetryAutoDiscoverable implements AutoDiscoverable {
     @Override
     public void configure(FeatureContext ctx) {
         ctx.register(HelidonTelemetryContainerFilter.class);
-        if (includesResponseWrite()) {
+        if (ctx.getConfiguration().getRuntimeType() == RuntimeType.SERVER && includesResponseWrite()) {
             ctx.register(HelidonTelemetryWriterInterceptor.class);
             ctx.register(new HelidonTelemetryRequestEventListener());
         }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
@@ -45,6 +45,7 @@ public class TelemetryAutoDiscoverable implements AutoDiscoverable {
     @Override
     public void configure(FeatureContext ctx) {
         ctx.register(HelidonTelemetryContainerFilter.class);
+        ctx.register(new HelidonTelemetryRequestEventListener());
 
         try {
             Instance<Tracer> tracers = CDI.current().select(Tracer.class);

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
@@ -45,6 +45,7 @@ public class TelemetryAutoDiscoverable implements AutoDiscoverable {
     @Override
     public void configure(FeatureContext ctx) {
         ctx.register(HelidonTelemetryContainerFilter.class);
+        ctx.register(HelidonTelemetryWriterInterceptor.class);
         ctx.register(new HelidonTelemetryRequestEventListener());
 
         try {

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryAutoDiscoverable.java
@@ -20,6 +20,7 @@ import io.helidon.tracing.Tracer;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.ws.rs.core.FeatureContext;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.glassfish.jersey.internal.spi.AutoDiscoverable;
 
 /**
@@ -45,8 +46,10 @@ public class TelemetryAutoDiscoverable implements AutoDiscoverable {
     @Override
     public void configure(FeatureContext ctx) {
         ctx.register(HelidonTelemetryContainerFilter.class);
-        ctx.register(HelidonTelemetryWriterInterceptor.class);
-        ctx.register(new HelidonTelemetryRequestEventListener());
+        if (includesResponseWrite()) {
+            ctx.register(HelidonTelemetryWriterInterceptor.class);
+            ctx.register(new HelidonTelemetryRequestEventListener());
+        }
 
         try {
             Instance<Tracer> tracers = CDI.current().select(Tracer.class);
@@ -59,7 +62,22 @@ public class TelemetryAutoDiscoverable implements AutoDiscoverable {
             ctx.register(HelidonTelemetryClientFilter.class);
         } catch (IllegalStateException e) {
             LOGGER.log(System.Logger.Level.TRACE,
-                       "Skipping Jersey client telemetry because no active CDI container is available");
+                       "Skipping Jersey client telemetry because no active CDI container is available",
+                       e);
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static boolean includesResponseWrite() {
+        try {
+            return ConfigProvider.getConfig()
+                    .getOptionalValue(HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, Boolean.class)
+                    .orElse(false);
+        } catch (IllegalStateException e) {
+            LOGGER.log(System.Logger.Level.TRACE,
+                       "Skipping response-write-inclusive telemetry because MP Config is unavailable",
+                       e);
+            return false;
         }
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteAgentTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteAgentTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddBean(AutoSpanIncludesWriteAgentTest.RegistrationResource.class)
+@AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
+@AddConfig(key = HelidonOpenTelemetry.OTEL_AGENT_PRESENT_PROPERTY, value = "true")
+@SuppressWarnings("removal")
+class AutoSpanIncludesWriteAgentTest {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void agentPresentOmitsResponseWriteProviders() {
+        boolean responseWriteProvidersRegistered = webTarget.path("/agent-provider-registration")
+                .request(MediaType.TEXT_PLAIN)
+                .get(Boolean.class);
+
+        assertThat("Response-write providers registered", responseWriteProvidersRegistered, is(false));
+    }
+
+    @Path("/agent-provider-registration")
+    @ApplicationScoped
+    public static class RegistrationResource {
+
+        @Context
+        private Configuration configuration;
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public boolean responseWriteProvidersRegistered() {
+            return configuration.isRegistered(HelidonTelemetryWriterInterceptor.class)
+                    || configuration.isRegistered(HelidonTelemetryRequestEventListener.class);
+        }
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteAsyncTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteAsyncTest.java
@@ -15,12 +15,15 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import io.helidon.microprofile.testing.junit5.AddConfig;
+
 import org.junit.jupiter.api.Test;
 
-class AutoSpanIncludesWriteDefaultTest extends AutoSpanIncludesWriteTestBase {
+@AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
+class AutoSpanIncludesWriteAsyncTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
-    void testDefaultEndsSpanBeforeWrite() {
-        checkSpanAtWrite(true, false);
+    void testAsyncStreamingOutputSpanIsChildOfAutomaticServerSpan() {
+        checkAsyncResponseWriteSpanParent();
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteAsyncTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteAsyncTest.java
@@ -15,15 +15,22 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import io.helidon.microprofile.testing.junit5.AddBean;
 import io.helidon.microprofile.testing.junit5.AddConfig;
 
 import org.junit.jupiter.api.Test;
 
 @AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
+@AddBean(AutoSpanIncludesWriteTestBase.ManagedAsyncRequestProbe.class)
 class AutoSpanIncludesWriteAsyncTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
     void testAsyncStreamingOutputSpanIsChildOfAutomaticServerSpan() {
         checkAsyncResponseWriteSpanParent();
+    }
+
+    @Test
+    void testManagedAsyncUsesThreadOwnedResourceScope() {
+        checkManagedAsyncResourceScope();
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteDefaultTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteDefaultTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import org.junit.jupiter.api.Test;
+
+class AutoSpanIncludesWriteDefaultTest extends AutoSpanIncludesWriteTestBase {
+
+    @Test
+    void testDefaultEndsSpanBeforeWrite() {
+        checkSpanAtWrite(true);
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteDefaultTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteDefaultTest.java
@@ -21,6 +21,6 @@ class AutoSpanIncludesWriteDefaultTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
     void testDefaultEndsSpanBeforeWrite() {
-        checkSpanAtWrite(true);
+        checkSpanAtWrite(true, true, false);
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteDefaultTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteDefaultTest.java
@@ -23,4 +23,9 @@ class AutoSpanIncludesWriteDefaultTest extends AutoSpanIncludesWriteTestBase {
     void testDefaultEndsSpanBeforeWrite() {
         checkSpanAtWrite(true, false);
     }
+
+    @Test
+    void testDefaultDoesNotRegisterDeferredProviders() {
+        checkDeferredProvidersRegistered(false);
+    }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteFalseTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteFalseTest.java
@@ -24,6 +24,6 @@ class AutoSpanIncludesWriteFalseTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
     void testFalseEndsSpanBeforeWrite() {
-        checkSpanAtWrite(true, true, false);
+        checkSpanAtWrite(true, false);
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteFalseTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteFalseTest.java
@@ -24,6 +24,6 @@ class AutoSpanIncludesWriteFalseTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
     void testFalseEndsSpanBeforeWrite() {
-        checkSpanAtWrite(true);
+        checkSpanAtWrite(true, true, false);
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteFalseTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteFalseTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.microprofile.testing.junit5.AddConfig;
+
+import org.junit.jupiter.api.Test;
+
+@AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "false")
+class AutoSpanIncludesWriteFalseTest extends AutoSpanIncludesWriteTestBase {
+
+    @Test
+    void testFalseEndsSpanBeforeWrite() {
+        checkSpanAtWrite(true);
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteFalseTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteFalseTest.java
@@ -26,4 +26,9 @@ class AutoSpanIncludesWriteFalseTest extends AutoSpanIncludesWriteTestBase {
     void testFalseEndsSpanBeforeWrite() {
         checkSpanAtWrite(true, false);
     }
+
+    @Test
+    void testFalseDoesNotRegisterDeferredProviders() {
+        checkDeferredProvidersRegistered(false);
+    }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteNestingTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteNestingTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+
+import org.junit.jupiter.api.Test;
+
+@AddBean(AutoSpanIncludesWriteTestBase.EntireRequestSpanFilter.class)
+@AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
+class AutoSpanIncludesWriteNestingTest extends AutoSpanIncludesWriteTestBase {
+
+    @Test
+    void testResponseWriteSpanIsChildOfEntireRequestSpan() {
+        checkResponseWriteSpanParent();
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteNestingTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteNestingTest.java
@@ -20,12 +20,17 @@ import io.helidon.microprofile.testing.junit5.AddConfig;
 
 import org.junit.jupiter.api.Test;
 
-@AddBean(AutoSpanIncludesWriteTestBase.EntireRequestSpanFilter.class)
+@AddBean(AutoSpanIncludesWriteTestBase.ChildSpanWriterInterceptor.class)
 @AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
 class AutoSpanIncludesWriteNestingTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
-    void testResponseWriteSpanIsChildOfEntireRequestSpan() {
-        checkResponseWriteSpanParent();
+    void testWriterInterceptorSpanIsChildOfAutomaticServerSpan() {
+        checkResponseWriteSpanParent("/writer-child", WRITER_CHILD_SPAN_NAME, "writer-child");
+    }
+
+    @Test
+    void testStreamingOutputSpanIsChildOfAutomaticServerSpan() {
+        checkResponseWriteSpanParent("/streaming-child", STREAMING_CHILD_SPAN_NAME, "streaming-child");
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
@@ -22,7 +22,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -50,10 +49,17 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
@@ -106,8 +112,7 @@ class AutoSpanIncludesWriteTestBase {
         spanExporter.clear();
     }
 
-    void checkSpanAtWrite(boolean expectedClosedAtWrite,
-                          boolean expectedEndedAtWrite,
+    void checkSpanAtWrite(boolean expectedEndedAtWrite,
                           boolean expectedCurrentAtWrite) {
         try (Response response = webTarget.path(BASE_PATH + "/ok")
                 .request(MediaType.TEXT_PLAIN)
@@ -118,11 +123,11 @@ class AutoSpanIncludesWriteTestBase {
 
         Span observedSpan = writeProbe.observedSpan();
         assertThat("Writer observed a span", observedSpan, notNullValue());
-        assertThat("Span scope state at entity serialization", writeProbe.spanClosed(), is(expectedClosedAtWrite));
         assertThat("Span end state at entity serialization", writeProbe.spanEnded(), is(expectedEndedAtWrite));
         assertThat("Automatic span current state at entity serialization",
                    writeProbe.spanWasCurrent(), is(expectedCurrentAtWrite));
         assertThat("Span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
+        assertThat("Span ended once", spanListener.endCount(observedSpan), is(1));
         spanExporter.spanData(2);
     }
 
@@ -138,11 +143,7 @@ class AutoSpanIncludesWriteTestBase {
         assertThat("Writer observed a span", observedSpan, notNullValue());
         assertThat("Span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
 
-        List<SpanData> spans = spanExporter.spanData(2);
-        SpanData serverSpan = spans.stream()
-                .filter(span -> span.getKind() == SpanKind.SERVER)
-                .findFirst()
-                .orElseThrow();
+        SpanData serverSpan = spanExporter.spanData(observedSpan);
         assertThat("Server span status", serverSpan.getStatus().getStatusCode(), is(StatusCode.ERROR));
         assertThat("HTTP status attribute",
                    serverSpan.getAttributes().get(AttributeKey.longKey(HTTP_STATUS_CODE)),
@@ -159,13 +160,12 @@ class AutoSpanIncludesWriteTestBase {
 
         Span serverSpanAtWrite = writeProbe.observedSpan();
         assertThat("Writer observed the automatic span", serverSpanAtWrite, notNullValue());
-        assertThat("Automatic span scope remained open during entity serialization",
-                   writeProbe.spanClosed(), is(false));
         assertThat("Automatic span remained open during entity serialization",
                    writeProbe.spanEnded(), is(false));
         assertThat("Automatic span was current during entity serialization",
                    writeProbe.spanWasCurrent(), is(true));
         assertThat("Automatic span eventually ended", spanListener.awaitEnded(serverSpanAtWrite), is(true));
+        assertThat("Automatic span ended once", spanListener.endCount(serverSpanAtWrite), is(1));
 
         List<SpanData> spans = spanExporter.spanData(3);
         SpanData serverSpan = spans.stream()
@@ -180,6 +180,31 @@ class AutoSpanIncludesWriteTestBase {
         assertThat("Response-write child span parent",
                    childSpan.getParentSpanContext().getSpanId(),
                    equalTo(serverSpan.getSpanContext().getSpanId()));
+    }
+
+    void checkAsyncResponseWriteSpanParent() {
+        checkResponseWriteSpanParent("/async-streaming-child", STREAMING_CHILD_SPAN_NAME, "async-streaming-child");
+        assertThat("Asynchronous entity writing used another thread",
+                   writeProbe.writeThread(), org.hamcrest.Matchers.not(equalTo(writeProbe.resourceThread())));
+    }
+
+    void checkMappedApplicationException() {
+        try (Response response = webTarget.path(BASE_PATH + "/mapped-not-found")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            assertThat("Response status", response.getStatus(), is(404));
+            assertThat("Response entity", response.readEntity(String.class), is("mapped-not-found"));
+        }
+
+        Span observedSpan = writeProbe.observedSpan();
+        assertThat("Mapped response writer observed the automatic span", observedSpan, notNullValue());
+        assertThat("Mapped response span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
+        assertThat("Mapped response span ended once", spanListener.endCount(observedSpan), is(1));
+        assertThat("Mapped application exception was not treated as a write failure",
+                   spanListener.failure(observedSpan), org.hamcrest.Matchers.nullValue());
+
+        SpanData serverSpan = spanExporter.spanData(observedSpan);
+        assertThat("Mapped 404 server span status", serverSpan.getStatus().getStatusCode(), is(StatusCode.UNSET));
     }
 
     void checkFailedWriteEndsSpan() {
@@ -199,12 +224,27 @@ class AutoSpanIncludesWriteTestBase {
         assertThat("Failed response span recorded the write failure",
                    spanListener.failure(observedSpan), notNullValue());
 
-        List<SpanData> spans = spanExporter.spanData(2);
-        SpanData serverSpan = spans.stream()
-                .filter(span -> span.getKind() == SpanKind.SERVER)
-                .findFirst()
-                .orElseThrow();
+        SpanData serverSpan = spanExporter.spanData(observedSpan);
         assertThat("Failed response span status", serverSpan.getStatus().getStatusCode(), is(StatusCode.ERROR));
+    }
+
+    void checkFailedResponseFilterEndsSpan() {
+        try (Response ignored = webTarget.path(BASE_PATH + "/response-filter-error")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            // Depending on how far response processing progressed, the client can receive an error response or an exception.
+        } catch (ProcessingException ignored) {
+            // The server-side lifecycle assertions below are authoritative for this test.
+        }
+
+        Span resourceSpan = writeProbe.resourceSpan();
+        assertThat("Resource observed the automatic span", resourceSpan, notNullValue());
+        assertThat("Failed response-filter span eventually ended", spanListener.awaitEnded(resourceSpan), is(true));
+        assertThat("Failed response-filter span ended once", spanListener.endCount(resourceSpan), is(1));
+        assertThat("Failed response-filter span recorded the failure",
+                   spanListener.failure(resourceSpan), notNullValue());
+        assertThat("Failed response-filter span status",
+                   spanExporter.spanData(resourceSpan).getStatus().getStatusCode(), is(StatusCode.ERROR));
     }
 
     void checkNoEntitySpanEnds() {
@@ -229,7 +269,6 @@ class AutoSpanIncludesWriteTestBase {
     public static class TestSpanListener implements SpanListener {
 
         private final AtomicReference<Span> latestStarted = new AtomicReference<>();
-        private final Set<Span> closed = ConcurrentHashMap.newKeySet();
         private final ConcurrentHashMap<Span, CompletableFuture<Void>> ended = new ConcurrentHashMap<>();
         private final ConcurrentHashMap<Span, AtomicInteger> endCounts = new ConcurrentHashMap<>();
         private final ConcurrentHashMap<Span, Throwable> failures = new ConcurrentHashMap<>();
@@ -238,11 +277,6 @@ class AutoSpanIncludesWriteTestBase {
         public void started(Span span) {
             ended.put(span, new CompletableFuture<>());
             latestStarted.set(span);
-        }
-
-        @Override
-        public void closed(Span span, Scope scope) {
-            closed.add(span);
         }
 
         @Override
@@ -259,10 +293,6 @@ class AutoSpanIncludesWriteTestBase {
 
         Span latestStarted() {
             return latestStarted.get();
-        }
-
-        boolean isClosed(Span span) {
-            return closed.contains(span);
         }
 
         boolean isEnded(Span span) {
@@ -290,7 +320,6 @@ class AutoSpanIncludesWriteTestBase {
 
         void reset() {
             latestStarted.set(null);
-            closed.clear();
             ended.clear();
             endCounts.clear();
             failures.clear();
@@ -305,9 +334,11 @@ class AutoSpanIncludesWriteTestBase {
 
         private final TestSpanListener spanListener;
         private final AtomicReference<Span> observedSpan = new AtomicReference<>();
-        private volatile boolean spanClosed;
         private volatile boolean spanEnded;
         private volatile boolean spanWasCurrent;
+        private volatile String resourceThread;
+        private volatile String writeThread;
+        private final AtomicReference<Span> resourceSpan = new AtomicReference<>();
 
         @Inject
         WriteProbe(TestSpanListener spanListener) {
@@ -318,20 +349,16 @@ class AutoSpanIncludesWriteTestBase {
         public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
             Span span = spanListener.latestStarted();
             observedSpan.set(span);
-            spanClosed = spanListener.isClosed(span);
             spanEnded = spanListener.isEnded(span);
             spanWasCurrent = Span.current()
                     .map(current -> current.context().spanId().equals(span.context().spanId()))
                     .orElse(false);
+            writeThread = Thread.currentThread().getName();
             context.proceed();
         }
 
         Span observedSpan() {
             return observedSpan.get();
-        }
-
-        boolean spanClosed() {
-            return spanClosed;
         }
 
         boolean spanEnded() {
@@ -342,11 +369,33 @@ class AutoSpanIncludesWriteTestBase {
             return spanWasCurrent;
         }
 
+        void resourceThread(String threadName) {
+            resourceThread = threadName;
+        }
+
+        String resourceThread() {
+            return resourceThread;
+        }
+
+        String writeThread() {
+            return writeThread;
+        }
+
+        void observeResourceSpan() {
+            resourceSpan.set(spanListener.latestStarted());
+        }
+
+        Span resourceSpan() {
+            return resourceSpan.get();
+        }
+
         void reset() {
             observedSpan.set(null);
-            spanClosed = false;
             spanEnded = false;
             spanWasCurrent = false;
+            resourceThread = null;
+            writeThread = null;
+            resourceSpan.set(null);
         }
     }
 
@@ -385,6 +434,32 @@ class AutoSpanIncludesWriteTestBase {
         }
     }
 
+    @Provider
+    @FailResponseFilter
+    @ApplicationScoped
+    public static class FailingResponseFilter implements ContainerResponseFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+                throws IOException {
+            throw new IOException("Deliberate response filter failure");
+        }
+    }
+
+    @Provider
+    @ApplicationScoped
+    public static class MappedNotFoundExceptionMapper implements ExceptionMapper<MappedNotFoundException> {
+        @Override
+        public Response toResponse(MappedNotFoundException exception) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .type(MediaType.TEXT_PLAIN)
+                    .entity("mapped-not-found")
+                    .build();
+        }
+    }
+
+    public static class MappedNotFoundException extends WebApplicationException {
+    }
+
     @NameBinding
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.TYPE, ElementType.METHOD})
@@ -397,16 +472,24 @@ class AutoSpanIncludesWriteTestBase {
     public @interface FailWrite {
     }
 
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface FailResponseFilter {
+    }
+
     @Path(BASE_PATH)
     @ObserveWrite
     @ApplicationScoped
     public static class TestResource {
 
         private final Tracer tracer;
+        private final WriteProbe writeProbe;
 
         @Inject
-        TestResource(Tracer tracer) {
+        TestResource(Tracer tracer, WriteProbe writeProbe) {
             this.tracer = tracer;
+            this.writeProbe = writeProbe;
         }
 
         @GET
@@ -435,14 +518,24 @@ class AutoSpanIncludesWriteTestBase {
         @Path("/streaming-child")
         @Produces(MediaType.TEXT_PLAIN)
         public StreamingOutput streamingChild() {
-            return output -> {
-                Span childSpan = tracer.spanBuilder(STREAMING_CHILD_SPAN_NAME).build();
-                try (Scope ignored = childSpan.activate()) {
-                    output.write("streaming-child".getBytes(StandardCharsets.UTF_8));
-                } finally {
-                    childSpan.end();
-                }
-            };
+            return streamingOutput("streaming-child");
+        }
+
+        @GET
+        @Path("/async-streaming-child")
+        @Produces(MediaType.TEXT_PLAIN)
+        public void asyncStreamingChild(@Suspended AsyncResponse response) {
+            writeProbe.resourceThread(Thread.currentThread().getName());
+            Thread.ofPlatform()
+                    .name("auto-span-response-writer")
+                    .start(() -> response.resume(streamingOutput("async-streaming-child")));
+        }
+
+        @GET
+        @Path("/mapped-not-found")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String mappedNotFound() {
+            throw new MappedNotFoundException();
         }
 
         @GET
@@ -454,9 +547,29 @@ class AutoSpanIncludesWriteTestBase {
         }
 
         @GET
+        @Path("/response-filter-error")
+        @Produces(MediaType.TEXT_PLAIN)
+        @FailResponseFilter
+        public String responseFilterError() {
+            writeProbe.observeResourceSpan();
+            return "never-written";
+        }
+
+        @GET
         @Path("/no-content")
         public Response noContent() {
             return Response.noContent().build();
+        }
+
+        private StreamingOutput streamingOutput(String value) {
+            return output -> {
+                Span childSpan = tracer.spanBuilder(STREAMING_CHILD_SPAN_NAME).build();
+                try (Scope ignored = childSpan.activate()) {
+                    output.write(value.getBytes(StandardCharsets.UTF_8));
+                } finally {
+                    childSpan.end();
+                }
+            };
         }
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
@@ -20,12 +20,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.microprofile.testing.junit5.AddBean;
@@ -33,10 +34,8 @@ import io.helidon.microprofile.testing.junit5.AddConfig;
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
-import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.SpanListener;
 import io.helidon.tracing.Tracer;
-import io.helidon.webserver.http.ServerResponse;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
@@ -49,14 +48,12 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NameBinding;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.container.ContainerRequestContext;
-import jakarta.ws.rs.container.ContainerRequestFilter;
-import jakarta.ws.rs.container.ContainerResponseContext;
-import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
@@ -78,7 +75,8 @@ import static org.hamcrest.Matchers.notNullValue;
 class AutoSpanIncludesWriteTestBase {
 
     private static final String BASE_PATH = "/auto-span-includes-write";
-    static final String ENTIRE_REQUEST_SPAN_NAME = "entireRequest";
+    static final String WRITER_CHILD_SPAN_NAME = "writerChild";
+    static final String STREAMING_CHILD_SPAN_NAME = "streamingChild";
 
     @Inject
     private WebTarget webTarget;
@@ -108,7 +106,9 @@ class AutoSpanIncludesWriteTestBase {
         spanExporter.clear();
     }
 
-    void checkSpanAtWrite(boolean expectedEndedAtWrite) {
+    void checkSpanAtWrite(boolean expectedClosedAtWrite,
+                          boolean expectedEndedAtWrite,
+                          boolean expectedCurrentAtWrite) {
         try (Response response = webTarget.path(BASE_PATH + "/ok")
                 .request(MediaType.TEXT_PLAIN)
                 .get()) {
@@ -118,8 +118,10 @@ class AutoSpanIncludesWriteTestBase {
 
         Span observedSpan = writeProbe.observedSpan();
         assertThat("Writer observed a span", observedSpan, notNullValue());
-        assertThat("Span scope was closed before entity serialization", writeProbe.spanClosed(), is(true));
+        assertThat("Span scope state at entity serialization", writeProbe.spanClosed(), is(expectedClosedAtWrite));
         assertThat("Span end state at entity serialization", writeProbe.spanEnded(), is(expectedEndedAtWrite));
+        assertThat("Automatic span current state at entity serialization",
+                   writeProbe.spanWasCurrent(), is(expectedCurrentAtWrite));
         assertThat("Span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
         spanExporter.spanData(2);
     }
@@ -147,35 +149,74 @@ class AutoSpanIncludesWriteTestBase {
                    is(500L));
     }
 
-    void checkResponseWriteSpanParent() {
-        try (Response response = webTarget.path(BASE_PATH + "/ok")
+    void checkResponseWriteSpanParent(String path, String childSpanName, String expectedEntity) {
+        try (Response response = webTarget.path(BASE_PATH + path)
                 .request(MediaType.TEXT_PLAIN)
                 .get()) {
             assertThat("Response status", response.getStatus(), is(200));
-            assertThat("Response entity", response.readEntity(String.class), is("ok"));
+            assertThat("Response entity", response.readEntity(String.class), is(expectedEntity));
         }
 
-        Span responseWriteSpan = writeProbe.observedSpan();
-        assertThat("Writer observed a span", responseWriteSpan, notNullValue());
-        assertThat("Response write span scope was closed before entity serialization",
-                   writeProbe.spanClosed(), is(true));
-        assertThat("Response write span remained open during entity serialization",
+        Span serverSpanAtWrite = writeProbe.observedSpan();
+        assertThat("Writer observed the automatic span", serverSpanAtWrite, notNullValue());
+        assertThat("Automatic span scope remained open during entity serialization",
+                   writeProbe.spanClosed(), is(false));
+        assertThat("Automatic span remained open during entity serialization",
                    writeProbe.spanEnded(), is(false));
-        assertThat("Response write span eventually ended", spanListener.awaitEnded(responseWriteSpan), is(true));
+        assertThat("Automatic span was current during entity serialization",
+                   writeProbe.spanWasCurrent(), is(true));
+        assertThat("Automatic span eventually ended", spanListener.awaitEnded(serverSpanAtWrite), is(true));
 
         List<SpanData> spans = spanExporter.spanData(3);
-        SpanData entireRequestSpan = spans.stream()
-                .filter(span -> span.getName().equals(ENTIRE_REQUEST_SPAN_NAME))
+        SpanData serverSpan = spans.stream()
+                .filter(span -> span.getKind() == SpanKind.SERVER)
                 .findFirst()
                 .orElseThrow();
-        SpanData exportedResponseWriteSpan = spans.stream()
-                .filter(span -> span.getSpanContext().getSpanId().equals(responseWriteSpan.context().spanId()))
+        SpanData childSpan = spans.stream()
+                .filter(span -> span.getName().equals(childSpanName))
                 .findFirst()
                 .orElseThrow();
 
-        assertThat("Response write span parent",
-                   exportedResponseWriteSpan.getParentSpanContext().getSpanId(),
-                   equalTo(entireRequestSpan.getSpanContext().getSpanId()));
+        assertThat("Response-write child span parent",
+                   childSpan.getParentSpanContext().getSpanId(),
+                   equalTo(serverSpan.getSpanContext().getSpanId()));
+    }
+
+    void checkFailedWriteEndsSpan() {
+        try (Response ignored = webTarget.path(BASE_PATH + "/write-error")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            // Depending on how far response writing progressed, the client can receive an error response or an exception.
+        } catch (ProcessingException ignored) {
+            // The server-side lifecycle assertions below are authoritative for this test.
+        }
+
+        Span observedSpan = writeProbe.observedSpan();
+        assertThat("Failing writer observed the automatic span", observedSpan, notNullValue());
+        assertThat("Automatic span was current in the failing writer", writeProbe.spanWasCurrent(), is(true));
+        assertThat("Failed response span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
+        assertThat("Failed response span ended once", spanListener.endCount(observedSpan), is(1));
+        assertThat("Failed response span recorded the write failure",
+                   spanListener.failure(observedSpan), notNullValue());
+
+        List<SpanData> spans = spanExporter.spanData(2);
+        SpanData serverSpan = spans.stream()
+                .filter(span -> span.getKind() == SpanKind.SERVER)
+                .findFirst()
+                .orElseThrow();
+        assertThat("Failed response span status", serverSpan.getStatus().getStatusCode(), is(StatusCode.ERROR));
+    }
+
+    void checkNoEntitySpanEnds() {
+        try (Response response = webTarget.path(BASE_PATH + "/no-content")
+                .request()
+                .get()) {
+            assertThat("Response status", response.getStatus(), is(204));
+        }
+
+        List<SpanData> spans = spanExporter.spanData(2);
+        assertThat("Entity-less response exported its server span",
+                   spans.stream().anyMatch(span -> span.getKind() == SpanKind.SERVER), is(true));
     }
 
     @NameBinding
@@ -190,6 +231,8 @@ class AutoSpanIncludesWriteTestBase {
         private final AtomicReference<Span> latestStarted = new AtomicReference<>();
         private final Set<Span> closed = ConcurrentHashMap.newKeySet();
         private final ConcurrentHashMap<Span, CompletableFuture<Void>> ended = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<Span, AtomicInteger> endCounts = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<Span, Throwable> failures = new ConcurrentHashMap<>();
 
         @Override
         public void started(Span span) {
@@ -204,11 +247,13 @@ class AutoSpanIncludesWriteTestBase {
 
         @Override
         public void ended(Span span) {
+            endCounts.computeIfAbsent(span, ignored -> new AtomicInteger()).incrementAndGet();
             ended.computeIfAbsent(span, ignored -> new CompletableFuture<>()).complete(null);
         }
 
         @Override
         public void ended(Span span, Throwable t) {
+            failures.put(span, t);
             ended(span);
         }
 
@@ -234,15 +279,27 @@ class AutoSpanIncludesWriteTestBase {
             }
         }
 
+        int endCount(Span span) {
+            AtomicInteger count = endCounts.get(span);
+            return count == null ? 0 : count.get();
+        }
+
+        Throwable failure(Span span) {
+            return failures.get(span);
+        }
+
         void reset() {
             latestStarted.set(null);
             closed.clear();
             ended.clear();
+            endCounts.clear();
+            failures.clear();
         }
     }
 
     @Provider
     @ObserveWrite
+    @Priority(Priorities.USER)
     @ApplicationScoped
     public static class WriteProbe implements WriterInterceptor {
 
@@ -250,6 +307,7 @@ class AutoSpanIncludesWriteTestBase {
         private final AtomicReference<Span> observedSpan = new AtomicReference<>();
         private volatile boolean spanClosed;
         private volatile boolean spanEnded;
+        private volatile boolean spanWasCurrent;
 
         @Inject
         WriteProbe(TestSpanListener spanListener) {
@@ -262,6 +320,9 @@ class AutoSpanIncludesWriteTestBase {
             observedSpan.set(span);
             spanClosed = spanListener.isClosed(span);
             spanEnded = spanListener.isEnded(span);
+            spanWasCurrent = Span.current()
+                    .map(current -> current.context().spanId().equals(span.context().spanId()))
+                    .orElse(false);
             context.proceed();
         }
 
@@ -277,52 +338,76 @@ class AutoSpanIncludesWriteTestBase {
             return spanEnded;
         }
 
+        boolean spanWasCurrent() {
+            return spanWasCurrent;
+        }
+
         void reset() {
             observedSpan.set(null);
             spanClosed = false;
             spanEnded = false;
+            spanWasCurrent = false;
         }
     }
 
     @Provider
-    @Priority(Priorities.HEADER_DECORATOR)
+    @WriterChild
+    @Priority(Priorities.USER + 100)
     @ApplicationScoped
-    public static class EntireRequestSpanFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    public static class ChildSpanWriterInterceptor implements WriterInterceptor {
 
         private final Tracer tracer;
 
-        @jakarta.ws.rs.core.Context
-        private ServerResponse serverResponse;
-
-        private Span entireRequestSpan;
-        private Scope entireRequestScope;
-
         @Inject
-        EntireRequestSpanFilter(Tracer tracer) {
+        ChildSpanWriterInterceptor(Tracer tracer) {
             this.tracer = tracer;
         }
 
         @Override
-        public void filter(ContainerRequestContext requestContext) {
-            Optional<SpanContext> propagatedSpanContext =
-                    tracer.extract(new RequestContextHeaderProvider(requestContext.getHeaders()));
-            entireRequestSpan = tracer.spanBuilder(ENTIRE_REQUEST_SPAN_NAME)
-                    .update(builder -> propagatedSpanContext.ifPresent(builder::parent))
-                    .build();
-            entireRequestScope = entireRequestSpan.activate();
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+            Span childSpan = tracer.spanBuilder(WRITER_CHILD_SPAN_NAME).build();
+            try (Scope ignored = childSpan.activate()) {
+                context.proceed();
+            } finally {
+                childSpan.end();
+            }
         }
+    }
 
+    @Provider
+    @FailWrite
+    @Priority(Priorities.USER + 100)
+    @ApplicationScoped
+    public static class FailingWriterInterceptor implements WriterInterceptor {
         @Override
-        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
-            entireRequestScope.close();
-            serverResponse.whenSent(entireRequestSpan::end);
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+            throw new IOException("Deliberate response write failure");
         }
+    }
+
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface WriterChild {
+    }
+
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface FailWrite {
     }
 
     @Path(BASE_PATH)
     @ObserveWrite
     @ApplicationScoped
     public static class TestResource {
+
+        private final Tracer tracer;
+
+        @Inject
+        TestResource(Tracer tracer) {
+            this.tracer = tracer;
+        }
 
         @GET
         @Path("/ok")
@@ -336,6 +421,42 @@ class AutoSpanIncludesWriteTestBase {
         @Produces(MediaType.TEXT_PLAIN)
         public Response error() {
             return Response.serverError().entity("error").build();
+        }
+
+        @GET
+        @Path("/writer-child")
+        @Produces(MediaType.TEXT_PLAIN)
+        @WriterChild
+        public String writerChild() {
+            return "writer-child";
+        }
+
+        @GET
+        @Path("/streaming-child")
+        @Produces(MediaType.TEXT_PLAIN)
+        public StreamingOutput streamingChild() {
+            return output -> {
+                Span childSpan = tracer.spanBuilder(STREAMING_CHILD_SPAN_NAME).build();
+                try (Scope ignored = childSpan.activate()) {
+                    output.write("streaming-child".getBytes(StandardCharsets.UTF_8));
+                } finally {
+                    childSpan.end();
+                }
+            };
+        }
+
+        @GET
+        @Path("/write-error")
+        @Produces(MediaType.TEXT_PLAIN)
+        @FailWrite
+        public String writeError() {
+            return "never-written";
+        }
+
+        @GET
+        @Path("/no-content")
+        public Response noContent() {
+            return Response.noContent().build();
         }
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.SpanListener;
+import io.helidon.tracing.Tracer;
+import io.helidon.webserver.http.ServerResponse;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NameBinding;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.junit.jupiter.api.BeforeEach;
+
+import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_STATUS_CODE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@HelidonTest
+@AddBean(TestSpanExporter.class)
+@AddBean(AutoSpanIncludesWriteTestBase.TestResource.class)
+@AddBean(AutoSpanIncludesWriteTestBase.WriteProbe.class)
+@AddBean(AutoSpanIncludesWriteTestBase.TestSpanListener.class)
+@AddConfig(key = "otel.sdk.disabled", value = "false")
+@AddConfig(key = "otel.traces.exporter", value = "in-memory")
+class AutoSpanIncludesWriteTestBase {
+
+    private static final String BASE_PATH = "/auto-span-includes-write";
+    static final String ENTIRE_REQUEST_SPAN_NAME = "entireRequest";
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Inject
+    private WriteProbe writeProbe;
+
+    @Inject
+    private TestSpanListener spanListener;
+
+    @Inject
+    private TestSpanExporter spanExporter;
+
+    @Inject
+    private Tracer tracer;
+
+    private boolean listenerRegistered;
+
+    @BeforeEach
+    void reset() {
+        if (!listenerRegistered) {
+            tracer.register(spanListener);
+            listenerRegistered = true;
+        }
+        writeProbe.reset();
+        spanListener.reset();
+        spanExporter.clear();
+    }
+
+    void checkSpanAtWrite(boolean expectedEndedAtWrite) {
+        try (Response response = webTarget.path(BASE_PATH + "/ok")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            assertThat("Response status", response.getStatus(), is(200));
+            assertThat("Response entity", response.readEntity(String.class), is("ok"));
+        }
+
+        Span observedSpan = writeProbe.observedSpan();
+        assertThat("Writer observed a span", observedSpan, notNullValue());
+        assertThat("Span scope was closed before entity serialization", writeProbe.spanClosed(), is(true));
+        assertThat("Span end state at entity serialization", writeProbe.spanEnded(), is(expectedEndedAtWrite));
+        assertThat("Span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
+        spanExporter.spanData(2);
+    }
+
+    void checkErrorStatus() {
+        try (Response response = webTarget.path(BASE_PATH + "/error")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            assertThat("Response status", response.getStatus(), is(500));
+            assertThat("Response entity", response.readEntity(String.class), is("error"));
+        }
+
+        Span observedSpan = writeProbe.observedSpan();
+        assertThat("Writer observed a span", observedSpan, notNullValue());
+        assertThat("Span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
+
+        List<SpanData> spans = spanExporter.spanData(2);
+        SpanData serverSpan = spans.stream()
+                .filter(span -> span.getKind() == SpanKind.SERVER)
+                .findFirst()
+                .orElseThrow();
+        assertThat("Server span status", serverSpan.getStatus().getStatusCode(), is(StatusCode.ERROR));
+        assertThat("HTTP status attribute",
+                   serverSpan.getAttributes().get(AttributeKey.longKey(HTTP_STATUS_CODE)),
+                   is(500L));
+    }
+
+    void checkResponseWriteSpanParent() {
+        try (Response response = webTarget.path(BASE_PATH + "/ok")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            assertThat("Response status", response.getStatus(), is(200));
+            assertThat("Response entity", response.readEntity(String.class), is("ok"));
+        }
+
+        Span responseWriteSpan = writeProbe.observedSpan();
+        assertThat("Writer observed a span", responseWriteSpan, notNullValue());
+        assertThat("Response write span scope was closed before entity serialization",
+                   writeProbe.spanClosed(), is(true));
+        assertThat("Response write span remained open during entity serialization",
+                   writeProbe.spanEnded(), is(false));
+        assertThat("Response write span eventually ended", spanListener.awaitEnded(responseWriteSpan), is(true));
+
+        List<SpanData> spans = spanExporter.spanData(3);
+        SpanData entireRequestSpan = spans.stream()
+                .filter(span -> span.getName().equals(ENTIRE_REQUEST_SPAN_NAME))
+                .findFirst()
+                .orElseThrow();
+        SpanData exportedResponseWriteSpan = spans.stream()
+                .filter(span -> span.getSpanContext().getSpanId().equals(responseWriteSpan.context().spanId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat("Response write span parent",
+                   exportedResponseWriteSpan.getParentSpanContext().getSpanId(),
+                   equalTo(entireRequestSpan.getSpanContext().getSpanId()));
+    }
+
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface ObserveWrite {
+    }
+
+    @ApplicationScoped
+    public static class TestSpanListener implements SpanListener {
+
+        private final AtomicReference<Span> latestStarted = new AtomicReference<>();
+        private final Set<Span> closed = ConcurrentHashMap.newKeySet();
+        private final ConcurrentHashMap<Span, CompletableFuture<Void>> ended = new ConcurrentHashMap<>();
+
+        @Override
+        public void started(Span span) {
+            ended.put(span, new CompletableFuture<>());
+            latestStarted.set(span);
+        }
+
+        @Override
+        public void closed(Span span, Scope scope) {
+            closed.add(span);
+        }
+
+        @Override
+        public void ended(Span span) {
+            ended.computeIfAbsent(span, ignored -> new CompletableFuture<>()).complete(null);
+        }
+
+        @Override
+        public void ended(Span span, Throwable t) {
+            ended(span);
+        }
+
+        Span latestStarted() {
+            return latestStarted.get();
+        }
+
+        boolean isClosed(Span span) {
+            return closed.contains(span);
+        }
+
+        boolean isEnded(Span span) {
+            CompletableFuture<Void> future = ended.get(span);
+            return future != null && future.isDone();
+        }
+
+        boolean awaitEnded(Span span) {
+            try {
+                ended.computeIfAbsent(span, ignored -> new CompletableFuture<>()).get(5, TimeUnit.SECONDS);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        void reset() {
+            latestStarted.set(null);
+            closed.clear();
+            ended.clear();
+        }
+    }
+
+    @Provider
+    @ObserveWrite
+    @ApplicationScoped
+    public static class WriteProbe implements WriterInterceptor {
+
+        private final TestSpanListener spanListener;
+        private final AtomicReference<Span> observedSpan = new AtomicReference<>();
+        private volatile boolean spanClosed;
+        private volatile boolean spanEnded;
+
+        @Inject
+        WriteProbe(TestSpanListener spanListener) {
+            this.spanListener = spanListener;
+        }
+
+        @Override
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+            Span span = spanListener.latestStarted();
+            observedSpan.set(span);
+            spanClosed = spanListener.isClosed(span);
+            spanEnded = spanListener.isEnded(span);
+            context.proceed();
+        }
+
+        Span observedSpan() {
+            return observedSpan.get();
+        }
+
+        boolean spanClosed() {
+            return spanClosed;
+        }
+
+        boolean spanEnded() {
+            return spanEnded;
+        }
+
+        void reset() {
+            observedSpan.set(null);
+            spanClosed = false;
+            spanEnded = false;
+        }
+    }
+
+    @Provider
+    @Priority(Priorities.HEADER_DECORATOR)
+    @ApplicationScoped
+    public static class EntireRequestSpanFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+        private final Tracer tracer;
+
+        @jakarta.ws.rs.core.Context
+        private ServerResponse serverResponse;
+
+        private Span entireRequestSpan;
+        private Scope entireRequestScope;
+
+        @Inject
+        EntireRequestSpanFilter(Tracer tracer) {
+            this.tracer = tracer;
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            Optional<SpanContext> propagatedSpanContext =
+                    tracer.extract(new RequestContextHeaderProvider(requestContext.getHeaders()));
+            entireRequestSpan = tracer.spanBuilder(ENTIRE_REQUEST_SPAN_NAME)
+                    .update(builder -> propagatedSpanContext.ifPresent(builder::parent))
+                    .build();
+            entireRequestScope = entireRequestSpan.activate();
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            entireRequestScope.close();
+            serverResponse.whenSent(entireRequestSpan::end);
+        }
+    }
+
+    @Path(BASE_PATH)
+    @ObserveWrite
+    @ApplicationScoped
+    public static class TestResource {
+
+        @GET
+        @Path("/ok")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String ok() {
+            return "ok";
+        }
+
+        @GET
+        @Path("/error")
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response error() {
+            return Response.serverError().entity("error").build();
+        }
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
@@ -87,6 +87,7 @@ class AutoSpanIncludesWriteTestBase {
 
     static final String WRITER_CHILD_SPAN_NAME = "writerChild";
     static final String STREAMING_CHILD_SPAN_NAME = "streamingChild";
+    static final String EXCEPTION_MAPPER_CHILD_SPAN_NAME = "exceptionMapperChild";
     private static final String BASE_PATH = "/auto-span-includes-write";
 
     @Inject
@@ -194,15 +195,21 @@ class AutoSpanIncludesWriteTestBase {
             assertThat("Response entity", response.readEntity(String.class), is("mapped-not-found"));
         }
 
-        Span observedSpan = writeProbe.observedSpan();
-        assertThat("Mapped response writer observed the automatic span", observedSpan, notNullValue());
-        assertThat("Mapped response span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
-        assertThat("Mapped response span ended once", spanListener.endCount(observedSpan), is(1));
+        Span serverSpanAtResource = writeProbe.resourceSpan();
+        assertThat("Mapped resource observed the automatic span", serverSpanAtResource, notNullValue());
+        assertThat("Mapped response span eventually ended", spanListener.awaitEnded(serverSpanAtResource), is(true));
+        assertThat("Mapped response span ended once", spanListener.endCount(serverSpanAtResource), is(1));
         assertThat("Mapped application exception was not treated as a write failure",
-                   spanListener.failure(observedSpan), nullValue());
+                   spanListener.failure(serverSpanAtResource), nullValue());
+        assertThat("Automatic span was current in the exception mapper",
+                   writeProbe.spanWasCurrentInExceptionMapper(), is(true));
 
-        SpanData serverSpan = spanExporter.spanData(observedSpan);
+        SpanData serverSpan = spanExporter.spanData(serverSpanAtResource);
         assertThat("Mapped 404 server span status", serverSpan.getStatus().getStatusCode(), is(StatusCode.UNSET));
+        SpanData exceptionMapperSpan = spanExporter.spanData(EXCEPTION_MAPPER_CHILD_SPAN_NAME, serverSpanAtResource);
+        assertThat("Exception mapper child span parent",
+                   exceptionMapperSpan.getParentSpanContext().getSpanId(),
+                   equalTo(serverSpan.getSpanContext().getSpanId()));
     }
 
     void checkFailedWriteEndsSpan() {
@@ -225,6 +232,8 @@ class AutoSpanIncludesWriteTestBase {
 
         SpanData serverSpan = spanExporter.spanData(observedSpan);
         assertThat("Failed response span status", serverSpan.getStatus().getStatusCode(), is(StatusCode.ERROR));
+        assertThat("Failed response HTTP status",
+                   serverSpan.getAttributes().get(AttributeKey.longKey(HTTP_STATUS_CODE)), is(500L));
     }
 
     void checkFailedResponseFilterEndsSpan() {
@@ -395,6 +404,7 @@ class AutoSpanIncludesWriteTestBase {
         private final AtomicReference<Span> resourceSpan = new AtomicReference<>();
         private volatile boolean spanEnded;
         private volatile boolean spanWasCurrent;
+        private volatile boolean spanWasCurrentInExceptionMapper;
         private volatile boolean spanWasCurrentInResource;
         private volatile String requestThread;
         private volatile String resourceThread;
@@ -410,7 +420,7 @@ class AutoSpanIncludesWriteTestBase {
             Span span = spanListener.latestStarted();
             observedSpan.set(span);
             spanEnded = spanListener.isEnded(span);
-            spanWasCurrent = Span.current()
+            spanWasCurrent |= Span.current()
                     .map(current -> current.context().spanId().equals(span.context().spanId()))
                     .orElse(false);
             writeThread = Thread.currentThread().getName();
@@ -458,6 +468,17 @@ class AutoSpanIncludesWriteTestBase {
                     .orElse(false);
         }
 
+        void observeExceptionMapperExecution() {
+            Span span = spanListener.latestStarted();
+            spanWasCurrentInExceptionMapper = Span.current()
+                    .map(current -> current.context().spanId().equals(span.context().spanId()))
+                    .orElse(false);
+        }
+
+        boolean spanWasCurrentInExceptionMapper() {
+            return spanWasCurrentInExceptionMapper;
+        }
+
         boolean spanWasCurrentInResource() {
             return spanWasCurrentInResource;
         }
@@ -474,6 +495,7 @@ class AutoSpanIncludesWriteTestBase {
             observedSpan.set(null);
             spanEnded = false;
             spanWasCurrent = false;
+            spanWasCurrentInExceptionMapper = false;
             spanWasCurrentInResource = false;
             requestThread = null;
             resourceThread = null;
@@ -536,13 +558,30 @@ class AutoSpanIncludesWriteTestBase {
     @Provider
     @ApplicationScoped
     public static class MappedNotFoundExceptionMapper implements ExceptionMapper<MappedNotFoundException> {
+        private final Tracer tracer;
+        private final WriteProbe writeProbe;
+
+        @Inject
+        MappedNotFoundExceptionMapper(Tracer tracer, WriteProbe writeProbe) {
+            this.tracer = tracer;
+            this.writeProbe = writeProbe;
+        }
+
         @Override
         public Response toResponse(MappedNotFoundException exception) {
             assertThat("Mapped exception", exception, notNullValue());
-            return Response.status(Response.Status.NOT_FOUND)
-                    .type(MediaType.TEXT_PLAIN)
-                    .entity("mapped-not-found")
-                    .build();
+            writeProbe.observeExceptionMapperExecution();
+            Span childSpan = tracer.spanBuilder(EXCEPTION_MAPPER_CHILD_SPAN_NAME).build();
+            Scope scope = childSpan.activate();
+            try {
+                return Response.status(Response.Status.NOT_FOUND)
+                        .type(MediaType.TEXT_PLAIN)
+                        .entity("mapped-not-found")
+                        .build();
+            } finally {
+                scope.close();
+                childSpan.end();
+            }
         }
     }
 
@@ -628,6 +667,7 @@ class AutoSpanIncludesWriteTestBase {
         @Path("/mapped-not-found")
         @Produces(MediaType.TEXT_PLAIN)
         public String mappedNotFound() {
+            writeProbe.observeResourceSpan();
             throw new MappedNotFoundException();
         }
 

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
@@ -156,6 +156,25 @@ class AutoSpanIncludesWriteTestBase {
                    is(500L));
     }
 
+    void checkFinalResponseStatusOverridesProvisionalServerError() {
+        try (Response response = webTarget.path(BASE_PATH + "/rewritten-error")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            assertThat("Response status", response.getStatus(), is(200));
+            assertThat("Response entity", response.readEntity(String.class), is("rewritten-error"));
+        }
+
+        Span observedSpan = writeProbe.observedSpan();
+        assertThat("Writer observed a span", observedSpan, notNullValue());
+        assertThat("Span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
+
+        SpanData serverSpan = spanExporter.spanData(observedSpan);
+        assertThat("Final successful server span status",
+                   serverSpan.getStatus().getStatusCode(), is(StatusCode.UNSET));
+        assertThat("Final HTTP status attribute",
+                   serverSpan.getAttributes().get(AttributeKey.longKey(HTTP_STATUS_CODE)), is(200L));
+    }
+
     void checkResponseWriteSpanParent(String path, String childSpanName, String expectedEntity) {
         try (Response response = webTarget.path(BASE_PATH + path)
                 .request(MediaType.TEXT_PLAIN)
@@ -320,6 +339,12 @@ class AutoSpanIncludesWriteTestBase {
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.TYPE, ElementType.METHOD})
     public @interface ManagedAsyncProbe {
+    }
+
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface RewriteServerError {
     }
 
     @ApplicationScoped
@@ -556,6 +581,18 @@ class AutoSpanIncludesWriteTestBase {
     }
 
     @Provider
+    @RewriteServerError
+    @Priority(Priorities.HEADER_DECORATOR)
+    @ApplicationScoped
+    public static class RewriteServerErrorFilter implements ContainerResponseFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            assertThat("Request context", requestContext, notNullValue());
+            responseContext.setStatus(Response.Status.OK.getStatusCode());
+        }
+    }
+
+    @Provider
     @ApplicationScoped
     public static class MappedNotFoundExceptionMapper implements ExceptionMapper<MappedNotFoundException> {
         private final Tracer tracer;
@@ -636,6 +673,14 @@ class AutoSpanIncludesWriteTestBase {
         @Produces(MediaType.TEXT_PLAIN)
         public Response error() {
             return Response.serverError().entity("error").build();
+        }
+
+        @GET
+        @Path("/rewritten-error")
+        @Produces(MediaType.TEXT_PLAIN)
+        @RewriteServerError
+        public Response rewrittenError() {
+            return Response.serverError().entity("rewritten-error").build();
         }
 
         @GET

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTestBase.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -53,9 +52,12 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
@@ -63,13 +65,16 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.glassfish.jersey.server.ManagedAsync;
 import org.junit.jupiter.api.BeforeEach;
 
 import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_STATUS_CODE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 @HelidonTest
 @AddBean(TestSpanExporter.class)
@@ -80,9 +85,9 @@ import static org.hamcrest.Matchers.notNullValue;
 @AddConfig(key = "otel.traces.exporter", value = "in-memory")
 class AutoSpanIncludesWriteTestBase {
 
-    private static final String BASE_PATH = "/auto-span-includes-write";
     static final String WRITER_CHILD_SPAN_NAME = "writerChild";
     static final String STREAMING_CHILD_SPAN_NAME = "streamingChild";
+    private static final String BASE_PATH = "/auto-span-includes-write";
 
     @Inject
     private WebTarget webTarget;
@@ -128,7 +133,7 @@ class AutoSpanIncludesWriteTestBase {
                    writeProbe.spanWasCurrent(), is(expectedCurrentAtWrite));
         assertThat("Span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
         assertThat("Span ended once", spanListener.endCount(observedSpan), is(1));
-        spanExporter.spanData(2);
+        spanExporter.spanData(observedSpan);
     }
 
     void checkErrorStatus() {
@@ -167,15 +172,8 @@ class AutoSpanIncludesWriteTestBase {
         assertThat("Automatic span eventually ended", spanListener.awaitEnded(serverSpanAtWrite), is(true));
         assertThat("Automatic span ended once", spanListener.endCount(serverSpanAtWrite), is(1));
 
-        List<SpanData> spans = spanExporter.spanData(3);
-        SpanData serverSpan = spans.stream()
-                .filter(span -> span.getKind() == SpanKind.SERVER)
-                .findFirst()
-                .orElseThrow();
-        SpanData childSpan = spans.stream()
-                .filter(span -> span.getName().equals(childSpanName))
-                .findFirst()
-                .orElseThrow();
+        SpanData serverSpan = spanExporter.spanData(serverSpanAtWrite);
+        SpanData childSpan = spanExporter.spanData(childSpanName, serverSpanAtWrite);
 
         assertThat("Response-write child span parent",
                    childSpan.getParentSpanContext().getSpanId(),
@@ -185,7 +183,7 @@ class AutoSpanIncludesWriteTestBase {
     void checkAsyncResponseWriteSpanParent() {
         checkResponseWriteSpanParent("/async-streaming-child", STREAMING_CHILD_SPAN_NAME, "async-streaming-child");
         assertThat("Asynchronous entity writing used another thread",
-                   writeProbe.writeThread(), org.hamcrest.Matchers.not(equalTo(writeProbe.resourceThread())));
+                   writeProbe.writeThread(), not(equalTo(writeProbe.resourceThread())));
     }
 
     void checkMappedApplicationException() {
@@ -201,19 +199,20 @@ class AutoSpanIncludesWriteTestBase {
         assertThat("Mapped response span eventually ended", spanListener.awaitEnded(observedSpan), is(true));
         assertThat("Mapped response span ended once", spanListener.endCount(observedSpan), is(1));
         assertThat("Mapped application exception was not treated as a write failure",
-                   spanListener.failure(observedSpan), org.hamcrest.Matchers.nullValue());
+                   spanListener.failure(observedSpan), nullValue());
 
         SpanData serverSpan = spanExporter.spanData(observedSpan);
         assertThat("Mapped 404 server span status", serverSpan.getStatus().getStatusCode(), is(StatusCode.UNSET));
     }
 
     void checkFailedWriteEndsSpan() {
-        try (Response ignored = webTarget.path(BASE_PATH + "/write-error")
+        try (Response response = webTarget.path(BASE_PATH + "/write-error")
                 .request(MediaType.TEXT_PLAIN)
                 .get()) {
-            // Depending on how far response writing progressed, the client can receive an error response or an exception.
-        } catch (ProcessingException ignored) {
-            // The server-side lifecycle assertions below are authoritative for this test.
+            assertThat("Failed write response family",
+                       response.getStatusInfo().getFamily(), not(Response.Status.Family.SUCCESSFUL));
+        } catch (ProcessingException expected) {
+            assertThat("Client observed the failed write", expected, notNullValue());
         }
 
         Span observedSpan = writeProbe.observedSpan();
@@ -229,12 +228,13 @@ class AutoSpanIncludesWriteTestBase {
     }
 
     void checkFailedResponseFilterEndsSpan() {
-        try (Response ignored = webTarget.path(BASE_PATH + "/response-filter-error")
+        try (Response response = webTarget.path(BASE_PATH + "/response-filter-error")
                 .request(MediaType.TEXT_PLAIN)
                 .get()) {
-            // Depending on how far response processing progressed, the client can receive an error response or an exception.
-        } catch (ProcessingException ignored) {
-            // The server-side lifecycle assertions below are authoritative for this test.
+            assertThat("Failed response-filter response family",
+                       response.getStatusInfo().getFamily(), not(Response.Status.Family.SUCCESSFUL));
+        } catch (ProcessingException expected) {
+            assertThat("Client observed the response-filter failure", expected, notNullValue());
         }
 
         Span resourceSpan = writeProbe.resourceSpan();
@@ -254,15 +254,63 @@ class AutoSpanIncludesWriteTestBase {
             assertThat("Response status", response.getStatus(), is(204));
         }
 
-        List<SpanData> spans = spanExporter.spanData(2);
+        Span resourceSpan = writeProbe.resourceSpan();
+        assertThat("Entity-less resource observed the automatic span", resourceSpan, notNullValue());
+        assertThat("Entity-less response ended its automatic span", spanListener.awaitEnded(resourceSpan), is(true));
         assertThat("Entity-less response exported its server span",
-                   spans.stream().anyMatch(span -> span.getKind() == SpanKind.SERVER), is(true));
+                   spanExporter.spanData(resourceSpan).getKind(), is(SpanKind.SERVER));
+    }
+
+    void checkDeferredProvidersRegistered(boolean expected) {
+        try (Response response = webTarget.path(BASE_PATH + "/deferred-providers-registered")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            assertThat("Response status", response.getStatus(), is(200));
+            assertThat("Deferred providers registration", response.readEntity(Boolean.class), is(expected));
+        }
+    }
+
+    void checkManagedAsyncResourceScope() {
+        try (Response response = webTarget.path(BASE_PATH + "/managed-async")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            assertThat("Response status", response.getStatus(), is(200));
+            assertThat("Response entity", response.readEntity(String.class), is("managed-async"));
+        }
+
+        assertThat("Managed resource ran on another thread",
+                   writeProbe.resourceThread(), not(equalTo(writeProbe.requestThread())));
+        assertThat("Automatic span was current in managed resource", writeProbe.spanWasCurrentInResource(), is(true));
     }
 
     @NameBinding
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.TYPE, ElementType.METHOD})
     public @interface ObserveWrite {
+    }
+
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface WriterChild {
+    }
+
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface FailWrite {
+    }
+
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface FailResponseFilter {
+    }
+
+    @NameBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface ManagedAsyncProbe {
     }
 
     @ApplicationScoped
@@ -281,8 +329,8 @@ class AutoSpanIncludesWriteTestBase {
 
         @Override
         public void ended(Span span) {
-            endCounts.computeIfAbsent(span, ignored -> new AtomicInteger()).incrementAndGet();
-            ended.computeIfAbsent(span, ignored -> new CompletableFuture<>()).complete(null);
+            endCounter(span).incrementAndGet();
+            completion(span).complete(null);
         }
 
         @Override
@@ -301,12 +349,10 @@ class AutoSpanIncludesWriteTestBase {
         }
 
         boolean awaitEnded(Span span) {
-            try {
-                ended.computeIfAbsent(span, ignored -> new CompletableFuture<>()).get(5, TimeUnit.SECONDS);
-                return true;
-            } catch (Exception e) {
-                return false;
-            }
+            return completion(span)
+                    .orTimeout(5, TimeUnit.SECONDS)
+                    .handle((result, failure) -> result == null && failure == null)
+                    .join();
         }
 
         int endCount(Span span) {
@@ -324,6 +370,18 @@ class AutoSpanIncludesWriteTestBase {
             endCounts.clear();
             failures.clear();
         }
+
+        private AtomicInteger endCounter(Span span) {
+            AtomicInteger newCounter = new AtomicInteger();
+            AtomicInteger previous = endCounts.putIfAbsent(span, newCounter);
+            return previous == null ? newCounter : previous;
+        }
+
+        private CompletableFuture<Void> completion(Span span) {
+            CompletableFuture<Void> newCompletion = new CompletableFuture<>();
+            CompletableFuture<Void> previous = ended.putIfAbsent(span, newCompletion);
+            return previous == null ? newCompletion : previous;
+        }
     }
 
     @Provider
@@ -334,11 +392,13 @@ class AutoSpanIncludesWriteTestBase {
 
         private final TestSpanListener spanListener;
         private final AtomicReference<Span> observedSpan = new AtomicReference<>();
+        private final AtomicReference<Span> resourceSpan = new AtomicReference<>();
         private volatile boolean spanEnded;
         private volatile boolean spanWasCurrent;
+        private volatile boolean spanWasCurrentInResource;
+        private volatile String requestThread;
         private volatile String resourceThread;
         private volatile String writeThread;
-        private final AtomicReference<Span> resourceSpan = new AtomicReference<>();
 
         @Inject
         WriteProbe(TestSpanListener spanListener) {
@@ -381,6 +441,27 @@ class AutoSpanIncludesWriteTestBase {
             return writeThread;
         }
 
+        void requestThread(String threadName) {
+            requestThread = threadName;
+        }
+
+        String requestThread() {
+            return requestThread;
+        }
+
+        void observeResourceExecution() {
+            Span span = spanListener.latestStarted();
+            resourceSpan.set(span);
+            resourceThread = Thread.currentThread().getName();
+            spanWasCurrentInResource = Span.current()
+                    .map(current -> current.context().spanId().equals(span.context().spanId()))
+                    .orElse(false);
+        }
+
+        boolean spanWasCurrentInResource() {
+            return spanWasCurrentInResource;
+        }
+
         void observeResourceSpan() {
             resourceSpan.set(spanListener.latestStarted());
         }
@@ -393,6 +474,8 @@ class AutoSpanIncludesWriteTestBase {
             observedSpan.set(null);
             spanEnded = false;
             spanWasCurrent = false;
+            spanWasCurrentInResource = false;
+            requestThread = null;
             resourceThread = null;
             writeThread = null;
             resourceSpan.set(null);
@@ -415,9 +498,11 @@ class AutoSpanIncludesWriteTestBase {
         @Override
         public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
             Span childSpan = tracer.spanBuilder(WRITER_CHILD_SPAN_NAME).build();
-            try (Scope ignored = childSpan.activate()) {
+            Scope scope = childSpan.activate();
+            try {
                 context.proceed();
             } finally {
+                scope.close();
                 childSpan.end();
             }
         }
@@ -430,6 +515,7 @@ class AutoSpanIncludesWriteTestBase {
     public static class FailingWriterInterceptor implements WriterInterceptor {
         @Override
         public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+            assertThat("Writer context", context, notNullValue());
             throw new IOException("Deliberate response write failure");
         }
     }
@@ -441,6 +527,8 @@ class AutoSpanIncludesWriteTestBase {
         @Override
         public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
                 throws IOException {
+            assertThat("Request context", requestContext, notNullValue());
+            assertThat("Response context", responseContext, notNullValue());
             throw new IOException("Deliberate response filter failure");
         }
     }
@@ -450,6 +538,7 @@ class AutoSpanIncludesWriteTestBase {
     public static class MappedNotFoundExceptionMapper implements ExceptionMapper<MappedNotFoundException> {
         @Override
         public Response toResponse(MappedNotFoundException exception) {
+            assertThat("Mapped exception", exception, notNullValue());
             return Response.status(Response.Status.NOT_FOUND)
                     .type(MediaType.TEXT_PLAIN)
                     .entity("mapped-not-found")
@@ -460,22 +549,23 @@ class AutoSpanIncludesWriteTestBase {
     public static class MappedNotFoundException extends WebApplicationException {
     }
 
-    @NameBinding
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.TYPE, ElementType.METHOD})
-    public @interface WriterChild {
-    }
+    @Provider
+    @ManagedAsyncProbe
+    @Priority(Priorities.USER)
+    @ApplicationScoped
+    public static class ManagedAsyncRequestProbe implements ContainerRequestFilter {
+        private final WriteProbe writeProbe;
 
-    @NameBinding
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.TYPE, ElementType.METHOD})
-    public @interface FailWrite {
-    }
+        @Inject
+        ManagedAsyncRequestProbe(WriteProbe writeProbe) {
+            this.writeProbe = writeProbe;
+        }
 
-    @NameBinding
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.TYPE, ElementType.METHOD})
-    public @interface FailResponseFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            assertThat("Request context", requestContext, notNullValue());
+            writeProbe.requestThread(Thread.currentThread().getName());
+        }
     }
 
     @Path(BASE_PATH)
@@ -485,6 +575,9 @@ class AutoSpanIncludesWriteTestBase {
 
         private final Tracer tracer;
         private final WriteProbe writeProbe;
+
+        @Context
+        private Configuration configuration;
 
         @Inject
         TestResource(Tracer tracer, WriteProbe writeProbe) {
@@ -558,15 +651,36 @@ class AutoSpanIncludesWriteTestBase {
         @GET
         @Path("/no-content")
         public Response noContent() {
+            writeProbe.observeResourceSpan();
             return Response.noContent().build();
+        }
+
+        @GET
+        @Path("/deferred-providers-registered")
+        @Produces(MediaType.TEXT_PLAIN)
+        public boolean deferredProvidersRegistered() {
+            return configuration.isRegistered(HelidonTelemetryWriterInterceptor.class)
+                    && configuration.isRegistered(HelidonTelemetryRequestEventListener.class);
+        }
+
+        @GET
+        @Path("/managed-async")
+        @Produces(MediaType.TEXT_PLAIN)
+        @ManagedAsync
+        @ManagedAsyncProbe
+        public String managedAsync() {
+            writeProbe.observeResourceExecution();
+            return "managed-async";
         }
 
         private StreamingOutput streamingOutput(String value) {
             return output -> {
                 Span childSpan = tracer.spanBuilder(STREAMING_CHILD_SPAN_NAME).build();
-                try (Scope ignored = childSpan.activate()) {
+                Scope scope = childSpan.activate();
+                try {
                     output.write(value.getBytes(StandardCharsets.UTF_8));
                 } finally {
+                    scope.close();
                     childSpan.end();
                 }
             };

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
@@ -55,4 +55,9 @@ class AutoSpanIncludesWriteTrueTest extends AutoSpanIncludesWriteTestBase {
     void testMappedApplicationExceptionIsNotAWriteFailure() {
         checkMappedApplicationException();
     }
+
+    @Test
+    void testTrueRegistersDeferredProviders() {
+        checkDeferredProvidersRegistered(true);
+    }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.microprofile.testing.junit5.AddConfig;
+
+import org.junit.jupiter.api.Test;
+
+@AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
+class AutoSpanIncludesWriteTrueTest extends AutoSpanIncludesWriteTestBase {
+
+    @Test
+    void testTrueEndsSpanAfterWrite() {
+        checkSpanAtWrite(false);
+    }
+
+    @Test
+    void testTruePreservesErrorStatus() {
+        checkErrorStatus();
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 @AddBean(AutoSpanIncludesWriteTestBase.FailingWriterInterceptor.class)
 @AddBean(AutoSpanIncludesWriteTestBase.FailingResponseFilter.class)
 @AddBean(AutoSpanIncludesWriteTestBase.MappedNotFoundExceptionMapper.class)
+@AddBean(AutoSpanIncludesWriteTestBase.RewriteServerErrorFilter.class)
 class AutoSpanIncludesWriteTrueTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
@@ -34,6 +35,11 @@ class AutoSpanIncludesWriteTrueTest extends AutoSpanIncludesWriteTestBase {
     @Test
     void testTruePreservesErrorStatus() {
         checkErrorStatus();
+    }
+
+    @Test
+    void testFinalResponseStatusOverridesProvisionalServerError() {
+        checkFinalResponseStatusOverridesProvisionalServerError();
     }
 
     @Test

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
@@ -22,11 +22,13 @@ import org.junit.jupiter.api.Test;
 
 @AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
 @AddBean(AutoSpanIncludesWriteTestBase.FailingWriterInterceptor.class)
+@AddBean(AutoSpanIncludesWriteTestBase.FailingResponseFilter.class)
+@AddBean(AutoSpanIncludesWriteTestBase.MappedNotFoundExceptionMapper.class)
 class AutoSpanIncludesWriteTrueTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
     void testTrueEndsSpanAfterWrite() {
-        checkSpanAtWrite(false, false, true);
+        checkSpanAtWrite(false, true);
     }
 
     @Test
@@ -40,7 +42,17 @@ class AutoSpanIncludesWriteTrueTest extends AutoSpanIncludesWriteTestBase {
     }
 
     @Test
+    void testTrueEndsSpanAfterResponseFilterFailure() {
+        checkFailedResponseFilterEndsSpan();
+    }
+
+    @Test
     void testTrueEndsSpanForEntitylessResponse() {
         checkNoEntitySpanEnds();
+    }
+
+    @Test
+    void testMappedApplicationExceptionIsNotAWriteFailure() {
+        checkMappedApplicationException();
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AutoSpanIncludesWriteTrueTest.java
@@ -15,20 +15,32 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import io.helidon.microprofile.testing.junit5.AddBean;
 import io.helidon.microprofile.testing.junit5.AddConfig;
 
 import org.junit.jupiter.api.Test;
 
 @AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
+@AddBean(AutoSpanIncludesWriteTestBase.FailingWriterInterceptor.class)
 class AutoSpanIncludesWriteTrueTest extends AutoSpanIncludesWriteTestBase {
 
     @Test
     void testTrueEndsSpanAfterWrite() {
-        checkSpanAtWrite(false);
+        checkSpanAtWrite(false, false, true);
     }
 
     @Test
     void testTruePreservesErrorStatus() {
         checkErrorStatus();
+    }
+
+    @Test
+    void testTrueEndsSpanAfterWriteFailure() {
+        checkFailedWriteEndsSpan();
+    }
+
+    @Test
+    void testTrueEndsSpanForEntitylessResponse() {
+        checkNoEntitySpanEnds();
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/HelidonTelemetryWriterInterceptorTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/HelidonTelemetryWriterInterceptorTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.tracing.Baggage;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.WritableBaggage;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HelidonTelemetryWriterInterceptorTest {
+
+    @Test
+    void removesLifecyclePropertyAfterSuccessfulWrite() throws IOException {
+        RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
+        TestWriterInterceptorContext context = new TestWriterInterceptorContext(lifecycle, null);
+
+        new HelidonTelemetryWriterInterceptor().aroundWriteTo(context);
+
+        assertThat("Writer chain invoked", context.proceedCount.get(), is(1));
+        assertThat("Writer scope closed", span.scope.closeCount.get(), is(1));
+        assertThat("Lifecycle property removed",
+                   context.getProperty(ServerSpanLifecycle.PROPERTY), nullValue());
+    }
+
+    @Test
+    void removesLifecyclePropertyAndCapturesFailedWrite() {
+        RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
+        IOException failure = new IOException("deliberate");
+        TestWriterInterceptorContext context = new TestWriterInterceptorContext(lifecycle, failure);
+
+        assertThrows(IOException.class, () -> new HelidonTelemetryWriterInterceptor().aroundWriteTo(context));
+        lifecycle.requestFinished(false);
+
+        assertThat("Writer chain invoked", context.proceedCount.get(), is(1));
+        assertThat("Writer scope closed", span.scope.closeCount.get(), is(1));
+        assertThat("Lifecycle property removed",
+                   context.getProperty(ServerSpanLifecycle.PROPERTY), nullValue());
+        assertThat("Write failure recorded", span.failure, instanceOf(IOException.class));
+    }
+
+    private static final class RecordingSpan implements Span {
+        private static final SpanContext CONTEXT = new SpanContext() {
+            @Override
+            public String traceId() {
+                return "trace";
+            }
+
+            @Override
+            public String spanId() {
+                return "span";
+            }
+
+            @Override
+            public void asParent(Builder<?> spanBuilder) {
+                Objects.requireNonNull(spanBuilder);
+            }
+
+            @Override
+            public Baggage baggage() {
+                return null;
+            }
+        };
+
+        private final RecordingScope scope = new RecordingScope();
+        private volatile Throwable failure;
+
+        @Override
+        public Span tag(String key, String value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            return this;
+        }
+
+        @Override
+        public Span tag(String key, Boolean value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            return this;
+        }
+
+        @Override
+        public Span tag(String key, Number value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            return this;
+        }
+
+        @Override
+        public void status(Status status) {
+            Objects.requireNonNull(status);
+        }
+
+        @Override
+        public SpanContext context() {
+            return CONTEXT;
+        }
+
+        @Override
+        public void addEvent(String name, Map<String, ?> attributes) {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(attributes);
+        }
+
+        @Override
+        public void end() {
+        }
+
+        @Override
+        public void end(Throwable t) {
+            failure = Objects.requireNonNull(t);
+        }
+
+        @Override
+        public Scope activate() {
+            return scope;
+        }
+
+        @Override
+        @SuppressWarnings("removal")
+        public Span baggage(String key, String value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            return this;
+        }
+
+        @Override
+        @SuppressWarnings("removal")
+        public Optional<String> baggage(String key) {
+            Objects.requireNonNull(key);
+            return Optional.empty();
+        }
+
+        @Override
+        public WritableBaggage baggage() {
+            return null;
+        }
+    }
+
+    private static final class RecordingScope implements Scope {
+        private final AtomicInteger closeCount = new AtomicInteger();
+
+        @Override
+        public void close() {
+            closeCount.incrementAndGet();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closeCount.get() > 0;
+        }
+    }
+
+    private static final class TestWriterInterceptorContext implements WriterInterceptorContext {
+        private final Map<String, Object> properties = new HashMap<>();
+        private final AtomicInteger proceedCount = new AtomicInteger();
+        private final IOException failure;
+        private final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        private Annotation[] annotations = new Annotation[0];
+        private Object entity = "entity";
+        private OutputStream outputStream = new ByteArrayOutputStream();
+        private Class<?> type = String.class;
+        private Type genericType = String.class;
+        private MediaType mediaType = MediaType.TEXT_PLAIN_TYPE;
+
+        private TestWriterInterceptorContext(ServerSpanLifecycle lifecycle, IOException failure) {
+            properties.put(ServerSpanLifecycle.PROPERTY, lifecycle);
+            this.failure = failure;
+        }
+
+        @Override
+        public void proceed() throws IOException {
+            proceedCount.incrementAndGet();
+            if (failure != null) {
+                throw failure;
+            }
+        }
+
+        @Override
+        public Object getEntity() {
+            return entity;
+        }
+
+        @Override
+        public void setEntity(Object entity) {
+            this.entity = entity;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return outputStream;
+        }
+
+        @Override
+        public void setOutputStream(OutputStream outputStream) {
+            this.outputStream = outputStream;
+        }
+
+        @Override
+        public MultivaluedMap<String, Object> getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public Object getProperty(String name) {
+            return properties.get(name);
+        }
+
+        @Override
+        public Collection<String> getPropertyNames() {
+            return properties.keySet();
+        }
+
+        @Override
+        public void setProperty(String name, Object object) {
+            properties.put(name, object);
+        }
+
+        @Override
+        public void removeProperty(String name) {
+            properties.remove(name);
+        }
+
+        @Override
+        public Annotation[] getAnnotations() {
+            return annotations;
+        }
+
+        @Override
+        public void setAnnotations(Annotation[] annotations) {
+            this.annotations = annotations;
+        }
+
+        @Override
+        public Class<?> getType() {
+            return type;
+        }
+
+        @Override
+        public void setType(Class<?> type) {
+            this.type = type;
+        }
+
+        @Override
+        public Type getGenericType() {
+            return genericType;
+        }
+
+        @Override
+        public void setGenericType(Type genericType) {
+            this.genericType = genericType;
+        }
+
+        @Override
+        public MediaType getMediaType() {
+            return mediaType;
+        }
+
+        @Override
+        public void setMediaType(MediaType mediaType) {
+            this.mediaType = mediaType;
+        }
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/PlainJerseyClientTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/PlainJerseyClientTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 class PlainJerseyClientTest {
+
     @Test
     void plainJerseyClientSkipsCdiDependentTelemetryFilter() {
         try (Client client = ClientBuilder.newBuilder().register(new SuccessfulResponseFilter()).build()) {
@@ -34,6 +35,26 @@ class PlainJerseyClientTest {
                     assertThat(response.getStatus(), is(200));
                     assertThat(response.readEntity(String.class), is("pong"));
                 }
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void plainJerseyClientSkipsServerResponseWriteProvidersWhenEnabled() {
+        String setting = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE;
+        String originalValue = System.getProperty(setting);
+        System.setProperty(setting, "true");
+        try (Client client = ClientBuilder.newBuilder().build()) {
+            assertThat("Server writer interceptor is not registered with a client",
+                       client.getConfiguration().isRegistered(HelidonTelemetryWriterInterceptor.class), is(false));
+            assertThat("Server request-event listener is not registered with a client",
+                       client.getConfiguration().isRegistered(HelidonTelemetryRequestEventListener.class), is(false));
+        } finally {
+            if (originalValue == null) {
+                System.clearProperty(setting);
+            } else {
+                System.setProperty(setting, originalValue);
             }
         }
     }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/ServerSpanLifecycleTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/ServerSpanLifecycleTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import io.helidon.tracing.Baggage;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.WritableBaggage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class ServerSpanLifecycleTest {
+
+    @Test
+    void successfulFinishedEventEndsSpanWithoutWebServerCallback() {
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
+        RecordingSpan span = new RecordingSpan();
+        RecordingScope requestScope = new RecordingScope();
+
+        lifecycle.requestFiltered(requestScope);
+        lifecycle.requestFinished(span, true);
+
+        assertThat("Span ended", span.endCount.get(), is(1));
+        assertThat("Span status", span.status, is(Span.Status.UNSET));
+        assertThat("Request scope closed", requestScope.closeCount.get(), is(1));
+    }
+
+    @Test
+    void unsuccessfulFinishedEventEndsSpanWithError() {
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
+        RecordingSpan span = new RecordingSpan();
+
+        lifecycle.requestFinished(span, false);
+
+        assertThat("Span ended", span.endCount.get(), is(1));
+        assertThat("Span status", span.status, is(Span.Status.ERROR));
+        assertThat("Span failure", span.failure, nullValue());
+    }
+
+    @Test
+    void repeatedFinishedEventsEndSpanOnce() {
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
+        RecordingSpan span = new RecordingSpan();
+        RecordingScope requestScope = new RecordingScope();
+
+        lifecycle.requestFiltered(requestScope);
+        lifecycle.requestFiltered(requestScope);
+        IntStream.range(0, 100).parallel().forEach(index -> lifecycle.requestFinished(span, index < 100));
+
+        assertThat("Span ended once", span.endCount.get(), is(1));
+        assertThat("Request scope closed once", requestScope.closeCount.get(), is(1));
+    }
+
+    @Test
+    void resourceMethodCanFinishBeforeRequest() {
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
+        RecordingSpan span = new RecordingSpan();
+        RecordingScope requestScope = new RecordingScope();
+
+        lifecycle.requestFiltered(requestScope);
+        lifecycle.resourceMethodStarted(span);
+        lifecycle.resourceMethodFinished(span);
+
+        assertThat("Request scope closed", requestScope.closeCount.get(), is(1));
+        assertThat("Resource scope closed", span.resourceScope.closeCount.get(), is(1));
+        assertThat("Span remains open", span.endCount.get(), is(0));
+
+        lifecycle.requestFinished(span, true);
+
+        assertThat("Span ended", span.endCount.get(), is(1));
+    }
+
+    @Test
+    void requestCanFinishBeforeResourceMethod() {
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
+        RecordingSpan span = new RecordingSpan();
+        RecordingScope requestScope = new RecordingScope();
+
+        lifecycle.requestFiltered(requestScope);
+        lifecycle.resourceMethodStarted(span);
+        lifecycle.requestFinished(span, true);
+
+        assertThat("Request scope closed", requestScope.closeCount.get(), is(1));
+        assertThat("Resource scope remains open", span.resourceScope.closeCount.get(), is(0));
+        assertThat("Span remains open", span.endCount.get(), is(0));
+
+        lifecycle.resourceMethodFinished(span);
+
+        assertThat("Resource scope closed", span.resourceScope.closeCount.get(), is(1));
+        assertThat("Span ended", span.endCount.get(), is(1));
+    }
+
+    @Test
+    void responseFailureIsCapturedOnlyAfterResponseProcessingStarts() {
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
+        RecordingSpan span = new RecordingSpan();
+        RuntimeException mappedResourceFailure = new RuntimeException("mapped");
+        RuntimeException responseFailure = new RuntimeException("response");
+
+        lifecycle.responseFailure(mappedResourceFailure);
+        lifecycle.responseProcessingStarted();
+        lifecycle.responseFailure(responseFailure);
+        lifecycle.requestFinished(span, true);
+
+        assertThat("Response failure recorded", span.failure, is(responseFailure));
+        assertThat("Span status", span.status, is(Span.Status.ERROR));
+    }
+
+    @Test
+    void writerFailureIsCaptured() {
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
+        RecordingSpan span = new RecordingSpan();
+        RuntimeException writerFailure = new RuntimeException("writer");
+
+        lifecycle.writerFailure(writerFailure);
+        lifecycle.requestFinished(span, false);
+
+        assertThat("Writer failure recorded", span.failure, is(writerFailure));
+        assertThat("Span status", span.status, is(Span.Status.ERROR));
+    }
+
+    private static final class RecordingSpan implements Span {
+        private static final SpanContext CONTEXT = new SpanContext() {
+            @Override
+            public String traceId() {
+                return "trace";
+            }
+
+            @Override
+            public String spanId() {
+                return "span";
+            }
+
+            @Override
+            public void asParent(Builder<?> spanBuilder) {
+                Objects.requireNonNull(spanBuilder);
+            }
+
+            @Override
+            public Baggage baggage() {
+                return null;
+            }
+        };
+
+        private final RecordingScope resourceScope = new RecordingScope();
+        private final AtomicInteger endCount = new AtomicInteger();
+        private volatile Status status = Status.UNSET;
+        private volatile Throwable failure;
+
+        @Override
+        public Span tag(String key, String value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            return this;
+        }
+
+        @Override
+        public Span tag(String key, Boolean value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            return this;
+        }
+
+        @Override
+        public Span tag(String key, Number value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            return this;
+        }
+
+        @Override
+        public void status(Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public SpanContext context() {
+            return CONTEXT;
+        }
+
+        @Override
+        public void addEvent(String name, Map<String, ?> attributes) {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(attributes);
+        }
+
+        @Override
+        public void end() {
+            endCount.incrementAndGet();
+        }
+
+        @Override
+        public void end(Throwable t) {
+            failure = t;
+            endCount.incrementAndGet();
+        }
+
+        @Override
+        public Scope activate() {
+            return resourceScope;
+        }
+
+        @Override
+        @SuppressWarnings("removal")
+        public Span baggage(String key, String value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            return this;
+        }
+
+        @Override
+        @SuppressWarnings("removal")
+        public Optional<String> baggage(String key) {
+            Objects.requireNonNull(key);
+            return Optional.empty();
+        }
+
+        @Override
+        public WritableBaggage baggage() {
+            return null;
+        }
+    }
+
+    private static final class RecordingScope implements Scope {
+        private final Thread owner = Thread.currentThread();
+        private final AtomicInteger closeCount = new AtomicInteger();
+
+        @Override
+        public void close() {
+            if (Thread.currentThread() != owner) {
+                throw new IllegalStateException("Scope closed from a thread other than its owner");
+            }
+            closeCount.incrementAndGet();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closeCount.get() > 0;
+        }
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/ServerSpanLifecycleTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/ServerSpanLifecycleTest.java
@@ -15,6 +15,9 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,8 +30,17 @@ import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.WritableBaggage;
 
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.internal.MapPropertiesDelegate;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_STATUS_CODE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -37,24 +49,22 @@ class ServerSpanLifecycleTest {
 
     @Test
     void successfulFinishedEventEndsSpanWithoutWebServerCallback() {
-        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
         RecordingSpan span = new RecordingSpan();
         RecordingScope requestScope = new RecordingScope();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, requestScope);
 
-        lifecycle.requestFiltered(requestScope);
-        lifecycle.requestFinished(span, true);
+        lifecycle.requestFinished(true);
 
         assertThat("Span ended", span.endCount.get(), is(1));
         assertThat("Span status", span.status, is(Span.Status.UNSET));
-        assertThat("Request scope closed", requestScope.closeCount.get(), is(1));
     }
 
     @Test
     void unsuccessfulFinishedEventEndsSpanWithError() {
-        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
         RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
 
-        lifecycle.requestFinished(span, false);
+        lifecycle.requestFinished(false);
 
         assertThat("Span ended", span.endCount.get(), is(1));
         assertThat("Span status", span.status, is(Span.Status.ERROR));
@@ -63,68 +73,133 @@ class ServerSpanLifecycleTest {
 
     @Test
     void repeatedFinishedEventsEndSpanOnce() {
-        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
         RecordingSpan span = new RecordingSpan();
         RecordingScope requestScope = new RecordingScope();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, requestScope);
 
-        lifecycle.requestFiltered(requestScope);
-        lifecycle.requestFiltered(requestScope);
-        IntStream.range(0, 100).parallel().forEach(index -> lifecycle.requestFinished(span, index < 100));
+        IntStream.range(0, 100).parallel().forEach(index -> lifecycle.requestFinished(index % 2 == 0));
 
         assertThat("Span ended once", span.endCount.get(), is(1));
-        assertThat("Request scope closed once", requestScope.closeCount.get(), is(1));
+    }
+
+    @Test
+    void requestScopeRemainsOpenUnderNestedContext() {
+        RecordingScope requestScope = new RecordingScope();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(new RecordingSpan(), requestScope);
+        ContextKey<String> nestedValue = ContextKey.named("nested-value");
+
+        try (io.opentelemetry.context.Scope ignored = Context.current().with(nestedValue, "nested").makeCurrent()) {
+            lifecycle.closeRequestScopeIfCurrent();
+            assertThat("Request scope remains open under a nested context", requestScope.closeCount.get(), is(0));
+        }
+
+        lifecycle.closeRequestScopeIfCurrent();
+        assertThat("Request scope closes after restoring its context", requestScope.closeCount.get(), is(1));
+    }
+
+    @Test
+    void finalResponseStatusReplacesEarlierStatus() {
+        RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
+
+        lifecycle.responseStatus(200);
+        lifecycle.responseStatus(500);
+        lifecycle.requestFinished(true);
+
+        assertThat("Final HTTP status", span.httpStatus, is(500));
+        assertThat("Span status", span.status, is(Span.Status.ERROR));
+    }
+
+    @Test
+    void finishedEventFinalizesStatusAndReleasesLifecycleReference() throws ReflectiveOperationException {
+        RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
+        lifecycle.responseStatus(200);
+        ContainerRequest request = containerRequest();
+        request.setProperty(ServerSpanLifecycle.PROPERTY, lifecycle);
+        ContainerResponse response = new ContainerResponse(request, Response.status(503).build());
+        RequestEvent finishedEvent = requestEvent(request, response, RequestEvent.Type.FINISHED, false);
+        RequestEventListener requestListener = new HelidonTelemetryRequestEventListener().onRequest(finishedEvent);
+
+        requestListener.onEvent(finishedEvent);
+
+        Field lifecycleField = requestListener.getClass().getDeclaredField("lifecycle");
+        lifecycleField.setAccessible(true);
+        assertThat("Listener releases lifecycle", lifecycleField.get(requestListener), nullValue());
+        assertThat("Monitoring listener does not mutate request properties",
+                   request.getProperty(ServerSpanLifecycle.PROPERTY), is(lifecycle));
+        assertThat("FINISHED response status", span.httpStatus, is(503));
+        assertThat("Unwritten response status", span.status, is(Span.Status.ERROR));
+        assertThat("Span ended", span.endCount.get(), is(1));
+    }
+
+    @Test
+    void listenerReleasesLifecycleAfterAsynchronousResourceFinishes() throws ReflectiveOperationException {
+        RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
+        ContainerRequest request = containerRequest();
+        request.setProperty(ServerSpanLifecycle.PROPERTY, lifecycle);
+        ContainerResponse response = new ContainerResponse(request, Response.ok().build());
+        RequestEventListener requestListener = new HelidonTelemetryRequestEventListener()
+                .onRequest(requestEvent(request, response, RequestEvent.Type.RESOURCE_METHOD_START, false));
+        Field lifecycleField = requestListener.getClass().getDeclaredField("lifecycle");
+        lifecycleField.setAccessible(true);
+
+        requestListener.onEvent(requestEvent(request, response, RequestEvent.Type.RESOURCE_METHOD_START, false));
+        requestListener.onEvent(requestEvent(request, response, RequestEvent.Type.FINISHED, true));
+
+        assertThat("Span remains open until resource completion", span.endCount.get(), is(0));
+        assertThat("Listener retains lifecycle until resource completion", lifecycleField.get(requestListener), is(lifecycle));
+
+        requestListener.onEvent(requestEvent(request, response, RequestEvent.Type.RESOURCE_METHOD_FINISHED, false));
+
+        assertThat("Span ends at resource completion", span.endCount.get(), is(1));
+        assertThat("Listener releases lifecycle after resource completion", lifecycleField.get(requestListener), nullValue());
     }
 
     @Test
     void resourceMethodCanFinishBeforeRequest() {
-        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
         RecordingSpan span = new RecordingSpan();
         RecordingScope requestScope = new RecordingScope();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, requestScope);
 
-        lifecycle.requestFiltered(requestScope);
-        lifecycle.resourceMethodStarted(span);
-        lifecycle.resourceMethodFinished(span);
+        lifecycle.resourceMethodStarted();
+        lifecycle.resourceMethodFinished();
 
-        assertThat("Request scope closed", requestScope.closeCount.get(), is(1));
-        assertThat("Resource scope closed", span.resourceScope.closeCount.get(), is(1));
         assertThat("Span remains open", span.endCount.get(), is(0));
 
-        lifecycle.requestFinished(span, true);
+        lifecycle.requestFinished(true);
 
         assertThat("Span ended", span.endCount.get(), is(1));
     }
 
     @Test
     void requestCanFinishBeforeResourceMethod() {
-        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
         RecordingSpan span = new RecordingSpan();
         RecordingScope requestScope = new RecordingScope();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, requestScope);
 
-        lifecycle.requestFiltered(requestScope);
-        lifecycle.resourceMethodStarted(span);
-        lifecycle.requestFinished(span, true);
+        lifecycle.resourceMethodStarted();
+        lifecycle.requestFinished(true);
 
-        assertThat("Request scope closed", requestScope.closeCount.get(), is(1));
-        assertThat("Resource scope remains open", span.resourceScope.closeCount.get(), is(0));
         assertThat("Span remains open", span.endCount.get(), is(0));
 
-        lifecycle.resourceMethodFinished(span);
+        lifecycle.resourceMethodFinished();
 
-        assertThat("Resource scope closed", span.resourceScope.closeCount.get(), is(1));
         assertThat("Span ended", span.endCount.get(), is(1));
     }
 
     @Test
     void responseFailureIsCapturedOnlyAfterResponseProcessingStarts() {
-        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
         RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
         RuntimeException mappedResourceFailure = new RuntimeException("mapped");
         RuntimeException responseFailure = new RuntimeException("response");
 
         lifecycle.responseFailure(mappedResourceFailure);
         lifecycle.responseProcessingStarted();
         lifecycle.responseFailure(responseFailure);
-        lifecycle.requestFinished(span, true);
+        lifecycle.requestFinished(true);
 
         assertThat("Response failure recorded", span.failure, is(responseFailure));
         assertThat("Span status", span.status, is(Span.Status.ERROR));
@@ -132,15 +207,35 @@ class ServerSpanLifecycleTest {
 
     @Test
     void writerFailureIsCaptured() {
-        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle();
         RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
         RuntimeException writerFailure = new RuntimeException("writer");
 
         lifecycle.writerFailure(writerFailure);
-        lifecycle.requestFinished(span, false);
+        lifecycle.requestFinished(false);
 
         assertThat("Writer failure recorded", span.failure, is(writerFailure));
         assertThat("Span status", span.status, is(Span.Status.ERROR));
+    }
+
+    private static ContainerRequest containerRequest() {
+        URI uri = URI.create("http://localhost/test");
+        return new ContainerRequest(uri, uri, "GET", null, new MapPropertiesDelegate());
+    }
+
+    private static RequestEvent requestEvent(ContainerRequest request,
+                                             ContainerResponse response,
+                                             RequestEvent.Type type,
+                                             boolean responseWritten) {
+        return (RequestEvent) Proxy.newProxyInstance(RequestEvent.class.getClassLoader(),
+                                                     new Class<?>[] {RequestEvent.class},
+                                                     (proxy, method, args) -> switch (method.getName()) {
+                                                     case "getType" -> type;
+                                                     case "getContainerRequest" -> request;
+                                                     case "getContainerResponse" -> response;
+                                                     case "isResponseWritten" -> responseWritten;
+                                                     default -> method.getReturnType() == boolean.class ? false : null;
+                                                     });
     }
 
     private static final class RecordingSpan implements Span {
@@ -166,10 +261,10 @@ class ServerSpanLifecycleTest {
             }
         };
 
-        private final RecordingScope resourceScope = new RecordingScope();
         private final AtomicInteger endCount = new AtomicInteger();
         private volatile Status status = Status.UNSET;
         private volatile Throwable failure;
+        private volatile int httpStatus;
 
         @Override
         public Span tag(String key, String value) {
@@ -189,6 +284,9 @@ class ServerSpanLifecycleTest {
         public Span tag(String key, Number value) {
             Objects.requireNonNull(key);
             Objects.requireNonNull(value);
+            if (HTTP_STATUS_CODE.equals(key)) {
+                httpStatus = value.intValue();
+            }
             return this;
         }
 
@@ -221,7 +319,7 @@ class ServerSpanLifecycleTest {
 
         @Override
         public Scope activate() {
-            return resourceScope;
+            return new RecordingScope();
         }
 
         @Override

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/ServerSpanLifecycleTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/ServerSpanLifecycleTest.java
@@ -15,7 +15,6 @@
  */
 package io.helidon.microprofile.telemetry;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.Map;
@@ -98,7 +97,7 @@ class ServerSpanLifecycleTest {
     }
 
     @Test
-    void finalResponseStatusReplacesEarlierStatus() {
+    void finalServerErrorStatusReplacesEarlierSuccess() {
         RecordingSpan span = new RecordingSpan();
         ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
 
@@ -111,7 +110,20 @@ class ServerSpanLifecycleTest {
     }
 
     @Test
-    void finishedEventFinalizesStatusAndReleasesLifecycleReference() throws ReflectiveOperationException {
+    void finalSuccessfulStatusReplacesEarlierServerError() {
+        RecordingSpan span = new RecordingSpan();
+        ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
+
+        lifecycle.responseStatus(500);
+        lifecycle.responseStatus(200);
+        lifecycle.requestFinished(true);
+
+        assertThat("Final HTTP status", span.httpStatus, is(200));
+        assertThat("Span status", span.status, is(Span.Status.UNSET));
+    }
+
+    @Test
+    void finishedEventFinalizesStatusAndEndsSpan() {
         RecordingSpan span = new RecordingSpan();
         ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
         lifecycle.responseStatus(200);
@@ -123,9 +135,6 @@ class ServerSpanLifecycleTest {
 
         requestListener.onEvent(finishedEvent);
 
-        Field lifecycleField = requestListener.getClass().getDeclaredField("lifecycle");
-        lifecycleField.setAccessible(true);
-        assertThat("Listener releases lifecycle", lifecycleField.get(requestListener), nullValue());
         assertThat("Monitoring listener does not mutate request properties",
                    request.getProperty(ServerSpanLifecycle.PROPERTY), is(lifecycle));
         assertThat("FINISHED response status", span.httpStatus, is(503));
@@ -134,7 +143,7 @@ class ServerSpanLifecycleTest {
     }
 
     @Test
-    void listenerReleasesLifecycleAfterAsynchronousResourceFinishes() throws ReflectiveOperationException {
+    void listenerDefersCompletionUntilAsynchronousResourceFinishes() {
         RecordingSpan span = new RecordingSpan();
         ServerSpanLifecycle lifecycle = new ServerSpanLifecycle(span, new RecordingScope());
         ContainerRequest request = containerRequest();
@@ -142,19 +151,14 @@ class ServerSpanLifecycleTest {
         ContainerResponse response = new ContainerResponse(request, Response.ok().build());
         RequestEventListener requestListener = new HelidonTelemetryRequestEventListener()
                 .onRequest(requestEvent(request, response, RequestEvent.Type.RESOURCE_METHOD_START, false));
-        Field lifecycleField = requestListener.getClass().getDeclaredField("lifecycle");
-        lifecycleField.setAccessible(true);
-
         requestListener.onEvent(requestEvent(request, response, RequestEvent.Type.RESOURCE_METHOD_START, false));
         requestListener.onEvent(requestEvent(request, response, RequestEvent.Type.FINISHED, true));
 
         assertThat("Span remains open until resource completion", span.endCount.get(), is(0));
-        assertThat("Listener retains lifecycle until resource completion", lifecycleField.get(requestListener), is(lifecycle));
 
         requestListener.onEvent(requestEvent(request, response, RequestEvent.Type.RESOURCE_METHOD_FINISHED, false));
 
         assertThat("Span ends at resource completion", span.endCount.get(), is(1));
-        assertThat("Listener releases lifecycle after resource completion", lifecycleField.get(requestListener), nullValue());
     }
 
     @Test

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestFilterSpanNesting.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestFilterSpanNesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.Tracer;
 
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -42,7 +43,6 @@ import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 @HelidonTest
 @AddBean(TestSpanExporter.class)
@@ -58,6 +59,7 @@ import static org.hamcrest.Matchers.is;
 @AddBean(TestFilterSpanNesting.IngressSpanSetter.class)
 @AddConfig(key = "otel.sdk.disabled", value = "false")
 @AddConfig(key = "otel.traces.exporter", value = "in-memory")
+@AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
 class TestFilterSpanNesting {
 
     private static Tracer staticTracer;
@@ -80,32 +82,47 @@ class TestFilterSpanNesting {
 
     @Test
     void testExternalParentSpan() {
-
-        var requestBuilder = webTarget.path("/parentSpanCheck")
-                .request(MediaType.TEXT_PLAIN);
-
-        // Our client filter will automatically establish a span for the outgoing Jakarta REST client request.
-        Response response = requestBuilder.get();
-
-        assertThat("Response status", response.getStatus(), is(200));
+        for (int i = 0; i < 2; i++) {
+            // Our client filter will automatically establish a span for the outgoing Jakarta REST client request.
+            try (Response response = webTarget.path("/parentSpanCheck")
+                    .request(MediaType.TEXT_PLAIN)
+                    .get()) {
+                assertThat("Response status", response.getStatus(), is(200));
+            }
+        }
 
         // Check structure of nested spans.
-        List<SpanData> spanData = testSpanExporter.spanData(3);
-        Optional<SpanData> ingressSpanData = spanData.stream()
+        List<SpanData> spanData = testSpanExporter.spanData(6);
+        List<SpanData> ingressSpans = spanData.stream()
                 .filter(sd -> sd.getName().equals("ingressSpan"))
-                .findFirst();
-        assertThat("ingress span data", ingressSpanData, OptionalMatcher.optionalPresent());
-
-        Optional<SpanData> spanFromJakartaFilter = spanData.stream()
+                .toList();
+        List<SpanData> serverSpans = spanData.stream()
                 .filter(sd -> sd.getName().equals("/parentSpanCheck"))
-                .findFirst();
-        assertThat("/parentSpanCheck span data", spanFromJakartaFilter, OptionalMatcher.optionalPresent());
+                .toList();
+        List<SpanData> clientSpans = spanData.stream()
+                .filter(sd -> sd.getKind() == SpanKind.CLIENT)
+                .toList();
+        assertThat("ingress span count", ingressSpans.size(), is(2));
+        assertThat("server span count", serverSpans.size(), is(2));
+        assertThat("client span count", clientSpans.size(), is(2));
 
-        // Make sure the parent for the span created by the container filter is the current span we set in our test filter,
-        // not the span inspired by the incoming headers.
-        assertThat("/parentSpanCheck parent span ID",
-                   spanFromJakartaFilter.get().getParentSpanContext().getSpanId(),
-                   equalTo(ingressSpanData.get().getSpanContext().getSpanId()));
+        for (SpanData serverSpan : serverSpans) {
+            Optional<SpanData> ingressSpan = ingressSpans.stream()
+                    .filter(candidate -> candidate.getSpanContext().getSpanId()
+                            .equals(serverSpan.getParentSpanContext().getSpanId()))
+                    .findFirst();
+            assertThat("Automatic server span parent", ingressSpan, OptionalMatcher.optionalPresent());
+            assertThat("Parent and child trace IDs",
+                       serverSpan.getSpanContext().getTraceId(),
+                       equalTo(ingressSpan.orElseThrow().getSpanContext().getTraceId()));
+        }
+
+        for (SpanData ingressSpan : ingressSpans) {
+            assertThat("Ingress span parent is the corresponding client span",
+                       clientSpans.stream().anyMatch(clientSpan -> clientSpan.getSpanContext().getSpanId()
+                               .equals(ingressSpan.getParentSpanContext().getSpanId())),
+                       is(true));
+        }
 
     }
 
@@ -115,7 +132,7 @@ class TestFilterSpanNesting {
 
         @GET
         @Produces(MediaType.TEXT_PLAIN)
-        public String parentSpanCheck(Request request) {
+        public String parentSpanCheck() {
             // The HelidonTelemetryContainerFilter should have been run to establish a new current span. Create a new child.
             return "Hello World!";
         }
@@ -149,6 +166,8 @@ class TestFilterSpanNesting {
 
         @Override
         public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+            assertThat("Request context", requestContext, notNullValue());
+            assertThat("Response context", responseContext, notNullValue());
             pseudoIngressScope.close();
             pseudoIngressSpan.end();
         }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestFilterSpanNesting.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestFilterSpanNesting.java
@@ -28,6 +28,7 @@ import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.Tracer;
 
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.annotation.Priority;
@@ -227,7 +228,7 @@ class TestFilterSpanNesting {
 
         @Override
         public void filter(ContainerRequestContext requestContext) {
-            io.opentelemetry.context.Scope scope = io.opentelemetry.api.baggage.Baggage.current()
+            io.opentelemetry.context.Scope scope = Baggage.current()
                     .toBuilder()
                     .put("late-filter", "active")
                     .build()

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestFilterSpanNesting.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestFilterSpanNesting.java
@@ -57,6 +57,8 @@ import static org.hamcrest.Matchers.notNullValue;
 @AddBean(TestSpanExporter.class)
 @AddBean(TestFilterSpanNesting.TestBean.class)
 @AddBean(TestFilterSpanNesting.IngressSpanSetter.class)
+@AddBean(TestFilterSpanNesting.LateChildSpanSetter.class)
+@AddBean(TestFilterSpanNesting.LateBaggageSetter.class)
 @AddConfig(key = "otel.sdk.disabled", value = "false")
 @AddConfig(key = "otel.traces.exporter", value = "in-memory")
 @AddConfig(key = HelidonTelemetryContainerFilter.AUTO_SPAN_INCLUDES_RESPONSE_WRITE, value = "true")
@@ -92,7 +94,7 @@ class TestFilterSpanNesting {
         }
 
         // Check structure of nested spans.
-        List<SpanData> spanData = testSpanExporter.spanData(6);
+        List<SpanData> spanData = testSpanExporter.spanData(8);
         List<SpanData> ingressSpans = spanData.stream()
                 .filter(sd -> sd.getName().equals("ingressSpan"))
                 .toList();
@@ -102,9 +104,13 @@ class TestFilterSpanNesting {
         List<SpanData> clientSpans = spanData.stream()
                 .filter(sd -> sd.getKind() == SpanKind.CLIENT)
                 .toList();
+        List<SpanData> lateFilterSpans = spanData.stream()
+                .filter(sd -> sd.getName().equals("lateFilterSpan"))
+                .toList();
         assertThat("ingress span count", ingressSpans.size(), is(2));
         assertThat("server span count", serverSpans.size(), is(2));
         assertThat("client span count", clientSpans.size(), is(2));
+        assertThat("late filter span count", lateFilterSpans.size(), is(2));
 
         for (SpanData serverSpan : serverSpans) {
             Optional<SpanData> ingressSpan = ingressSpans.stream()
@@ -121,6 +127,13 @@ class TestFilterSpanNesting {
             assertThat("Ingress span parent is the corresponding client span",
                        clientSpans.stream().anyMatch(clientSpan -> clientSpan.getSpanContext().getSpanId()
                                .equals(ingressSpan.getParentSpanContext().getSpanId())),
+                       is(true));
+        }
+
+        for (SpanData lateFilterSpan : lateFilterSpans) {
+            assertThat("Later request-filter span is a child of the automatic server span",
+                       serverSpans.stream().anyMatch(serverSpan -> serverSpan.getSpanContext().getSpanId()
+                               .equals(lateFilterSpan.getParentSpanContext().getSpanId())),
                        is(true));
         }
 
@@ -145,9 +158,8 @@ class TestFilterSpanNesting {
     @Provider
     @Priority(Priorities.HEADER_DECORATOR)
     static class IngressSpanSetter implements ContainerRequestFilter, ContainerResponseFilter {
-
-        private Span pseudoIngressSpan;
-        private Scope pseudoIngressScope;
+        private static final String SCOPE_PROPERTY = IngressSpanSetter.class.getName() + ".scope";
+        private static final String SPAN_PROPERTY = IngressSpanSetter.class.getName() + ".span";
 
         @Override
         public void filter(ContainerRequestContext requestContext) throws IOException {
@@ -158,18 +170,77 @@ class TestFilterSpanNesting {
             Optional<SpanContext> helidonSpanContext =
                     staticTracer.extract(new RequestContextHeaderProvider(requestContext.getHeaders()));
 
-            pseudoIngressSpan = staticTracer.spanBuilder("ingressSpan")
+            Span pseudoIngressSpan = staticTracer.spanBuilder("ingressSpan")
                     .update(spanBuilder -> helidonSpanContext.ifPresent(spanBuilder::parent))
                     .build();
-            pseudoIngressScope = pseudoIngressSpan.activate();
+            requestContext.setProperty(SPAN_PROPERTY, pseudoIngressSpan);
+            requestContext.setProperty(SCOPE_PROPERTY, pseudoIngressSpan.activate());
         }
 
         @Override
         public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
             assertThat("Request context", requestContext, notNullValue());
             assertThat("Response context", responseContext, notNullValue());
-            pseudoIngressScope.close();
-            pseudoIngressSpan.end();
+            ((Scope) requestContext.getProperty(SCOPE_PROPERTY)).close();
+            ((Span) requestContext.getProperty(SPAN_PROPERTY)).end();
+            requestContext.removeProperty(SCOPE_PROPERTY);
+            requestContext.removeProperty(SPAN_PROPERTY);
+        }
+    }
+
+    /**
+     * Opens a child scope after the telemetry request filter and closes it from the paired response filter.
+     */
+    @Provider
+    @Priority(Priorities.USER + 1000)
+    static class LateChildSpanSetter implements ContainerRequestFilter, ContainerResponseFilter {
+        private static final String SCOPE_PROPERTY = LateChildSpanSetter.class.getName() + ".scope";
+        private static final String SPAN_PROPERTY = LateChildSpanSetter.class.getName() + ".span";
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            assertThat("Request context", requestContext, notNullValue());
+            Span span = staticTracer.spanBuilder("lateFilterSpan").build();
+            requestContext.setProperty(SPAN_PROPERTY, span);
+            requestContext.setProperty(SCOPE_PROPERTY, span.activate());
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            assertThat("Request context", requestContext, notNullValue());
+            assertThat("Response context", responseContext, notNullValue());
+            ((Scope) requestContext.getProperty(SCOPE_PROPERTY)).close();
+            ((Span) requestContext.getProperty(SPAN_PROPERTY)).end();
+            requestContext.removeProperty(SCOPE_PROPERTY);
+            requestContext.removeProperty(SPAN_PROPERTY);
+        }
+    }
+
+    /**
+     * Opens a nested context which retains the automatic span and changes only baggage. Comparing current span IDs cannot
+     * distinguish this scope from the automatic request scope.
+     */
+    @Provider
+    @Priority(Priorities.USER + 1100)
+    static class LateBaggageSetter implements ContainerRequestFilter, ContainerResponseFilter {
+        private static final String SCOPE_PROPERTY = LateBaggageSetter.class.getName() + ".scope";
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            io.opentelemetry.context.Scope scope = io.opentelemetry.api.baggage.Baggage.current()
+                    .toBuilder()
+                    .put("late-filter", "active")
+                    .build()
+                    .makeCurrent();
+            requestContext.setProperty(SCOPE_PROPERTY, scope);
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            assertThat("Request context", requestContext, notNullValue());
+            assertThat("Response context", responseContext, notNullValue());
+            ((io.opentelemetry.context.Scope) requestContext.getProperty(SCOPE_PROPERTY)).close();
+            requestContext.removeProperty(SCOPE_PROPERTY);
         }
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.testing.junit5.MatcherWithRetry;
 import io.helidon.tracing.Span;
@@ -29,9 +28,8 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import jakarta.enterprise.context.ApplicationScoped;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.notNullValue;
 
 // Partially inspired by the MP Telemetry TCK InMemorySpanExporter.
 @ApplicationScoped
@@ -42,9 +40,6 @@ public class TestSpanExporter implements SpanExporter {
 
     private final int RETRY_COUNT = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryCount", 120);
     private final int RETRY_DELAY_MS = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryDelayMs", 500);
-
-
-    private enum State {READY, STOPPED}
 
     private State state = State.READY;
 
@@ -94,7 +89,22 @@ public class TestSpanExporter implements SpanExporter {
                                                             .filter(item -> item.getSpanContext().getSpanId().equals(spanId))
                                                             .findFirst()
                                                             .orElse(null),
-                                                    org.hamcrest.Matchers.notNullValue(),
+                                                    notNullValue(),
+                                                    RETRY_COUNT,
+                                                    RETRY_DELAY_MS);
+    }
+
+    SpanData spanData(String spanName, Span parent) {
+        String parentSpanId = parent.context().spanId();
+        return MatcherWithRetry.assertThatWithRetry("Expected exported child span",
+                                                    () -> spanData.stream()
+                                                            .filter(item -> item.getName().equals(spanName))
+                                                            .filter(item -> item.getParentSpanContext()
+                                                                    .getSpanId()
+                                                                    .equals(parentSpanId))
+                                                            .findFirst()
+                                                            .orElse(null),
+                                                    notNullValue(),
                                                     RETRY_COUNT,
                                                     RETRY_DELAY_MS);
     }
@@ -102,4 +112,6 @@ public class TestSpanExporter implements SpanExporter {
     void clear() {
         spanData.clear();
     }
+
+    private enum State {READY, STOPPED}
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.testing.junit5.MatcherWithRetry;
+import io.helidon.tracing.Span;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -84,6 +85,18 @@ public class TestSpanExporter implements SpanExporter {
                     + " ms for expected spans to arrive.");
         }
         return result;
+    }
+
+    SpanData spanData(Span span) {
+        String spanId = span.context().spanId();
+        return MatcherWithRetry.assertThatWithRetry("Expected exported span",
+                                                    () -> spanData.stream()
+                                                            .filter(item -> item.getSpanContext().getSpanId().equals(spanId))
+                                                            .findFirst()
+                                                            .orElse(null),
+                                                    org.hamcrest.Matchers.notNullValue(),
+                                                    RETRY_COUNT,
+                                                    RETRY_DELAY_MS);
     }
 
     void clear() {


### PR DESCRIPTION
### Description
Resolves helidon-io/helidon#12344 

## Release Note

____
Optional response-preparation coverage for REST spans using MicroProfile Telemetry

Helidon MP adds the new deprecated configuration setting
`telemetry.span.includes-response-write`. The default value `false` preserves
existing Helidon 4 behavior in which the automatic incoming REST span ends
before response-entity serialization.

Setting it to `true` keeps the span open through Jersey response processing,
including response serialization and encoding into Helidon’s response stream.
If an asynchronous resource method is still executing when Jersey finishes
processing the response, the span ends when that resource method returns.

The span does not include the later WebServer socket commit, network delivery,
or client receipt or acknowledgement.

The setting is planned for removal in a future major release, after which
automatic incoming REST spans will always include response preparation through
Jersey completion.
____

## Summary

Adds the deprecated compatibility setting
`telemetry.span.includes-response-write`, which controls whether an automatic
incoming REST server span includes response preparation.

The setting defaults to `false`, preserving existing Helidon 4 behavior. When
set to `true`, the span remains open through Jersey response processing, after
entity serialization and encoding have populated Helidon’s response stream. If
an asynchronous resource method is still executing at Jersey `FINISHED`, the
span remains open until that method returns.

This boundary does not include the later WebServer socket commit, network
delivery, or client acknowledgement. After the setting is removed in a future
major release, automatic spans will always include response preparation through
Jersey completion.

## Design/Implementation

The opt-in lifecycle uses phase-specific, thread-owned scope activation:

- The initial request-filter scope is closed on its owning dispatcher thread
  when the exact OpenTelemetry context established by the automatic span is
  current.
- If a later request filter has established a nested span or baggage context,
  initial-scope closure is deferred until the telemetry response filter runs
  after the paired response filter has restored the original context.
- Separate scopes make the automatic span current during resource-method
  execution and exception mapping, including managed asynchronous execution.
- The automatic span is not forced current across arbitrary response filters,
  preserving the nesting established by paired request and response filters.
- An outer writer interceptor makes the span current during response-entity
  materialization, so spans created by writer interceptors, message-body
  writers, and `StreamingOutput` become children of the automatic server span.
- Jersey `FINISHED` records completion of response processing and makes the
  span eligible to end. If a resource method is still executing, completion is
  deferred until `RESOURCE_METHOD_FINISHED`.
- The response filter records a provisional HTTP status, and Jersey `FINISHED`
  replaces it with the final response status when available. The lifecycle
  applies that final status immediately before ending the span, so later
  response-filter changes are authoritative and an interim 5xx status does not
  remain sticky.
- Serialization failures, response-processing exceptions, and unsuccessful
  response writes mark the span as erroneous and record the available failure.
- VarHandle-based atomic state transitions ensure the span ends only once,
  regardless of asynchronous event ordering.
- The writer interceptor removes the lifecycle request property after initial
  entity processing, and the request listener releases its lifecycle reference
  after terminal completion. This avoids retaining ended telemetry state for
  long-lived `ChunkedOutput` and SSE responses.
- The request listener and writer interceptor are registered only for server
  runtimes when response-write inclusion is enabled and no OpenTelemetry Java
  agent is present. They add no per-request processing to the default,
  Java-agent, or Jersey-client paths.

The existing synchronous behavior remains unchanged when the setting is omitted
or explicitly set to `false`. The container filter retains its Java-agent guard
as defensive protection, and requests suppressed by a telemetry filter helper
remain unchanged.

The telemetry documentation describes this setting and the existing deprecated
span-naming compatibility settings.

## Testing

Added or updated coverage for:

- Omitted and explicitly disabled configuration.
- Successful responses and entity-less responses.
- HTTP 500 responses and mapped exceptions.
- Final HTTP status after a failed entity write.
- Writer and response-filter failures.
- Writer-interceptor and `StreamingOutput` child-span relationships.
- Exception-mapper child-span relationships.
- Managed asynchronous and suspended resource methods.
- Scope ownership across dispatcher, managed-executor, exception-mapper, and
  entity-writer threads.
- Both possible orderings of resource-method completion and Jersey `FINISHED`.
- Atomic and idempotent span completion.
- Child-span and baggage-only nesting in paired request and response filters.
- Prevention of stale trace and baggage context between sequential requests.
- Removal of the lifecycle request property after successful and failed writes.
- Release of the request listener’s lifecycle reference after synchronous and
  asynchronous completion.
- Absence of the opt-in providers when configuration is omitted or `false`.
- Server-only registration of the opt-in providers, including their absence
  from Jersey clients.

Verification completed successfully:

- `mvn -pl microprofile/telemetry -Pcheckstyle verify`
  - 51 tests passed across the default and specialized Surefire executions.
  - 0 Checkstyle violations.
- `etc/scripts/copyright.sh`
  - `COPYRIGHT OK`.
- `git diff --check`
  - Passed.

### Documentation

Update included in PR.