### PR TITLE
Resolve HOCON included self-references and unresolved merges (27.x)

### DIFF
--- a/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
@@ -18,11 +18,18 @@ package io.helidon.config.hocon;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.helidon.common.Api;
 import io.helidon.common.Weight;
@@ -41,6 +48,10 @@ import com.typesafe.config.ConfigList;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigParseOptions;
 import com.typesafe.config.ConfigResolveOptions;
+import com.typesafe.config.ConfigResolver;
+import com.typesafe.config.ConfigUtil;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueFactory;
 
 /**
  * Typesafe (Lightbend) Config (HOCON) {@link ConfigParser} implementation that supports following media types:
@@ -69,6 +80,8 @@ public class HoconConfigParser implements ConfigParser {
     private static final List<String> SUPPORTED_SUFFIXES = List.of("json", "conf");
     private static final Set<MediaType> SUPPORTED_MEDIA_TYPES =
             Set.of(MediaTypes.APPLICATION_HOCON, MediaTypes.APPLICATION_JSON);
+    private static final Pattern HOCON_REFERENCE = Pattern.compile("(?<!\\\\)\\$\\{([^}]+)\\}");
+    private static final String LOCAL_RESOLVE_PATH = "helidon-local-resolution";
 
     private final boolean resolvingEnabled;
     private final ConfigResolveOptions resolveOptions;
@@ -134,9 +147,9 @@ public class HoconConfigParser implements ConfigParser {
             typesafeConfig = ConfigFactory.parseReader(readable, parseOptions);
             if (resolvingEnabled) {
                 typesafeConfig = typesafeConfig.resolve(resolveOptions);
+                return fromConfig(typesafeConfig.root(), typesafeConfig, List.of(), false);
             }
-
-            return fromConfig(typesafeConfig.root());
+            return fromConfig(typesafeConfig.root(), typesafeConfig, List.of(), true);
         } catch (ConfigException e) {
             throw e;
         } catch (Exception e) {
@@ -154,17 +167,20 @@ public class HoconConfigParser implements ConfigParser {
         return "HOCON(" + MediaTypes.APPLICATION_HOCON.text() + ")";
     }
 
-    private static ObjectNode fromConfig(ConfigObject config) {
+    private static ObjectNode fromConfig(ConfigObject configObject, Config config, List<String> path, boolean locallyResolve) {
         ObjectNode.Builder builder = ObjectNode.builder();
-        config.forEach((unescapedKey, value) -> {
+        configObject.forEach((unescapedKey, value) -> {
+            List<String> childPath = childPath(path, unescapedKey);
+            ConfigValue valueToConvert = valueToConvert(value, config, childPath, locallyResolve);
+
             String key = io.helidon.config.Config.Key.escapeName(unescapedKey);
-            if (value instanceof ConfigList configList) {
-                builder.addList(key, fromList(configList));
-            } else if (value instanceof ConfigObject configObject) {
-                builder.addObject(key, fromConfig(configObject));
+            if (valueToConvert instanceof ConfigList configList) {
+                builder.addList(key, fromList(configList, config, childPath, locallyResolve));
+            } else if (valueToConvert instanceof ConfigObject hoconObject) {
+                builder.addObject(key, fromConfig(hoconObject, config, childPath, locallyResolve));
             } else {
                 try {
-                    Object unwrapped = value.unwrapped();
+                    Object unwrapped = valueToConvert.unwrapped();
                     if (unwrapped == null) {
                         builder.addValue(key, "");
                     } else {
@@ -174,23 +190,26 @@ public class HoconConfigParser implements ConfigParser {
                     // An unresolved ConfigReference resolved later in config module since
                     // Helidon and Hocon use the same reference syntax and resolving here
                     // would be too early for resolution across sources
-                    builder.addValue(key, value.render());
+                    builder.addValue(key, valueToConvert.render());
                 }
             }
         });
         return builder.build();
     }
 
-    private static ListNode fromList(ConfigList list) {
+    private static ListNode fromList(ConfigList list, Config config, List<String> path, boolean locallyResolve) {
         ListNode.Builder builder = ListNode.builder();
-        list.forEach(value -> {
-            if (value instanceof ConfigList configList) {
-                builder.addList(fromList(configList));
-            } else if (value instanceof ConfigObject configObject) {
-                builder.addObject(fromConfig(configObject));
+        for (int i = 0; i < list.size(); i++) {
+            ConfigValue value = list.get(i);
+            List<String> childPath = childPath(path, String.valueOf(i));
+            ConfigValue valueToConvert = valueToConvert(value, config, childPath, locallyResolve);
+            if (valueToConvert instanceof ConfigList configList) {
+                builder.addList(fromList(configList, config, childPath, locallyResolve));
+            } else if (valueToConvert instanceof ConfigObject configObject) {
+                builder.addObject(fromConfig(configObject, config, childPath, locallyResolve));
             } else {
                 try {
-                    Object unwrapped = value.unwrapped();
+                    Object unwrapped = valueToConvert.unwrapped();
                     if (unwrapped == null) {
                         builder.addValue("");
                     } else {
@@ -200,11 +219,126 @@ public class HoconConfigParser implements ConfigParser {
                     // An unresolved ConfigReference resolved later in config module since
                     // Helidon and Hocon use the same reference syntax and resolving here
                     // would be too early for resolution across sources
-                    builder.addValue(value.render());
+                    builder.addValue(valueToConvert.render());
                 }
             }
-        });
+        }
         return builder.build();
+    }
+
+    private static ConfigValue valueToConvert(ConfigValue value, Config config, List<String> path, boolean locallyResolve) {
+        if (!locallyResolve || !needsLocalResolution(value)) {
+            return value;
+        }
+
+        String hoconPath = ConfigUtil.joinPath(path);
+        try {
+            // Materialize delayed HOCON merges while preserving required references for Helidon source-merge resolution.
+            return config.withOnlyPath(hoconPath)
+                    .resolve(localResolveOptions(value))
+                    .getValue(hoconPath);
+        } catch (com.typesafe.config.ConfigException e) {
+            return resolveLocalValue(value);
+        }
+    }
+
+    private static ConfigValue resolveLocalValue(ConfigValue value) {
+        try {
+            return value.atPath(LOCAL_RESOLVE_PATH)
+                    .resolve(localResolveOptions(value))
+                    .getValue(LOCAL_RESOLVE_PATH);
+        } catch (com.typesafe.config.ConfigException e) {
+            return value;
+        }
+    }
+
+    private static boolean needsLocalResolution(ConfigValue value) {
+        try {
+            value.valueType();
+            return false;
+        } catch (com.typesafe.config.ConfigException.NotResolved e) {
+            return true;
+        }
+    }
+
+    private static ConfigResolveOptions localResolveOptions(ConfigValue value) {
+        return ConfigResolveOptions.defaults()
+                .setAllowUnresolved(true)
+                .setUseSystemEnvironment(false)
+                .appendResolver(new DeferredReferenceResolver(references(value)));
+    }
+
+    static List<HoconReference> references(ConfigValue value) {
+        List<HoconReference> result = new ArrayList<>();
+        Matcher matcher = HOCON_REFERENCE.matcher(value.render());
+        while (matcher.find()) {
+            String reference = matcher.group(1).trim();
+            boolean optional = reference.startsWith("?");
+            if (optional) {
+                reference = reference.substring(1).trim();
+            }
+            try {
+                result.add(new HoconReference(ConfigUtil.splitPath(reference), optional));
+            } catch (com.typesafe.config.ConfigException e) {
+                // Ignore values that are not parseable as HOCON paths.
+            }
+        }
+        return result;
+    }
+
+    static String helidonPath(List<String> hoconPath) {
+        StringBuilder path = new StringBuilder();
+        for (String element : hoconPath) {
+            if (!path.isEmpty()) {
+                path.append('.');
+            }
+            path.append(io.helidon.config.Config.Key.escapeName(element));
+        }
+        return path.toString();
+    }
+
+    private static List<String> childPath(List<String> path, String child) {
+        List<String> childPath = new ArrayList<>(path.size() + 1);
+        childPath.addAll(path);
+        childPath.add(child);
+        return childPath;
+    }
+
+    private static class DeferredReferenceResolver implements ConfigResolver {
+        private final Map<String, Deque<HoconReference>> references;
+
+        DeferredReferenceResolver(List<HoconReference> references) {
+            this.references = new HashMap<>();
+            references.forEach(reference -> this.references.computeIfAbsent(ConfigUtil.joinPath(reference.path()),
+                                                                            it -> new ArrayDeque<>())
+                    .add(reference));
+        }
+
+        @Override
+        public ConfigValue lookup(String path) {
+            List<String> referencePath;
+            try {
+                referencePath = ConfigUtil.splitPath(path);
+            } catch (com.typesafe.config.ConfigException e) {
+                return ConfigValueFactory.fromAnyRef("${" + path + "}");
+            }
+
+            Deque<HoconReference> references = this.references.get(ConfigUtil.joinPath(referencePath));
+            HoconReference reference = references == null ? null : references.poll();
+            if (reference != null && reference.optional()) {
+                return null;
+            }
+
+            return ConfigValueFactory.fromAnyRef("${" + helidonPath(referencePath) + "}");
+        }
+
+        @Override
+        public ConfigResolver withFallback(ConfigResolver fallback) {
+            return this;
+        }
+    }
+
+    record HoconReference(List<String> path, boolean optional) {
     }
 
 }

--- a/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParserBuilder.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParserBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,9 @@ import com.typesafe.config.ConfigResolveOptions;
 /**
  * HOCON ConfigParser Builder.
  * <p>
- * {@link Config#resolve() HOCON resolving substitutions support} is by default enabled.
- * {@link ConfigResolveOptions#defaults()} is used to resolve loaded configuration.
- * It is possible to {@link #resolvingEnabled(boolean)}} to disable this feature
- * or specify custom {@link #resolveOptions(ConfigResolveOptions) ConfigResolveOptions} instance.
+ * Full {@link Config#resolve() HOCON substitution resolution} is disabled by default.
+ * It is possible to {@link #resolvingEnabled(boolean)} enable this feature or specify custom
+ * {@link #resolveOptions(ConfigResolveOptions) ConfigResolveOptions}.
  */
 public final class HoconConfigParserBuilder implements Builder<HoconConfigParserBuilder, ConfigParser> {
 
@@ -47,12 +46,13 @@ public final class HoconConfigParserBuilder implements Builder<HoconConfigParser
     }
 
     /**
-     * Enables/disables HOCON resolving substitutions support. Default is {@code false}.
+     * Enables/disables full HOCON substitution resolution support. Default is {@code false}.
      * <p>
-     * Note: Even if you disable substitution at HOCON parsing time, values can still be resolved at a later time by the
-     * Helidon Config system.
+     * When disabled, the parser may still use local HOCON resolution to materialize HOCON merges and self-references
+     * from the parsed source and its includes. Required unresolved substitutions are preserved for later resolution by
+     * the Helidon Config system.
      *
-     * @param enabled use to enable or disable substitution
+     * @param enabled use to enable or disable full substitution resolution
      * @return modified builder instance
      */
     public HoconConfigParserBuilder resolvingEnabled(boolean enabled) {

--- a/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link HoconConfigParser}.
@@ -81,6 +82,226 @@ public class HoconConfigParserTest {
 
         assertThat(node.entrySet(), hasSize(1));
         assertThat(node.get("env-var"), valueNode("This Is My ENV VARS Value."));
+    }
+
+    @Test
+    void testReferencePathRegexSupportsHoconSyntaxAndHelidonEscaping() {
+        com.typesafe.config.Config hocon = com.typesafe.config.ConfigFactory.parseString(""
+                + "required = ${root.target}\n"
+                + "optional = ${? root.optional }\n"
+                + "requiredWithWhitespace = ${ root.spaced }\n"
+                + "quoted = ${root.\"oracle.com\"}\n");
+
+        assertThat(HoconConfigParser.references(hocon.root().get("required")),
+                   is(List.of(new HoconConfigParser.HoconReference(List.of("root", "target"), false))));
+        assertThat(HoconConfigParser.references(hocon.root().get("optional")),
+                   is(List.of(new HoconConfigParser.HoconReference(List.of("root", "optional"), true))));
+        assertThat(HoconConfigParser.references(hocon.root().get("requiredWithWhitespace")),
+                   is(List.of(new HoconConfigParser.HoconReference(List.of("root", "spaced"), false))));
+        assertThat(HoconConfigParser.references(hocon.root().get("quoted")),
+                   is(List.of(new HoconConfigParser.HoconReference(List.of("root", "oracle.com"), false))));
+        assertThat(HoconConfigParser.references(com.typesafe.config.ConfigValueFactory.fromAnyRef("${?same}${same}")),
+                   is(List.of(new HoconConfigParser.HoconReference(List.of("same"), true),
+                              new HoconConfigParser.HoconReference(List.of("same"), false))));
+        assertThat(HoconConfigParser.references(com.typesafe.config.ConfigValueFactory.fromAnyRef("\\${root.escaped}")),
+                   is(List.of()));
+        assertThat(HoconConfigParser.references(com.typesafe.config.ConfigValueFactory.fromAnyRef("${bad[}")),
+                   is(List.of()));
+        assertThat(HoconConfigParser.helidonPath(List.of("root", "oracle.com")),
+                   is("root.oracle~1com"));
+    }
+
+    @Test
+    void testUnresolvedMergeKeepsReferenceDeferred() {
+        String hocon = ""
+                + "root.object {\n"
+                + "  target: \"base\"\n"
+                + "  value: \"base\"\n"
+                + "}\n"
+                + "root.object {\n"
+                + "  value: ${root.object.target}\n"
+                + "}\n";
+
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addParser(HoconConfigParser.create())
+                .disableParserServices()
+                .addSource(ConfigSources.create(Map.of("root.object.target", "override")))
+                .addSource(ConfigSources.create(hocon, MediaTypes.APPLICATION_HOCON))
+                .build();
+
+        assertThat(config.get("root.object.value").asString().orElse(null), is("override"));
+    }
+
+    @Test
+    void testUnresolvedMergeInListKeepsReferenceDeferred() {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addParser(HoconConfigParser.create())
+                .disableParserServices()
+                .addSource(ConfigSources.create(Map.of("T", "override")))
+                .addSource(ConfigSources.create("items = [{ a = \"base\", a = ${T} }]\n",
+                                                MediaTypes.APPLICATION_HOCON))
+                .build();
+
+        assertThat(config.get("items.0.a").asString().orElse(null), is("override"));
+    }
+
+    @Test
+    void testHiddenUnresolvedSubstitutionIsNotEvaluated() {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addParser(HoconConfigParser.create())
+                .disableParserServices()
+                .addSource(ConfigSources.create("foo = ${does-not-exist}\nfoo = 42\n",
+                                                MediaTypes.APPLICATION_HOCON))
+                .build();
+
+        assertThat(config.get("foo").asString().orElse(null), is("42"));
+    }
+
+    @Test
+    void testObjectReferenceUsesFinalMergedValue() {
+        String hocon = ""
+                + "bar : { foo : 42,\n"
+                + "        baz : ${bar.foo}\n"
+                + "      }\n"
+                + "bar : { foo : 43 }\n";
+
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addParser(HoconConfigParser.create())
+                .disableParserServices()
+                .addSource(ConfigSources.create(hocon, MediaTypes.APPLICATION_HOCON))
+                .build();
+
+        assertThat(config.get("bar.baz").asString().orElse(null), is("43"));
+    }
+
+    @Test
+    void testIncludedSelfReferenceUsesIncludedValue() {
+        ConfigParser parser = HoconConfigParser.create();
+        ObjectNode node = parser.parse((StringContent) () -> ""
+                                               + "include \"prod\"\n"
+                                               + "basicAuthEnabledServices: ${basicAuthEnabledServices} [\n"
+                                               + "  \"canary-unstable-alpha\",\n"
+                                               + "  \"canary-unstable-beta\",\n"
+                                               + "  \"canary-unstable-gamma\"\n"
+                                               + "]\n",
+                                       name -> {
+                                           if ("prod.conf".equals(name)) {
+                                               return Optional.of(new ByteArrayInputStream((""
+                                                       + "basicAuthEnabledServices = [\"prod-service\"]\n")
+                                                       .getBytes(StandardCharsets.UTF_8)));
+                                           }
+                                           return Optional.empty();
+                                       });
+
+        ListNode services = (ListNode) node.get("basicAuthEnabledServices");
+        assertThat(services, hasSize(4));
+        assertThat(services.get(0), valueNode("prod-service"));
+        assertThat(services.get(1), valueNode("canary-unstable-alpha"));
+        assertThat(services.get(2), valueNode("canary-unstable-beta"));
+        assertThat(services.get(3), valueNode("canary-unstable-gamma"));
+    }
+
+    @Test
+    void testMissingSelfReferenceStillFails() {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addParser(HoconConfigParser.create())
+                .disableParserServices()
+                .addSource(ConfigSources.create(""
+                                                        + "basicAuthEnabledServices: ${basicAuthEnabledServices} [\n"
+                                                        + "  \"canary-unstable-alpha\",\n"
+                                                        + "  \"canary-unstable-beta\",\n"
+                                                        + "  \"canary-unstable-gamma\"\n"
+                                                        + "]\n",
+                                                MediaTypes.APPLICATION_HOCON))
+                .build();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                       () -> config.get("basicAuthEnabledServices")
+                                                               .asList(String.class)
+                                                               .get());
+        assertThat(exception.getMessage(), is("Recursive update"));
+    }
+
+    @Test
+    void testMetricsOverrideReferenceMaterializesDelayedMerge() {
+        String hocon = ""
+                + "metrics.publishers.oci {\n"
+                + "  type: oci\n"
+                + "  enabled: false\n"
+                + "  sample-gauges: false\n"
+                + "  gauge-sample-interval = \"PT3S\"\n"
+                + "  project = \"emailMessageTransformerApi\"\n"
+                + "  fleet = \"\"\n"
+                + "}\n"
+                + "metrics.publishers.oci {\n"
+                + "  type: oci\n"
+                + "  enabled: true\n"
+                + "  project: ${T2_PROJECT}\n"
+                + "  fleet: ${T2_FLEET}\n"
+                + "  sample-gauges: false\n"
+                + "  default-dimensions {\n"
+                + "    project: ${T2_PROJECT}\n"
+                + "    fleet: ${T2_FLEET}\n"
+                + "  }\n"
+                + "}\n";
+
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addParser(HoconConfigParser.create())
+                .disableParserServices()
+                .addSource(ConfigSources.create(Map.of("T2_PROJECT", "ed_dedicated_intc",
+                                                       "T2_FLEET", "ed-intc-omta")))
+                .addSource(ConfigSources.create(hocon, MediaTypes.APPLICATION_HOCON))
+                .build();
+
+        assertThat(config.get("metrics.publishers.oci.project").asString().orElse(null), is("ed_dedicated_intc"));
+        assertThat(config.get("metrics.publishers.oci.fleet").asString().orElse(null), is("ed-intc-omta"));
+        assertThat(config.get("metrics.publishers.oci.default-dimensions.project").asString().orElse(null),
+                   is("ed_dedicated_intc"));
+        assertThat(config.get("metrics.publishers.oci.default-dimensions.fleet").asString().orElse(null),
+                   is("ed-intc-omta"));
+    }
+
+    @Test
+    void testMixedOptionalAndRequiredReferenceDefersOnlyRequiredOccurrence() {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addParser(HoconConfigParser.create())
+                .disableParserServices()
+                .addSource(ConfigSources.create(Map.of("external", "override")))
+                .addSource(ConfigSources.create("value = ${?external}${external}\n",
+                                                MediaTypes.APPLICATION_HOCON))
+                .build();
+
+        assertThat(config.get("value").asString().orElse(null), is("override"));
+    }
+
+    @Test
+    void testQuotedReferenceUsesHelidonEscapedKey() {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addParser(HoconConfigParser.create())
+                .disableParserServices()
+                .addSource(ConfigSources.create("root.\"oracle.com\" = override\n",
+                                                MediaTypes.APPLICATION_HOCON))
+                .addSource(ConfigSources.create("value = ${root.\"oracle.com\"}\n",
+                                                MediaTypes.APPLICATION_HOCON))
+                .build();
+
+        assertThat(config.get("value").asString().orElse(null), is("override"));
     }
 
     @Test

--- a/config/hocon/src/test/java/io/helidon/config/hocon/IncludeTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/IncludeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,13 @@
 package io.helidon.config.hocon;
 
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.ClasspathConfigSource;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 import io.helidon.config.FileConfigSource;
 import io.helidon.config.spi.ConfigParserException;
 
@@ -66,6 +70,70 @@ class IncludeTest {
     }
 
     @Test
+    void testSelfReferenceFromIncludedValue() {
+        Config config = Config.just(ClasspathConfigSource.create("conf/self-reference-override.conf"));
+
+        List<String> value = config.get("items")
+                .asList(String.class)
+                .orElse(List.of());
+
+        assertThat(value, is(List.of("base-alpha",
+                                     "base-beta",
+                                     "override-alpha",
+                                     "override-beta",
+                                     "override-gamma")));
+    }
+
+    @Test
+    void testBasicAuthEnabledServicesSelfReferenceFromIncludedProd() {
+        Config config = Config.just(ClasspathConfigSource.create("conf/basic-auth-services.conf"));
+
+        List<String> value = config.get("basicAuthEnabledServices")
+                .asList(String.class)
+                .orElse(List.of());
+
+        assertThat(value, is(List.of("prod-alpha",
+                                     "prod-beta",
+                                     "canary-unstable-alpha",
+                                     "canary-unstable-beta",
+                                     "canary-unstable-gamma")));
+    }
+
+    @Test
+    void testBasicAuthEnabledServicesSelfReferenceWithoutIncludedValueFails() {
+        String hocon = ""
+                + "basicAuthEnabledServices: ${basicAuthEnabledServices} [\n"
+                + "  \"canary-unstable-alpha\",\n"
+                + "  \"canary-unstable-beta\",\n"
+                + "  \"canary-unstable-gamma\"\n"
+                + "]\n";
+
+        Config config = Config.just(ConfigSources.create(hocon, MediaTypes.APPLICATION_HOCON));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                                                () -> config.get("basicAuthEnabledServices")
+                                                        .asList(String.class)
+                                                        .get());
+
+        assertThat(ex.getMessage(), is("Recursive update"));
+    }
+
+    @Test
+    void testSelfReferenceKeepsNestedReferencesDeferred() {
+        Config config = Config.builder(ConfigSources.create(Map.of("itemName", "external")),
+                                       ClasspathConfigSource.create("conf/self-reference-deferred-override.conf"))
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .build();
+
+        List<String> value = config.get("items")
+                .asList(String.class)
+                .orElse(List.of());
+
+        assertThat(value, is(List.of("external", "override")));
+    }
+
+    @Test
     void testIncludesWithRequiredIncludeNotPresent() {
         ConfigParserException cpe = assertThrows(ConfigParserException.class, () ->
                 Config.just(FileConfigSource.builder()
@@ -91,5 +159,25 @@ class IncludeTest {
 
         assertThat("server.port should be loaded from sub/included.conf", value, notNullValue());
         assertThat(value, is("8080"));
+    }
+
+    @Test
+    void testIncludedReferenceOverridesBaseValue() {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addSource(ConfigSources.create(Map.of("T2_PROJECT", "ed_dedicated_intc",
+                                                       "T2_FLEET", "ed-intc-omta")))
+                .addSource(ClasspathConfigSource.create("conf/merge-reference-override.conf"))
+                .build();
+
+        assertThat(config.get("metrics.publishers.oci.enabled").asString().orElse(null), is("true"));
+        assertThat(config.get("metrics.publishers.oci.gauge-sample-interval").asString().orElse(null), is("PT3S"));
+        assertThat(config.get("metrics.publishers.oci.project").asString().orElse(null), is("ed_dedicated_intc"));
+        assertThat(config.get("metrics.publishers.oci.fleet").asString().orElse(null), is("ed-intc-omta"));
+        assertThat(config.get("metrics.publishers.oci.default-dimensions.project").asString().orElse(null),
+                   is("ed_dedicated_intc"));
+        assertThat(config.get("metrics.publishers.oci.default-dimensions.fleet").asString().orElse(null),
+                   is("ed-intc-omta"));
     }
 }

--- a/config/hocon/src/test/resources/conf/basic-auth-services.conf
+++ b/config/hocon/src/test/resources/conf/basic-auth-services.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include "prod"
+
+basicAuthEnabledServices: ${basicAuthEnabledServices} [
+  "canary-unstable-alpha",
+  "canary-unstable-beta",
+  "canary-unstable-gamma"
+]

--- a/config/hocon/src/test/resources/conf/merge-reference-base.conf
+++ b/config/hocon/src/test/resources/conf/merge-reference-base.conf
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+metrics {
+  publishers {
+    oci {
+      type: oci
+      enabled: false
+      sample-gauges: false
+      gauge-sample-interval = "PT3S"
+      project = "emailMessageTransformerApi"
+      fleet = ""
+    }
+  }
+}

--- a/config/hocon/src/test/resources/conf/merge-reference-override.conf
+++ b/config/hocon/src/test/resources/conf/merge-reference-override.conf
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include "merge-reference-base.conf"
+
+metrics {
+  publishers {
+    oci {
+      type: oci
+      enabled: true
+      project: ${T2_PROJECT}
+      fleet: ${T2_FLEET}
+      sample-gauges: false
+      default-dimensions {
+        project: ${T2_PROJECT}
+        fleet: ${T2_FLEET}
+      }
+    }
+  }
+}

--- a/config/hocon/src/test/resources/conf/prod.conf
+++ b/config/hocon/src/test/resources/conf/prod.conf
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+basicAuthEnabledServices: [
+  "prod-alpha",
+  "prod-beta"
+]

--- a/config/hocon/src/test/resources/conf/self-reference-base.conf
+++ b/config/hocon/src/test/resources/conf/self-reference-base.conf
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+items: [
+  "base-alpha",
+  "base-beta"
+]

--- a/config/hocon/src/test/resources/conf/self-reference-deferred-base.conf
+++ b/config/hocon/src/test/resources/conf/self-reference-deferred-base.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+itemName = "local"
+items = [${itemName}]

--- a/config/hocon/src/test/resources/conf/self-reference-deferred-override.conf
+++ b/config/hocon/src/test/resources/conf/self-reference-deferred-override.conf
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include "self-reference-deferred-base"
+
+items = ${items} ["override"]

--- a/config/hocon/src/test/resources/conf/self-reference-override.conf
+++ b/config/hocon/src/test/resources/conf/self-reference-override.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include "self-reference-base"
+
+items: ${items} [
+  "override-alpha",
+  "override-beta",
+  "override-gamma"
+]

--- a/docs/src/main/asciidoc/se/config/supported-formats.adoc
+++ b/docs/src/main/asciidoc/se/config/supported-formats.adoc
@@ -186,7 +186,9 @@ include::{sourcedir}/se/config/SupportedFormatsSnippets.java[tag=snippet_9, inde
 ----
 
 <1> Creates new instance of the parser builder.
-<2> Disables resolution of substitutions.
+<2> Disables full HOCON substitution resolution. The parser might still use local HOCON resolution to materialize
+merges and self-references from the parsed source and its includes; unresolved required substitutions are preserved
+for later Helidon Config resolution.
 (See the link:https://github.com/lightbend/config/blob/master/HOCON.md#substitutions[HOCON documentation].)
 <3> Builds a new instance of the HOCON config parser.
 


### PR DESCRIPTION
Resolves #12349

Carries the HOCON local-resolution fix from #12119 and PR #12120 forward to `main`.

This PR is intentionally a source-faithful carry-forward of the merged 4.x change. It is not an attempt to resolve findings or other issues inherited from source commit [`4ede2990`](https://github.com/helidon-io/helidon/commit/4ede299053fc3ff1dca2fb91b77a26a2cd745c4c); those remain unchanged.

### Summary

- Materializes delayed HOCON merges and included self-references before converting them to Helidon config nodes.
- Preserves required unresolved substitutions for later Helidon cross-source resolution.
- Retains the merged source handling for mixed optional/required occurrences and quoted HOCON paths.
- Carries the source regression tests and documentation unchanged.

### Release Note

____
The HOCON parser now materializes local delayed merges and included self-references even when full HOCON substitution resolution is disabled. Required unresolved substitutions remain available for later Helidon Config resolution.
____

### Documentation

The HOCON builder Javadoc and supported-formats guide clarify the distinction between full substitution resolution and local merge/self-reference materialization.
